### PR TITLE
Fixes inconsistency `Required`, `Optional` and `ForceNew` properties between code and document.

### DIFF
--- a/website/docs/r/active_directory_domain_service.html.markdown
+++ b/website/docs/r/active_directory_domain_service.html.markdown
@@ -164,11 +164,11 @@ resource "azurerm_active_directory_domain_service" "example" {
 
 The following arguments are supported:
 
-* `domain_name` - (Required) The Active Directory domain to use. See [official documentation](https://docs.microsoft.com/azure/active-directory-domain-services/tutorial-create-instance#create-a-managed-domain) for constraints and recommendations.
+* `domain_name` - (Required) The Active Directory domain to use. See [official documentation](https://docs.microsoft.com/azure/active-directory-domain-services/tutorial-create-instance#create-a-managed-domain) for constraints and recommendations. Changing this forces a new resource to be created.
 
 * `domain_configuration_type` - (Optional)  The configuration type of this Active Directory Domain. Possible values are `FullySynced` and `ResourceTrusting`. Changing this forces a new resource to be created.
 
-* `filtered_sync_enabled` - Whether to enable group-based filtered sync (also called scoped synchronisation). Defaults to `false`.
+* `filtered_sync_enabled` - (Optional) Whether to enable group-based filtered sync (also called scoped synchronisation). Defaults to `false`.
 
 * `secure_ldap` - (Optional) A `secure_ldap` block as defined below.
 
@@ -214,7 +214,7 @@ A `notifications` block supports the following:
 
 An `initial_replica_set` block supports the following:
 
-* `subnet_id` - (Required) The ID of the subnet in which to place the initial replica set.
+* `subnet_id` - (Required) The ID of the subnet in which to place the initial replica set. Changing this forces a new resource to be created.
 
 ---
 

--- a/website/docs/r/active_directory_domain_service_replica_set.html.markdown
+++ b/website/docs/r/active_directory_domain_service_replica_set.html.markdown
@@ -284,7 +284,7 @@ The following arguments are supported:
   
 * `location` - (Required) The Azure location where this Replica Set should exist. Changing this forces a new resource to be created.
 
-* `subnet_id` - (Required) The ID of the subnet in which to place this Replica Set.
+* `subnet_id` - (Required) The ID of the subnet in which to place this Replica Set. Changing this forces a new resource to be created.
   
 ## Attributes Reference
 

--- a/website/docs/r/api_management.html.markdown
+++ b/website/docs/r/api_management.html.markdown
@@ -113,7 +113,7 @@ A `additional_location` block supports the following:
 
 * `capacity` - (Optional) The number of compute units in this region. Defaults to the capacity of the main region.
 
-* `zones` - (Optional) A list of availability zones.
+* `zones` - (Optional) A list of availability zones. Changing this forces a new resource to be created.
 
 * `public_ip_address_id` - (Optional) ID of a standard SKU IPv4 Public IP.
 

--- a/website/docs/r/api_management_api.html.markdown
+++ b/website/docs/r/api_management_api.html.markdown
@@ -54,7 +54,7 @@ The following arguments are supported:
 
 * `resource_group_name` - (Required) The Name of the Resource Group where the API Management API exists. Changing this forces a new resource to be created.
 
-* `revision` - (Required) The Revision which used for this API.
+* `revision` - (Required) The Revision which used for this API. Changing this forces a new resource to be created.
 
 ---
 

--- a/website/docs/r/api_management_api_operation.html.markdown
+++ b/website/docs/r/api_management_api_operation.html.markdown
@@ -148,7 +148,7 @@ A `query_parameter` block supports the following:
 
 A `request` block supports the following:
 
-* `description` - (Required) A description of the HTTP Request, which may include HTML tags.
+* `description` - (Optional) A description of the HTTP Request, which may include HTML tags.
 
 * `header` - (Optional) One or more `header` blocks as defined above.
 
@@ -182,7 +182,7 @@ A `response` block supports the following:
 
 * `status_code` - (Required) The HTTP Status Code.
 
-* `description` - (Required) A description of the HTTP Response, which may include HTML tags.
+* `description` - (Optional) A description of the HTTP Response, which may include HTML tags.
 
 * `header` - (Optional) One or more `header` blocks as defined above.
 

--- a/website/docs/r/api_management_api_operation_policy.html.markdown
+++ b/website/docs/r/api_management_api_operation_policy.html.markdown
@@ -75,7 +75,7 @@ The following arguments are supported:
 
 * `resource_group_name` - (Required) The name of the Resource Group in which the API Management Service exists. Changing this forces a new resource to be created.
 
-* `operation_id` - (Required) The operation identifier within an API. Must be unique in the current API Management service instance.
+* `operation_id` - (Required) The operation identifier within an API. Must be unique in the current API Management service instance. Changing this forces a new resource to be created.
 
 * `xml_content` - (Optional) The XML Content for this Policy.
 

--- a/website/docs/r/api_management_api_operation_tag.html.markdown
+++ b/website/docs/r/api_management_api_operation_tag.html.markdown
@@ -52,7 +52,7 @@ The following arguments are supported:
 
 ---
 
-* `display_name` - (Optional) The display name of the API Management API Operation Tag.
+* `display_name` - (Required) The display name of the API Management API Operation Tag.
 
 ## Attributes Reference
 

--- a/website/docs/r/api_management_backend.html.markdown
+++ b/website/docs/r/api_management_backend.html.markdown
@@ -93,9 +93,9 @@ A `proxy` block supports the following:
 
 * `password` - (Optional) The password to connect to the proxy server.
 
-* `url` - (Optional) The URL of the proxy server.
+* `url` - (Required) The URL of the proxy server.
 
-* `username` - (Optional) The username to connect to the proxy server.
+* `username` - (Required) The username to connect to the proxy server.
 
 ---
 

--- a/website/docs/r/api_management_certificate.html.markdown
+++ b/website/docs/r/api_management_certificate.html.markdown
@@ -140,9 +140,9 @@ The following arguments are supported:
 
 -> **NOTE:** Either `data` or `key_vault_secret_id` must be specified - but not both.
 
-* `data` - (Optional) The base-64 encoded certificate data, which must be a PFX file. Changing this forces a new resource to be created.
+* `data` - (Optional) The base-64 encoded certificate data, which must be a PFX file. 
 
-* `password` - (Optional) The password used for this certificate. Changing this forces a new resource to be created.
+* `password` - (Optional) The password used for this certificate. 
 
 * `key_vault_secret_id` - (Optional) The ID of the Key Vault Secret containing the SSL Certificate, which must be of the type `application/x-pkcs12`.
 

--- a/website/docs/r/api_management_group.html.markdown
+++ b/website/docs/r/api_management_group.html.markdown
@@ -51,9 +51,9 @@ The following arguments are supported:
 
 * `description` - (Optional) The description of this API Management Group.
 
-* `external_id` - (Optional) The identifier of the external Group. For example, an Azure Active Directory group `aad://<tenant>.onmicrosoft.com/groups/<group object id>`.
+* `external_id` - (Optional) The identifier of the external Group. For example, an Azure Active Directory group `aad://<tenant>.onmicrosoft.com/groups/<group object id>`. Changing this forces a new resource to be created.
 
-* `type` - (Optional) The type of this API Management Group. Possible values are `custom`, `external` and `system`. Default is `custom`.
+* `type` - (Optional) The type of this API Management Group. Possible values are `custom`, `external` and `system`. Default is `custom`. Changing this forces a new resource to be created.
 
 ## Attributes Reference
 

--- a/website/docs/r/api_management_product.html.markdown
+++ b/website/docs/r/api_management_product.html.markdown
@@ -57,7 +57,7 @@ The following arguments are supported:
 
 * `resource_group_name` - (Required) The name of the Resource Group in which the API Management Service should be exist. Changing this forces a new resource to be created.
 
-* `subscription_required` - (Required) Is a Subscription required to access API's included in this Product?
+* `subscription_required` - (Optional) Is a Subscription required to access API's included in this Product?
 
 ---
 

--- a/website/docs/r/app_service.html.markdown
+++ b/website/docs/r/app_service.html.markdown
@@ -65,7 +65,7 @@ The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the App Service. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) The name of the resource group in which to create the App Service.
+* `resource_group_name` - (Required) The name of the resource group in which to create the App Service. Changing this forces a new resource to be created.
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 
@@ -409,9 +409,9 @@ A `backup` block supports the following:
 
 * `name` (Required) Specifies the name for this Backup.
 
-* `enabled` - (Required) Is this Backup enabled?
+* `enabled` - (Optional) Is this Backup enabled?
 
-* `storage_account_url` (Optional) The SAS URL to a Storage Container where Backups should be saved.
+* `storage_account_url` (Required) The SAS URL to a Storage Container where Backups should be saved.
 
 * `schedule` - (Optional) A `schedule` block as defined below.
 
@@ -433,7 +433,7 @@ A `schedule` block supports the following:
 
 A `source_control` block supports the following:
 
-* `repo_url` - (Required) The URL of the source code repository.
+* `repo_url` - (Optional) The URL of the source code repository.
 
 * `branch` - (Optional) The branch of the remote repository to use. Defaults to 'master'.
 

--- a/website/docs/r/app_service_connection.html.markdown
+++ b/website/docs/r/app_service_connection.html.markdown
@@ -94,7 +94,7 @@ The following arguments are supported:
 
 * `type` - (Required) The authentication type. Possible values are `systemAssignedIdentity`, `userAssignedIdentity`, `servicePrincipalSecret`, `servicePrincipalCertificate`, `secret`.
 
-* `name` - (Optional) Username or account name for secret auth. `name` and `secret` should be either both specified or both not specified when `type` is set to `secret`.
+* `name` - (Required) Username or account name for secret auth. `name` and `secret` should be either both specified or both not specified when `type` is set to `secret`.
 
 * `secret` - (Optional) Password or account key for secret auth. `secret` and `name` should be either both specified or both not specified when `type` is set to `secret`.
 

--- a/website/docs/r/app_service_environment.html.markdown
+++ b/website/docs/r/app_service_environment.html.markdown
@@ -67,7 +67,7 @@ resource "azurerm_app_service_environment" "example" {
 
 * `cluster_setting` - (Optional) Zero or more `cluster_setting` blocks as defined below.
 
-* `internal_load_balancing_mode` - (Optional) Specifies which endpoints to serve internally in the Virtual Network for the App Service Environment. Possible values are `None`, `Web`, `Publishing` and combined value `"Web, Publishing"`. Defaults to `None`.
+* `internal_load_balancing_mode` - (Optional) Specifies which endpoints to serve internally in the Virtual Network for the App Service Environment. Possible values are `None`, `Web`, `Publishing` and combined value `"Web, Publishing"`. Defaults to `None`. Changing this forces a new resource to be created.
 
 * `pricing_tier` - (Optional) Pricing tier for the front end instances. Possible values are `I1`, `I2` and `I3`. Defaults to `I1`.
 
@@ -77,7 +77,7 @@ resource "azurerm_app_service_environment" "example" {
 
 ~> **NOTE:** `allowed_user_ip_cidrs` The addresses that will be used for all outbound traffic from your App Service Environment to the internet to avoid asymmetric routing challenge. If you're routing the traffic on premises, these addresses are your NATs or gateway IPs. If you want to route the App Service Environment outbound traffic through an NVA, the egress address is the public IP of the NVA. Please visit [Create your ASE with the egress addresses](https://docs.microsoft.com/azure/app-service/environment/forced-tunnel-support#add-your-own-ips-to-the-ase-azure-sql-firewall)
 
-* `resource_group_name` - (Optional) The name of the Resource Group where the App Service Environment exists. Defaults to the Resource Group of the Subnet (specified by `subnet_id`).
+* `resource_group_name` - (Required) The name of the Resource Group where the App Service Environment exists. Defaults to the Resource Group of the Subnet (specified by `subnet_id`).
 
 * `tags` - (Optional) A mapping of tags to assign to the resource. Changing this forces a new resource to be created.
 

--- a/website/docs/r/app_service_environment_v3.html.markdown
+++ b/website/docs/r/app_service_environment_v3.html.markdown
@@ -85,7 +85,7 @@ resource "azurerm_service_plan" "example" {
 
 * `name` - (Required) The name of the App Service Environment. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) The name of the Resource Group where the App Service Environment exists. Defaults to the Resource Group of the Subnet (specified by `subnet_id`).
+* `resource_group_name` - (Required) The name of the Resource Group where the App Service Environment exists. Defaults to the Resource Group of the Subnet (specified by `subnet_id`). Changing this forces a new resource to be created.
 
 * `subnet_id` - (Required) The ID of the Subnet which the App Service Environment should be connected to. Changing this forces a new resource to be created.
 
@@ -99,13 +99,13 @@ resource "azurerm_service_plan" "example" {
 
 * `dedicated_host_count` - (Optional) This ASEv3 should use dedicated Hosts. Possible values are `2`. Changing this forces a new resource to be created.
 
-* `zone_redundant` - (Optional) Set to `true` to deploy the ASEv3 with availability zones supported. Zonal ASEs can be deployed in some regions, you can refer to [Availability Zone support for App Service Environments](https://docs.microsoft.com/azure/app-service/environment/zone-redundancy). You can only set either `dedicated_host_count` or `zone_redundant` but not both.
+* `zone_redundant` - (Optional) Set to `true` to deploy the ASEv3 with availability zones supported. Zonal ASEs can be deployed in some regions, you can refer to [Availability Zone support for App Service Environments](https://docs.microsoft.com/azure/app-service/environment/zone-redundancy). You can only set either `dedicated_host_count` or `zone_redundant` but not both. Changing this forces a new resource to be created.
 
 ~> **NOTE:** Setting this value will provision 2 Physical Hosts for your App Service Environment V3, this is done at additional cost, please be aware of the pricing commitment in the [General Availability Notes](https://techcommunity.microsoft.com/t5/apps-on-azure/announcing-app-service-environment-v3-ga/ba-p/2517990)
 
-* `internal_load_balancing_mode` - (Optional) Specifies which endpoints to serve internally in the Virtual Network for the App Service Environment. Possible values are `None` (for an External VIP Type), and `"Web, Publishing"` (for an Internal VIP Type). Defaults to `None`.
+* `internal_load_balancing_mode` - (Optional) Specifies which endpoints to serve internally in the Virtual Network for the App Service Environment. Possible values are `None` (for an External VIP Type), and `"Web, Publishing"` (for an Internal VIP Type). Defaults to `None`. Changing this forces a new resource to be created.
 
-* `tags` - (Optional) A mapping of tags to assign to the resource. Changing this forces a new resource to be created.
+* `tags` - (Optional) A mapping of tags to assign to the resource. 
 
 ~> **NOTE:** The underlying API does not currently support changing Tags on this resource. Making changes in the portal for tags will cause Terraform to detect a change that will force a recreation of the ASEV3 unless `ignore_changes` lifecycle meta-argument is used.
 

--- a/website/docs/r/app_service_hybrid_connection.html.markdown
+++ b/website/docs/r/app_service_hybrid_connection.html.markdown
@@ -77,7 +77,7 @@ The following arguments are supported:
 
 * `relay_id` - (Required) The ID of the Service Bus Relay. Changing this forces a new resource to be created.
 
-* `hostname` - (Optional) The hostname of the endpoint.
+* `hostname` - (Required) The hostname of the endpoint.
 
 * `port` - (Required) The port of the endpoint.
 

--- a/website/docs/r/app_service_plan.html.markdown
+++ b/website/docs/r/app_service_plan.html.markdown
@@ -103,7 +103,7 @@ The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the App Service Plan component. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) The name of the resource group in which to create the App Service Plan component.
+* `resource_group_name` - (Required) The name of the resource group in which to create the App Service Plan component. Changing this forces a new resource to be created.
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 
@@ -111,7 +111,7 @@ The following arguments are supported:
 
 ~> **NOTE:** When creating a `Linux` App Service Plan, the `reserved` field must be set to `true`, and when creating a `Windows`/`app` App Service Plan the `reserved` field must be set to `false`.
 
-* `maximum_elastic_worker_count` - The maximum number of total workers allowed for this ElasticScaleEnabled App Service Plan.
+* `maximum_elastic_worker_count` - (Optional) The maximum number of total workers allowed for this ElasticScaleEnabled App Service Plan.
 
 * `sku` - (Required) A `sku` block as documented below.
 

--- a/website/docs/r/app_service_slot.html.markdown
+++ b/website/docs/r/app_service_slot.html.markdown
@@ -145,9 +145,9 @@ resource "azurerm_app_service_slot" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name of the App Service Slot component. Changing this forces a new resource to be created.
+* `name` - (Required) Specifies the name of the App Service Slot component. Changing this forces a new resource to be created. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) The name of the resource group in which to create the App Service Slot component.
+* `resource_group_name` - (Required) The name of the resource group in which to create the App Service Slot component. Changing this forces a new resource to be created.
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 
@@ -199,7 +199,7 @@ A `storage_account` block supports the following:
 
 `connection_string` supports the following:
 
-* `name` - (Required) The name of the Connection String.
+* `name` - (Required) The name of the Connection String. Changing this forces a new resource to be created.
 * `type` - (Required) The type of the Connection String. Possible values are `APIHub`, `Custom`, `DocDb`, `EventHub`, `MySQL`, `NotificationHub`, `PostgreSQL`, `RedisCache`, `ServiceBus`, `SQLAzure`, and  `SQLServer`.
 * `value` - (Required) The value for the Connection String.
 

--- a/website/docs/r/application_gateway.html.markdown
+++ b/website/docs/r/application_gateway.html.markdown
@@ -243,7 +243,7 @@ A `backend_http_settings` block supports the following:
 
 * `protocol`- (Required) The Protocol which should be used. Possible values are `Http` and `Https`.
 
-* `request_timeout` - (Required) The request timeout in seconds, which must be between 1 and 86400 seconds. Defaults to `30`.
+* `request_timeout` - (Optional) The request timeout in seconds, which must be between 1 and 86400 seconds. Defaults to `30`.
 
 * `host_name` - (Optional) Host header to be sent to the backend servers. Cannot be set if `pick_host_name_from_backend_address` is set to `true`.
 
@@ -453,7 +453,7 @@ A `sku` block supports the following:
 
 * `tier` - (Required) The Tier of the SKU to use for this Application Gateway. Possible values are `Standard`, `Standard_v2`, `WAF` and `WAF_v2`.
 
-* `capacity` - (Required) The Capacity of the SKU to use for this Application Gateway. When using a V1 SKU this value must be between 1 and 32, and 1 to 125 for a V2 SKU. This property is optional if `autoscale_configuration` is set.
+* `capacity` - (Optional) The Capacity of the SKU to use for this Application Gateway. When using a V1 SKU this value must be between 1 and 32, and 1 to 125 for a V2 SKU. This property is optional if `autoscale_configuration` is set.
 
 ---
 
@@ -539,7 +539,7 @@ A `waf_configuration` block supports the following:
 
 * `firewall_mode` - (Required) The Web Application Firewall Mode. Possible values are `Detection` and `Prevention`.
 
-* `rule_set_type` - (Required) The Type of the Rule Set used for this Web Application Firewall. Currently, only `OWASP` is supported.
+* `rule_set_type` - (Optional) The Type of the Rule Set used for this Web Application Firewall. Currently, only `OWASP` is supported.
 
 * `rule_set_version` - (Required) The Version of the Rule Set used for this Web Application Firewall. Possible values are `2.2.9`, `3.0`, `3.1`,  and `3.2`.
 

--- a/website/docs/r/application_insights.html.markdown
+++ b/website/docs/r/application_insights.html.markdown
@@ -74,8 +74,7 @@ The following arguments are supported:
 * `name` - (Required) Specifies the name of the Application Insights component. Changing this forces a
     new resource to be created.
 
-* `resource_group_name` - (Required) The name of the resource group in which to Changing this forces a new resource to be created.
-    create the Application Insights component.
+* `resource_group_name` - (Required) The name of the resource group in which to create the Application Insights component. Changing this forces a new resource to be created.
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 

--- a/website/docs/r/application_insights.html.markdown
+++ b/website/docs/r/application_insights.html.markdown
@@ -74,7 +74,7 @@ The following arguments are supported:
 * `name` - (Required) Specifies the name of the Application Insights component. Changing this forces a
     new resource to be created.
 
-* `resource_group_name` - (Required) The name of the resource group in which to
+* `resource_group_name` - (Required) The name of the resource group in which to Changing this forces a new resource to be created.
     create the Application Insights component.
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.

--- a/website/docs/r/application_insights_smart_detection_rule.html.markdown
+++ b/website/docs/r/application_insights_smart_detection_rule.html.markdown
@@ -36,7 +36,7 @@ resource "azurerm_application_insights_smart_detection_rule" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name of the Application Insights Smart Detection Rule. Valid values include `Slow page load time`, `Slow server response time`, `Long dependency duration`, `Degradation in server response time`, `Degradation in dependency duration`, `Degradation in trace severity ratio`, `Abnormal rise in exception volume`, `Potential memory leak detected`, `Potential security issue detected` and `Abnormal rise in daily data volume`
+* `name` - (Required) Specifies the name of the Application Insights Smart Detection Rule. Valid values include `Slow page load time`, `Slow server response time`, `Long dependency duration`, `Degradation in server response time`, `Degradation in dependency duration`, `Degradation in trace severity ratio`, `Abnormal rise in exception volume`, `Potential memory leak detected`, `Potential security issue detected` and `Abnormal rise in daily data volume` Changing this forces a new resource to be created.
 `Long dependency duration`, `Degradation in server response time`, `Degradation in dependency duration`, `Degradation in trace severity ratio`, `Abnormal rise in exception volume`,
  `Potential memory leak detected`, `Potential security issue detected`, `Abnormal rise in daily data volume`.  Changing this forces a new resource to be created.
 

--- a/website/docs/r/application_insights_smart_detection_rule.html.markdown
+++ b/website/docs/r/application_insights_smart_detection_rule.html.markdown
@@ -36,9 +36,7 @@ resource "azurerm_application_insights_smart_detection_rule" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name of the Application Insights Smart Detection Rule. Valid values include `Slow page load time`, `Slow server response time`, `Long dependency duration`, `Degradation in server response time`, `Degradation in dependency duration`, `Degradation in trace severity ratio`, `Abnormal rise in exception volume`, `Potential memory leak detected`, `Potential security issue detected` and `Abnormal rise in daily data volume` Changing this forces a new resource to be created.
-`Long dependency duration`, `Degradation in server response time`, `Degradation in dependency duration`, `Degradation in trace severity ratio`, `Abnormal rise in exception volume`,
- `Potential memory leak detected`, `Potential security issue detected`, `Abnormal rise in daily data volume`.  Changing this forces a new resource to be created.
+* `name` - (Required) Specifies the name of the Application Insights Smart Detection Rule. Valid values include `Slow page load time`, `Slow server response time`, `Long dependency duration`, `Degradation in server response time`, `Degradation in dependency duration`, `Degradation in trace severity ratio`, `Abnormal rise in exception volume`, `Potential memory leak detected`, `Potential security issue detected` and `Abnormal rise in daily data volume`, `Long dependency duration`, `Degradation in server response time`, `Degradation in dependency duration`, `Degradation in trace severity ratio`, `Abnormal rise in exception volume`, `Potential memory leak detected`, `Potential security issue detected`, `Abnormal rise in daily data volume`.  Changing this forces a new resource to be created.
 
 * `application_insights_id` - (Required) The ID of the Application Insights component on which the Smart Detection Rule operates. Changing this forces a new resource to be created.
 

--- a/website/docs/r/application_insights_workbook.html.markdown
+++ b/website/docs/r/application_insights_workbook.html.markdown
@@ -78,13 +78,13 @@ The following arguments are supported:
 
 An `identity` block exports the following:
 
-* `type` - The type of Managed Service Identity that is configured on this Workbook. Possible values are `UserAssigned`, `SystemAssigned` and `SystemAssigned, UserAssigned`.
+* `type` - The type of Managed Service Identity that is configured on this Workbook. Possible values are `UserAssigned`, `SystemAssigned` and `SystemAssigned, UserAssigned`. Changing this forces a new resource to be created.
 
 * `principal_id` - The Principal ID of the System Assigned Managed Service Identity that is configured on this Workbook.
 
 * `tenant_id` - The Tenant ID of the System Assigned Managed Service Identity that is configured on this Workbook.
 
-* `identity_ids` - The list of User Assigned Managed Identity IDs assigned to this Workbook.
+* `identity_ids` - The list of User Assigned Managed Identity IDs assigned to this Workbook. Changing this forces a new resource to be created.
 
 ## Attributes Reference
 

--- a/website/docs/r/application_security_group.html.markdown
+++ b/website/docs/r/application_security_group.html.markdown
@@ -35,7 +35,7 @@ The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the Application Security Group. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) The name of the resource group in which to create the Application Security Group.
+* `resource_group_name` - (Required) The name of the resource group in which to create the Application Security Group. Changing this forces a new resource to be created.
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 

--- a/website/docs/r/automation_connection.html.markdown
+++ b/website/docs/r/automation_connection.html.markdown
@@ -58,7 +58,7 @@ The following arguments are supported:
 
 * `type` - (Required) The type of the Connection - can be either builtin type such as `Azure`, `AzureClassicCertificate`, and `AzureServicePrincipal`, or a user defined types. Changing this forces a new resource to be created.
 
-* `values` - (Optional) A mapping of key value pairs passed to the connection. Different `type` needs different parameters in the `values`. Builtin types have required field values as below:
+* `values` - (Required) A mapping of key value pairs passed to the connection. Different `type` needs different parameters in the `values`. Builtin types have required field values as below:
 
   * `Azure`: parameters `AutomationCertificateName` and `SubscriptionID`.
 

--- a/website/docs/r/automation_dsc_configuration.html.markdown
+++ b/website/docs/r/automation_dsc_configuration.html.markdown
@@ -46,7 +46,7 @@ The following arguments are supported:
 
 * `content_embedded` - (Required) The PowerShell DSC Configuration script.
 
-* `location` - (Required) Must be the same location as the Automation Account.
+* `location` - (Required) Must be the same location as the Automation Account. Changing this forces a new resource to be created.
 
 * `log_verbose` - (Optional) Verbose log option.
 

--- a/website/docs/r/automation_hybrid_runbook_worker_group.html.markdown
+++ b/website/docs/r/automation_hybrid_runbook_worker_group.html.markdown
@@ -26,7 +26,7 @@ The following arguments are supported:
 
 * `automation_account_name` - (Required) The name of the Automation Account in which the Runbook Worker Group is created. Changing this forces a new resource to be created.
 
-* `name` - (Required) The name which should be used for this Automation Account Runbook Worker Group.
+* `name` - (Required) The name which should be used for this Automation Account Runbook Worker Group. Changing this forces a new resource to be created.
 
 * `resource_group_name` - (Required) The name of the Resource Group where the Automation should exist. Changing this forces a new Automation to be created.
 

--- a/website/docs/r/automation_runbook.html.markdown
+++ b/website/docs/r/automation_runbook.html.markdown
@@ -88,7 +88,7 @@ The following arguments are supported:
 
 * `automation_account_name` - (Required) The name of the automation account in which the Runbook is created. Changing this forces a new resource to be created.
 
-* `runbook_type` - (Required) The type of the runbook - can be either `Graph`, `GraphPowerShell`, `GraphPowerShellWorkflow`, `PowerShellWorkflow`, `PowerShell`, `Python3`, `Python2` or `Script`.
+* `runbook_type` - (Required) The type of the runbook - can be either `Graph`, `GraphPowerShell`, `GraphPowerShellWorkflow`, `PowerShellWorkflow`, `PowerShell`, `Python3`, `Python2` or `Script`. Changing this forces a new resource to be created.
 
 * `log_progress` - (Required) Progress log option.
 

--- a/website/docs/r/automation_software_update_configuration.html.markdown
+++ b/website/docs/r/automation_software_update_configuration.html.markdown
@@ -91,7 +91,7 @@ A `linux` block supports the following:
 
 A `windows` block supports the following:
 
-* `classification_included` - (Deprecated) Specifies the update classification. Possible values are `Unclassified`, `Critical`, `Security`, `UpdateRollup`, `FeaturePack`, `ServicePack`, `Definition`, `Tools` and `Updates`.
+* `classification_included` - (Optional) (Deprecated) Specifies the update classification. Possible values are `Unclassified`, `Critical`, `Security`, `UpdateRollup`, `FeaturePack`, `ServicePack`, `Definition`, `Tools` and `Updates`.
 
 * `classifications_included` - (Optional) Specifies the list of update classification. Possible values are `Unclassified`, `Critical`, `Security`, `UpdateRollup`, `FeaturePack`, `ServicePack`, `Definition`, `Tools` and `Updates`.
 
@@ -159,7 +159,7 @@ A `schedule` block supports the following:
 
 * `is_enabled` - (Optional) Whether the schedule is enabled.
 
-* `frequency` - (Required) The frequency of the schedule. - can be either `OneTime`, `Day`, `Hour`, `Week`, or `Month`.
+* `frequency` - (Optional) The frequency of the schedule. - can be either `OneTime`, `Day`, `Hour`, `Week`, or `Month`.
 
 * `description` -  (Optional) A description for this Schedule.
 

--- a/website/docs/r/automation_webhook.html.markdown
+++ b/website/docs/r/automation_webhook.html.markdown
@@ -74,7 +74,7 @@ The following arguments are supported:
 
 * `parameters` - (Optional) Map of input parameters passed to runbook.
 
-* `uri` - (Optional) URI to initiate the webhook. Can be generated using [Generate URI API](https://docs.microsoft.com/rest/api/automation/webhook/generate-uri). By default, new URI is generated on each new resource creation. Changing this forces a new resource to be created.
+* `uri` - (Optional) URI to initiate the webhook. Can be generated using [Generate URI API](https://docs.microsoft.com/rest/api/automation/webhook/generate-uri). By default, new URI is generated on each new resource creation. Changing this forces a new resource to be created. Changing this forces a new resource to be created.
 
 ## Attributes Reference
 

--- a/website/docs/r/availability_set.html.markdown
+++ b/website/docs/r/availability_set.html.markdown
@@ -50,7 +50,7 @@ The following arguments are supported:
 
 * `proximity_placement_group_id` - (Optional) The ID of the Proximity Placement Group to which this Virtual Machine should be assigned. Changing this forces a new resource to be created.
 
-* `managed` - (Optional) Specifies whether the availability set is managed or not. Possible values are `true` (to specify aligned) or `false` (to specify classic). Default is `true`.
+* `managed` - (Optional) Specifies whether the availability set is managed or not. Possible values are `true` (to specify aligned) or `false` (to specify classic). Default is `true`. Changing this forces a new resource to be created.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 

--- a/website/docs/r/backup_container_storage_account.html.markdown
+++ b/website/docs/r/backup_container_storage_account.html.markdown
@@ -44,11 +44,11 @@ resource "azurerm_backup_container_storage_account" "container" {
 
 The following arguments are supported:
 
-* `resource_group_name` - (Required) Name of the resource group where the vault is located.
+* `resource_group_name` - (Required) Name of the resource group where the vault is located. Changing this forces a new resource to be created.
 
-* `recovery_vault_name` - (Required) The name of the vault where the storage account will be registered.
+* `recovery_vault_name` - (Required) The name of the vault where the storage account will be registered. Changing this forces a new resource to be created.
 
-* `storage_account_id` - (Required) The ID of the Storage Account to be registered
+* `storage_account_id` - (Required) The ID of the Storage Account to be registered Changing this forces a new resource to be created.
 
 -> **NOTE** Azure Backup places a Resource Lock on the storage account that will cause deletion to fail until the account is unregistered from Azure Backup
 

--- a/website/docs/r/backup_protected_vm.html.markdown
+++ b/website/docs/r/backup_protected_vm.html.markdown
@@ -57,7 +57,7 @@ The following arguments are supported:
 
 * `recovery_vault_name` - (Required) Specifies the name of the Recovery Services Vault to use. Changing this forces a new resource to be created.
 
-* `source_vm_id` - (Required) Specifies the ID of the VM to backup. Changing this forces a new resource to be created.
+* `source_vm_id` - (Optional) Specifies the ID of the VM to backup. Changing this forces a new resource to be created.
 
 ~> **NOTE:** After creation, the `source_vm_id` property can be removed without forcing a new resource to be created; however, setting it to a different ID will create a new resource.
 This allows the source vm to be deleted without having to remove the backup.

--- a/website/docs/r/bastion_host.html.markdown
+++ b/website/docs/r/bastion_host.html.markdown
@@ -62,7 +62,7 @@ The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the Bastion Host. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) The name of the resource group in which to create the Bastion Host.
+* `resource_group_name` - (Required) The name of the resource group in which to create the Bastion Host. Changing this forces a new resource to be created.
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.  Review [Azure Bastion Host FAQ](https://docs.microsoft.com/azure/bastion/bastion-faq) for supported locations.
 
@@ -98,13 +98,13 @@ The following arguments are supported:
 
 A `ip_configuration` block supports the following:
 
-* `name` - (Required) The name of the IP configuration.
+* `name` - (Required) The name of the IP configuration. Changing this forces a new resource to be created.
 
-* `subnet_id` - (Required) Reference to a subnet in which this Bastion Host has been created.
+* `subnet_id` - (Required) Reference to a subnet in which this Bastion Host has been created. Changing this forces a new resource to be created.
 
 ~> **Note:** The Subnet used for the Bastion Host must have the name `AzureBastionSubnet` and the subnet mask must be at least a `/26`.
 
-* `public_ip_address_id` (Required)  Reference to a Public IP Address to associate with this Bastion Host.
+* `public_ip_address_id` (Required)  Reference to a Public IP Address to associate with this Bastion Host. Changing this forces a new resource to be created.
 
 ## Attributes Reference
 

--- a/website/docs/r/batch_account.html.markdown
+++ b/website/docs/r/batch_account.html.markdown
@@ -56,7 +56,7 @@ The following arguments are supported:
 
 * `pool_allocation_mode` - (Optional) Specifies the mode to use for pool allocation. Possible values are `BatchService` or `UserSubscription`. Defaults to `BatchService`.
 
-* `public_network_access_enabled` - (Optional) Whether public network access is allowed for this server. Defaults to `true`.
+* `public_network_access_enabled` - (Optional) Whether public network access is allowed for this server. Defaults to `true`. Changing this forces a new resource to be created.
 
 ~> **NOTE:** When using `UserSubscription` mode, an Azure KeyVault reference has to be specified. See `key_vault_reference` below.
 

--- a/website/docs/r/batch_certificate.html.markdown
+++ b/website/docs/r/batch_certificate.html.markdown
@@ -64,7 +64,7 @@ The following arguments are supported:
 
 * `password` - (Optional) The password to access the certificate's private key. This can only be specified when `format` is `Pfx`.
 
-* `thumbprint` - (Required) The thumbprint of the certificate. At this time the only supported value is 'SHA1'.
+* `thumbprint` - (Required) The thumbprint of the certificate. At this time the only supported value is 'SHA1'. Changing this forces a new resource to be created.
 
 ## Attributes Reference
 

--- a/website/docs/r/batch_pool.html.markdown
+++ b/website/docs/r/batch_pool.html.markdown
@@ -120,15 +120,15 @@ The following arguments are supported:
 
 * `account_name` - (Required) Specifies the name of the Batch account in which the pool will be created. Changing this forces a new resource to be created.
 
-* `node_agent_sku_id` - (Required) Specifies the SKU of the node agents that will be created in the Batch pool.
+* `node_agent_sku_id` - (Required) Specifies the SKU of the node agents that will be created in the Batch pool. Changing this forces a new resource to be created.
 
-* `vm_size` - (Required) Specifies the size of the VM created in the Batch pool.
+* `vm_size` - (Required) Specifies the size of the VM created in the Batch pool. Changing this forces a new resource to be created.
 
 * `storage_image_reference` - (Required) A `storage_image_reference` for the virtual machines that will compose the Batch pool.
 
 * `data_disks` - (Optional) A `data_disks` block describes the data disk settings.
 
-* `display_name` - (Optional) Specifies the display name of the Batch pool.
+* `display_name` - (Optional) Specifies the display name of the Batch pool. Changing this forces a new resource to be created.
 
 * `disk_encryption` - (Optional) A `disk_encryption` block describes the disk encryption configuration applied on compute nodes in the pool. Disk encryption configuration is not supported on Linux pool created with Virtual Machine Image or Shared Image Gallery Image.
 
@@ -186,7 +186,7 @@ A `data_disks` block supports the following:
 
 * `lun` - (Required) The lun is used to uniquely identify each data disk. If attaching multiple disks, each should have a distinct lun. The value must be between 0 and 63, inclusive.
 
-* `caching` - (Required) Values are: "none" - The caching mode for the disk is not enabled. "readOnly" - The caching mode for the disk is read only. "readWrite" - The caching mode for the disk is read and write. The default value for caching is "none". For information about the caching options see: <https://blogs.msdn.microsoft.com/windowsazurestorage/2012/06/27/exploring-windows-azure-drives-disks-and-images/>. Possible values are `None`, `ReadOnly` and `ReadWrite`.
+* `caching` - (Optional) Values are: "none" - The caching mode for the disk is not enabled. "readOnly" - The caching mode for the disk is read only. "readWrite" - The caching mode for the disk is read and write. The default value for caching is "none". For information about the caching options see: <https://blogs.msdn.microsoft.com/windowsazurestorage/2012/06/27/exploring-windows-azure-drives-disks-and-images/>. Possible values are `None`, `ReadOnly` and `ReadWrite`.
 
 * `disk_size_gb` - (Required) The initial disk size in GB when creating new data disk.
 
@@ -227,7 +227,7 @@ A `node_placement` block supports the following:
 
 Node placement Policy type on Batch Pools. Allocation policy used by Batch Service to provision the nodes. If not specified, Batch will use the regional policy.
 
-* `policy` - (Required) The placement policy for allocating nodes in the pool. Values are: "Regional": All nodes in the pool will be allocated in the same region; "Zonal": Nodes in the pool will be spread across different zones with the best effort balancing.
+* `policy` - (Optional) The placement policy for allocating nodes in the pool. Values are: "Regional": All nodes in the pool will be allocated in the same region; "Zonal": Nodes in the pool will be spread across different zones with the best effort balancing.
 
 ---
 
@@ -237,17 +237,17 @@ This block provisions virtual machines in the Batch Pool from one of two sources
 
 To provision from an Azure Platform Image, the following fields are applicable:
 
-* `publisher` - (Required) Specifies the publisher of the image used to create the virtual machines. Changing this forces a new resource to be created.
+* `publisher` - (Optional) Specifies the publisher of the image used to create the virtual machines. Changing this forces a new resource to be created.
 
-* `offer` - (Required) Specifies the offer of the image used to create the virtual machines. Changing this forces a new resource to be created.
+* `offer` - (Optional) Specifies the offer of the image used to create the virtual machines. Changing this forces a new resource to be created.
 
-* `sku` - (Required) Specifies the SKU of the image used to create the virtual machines. Changing this forces a new resource to be created.
+* `sku` - (Optional) Specifies the SKU of the image used to create the virtual machines. Changing this forces a new resource to be created.
 
 * `version` - (Optional) Specifies the version of the image used to create the virtual machines. Changing this forces a new resource to be created.
 
 To provision a Custom Image, the following fields are applicable:
 
-* `id` - (Required) Specifies the ID of the Custom Image which the virtual machines should be created from. Changing this forces a new resource to be created. See [official documentation](https://docs.microsoft.com/azure/batch/batch-custom-images) for more details.
+* `id` - (Optional) Specifies the ID of the Custom Image which the virtual machines should be created from. Changing this forces a new resource to be created. See [official documentation](https://docs.microsoft.com/azure/batch/batch-custom-images) for more details.
 
 ---
 
@@ -337,9 +337,9 @@ A `container_configuration` block supports the following:
 
 * `type` - (Optional) The type of container configuration. Possible value is `DockerCompatible`.
 
-* `container_image_names` - (Optional) A list of container image names to use, as would be specified by `docker pull`.
+* `container_image_names` - (Optional) A list of container image names to use, as would be specified by `docker pull`. Changing this forces a new resource to be created.
 
-* `container_registries` - (Optional) Additional container registries from which container images can be pulled by the pool's VMs.
+* `container_registries` - (Optional) Additional container registries from which container images can be pulled by the pool's VMs. Changing this forces a new resource to be created.
 
 ---
 
@@ -449,7 +449,7 @@ A `network_configuration` block supports the following:
 
 * `subnet_id` - (Required) The ARM resource identifier of the virtual network subnet which the compute nodes of the pool will join. Changing this forces a new resource to be created.
 
-* `dynamic_vnet_assignment_scope` - (Optional) The scope of dynamic vnet assignment. Allowed values: `none`, `job`.
+* `dynamic_vnet_assignment_scope` - (Optional) The scope of dynamic vnet assignment. Allowed values: `none`, `job`. Changing this forces a new resource to be created.
 
 * `public_ips` - (Optional) A list of public IP ids that will be allocated to nodes. Changing this forces a new resource to be created.
 
@@ -487,7 +487,7 @@ A `network_security_group_rules` block supports the following:
 
 A `task_scheduling_policy` block supports the following:
 
-* `node_fill_type` - (Required) Supported values are "Pack" and "Spread". "Pack" means as many tasks as possible (taskSlotsPerNode) should be assigned to each node in the pool before any tasks are assigned to the next node in the pool. "Spread" means that tasks should be assigned evenly across all nodes in the pool.
+* `node_fill_type` - (Optional) Supported values are "Pack" and "Spread". "Pack" means as many tasks as possible (taskSlotsPerNode) should be assigned to each node in the pool before any tasks are assigned to the next node in the pool. "Spread" means that tasks should be assigned evenly across all nodes in the pool.
 
 ---
 
@@ -525,7 +525,7 @@ A `windows` block supports the following:
 
 Windows operating system settings on the virtual machine. This property must not be specified if the imageReference specifies a Linux OS image.
 
-* `enable_automatic_updates` - (Required) Whether automatic updates are enabled on the virtual machine. If omitted, the default value is true.
+* `enable_automatic_updates` - (Optional) Whether automatic updates are enabled on the virtual machine. If omitted, the default value is true.
 
 ---
 

--- a/website/docs/r/blueprint_assignment.html.markdown
+++ b/website/docs/r/blueprint_assignment.html.markdown
@@ -106,7 +106,7 @@ resource "azurerm_blueprint_assignment" "example" {
 
 ## Argument Reference
 
-* `name` - (Required) The name of the Blueprint Assignment Changing this forces a new resource to be created.
+* `name` - (Required) The name of the Blueprint Assignment. Changing this forces a new resource to be created.
 
 * `target_subscription_id` - (Required) The Subscription ID the Blueprint Published Version is to be applied to. Changing this forces a new resource to be created.
 

--- a/website/docs/r/blueprint_assignment.html.markdown
+++ b/website/docs/r/blueprint_assignment.html.markdown
@@ -106,11 +106,11 @@ resource "azurerm_blueprint_assignment" "example" {
 
 ## Argument Reference
 
-* `name` - (Required) The name of the Blueprint Assignment
+* `name` - (Required) The name of the Blueprint Assignment Changing this forces a new resource to be created.
 
-* `target_subscription_id` - (Required) The Subscription ID the Blueprint Published Version is to be applied to.
+* `target_subscription_id` - (Required) The Subscription ID the Blueprint Published Version is to be applied to. Changing this forces a new resource to be created.
 
-* `location` - (Required) The Azure location of the Assignment.
+* `location` - (Required) The Azure location of the Assignment. Changing this forces a new resource to be created.
 
 * `identity` - (Required) An `identity` block as defined below.
 

--- a/website/docs/r/cdn_endpoint.html.markdown
+++ b/website/docs/r/cdn_endpoint.html.markdown
@@ -46,9 +46,9 @@ The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the CDN Endpoint. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) The name of the resource group in which to create the CDN Endpoint.
+* `resource_group_name` - (Required) The name of the resource group in which to create the CDN Endpoint. Changing this forces a new resource to be created.
 
-* `profile_name` - (Required) The CDN Profile to which to attach the CDN Endpoint.
+* `profile_name` - (Required) The CDN Profile to which to attach the CDN Endpoint. Changing this forces a new resource to be created.
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 

--- a/website/docs/r/cdn_frontdoor_firewall_policy.html.markdown
+++ b/website/docs/r/cdn_frontdoor_firewall_policy.html.markdown
@@ -135,13 +135,13 @@ The following arguments are supported:
 
 * `resource_group_name` - (Required) The name of the resource group. Changing this forces a new resource to be created.
 
-* `sku_name` - (Required) The sku's pricing tier for this Front Door Firewall Policy. Possible values include `Standard_AzureFrontDoor` or `Premium_AzureFrontDoor`.
+* `sku_name` - (Required) The sku's pricing tier for this Front Door Firewall Policy. Possible values include `Standard_AzureFrontDoor` or `Premium_AzureFrontDoor`. Changing this forces a new resource to be created.
 
 -> **NOTE:** The `Standard_AzureFrontDoor` Front Door Firewall Policy sku may contain `custom` rules only. The `Premium_AzureFrontDoor` Front Door Firewall Policy skus may contain both `custom` and `managed` rules.
 
 * `enabled` - (Optional) Is the Front Door Firewall Policy enabled? Defaults to `true`.
 
-* `mode` - (Optional) The Front Door Firewall Policy mode. Possible values are `Detection`, `Prevention`. Defaults to `Prevention`.
+* `mode` - (Required) The Front Door Firewall Policy mode. Possible values are `Detection`, `Prevention`. Defaults to `Prevention`.
 
 -> **NOTE:** When run in `Detection` mode, the Front Door Firewall Policy doesn't take any other actions other than monitoring and logging the request and its matched Front Door Rule to the Web Application Firewall logs.
 
@@ -167,7 +167,7 @@ A `custom_rule` block supports the following:
 
 * `enabled` - (Optional) Is the rule is enabled or disabled? Defaults to `true`.
 
-* `priority` - (Required) The priority of the rule. Rules with a lower value will be evaluated before rules with a higher value. Defaults to `1`.
+* `priority` - (Optional) The priority of the rule. Rules with a lower value will be evaluated before rules with a higher value. Defaults to `1`.
 
 * `type` - (Required) The type of rule. Possible values are `MatchRule` or `RateLimitRule`.
 

--- a/website/docs/r/cdn_frontdoor_origin.html.markdown
+++ b/website/docs/r/cdn_frontdoor_origin.html.markdown
@@ -240,7 +240,7 @@ A `private_link` block supports the following:
 
 -> **NOTE:** `target_type` cannot be specified when using a Load Balancer as an Origin.
 
-* `location` - (Required) Specifies the location where the Private Link resource should exist.
+* `location` - (Required) Specifies the location where the Private Link resource should exist. Changing this forces a new resource to be created.
 
 * `private_link_target_id` - (Required) The ID of the Azure Resource to connect to via the Private Link.
 

--- a/website/docs/r/cdn_frontdoor_profile.html.markdown
+++ b/website/docs/r/cdn_frontdoor_profile.html.markdown
@@ -39,7 +39,7 @@ The following arguments are supported:
 
 * `sku_name` - (Required) Specifies the SKU for this Front Door Profile. Possible values include `Standard_AzureFrontDoor` and `Premium_AzureFrontDoor`. Changing this forces a new resource to be created.
 
-* `response_timeout_seconds` - Specifies the maximum response timeout in seconds. Possible values are between `16` and `240` seconds (inclusive). Defaults to `120` seconds.
+* `response_timeout_seconds` - (Optional) Specifies the maximum response timeout in seconds. Possible values are between `16` and `240` seconds (inclusive). Defaults to `120` seconds.
 
 * `tags` - (Optional) Specifies a mapping of tags to assign to the resource.
 

--- a/website/docs/r/cdn_frontdoor_route.html.markdown
+++ b/website/docs/r/cdn_frontdoor_route.html.markdown
@@ -124,7 +124,7 @@ The following arguments are supported:
 
 * `cdn_frontdoor_origin_ids` - (Required) One or more Front Door Origin resource IDs that this Front Door Route will link to.
 
-* `forwarding_protocol` - (Required) The Protocol that will be use when forwarding traffic to backends. Possible values are `HttpOnly`, `HttpsOnly` or `MatchRequest`.
+* `forwarding_protocol` - (Optional) The Protocol that will be use when forwarding traffic to backends. Possible values are `HttpOnly`, `HttpsOnly` or `MatchRequest`.
 
 * `patterns_to_match` - (Required) The route patterns of the rule.
 

--- a/website/docs/r/cdn_profile.html.markdown
+++ b/website/docs/r/cdn_profile.html.markdown
@@ -40,12 +40,12 @@ The following arguments are supported:
 * `name` - (Required) Specifies the name of the CDN Profile. Changing this forces a
     new resource to be created.
 
-* `resource_group_name` - (Required) The name of the resource group in which to
+* `resource_group_name` - (Required) The name of the resource group in which to Changing this forces a new resource to be created.
     create the CDN Profile.
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 
-* `sku` - (Required) The pricing related information of current CDN profile. Accepted values are `Standard_Akamai`, `Standard_ChinaCdn`, `Standard_Microsoft`, `Standard_Verizon` or `Premium_Verizon`.
+* `sku` - (Required) The pricing related information of current CDN profile. Accepted values are `Standard_Akamai`, `Standard_ChinaCdn`, `Standard_Microsoft`, `Standard_Verizon` or `Premium_Verizon`. Changing this forces a new resource to be created.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 

--- a/website/docs/r/cdn_profile.html.markdown
+++ b/website/docs/r/cdn_profile.html.markdown
@@ -40,8 +40,7 @@ The following arguments are supported:
 * `name` - (Required) Specifies the name of the CDN Profile. Changing this forces a
     new resource to be created.
 
-* `resource_group_name` - (Required) The name of the resource group in which to Changing this forces a new resource to be created.
-    create the CDN Profile.
+* `resource_group_name` - (Required) The name of the resource group in which to create the CDN Profile. Changing this forces a new resource to be created.
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 

--- a/website/docs/r/cognitive_account.html.markdown
+++ b/website/docs/r/cognitive_account.html.markdown
@@ -52,7 +52,7 @@ The following arguments are supported:
 
 * `sku_name` - (Required) Specifies the SKU Name for this Cognitive Service Account. Possible values are `F0`, `F1`, `S0`, `S`, `S1`, `S2`, `S3`, `S4`, `S5`, `S6`, `P0`, `P1`, `P2` and `E0`.
 
-* `custom_subdomain_name` - (Required) The subdomain name used for token-based authentication. Changing this forces a new resource to be created.
+* `custom_subdomain_name` - (Optional) The subdomain name used for token-based authentication. Changing this forces a new resource to be created.
 
 * `dynamic_throttling_enabled` - (Optional) Whether to enable the dynamic throttling for this Cognitive Service Account. Defaults to `false`.
 
@@ -82,9 +82,9 @@ The following arguments are supported:
 
 * `qna_runtime_endpoint` - (Optional) A URL to link a QnAMaker cognitive account to a QnA runtime.
 
-* `custom_question_answering_search_service_id` - If `kind` is `TextAnalytics` this specifies the ID of the Search service.
+* `custom_question_answering_search_service_id` - (Optional) If `kind` is `TextAnalytics` this specifies the ID of the Search service.
 
-* `custom_question_answering_search_service_key` - If `kind` is `TextAnalytics` this specifies the key of the Search service.
+* `custom_question_answering_search_service_key` - (Optional) If `kind` is `TextAnalytics` this specifies the key of the Search service.
 
 -> **NOTE:** `custom_question_answering_search_service_id` and `custom_question_answering_search_service_key` are used for [Custom Question Answering, the renamed version of QnA Maker](https://docs.microsoft.com/azure/cognitive-services/qnamaker/custom-question-answering), while `qna_runtime_endpoint` is used for [the old version of QnA Maker](https://docs.microsoft.com/azure/cognitive-services/qnamaker/overview/overview)
 

--- a/website/docs/r/consumption_budget_management_group.html.markdown
+++ b/website/docs/r/consumption_budget_management_group.html.markdown
@@ -86,7 +86,7 @@ The following arguments are supported:
 
 * `amount` - (Required) The total amount of cost to track with the budget.
 
-* `time_grain` - (Required) The time covered by a budget. Tracking of the amount will be reset based on the time grain. Must be one of `BillingAnnual`, `BillingMonth`, `BillingQuarter`, `Annually`, `Monthly` and `Quarterly`. Defaults to `Monthly`.
+* `time_grain` - (Optional) The time covered by a budget. Tracking of the amount will be reset based on the time grain. Must be one of `BillingAnnual`, `BillingMonth`, `BillingQuarter`, `Annually`, `Monthly` and `Quarterly`. Defaults to `Monthly`.
 
 * `time_period` - (Required) A `time_period` block as defined below.
 

--- a/website/docs/r/consumption_budget_resource_group.html.markdown
+++ b/website/docs/r/consumption_budget_resource_group.html.markdown
@@ -96,7 +96,7 @@ The following arguments are supported:
 
 * `amount` - (Required) The total amount of cost to track with the budget.
 
-* `time_grain` - (Required) The time covered by a budget. Tracking of the amount will be reset based on the time grain. Must be one of `BillingAnnual`, `BillingMonth`, `BillingQuarter`, `Annually`, `Monthly` and `Quarterly`. Defaults to `Monthly`.
+* `time_grain` - (Optional) The time covered by a budget. Tracking of the amount will be reset based on the time grain. Must be one of `BillingAnnual`, `BillingMonth`, `BillingQuarter`, `Annually`, `Monthly` and `Quarterly`. Defaults to `Monthly`.
 
 * `time_period` - (Required) A `time_period` block as defined below.
 
@@ -130,7 +130,7 @@ A `notification` block supports the following:
 
 * `threshold` - (Required) Threshold value associated with a notification. Notification is sent when the cost exceeded the threshold. It is always percent and has to be between 0 and 1000.
 
-* `threshold_type` - (Optional) The type of threshold for the notification. This determines whether the notification is triggered by forecasted costs or actual costs. The allowed values are `Actual` and `Forecasted`. Default is `Actual`.
+* `threshold_type` - (Optional) The type of threshold for the notification. This determines whether the notification is triggered by forecasted costs or actual costs. The allowed values are `Actual` and `Forecasted`. Default is `Actual`. Changing this forces a new resource to be created.
 
 * `contact_emails` - (Optional) Specifies a list of email addresses to send the budget notification to when the threshold is exceeded.
 

--- a/website/docs/r/consumption_budget_subscription.html.markdown
+++ b/website/docs/r/consumption_budget_subscription.html.markdown
@@ -100,7 +100,7 @@ The following arguments are supported:
 
 * `amount` - (Required) The total amount of cost to track with the budget.
 
-* `time_grain` - (Required) The time covered by a budget. Tracking of the amount will be reset based on the time grain. Must be one of `BillingAnnual`, `BillingMonth`, `BillingQuarter`, `Annually`, `Monthly` and `Quarterly`. Defaults to `Monthly`.
+* `time_grain` - (Optional) The time covered by a budget. Tracking of the amount will be reset based on the time grain. Must be one of `BillingAnnual`, `BillingMonth`, `BillingQuarter`, `Annually`, `Monthly` and `Quarterly`. Defaults to `Monthly`.
 
 * `time_period` - (Required) A `time_period` block as defined below.
 

--- a/website/docs/r/container_group.html.markdown
+++ b/website/docs/r/container_group.html.markdown
@@ -85,7 +85,7 @@ The following arguments are supported:
 
 ~> **Note:** DNS label/name is not supported when deploying to virtual networks.
 
-* `dns_name_label_reuse_policy` - (Optional) The value representing the security enum. `Noreuse`, `ResourceGroupReuse`, `SubscriptionReuse`, `TenantReuse` or `Unsecure`. Defaults to `Unsecure`. Changing this forces a new resource to be created.
+* `dns_name_label_reuse_policy` - (Optional) The value representing the security enum. `Noreuse`, `ResourceGroupReuse`, `SubscriptionReuse`, `TenantReuse` or `Unsecure`. Defaults to `Unsecure`. 
 
 * `exposed_port` - (Optional) Zero or more `exposed_port` blocks as defined below. Changing this forces a new resource to be created.
 
@@ -103,7 +103,7 @@ The following arguments are supported:
 
 * `restart_policy` - (Optional) Restart policy for the container group. Allowed values are `Always`, `Never`, `OnFailure`. Defaults to `Always`. Changing this forces a new resource to be created.
 
-* `zones` - (Optional) A list of Availability Zones in which this Container Group is located.
+* `zones` - (Optional) A list of Availability Zones in which this Container Group is located. Changing this forces a new resource to be created.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 

--- a/website/docs/r/container_registry.html.markdown
+++ b/website/docs/r/container_registry.html.markdown
@@ -139,7 +139,7 @@ The following arguments are supported:
 
 * `resource_group_name` - (Required) The name of the resource group in which to create the Container Registry. Changing this forces a new resource to be created.
 
-* `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
+* `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created. Changing this forces a new resource to be created.
 
 * `sku` - (Required) The SKU name of the container registry. Possible values are  `Basic`, `Standard` and `Premium`.
 
@@ -165,7 +165,7 @@ The following arguments are supported:
 
 * `trust_policy` - (Optional) A `trust_policy` block as documented below.
 
-* `zone_redundancy_enabled` - (Optional) Whether zone redundancy is enabled for this Container Registry? Changing this forces a new resource to be created. Defaults to `false`.
+* `zone_redundancy_enabled` - (Optional) Whether zone redundancy is enabled for this Container Registry? Changing this forces a new resource to be created. Defaults to `false`. Changing this forces a new resource to be created.
 
 * `export_policy_enabled` - (Optional) Boolean value that indicates whether export policy is enabled. Defaults to `true`. In order to set it to `false`, make sure the `public_network_access_enabled` is also set to `false`.
 
@@ -185,11 +185,11 @@ The following arguments are supported:
 
 `georeplications` supports the following:
 
-* `location` - (Required) A location where the container registry should be geo-replicated.
+* `location` - (Required) A location where the container registry should be geo-replicated. Changing this forces a new resource to be created.
 
 * `regional_endpoint_enabled` - (Optional) Whether regional endpoint is enabled for this Container Registry? Defaults to `false`.
 
-* `zone_redundancy_enabled` - (Optional) Whether zone redundancy is enabled for this replication location? Defaults to `false`.
+* `zone_redundancy_enabled` - (Optional) Whether zone redundancy is enabled for this replication location? Defaults to `false`. Changing this forces a new resource to be created.
 
   ~> **NOTE:** Changing the `zone_redundancy_enabled` forces the a underlying replication to be created.
 

--- a/website/docs/r/container_registry_task.html.markdown
+++ b/website/docs/r/container_registry_task.html.markdown
@@ -163,9 +163,9 @@ A `encoded_step` block supports the following:
 
 * `task_content` - (Required) The (optionally base64 encoded) content of the build template.
 
-* `context_access_token` - (Required) The token (Git PAT or SAS token of storage account blob) associated with the context for this step.
+* `context_access_token` - (Optional) The token (Git PAT or SAS token of storage account blob) associated with the context for this step.
 
-* `context_path` - (Required) The URL (absolute or relative) of the source context for this step.
+* `context_path` - (Optional) The URL (absolute or relative) of the source context for this step.
 
 * `secret_values` - (Optional) Specifies a map of secret values that can be passed when running a task.
 
@@ -179,9 +179,9 @@ A `file_step` block supports the following:
 
 * `task_file_path` - (Required) The task template file path relative to the source context.
 
-* `context_access_token` - (Required) The token (Git PAT or SAS token of storage account blob) associated with the context for this step.
+* `context_access_token` - (Optional) The token (Git PAT or SAS token of storage account blob) associated with the context for this step.
 
-* `context_path` - (Required) The URL (absolute or relative) of the source context for this step.
+* `context_path` - (Optional) The URL (absolute or relative) of the source context for this step.
 
 * `secret_values` - (Optional) Specifies a map of secret values that can be passed when running a task.
 

--- a/website/docs/r/cosmosdb_account.html.markdown
+++ b/website/docs/r/cosmosdb_account.html.markdown
@@ -70,11 +70,11 @@ resource "azurerm_cosmosdb_account" "db" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name of the CosmosDB Account. Changing this forces a new resource to be created.
+* `name` - (Required) Specifies the name of the CosmosDB Account. Changing this forces a new resource to be created. Changing this forces a new resource to be created.
 
 * `resource_group_name` - (Required) The name of the resource group in which the CosmosDB Account is created. Changing this forces a new resource to be created.
 
-* `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
+* `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created. Changing this forces a new resource to be created.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
@@ -158,7 +158,7 @@ The following arguments are supported:
 
 `geo_location` Configures the geographic locations the data is replicated to and supports the following:
 
-* `location` - (Required) The name of the Azure region to host replicated data.
+* `location` - (Required) The name of the Azure region to host replicated data. Changing this forces a new resource to be created.
 * `failover_priority` - (Required) The failover priority of the region. A failover priority of `0` indicates a write region. The maximum value for a failover priority = (total number of regions - 1). Failover priority values must be unique for each of the regions in which the database account exists. Changing this causes the location to be re-provisioned and cannot be changed for the location with failover priority `0`.
 * `zone_redundant` - (Optional) Should zone redundancy be enabled for this region? Defaults to `false`.
 
@@ -166,7 +166,7 @@ The following arguments are supported:
 
 `capabilities` Configures the capabilities to enable for this Cosmos DB account:
 
-* `name` - (Required) The capability to enable - Possible values are `AllowSelfServeUpgradeToMongo36`, `DisableRateLimitingResponses`, `EnableAggregationPipeline`, `EnableCassandra`, `EnableGremlin`, `EnableMongo`, `EnableMongo16MBDocumentSupport`, `EnableTable`, `EnableServerless`, `MongoDBv3.4` and `mongoEnableDocLevelTTL`.
+* `name` - (Required) The capability to enable - Possible values are `AllowSelfServeUpgradeToMongo36`, `DisableRateLimitingResponses`, `EnableAggregationPipeline`, `EnableCassandra`, `EnableGremlin`, `EnableMongo`, `EnableMongo16MBDocumentSupport`, `EnableTable`, `EnableServerless`, `MongoDBv3.4` and `mongoEnableDocLevelTTL`. Changing this forces a new resource to be created.
 
 **NOTE:**  Setting `MongoDBv3.4` also requires setting `EnableMongo`.
 

--- a/website/docs/r/cosmosdb_cassandra_cluster.html.markdown
+++ b/website/docs/r/cosmosdb_cassandra_cluster.html.markdown
@@ -75,7 +75,7 @@ The following arguments are supported:
 
 * `delegated_management_subnet_id` - (Required) The ID of the delegated management subnet for this Cassandra Cluster. Changing this forces a new Cassandra Cluster to be created.
 
-* `default_admin_password` - (Required) The initial admin password for this Cassandra Cluster.
+* `default_admin_password` - (Required) The initial admin password for this Cassandra Cluster. Changing this forces a new resource to be created.
 
 * `authentication_method` - (Optional) The authentication method that is used to authenticate clients. Possible values are `None` and `Cassandra`. Defaults to `Cassandra`.
 

--- a/website/docs/r/cosmosdb_cassandra_datacenter.html.markdown
+++ b/website/docs/r/cosmosdb_cassandra_datacenter.html.markdown
@@ -86,7 +86,7 @@ The following arguments are supported:
 
 * `delegated_management_subnet_id` - (Required) The ID of the delegated management subnet for this Cassandra Datacenter. Changing this forces a new Cassandra Datacenter to be created.
 
-* `node_count` - (Required) The number of nodes the Cassandra Datacenter should have. The number should be equal or greater than `3`. Defaults to `3`.
+* `node_count` - (Optional) The number of nodes the Cassandra Datacenter should have. The number should be equal or greater than `3`. Defaults to `3`.
 
 ---
 

--- a/website/docs/r/cosmosdb_gremlin_graph.html.markdown
+++ b/website/docs/r/cosmosdb_gremlin_graph.html.markdown
@@ -124,7 +124,7 @@ An `conflict_resolution_policy` block supports the following:
 
 An `unique_key` block supports the following:
 
-* `paths` - (Required) A list of paths to use for this unique key.
+* `paths` - (Required) A list of paths to use for this unique key. Changing this forces a new resource to be created.
 
 ---
 

--- a/website/docs/r/cosmosdb_mongo_collection.html.markdown
+++ b/website/docs/r/cosmosdb_mongo_collection.html.markdown
@@ -48,7 +48,7 @@ The following arguments are supported:
 * `name` - (Required) Specifies the name of the Cosmos DB Mongo Collection. Changing this forces a new resource to be created.
 * `resource_group_name` - (Required) The name of the resource group in which the Cosmos DB Mongo Collection is created. Changing this forces a new resource to be created.
 * `database_name` - (Required) The name of the Cosmos DB Mongo Database in which the Cosmos DB Mongo Collection is created. Changing this forces a new resource to be created.
-* `shard_key` - (Optional) The name of the key to partition on for sharding. There must not be any other unique index keys.
+* `shard_key` - (Optional) The name of the key to partition on for sharding. There must not be any other unique index keys. Changing this forces a new resource to be created.
 * `analytical_storage_ttl` - (Optional) The default time to live of Analytical Storage for this Mongo Collection. If present and the value is set to `-1`, it is equal to infinity, and items don’t expire by default. If present and the value is set to some number `n` – items will expire `n` seconds after their last modified time.
 * `default_ttl_seconds` - (Optional) The default Time To Live in seconds. If the value is `-1`, items are not automatically expired.
 * `index` - (Optional) One or more `index` blocks as defined below.

--- a/website/docs/r/cosmosdb_sql_container.html.markdown
+++ b/website/docs/r/cosmosdb_sql_container.html.markdown
@@ -96,7 +96,7 @@ An `autoscale_settings` block supports the following:
 ---
 A `unique_key` block supports the following:
 
-* `paths` - (Required) A list of paths to use for this unique key.
+* `paths` - (Required) A list of paths to use for this unique key. Changing this forces a new resource to be created.
 
 ---
 An `indexing_policy` block supports the following:

--- a/website/docs/r/custom_provider.html.markdown
+++ b/website/docs/r/custom_provider.html.markdown
@@ -36,7 +36,7 @@ The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the Custom Provider. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) The name of the resource group in which to create the Custom Provider.
+* `resource_group_name` - (Required) The name of the resource group in which to create the Custom Provider. Changing this forces a new resource to be created.
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 
@@ -46,7 +46,7 @@ The following arguments are supported:
 
 * `validation` - (Optional) Any number of `validation` block as defined below.
 
-* `tags` - (Optional) A mapping of tags to assign to the resource.
+* `tags` - (Optional) A mapping of tags to assign to the resource. Changing this forces a new resource to be created.
 
 ---
 

--- a/website/docs/r/dashboard.html.markdown
+++ b/website/docs/r/dashboard.html.markdown
@@ -252,7 +252,7 @@ The following arguments are supported:
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 
-* `dashboard_properties` - (Required) JSON data representing dashboard body. See above for details on how to obtain this from the Portal.
+* `dashboard_properties` - (Optional) JSON data representing dashboard body. See above for details on how to obtain this from the Portal.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 

--- a/website/docs/r/dashboard_grafana.html.markdown
+++ b/website/docs/r/dashboard_grafana.html.markdown
@@ -66,7 +66,7 @@ The following arguments are supported:
 
 An `identity` block supports the following:
 
-* `type` - (Required) Specifies the type of Managed Service Identity. The only possible values is `SystemAssigned`.
+* `type` - (Required) Specifies the type of Managed Service Identity. The only possible values is `SystemAssigned`. Changing this forces a new resource to be created.
 
 ## Attributes Reference
 

--- a/website/docs/r/data_factory.html.markdown
+++ b/website/docs/r/data_factory.html.markdown
@@ -31,7 +31,7 @@ The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the Data Factory. Changing this forces a new resource to be created. Must be globally unique. See the [Microsoft documentation](https://docs.microsoft.com/azure/data-factory/naming-rules) for all restrictions.
 
-* `resource_group_name` - (Required) The name of the resource group in which to create the Data Factory.
+* `resource_group_name` - (Required) The name of the resource group in which to create the Data Factory. Changing this forces a new resource to be created.
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 

--- a/website/docs/r/data_factory_custom_dataset.html.markdown
+++ b/website/docs/r/data_factory_custom_dataset.html.markdown
@@ -123,7 +123,7 @@ JSON
 
 * `linked_service` - (Required) A `linked_service` block as defined below.
 
-* `type` - (Required) The type of dataset that will be associated with Data Factory.
+* `type` - (Required) The type of dataset that will be associated with Data Factory. Changing this forces a new resource to be created.
 
 * `type_properties_json` - (Required) A JSON object that contains the properties of the Data Factory Dataset.
 

--- a/website/docs/r/data_factory_dataset_azure_blob.html.markdown
+++ b/website/docs/r/data_factory_dataset_azure_blob.html.markdown
@@ -69,9 +69,9 @@ The following supported arguments are common across all Azure Data Factory Datas
 
 The following supported arguments are specific to Azure Blob Dataset:
 
-* `path` - (Required) The path of the Azure Blob.
+* `path` - (Optional) The path of the Azure Blob.
 
-* `filename` - (Required) The filename of the Azure Blob.
+* `filename` - (Optional) The filename of the Azure Blob.
 
 * `dynamic_path_enabled` - (Optional) Is the `path` using dynamic expression, function or system variables? Defaults to `false`.
 

--- a/website/docs/r/data_factory_dataset_delimited_text.html.markdown
+++ b/website/docs/r/data_factory_dataset_delimited_text.html.markdown
@@ -118,9 +118,9 @@ An `azure_blob_fs_location` block supports the following:
 
 * `file_system` - (Required) The storage data lake gen2 file system on the Azure Blob Storage Account hosting the file.
 
-* `path` - (Required) The folder path to the file.
+* `path` - (Optional) The folder path to the file.
 
-* `filename` - (Required) The filename of the file.
+* `filename` - (Optional) The filename of the file.
 
 ---
 

--- a/website/docs/r/data_factory_dataset_http.html.markdown
+++ b/website/docs/r/data_factory_dataset_http.html.markdown
@@ -67,11 +67,11 @@ The following supported arguments are common across all Azure Data Factory Datas
 
 The following supported arguments are specific to HTTP Dataset:
 
-* `relative_url` - (Required) The relative URL based on the URL in the HTTP Linked Service.
+* `relative_url` - (Optional) The relative URL based on the URL in the HTTP Linked Service.
 
-* `request_body` - (Required) The body for the HTTP request.
+* `request_body` - (Optional) The body for the HTTP request.
 
-* `request_method` - (Required) The HTTP method for the HTTP request. (e.g. GET, POST)
+* `request_method` - (Optional) The HTTP method for the HTTP request. (e.g. GET, POST)
 
 ---
 

--- a/website/docs/r/data_factory_dataset_json.html.markdown
+++ b/website/docs/r/data_factory_dataset_json.html.markdown
@@ -77,7 +77,7 @@ The following supported arguments are specific to JSON Dataset:
 
 The following supported arguments are specific to Delimited Text Dataset:
 
-* `encoding` - (Required) The encoding format for the file.
+* `encoding` - (Optional) The encoding format for the file.
 
 ---
 

--- a/website/docs/r/data_factory_dataset_parquet.html.markdown
+++ b/website/docs/r/data_factory_dataset_parquet.html.markdown
@@ -92,7 +92,7 @@ A `http_server_location` block supports the following:
 
 * `relative_url` - (Required) The base URL to the web server hosting the file.
 
-* `filename` - (Optional) The filename of the file on the web server.
+* `filename` - (Required) The filename of the file on the web server.
 
 * `dynamic_path_enabled` - (Optional) Is the `path` using dynamic expression, function or system variables? Defaults to `false`.
 
@@ -105,7 +105,7 @@ A `azure_blob_storage_location` block supports the following:
 
 * `container` - (Required) The container on the Azure Blob Storage Account hosting the file.
 
-* `filename` - (Required) The filename of the file on the web server.
+* `filename` - (Optional) The filename of the file on the web server.
 
 * `dynamic_container_enabled` - (Optional) Is the `container` using dynamic expression, function or system variables? Defaults to `false`.
 

--- a/website/docs/r/data_factory_linked_custom_service.html.markdown
+++ b/website/docs/r/data_factory_linked_custom_service.html.markdown
@@ -66,7 +66,7 @@ JSON
 
 * `data_factory_id` - (Required) The Data Factory ID in which to associate the Linked Service with. Changing this forces a new resource.
 
-* `type` - (Required) The type of data stores that will be connected to Data Factory. For full list of supported data stores, please refer to [Azure Data Factory connector](https://docs.microsoft.com/azure/data-factory/connector-overview).
+* `type` - (Required) The type of data stores that will be connected to Data Factory. For full list of supported data stores, please refer to [Azure Data Factory connector](https://docs.microsoft.com/azure/data-factory/connector-overview). Changing this forces a new resource to be created.
 
 * `type_properties_json` - (Required) A JSON object that contains the properties of the Data Factory Linked Service.
 

--- a/website/docs/r/data_factory_linked_service_azure_sql_database.html.markdown
+++ b/website/docs/r/data_factory_linked_service_azure_sql_database.html.markdown
@@ -42,7 +42,7 @@ The following arguments are supported:
 
 * `data_factory_id` - (Required) The Data Factory ID in which to associate the Linked Service with. Changing this forces a new resource.
 
-* `connection_string` - (Required) The connection string in which to authenticate with Azure SQL Database. Exactly one of either `connection_string` or `key_vault_connection_string` is required.
+* `connection_string` - (Optional) The connection string in which to authenticate with Azure SQL Database. Exactly one of either `connection_string` or `key_vault_connection_string` is required.
 
 * `use_managed_identity` - (Optional) Whether to use the Data Factory's managed identity to authenticate against the Azure SQL Database. Incompatible with `service_principal_id` and `service_principal_key`
 

--- a/website/docs/r/data_factory_linked_service_azure_table_storage.html.markdown
+++ b/website/docs/r/data_factory_linked_service_azure_table_storage.html.markdown
@@ -45,7 +45,7 @@ The following supported arguments are common across all Azure Data Factory Linke
 * `name` - (Required) Specifies the name of the Data Factory Linked Service. Changing this forces a new resource to be created. Must be unique within a data
   factory. See the [Microsoft documentation](https://docs.microsoft.com/azure/data-factory/naming-rules) for all restrictions.
 
-* `data_factory_id` - (Optional) The Data Factory ID in which to associate the Linked Service with. Changing this forces a new resource.
+* `data_factory_id` - (Required) The Data Factory ID in which to associate the Linked Service with. Changing this forces a new resource.
 
 * `description` - (Optional) The description for the Data Factory Linked Service.
 

--- a/website/docs/r/data_factory_linked_service_cosmosdb_mongoapi.html.markdown
+++ b/website/docs/r/data_factory_linked_service_cosmosdb_mongoapi.html.markdown
@@ -58,7 +58,7 @@ The following supported arguments are specific to CosmosDB Linked Service:
 
 * `database` - (Optional) The name of the database.
 
-* `connection_string` - (Required) The connection string.
+* `connection_string` - (Optional) The connection string.
 
 * `server_version_is_32_or_higher` - (Optional) Whether API server version is 3.2 or higher. Defaults to `false`.
 

--- a/website/docs/r/data_factory_linked_service_kusto.html.markdown
+++ b/website/docs/r/data_factory_linked_service_kusto.html.markdown
@@ -98,7 +98,7 @@ The following supported arguments are specific to Azure Kusto Linked Service:
 
 * `service_principal_key` - (Optional) The service principal key in which to authenticate against the Kusto Database.
 
-* `tenant` - (Required) The service principal tenant id or name in which to authenticate against the Kusto Database.
+* `tenant` - (Optional) The service principal tenant id or name in which to authenticate against the Kusto Database.
 
 ~> **NOTE** If `service_principal_id` is used, `service_principal_key` and `tenant` is also required.
 

--- a/website/docs/r/data_protection_backup_vault.html.markdown
+++ b/website/docs/r/data_protection_backup_vault.html.markdown
@@ -37,7 +37,7 @@ The following arguments are supported:
 
 * `location` - (Required) The Azure Region where the Backup Vault should exist. Changing this forces a new Backup Vault to be created.
 
-* `datastore_type` - (Required) Specifies the type of the data store. Possible values are `ArchiveStore`, `SnapshotStore` and `VaultStore`.
+* `datastore_type` - (Required) Specifies the type of the data store. Possible values are `ArchiveStore`, `SnapshotStore` and `VaultStore`. Changing this forces a new resource to be created.
 
 * `redundancy` - (Required) Specifies the backup storage redundancy. Possible values are `GeoRedundant` and `LocallyRedundant`. Changing this forces a new Backup Vault to be created.
 

--- a/website/docs/r/data_share.html.markdown
+++ b/website/docs/r/data_share.html.markdown
@@ -71,7 +71,7 @@ The following arguments are supported:
 
 A `snapshot_schedule` block supports the following:
 
-* `name` - The name of the snapshot schedule.
+* `name` - (Required) The name of the snapshot schedule.
 
 * `recurrence` - (Required) The interval of the synchronization with the source data. Possible values are `Hour` and `Day`.
 

--- a/website/docs/r/data_share_account.html.markdown
+++ b/website/docs/r/data_share_account.html.markdown
@@ -57,7 +57,7 @@ The following arguments are supported:
 
 An `identity` block supports the following:
 
-* `type` - (Required) Specifies the type of Managed Service Identity that should be configured on this Data Share Account. The only possible value is `SystemAssigned`.
+* `type` - (Required) Specifies the type of Managed Service Identity that should be configured on this Data Share Account. The only possible value is `SystemAssigned`. Changing this forces a new resource to be created.
 
 ~> **NOTE:** The assigned `principal_id` and `tenant_id` can be retrieved after the identity `type` has been set to `SystemAssigned` and the Data Share Account has been created. More details are available below.
 

--- a/website/docs/r/dev_test_global_vm_shutdown_schedule.html.markdown
+++ b/website/docs/r/dev_test_global_vm_shutdown_schedule.html.markdown
@@ -113,7 +113,7 @@ A `notification_settings` - (Required)  - block supports the following:
 
 * `time_in_minutes` - (Optional) Time in minutes between 15 and 120 before a shutdown event at which a notification will be sent. Defaults to `30`.
 
-* `webhook_url` - The webhook URL to which the notification will be sent. Optional if `enabled` is `true`. Optional otherwise.
+* `webhook_url` - (Optional) The webhook URL to which the notification will be sent.
 
 ## Attributes Reference
 

--- a/website/docs/r/dev_test_global_vm_shutdown_schedule.html.markdown
+++ b/website/docs/r/dev_test_global_vm_shutdown_schedule.html.markdown
@@ -107,13 +107,13 @@ The following arguments are supported:
 
 A `notification_settings` - (Required)  - block supports the following:
 
-* `enabled` - (Optional) Whether to enable pre-shutdown notifications. Possible values are `true` and `false`. Defaults to `false`
+* `enabled` - (Required) Whether to enable pre-shutdown notifications. Possible values are `true` and `false`. Defaults to `false`
 
 * `email` - (Optional) E-mail address to which the notification will be sent.
 
 * `time_in_minutes` - (Optional) Time in minutes between 15 and 120 before a shutdown event at which a notification will be sent. Defaults to `30`.
 
-* `webhook_url` - The webhook URL to which the notification will be sent. Required if `enabled` is `true`. Optional otherwise.
+* `webhook_url` - The webhook URL to which the notification will be sent. Optional if `enabled` is `true`. Optional otherwise.
 
 ## Attributes Reference
 

--- a/website/docs/r/dev_test_lab.html.markdown
+++ b/website/docs/r/dev_test_lab.html.markdown
@@ -39,7 +39,7 @@ The following arguments are supported:
 
 * `location` - (Required) Specifies the supported Azure location where the Dev Test Lab should exist. Changing this forces a new resource to be created.
 
-* `storage_type` - (Optional) The type of storage used by the Dev Test Lab. Possible values are `Standard` and `Premium`. Defaults to `Premium`. Changing this forces a new resource to be created.
+* `storage_type` - (Optional) The type of storage used by the Dev Test Lab. Possible values are `Standard` and `Premium`. Defaults to `Premium`. 
 
 -> **Note:** `storage_type` has been deprecated as the API no longer supports it and will be removed in Version 4.0 of the provider.
 

--- a/website/docs/r/dev_test_linux_virtual_machine.html.markdown
+++ b/website/docs/r/dev_test_linux_virtual_machine.html.markdown
@@ -123,7 +123,7 @@ A `gallery_image_reference` block supports the following:
 
 A `inbound_nat_rule` block supports the following:
 
-* `protocol` - (Required) The Protocol used for this NAT Rule. Possible values are `Tcp` and `Udp`. Changing this forces a new resource to be created.
+* `protocol` - (Required) The Protocol used for this NAT Rule. Possible values are `Tcp` and `Udp`. 
 
 * `backend_port` - (Required) The Backend Port associated with this NAT Rule. Changing this forces a new resource to be created.
 

--- a/website/docs/r/dev_test_schedule.html.markdown
+++ b/website/docs/r/dev_test_schedule.html.markdown
@@ -51,7 +51,7 @@ resource "azurerm_dev_test_schedule" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the dev test lab schedule. Valid value for name depends on the `task_type`. For instance for task_type `LabVmsStartupTask` the name needs to be `LabVmAutoStart`.
+* `name` - (Required) The name of the dev test lab schedule. Valid value for name depends on the `task_type`. For instance for task_type `LabVmsStartupTask` the name needs to be `LabVmAutoStart`. Changing this forces a new resource to be created.
 
 * `location` - (Required) The location where the schedule is created. Changing this forces a new resource to be created.
 
@@ -59,7 +59,7 @@ The following arguments are supported:
 
 * `lab_name` - (Required) The name of the dev test lab. Changing this forces a new resource to be created.
 
-* `status` - The status of this schedule. Possible values are `Enabled` and `Disabled`. Defaults to `Disabled`.
+* `status` - (Optional) The status of this schedule. Possible values are `Enabled` and `Disabled`. Defaults to `Disabled`.
 
 * `task_type` - (Required) The task type of the schedule. Possible values include `LabVmsShutdownTask` and `LabVmAutoStart`.
 
@@ -71,25 +71,25 @@ The following arguments are supported:
 
 A `weekly_recurrence` - block supports the following:
 
-* `time` - The time when the schedule takes effect.
+* `time` - (Required) The time when the schedule takes effect.
 
-* `week_days` -  A list of days that this schedule takes effect . Possible values include `Monday`, `Tuesday`, `Wednesday`, `Thursday`, `Friday`, `Saturday` and `Sunday`.
+* `week_days` - (Optional) A list of days that this schedule takes effect . Possible values include `Monday`, `Tuesday`, `Wednesday`, `Thursday`, `Friday`, `Saturday` and `Sunday`.
 
 ---
 
 A `daily_recurrence` - block supports the following:
 
-* `time` - The time each day when the schedule takes effect.
+* `time` - (Required) The time each day when the schedule takes effect.
 
 ---
 
 A `notification_settings` - (Required)  - block supports the following:
 
-* `status` - The status of the notification. Possible values are `Enabled` and `Disabled`. Defaults to `Disabled`
+* `status` - (Optional) The status of the notification. Possible values are `Enabled` and `Disabled`. Defaults to `Disabled`
 
-* `time_in_minutes` - Time in minutes before event at which notification will be sent.
+* `time_in_minutes` - (Optional) Time in minutes before event at which notification will be sent.
 
-* `webhook_url` - The webhook URL to which the notification will be sent.
+* `webhook_url` - (Optional) The webhook URL to which the notification will be sent.
 
 ## Attributes Reference
 

--- a/website/docs/r/dev_test_virtual_network.html.markdown
+++ b/website/docs/r/dev_test_virtual_network.html.markdown
@@ -60,9 +60,9 @@ The following arguments are supported:
 
 A `subnet` block supports the following:
 
-* `use_public_ip_address` - (Required) Can Virtual Machines in this Subnet use Public IP Addresses? Possible values are `Allow`, `Default` and `Deny`.
+* `use_public_ip_address` - (Optional) Can Virtual Machines in this Subnet use Public IP Addresses? Possible values are `Allow`, `Default` and `Deny`.
 
-* `use_in_virtual_machine_creation` - (Required) Can this subnet be used for creating Virtual Machines? Possible values are `Allow`, `Default` and `Deny`.
+* `use_in_virtual_machine_creation` - (Optional) Can this subnet be used for creating Virtual Machines? Possible values are `Allow`, `Default` and `Deny`.
 
 ## Attributes Reference
 

--- a/website/docs/r/dev_test_windows_virtual_machine.html.markdown
+++ b/website/docs/r/dev_test_windows_virtual_machine.html.markdown
@@ -119,7 +119,7 @@ A `gallery_image_reference` block supports the following:
 
 A `inbound_nat_rule` block supports the following:
 
-* `protocol` - (Required) The Protocol used for this NAT Rule. Possible values are `Tcp` and `Udp`. Changing this forces a new resource to be created.
+* `protocol` - (Required) The Protocol used for this NAT Rule. Possible values are `Tcp` and `Udp`. 
 
 * `backend_port` - (Required) The Backend Port associated with this NAT Rule. Changing this forces a new resource to be created.
 

--- a/website/docs/r/disk_encryption_set.html.markdown
+++ b/website/docs/r/disk_encryption_set.html.markdown
@@ -126,7 +126,7 @@ In this case, `azurerm_key_vault_access_policy` is not needed.
 
 * `auto_key_rotation_enabled` - (Optional) Boolean flag to specify whether Azure Disk Encryption Set automatically rotates encryption Key to latest version. Defaults to `false`.
 
-* `encryption_type` - (Optional) The type of key used to encrypt the data of the disk. Possible values are `EncryptionAtRestWithCustomerKey`, `EncryptionAtRestWithPlatformAndCustomerKeys` and `ConfidentialVmEncryptedWithCustomerKey`. Defaults to `EncryptionAtRestWithCustomerKey`.
+* `encryption_type` - (Optional) The type of key used to encrypt the data of the disk. Possible values are `EncryptionAtRestWithCustomerKey`, `EncryptionAtRestWithPlatformAndCustomerKeys` and `ConfidentialVmEncryptedWithCustomerKey`. Defaults to `EncryptionAtRestWithCustomerKey`. Changing this forces a new resource to be created.
 
 * `federated_client_id` - (Optional) Multi-tenant application client id to access key vault in a different tenant.
 

--- a/website/docs/r/dns_a_record.html.markdown
+++ b/website/docs/r/dns_a_record.html.markdown
@@ -68,7 +68,7 @@ resource "azurerm_dns_a_record" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the DNS A Record.
+* `name` - (Required) The name of the DNS A Record. Changing this forces a new resource to be created.
 
 * `resource_group_name` - (Required) Specifies the resource group where the DNS Zone (parent resource) exists. Changing this forces a new resource to be created.
 

--- a/website/docs/r/dns_aaaa_record.html.markdown
+++ b/website/docs/r/dns_aaaa_record.html.markdown
@@ -68,7 +68,7 @@ resource "azurerm_dns_aaaa_record" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the DNS AAAA Record.
+* `name` - (Required) The name of the DNS AAAA Record. Changing this forces a new resource to be created.
 
 * `resource_group_name` - (Required) Specifies the resource group where the DNS Zone (parent resource) exists. Changing this forces a new resource to be created.
 

--- a/website/docs/r/dns_caa_record.html.markdown
+++ b/website/docs/r/dns_caa_record.html.markdown
@@ -65,7 +65,7 @@ resource "azurerm_dns_caa_record" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the DNS CAA Record. If you are creating the record in the apex of the zone use `"@"` as the name.
+* `name` - (Required) The name of the DNS CAA Record. If you are creating the record in the apex of the zone use `"@"` as the name. Changing this forces a new resource to be created.
 
 * `resource_group_name` - (Required) Specifies the resource group where the DNS Zone (parent resource) exists. Changing this forces a new resource to be created.
 

--- a/website/docs/r/dns_cname_record.html.markdown
+++ b/website/docs/r/dns_cname_record.html.markdown
@@ -68,7 +68,7 @@ resource "azurerm_dns_cname_record" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the DNS CNAME Record.
+* `name` - (Required) The name of the DNS CNAME Record. Changing this forces a new resource to be created.
 
 * `resource_group_name` - (Required) Specifies the resource group where the DNS Zone (parent resource) exists. Changing this forces a new resource to be created.
 
@@ -76,7 +76,7 @@ The following arguments are supported:
 
 * `ttl` - (Required) The Time To Live (TTL) of the DNS record in seconds.
 
-* `record` - (Required) The target of the CNAME.
+* `record` - (Optional) The target of the CNAME.
 
 * `target_resource_id` - (Optional) The Azure resource id of the target object. Conflicts with `record`.
 

--- a/website/docs/r/dns_ns_record.html.markdown
+++ b/website/docs/r/dns_ns_record.html.markdown
@@ -43,7 +43,7 @@ resource "azurerm_dns_ns_record" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the DNS NS Record.
+* `name` - (Required) The name of the DNS NS Record. Changing this forces a new resource to be created.
 
 * `resource_group_name` - (Required) Specifies the resource group where the DNS Zone (parent resource) exists. Changing this forces a new resource to be created.
 

--- a/website/docs/r/dns_ptr_record.html.markdown
+++ b/website/docs/r/dns_ptr_record.html.markdown
@@ -38,7 +38,7 @@ resource "azurerm_dns_ptr_record" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the DNS PTR Record.
+* `name` - (Required) The name of the DNS PTR Record. Changing this forces a new resource to be created.
 
 * `resource_group_name` - (Required) Specifies the resource group where the DNS Zone (parent resource) exists. Changing this forces a new resource to be created.
 

--- a/website/docs/r/dns_srv_record.html.markdown
+++ b/website/docs/r/dns_srv_record.html.markdown
@@ -48,7 +48,7 @@ resource "azurerm_dns_srv_record" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the DNS SRV Record.
+* `name` - (Required) The name of the DNS SRV Record. Changing this forces a new resource to be created.
 
 * `resource_group_name` - (Required) Specifies the resource group where the DNS Zone (parent resource) exists. Changing this forces a new resource to be created.
 

--- a/website/docs/r/dns_txt_record.html.markdown
+++ b/website/docs/r/dns_txt_record.html.markdown
@@ -49,7 +49,7 @@ resource "azurerm_dns_txt_record" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the DNS TXT Record.
+* `name` - (Required) The name of the DNS TXT Record. Changing this forces a new resource to be created.
 
 * `resource_group_name` - (Required) Specifies the resource group where the DNS Zone (parent resource) exists. Changing this forces a new resource to be created.
 

--- a/website/docs/r/dns_zone.html.markdown
+++ b/website/docs/r/dns_zone.html.markdown
@@ -28,7 +28,7 @@ resource "azurerm_dns_zone" "example-public" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the DNS Zone. Must be a valid domain name.
+* `name` - (Required) The name of the DNS Zone. Must be a valid domain name. Changing this forces a new resource to be created.
 
 * `resource_group_name` - (Required) Specifies the resource group where the resource exists. Changing this forces a new resource to be created.
 

--- a/website/docs/r/elastic_cloud_elasticsearch.html.markdown
+++ b/website/docs/r/elastic_cloud_elasticsearch.html.markdown
@@ -35,7 +35,7 @@ The following arguments are supported:
 
 * `location` - (Required) The Azure Region where the Elasticsearch resource should exist. Changing this forces a new Elasticsearch to be created.
 
-* `name` - (Required) The name which should be used for this Elasticsearch resource. Changing this forces a new Elasticsearch to be created.
+* `name` - (Required) The name which should be used for this Elasticsearch resource. Changing this forces a new Elasticsearch to be created. Changing this forces a new resource to be created.
 
 * `resource_group_name` - (Required) The name of the Resource Group where the Elasticsearch resource should exist. Changing this forces a new Elasticsearch to be created.
 
@@ -55,7 +55,7 @@ The `filtering_tag` block supports the following:
 
 * `action` - (Required) Specifies the type of action which should be taken when the Tag matches the `name` and `value`. Possible values are `Exclude` and `Include`.
 
-* `name` - (Required) Specifies the name (key) of the Tag which should be filtered.
+* `name` - (Required) Specifies the name (key) of the Tag which should be filtered. Changing this forces a new resource to be created.
 
 * `value` - (Required) Specifies the value of the Tag which should be filtered.
 

--- a/website/docs/r/eventhub_cluster.html.markdown
+++ b/website/docs/r/eventhub_cluster.html.markdown
@@ -37,7 +37,7 @@ The following arguments are supported:
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 
-* `sku_name` - (Required) The SKU name of the EventHub Cluster. The only supported value at this time is `Dedicated_1`.
+* `sku_name` - (Required) The SKU name of the EventHub Cluster. The only supported value at this time is `Dedicated_1`. Changing this forces a new resource to be created.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 

--- a/website/docs/r/eventhub_namespace_disaster_recovery_config.html.markdown
+++ b/website/docs/r/eventhub_namespace_disaster_recovery_config.html.markdown
@@ -50,7 +50,7 @@ The following arguments are supported:
 
 * `resource_group_name` - (Required) The name of the resource group in which the Disaster Recovery Config exists. Changing this forces a new resource to be created.
 
-* `partner_namespace_id` - (Optional) The ID of the EventHub Namespace to replicate to.
+* `partner_namespace_id` - (Required) The ID of the EventHub Namespace to replicate to.
 
 * `wait_for_replication` - (Optional) Should the resource wait for replication upon creation? Defaults to `false`.
 

--- a/website/docs/r/express_route_circuit.html.markdown
+++ b/website/docs/r/express_route_circuit.html.markdown
@@ -61,7 +61,7 @@ The following arguments are supported:
 
 * `allow_classic_operations` - (Optional) Allow the circuit to interact with classic (RDFE) resources. Defaults to `false`.
 
-* `express_route_port_id` - (Optional) The ID of the Express Route Port this Express Route Circuit is based on.
+* `express_route_port_id` - (Optional) The ID of the Express Route Port this Express Route Circuit is based on. Changing this forces a new resource to be created.
 
 * `bandwidth_in_gbps` - (Optional) The bandwidth in Gbps of the circuit being created on the Express Route Port.
 

--- a/website/docs/r/express_route_circuit_authorization.html.markdown
+++ b/website/docs/r/express_route_circuit_authorization.html.markdown
@@ -52,10 +52,10 @@ The following arguments are supported:
 * `name` - (Required) The name of the ExpressRoute circuit. Changing this forces a
     new resource to be created.
 
-* `resource_group_name` - (Required) The name of the resource group in which to
+* `resource_group_name` - (Required) The name of the resource group in which to Changing this forces a new resource to be created.
     create the ExpressRoute circuit. Changing this forces a new resource to be created.
 
-* `express_route_circuit_name` - (Required) The name of the Express Route Circuit in which to create the Authorization.
+* `express_route_circuit_name` - (Required) The name of the Express Route Circuit in which to create the Authorization. Changing this forces a new resource to be created.
 
 ## Attributes Reference
 

--- a/website/docs/r/express_route_circuit_peering.html.markdown
+++ b/website/docs/r/express_route_circuit_peering.html.markdown
@@ -114,11 +114,11 @@ resource "azurerm_express_route_circuit_peering" "example" {
 
 The following arguments are supported:
 
-* `peering_type` - (Required) The type of the ExpressRoute Circuit Peering. Acceptable values include `AzurePrivatePeering`, `AzurePublicPeering` and `MicrosoftPeering`. Changing this forces a new resource to be created.
+* `peering_type` - (Required) The type of the ExpressRoute Circuit Peering. Acceptable values include `AzurePrivatePeering`, `AzurePublicPeering` and `MicrosoftPeering`. 
 
 ~> **NOTE:** only one Peering of each Type can be created. Attempting to create multiple peerings of the same type will overwrite the original peering.
 
-* `express_route_circuit_name` - (Required) The name of the ExpressRoute Circuit in which to create the Peering.
+* `express_route_circuit_name` - (Required) The name of the ExpressRoute Circuit in which to create the Peering. Changing this forces a new resource to be created.
 
 * `resource_group_name` - (Required) The name of the resource group in which to create the Express Route Circuit Peering. Changing this forces a new resource to be created.
 

--- a/website/docs/r/express_route_gateway.html.markdown
+++ b/website/docs/r/express_route_gateway.html.markdown
@@ -55,7 +55,7 @@ The following arguments are supported:
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 
-* `virtual_hub_id` - (Required) The ID of a Virtual HUB within which the ExpressRoute gateway should be created.
+* `virtual_hub_id` - (Required) The ID of a Virtual HUB within which the ExpressRoute gateway should be created. Changing this forces a new resource to be created.
 
 * `scale_units` - (Required) The number of scale units with which to provision the ExpressRoute gateway. Each scale unit is equal to 2Gbps, with support for up to 10 scale units (20Gbps).
 

--- a/website/docs/r/firewall.html.markdown
+++ b/website/docs/r/firewall.html.markdown
@@ -96,7 +96,7 @@ An `ip_configuration` block supports the following:
 
 * `name` - (Required) Specifies the name of the IP Configuration.
 
-* `subnet_id` - (Optional) Reference to the subnet associated with the IP Configuration.
+* `subnet_id` - (Optional) Reference to the subnet associated with the IP Configuration. Changing this forces a new resource to be created.
 
 -> **NOTE** The Subnet used for the Firewall must have the name `AzureFirewallSubnet` and the subnet mask must be at least a `/26`.
 

--- a/website/docs/r/firewall_network_rule_collection.html.markdown
+++ b/website/docs/r/firewall_network_rule_collection.html.markdown
@@ -110,7 +110,7 @@ A `rule` block supports the following:
 
 * `description` - (Optional) Specifies a description for the rule.
 
-* `source_addresses` - (Required) A list of source IP addresses and/or IP ranges.
+* `source_addresses` - (Optional) A list of source IP addresses and/or IP ranges.
 
 * `source_ip_groups` - (Optional) A list of IP Group IDs for the rule.
 

--- a/website/docs/r/frontdoor.html.markdown
+++ b/website/docs/r/frontdoor.html.markdown
@@ -81,7 +81,7 @@ resource "azurerm_frontdoor" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name of the Front Door service. Must be globally unique. Changing this forces a new resource to be created.
+* `name` - (Required) Specifies the name of the Front Door service. Must be globally unique. Changing this forces a new resource to be created. Changing this forces a new resource to be created.
 
 * `resource_group_name` - (Required) Specifies the name of the Resource Group in which the Front Door service should exist. Changing this forces a new resource to be created.
 
@@ -125,7 +125,7 @@ The `backend` block supports the following:
 
 The `backend_pool` block supports the following:
 
-* `name` - (Required) Specifies the name of the Backend Pool.
+* `name` - (Required) Specifies the name of the Backend Pool. Changing this forces a new resource to be created.
 
 * `backend` - (Required) A `backend` block as defined below.
 
@@ -147,7 +147,7 @@ The `backend_pool_settings` block supports the following:
 
 The `frontend_endpoint` block supports the following:
 
-* `name` - (Required) Specifies the name of the `frontend_endpoint`.
+* `name` - (Required) Specifies the name of the `frontend_endpoint`. Changing this forces a new resource to be created.
 
 * `host_name` - (Required) Specifies the host name of the `frontend_endpoint`. Must be a domain name. In order to use a name.azurefd.net domain, the name value must match the Front Door name.
 
@@ -161,7 +161,7 @@ The `frontend_endpoint` block supports the following:
 
 The `backend_pool_health_probe` block supports the following:
 
-* `name` - (Required) Specifies the name of the Health Probe.
+* `name` - (Required) Specifies the name of the Health Probe. Changing this forces a new resource to be created.
 
 * `enabled` - (Optional) Is this health probe enabled? Defaults to `true`.
 
@@ -179,7 +179,7 @@ The `backend_pool_health_probe` block supports the following:
 
 The `backend_pool_load_balancing` block supports the following:
 
-* `name` - (Required) Specifies the name of the Load Balancer.
+* `name` - (Required) Specifies the name of the Load Balancer. Changing this forces a new resource to be created.
 
 * `sample_size` - (Optional) The number of samples to consider for load balancing decisions. Defaults to `4`.
 
@@ -191,7 +191,7 @@ The `backend_pool_load_balancing` block supports the following:
 
 The `routing_rule` block supports the following:
 
-* `name` - (Required) Specifies the name of the Routing Rule.
+* `name` - (Required) Specifies the name of the Routing Rule. Changing this forces a new resource to be created.
 
 * `frontend_endpoints` - (Required) The names of the `frontend_endpoint` blocks within this resource to associate with this `routing_rule`.
 

--- a/website/docs/r/frontdoor_custom_https_configuration.html.markdown
+++ b/website/docs/r/frontdoor_custom_https_configuration.html.markdown
@@ -99,7 +99,7 @@ resource "azurerm_frontdoor_custom_https_configuration" "example_custom_https_1"
 
 The `custom_https_configuration` block is also valid inside an `azurerm_frontdoor_custom_https_configuration`, which supports the following arguments:
 
-* `frontend_endpoint_id` - (Required) The ID of the Front Door Frontend Endpoint which this configuration refers to.
+* `frontend_endpoint_id` - (Required) The ID of the Front Door Frontend Endpoint which this configuration refers to. Changing this forces a new resource to be created.
 
 * `custom_https_provisioning_enabled` - (Required) Should the HTTPS protocol be enabled for this custom domain associated with the Front Door?
 

--- a/website/docs/r/frontdoor_firewall_policy.html.markdown
+++ b/website/docs/r/frontdoor_firewall_policy.html.markdown
@@ -127,7 +127,7 @@ resource "azurerm_frontdoor_firewall_policy" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the policy. Changing this forces a new resource to be created.
+* `name` - (Required) The name of the policy. Changing this forces a new resource to be created. Changing this forces a new resource to be created.
 
 * `resource_group_name` - (Required) The name of the resource group. Changing this forces a new resource to be created.
 
@@ -151,7 +151,7 @@ The following arguments are supported:
 
 The `custom_rule` block supports the following:
 
-* `name` - (Required) Gets name of the resource that is unique within a policy. This name can be used to access the resource.
+* `name` - (Required) Gets name of the resource that is unique within a policy. This name can be used to access the resource. Changing this forces a new resource to be created.
 
 * `action` - (Required) The action to perform when the rule is matched. Possible values are `Allow`, `Block`, `Log`, or `Redirect`.
 

--- a/website/docs/r/frontdoor_rules_engine.html.markdown
+++ b/website/docs/r/frontdoor_rules_engine.html.markdown
@@ -109,7 +109,7 @@ resource "azurerm_frontdoor_rules_engine" "example_rules_engine" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the Rules engine configuration. Changing this forces a new resource to be created.
+* `name` - (Required) The name of the Rules engine configuration. Changing this forces a new resource to be created. Changing this forces a new resource to be created.
 
 * `frontdoor_name` - (Required) The name of the Front Door instance. Changing this forces a new resource to be created.
 
@@ -121,7 +121,7 @@ The following arguments are supported:
 
 The `rule` block supports the following:
 
-* `name` - (Required) The name of the rule.
+* `name` - (Required) The name of the rule. Changing this forces a new resource to be created.
 
 * `priority` - (Required) Priority of the rule, must be unique per rules engine definition.
 

--- a/website/docs/r/function_app.html.markdown
+++ b/website/docs/r/function_app.html.markdown
@@ -195,7 +195,7 @@ resource "azurerm_function_app" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name of the Function App. Changing this forces a new resource to be created. Limit the function name to 32 characters to avoid naming collisions. For more information about [Function App naming rule](https://docs.microsoft.com/azure/azure-resource-manager/management/resource-name-rules#microsoftweb) Changing this forces a new resource to be created.
+* `name` - (Required) Specifies the name of the Function App. Changing this forces a new resource to be created. Limit the function name to 32 characters to avoid naming collisions. For more information about [Function App naming rule](https://docs.microsoft.com/azure/azure-resource-manager/management/resource-name-rules#microsoftweb). Changing this forces a new resource to be created.
 
 * `resource_group_name` - (Required) The name of the resource group in which to create the Function App. Changing this forces a new resource to be created.
 

--- a/website/docs/r/function_app.html.markdown
+++ b/website/docs/r/function_app.html.markdown
@@ -195,9 +195,9 @@ resource "azurerm_function_app" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name of the Function App. Changing this forces a new resource to be created. Limit the function name to 32 characters to avoid naming collisions. For more information about [Function App naming rule](https://docs.microsoft.com/azure/azure-resource-manager/management/resource-name-rules#microsoftweb)
+* `name` - (Required) Specifies the name of the Function App. Changing this forces a new resource to be created. Limit the function name to 32 characters to avoid naming collisions. For more information about [Function App naming rule](https://docs.microsoft.com/azure/azure-resource-manager/management/resource-name-rules#microsoftweb) Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) The name of the resource group in which to create the Function App.
+* `resource_group_name` - (Required) The name of the resource group in which to create the Function App. Changing this forces a new resource to be created.
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 
@@ -225,7 +225,7 @@ The following arguments are supported:
 
 * `key_vault_reference_identity_id` - (Optional) The User Assigned Identity Id used for looking up KeyVault secrets. The identity must be assigned to the application. See [Access vaults with a user-assigned identity](https://docs.microsoft.com/azure/app-service/app-service-key-vault-references#access-vaults-with-a-user-assigned-identity) for more information.
 
-* `os_type` - (Optional) A string indicating the Operating System type for this function app. Possible values are `linux` and ``(empty string).
+* `os_type` - (Optional) A string indicating the Operating System type for this function app. Possible values are `linux` and ``(empty string). Changing this forces a new resource to be created.
 
 ~> **NOTE:** This value will be `linux` for Linux derivatives, or an empty string for Windows (default). When set to `linux` you must also set `azurerm_app_service_plan` arguments as `kind = "Linux"` and `reserved = true`
 
@@ -233,7 +233,7 @@ The following arguments are supported:
 
 * `source_control` - (Optional) A `source_control` block, as defined below.
 
-* `storage_account_name` - (Required) The backend storage account name which will be used by this Function App (such as the dashboard, logs).
+* `storage_account_name` - (Required) The backend storage account name which will be used by this Function App (such as the dashboard, logs). Changing this forces a new resource to be created.
 
 * `storage_account_access_key` - (Required) The access key which will be used to access the backend storage account for the Function App.
 
@@ -249,7 +249,7 @@ The following arguments are supported:
 
 `connection_string` supports the following:
 
-* `name` - (Required) The name of the Connection String.
+* `name` - (Required) The name of the Connection String. Changing this forces a new resource to be created.
 
 * `type` - (Required) The type of the Connection String. Possible values are `APIHub`, `Custom`, `DocDb`, `EventHub`, `MySQL`, `NotificationHub`, `PostgreSQL`, `RedisCache`, `ServiceBus`, `SQLAzure` and  `SQLServer`.
 
@@ -467,7 +467,7 @@ A `headers` block supports the following:
 
 A `source_control` block supports the following:
 
-* `repo_url` - (Required) The URL of the source code repository.
+* `repo_url` - (Optional) The URL of the source code repository.
 
 * `branch` - (Optional) The branch of the remote repository to use. Defaults to 'master'.
 

--- a/website/docs/r/function_app_function.html.markdown
+++ b/website/docs/r/function_app_function.html.markdown
@@ -181,9 +181,9 @@ The following arguments are supported:
 
 A `file` block supports the following:
 
-* `name` - (Required) The filename of the file to be uploaded.
+* `name` - (Required) The filename of the file to be uploaded. Changing this forces a new resource to be created.
 
-* `content` - (Required) The content of the file.
+* `content` - (Required) The content of the file. Changing this forces a new resource to be created.
 
 ## Attributes Reference
 

--- a/website/docs/r/function_app_slot.html.markdown
+++ b/website/docs/r/function_app_slot.html.markdown
@@ -64,17 +64,17 @@ resource "azurerm_function_app_slot" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name of the Function App. Changing this forces a new resource to be created.
+* `name` - (Required) Specifies the name of the Function App. Changing this forces a new resource to be created. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) The name of the resource group in which to create the Function App Slot.
+* `resource_group_name` - (Required) The name of the resource group in which to create the Function App Slot. Changing this forces a new resource to be created.
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 
-* `app_service_plan_id` - (Required) The ID of the App Service Plan within which to create this Function App Slot.
+* `app_service_plan_id` - (Required) The ID of the App Service Plan within which to create this Function App Slot. Changing this forces a new resource to be created.
 
 * `function_app_name` - (Required) The name of the Function App within which to create the Function App Slot. Changing this forces a new resource to be created.
 
-* `storage_account_name` - (Required) The backend storage account name which will be used by the Function App (such as the dashboard, logs).
+* `storage_account_name` - (Required) The backend storage account name which will be used by the Function App (such as the dashboard, logs). Changing this forces a new resource to be created.
 
 * `storage_account_access_key` - (Required) The access key which will be used to access the backend storage account for the Function App.
 
@@ -92,7 +92,7 @@ The following arguments are supported:
 
 * `connection_string` - (Optional) A `connection_string` block as defined below.
 
-* `os_type` - (Optional) A string indicating the Operating System type for this function app. The only possible value is `linux`.
+* `os_type` - (Optional) A string indicating the Operating System type for this function app. The only possible value is `linux`. Changing this forces a new resource to be created.
 
 ~> **NOTE:** This value will be `linux` for Linux Derivatives or an empty string for Windows (default).
 
@@ -114,7 +114,7 @@ The following arguments are supported:
 
 `connection_string` supports the following:
 
-* `name` - (Required) The name of the Connection String.
+* `name` - (Required) The name of the Connection String. Changing this forces a new resource to be created.
 * `type` - (Required) The type of the Connection String. Possible values are `APIHub`, `Custom`, `DocDb`, `EventHub`, `MySQL`, `NotificationHub`, `PostgreSQL`, `RedisCache`, `ServiceBus`, `SQLAzure` and  `SQLServer`.
 * `value` - (Required) The value for the Connection String.
 

--- a/website/docs/r/hdinsight_kafka_cluster.html.markdown
+++ b/website/docs/r/hdinsight_kafka_cluster.html.markdown
@@ -366,7 +366,7 @@ A `rest_proxy` block supports the following:
 
 * `security_group_id` - (Required) The Azure Active Directory Security Group ID. Changing this forces a new resource to be created.
 
-* `security_group_name` - (Optional) The Azure Active Directory Security Group name. Changing this forces a new resource to be created.
+* `security_group_name` - (Required) The Azure Active Directory Security Group name. Changing this forces a new resource to be created.
 
 -> **Note:** The `security_group_name` property will be Required in version 3.0 of the AzureRM Provider.
 

--- a/website/docs/r/healthcare_fhir_service.html.markdown
+++ b/website/docs/r/healthcare_fhir_service.html.markdown
@@ -71,7 +71,7 @@ The following arguments are supported:
 
 * `location` - (Required) Specifies the Azure Region where the Healthcare FHIR Service should be created. Changing this forces a new Healthcare FHIR Service to be created.
 
-* `kind` - (Required) Specifies the kind of the Healthcare FHIR Service. Possible values are: `fhir-Stu3` and `fhir-R4`. Defaults to `fhir-R4`. Changing this forces a new Healthcare FHIR Service to be created.
+* `kind` - (Optional) Specifies the kind of the Healthcare FHIR Service. Possible values are: `fhir-Stu3` and `fhir-R4`. Defaults to `fhir-R4`. Changing this forces a new Healthcare FHIR Service to be created.
 
 * `identity` - (Optional) An `identity` block as defined below.
 
@@ -98,15 +98,15 @@ A `cors` block supports the following:
 * `allowed_origins` - (Required) A set of origins to be allowed via CORS.
 * `allowed_headers` - (Required) A set of headers to be allowed via CORS.
 * `allowed_methods` - (Required) The methods to be allowed via CORS. Possible values are `DELETE`, `GET`, `HEAD`, `MERGE`, `POST`, `OPTIONS` and `PUT`.
-* `max_age_in_seconds` - (Required) The max age to be allowed via CORS.
+* `max_age_in_seconds` - (Optional) The max age to be allowed via CORS.
 * `credentials_allowed` - (Optional) If credentials are allowed via CORS.
 
 ---
 An `authentication` supports the following:
 
-* `authority` - (Optional) The Azure Active Directory (tenant) that serves as the authentication authority to access the service. The default authority is the Directory defined in the authentication scheme in use when running Terraform.
+* `authority` - (Required) The Azure Active Directory (tenant) that serves as the authentication authority to access the service. The default authority is the Directory defined in the authentication scheme in use when running Terraform.
   Authority must be registered to Azure AD and in the following format: <https://{Azure-AD-endpoint}/{tenant-id>}.
-* `audience` - (Optional) The intended audience to receive authentication tokens for the service. The default value is `https://<name>.fhir.azurehealthcareapis.com`.
+* `audience` - (Required) The intended audience to receive authentication tokens for the service. The default value is `https://<name>.fhir.azurehealthcareapis.com`.
 
 ---
 

--- a/website/docs/r/healthcare_service.html.markdown
+++ b/website/docs/r/healthcare_service.html.markdown
@@ -50,9 +50,9 @@ resource "azurerm_healthcare_service" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the service instance. Used for service endpoint, must be unique within the audience.
-* `resource_group_name` - (Required) The name of the Resource Group in which to create the Service.
-* `location` - (Required) Specifies the supported Azure Region where the Service should be created.
+* `name` - (Required) The name of the service instance. Used for service endpoint, must be unique within the audience. Changing this forces a new resource to be created.
+* `resource_group_name` - (Required) The name of the Resource Group in which to create the Service. Changing this forces a new resource to be created.
+* `location` - (Required) Specifies the supported Azure Region where the Service should be created. Changing this forces a new resource to be created.
 
 ~> **Please Note**: Not all locations support this resource. Some are `West US 2`, `North Central US`, and `UK West`.
 
@@ -74,16 +74,16 @@ An `authentication_configuration` supports the following:
 * `authority` - (Optional) The Azure Active Directory (tenant) that serves as the authentication authority to access the service. The default authority is the Directory defined in the authentication scheme in use when running Terraform.
 Authority must be registered to Azure AD and in the following format: <https://{Azure-AD-endpoint}/{tenant-id>}.
 * `audience` - (Optional) The intended audience to receive authentication tokens for the service. The default value is <https://azurehealthcareapis.com>
-* `smart_proxy_enabled` - (Boolean) Enables the 'SMART on FHIR' option for mobile and web implementations.
+* `smart_proxy_enabled` - (Optional) (Boolean) Enables the 'SMART on FHIR' option for mobile and web implementations.
 
 ---
 A `cors_configuration` block supports the following:
 
-* `allowed_origins` - (Required) A set of origins to be allowed via CORS.
-* `allowed_headers` - (Required) A set of headers to be allowed via CORS.
-* `allowed_methods` - (Required) The methods to be allowed via CORS. Possible values are `DELETE`, `GET`, `HEAD`, `MERGE`, `POST`, `OPTIONS` and `PUT`.
-* `max_age_in_seconds` - (Required) The max age to be allowed via CORS.
-* `allow_credentials` - (Boolean) If credentials are allowed via CORS.
+* `allowed_origins` - (Optional) A set of origins to be allowed via CORS.
+* `allowed_headers` - (Optional) A set of headers to be allowed via CORS.
+* `allowed_methods` - (Optional) The methods to be allowed via CORS. Possible values are `DELETE`, `GET`, `HEAD`, `MERGE`, `POST`, `OPTIONS` and `PUT`.
+* `max_age_in_seconds` - (Optional) The max age to be allowed via CORS.
+* `allow_credentials` - (Optional) (Boolean) If credentials are allowed via CORS.
 
 ## Attributes Reference
 

--- a/website/docs/r/hpc_cache.html.markdown
+++ b/website/docs/r/hpc_cache.html.markdown
@@ -182,9 +182,9 @@ A `dns` block contains the following:
 
 An `identity` block supports the following:
 
-* `type` - (Required) Specifies the type of Managed Service Identity that should be configured on this HPC Cache. Only possible value is `UserAssigned`.
+* `type` - (Required) Specifies the type of Managed Service Identity that should be configured on this HPC Cache. Only possible value is `UserAssigned`. Changing this forces a new resource to be created.
 
-* `identity_ids` - (Required) Specifies a list of User Assigned Managed Identity IDs to be assigned to this HPC Cache.
+* `identity_ids` - (Required) Specifies a list of User Assigned Managed Identity IDs to be assigned to this HPC Cache. Changing this forces a new resource to be created.
 
 ## Attributes Reference
 

--- a/website/docs/r/image.html.markdown
+++ b/website/docs/r/image.html.markdown
@@ -102,16 +102,16 @@ The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the image. Changing this forces a
     new resource to be created.
-* `resource_group_name` - (Required) The name of the resource group in which to create
+* `resource_group_name` - (Required) The name of the resource group in which to create Changing this forces a new resource to be created.
     the image. Changing this forces a new resource to be created.
-* `location` - (Required) Specified the supported Azure location where the resource exists.
+* `location` - (Required) Specified the supported Azure location where the resource exists. Changing this forces a new resource to be created.
     Changing this forces a new resource to be created.
 * `source_virtual_machine_id` - (Optional) The Virtual Machine ID from which to create the image.
 * `os_disk` - (Optional) One or more `os_disk` elements as defined below.
 * `data_disk` - (Optional) One or more `data_disk` elements as defined below.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 * `zone_resilient` - (Optional) Is zone resiliency enabled?  Defaults to `false`.  Changing this forces a new resource to be created.
-* `hyper_v_generation` - (Optional) The HyperVGenerationType of the VirtualMachine created from the image as `V1`, `V2`. The default is `V1`.
+* `hyper_v_generation` - (Optional) The HyperVGenerationType of the VirtualMachine created from the image as `V1`, `V2`. The default is `V1`. Changing this forces a new resource to be created.
 
 ~> **Note:** `zone_resilient` can only be set to `true` if the image is stored in a region that supports availability zones.
 

--- a/website/docs/r/image.html.markdown
+++ b/website/docs/r/image.html.markdown
@@ -102,7 +102,7 @@ The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the image. Changing this forces a
     new resource to be created.
-* `resource_group_name` - (Required) The name of the resource group in which to create Changing this forces a new resource to be created.
+* `resource_group_name` - (Required) The name of the resource group in which to create. Changing this forces a new resource to be created.
     the image. Changing this forces a new resource to be created.
 * `location` - (Required) Specified the supported Azure location where the resource exists. Changing this forces a new resource to be created.
     Changing this forces a new resource to be created.

--- a/website/docs/r/iot_time_series_insights_access_policy.html.markdown
+++ b/website/docs/r/iot_time_series_insights_access_policy.html.markdown
@@ -43,9 +43,9 @@ The following arguments are supported:
 
 * `time_series_insights_environment_id` - (Required) The resource ID of the Azure IoT Time Series Insights Environment in which to create the Azure IoT Time Series Insights Reference Data Set. Changing this forces a new resource to be created.
 
-* `principal_object_id` - (Optional) The id of the principal in Azure Active Directory.
+* `principal_object_id` - (Required) The id of the principal in Azure Active Directory.
 
-* `roles` - (Optional) A list of roles to apply to the Access Policy. Valid values include `Contributor` and `Reader`.
+* `roles` - (Required) A list of roles to apply to the Access Policy. Valid values include `Contributor` and `Reader`.
 
 * `description` - (Optional) The description of the Azure IoT Time Series Insights Access Policy.
 

--- a/website/docs/r/iot_time_series_insights_gen2_environment.html.markdown
+++ b/website/docs/r/iot_time_series_insights_gen2_environment.html.markdown
@@ -44,13 +44,13 @@ The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the Azure IoT Time Series Insights Gen2 Environment. Changing this forces a new resource to be created. Must be globally unique.
 
-* `resource_group_name` - (Required) The name of the resource group in which to create the Azure IoT Time Series Insights Gen2 Environment.
+* `resource_group_name` - (Required) The name of the resource group in which to create the Azure IoT Time Series Insights Gen2 Environment. Changing this forces a new resource to be created.
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 
-* `sku_name` - (Required) Specifies the SKU Name for this IoT Time Series Insights Gen2 Environment. Currently it supports only `L1`. For gen2, capacity cannot be specified.
+* `sku_name` - (Required) Specifies the SKU Name for this IoT Time Series Insights Gen2 Environment. Currently it supports only `L1`. For gen2, capacity cannot be specified. Changing this forces a new resource to be created.
 
-* `warm_store_data_retention_time` - (Required) Specifies the ISO8601 timespan specifying the minimum number of days the environment's events will be available for query. Changing this forces a new resource to be created.
+* `warm_store_data_retention_time` - (Required) Specifies the ISO8601 timespan specifying the minimum number of days the environment's events will be available for query. 
 
 * `storage` - (Required) A `storage` block as defined below.
 
@@ -62,7 +62,7 @@ The following arguments are supported:
 
 A `storage` block supports the following:
 
-* `name` - (Required) Name of storage account for Azure IoT Time Series Insights Gen2 Environment
+* `name` - (Required) Name of storage account for Azure IoT Time Series Insights Gen2 Environment Changing this forces a new resource to be created.
 
 * `key` - (Required) Access key of storage account for Azure IoT Time Series Insights Gen2 Environment
 

--- a/website/docs/r/iot_time_series_insights_gen2_environment.html.markdown
+++ b/website/docs/r/iot_time_series_insights_gen2_environment.html.markdown
@@ -62,7 +62,7 @@ The following arguments are supported:
 
 A `storage` block supports the following:
 
-* `name` - (Required) Name of storage account for Azure IoT Time Series Insights Gen2 Environment Changing this forces a new resource to be created.
+* `name` - (Required) Name of storage account for Azure IoT Time Series Insights Gen2 Environment. Changing this forces a new resource to be created.
 
 * `key` - (Required) Access key of storage account for Azure IoT Time Series Insights Gen2 Environment
 

--- a/website/docs/r/iot_time_series_insights_standard_environment.html.markdown
+++ b/website/docs/r/iot_time_series_insights_standard_environment.html.markdown
@@ -32,7 +32,7 @@ The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the Azure IoT Time Series Insights Standard Environment. Changing this forces a new resource to be created. Must be globally unique.
 
-* `resource_group_name` - (Required) The name of the resource group in which to create the Azure IoT Time Series Insights Standard Environment.
+* `resource_group_name` - (Required) The name of the resource group in which to create the Azure IoT Time Series Insights Standard Environment. Changing this forces a new resource to be created.
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 

--- a/website/docs/r/iothub_dps.html.markdown
+++ b/website/docs/r/iothub_dps.html.markdown
@@ -43,7 +43,7 @@ The following arguments are supported:
 
 * `allocation_policy` - (Optional) The allocation policy of the IoT Device Provisioning Service (`Hashed`, `GeoLatency` or `Static`). Defaults to `Hashed`.
 
-* `data_residency_enabled` - (Optional) Specifies if the IoT Device Provisioning Service has data residency and disaster recovery enabled. Defaults to `false`.
+* `data_residency_enabled` - (Optional) Specifies if the IoT Device Provisioning Service has data residency and disaster recovery enabled. Defaults to `false`. Changing this forces a new resource to be created.
 
 * `sku` - (Required) A `sku` block as defined below.
 

--- a/website/docs/r/iothub_dps_certificate.html.markdown
+++ b/website/docs/r/iothub_dps_certificate.html.markdown
@@ -50,7 +50,7 @@ The following arguments are supported:
 
 * `certificate_content` - (Required) The Base-64 representation of the X509 leaf certificate .cer file or just a .pem file content.
 
-* `is_verified` - (Optional) Specifies if the certificate is created in verified state. Defaults to `false`.
+* `is_verified` - (Optional) Specifies if the certificate is created in verified state. Defaults to `false`. Changing this forces a new resource to be created.
 
 ## Attributes Reference
 

--- a/website/docs/r/iothub_endpoint_eventhub.html.markdown
+++ b/website/docs/r/iothub_endpoint_eventhub.html.markdown
@@ -74,7 +74,7 @@ resource "azurerm_iothub_endpoint_eventhub" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the endpoint. The name must be unique across endpoint types. The following names are reserved:  `events`, `operationsMonitoringEvents`, `fileNotifications` and `$default`.
+* `name` - (Required) The name of the endpoint. The name must be unique across endpoint types. The following names are reserved:  `events`, `operationsMonitoringEvents`, `fileNotifications` and `$default`. Changing this forces a new resource to be created.
 
 * `resource_group_name` - (Required) The name of the resource group under which the Event Hub has been created. Changing this forces a new resource to be created.
 
@@ -90,7 +90,7 @@ The following arguments are supported:
 
 * `connection_string` - (Optional) The connection string for the endpoint. This attribute can only be specified and is mandatory when `authentication_type` is `keyBased`.
 
-* `iothub_id` - (Required) The IoTHub ID for the endpoint.
+* `iothub_id` - (Required) The IoTHub ID for the endpoint. Changing this forces a new resource to be created.
 
 ## Attributes Reference
 

--- a/website/docs/r/iothub_endpoint_servicebus_queue.html.markdown
+++ b/website/docs/r/iothub_endpoint_servicebus_queue.html.markdown
@@ -71,7 +71,7 @@ resource "azurerm_iothub_endpoint_servicebus_queue" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the endpoint. The name must be unique across endpoint types. The following names are reserved:  `events`, `operationsMonitoringEvents`, `fileNotifications` and `$default`.
+* `name` - (Required) The name of the endpoint. The name must be unique across endpoint types. The following names are reserved:  `events`, `operationsMonitoringEvents`, `fileNotifications` and `$default`. Changing this forces a new resource to be created.
 
 * `resource_group_name` - (Required) The name of the resource group under which the Service Bus Queue has been created. Changing this forces a new resource to be created.
 
@@ -87,7 +87,7 @@ The following arguments are supported:
 
 * `connection_string` - (Optional) The connection string for the endpoint. This attribute can only be specified and is mandatory when `authentication_type` is `keyBased`.
 
-* `iothub_id` - (Required) The IoTHub ID for the endpoint.
+* `iothub_id` - (Required) The IoTHub ID for the endpoint. Changing this forces a new resource to be created.
 
 ## Attributes Reference
 

--- a/website/docs/r/iothub_endpoint_servicebus_topic.html.markdown
+++ b/website/docs/r/iothub_endpoint_servicebus_topic.html.markdown
@@ -69,7 +69,7 @@ resource "azurerm_iothub_endpoint_servicebus_topic" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the endpoint. The name must be unique across endpoint types. The following names are reserved:  `events`, `operationsMonitoringEvents`, `fileNotifications` and `$default`.
+* `name` - (Required) The name of the endpoint. The name must be unique across endpoint types. The following names are reserved:  `events`, `operationsMonitoringEvents`, `fileNotifications` and `$default`. Changing this forces a new resource to be created.
 
 * `resource_group_name` - (Required) The name of the resource group under which the Service Bus Topic has been created. Changing this forces a new resource to be created.
 
@@ -85,7 +85,7 @@ The following arguments are supported:
 
 * `connection_string` - (Optional) The connection string for the endpoint. This attribute can only be specified and is mandatory when `authentication_type` is `keyBased`.
 
-* `iothub_id` - (Required) The IoTHub ID for the endpoint.
+* `iothub_id` - (Required) The IoTHub ID for the endpoint. Changing this forces a new resource to be created.
 
 ## Attributes Reference
 

--- a/website/docs/r/iothub_endpoint_storage_container.html.markdown
+++ b/website/docs/r/iothub_endpoint_storage_container.html.markdown
@@ -64,13 +64,13 @@ resource "azurerm_iothub_endpoint_storage_container" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the endpoint. The name must be unique across endpoint types. The following names are reserved:  `events`, `operationsMonitoringEvents`, `fileNotifications` and `$default`.
+* `name` - (Required) The name of the endpoint. The name must be unique across endpoint types. The following names are reserved:  `events`, `operationsMonitoringEvents`, `fileNotifications` and `$default`. Changing this forces a new resource to be created.
 
 * `resource_group_name` - (Required) The name of the resource group under which the Storage Container has been created. Changing this forces a new resource to be created.
 
 * `container_name` - (Required) The name of storage container in the storage account.
 
-* `iothub_id` - (Required) The IoTHub ID for the endpoint.
+* `iothub_id` - (Required) The IoTHub ID for the endpoint. Changing this forces a new resource to be created.
 
 * `authentication_type` - (Optional) Type used to authenticate against the storage endpoint. Possible values are `keyBased` and `identityBased`. Defaults to `keyBased`.
 

--- a/website/docs/r/iothub_enrichment.html.markdown
+++ b/website/docs/r/iothub_enrichment.html.markdown
@@ -87,7 +87,7 @@ resource "azurerm_iothub_enrichment" "example" {
 
 The following arguments are supported:
 
-* `key` - (Required) The key of the enrichment.
+* `key` - (Required) The key of the enrichment. Changing this forces a new resource to be created.
 
 * `value` - (Required) The value of the enrichment. Value can be any static string, the name of the IoT hub sending the message (use `$iothubname`) or information from the device twin (ex: `$twin.tags.latitude`)
 

--- a/website/docs/r/iothub_fallback_route.html.markdown
+++ b/website/docs/r/iothub_fallback_route.html.markdown
@@ -84,7 +84,7 @@ The following arguments are supported:
 
 * `iothub_name` - (Required) The name of the IoTHub to which this Fallback Route belongs. Changing this forces a new resource to be created.
 
-* `source` - (Required) The source that the routing rule is to be applied to. Possible values include: `DeviceConnectionStateEvents`, `DeviceJobLifecycleEvents`, `DeviceLifecycleEvents`, `DeviceMessages`, `DigitalTwinChangeEvents`, `Invalid`, `TwinChangeEvents`.
+* `source` - (Optional) The source that the routing rule is to be applied to. Possible values include: `DeviceConnectionStateEvents`, `DeviceJobLifecycleEvents`, `DeviceLifecycleEvents`, `DeviceMessages`, `DigitalTwinChangeEvents`, `Invalid`, `TwinChangeEvents`.
 
 * `enabled` - (Required) Used to specify whether the fallback route is enabled.
 

--- a/website/docs/r/iothub_route.html.markdown
+++ b/website/docs/r/iothub_route.html.markdown
@@ -84,7 +84,7 @@ The following arguments are supported:
 
 * `iothub_name` - (Required) The name of the IoTHub to which this Route belongs. Changing this forces a new resource to be created.
 
-* `source` - (Optional) The source that the routing rule is to be applied to. Possible values include: `DeviceConnectionStateEvents`, `DeviceJobLifecycleEvents`, `DeviceLifecycleEvents`, `DeviceMessages`, `DigitalTwinChangeEvents`, `Invalid`, `TwinChangeEvents`. Defaults to `DeviceMessages`.
+* `source` - (Required) The source that the routing rule is to be applied to. Possible values include: `DeviceConnectionStateEvents`, `DeviceJobLifecycleEvents`, `DeviceLifecycleEvents`, `DeviceMessages`, `DigitalTwinChangeEvents`, `Invalid`, `TwinChangeEvents`. Defaults to `DeviceMessages`.
 
 * `condition` - (Optional) The condition that is evaluated to apply the routing rule. If no condition is provided, it evaluates to `true` by default. For grammar, see: <https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-query-language>.
 

--- a/website/docs/r/key_vault_access_policy.html.markdown
+++ b/website/docs/r/key_vault_access_policy.html.markdown
@@ -51,8 +51,7 @@ resource "azurerm_key_vault_access_policy" "example" {
 
 The following arguments are supported:
 
-* `key_vault_id` - (Required) Specifies the id of the Key Vault resource. Changing this Changing this forces a new resource to be created.
-    forces a new resource to be created.
+* `key_vault_id` - (Required) Specifies the id of the Key Vault resource. Changing this forces a new resource to be created.
 
 * `tenant_id` - (Required) The Azure Active Directory tenant ID that should be used Changing this forces a new resource to be created.
     for authenticating requests to the key vault. Changing this forces a new resource

--- a/website/docs/r/key_vault_access_policy.html.markdown
+++ b/website/docs/r/key_vault_access_policy.html.markdown
@@ -53,9 +53,7 @@ The following arguments are supported:
 
 * `key_vault_id` - (Required) Specifies the id of the Key Vault resource. Changing this forces a new resource to be created.
 
-* `tenant_id` - (Required) The Azure Active Directory tenant ID that should be used Changing this forces a new resource to be created.
-    for authenticating requests to the key vault. Changing this forces a new resource
-    to be created.
+* `tenant_id` - (Required) The Azure Active Directory tenant ID that should be used for authenticating requests to the key vault. Changing this forces a new resource to be created.
 
 * `object_id` - (Required) The object ID of a user, service principal or security Changing this forces a new resource to be created.
     group in the Azure Active Directory tenant for the vault. The object ID must

--- a/website/docs/r/key_vault_access_policy.html.markdown
+++ b/website/docs/r/key_vault_access_policy.html.markdown
@@ -55,10 +55,7 @@ The following arguments are supported:
 
 * `tenant_id` - (Required) The Azure Active Directory tenant ID that should be used for authenticating requests to the key vault. Changing this forces a new resource to be created.
 
-* `object_id` - (Required) The object ID of a user, service principal or security Changing this forces a new resource to be created.
-    group in the Azure Active Directory tenant for the vault. The object ID must
-    be unique for the list of access policies. Changing this forces a new resource
-    to be created.
+* `object_id` - (Required) The object ID of a user, service principal or security group in the Azure Active Directory tenant for the vault. The object ID must be unique for the list of access policies. Changing this forces a new resource to be created.
 
 * `application_id` - (Optional) The object ID of an Application in Azure Active Directory. Changing this forces a new resource to be created.
 

--- a/website/docs/r/key_vault_access_policy.html.markdown
+++ b/website/docs/r/key_vault_access_policy.html.markdown
@@ -51,19 +51,19 @@ resource "azurerm_key_vault_access_policy" "example" {
 
 The following arguments are supported:
 
-* `key_vault_id` - (Required) Specifies the id of the Key Vault resource. Changing this
+* `key_vault_id` - (Required) Specifies the id of the Key Vault resource. Changing this Changing this forces a new resource to be created.
     forces a new resource to be created.
 
-* `tenant_id` - (Required) The Azure Active Directory tenant ID that should be used
+* `tenant_id` - (Required) The Azure Active Directory tenant ID that should be used Changing this forces a new resource to be created.
     for authenticating requests to the key vault. Changing this forces a new resource
     to be created.
 
-* `object_id` - (Required) The object ID of a user, service principal or security
+* `object_id` - (Required) The object ID of a user, service principal or security Changing this forces a new resource to be created.
     group in the Azure Active Directory tenant for the vault. The object ID must
     be unique for the list of access policies. Changing this forces a new resource
     to be created.
 
-* `application_id` - (Optional) The object ID of an Application in Azure Active Directory.
+* `application_id` - (Optional) The object ID of an Application in Azure Active Directory. Changing this forces a new resource to be created.
 
 * `certificate_permissions` - (Optional) List of certificate permissions, must be one or more from the following: `Backup`, `Create`, `Delete`, `DeleteIssuers`, `Get`, `GetIssuers`, `Import`, `List`, `ListIssuers`, `ManageContacts`, `ManageIssuers`, `Purge`, `Recover`, `Restore`, `SetIssuers` and `Update`.
 

--- a/website/docs/r/key_vault_certificate.html.markdown
+++ b/website/docs/r/key_vault_certificate.html.markdown
@@ -225,7 +225,7 @@ The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the Key Vault Certificate. Changing this forces a new resource to be created.
 
-* `key_vault_id` - (Required) The ID of the Key Vault where the Certificate should be created.
+* `key_vault_id` - (Required) The ID of the Key Vault where the Certificate should be created. Changing this forces a new resource to be created.
 
 * `certificate` - (Optional) A `certificate` block as defined below, used to Import an existing certificate.
 

--- a/website/docs/r/key_vault_certificate_issuer.html.markdown
+++ b/website/docs/r/key_vault_certificate_issuer.html.markdown
@@ -42,7 +42,7 @@ resource "azurerm_key_vault_certificate_issuer" "example" {
 
 The following arguments are supported:
 
-* `key_vault_id` - (Required) The ID of the Key Vault in which to create the Certificate Issuer.
+* `key_vault_id` - (Required) The ID of the Key Vault in which to create the Certificate Issuer. Changing this forces a new resource to be created.
 
 * `name` - (Required) The name which should be used for this Key Vault Certificate Issuer. Changing this forces a new Key Vault Certificate Issuer to be created.
 

--- a/website/docs/r/key_vault_managed_storage_account.html.markdown
+++ b/website/docs/r/key_vault_managed_storage_account.html.markdown
@@ -158,7 +158,7 @@ The following arguments are supported:
 
 * `regeneration_period` - (Optional) How often Storage Account access key should be regenerated. Value needs to be in [ISO 8601 duration format](https://en.wikipedia.org/wiki/ISO_8601#Durations).
 
-* `tags` - (Optional) A mapping of tags which should be assigned to the Key Vault Managed Storage Account.
+* `tags` - (Optional) A mapping of tags which should be assigned to the Key Vault Managed Storage Account. Changing this forces a new resource to be created.
 
 ## Attributes Reference
 

--- a/website/docs/r/key_vault_managed_storage_account_sas_token_definition.html.markdown
+++ b/website/docs/r/key_vault_managed_storage_account_sas_token_definition.html.markdown
@@ -123,7 +123,7 @@ The following arguments are supported:
 
 ---
 
-* `tags` - (Optional) A mapping of tags which should be assigned to the SAS Definition.
+* `tags` - (Optional) A mapping of tags which should be assigned to the SAS Definition. Changing this forces a new resource to be created.
 
 ## Attributes Reference
 

--- a/website/docs/r/key_vault_secret.html.markdown
+++ b/website/docs/r/key_vault_secret.html.markdown
@@ -70,7 +70,7 @@ The following arguments are supported:
 
 ~> **Note:** Key Vault strips newlines. To preserve newlines in multi-line secrets try replacing them with `\n` or by base 64 encoding them with `replace(file("my_secret_file"), "/\n/", "\n")` or `base64encode(file("my_secret_file"))`, respectively.
 
-* `key_vault_id` - (Required) The ID of the Key Vault where the Secret should be created.
+* `key_vault_id` - (Required) The ID of the Key Vault where the Secret should be created. Changing this forces a new resource to be created.
 
 * `content_type` - (Optional) Specifies the content type for the Key Vault Secret.
 

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -141,11 +141,11 @@ In addition, one of either `identity` or `service_principal` blocks must be spec
 
 -> **Note:** If `network_profile` is not defined, `kubenet` profile will be used by default.
 
-* `node_resource_group` - (Optional) The name of the Resource Group where the Kubernetes Nodes should exist. Changing this forces a new resource to be created.
+* `node_resource_group` - (Optional) The name of the Resource Group where the Kubernetes Nodes should exist. Changing this forces a new resource to be created. Changing this forces a new resource to be created.
 
 -> **Note:** Azure requires that a new, non-existent Resource Group is used, as otherwise the provisioning of the Kubernetes Service will fail.
 
-* `oidc_issuer_enabled` - (Required) Enable or Disable the [OIDC issuer URL](https://docs.microsoft.com/azure/aks/cluster-configuration#oidc-issuer-preview)
+* `oidc_issuer_enabled` - (Optional) Enable or Disable the [OIDC issuer URL](https://docs.microsoft.com/azure/aks/cluster-configuration#oidc-issuer-preview)
 
 * `oms_agent` - (Optional) A `oms_agent` block as defined below.
 
@@ -258,39 +258,39 @@ resource "azurerm_subnet" "virtual" {
 
 An `auto_scaler_profile` block supports the following:
 
-* `balance_similar_node_groups` - Detect similar node groups and balance the number of nodes between them. Defaults to `false`.
+* `balance_similar_node_groups` - (Optional) Detect similar node groups and balance the number of nodes between them. Defaults to `false`.
 
-* `expander` - Expander to use. Possible values are `least-waste`, `priority`, `most-pods` and `random`. Defaults to `random`.
+* `expander` - (Optional) Expander to use. Possible values are `least-waste`, `priority`, `most-pods` and `random`. Defaults to `random`.
 
-* `max_graceful_termination_sec` - Maximum number of seconds the cluster autoscaler waits for pod termination when trying to scale down a node. Defaults to `600`.
+* `max_graceful_termination_sec` - (Optional) Maximum number of seconds the cluster autoscaler waits for pod termination when trying to scale down a node. Defaults to `600`.
 
-* `max_node_provisioning_time` - Maximum time the autoscaler waits for a node to be provisioned. Defaults to `15m`.
+* `max_node_provisioning_time` - (Optional) Maximum time the autoscaler waits for a node to be provisioned. Defaults to `15m`.
 
-* `max_unready_nodes` - Maximum Number of allowed unready nodes. Defaults to `3`.
+* `max_unready_nodes` - (Optional) Maximum Number of allowed unready nodes. Defaults to `3`.
 
-* `max_unready_percentage` - Maximum percentage of unready nodes the cluster autoscaler will stop if the percentage is exceeded. Defaults to `45`.
+* `max_unready_percentage` - (Optional) Maximum percentage of unready nodes the cluster autoscaler will stop if the percentage is exceeded. Defaults to `45`.
 
-* `new_pod_scale_up_delay` - For scenarios like burst/batch scale where you don't want CA to act before the kubernetes scheduler could schedule all the pods, you can tell CA to ignore unscheduled pods before they're a certain age. Defaults to `10s`.
+* `new_pod_scale_up_delay` - (Optional) For scenarios like burst/batch scale where you don't want CA to act before the kubernetes scheduler could schedule all the pods, you can tell CA to ignore unscheduled pods before they're a certain age. Defaults to `10s`.
 
-* `scale_down_delay_after_add` - How long after the scale up of AKS nodes the scale down evaluation resumes. Defaults to `10m`.
+* `scale_down_delay_after_add` - (Optional) How long after the scale up of AKS nodes the scale down evaluation resumes. Defaults to `10m`.
 
-* `scale_down_delay_after_delete` - How long after node deletion that scale down evaluation resumes. Defaults to the value used for `scan_interval`.
+* `scale_down_delay_after_delete` - (Optional) How long after node deletion that scale down evaluation resumes. Defaults to the value used for `scan_interval`.
 
-* `scale_down_delay_after_failure` - How long after scale down failure that scale down evaluation resumes. Defaults to `3m`.
+* `scale_down_delay_after_failure` - (Optional) How long after scale down failure that scale down evaluation resumes. Defaults to `3m`.
 
-* `scan_interval` - How often the AKS Cluster should be re-evaluated for scale up/down. Defaults to `10s`.
+* `scan_interval` - (Optional) How often the AKS Cluster should be re-evaluated for scale up/down. Defaults to `10s`.
 
-* `scale_down_unneeded` - How long a node should be unneeded before it is eligible for scale down. Defaults to `10m`.
+* `scale_down_unneeded` - (Optional) How long a node should be unneeded before it is eligible for scale down. Defaults to `10m`.
 
-* `scale_down_unready` - How long an unready node should be unneeded before it is eligible for scale down. Defaults to `20m`.
+* `scale_down_unready` - (Optional) How long an unready node should be unneeded before it is eligible for scale down. Defaults to `20m`.
 
-* `scale_down_utilization_threshold` - Node utilization level, defined as sum of requested resources divided by capacity, below which a node can be considered for scale down. Defaults to `0.5`.
+* `scale_down_utilization_threshold` - (Optional) Node utilization level, defined as sum of requested resources divided by capacity, below which a node can be considered for scale down. Defaults to `0.5`.
 
-* `empty_bulk_delete_max` - Maximum number of empty nodes that can be deleted at the same time. Defaults to `10`.
+* `empty_bulk_delete_max` - (Optional) Maximum number of empty nodes that can be deleted at the same time. Defaults to `10`.
 
-* `skip_nodes_with_local_storage` - If `true` cluster autoscaler will never delete nodes with pods with local storage, for example, EmptyDir or HostPath. Defaults to `true`.
+* `skip_nodes_with_local_storage` - (Optional) If `true` cluster autoscaler will never delete nodes with pods with local storage, for example, EmptyDir or HostPath. Defaults to `true`.
 
-* `skip_nodes_with_system_pods` - If `true` cluster autoscaler will never delete nodes with pods from kube-system (except for DaemonSet or mirror pods). Defaults to `true`.
+* `skip_nodes_with_system_pods` - (Optional) If `true` cluster autoscaler will never delete nodes with pods from kube-system (except for DaemonSet or mirror pods). Defaults to `true`.
 
 ---
 
@@ -308,11 +308,11 @@ When `managed` is set to `true` the following properties can be specified:
 
 When `managed` is set to `false` the following properties can be specified:
 
-* `client_app_id` - (Required) The Client ID of an Azure Active Directory Application.
+* `client_app_id` - (Optional) The Client ID of an Azure Active Directory Application.
 
-* `server_app_id` - (Required) The Server ID of an Azure Active Directory Application.
+* `server_app_id` - (Optional) The Server ID of an Azure Active Directory Application.
 
-* `server_app_secret` - (Required) The Server Secret of an Azure Active Directory Application.
+* `server_app_secret` - (Optional) The Server Secret of an Azure Active Directory Application.
 
 ---
 
@@ -330,7 +330,7 @@ A `default_node_pool` block supports the following:
 
 -> **Note:** If you're using AutoScaling, you may wish to use [Terraform's `ignore_changes` functionality](https://www.terraform.io/docs/language/meta-arguments/lifecycle.html#ignore_changes) to ignore changes to the `node_count` field.
 
-* `enable_host_encryption` - (Optional) Should the nodes in the Default Node Pool have host encryption enabled? Defaults to `false`.
+* `enable_host_encryption` - (Optional) Should the nodes in the Default Node Pool have host encryption enabled? Defaults to `false`. Changing this forces a new resource to be created.
 
 * `enable_node_public_ip` - (Optional) Should nodes in this Node Pool have a Public IP Address? Defaults to `false`. Changing this forces a new resource to be created.
 
@@ -370,13 +370,13 @@ A `default_node_pool` block supports the following:
 
 * `scale_down_mode` - (Optional) Specifies the autoscaling behaviour of the Kubernetes Cluster. If not specified, it defaults to 'ScaleDownModeDelete'. Possible values include 'ScaleDownModeDelete' and 'ScaleDownModeDeallocate'. Changing this forces a new resource to be created.
 
-* `type` - (Optional) The type of Node Pool which should be created. Possible values are `AvailabilitySet` and `VirtualMachineScaleSets`. Defaults to `VirtualMachineScaleSets`.
+* `type` - (Optional) The type of Node Pool which should be created. Possible values are `AvailabilitySet` and `VirtualMachineScaleSets`. Defaults to `VirtualMachineScaleSets`. Changing this forces a new resource to be created.
 
 * `tags` - (Optional) A mapping of tags to assign to the Node Pool.
 
 ~> At this time there's a bug in the AKS API where Tags for a Node Pool are not stored in the correct case - you [may wish to use Terraform's `ignore_changes` functionality to ignore changes to the casing](https://www.terraform.io/language/meta-arguments/lifecycle#ignore_changess) until this is fixed in the AKS API.
 
-* `ultra_ssd_enabled` - (Optional) Used to specify whether the UltraSSD is enabled in the Default Node Pool. Defaults to `false`. See [the documentation](https://docs.microsoft.com/azure/aks/use-ultra-disks) for more information.
+* `ultra_ssd_enabled` - (Optional) Used to specify whether the UltraSSD is enabled in the Default Node Pool. Defaults to `false`. See [the documentation](https://docs.microsoft.com/azure/aks/use-ultra-disks) for more information. Changing this forces a new resource to be created.
 
 * `upgrade_settings` - (Optional) A `upgrade_settings` block as documented below.
 
@@ -386,9 +386,9 @@ A `default_node_pool` block supports the following:
 
 If `enable_auto_scaling` is set to `true`, then the following fields can also be configured:
 
-* `max_count` - (Required) The maximum number of nodes which should exist in this Node Pool. If specified this must be between `1` and `1000`.
+* `max_count` - (Optional) The maximum number of nodes which should exist in this Node Pool. If specified this must be between `1` and `1000`.
 
-* `min_count` - (Required) The minimum number of nodes which should exist in this Node Pool. If specified this must be between `1` and `1000`.
+* `min_count` - (Optional) The minimum number of nodes which should exist in this Node Pool. If specified this must be between `1` and `1000`.
 
 * `node_count` - (Optional) The initial number of nodes which should exist in this Node Pool. If specified this must be between `1` and `1000` and between `min_count` and `max_count`.
 
@@ -396,7 +396,7 @@ If `enable_auto_scaling` is set to `true`, then the following fields can also be
 
 If `enable_auto_scaling` is set to `false`, then the following fields can also be configured:
 
-* `node_count` - (Required) The number of nodes which should exist in this Node Pool. If specified this must be between `1` and `1000`.
+* `node_count` - (Optional) The number of nodes which should exist in this Node Pool. If specified this must be between `1` and `1000`.
 
 -> **Note:** If `enable_auto_scaling` is set to `false` both `min_count` and `max_count` fields need to be set to `null` or omitted from the configuration.
 
@@ -420,9 +420,9 @@ An `identity` block supports the following:
 
 A `key_vault_secrets_provider` block supports the following:
 
-* `secret_rotation_enabled` - (Required) Is secret rotation enabled?
+* `secret_rotation_enabled` - (Optional) Is secret rotation enabled?
 
-* `secret_rotation_interval` - (Required) The interval to poll for secret rotation. This attribute is only set when `secret_rotation` is true and defaults to `2m`.
+* `secret_rotation_interval` - (Optional) The interval to poll for secret rotation. This attribute is only set when `secret_rotation` is true and defaults to `2m`.
 
 ---
 
@@ -532,7 +532,7 @@ A `network_profile` block supports the following:
 
 * `docker_bridge_cidr` - (Optional) IP address (in CIDR notation) used as the Docker bridge IP address on nodes. Changing this forces a new resource to be created.
 
-* `outbound_type` - (Optional) The outbound (egress) routing method which should be used for this Kubernetes Cluster. Possible values are `loadBalancer`, `userDefinedRouting`, `managedNATGateway` and `userAssignedNATGateway`. Defaults to `loadBalancer`.
+* `outbound_type` - (Optional) The outbound (egress) routing method which should be used for this Kubernetes Cluster. Possible values are `loadBalancer`, `userDefinedRouting`, `managedNATGateway` and `userAssignedNATGateway`. Defaults to `loadBalancer`. Changing this forces a new resource to be created.
 
 * `pod_cidr` - (Optional) The CIDR to use for pod IP addresses. This field can only be set when `network_plugin` is set to `kubenet`. Changing this forces a new resource to be created.
 
@@ -552,7 +552,7 @@ Examples of how to use [AKS with Advanced Networking](https://docs.microsoft.com
 
 ->**Note:** Dual-stack networking requires that the Preview Feature `Microsoft.ContainerService/AKS-EnableDualStack` is enabled and the Resource Provider is re-registered, see [the documentation](https://docs.microsoft.com/azure/aks/configure-kubenet-dual-stack?tabs=azure-cli%2Ckubectl#register-the-aks-enabledualstack-preview-feature) for more information.
 
-* `load_balancer_sku` - (Optional) Specifies the SKU of the Load Balancer used for this Kubernetes Cluster. Possible values are `basic` and `standard`. Defaults to `standard`.
+* `load_balancer_sku` - (Optional) Specifies the SKU of the Load Balancer used for this Kubernetes Cluster. Possible values are `basic` and `standard`. Defaults to `standard`. Changing this forces a new resource to be created.
 
 * `load_balancer_profile` - (Optional) A `load_balancer_profile` block. This can only be specified when `load_balancer_sku` is set to `standard`.
 
@@ -698,9 +698,9 @@ A `web_app_routing` block supports the following:
 
 A `windows_profile` block supports the following:
 
-* `admin_username` - (Required) The Admin Username for Windows VMs.
+* `admin_username` - (Required) The Admin Username for Windows VMs. Changing this forces a new resource to be created.
 
-* `admin_password` - (Required) The Admin Password for Windows VMs. Length must be between 14 and 123 characters.
+* `admin_password` - (Optional) The Admin Password for Windows VMs. Length must be between 14 and 123 characters.
 
 * `license` - (Optional) Specifies the type of on-premise license which should be used for Node Pool Windows Virtual Machine. At this time the only possible value is `Windows_Server`.
 
@@ -727,11 +727,11 @@ A `workload_autoscaler_profile` block supports the following:
 
 A `http_proxy_config` block supports the following:
 
-* `http_proxy` - (Optional) The proxy address to be used when communicating over HTTP.
+* `http_proxy` - (Optional) The proxy address to be used when communicating over HTTP. Changing this forces a new resource to be created.
 
-* `https_proxy` - (Optional) The proxy address to be used when communicating over HTTPS.
+* `https_proxy` - (Optional) The proxy address to be used when communicating over HTTPS. Changing this forces a new resource to be created.
 
-* `no_proxy` - (Optional) The list of domains that will not use the proxy for communication.
+* `no_proxy` - (Optional) The list of domains that will not use the proxy for communication. Changing this forces a new resource to be created.
 
 -> **Note:** If you specify the `default_node_pool.0.vnet_subnet_id`, be sure to include the Subnet CIDR in the `no_proxy` list.
 

--- a/website/docs/r/kubernetes_cluster_node_pool.html.markdown
+++ b/website/docs/r/kubernetes_cluster_node_pool.html.markdown
@@ -74,7 +74,7 @@ The following arguments are supported:
 
 * `enable_auto_scaling` - (Optional) Whether to enable [auto-scaler](https://docs.microsoft.com/azure/aks/cluster-autoscaler). Defaults to `false`.
 
-* `enable_host_encryption` - (Optional) Should the nodes in this Node Pool have host encryption enabled? Defaults to `false`.
+* `enable_host_encryption` - (Optional) Should the nodes in this Node Pool have host encryption enabled? Defaults to `false`. Changing this forces a new resource to be created.
 
 ~> **NOTE:** Additional fields must be configured depending on the value of this field - see below.
 
@@ -138,11 +138,11 @@ The following arguments are supported:
 
 * `scale_down_mode` - (Optional) Specifies how the node pool should deal with scaled-down nodes. Allowed values are `Delete` and `Deallocate`. Defaults to `Delete`.
 
-* `ultra_ssd_enabled` - (Optional) Used to specify whether the UltraSSD is enabled in the Node Pool. Defaults to `false`. See [the documentation](https://docs.microsoft.com/azure/aks/use-ultra-disks) for more information.
+* `ultra_ssd_enabled` - (Optional) Used to specify whether the UltraSSD is enabled in the Node Pool. Defaults to `false`. See [the documentation](https://docs.microsoft.com/azure/aks/use-ultra-disks) for more information. Changing this forces a new resource to be created.
 
 * `upgrade_settings` - (Optional) A `upgrade_settings` block as documented below.
 
-* `vnet_subnet_id` - (Optional) The ID of the Subnet where this Node Pool should exist.
+* `vnet_subnet_id` - (Optional) The ID of the Subnet where this Node Pool should exist. Changing this forces a new resource to be created.
 
 -> **NOTE:** At this time the `vnet_subnet_id` must be the same for all node pools in the cluster
 
@@ -158,9 +158,9 @@ The following arguments are supported:
 
 If `enable_auto_scaling` is set to `true`, then the following fields can also be configured:
 
-* `max_count` - (Required) The maximum number of nodes which should exist within this Node Pool. Valid values are between `0` and `1000` and must be greater than or equal to `min_count`.
+* `max_count` - (Optional) The maximum number of nodes which should exist within this Node Pool. Valid values are between `0` and `1000` and must be greater than or equal to `min_count`.
 
-* `min_count` - (Required) The minimum number of nodes which should exist within this Node Pool. Valid values are between `0` and `1000` and must be less than or equal to `max_count`.
+* `min_count` - (Optional) The minimum number of nodes which should exist within this Node Pool. Valid values are between `0` and `1000` and must be less than or equal to `max_count`.
 
 * `node_count` - (Optional) The initial number of nodes which should exist within this Node Pool. Valid values are between `0` and `1000` (inclusive) for user pools and between `1` and `1000` (inclusive) for system pools and must be a value in the range `min_count` - `max_count`.
 
@@ -168,7 +168,7 @@ If `enable_auto_scaling` is set to `true`, then the following fields can also be
 
 If `enable_auto_scaling` is set to `false`, then the following fields can also be configured:
 
-* `node_count` - (Required) The number of nodes which should exist within this Node Pool. Valid values are between `0` and `1000` (inclusive) for user pools and between `1` and `1000` (inclusive) for system pools.
+* `node_count` - (Optional) The number of nodes which should exist within this Node Pool. Valid values are between `0` and `1000` (inclusive) for user pools and between `1` and `1000` (inclusive) for system pools.
 
 ---
 

--- a/website/docs/r/kusto_attached_database_configuration.html.markdown
+++ b/website/docs/r/kusto_attached_database_configuration.html.markdown
@@ -85,9 +85,9 @@ The following arguments are supported:
 
 * `cluster_name` - (Required) Specifies the name of the Kusto Cluster for which the configuration will be created. Changing this forces a new resource to be created.
 
-* `cluster_resource_id` - (Required) The resource id of the cluster where the databases you would like to attach reside.
+* `cluster_resource_id` - (Required) The resource id of the cluster where the databases you would like to attach reside. Changing this forces a new resource to be created.
 
-* `database_name` - (Required) The name of the database which you would like to attach, use * if you want to follow all current and future databases.
+* `database_name` - (Required) The name of the database which you would like to attach, use * if you want to follow all current and future databases. Changing this forces a new resource to be created.
 
 * `default_principal_modification_kind` - (Optional) The default principals modification kind. Valid values are: `None` (default), `Replace` and `Union`.
 

--- a/website/docs/r/kusto_cluster_customer_managed_key.html.markdown
+++ b/website/docs/r/kusto_cluster_customer_managed_key.html.markdown
@@ -88,7 +88,7 @@ The following arguments are supported:
 
 * `cluster_id` - (Required) The ID of the Kusto Cluster. Changing this forces a new resource to be created.
 
-* `key_vault_id` - (Required) The ID of the Key Vault. Changing this forces a new resource to be created.
+* `key_vault_id` - (Required) The ID of the Key Vault. 
 
 * `key_name` - (Required) The name of Key Vault Key.
 

--- a/website/docs/r/kusto_eventgrid_data_connection.html.markdown
+++ b/website/docs/r/kusto_eventgrid_data_connection.html.markdown
@@ -116,8 +116,7 @@ The following arguments are supported:
 
 * `eventhub_id` - (Required) Specifies the resource id of the Event Hub this data connection will use for ingestion. Changing this forces a new resource to be created.
 
-* `eventhub_consumer_group_name` - (Required) Specifies the Event Hub consumer group this data connection will use for Changing this forces a new resource to be created.
-  ingestion. Changing this forces a new resource to be created.
+* `eventhub_consumer_group_name` - (Required) Specifies the Event Hub consumer group this data connection will use for ingestion. Changing this forces a new resource to be created.
 
 * `blob_storage_event_type` - (Optional) Specifies the blob storage event type that needs to be processed. Possible Values are `Microsoft.Storage.BlobCreated` and `Microsoft.Storage.BlobRenamed`. Defaults to `Microsoft.Storage.BlobCreated`.
 

--- a/website/docs/r/kusto_eventgrid_data_connection.html.markdown
+++ b/website/docs/r/kusto_eventgrid_data_connection.html.markdown
@@ -114,17 +114,17 @@ The following arguments are supported:
 
 * `storage_account_id` - (Required) Specifies the resource id of the Storage Account this data connection will use for ingestion. Changing this forces a new resource to be created.
 
-* `eventhub_id` - (Required) Specifies the resource id of the Event Hub this data connection will use for ingestion.
+* `eventhub_id` - (Required) Specifies the resource id of the Event Hub this data connection will use for ingestion. Changing this forces a new resource to be created.
   Changing this forces a new resource to be created.
 
-* `eventhub_consumer_group_name` - (Required) Specifies the Event Hub consumer group this data connection will use for
+* `eventhub_consumer_group_name` - (Required) Specifies the Event Hub consumer group this data connection will use for Changing this forces a new resource to be created.
   ingestion. Changing this forces a new resource to be created.
 
 * `blob_storage_event_type` - (Optional) Specifies the blob storage event type that needs to be processed. Possible Values are `Microsoft.Storage.BlobCreated` and `Microsoft.Storage.BlobRenamed`. Defaults to `Microsoft.Storage.BlobCreated`.
 
 * `data_format` - (Optional) Specifies the data format of the EventHub messages. Allowed values: `APACHEAVRO`, `AVRO`, `CSV`, `JSON`, `MULTIJSON`, `ORC`, `PARQUET`, `PSV`, `RAW`, `SCSV`, `SINGLEJSON`, `SOHSV`, `TSV`, `TSVE`, `TXT` and `W3CLOGFILE`.
 
-* `database_routing_type` - (Optional) Indication for database routing information from the data connection, by default only database routing information is allowed. Allowed values: `Single`, `Multi`.
+* `database_routing_type` - (Optional) Indication for database routing information from the data connection, by default only database routing information is allowed. Allowed values: `Single`, `Multi`. Changing this forces a new resource to be created.
 
 * `eventgrid_resource_id` - (Optional) The resource ID of the event grid that is subscribed to the storage account events.
 

--- a/website/docs/r/kusto_eventgrid_data_connection.html.markdown
+++ b/website/docs/r/kusto_eventgrid_data_connection.html.markdown
@@ -115,7 +115,6 @@ The following arguments are supported:
 * `storage_account_id` - (Required) Specifies the resource id of the Storage Account this data connection will use for ingestion. Changing this forces a new resource to be created.
 
 * `eventhub_id` - (Required) Specifies the resource id of the Event Hub this data connection will use for ingestion. Changing this forces a new resource to be created.
-  Changing this forces a new resource to be created.
 
 * `eventhub_consumer_group_name` - (Required) Specifies the Event Hub consumer group this data connection will use for Changing this forces a new resource to be created.
   ingestion. Changing this forces a new resource to be created.

--- a/website/docs/r/kusto_eventhub_data_connection.html.markdown
+++ b/website/docs/r/kusto_eventhub_data_connection.html.markdown
@@ -106,7 +106,7 @@ The following arguments are supported:
 
 * `data_format` - (Optional) Specifies the data format of the EventHub messages. Allowed values: `APACHEAVRO`, `AVRO`, `CSV`, `JSON`, `MULTIJSON`, `ORC`, `PARQUET`, `PSV`, `RAW`, `SCSV`, `SINGLEJSON`, `SOHSV`, `TSVE`, `TSV`, `TXT`, and `W3CLOGFILE`.
 
-* `database_routing_type` - (Optional) Indication for database routing information from the data connection, by default only database routing information is allowed. Allowed values: `Single`, `Multi`.
+* `database_routing_type` - (Optional) Indication for database routing information from the data connection, by default only database routing information is allowed. Allowed values: `Single`, `Multi`. Changing this forces a new resource to be created.
 
 ## Attributes Reference
 

--- a/website/docs/r/kusto_iothub_data_connection.html.markdown
+++ b/website/docs/r/kusto_iothub_data_connection.html.markdown
@@ -104,13 +104,13 @@ The following arguments are supported:
 
 * `event_system_properties` - (Optional) Specifies the System Properties that each IoT Hub message should contain. Changing this forces a new resource to be created. Possible values are `message-id`, `sequence-number`, `to`, `absolute-expiry-time`, `iothub-enqueuedtime`, `correlation-id`, `user-id`, `iothub-ack`, `iothub-connection-device-id`, `iothub-connection-auth-generation-id` and `iothub-connection-auth-method`.
 
-* `table_name` - (Optional) Specifies the target table name used for the message ingestion. Table must exist before resource is created.
+* `table_name` - (Optional) Specifies the target table name used for the message ingestion. Table must exist before resource is created. Changing this forces a new resource to be created.
 
-* `mapping_rule_name` - (Optional) Specifies the mapping rule used for the message ingestion. Mapping rule must exist before resource is created.
+* `mapping_rule_name` - (Optional) Specifies the mapping rule used for the message ingestion. Mapping rule must exist before resource is created. Changing this forces a new resource to be created.
 
-* `data_format` - (Optional) Specifies the data format of the IoTHub messages. Allowed values: `APACHEAVRO`, `AVRO`, `CSV`, `JSON`, `MULTIJSON`, `ORC`, `PARQUET`, `PSV`, `RAW`, `SCSV`, `SINGLEJSON`, `SOHSV`, `TSV`, `TSVE`, `TXT` and `W3CLOGFILE`.
+* `data_format` - (Optional) Specifies the data format of the IoTHub messages. Allowed values: `APACHEAVRO`, `AVRO`, `CSV`, `JSON`, `MULTIJSON`, `ORC`, `PARQUET`, `PSV`, `RAW`, `SCSV`, `SINGLEJSON`, `SOHSV`, `TSV`, `TSVE`, `TXT` and `W3CLOGFILE`. Changing this forces a new resource to be created.
 
-* `database_routing_type` - (Optional) Indication for database routing information from the data connection, by default only database routing information is allowed. Allowed values: `Single`, `Multi`.
+* `database_routing_type` - (Optional) Indication for database routing information from the data connection, by default only database routing information is allowed. Allowed values: `Single`, `Multi`. Changing this forces a new resource to be created.
 
 ## Attributes Reference
 

--- a/website/docs/r/kusto_script.html.markdown
+++ b/website/docs/r/kusto_script.html.markdown
@@ -104,9 +104,9 @@ The following arguments are supported:
 
 * `force_an_update_when_value_changed` - (Optional) A unique string. If changed the script will be applied again.
 
-* `script_content` - (Optional) The script content. This property should be used when the script is provide inline and not through file in a SA. Must not be used together with `url` and `sas_token` properties.
+* `script_content` - (Optional) The script content. This property should be used when the script is provide inline and not through file in a SA. Must not be used together with `url` and `sas_token` properties. Changing this forces a new resource to be created.
 
-* `sas_token` - (Optional) The SAS token used to access the script. Must be provided when using scriptUrl property.
+* `sas_token` - (Optional) The SAS token used to access the script. Must be provided when using scriptUrl property. Changing this forces a new resource to be created.
 
 * `url` - (Optional) The url to the KQL script blob file.  Must not be used together with scriptContent property. Please reference [this documentation](https://docs.microsoft.com/azure/data-explorer/database-script) that describes the commands that are allowed in the script.
 

--- a/website/docs/r/lb.html.markdown
+++ b/website/docs/r/lb.html.markdown
@@ -41,11 +41,11 @@ resource "azurerm_lb" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name of the Load Balancer.
+* `name` - (Required) Specifies the name of the Load Balancer. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) The name of the Resource Group in which to create the Load Balancer.
+* `resource_group_name` - (Required) The name of the Resource Group in which to create the Load Balancer. Changing this forces a new resource to be created.
 
-* `location` - (Required) Specifies the supported Azure Region where the Load Balancer should be created.
+* `location` - (Required) Specifies the supported Azure Region where the Load Balancer should be created. Changing this forces a new resource to be created.
 
 ---
 
@@ -53,7 +53,7 @@ The following arguments are supported:
 
 * `frontend_ip_configuration` - (Optional) One or multiple `frontend_ip_configuration` blocks as documented below.
 
-* `sku` - (Optional) The SKU of the Azure Load Balancer. Accepted values are `Basic`, `Standard` and `Gateway`. Defaults to `Basic`.
+* `sku` - (Optional) The SKU of the Azure Load Balancer. Accepted values are `Basic`, `Standard` and `Gateway`. Defaults to `Basic`. Changing this forces a new resource to be created.
 
 -> **NOTE:** The `Microsoft.Network/AllowGatewayLoadBalancer` feature is required to be registered in order to use the `Gateway` SKU. The feature can only be registered by the Azure service team, please submit an [Azure support ticket](https://azure.microsoft.com/en-us/support/create-ticket/) for that.
 
@@ -62,7 +62,7 @@ The following arguments are supported:
 
 `frontend_ip_configuration` supports the following:
 
-* `name` - (Required) Specifies the name of the frontend IP configuration.
+* `name` - (Required) Specifies the name of the frontend IP configuration. Changing this forces a new resource to be created.
 
 * `zones` - (Optional) Specifies a list of Availability Zones in which the IP Address for this Load Balancer should be located. Changing this forces a new Load Balancer to be created.
 

--- a/website/docs/r/lb_backend_address_pool.html.markdown
+++ b/website/docs/r/lb_backend_address_pool.html.markdown
@@ -48,9 +48,9 @@ resource "azurerm_lb_backend_address_pool" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name of the Backend Address Pool.
+* `name` - (Required) Specifies the name of the Backend Address Pool. Changing this forces a new resource to be created.
   
-* `loadbalancer_id` - (Required) The ID of the Load Balancer in which to create the Backend Address Pool.
+* `loadbalancer_id` - (Required) The ID of the Load Balancer in which to create the Backend Address Pool. Changing this forces a new resource to be created.
 
 * `tunnel_interface` - (Optional) One or more `tunnel_interface` blocks as defined below.
 

--- a/website/docs/r/lb_nat_pool.html.markdown
+++ b/website/docs/r/lb_nat_pool.html.markdown
@@ -56,9 +56,9 @@ resource "azurerm_lb_nat_pool" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name of the NAT pool.
-* `resource_group_name` - (Required) The name of the resource group in which to create the resource.
-* `loadbalancer_id` - (Required) The ID of the Load Balancer in which to create the NAT pool.
+* `name` - (Required) Specifies the name of the NAT pool. Changing this forces a new resource to be created.
+* `resource_group_name` - (Required) The name of the resource group in which to create the resource. Changing this forces a new resource to be created.
+* `loadbalancer_id` - (Required) The ID of the Load Balancer in which to create the NAT pool. Changing this forces a new resource to be created.
 * `frontend_ip_configuration_name` - (Required) The name of the frontend IP configuration exposing this rule.
 * `protocol` - (Required) The transport protocol for the external endpoint. Possible values are `All`, `Tcp` and `Udp`.
 * `frontend_port_start` - (Required) The first port number in the range of external ports that will be used to provide Inbound NAT to NICs associated with this Load Balancer. Possible values range between 1 and 65534, inclusive.

--- a/website/docs/r/lb_nat_rule.html.markdown
+++ b/website/docs/r/lb_nat_rule.html.markdown
@@ -73,9 +73,9 @@ resource "azurerm_lb_nat_rule" "example1" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name of the NAT Rule.
-* `resource_group_name` - (Required) The name of the resource group in which to create the resource.
-* `loadbalancer_id` - (Required) The ID of the Load Balancer in which to create the NAT Rule.
+* `name` - (Required) Specifies the name of the NAT Rule. Changing this forces a new resource to be created.
+* `resource_group_name` - (Required) The name of the resource group in which to create the resource. Changing this forces a new resource to be created.
+* `loadbalancer_id` - (Required) The ID of the Load Balancer in which to create the NAT Rule. Changing this forces a new resource to be created.
 * `frontend_ip_configuration_name` - (Required) The name of the frontend IP configuration exposing this rule.
 * `protocol` - (Required) The transport protocol for the external endpoint. Possible values are `Udp`, `Tcp` or `All`.
 * `frontend_port` - (Optional) The port for the external endpoint. Port numbers for each Rule must be unique within the Load Balancer. Possible values range between 1 and 65534, inclusive.

--- a/website/docs/r/lb_probe.html.markdown
+++ b/website/docs/r/lb_probe.html.markdown
@@ -49,8 +49,8 @@ resource "azurerm_lb_probe" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name of the Probe.
-* `loadbalancer_id` - (Required) The ID of the LoadBalancer in which to create the NAT Rule.
+* `name` - (Required) Specifies the name of the Probe. Changing this forces a new resource to be created.
+* `loadbalancer_id` - (Required) The ID of the LoadBalancer in which to create the NAT Rule. Changing this forces a new resource to be created.
 * `protocol` - (Optional) Specifies the protocol of the end point. Possible values are `Http`, `Https` or `Tcp`. If TCP is specified, a received ACK is required for the probe to be successful. If HTTP is specified, a 200 OK response from the specified URI is required for the probe to be successful.
 * `port` - (Required) Port on which the Probe queries the backend endpoint. Possible values range from 1 to 65535, inclusive.
 * `request_path` - (Optional) The URI used for requesting health status from the backend endpoint. Required if protocol is set to `Http` or `Https`. Otherwise, it is not allowed.

--- a/website/docs/r/lb_rule.html.markdown
+++ b/website/docs/r/lb_rule.html.markdown
@@ -52,8 +52,8 @@ resource "azurerm_lb_rule" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name of the LB Rule.
-* `loadbalancer_id` - (Required) The ID of the Load Balancer in which to create the Rule.
+* `name` - (Required) Specifies the name of the LB Rule. Changing this forces a new resource to be created.
+* `loadbalancer_id` - (Required) The ID of the Load Balancer in which to create the Rule. Changing this forces a new resource to be created.
 * `frontend_ip_configuration_name` - (Required) The name of the frontend IP configuration to which the rule is associated.
 * `protocol` - (Required) The transport protocol for the external endpoint. Possible values are `Tcp`, `Udp` or `All`.
 * `frontend_port` - (Required) The port for the external endpoint. Port numbers for each Rule must be unique within the Load Balancer. Possible values range between 0 and 65534, inclusive.

--- a/website/docs/r/linux_function_app_slot.html.markdown
+++ b/website/docs/r/linux_function_app_slot.html.markdown
@@ -128,7 +128,7 @@ The following arguments are supported:
 
 an `auth_settings` block supports the following:
 
-* `enabled` - (Required) Should the Authentication / Authorization feature be enabled?
+* `enabled` - (Optional) Should the Authentication / Authorization feature be enabled?
 
 * `active_directory` - (Optional) an `active_directory` block as detailed below.
 

--- a/website/docs/r/linux_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/linux_virtual_machine_scale_set.html.markdown
@@ -136,7 +136,7 @@ resource "azurerm_linux_virtual_machine_scale_set" "example" {
 
 ~> **NOTE:** `single_placement_group` must be set to `false` when `capacity_reservation_group_id` is specified.
 
-* `computer_name_prefix` - (Optional) The prefix which should be used for the name of the Virtual Machines in this Scale Set. If unspecified this defaults to the value for the `name` field. If the value of the `name` field is not a valid `computer_name_prefix`, then you must specify `computer_name_prefix`.
+* `computer_name_prefix` - (Optional) The prefix which should be used for the name of the Virtual Machines in this Scale Set. If unspecified this defaults to the value for the `name` field. If the value of the `name` field is not a valid `computer_name_prefix`, then you must specify `computer_name_prefix`. Changing this forces a new resource to be created.
 
 * `custom_data` - (Optional) The Base64-Encoded Custom Data which should be used for this Virtual Machine Scale Set.
 
@@ -144,7 +144,7 @@ resource "azurerm_linux_virtual_machine_scale_set" "example" {
 
 * `data_disk` - (Optional) One or more `data_disk` blocks as defined below.
 
-* `disable_password_authentication` - Should Password Authentication be disabled on this Virtual Machine Scale Set? Defaults to `true`.
+* `disable_password_authentication` - (Optional) Should Password Authentication be disabled on this Virtual Machine Scale Set? Defaults to `true`.
 
 -> In general we'd recommend using SSH Keys for authentication rather than Passwords - but there's tradeoff's to each - please [see this thread for more information](https://security.stackexchange.com/questions/69407/why-is-using-an-ssh-key-more-secure-than-using-passwords).
 
@@ -224,7 +224,7 @@ resource "azurerm_linux_virtual_machine_scale_set" "example" {
 
 * `termination_notification` - (Optional) A `termination_notification` block as defined below.
 
-* `upgrade_mode` - (Optional) Specifies how Upgrades (e.g. changing the Image/SKU) should be performed to Virtual Machine Instances. Possible values are `Automatic`, `Manual` and `Rolling`. Defaults to `Manual`.
+* `upgrade_mode` - (Optional) Specifies how Upgrades (e.g. changing the Image/SKU) should be performed to Virtual Machine Instances. Possible values are `Automatic`, `Manual` and `Rolling`. Defaults to `Manual`. Changing this forces a new resource to be created.
 
 * `user_data` - (Optional) The Base64-Encoded User Data which should be used for this Virtual Machine Scale Set.
 
@@ -304,7 +304,7 @@ A `data_disk` block supports the following:
 
 -> **NOTE:** `UltraSSD_LRS` is only supported when `ultra_ssd_enabled` within the `additional_capabilities` block is enabled.
 
-* `disk_encryption_set_id` - (Optional) The ID of the Disk Encryption Set which should be used to encrypt this Data Disk.
+* `disk_encryption_set_id` - (Optional) The ID of the Disk Encryption Set which should be used to encrypt this Data Disk. Changing this forces a new resource to be created.
 
 -> **NOTE:** The Disk Encryption Set must have the `Reader` Role Assignment scoped on the Key Vault - in addition to an Access Policy to the Key Vault
 
@@ -450,11 +450,11 @@ An `os_disk` block supports the following:
 
 * `caching` - (Required) The Type of Caching which should be used for the Internal OS Disk. Possible values are `None`, `ReadOnly` and `ReadWrite`.
 
-* `storage_account_type` - (Required) The Type of Storage Account which should back this the Internal OS Disk. Possible values include `Standard_LRS`, `StandardSSD_LRS`, `StandardSSD_ZRS`, `Premium_LRS` and `Premium_ZRS`.
+* `storage_account_type` - (Required) The Type of Storage Account which should back this the Internal OS Disk. Possible values include `Standard_LRS`, `StandardSSD_LRS`, `StandardSSD_ZRS`, `Premium_LRS` and `Premium_ZRS`. Changing this forces a new resource to be created.
 
 * `diff_disk_settings` - (Optional) A `diff_disk_settings` block as defined above. Changing this forces a new resource to be created.
 
-* `disk_encryption_set_id` - (Optional) The ID of the Disk Encryption Set which should be used to encrypt this OS Disk. Conflicts with `secure_vm_disk_encryption_set_id`.
+* `disk_encryption_set_id` - (Optional) The ID of the Disk Encryption Set which should be used to encrypt this OS Disk. Conflicts with `secure_vm_disk_encryption_set_id`. Changing this forces a new resource to be created.
 
 -> **NOTE:** The Disk Encryption Set must have the `Reader` Role Assignment scoped on the Key Vault - in addition to an Access Policy to the Key Vault
 
@@ -570,13 +570,13 @@ A `termination_notification` block supports the following:
 
 A `source_image_reference` block supports the following:
 
-* `publisher` - (Optional) Specifies the publisher of the image used to create the virtual machines.
+* `publisher` - (Required) Specifies the publisher of the image used to create the virtual machines.
 
-* `offer` - (Optional) Specifies the offer of the image used to create the virtual machines.
+* `offer` - (Required) Specifies the offer of the image used to create the virtual machines.
 
-* `sku` - (Optional) Specifies the SKU of the image used to create the virtual machines.
+* `sku` - (Required) Specifies the SKU of the image used to create the virtual machines.
 
-* `version` - (Optional) Specifies the version of the image used to create the virtual machines.
+* `version` - (Required) Specifies the version of the image used to create the virtual machines.
 
 ---
 

--- a/website/docs/r/local_network_gateway.html.markdown
+++ b/website/docs/r/local_network_gateway.html.markdown
@@ -31,8 +31,7 @@ resource "azurerm_local_network_gateway" "home" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the local network gateway. Changing this Changing this forces a new resource to be created.
-    forces a new resource to be created.
+* `name` - (Required) The name of the local network gateway. Changing this forces a new resource to be created.
 
 * `resource_group_name` - (Required) The name of the resource group in which to Changing this forces a new resource to be created.
     create the local network gateway.

--- a/website/docs/r/local_network_gateway.html.markdown
+++ b/website/docs/r/local_network_gateway.html.markdown
@@ -31,13 +31,13 @@ resource "azurerm_local_network_gateway" "home" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the local network gateway. Changing this
+* `name` - (Required) The name of the local network gateway. Changing this Changing this forces a new resource to be created.
     forces a new resource to be created.
 
-* `resource_group_name` - (Required) The name of the resource group in which to
+* `resource_group_name` - (Required) The name of the resource group in which to Changing this forces a new resource to be created.
     create the local network gateway.
 
-* `location` - (Required) The location/region where the local network gateway is
+* `location` - (Required) The location/region where the local network gateway is Changing this forces a new resource to be created.
     created. Changing this forces a new resource to be created.
 
 * `address_space` - (Optional) The list of string CIDRs representing the

--- a/website/docs/r/local_network_gateway.html.markdown
+++ b/website/docs/r/local_network_gateway.html.markdown
@@ -35,8 +35,7 @@ The following arguments are supported:
 
 * `resource_group_name` - (Required) The name of the resource group in which to create the local network gateway. Changing this forces a new resource to be created.
 
-* `location` - (Required) The location/region where the local network gateway is Changing this forces a new resource to be created.
-    created. Changing this forces a new resource to be created.
+* `location` - (Required) The location/region where the local network gateway is created. Changing this forces a new resource to be created.
 
 * `address_space` - (Optional) The list of string CIDRs representing the
     address spaces the gateway exposes.

--- a/website/docs/r/local_network_gateway.html.markdown
+++ b/website/docs/r/local_network_gateway.html.markdown
@@ -33,8 +33,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the local network gateway. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) The name of the resource group in which to Changing this forces a new resource to be created.
-    create the local network gateway.
+* `resource_group_name` - (Required) The name of the resource group in which to create the local network gateway. Changing this forces a new resource to be created.
 
 * `location` - (Required) The location/region where the local network gateway is Changing this forces a new resource to be created.
     created. Changing this forces a new resource to be created.

--- a/website/docs/r/log_analytics_cluster.html.markdown
+++ b/website/docs/r/log_analytics_cluster.html.markdown
@@ -57,7 +57,7 @@ The following arguments are supported:
 
 An `identity` block supports the following:
 
-* `type` - (Required) Specifies the type of Managed Service Identity that should be configured on this Log Analytics Cluster. The only possible value is `SystemAssigned`.
+* `type` - (Required) Specifies the type of Managed Service Identity that should be configured on this Log Analytics Cluster. The only possible value is `SystemAssigned`. Changing this forces a new resource to be created.
 
 ~> **NOTE:** The assigned `principal_id` and `tenant_id` can be retrieved after the identity `type` has been set to `SystemAssigned` and the Log Analytics Cluster has been created. More details are available below.
 

--- a/website/docs/r/log_analytics_linked_service.html.markdown
+++ b/website/docs/r/log_analytics_linked_service.html.markdown
@@ -50,7 +50,7 @@ The following arguments are supported:
 
 * `resource_group_name` - (Required) The name of the resource group in which the Log Analytics Linked Service is created. Changing this forces a new resource to be created.
 
-* `workspace_id` - (Required) The ID of the Log Analytics Workspace that will contain the Log Analytics Linked Service resource. Changing this forces a new resource to be created.
+* `workspace_id` - (Required) The ID of the Log Analytics Workspace that will contain the Log Analytics Linked Service resource. 
 
 * `read_access_id` - (Optional) The ID of the readable Resource that will be linked to the workspace. This should be used for linking to an Automation Account resource.
 

--- a/website/docs/r/log_analytics_saved_search.html.markdown
+++ b/website/docs/r/log_analytics_saved_search.html.markdown
@@ -54,7 +54,7 @@ The following arguments are supported:
 
 * `function_parameters` - (Optional) The function parameters if the query serves as a function. Changing this forces a new resource to be created.
 
-* `tags` - (Optional) A mapping of tags which should be assigned to the Logs Analytics Saved Search.
+* `tags` - (Optional) A mapping of tags which should be assigned to the Logs Analytics Saved Search. Changing this forces a new resource to be created.
 
 ## Attributes Reference
 

--- a/website/docs/r/log_analytics_solution.html.markdown
+++ b/website/docs/r/log_analytics_solution.html.markdown
@@ -74,7 +74,7 @@ A `plan` block includes:
 
 * `product` - (Required) The product name of the solution. For example `OMSGallery/Containers`. Changing this forces a new resource to be created.
 
-* `promotion_code` - (Optional) A promotion code to be used with the solution.
+* `promotion_code` - (Optional) A promotion code to be used with the solution. Changing this forces a new resource to be created.
 
 ## Timeouts
 

--- a/website/docs/r/logic_app_integration_account_session.html.markdown
+++ b/website/docs/r/logic_app_integration_account_session.html.markdown
@@ -48,7 +48,7 @@ The following arguments are supported:
 
 * `integration_account_name` - (Required) The name of the Logic App Integration Account. Changing this forces a new Logic App Integration Account Session to be created.
 
-* `content` - (Optional) The content of the Logic App Integration Account Session.
+* `content` - (Required) The content of the Logic App Integration Account Session.
 
 ## Attributes Reference
 

--- a/website/docs/r/logic_app_standard.html.markdown
+++ b/website/docs/r/logic_app_standard.html.markdown
@@ -113,7 +113,7 @@ The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the Logic App Changing this forces a new resource to be created. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) The name of the resource group in which to create the Logic App Changing this forces a new resource to be created.
+* `resource_group_name` - (Required) The name of the resource group in which to create the Logic App. Changing this forces a new resource to be created.
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 
@@ -141,7 +141,7 @@ The following arguments are supported:
 
 * `site_config` - (Optional) A `site_config` object as defined below.
 
-* `storage_account_name` - (Required) The backend storage account name which will be used by this Logic App (e.g. for Stateful workflows data) Changing this forces a new resource to be created.
+* `storage_account_name` - (Required) The backend storage account name which will be used by this Logic App (e.g. for Stateful workflows data). Changing this forces a new resource to be created.
 
 * `storage_account_access_key` - (Required) The access key which will be used to access the backend storage account for the Logic App
 

--- a/website/docs/r/logic_app_standard.html.markdown
+++ b/website/docs/r/logic_app_standard.html.markdown
@@ -111,9 +111,9 @@ resource "azurerm_logic_app_standard" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name of the Logic App Changing this forces a new resource to be created.
+* `name` - (Required) Specifies the name of the Logic App Changing this forces a new resource to be created. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) The name of the resource group in which to create the Logic App
+* `resource_group_name` - (Required) The name of the resource group in which to create the Logic App Changing this forces a new resource to be created.
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 
@@ -141,7 +141,7 @@ The following arguments are supported:
 
 * `site_config` - (Optional) A `site_config` object as defined below.
 
-* `storage_account_name` - (Required) The backend storage account name which will be used by this Logic App (e.g. for Stateful workflows data)
+* `storage_account_name` - (Required) The backend storage account name which will be used by this Logic App (e.g. for Stateful workflows data) Changing this forces a new resource to be created.
 
 * `storage_account_access_key` - (Required) The access key which will be used to access the backend storage account for the Logic App
 
@@ -165,7 +165,7 @@ The following arguments are supported:
 
 `connection_string` supports the following:
 
-* `name` - (Required) The name of the Connection String.
+* `name` - (Required) The name of the Connection String. Changing this forces a new resource to be created.
 
 * `type` - (Required) The type of the Connection String. Possible values are `APIHub`, `Custom`, `DocDb`, `EventHub`, `MySQL`, `NotificationHub`, `PostgreSQL`, `RedisCache`, `ServiceBus`, `SQLAzure` and  `SQLServer`.
 

--- a/website/docs/r/logic_app_trigger_recurrence.html.markdown
+++ b/website/docs/r/logic_app_trigger_recurrence.html.markdown
@@ -56,11 +56,11 @@ The following arguments are supported:
 
 A `schedule` block supports the following:
 
-* `at_these_minutes` - Specifies a list of minutes when the trigger should run. Valid values are between 0 and 59.
+* `at_these_minutes` - (Optional) Specifies a list of minutes when the trigger should run. Valid values are between 0 and 59.
 
-* `at_these_hours` - Specifies a list of hours when the trigger should run. Valid values are between 0 and 23.
+* `at_these_hours` - (Optional) Specifies a list of hours when the trigger should run. Valid values are between 0 and 23.
 
-* `on_these_days` - Specifies a list of days when the trigger should run. Valid values include `Monday`, `Tuesday`, `Wednesday`, `Thursday`, `Friday`, `Saturday`, and `Sunday`.
+* `on_these_days` - (Optional) Specifies a list of days when the trigger should run. Valid values include `Monday`, `Tuesday`, `Wednesday`, `Thursday`, `Friday`, `Saturday`, and `Sunday`.
 
 ## Attributes Reference
 

--- a/website/docs/r/machine_learning_compute_cluster.html.markdown
+++ b/website/docs/r/machine_learning_compute_cluster.html.markdown
@@ -133,9 +133,9 @@ The following arguments are supported:
 
 An `identity` block supports the following:
 
-* `type` - (Required) Specifies the type of Managed Service Identity that should be configured on this Machine Learning Compute Cluster. Possible values are `SystemAssigned`, `UserAssigned`, `SystemAssigned, UserAssigned` (to enable both).
+* `type` - (Required) Specifies the type of Managed Service Identity that should be configured on this Machine Learning Compute Cluster. Possible values are `SystemAssigned`, `UserAssigned`, `SystemAssigned, UserAssigned` (to enable both). Changing this forces a new resource to be created.
 
-* `identity_ids` - (Optional) Specifies a list of User Assigned Managed Identity IDs to be assigned to this Machine Learning Compute Cluster.
+* `identity_ids` - (Optional) Specifies a list of User Assigned Managed Identity IDs to be assigned to this Machine Learning Compute Cluster. Changing this forces a new resource to be created.
 
 ~> **NOTE:** This is required when `type` is set to `UserAssigned` or `SystemAssigned, UserAssigned`.
 

--- a/website/docs/r/machine_learning_compute_instance.html.markdown
+++ b/website/docs/r/machine_learning_compute_instance.html.markdown
@@ -127,9 +127,9 @@ The following arguments are supported:
 
 An `identity` block supports the following:
 
-* `type` - (Required) Specifies the type of Managed Service Identity that should be configured on this Machine Learning Compute Instance. Possible values are `SystemAssigned`, `UserAssigned`, `SystemAssigned, UserAssigned` (to enable both).
+* `type` - (Required) Specifies the type of Managed Service Identity that should be configured on this Machine Learning Compute Instance. Possible values are `SystemAssigned`, `UserAssigned`, `SystemAssigned, UserAssigned` (to enable both). Changing this forces a new resource to be created.
 
-* `identity_ids` - (Optional) Specifies a list of User Assigned Managed Identity IDs to be assigned to this Machine Learning Compute Instance.
+* `identity_ids` - (Optional) Specifies a list of User Assigned Managed Identity IDs to be assigned to this Machine Learning Compute Instance. Changing this forces a new resource to be created.
 
 ~> **NOTE:** This is required when `type` is set to `UserAssigned` or `SystemAssigned, UserAssigned`.
 

--- a/website/docs/r/machine_learning_inference_cluster.html.markdown
+++ b/website/docs/r/machine_learning_inference_cluster.html.markdown
@@ -141,9 +141,9 @@ The following arguments are supported:
 
 An `identity` block supports the following:
 
-* `type` - (Required) Specifies the type of Managed Service Identity that should be configured on this Machine Learning Inference Cluster. Possible values are `SystemAssigned`, `UserAssigned`, `SystemAssigned, UserAssigned` (to enable both).
+* `type` - (Required) Specifies the type of Managed Service Identity that should be configured on this Machine Learning Inference Cluster. Possible values are `SystemAssigned`, `UserAssigned`, `SystemAssigned, UserAssigned` (to enable both). Changing this forces a new resource to be created.
 
-* `identity_ids` - (Optional) Specifies a list of User Assigned Managed Identity IDs to be assigned to this Machine Learning Inference Cluster.
+* `identity_ids` - (Optional) Specifies a list of User Assigned Managed Identity IDs to be assigned to this Machine Learning Inference Cluster. Changing this forces a new resource to be created.
 
 ~> **NOTE:** This is required when `type` is set to `UserAssigned` or `SystemAssigned, UserAssigned`.
 

--- a/website/docs/r/machine_learning_synapse_spark.html.markdown
+++ b/website/docs/r/machine_learning_synapse_spark.html.markdown
@@ -123,9 +123,9 @@ The following arguments are supported:
 
 An `identity` block supports the following:
 
-* `type` - (Required) Specifies the type of Managed Service Identity that should be configured on this Machine Learning Synapse Spark. Possible values are `SystemAssigned`, `UserAssigned`, `SystemAssigned, UserAssigned` (to enable both).
+* `type` - (Required) Specifies the type of Managed Service Identity that should be configured on this Machine Learning Synapse Spark. Possible values are `SystemAssigned`, `UserAssigned`, `SystemAssigned, UserAssigned` (to enable both). Changing this forces a new resource to be created.
 
-* `identity_ids` - (Optional) Specifies a list of User Assigned Managed Identity IDs to be assigned to this Machine Learning Synapse Spark.
+* `identity_ids` - (Optional) Specifies a list of User Assigned Managed Identity IDs to be assigned to this Machine Learning Synapse Spark. Changing this forces a new resource to be created.
 
 ~> **NOTE:** This is required when `type` is set to `UserAssigned` or `SystemAssigned, UserAssigned`.
 

--- a/website/docs/r/machine_learning_workspace.html.markdown
+++ b/website/docs/r/machine_learning_workspace.html.markdown
@@ -344,7 +344,7 @@ The following arguments are supported:
 
 * `resource_group_name` - (Required) Specifies the name of the Resource Group in which the Machine Learning Workspace should exist. Changing this forces a new resource to be created.
 
-* `location` - (Optional) Specifies the supported Azure location where the Machine Learning Workspace should exist. Changing this forces a new resource to be created.
+* `location` - (Required) Specifies the supported Azure location where the Machine Learning Workspace should exist. Changing this forces a new resource to be created.
 
 * `application_insights_id` - (Required) The ID of the Application Insights associated with this Machine Learning Workspace. Changing this forces a new resource to be created.
 
@@ -360,13 +360,13 @@ The following arguments are supported:
 
 -> **NOTE:** The `admin_enabled` should be `true` in order to associate the Container Registry to this Machine Learning Workspace.
 
-* `public_access_behind_virtual_network_enabled` - (Optional) Enable public access when this Machine Learning Workspace is behind a VNet.
+* `public_access_behind_virtual_network_enabled` - (Optional) Enable public access when this Machine Learning Workspace is behind a VNet. Changing this forces a new resource to be created.
 
 * `public_network_access_enabled` - (Optional) Enable public access when this Machine Learning Workspace is behind VNet.
 
 ~> **NOTE:** `public_access_behind_virtual_network_enabled` is deprecated and will be removed in favour of the property `public_network_access_enabled`.
 
-* `image_build_compute_name` - (Optional) The compute name for image build of the Machine Learning Workspace.
+* `image_build_compute_name` - (Optional) The compute name for image build of the Machine Learning Workspace. Changing this forces a new resource to be created.
 
 * `description` - (Optional) The description of this Machine Learning Workspace.
 

--- a/website/docs/r/managed_application.html.markdown
+++ b/website/docs/r/managed_application.html.markdown
@@ -63,7 +63,7 @@ resource "azurerm_managed_application" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name of the Managed Application. Changing this forces a new resource to be created.
+* `name` - (Required) Specifies the name of the Managed Application. Changing this forces a new resource to be created. Changing this forces a new resource to be created.
 
 * `resource_group_name` - (Required) The name of the Resource Group where the Managed Application should exist. Changing this forces a new resource to be created.
 
@@ -87,7 +87,7 @@ The following arguments are supported:
 
 The `plan` block exports the following:
 
-* `name` - (Required) Specifies the name of the plan from the marketplace.
+* `name` - (Required) Specifies the name of the plan from the marketplace. Changing this forces a new resource to be created.
 
 * `product` - (Required) Specifies the product of the plan from the marketplace.
 

--- a/website/docs/r/managed_application_definition.html.markdown
+++ b/website/docs/r/managed_application_definition.html.markdown
@@ -56,7 +56,7 @@ The following arguments are supported:
 
 * `create_ui_definition` - (Optional) Specifies the `createUiDefinition` JSON for the backing template with `Microsoft.Solutions/applications` resource.
 
-* `display_name` - (Optional) Specifies the managed application definition display name.
+* `display_name` - (Required) Specifies the managed application definition display name.
 
 * `description` - (Optional) Specifies the managed application definition description.
 

--- a/website/docs/r/managed_disk.html.markdown
+++ b/website/docs/r/managed_disk.html.markdown
@@ -129,7 +129,7 @@ The following arguments are supported:
 
 * `os_type` - (Optional) Specify a value when the source of an `Import` or `Copy` operation targets a source that contains an operating system. Valid values are `Linux` or `Windows`.
 
-* `source_resource_id` - (Optional) The ID of an existing Managed Disk or Snapshot to copy when `create_option` is `Copy` or the recovery point to restore when `create_option` is `Restore` Changing this forces a new resource to be created.
+* `source_resource_id` - (Optional) The ID of an existing Managed Disk or Snapshot to copy when `create_option` is `Copy` or the recovery point to restore when `create_option` is `Restore`. Changing this forces a new resource to be created.
 
 * `source_uri` - (Optional) URI to a valid VHD file to be used when `create_option` is `Import`. Changing this forces a new resource to be created.
 

--- a/website/docs/r/managed_disk.html.markdown
+++ b/website/docs/r/managed_disk.html.markdown
@@ -74,7 +74,7 @@ The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the Managed Disk. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) The name of the Resource Group where the Managed Disk should exist.
+* `resource_group_name` - (Required) The name of the Resource Group where the Managed Disk should exist. Changing this forces a new resource to be created.
 
 * `location` - (Required) Specified the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 
@@ -119,9 +119,9 @@ The following arguments are supported:
 
 * `hyper_v_generation` - (Optional) The HyperV Generation of the Disk when the source of an `Import` or `Copy` operation targets a source that contains an operating system. Possible values are `V1` and `V2`. Changing this forces a new resource to be created.
 
-* `image_reference_id` - (Optional) ID of an existing platform/marketplace disk image to copy when `create_option` is `FromImage`. This field cannot be specified if gallery_image_reference_id is specified.
+* `image_reference_id` - (Optional) ID of an existing platform/marketplace disk image to copy when `create_option` is `FromImage`. This field cannot be specified if gallery_image_reference_id is specified. Changing this forces a new resource to be created.
 
-* `gallery_image_reference_id` - (Optional) ID of a Gallery Image Version to copy when `create_option` is `FromImage`. This field cannot be specified if image_reference_id is specified.
+* `gallery_image_reference_id` - (Optional) ID of a Gallery Image Version to copy when `create_option` is `FromImage`. This field cannot be specified if image_reference_id is specified. Changing this forces a new resource to be created.
 
 * `logical_sector_size` - (Optional) Logical Sector Size. Possible values are: `512` and `4096`. Defaults to `4096`. Changing this forces a new resource to be created.
 
@@ -129,9 +129,9 @@ The following arguments are supported:
 
 * `os_type` - (Optional) Specify a value when the source of an `Import` or `Copy` operation targets a source that contains an operating system. Valid values are `Linux` or `Windows`.
 
-* `source_resource_id` - (Optional) The ID of an existing Managed Disk or Snapshot to copy when `create_option` is `Copy` or the recovery point to restore when `create_option` is `Restore`
+* `source_resource_id` - (Optional) The ID of an existing Managed Disk or Snapshot to copy when `create_option` is `Copy` or the recovery point to restore when `create_option` is `Restore` Changing this forces a new resource to be created.
 
-* `source_uri` - (Optional) URI to a valid VHD file to be used when `create_option` is `Import`.
+* `source_uri` - (Optional) URI to a valid VHD file to be used when `create_option` is `Import`. Changing this forces a new resource to be created.
 
 * `storage_account_id` - (Optional) The ID of the Storage Account where the `source_uri` is located. Required when `create_option` is set to `Import`.  Changing this forces a new resource to be created.
 
@@ -143,7 +143,7 @@ The following arguments are supported:
 
 -> **Note:** Premium SSD maxShares limit: `P15` and `P20` disks: 2. `P30`,`P40`,`P50` disks: 5. `P60`,`P70`,`P80` disks: 10. For ultra disks the `max_shares` minimum value is 1 and the maximum is 5.
 
-* `trusted_launch_enabled` (Optional) Specifies if Trusted Launch is enabled for the Managed Disk. Defaults to `false`.
+* `trusted_launch_enabled` (Optional) Specifies if Trusted Launch is enabled for the Managed Disk. Defaults to `false`. Changing this forces a new resource to be created.
 
 -> **Note:** Trusted Launch can only be enabled when `create_option` is `FromImage` or `Import`.
 
@@ -167,9 +167,9 @@ The following arguments are supported:
 
 ~> **Note:** Availability Zones are [only supported in select regions at this time](https://docs.microsoft.com/azure/availability-zones/az-overview).
 
-* `network_access_policy` - Policy for accessing the disk via network. Allowed values are `AllowAll`, `AllowPrivate`, and `DenyAll`.
+* `network_access_policy` - (Optional) Policy for accessing the disk via network. Allowed values are `AllowAll`, `AllowPrivate`, and `DenyAll`.
 
-* `disk_access_id` - The ID of the disk access resource for using private endpoints on disks.
+* `disk_access_id` - (Optional) The ID of the disk access resource for using private endpoints on disks.
 
 ~> **Note:** `disk_access_id` is only supported when `network_access_policy` is set to `AllowPrivate`.
 

--- a/website/docs/r/management_group.html.markdown
+++ b/website/docs/r/management_group.html.markdown
@@ -45,7 +45,7 @@ The following arguments are supported:
 
 * `display_name` - (Optional) A friendly name for this Management Group. If not specified, this will be the same as the `name`.
 
-* `parent_management_group_id` - (Optional) The ID of the Parent Management Group. Changing this forces a new resource to be created.
+* `parent_management_group_id` - (Optional) The ID of the Parent Management Group. 
 
 * `subscription_ids` - (Optional) A list of Subscription GUIDs which should be assigned to the Management Group.
 

--- a/website/docs/r/management_group_policy_assignment.html.markdown
+++ b/website/docs/r/management_group_policy_assignment.html.markdown
@@ -82,7 +82,7 @@ The following arguments are supported:
 
 A `identity` block supports the following:
 
-* `type` - (Optional) The Type of Managed Identity which should be added to this Policy Definition. Possible values are `SystemAssigned` and `UserAssigned`.
+* `type` - (Required) The Type of Managed Identity which should be added to this Policy Definition. Possible values are `SystemAssigned` and `UserAssigned`.
 
 * `identity_ids` - (Optional) A list of User Managed Identity IDs which should be assigned to the Policy Definition.
 

--- a/website/docs/r/management_group_template_deployment.html.markdown
+++ b/website/docs/r/management_group_template_deployment.html.markdown
@@ -113,7 +113,7 @@ The following arguments are supported:
 
 * `location` - (Required) The Azure Region where the Template should exist. Changing this forces a new Template to be created.
 
-* `management_group_id` - (Required) The ID of the Management Group to apply the Deployment Template to.
+* `management_group_id` - (Required) The ID of the Management Group to apply the Deployment Template to. Changing this forces a new resource to be created.
 
 * `name` - (Required) The name which should be used for this Template Deployment. Changing this forces a new Template Deployment to be created.
 

--- a/website/docs/r/maps_account.html.markdown
+++ b/website/docs/r/maps_account.html.markdown
@@ -37,7 +37,7 @@ The following arguments are supported:
 
 * `resource_group_name` - (Required) The name of the Resource Group in which the Azure Maps Account should exist. Changing this forces a new resource to be created.
 
-* `sku_name` - (Required) The SKU of the Azure Maps Account. Possible values are `S0`, `S1` and `G2`.
+* `sku_name` - (Required) The SKU of the Azure Maps Account. Possible values are `S0`, `S1` and `G2`. Changing this forces a new resource to be created.
 
 * `tags` - (Optional) A mapping of tags to assign to the Azure Maps Account.
 

--- a/website/docs/r/maps_creator.html.markdown
+++ b/website/docs/r/maps_creator.html.markdown
@@ -48,7 +48,7 @@ The following arguments are supported:
 
 * `maps_account_id` - (Required) The ID of the Azure Maps Creator. Changing this forces a new resource to be created.
 
-* `location` - (Required) The Azure Region where the Azure Maps Creator should exist.
+* `location` - (Required) The Azure Region where the Azure Maps Creator should exist. Changing this forces a new resource to be created.
 
 * `storage_units` - (Required) The storage units to be allocated. Integer values from 1 to 100, inclusive.
 

--- a/website/docs/r/mariadb_configuration.html.markdown
+++ b/website/docs/r/mariadb_configuration.html.markdown
@@ -47,7 +47,7 @@ The following arguments are supported:
 
 * `resource_group_name` - (Required) The name of the resource group in which the MariaDB Server exists. Changing this forces a new resource to be created.
 
-* `value` - (Required) Specifies the value of the MariaDB Configuration. See the MariaDB documentation for valid values.
+* `value` - (Required) Specifies the value of the MariaDB Configuration. See the MariaDB documentation for valid values. Changing this forces a new resource to be created.
 
 ## Attributes Reference
 

--- a/website/docs/r/mariadb_firewall_rule.html.markdown
+++ b/website/docs/r/mariadb_firewall_rule.html.markdown
@@ -44,9 +44,9 @@ The following arguments are supported:
 
 * `resource_group_name` - (Required) The name of the resource group in which the MariaDB Server exists. Changing this forces a new resource to be created.
 
-* `start_ip_address` - (Required) Specifies the Start IP Address associated with this Firewall Rule. Changing this forces a new resource to be created.
+* `start_ip_address` - (Required) Specifies the Start IP Address associated with this Firewall Rule. 
 
-* `end_ip_address` - (Required) Specifies the End IP Address associated with this Firewall Rule. Changing this forces a new resource to be created.
+* `end_ip_address` - (Required) Specifies the End IP Address associated with this Firewall Rule. 
 
 -> **NOTE:** The Azure feature `Allow access to Azure services` can be enabled by setting `start_ip_address` and `end_ip_address` to `0.0.0.0` which ([is documented in the Azure API Docs](https://docs.microsoft.com/rest/api/sql/firewallrules/createorupdate)).
 

--- a/website/docs/r/mariadb_server.html.markdown
+++ b/website/docs/r/mariadb_server.html.markdown
@@ -56,9 +56,9 @@ The following arguments are supported:
 
 * `version` - (Required) Specifies the version of MariaDB to use. Possible values are `10.2` and `10.3`. Changing this forces a new resource to be created.
 
-* `administrator_login` - (Required) The Administrator login for the MariaDB Server. Changing this forces a new resource to be created.
+* `administrator_login` - (Optional) The Administrator login for the MariaDB Server. Changing this forces a new resource to be created.
 
-* `administrator_login_password` - (Required) The Password associated with the `administrator_login` for the MariaDB Server.
+* `administrator_login_password` - (Optional) The Password associated with the `administrator_login` for the MariaDB Server.
 
 * `auto_grow_enabled` - (Optional) Enable/Disable auto-growing of the storage. Storage auto-grow prevents your server from running out of storage and becoming read-only. If storage auto grow is enabled, the storage automatically grows without impacting the workload. The default value if not explicitly specified is `true`.
 
@@ -76,7 +76,7 @@ The following arguments are supported:
 
 * `ssl_enforcement_enabled` - (Required) Specifies if SSL should be enforced on connections. Possible values are `true` and `false`.
 
-* `storage_mb` - (Required) Max storage allowed for a server. Possible values are between `5120` MB (5GB) and `1024000`MB (1TB) for the Basic SKU and between `5120` MB (5GB) and `4096000` MB (4TB) for General Purpose/Memory Optimized SKUs. For more information see the [product documentation](https://docs.microsoft.com/rest/api/mariadb/servers/create#storageprofile).
+* `storage_mb` - (Optional) Max storage allowed for a server. Possible values are between `5120` MB (5GB) and `1024000`MB (1TB) for the Basic SKU and between `5120` MB (5GB) and `4096000` MB (4TB) for General Purpose/Memory Optimized SKUs. For more information see the [product documentation](https://docs.microsoft.com/rest/api/mariadb/servers/create#storageprofile).
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 

--- a/website/docs/r/media_job.html.markdown
+++ b/website/docs/r/media_job.html.markdown
@@ -109,7 +109,7 @@ An `input_asset` block supports the following:
 
 * `name` - (Required) The name of the input Asset. Changing this forces a new Media Job to be created.
 
-* `label` - (Optional) A label that is assigned to a JobInputClip, that is used to satisfy a reference used in the Transform. For example, a Transform can be authored so as to take an image file with the label 'xyz' and apply it as an overlay onto the input video before it is encoded. When submitting a Job, exactly one of the JobInputs should be the image file, and it should have the label 'xyz'.
+* `label` - (Optional) A label that is assigned to a JobInputClip, that is used to satisfy a reference used in the Transform. For example, a Transform can be authored so as to take an image file with the label 'xyz' and apply it as an overlay onto the input video before it is encoded. When submitting a Job, exactly one of the JobInputs should be the image file, and it should have the label 'xyz'. Changing this forces a new resource to be created.
 
 ---
 
@@ -117,7 +117,7 @@ An `output_asset` block supports the following:
 
 * `name` - (Required) The name of the output Asset. Changing this forces a new Media Job to be created.
 
-* `label` - (Optional) A label that is assigned to a JobOutput in order to help uniquely identify it. This is useful when your Transform has more than one TransformOutput, whereby your Job has more than one JobOutput. In such cases, when you submit the Job, you will add two or more JobOutputs, in the same order as TransformOutputs in the Transform. Subsequently, when you retrieve the Job, either through events or on a GET request, you can use the label to easily identify the JobOutput. If a label is not provided, a default value of '{presetName}_{outputIndex}' will be used, where the preset name is the name of the preset in the corresponding TransformOutput and the output index is the relative index of the this JobOutput within the Job. Note that this index is the same as the relative index of the corresponding TransformOutput within its Transform.
+* `label` - (Optional) A label that is assigned to a JobOutput in order to help uniquely identify it. This is useful when your Transform has more than one TransformOutput, whereby your Job has more than one JobOutput. In such cases, when you submit the Job, you will add two or more JobOutputs, in the same order as TransformOutputs in the Transform. Subsequently, when you retrieve the Job, either through events or on a GET request, you can use the label to easily identify the JobOutput. If a label is not provided, a default value of '{presetName}_{outputIndex}' will be used, where the preset name is the name of the preset in the corresponding TransformOutput and the output index is the relative index of the this JobOutput within the Job. Note that this index is the same as the relative index of the corresponding TransformOutput within its Transform. Changing this forces a new resource to be created.
 
 ## Attributes Reference
 

--- a/website/docs/r/media_live_event.html.markdown
+++ b/website/docs/r/media_live_event.html.markdown
@@ -90,7 +90,7 @@ The following arguments are supported:
 
 ---
 
-* `auto_start_enabled` - (Optional) The flag indicates if the resource should be automatically started on creation. Default is `false`.
+* `auto_start_enabled` - (Optional) The flag indicates if the resource should be automatically started on creation. Default is `false`. Changing this forces a new resource to be created.
 
 * `cross_site_access_policy` - (Optional) A `cross_site_access_policy` block as defined below.
 
@@ -156,7 +156,7 @@ A `ip_access_control_allow` block supports the following:
 
 A `preview` block supports the following:
 
-* `alternative_media_id` - (Optional) An alternative media identifier associated with the streaming locator created for the preview. The identifier can be used in the `CustomLicenseAcquisitionUrlTemplate` or the `CustomKeyAcquisitionUrlTemplate` of the Streaming Policy specified in the `streaming_policy_name` field. Changing this forces a new resource to be created.
+* `alternative_media_id` - (Optional) An alternative media identifier associated with the streaming locator created for the preview. The identifier can be used in the `CustomLicenseAcquisitionUrlTemplate` or the `CustomKeyAcquisitionUrlTemplate` of the Streaming Policy specified in the `streaming_policy_name` field. 
 
 * `ip_access_control_allow` - (Optional) One or more `ip_access_control_allow` blocks as defined above.
 

--- a/website/docs/r/media_services_account.html.markdown
+++ b/website/docs/r/media_services_account.html.markdown
@@ -64,7 +64,7 @@ A `storage_account` block supports the following:
 
 * `id` - (Required) Specifies the ID of the Storage Account that will be associated with the Media Services instance.
 
-* `is_primary` - (Required) Specifies whether the storage account should be the primary account or not. Defaults to `false`.
+* `is_primary` - (Optional) Specifies whether the storage account should be the primary account or not. Defaults to `false`.
 
 ~> **NOTE:** Whilst multiple `storage_account` blocks can be specified - one of them must be set to the primary
 

--- a/website/docs/r/monitor_action_group.html.markdown
+++ b/website/docs/r/monitor_action_group.html.markdown
@@ -120,8 +120,8 @@ resource "azurerm_monitor_action_group" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the Action Group. Changing this forces a new resource to be created.
-* `resource_group_name` - (Required) The name of the resource group in which to create the Action Group instance.
+* `name` - (Required) The name of the Action Group. Changing this forces a new resource to be created. Changing this forces a new resource to be created.
+* `resource_group_name` - (Required) The name of the resource group in which to create the Action Group instance. Changing this forces a new resource to be created.
 * `short_name` - (Required) The short name of the action group. This will be used in SMS messages.
 * `enabled` - (Optional) Whether this action group is enabled. If an action group is not enabled, then none of its receivers will receive communications. Defaults to `true`.
 * `arm_role_receiver` - (Optional) One or more `arm_role_receiver` blocks as defined below.
@@ -141,7 +141,7 @@ The following arguments are supported:
 
 `arm_role_receiver` supports the following:
 
-* `name` - (Required) The name of the ARM role receiver.
+* `name` - (Required) The name of the ARM role receiver. Changing this forces a new resource to be created.
 * `role_id` - (Required) The arm role id.
 * `use_common_alert_schema` - (Optional) Enables or disables the common alert schema.
 
@@ -149,7 +149,7 @@ The following arguments are supported:
 
 `automation_runbook_receiver` supports the following:
 
-* `name` - (Required) The name of the automation runbook receiver.
+* `name` - (Required) The name of the automation runbook receiver. Changing this forces a new resource to be created.
 * `automation_account_id` - (Required) The automation account ID which holds this runbook and authenticates to Azure resources.
 * `runbook_name` - (Required) The name for this runbook.
 * `webhook_resource_id` - (Required) The resource id for webhook linked to this runbook.
@@ -161,14 +161,14 @@ The following arguments are supported:
 
 `azure_app_push_receiver` supports the following:
 
-* `name` - (Required) The name of the Azure app push receiver.
+* `name` - (Required) The name of the Azure app push receiver. Changing this forces a new resource to be created.
 * `email_address` - (Required) The email address of the user signed into the mobile app who will receive push notifications from this receiver.
 
 ---
 
 `azure_function_receiver` supports the following:
 
-* `name` - (Required) The name of the Azure Function receiver.
+* `name` - (Required) The name of the Azure Function receiver. Changing this forces a new resource to be created.
 * `function_app_resource_id` - (Required) The Azure resource ID of the function app.
 * `function_name` - (Required) The function name in the function app.
 * `http_trigger_url` - (Required) The HTTP trigger url where HTTP request sent to.
@@ -178,7 +178,7 @@ The following arguments are supported:
 
 `email_receiver` supports the following:
 
-* `name` - (Required) The name of the email receiver. Names must be unique (case-insensitive) across all receivers within an action group.
+* `name` - (Required) The name of the email receiver. Names must be unique (case-insensitive) across all receivers within an action group. Changing this forces a new resource to be created.
 * `email_address` - (Required) The email address of this receiver.
 * `use_common_alert_schema` - (Optional) Enables or disables the common alert schema.
 
@@ -186,7 +186,7 @@ The following arguments are supported:
 
 `event_hub_receiver` supports the following:
 
-* `name` - (Required) The name of the EventHub Receiver, must be unique within action group.
+* `name` - (Required) The name of the EventHub Receiver, must be unique within action group. Changing this forces a new resource to be created.
 * `event_hub_id` - (Optional) The resource ID of the respective Event Hub.
 * `event_hub_name` - (Optional) The name of the specific Event Hub queue.
 * `event_hub_namespace` - (Optional) The namespace name of the Event Hub.
@@ -201,7 +201,7 @@ The following arguments are supported:
 
 `itsm_receiver` supports the following:
 
-* `name` - (Required) The name of the ITSM receiver.
+* `name` - (Required) The name of the ITSM receiver. Changing this forces a new resource to be created.
 * `workspace_id` - (Required) The Azure Log Analytics workspace ID where this connection is defined. Format is `<subscription id>|<workspace id>`, for example `00000000-0000-0000-0000-000000000000|00000000-0000-0000-0000-000000000000`.
 * `connection_id` - (Required) The unique connection identifier of the ITSM connection.
 * `ticket_configuration` - (Required) A JSON blob for the configurations of the ITSM action. CreateMultipleWorkItems option will be part of this blob as well.
@@ -213,7 +213,7 @@ The following arguments are supported:
 
 `logic_app_receiver` supports the following:
 
-* `name` - (Required) The name of the logic app receiver.
+* `name` - (Required) The name of the logic app receiver. Changing this forces a new resource to be created.
 * `resource_id` - (Required) The Azure resource ID of the logic app.
 * `callback_url` - (Required) The callback url where HTTP request sent to.
 * `use_common_alert_schema` - (Optional) Enables or disables the common alert schema.
@@ -222,7 +222,7 @@ The following arguments are supported:
 
 `sms_receiver` supports the following:
 
-* `name` - (Required) The name of the SMS receiver. Names must be unique (case-insensitive) across all receivers within an action group.
+* `name` - (Required) The name of the SMS receiver. Names must be unique (case-insensitive) across all receivers within an action group. Changing this forces a new resource to be created.
 * `country_code` - (Required) The country code of the SMS receiver.
 * `phone_number` - (Required) The phone number of the SMS receiver.
 
@@ -230,7 +230,7 @@ The following arguments are supported:
 
 `voice_receiver` supports the following:
 
-* `name` - (Required) The name of the voice receiver.
+* `name` - (Required) The name of the voice receiver. Changing this forces a new resource to be created.
 * `country_code` - (Required) The country code of the voice receiver.
 * `phone_number` - (Required) The phone number of the voice receiver.
 
@@ -238,7 +238,7 @@ The following arguments are supported:
 
 `webhook_receiver` supports the following:
 
-* `name` - (Required) The name of the webhook receiver. Names must be unique (case-insensitive) across all receivers within an action group.
+* `name` - (Required) The name of the webhook receiver. Names must be unique (case-insensitive) across all receivers within an action group. Changing this forces a new resource to be created.
 * `service_uri` - (Required) The URI where webhooks should be sent.
 * `use_common_alert_schema` - (Optional) Enables or disables the common alert schema.
 * `aad_auth` - (Optional) The `aad_auth` block as defined below

--- a/website/docs/r/monitor_activity_log_alert.html.markdown
+++ b/website/docs/r/monitor_activity_log_alert.html.markdown
@@ -64,7 +64,7 @@ resource "azurerm_monitor_activity_log_alert" "main" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the activity log alert. Changing this forces a new resource to be created.
-* `resource_group_name` - (Required) The name of the resource group in which to create the activity log alert instance.
+* `resource_group_name` - (Required) The name of the resource group in which to create the activity log alert instance. Changing this forces a new resource to be created.
 * `scopes` - (Required) The Scope at which the Activity Log should be applied, for example a the Resource ID of a Subscription or a Resource (such as a Storage Account).
 * `criteria` - (Required) A `criteria` block as defined below.
 * `action` - (Optional) One or more `action` blocks as defined below.

--- a/website/docs/r/monitor_autoscale_setting.html.markdown
+++ b/website/docs/r/monitor_autoscale_setting.html.markdown
@@ -432,7 +432,7 @@ The following arguments are supported:
 
 * `profile` - (Required) Specifies one or more (up to 20) `profile` blocks as defined below.
 
-* `target_resource_id` - (Required) Specifies the resource ID of the resource that the autoscale setting should be added to.
+* `target_resource_id` - (Required) Specifies the resource ID of the resource that the autoscale setting should be added to. Changing this forces a new resource to be created.
 
 * `enabled` - (Optional) Specifies whether automatic scaling is enabled for the target resource. Defaults to `true`.
 

--- a/website/docs/r/monitor_metric_alert.html.markdown
+++ b/website/docs/r/monitor_metric_alert.html.markdown
@@ -68,7 +68,7 @@ resource "azurerm_monitor_metric_alert" "example" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the Metric Alert. Changing this forces a new resource to be created.
-* `resource_group_name` - (Required) The name of the resource group in which to create the Metric Alert instance.
+* `resource_group_name` - (Required) The name of the resource group in which to create the Metric Alert instance. Changing this forces a new resource to be created.
 * `scopes` - (Required) A set of strings of resource IDs at which the metric criteria should be applied.
 * `criteria` - (Optional) One or more (static) `criteria` blocks as defined below.
 

--- a/website/docs/r/monitor_scheduled_query_rules_alert.html.markdown
+++ b/website/docs/r/monitor_scheduled_query_rules_alert.html.markdown
@@ -106,7 +106,7 @@ QUERY
 The following arguments are supported:
 
 * `name` - (Required) The name of the scheduled query rule. Changing this forces a new resource to be created.
-* `resource_group_name` - (Required) The name of the resource group in which to create the scheduled query rule instance.
+* `resource_group_name` - (Required) The name of the resource group in which to create the scheduled query rule instance. Changing this forces a new resource to be created.
 * `location` - (Required) Specifies the Azure Region where the resource should exist. Changing this forces a new resource to be created.
 * `data_source_id` - (Required) The resource URI over which log search query is to be run.
 * `frequency` - (Required) Frequency (in minutes) at which rule condition should be evaluated.  Values must be between 5 and 1440 (inclusive).

--- a/website/docs/r/monitor_scheduled_query_rules_alert_v2.html.markdown
+++ b/website/docs/r/monitor_scheduled_query_rules_alert_v2.html.markdown
@@ -96,7 +96,7 @@ The following arguments are supported:
 
 * `criteria` - (Required) A `criteria` block as defined below.
 
-* `evaluation_frequency` - (Required) How often the scheduled query rule is evaluated, represented in ISO 8601 duration format. Possible values are `PT1M`, `PT5M`, `PT10M`, `PT15M`, `PT30M`, `PT45M`, `PT1H`, `PT2H`, `PT3H`, `PT4H`, `PT5H`, `PT6H`, `P1D`.
+* `evaluation_frequency` - (Optional) How often the scheduled query rule is evaluated, represented in ISO 8601 duration format. Possible values are `PT1M`, `PT5M`, `PT10M`, `PT15M`, `PT30M`, `PT45M`, `PT1H`, `PT2H`, `PT3H`, `PT4H`, `PT5H`, `PT6H`, `P1D`.
 
 -> **Note** `evaluation_frequency` cannot be greater than the query look back which is `window_duration`*`number_of_evaluation_periods`.
 

--- a/website/docs/r/monitor_scheduled_query_rules_log.html.markdown
+++ b/website/docs/r/monitor_scheduled_query_rules_log.html.markdown
@@ -86,8 +86,8 @@ resource "azurerm_monitor_scheduled_query_rules_log" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the scheduled query rule. Changing this forces a new resource to be created.
-* `resource_group_name` - (Required) The name of the resource group in which to create the scheduled query rule instance.
+* `name` - (Required) The name of the scheduled query rule. Changing this forces a new resource to be created. Changing this forces a new resource to be created.
+* `resource_group_name` - (Required) The name of the resource group in which to create the scheduled query rule instance. Changing this forces a new resource to be created.
 * `location` - (Required) Specifies the Azure Region where the resource should exist. Changing this forces a new resource to be created.
 * `criteria` - (Required) A `criteria` block as defined below.
 * `data_source_id` - (Required) The resource URI over which log search query is to be run.
@@ -106,7 +106,7 @@ The following arguments are supported:
 
 `dimension` supports the following:
 
-* `name` - (Required) Name of the dimension.
+* `name` - (Required) Name of the dimension. Changing this forces a new resource to be created.
 * `operator` - (Required) Operator for dimension values, - 'Include'.
 * `values` - (Required) List of dimension values.
 

--- a/website/docs/r/mssql_database.html.markdown
+++ b/website/docs/r/mssql_database.html.markdown
@@ -59,7 +59,7 @@ resource "azurerm_mssql_database" "test" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the MS SQL Database. Changing this forces a new resource to be created.
+* `name` - (Required) The name of the MS SQL Database. Changing this forces a new resource to be created. Changing this forces a new resource to be created.
 
 * `server_id` - (Required) The id of the MS SQL Server on which to create the database. Changing this forces a new resource to be created.
 
@@ -67,7 +67,7 @@ The following arguments are supported:
 
 * `auto_pause_delay_in_minutes` - (Optional) Time in minutes after which database is automatically paused. A value of `-1` means that automatic pause is disabled. This property is only settable for General Purpose Serverless databases.
 
-* `create_mode` - (Optional) The create mode of the database. Possible values are `Copy`, `Default`, `OnlineSecondary`, `PointInTimeRestore`, `Recovery`, `Restore`, `RestoreExternalBackup`, `RestoreExternalBackupSecondary`, `RestoreLongTermRetentionBackup` and `Secondary`. Mutually exclusive with `import`.
+* `create_mode` - (Optional) The create mode of the database. Possible values are `Copy`, `Default`, `OnlineSecondary`, `PointInTimeRestore`, `Recovery`, `Restore`, `RestoreExternalBackup`, `RestoreExternalBackupSecondary`, `RestoreLongTermRetentionBackup` and `Secondary`. Mutually exclusive with `import`. Changing this forces a new resource to be created.
 
 * `import` - (Optional) A Database Import block as documented below. Mutually exclusive with `create_mode`.
 
@@ -99,7 +99,7 @@ The following arguments are supported:
 
 * `min_capacity` - (Optional) Minimal capacity that database will always have allocated, if not paused. This property is only settable for General Purpose Serverless databases.
 
-* `restore_point_in_time` - (Required) Specifies the point in time (ISO8601 format) of the source database that will be restored to create the new database. This property is only settable for `create_mode`= `PointInTimeRestore`  databases.
+* `restore_point_in_time` - (Optional) Specifies the point in time (ISO8601 format) of the source database that will be restored to create the new database. This property is only settable for `create_mode`= `PointInTimeRestore`  databases.
 
 * `recover_database_id` - (Optional) The ID of the database to be recovered. This property is only applicable when the `create_mode` is `Recovery`.
 
@@ -121,7 +121,7 @@ The following arguments are supported:
 
 * `threat_detection_policy` - (Optional) Threat detection policy configuration. The `threat_detection_policy` block supports fields documented below.
 
-* `transparent_data_encryption_enabled` - If set to true, Transparent Data Encryption will be enabled on the database. Defaults to `true`.
+* `transparent_data_encryption_enabled` - (Optional) If set to true, Transparent Data Encryption will be enabled on the database. Defaults to `true`.
 
 * -> **NOTE:** TDE cannot be disabled on servers with SKUs other than ones starting with DW.
 
@@ -158,7 +158,7 @@ A `long_term_retention_policy` block supports the following:
 * `weekly_retention` - (Optional) The weekly retention policy for an LTR backup in an ISO 8601 format. Valid value is between 1 to 520 weeks. e.g. `P1Y`, `P1M`, `P1W` or `P7D`.
 * `monthly_retention` - (Optional) The monthly retention policy for an LTR backup in an ISO 8601 format. Valid value is between 1 to 120 months. e.g. `P1Y`, `P1M`, `P4W` or `P30D`.
 * `yearly_retention` - (Optional) The yearly retention policy for an LTR backup in an ISO 8601 format. Valid value is between 1 to 10 years. e.g. `P1Y`, `P12M`, `P52W` or `P365D`.
-* `week_of_year` - (Required) The week of year to take the yearly backup. Value has to be between `1` and `52`.
+* `week_of_year` - (Optional) The week of year to take the yearly backup. Value has to be between `1` and `52`.
 
 ---
 

--- a/website/docs/r/mssql_database_extended_auditing_policy.html.markdown
+++ b/website/docs/r/mssql_database_extended_auditing_policy.html.markdown
@@ -59,7 +59,7 @@ The following arguments are supported:
 
 * `database_id` - (Required) The ID of the SQL database to set the extended auditing policy. Changing this forces a new resource to be created.
 
-* `enabled` - (Required) Whether to enable the extended auditing policy. Possible values are `true` and `false`. Defaults to `true`.
+* `enabled` - (Optional) Whether to enable the extended auditing policy. Possible values are `true` and `false`. Defaults to `true`.
 
 ->**NOTE:**  If `enabled` is `true`, `storage_endpoint` or `log_monitoring_enabled` are required.
 

--- a/website/docs/r/mssql_elasticpool.html.markdown
+++ b/website/docs/r/mssql_elasticpool.html.markdown
@@ -53,9 +53,9 @@ resource "azurerm_mssql_elasticpool" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the elastic pool. This needs to be globally unique. Changing this forces a new resource to be created.
+* `name` - (Required) The name of the elastic pool. This needs to be globally unique. Changing this forces a new resource to be created. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) The name of the resource group in which to create the elastic pool. This must be the same as the resource group of the underlying SQL server.
+* `resource_group_name` - (Required) The name of the resource group in which to create the elastic pool. This must be the same as the resource group of the underlying SQL server. Changing this forces a new resource to be created.
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 
@@ -83,7 +83,7 @@ The following arguments are supported:
 
 `sku` supports the following:
 
-* `name` - (Required) Specifies the SKU Name for this Elasticpool. The name of the SKU, will be either `vCore` based `tier` + `family` pattern (e.g. GP_Gen4, BC_Gen5) or the `DTU` based `BasicPool`, `StandardPool`, or `PremiumPool` pattern.
+* `name` - (Required) Specifies the SKU Name for this Elasticpool. The name of the SKU, will be either `vCore` based `tier` + `family` pattern (e.g. GP_Gen4, BC_Gen5) or the `DTU` based `BasicPool`, `StandardPool`, or `PremiumPool` pattern. Changing this forces a new resource to be created.
 
 * `capacity` - (Required) The scale up/out capacity, representing server's compute units. For more information see the documentation for your Elasticpool configuration: [vCore-based](https://docs.microsoft.com/azure/sql-database/sql-database-vcore-resource-limits-elastic-pools) or [DTU-based](https://docs.microsoft.com/azure/sql-database/sql-database-dtu-resource-limits-elastic-pools).
 

--- a/website/docs/r/mssql_firewall_rule.html.markdown
+++ b/website/docs/r/mssql_firewall_rule.html.markdown
@@ -39,9 +39,9 @@ resource "azurerm_mssql_firewall_rule" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the firewall rule.
+* `name` - (Required) The name of the firewall rule. Changing this forces a new resource to be created.
 
-* `server_id` - (Required) The resource ID of the SQL Server on which to create the Firewall Rule.
+* `server_id` - (Required) The resource ID of the SQL Server on which to create the Firewall Rule. Changing this forces a new resource to be created.
 
 * `start_ip_address` - (Required) The starting IP address to allow through the firewall for this rule.
 

--- a/website/docs/r/mssql_managed_instance.html.markdown
+++ b/website/docs/r/mssql_managed_instance.html.markdown
@@ -215,15 +215,15 @@ The following arguments are supported:
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 
-* `name` - (Required) The name of the SQL Managed Instance. This needs to be globally unique within Azure.
+* `name` - (Required) The name of the SQL Managed Instance. This needs to be globally unique within Azure. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) The name of the resource group in which to create the SQL Managed Instance.
+* `resource_group_name` - (Required) The name of the resource group in which to create the SQL Managed Instance. Changing this forces a new resource to be created.
 
 * `sku_name` - (Required) Specifies the SKU Name for the SQL Managed Instance. Valid values include `GP_Gen4`, `GP_Gen5`, `GP_Gen8IM`, `GP_Gen8IH`, `BC_Gen4`, `BC_Gen5`, `BC_Gen8IM` or `BC_Gen8IH`.
 
 * `storage_size_in_gb` - (Required) Maximum storage space for the SQL Managed instance. This should be a multiple of 32 (GB).
 
-* `subnet_id` - (Required) The subnet resource id that the SQL Managed Instance will be associated with.
+* `subnet_id` - (Required) The subnet resource id that the SQL Managed Instance will be associated with. Changing this forces a new resource to be created.
 
 * `vcores` - (Required) Number of cores that should be assigned to the SQL Managed Instance. Values can be `8`, `16`, or `24` for Gen4 SKUs, or `4`, `8`, `16`, `24`, `32`, `40`, `64`, or `80` for Gen5 SKUs.
 

--- a/website/docs/r/mssql_managed_instance_failover_group.html.markdown
+++ b/website/docs/r/mssql_managed_instance_failover_group.html.markdown
@@ -119,7 +119,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name which should be used for this Managed Instance Failover Group. Changing this forces a new resource to be created.
 
-* `location` - The Azure Region where the Managed Instance Failover Group should exist. Changing this forces a new resource to be created.
+* `location` - (Required) The Azure Region where the Managed Instance Failover Group should exist. Changing this forces a new resource to be created.
 
 * `managed_instance_id` - (Required) The ID of the Azure SQL Managed Instance which will be replicated using a Managed Instance Failover Group. Changing this forces a new resource to be created.
 

--- a/website/docs/r/mssql_managed_instance_transparent_data_encryption.html.markdown
+++ b/website/docs/r/mssql_managed_instance_transparent_data_encryption.html.markdown
@@ -181,7 +181,7 @@ resource "azurerm_mssql_managed_instance_transparent_data_encryption" "example" 
 
 The following arguments are supported:
 
-* `managed_instance_id` - (Required) Specifies the name of the MS SQL Managed Instance.
+* `managed_instance_id` - (Required) Specifies the name of the MS SQL Managed Instance. Changing this forces a new resource to be created.
 
 ---
 

--- a/website/docs/r/mssql_outbound_firewall_rule.html.markdown
+++ b/website/docs/r/mssql_outbound_firewall_rule.html.markdown
@@ -39,9 +39,9 @@ resource "azurerm_mssql_outbound_firewall_rule" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the outbound firewall rule. This should be a FQDN.
+* `name` - (Required) The name of the outbound firewall rule. This should be a FQDN. Changing this forces a new resource to be created.
 
-* `server_id` - (Required) The resource ID of the SQL Server on which to create the Outbound Firewall Rule.
+* `server_id` - (Required) The resource ID of the SQL Server on which to create the Outbound Firewall Rule. Changing this forces a new resource to be created.
 
 ## Attributes Reference
 

--- a/website/docs/r/mssql_server.html.markdown
+++ b/website/docs/r/mssql_server.html.markdown
@@ -46,13 +46,13 @@ resource "azurerm_mssql_server" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the Microsoft SQL Server. This needs to be globally unique within Azure.
+* `name` - (Required) The name of the Microsoft SQL Server. This needs to be globally unique within Azure. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) The name of the resource group in which to create the Microsoft SQL Server.
+* `resource_group_name` - (Required) The name of the resource group in which to create the Microsoft SQL Server. Changing this forces a new resource to be created.
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 
-* `version` - (Required) The version for the new server. Valid values are: 2.0 (for v11 server) and 12.0 (for v12 server).
+* `version` - (Required) The version for the new server. Valid values are: 2.0 (for v11 server) and 12.0 (for v12 server). Changing this forces a new resource to be created.
 
 * `administrator_login` - (Optional) The administrator login name for the new server. Required unless `azuread_authentication_only` in the `azuread_administrator` block is `true`. When omitted, Azure will generate a default username which cannot be subsequently changed. Changing this forces a new resource to be created.
 

--- a/website/docs/r/mssql_server_extended_auditing_policy.html.markdown
+++ b/website/docs/r/mssql_server_extended_auditing_policy.html.markdown
@@ -163,7 +163,7 @@ The following arguments are supported:
 
 * `server_id` - (Required) The ID of the SQL Server to set the extended auditing policy. Changing this forces a new resource to be created.
 
-* `enabled` - (Required) Whether to enable the extended auditing policy. Possible values are `true` and `false`. Defaults to `true`.
+* `enabled` - (Optional) Whether to enable the extended auditing policy. Possible values are `true` and `false`. Defaults to `true`.
 
 ->**NOTE:**  If `enabled` is `true`, `storage_endpoint` or `log_monitoring_enabled` are required.
 

--- a/website/docs/r/mssql_server_microsoft_support_auditing_policy.html.markdown
+++ b/website/docs/r/mssql_server_microsoft_support_auditing_policy.html.markdown
@@ -160,7 +160,7 @@ The following arguments are supported:
 
 * `server_id` - (Required) The ID of the SQL Server to set the extended auditing policy. Changing this forces a new resource to be created.
 
-* `enabled` - (Required) Whether to enable the extended auditing policy. Possible values are `true` and `false`. Defaults to `true`.
+* `enabled` - (Optional) Whether to enable the extended auditing policy. Possible values are `true` and `false`. Defaults to `true`.
 
 ->**NOTE:**  If `enabled` is `true`, `blob_storage_endpoint` or `log_monitoring_enabled` are required.
 

--- a/website/docs/r/mssql_server_transparent_data_encryption.html.markdown
+++ b/website/docs/r/mssql_server_transparent_data_encryption.html.markdown
@@ -146,7 +146,7 @@ resource "azurerm_mssql_server_transparent_data_encryption" "example" {
 
 The following arguments are supported:
 
-* `server_id` - (Required) Specifies the name of the MS SQL Server.
+* `server_id` - (Required) Specifies the name of the MS SQL Server. Changing this forces a new resource to be created.
 
 ---
 

--- a/website/docs/r/mssql_virtual_machine.html.markdown
+++ b/website/docs/r/mssql_virtual_machine.html.markdown
@@ -43,7 +43,7 @@ The following arguments are supported:
 
 * `virtual_machine_id` - (Required) The ID of the Virtual Machine. Changing this forces a new resource to be created.
 
-* `sql_license_type` - (Optional) The SQL Server license type. Possible values are `AHUB` (Azure Hybrid Benefit), `DR` (Disaster Recovery), and `PAYG` (Pay-As-You-Go). Changing this forces a new resource to be created.
+* `sql_license_type` - (Required) The SQL Server license type. Possible values are `AHUB` (Azure Hybrid Benefit), `DR` (Disaster Recovery), and `PAYG` (Pay-As-You-Go). Changing this forces a new resource to be created.
 
 * `auto_backup` (Optional) An `auto_backup` block as defined below. This block can be added to an existing resource, but removing this block forces a new resource to be created.
 

--- a/website/docs/r/mysql_configuration.html.markdown
+++ b/website/docs/r/mysql_configuration.html.markdown
@@ -65,7 +65,7 @@ The following arguments are supported:
 
 * `resource_group_name` - (Required) The name of the resource group in which the MySQL Server exists. Changing this forces a new resource to be created.
 
-* `value` - (Required) Specifies the value of the MySQL Configuration. See the MySQL documentation for valid values.
+* `value` - (Required) Specifies the value of the MySQL Configuration. See the MySQL documentation for valid values. Changing this forces a new resource to be created.
 
 ## Attributes Reference
 

--- a/website/docs/r/mysql_firewall_rule.html.markdown
+++ b/website/docs/r/mysql_firewall_rule.html.markdown
@@ -88,9 +88,9 @@ The following arguments are supported:
 
 * `resource_group_name` - (Required) The name of the resource group in which the MySQL Server exists. Changing this forces a new resource to be created.
 
-* `start_ip_address` - (Required) Specifies the Start IP Address associated with this Firewall Rule. Changing this forces a new resource to be created.
+* `start_ip_address` - (Required) Specifies the Start IP Address associated with this Firewall Rule. 
 
-* `end_ip_address` - (Required) Specifies the End IP Address associated with this Firewall Rule. Changing this forces a new resource to be created.
+* `end_ip_address` - (Required) Specifies the End IP Address associated with this Firewall Rule. 
 
 -> **NOTE:** The Azure feature `Allow access to Azure services` can be enabled by setting `start_ip_address` and `end_ip_address` to `0.0.0.0` which ([is documented in the Azure API Docs](https://docs.microsoft.com/rest/api/sql/firewallrules/createorupdate)).
 

--- a/website/docs/r/mysql_flexible_server.html.markdown
+++ b/website/docs/r/mysql_flexible_server.html.markdown
@@ -109,7 +109,7 @@ The following arguments are supported:
 
 ~> **NOTE:** The `private_dns_zone_id` is required when setting a `delegated_subnet_id`. The `azurerm_private_dns_zone` should end with suffix `.mysql.database.azure.com`.
 
-* `replication_role` - The replication role. Possible value is `None`.
+* `replication_role` - (Optional) The replication role. Possible value is `None`.
 
 ~> **NOTE:** The `replication_role` cannot be set while creating and only can be updated from `Replica` to `None`.
 

--- a/website/docs/r/mysql_flexible_server_configuration.html.markdown
+++ b/website/docs/r/mysql_flexible_server_configuration.html.markdown
@@ -53,7 +53,7 @@ The following arguments are supported:
 
 * `resource_group_name` - (Required) The name of the resource group in which the MySQL Flexible Server exists. Changing this forces a new resource to be created.
 
-* `value` - (Required) Specifies the value of the MySQL Flexible Server Configuration. See the MySQL documentation for valid values.
+* `value` - (Required) Specifies the value of the MySQL Flexible Server Configuration. See the MySQL documentation for valid values. Changing this forces a new resource to be created.
 
 ## Attributes Reference
 

--- a/website/docs/r/mysql_flexible_server_firewall_rule.html.markdown
+++ b/website/docs/r/mysql_flexible_server_firewall_rule.html.markdown
@@ -89,9 +89,9 @@ The following arguments are supported:
 
 * `resource_group_name` - (Required) The name of the resource group in which the MySQL Flexible Server exists. Changing this forces a new resource to be created.
 
-* `start_ip_address` - (Required) Specifies the Start IP Address associated with this Firewall Rule. Changing this forces a new resource to be created.
+* `start_ip_address` - (Required) Specifies the Start IP Address associated with this Firewall Rule. 
 
-* `end_ip_address` - (Required) Specifies the End IP Address associated with this Firewall Rule. Changing this forces a new resource to be created.
+* `end_ip_address` - (Required) Specifies the End IP Address associated with this Firewall Rule. 
 
 -> **NOTE:** The Azure feature `Allow access to Azure services` can be enabled by setting `start_ip_address` and `end_ip_address` to `0.0.0.0` which ([is documented in the Azure API Docs](https://docs.microsoft.com/rest/api/sql/firewallrules/createorupdate)).
 

--- a/website/docs/r/mysql_server.html.markdown
+++ b/website/docs/r/mysql_server.html.markdown
@@ -81,7 +81,7 @@ The following arguments are supported:
 
 * `ssl_minimal_tls_version_enforced` - (Optional) The minimum TLS version to support on the sever. Possible values are `TLSEnforcementDisabled`, `TLS1_0`, `TLS1_1`, and `TLS1_2`. Defaults to `TLS1_2`.
 
-* `storage_mb` - (Required) Max storage allowed for a server. Possible values are between `5120` MB(5GB) and `1048576` MB(1TB) for the Basic SKU and between `5120` MB(5GB) and `16777216` MB(16TB) for General Purpose/Memory Optimized SKUs. For more information see the [product documentation](https://docs.microsoft.com/azure/mysql/concepts-pricing-tiers).
+* `storage_mb` - (Optional) Max storage allowed for a server. Possible values are between `5120` MB(5GB) and `1048576` MB(1TB) for the Basic SKU and between `5120` MB(5GB) and `16777216` MB(16TB) for General Purpose/Memory Optimized SKUs. For more information see the [product documentation](https://docs.microsoft.com/azure/mysql/concepts-pricing-tiers).
 
 * `threat_detection_policy` - (Optional) Threat detection policy configuration, known in the API as Server Security Alerts Policy. The `threat_detection_policy` block supports fields documented below.
 

--- a/website/docs/r/nat_gateway.html.markdown
+++ b/website/docs/r/nat_gateway.html.markdown
@@ -52,7 +52,7 @@ The following arguments are supported:
 
 * `resource_group_name` - (Required) Specifies the name of the Resource Group in which the NAT Gateway should exist. Changing this forces a new resource to be created.
 
-* `location` - (Optional) Specifies the supported Azure location where the NAT Gateway should exist. Changing this forces a new resource to be created.
+* `location` - (Required) Specifies the supported Azure location where the NAT Gateway should exist. Changing this forces a new resource to be created.
 
 * `idle_timeout_in_minutes` - (Optional) The idle timeout which should be used in minutes. Defaults to `4`.
 
@@ -62,7 +62,7 @@ The following arguments are supported:
 
 * `sku_name` - (Optional) The SKU which should be used. At this time the only supported value is `Standard`. Defaults to `Standard`.
 
-* `tags` - (Optional) A mapping of tags to assign to the resource. Changing this forces a new resource to be created.
+* `tags` - (Optional) A mapping of tags to assign to the resource. 
 
 * `zones` - (Optional) Specifies a list of Availability Zones in which this NAT Gateway should be located. Changing this forces a new NAT Gateway to be created.
 

--- a/website/docs/r/netapp_snapshot_policy.html.markdown
+++ b/website/docs/r/netapp_snapshot_policy.html.markdown
@@ -62,13 +62,13 @@ resource "azurerm_netapp_snapshot_policy" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the NetApp Snapshot Policy. Changing this forces a new resource to be created.
+* `name` - (Required) The name of the NetApp Snapshot Policy. Changing this forces a new resource to be created. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) The name of the resource group where the NetApp Snapshot Policy should be created. Changing this forces a new resource to be created.
+* `resource_group_name` - (Required) The name of the resource group where the NetApp Snapshot Policy should be created. Changing this forces a new resource to be created. Changing this forces a new resource to be created.
 
-* `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
+* `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created. Changing this forces a new resource to be created.
 
-* `account_name` - (Required) The name of the NetApp Account in which the NetApp Snapshot Policy should be created. Changing this forces a new resource to be created.
+* `account_name` - (Required) The name of the NetApp Account in which the NetApp Snapshot Policy should be created. Changing this forces a new resource to be created. Changing this forces a new resource to be created.
 
 * `enabled` - (Required) Defines that the NetApp Snapshot Policy is enabled or not.
 

--- a/website/docs/r/netapp_volume.html.markdown
+++ b/website/docs/r/netapp_volume.html.markdown
@@ -111,21 +111,21 @@ The following arguments are supported:
 
 * `pool_name` - (Required) The name of the NetApp pool in which the NetApp Volume should be created. Changing this forces a new resource to be created.
 
-* `service_level` - (Required) The target performance of the file system. Valid values include `Premium`, `Standard`, or `Ultra`.
+* `service_level` - (Required) The target performance of the file system. Valid values include `Premium`, `Standard`, or `Ultra`. Changing this forces a new resource to be created.
 
 * `protocols` - (Optional) The target volume protocol expressed as a list. Supported single value include `CIFS`, `NFSv3`, or `NFSv4.1`. If argument is not defined it will default to `NFSv3`. Changing this forces a new resource to be created and data will be lost. Dual protocol scenario is supported for CIFS and NFSv3, for more information, please refer to [Create a dual-protocol volume for Azure NetApp Files](https://docs.microsoft.com/azure/azure-netapp-files/create-volumes-dual-protocol) document.
 
-* `security_style` - (Optional) Volume security style, accepted values are `Unix` or `Ntfs`. If not provided, single-protocol volume is created defaulting to `Unix` if it is `NFSv3` or `NFSv4.1` volume, if `CIFS`, it will default to `Ntfs`. In a dual-protocol volume, if not provided, its value will be `Ntfs`.
+* `security_style` - (Optional) Volume security style, accepted values are `Unix` or `Ntfs`. If not provided, single-protocol volume is created defaulting to `Unix` if it is `NFSv3` or `NFSv4.1` volume, if `CIFS`, it will default to `Ntfs`. In a dual-protocol volume, if not provided, its value will be `Ntfs`. Changing this forces a new resource to be created.
 
 * `subnet_id` - (Required) The ID of the Subnet the NetApp Volume resides in, which must have the `Microsoft.NetApp/volumes` delegation. Changing this forces a new resource to be created.
 
-* `network_features` - (Optional) Indicates which network feature to use, accepted values are `Basic` or `Standard`, it defaults to `Basic` if not defined. This is a feature in public preview and for more information about it and how to register, please refer to [Configure network features for an Azure NetApp Files volume](https://docs.microsoft.com/en-us/azure/azure-netapp-files/configure-network-features).
+* `network_features` - (Optional) Indicates which network feature to use, accepted values are `Basic` or `Standard`, it defaults to `Basic` if not defined. This is a feature in public preview and for more information about it and how to register, please refer to [Configure network features for an Azure NetApp Files volume](https://docs.microsoft.com/en-us/azure/azure-netapp-files/configure-network-features). Changing this forces a new resource to be created.
 
 * `storage_quota_in_gb` - (Required) The maximum Storage Quota allowed for a file system in Gigabytes.
 
 * `snapshot_directory_visible` - (Optional) Specifies whether the .snapshot (NFS clients) or ~snapshot (SMB clients) path of a volume is visible, default value is true.
 
-* `create_from_snapshot_resource_id` - (Optional) Creates volume from snapshot. Following properties must be the same as the original volume where the snapshot was taken from: `protocols`, `subnet_id`, `location`, `service_level`, `resource_group_name`, `account_name` and `pool_name`.
+* `create_from_snapshot_resource_id` - (Optional) Creates volume from snapshot. Following properties must be the same as the original volume where the snapshot was taken from: `protocols`, `subnet_id`, `location`, `service_level`, `resource_group_name`, `account_name` and `pool_name`. Changing this forces a new resource to be created.
 
 * `data_protection_replication` - (Optional) A `data_protection_replication` block as defined below.
 
@@ -161,7 +161,7 @@ A `data_protection_replication` block is used when enabling the Cross-Region Rep
 
 * `endpoint_type` - (Optional) The endpoint type, default value is `dst` for destination.
   
-* `remote_volume_location` - (Required) Location of the primary volume.
+* `remote_volume_location` - (Required) Location of the primary volume. Changing this forces a new resource to be created.
 
 * `remote_volume_resource_id` - (Required) Resource ID of the primary volume.
   

--- a/website/docs/r/network_interface.html.markdown
+++ b/website/docs/r/network_interface.html.markdown
@@ -54,7 +54,7 @@ The following arguments are supported:
 
 * `location` - (Required) The location where the Network Interface should exist. Changing this forces a new resource to be created.
 
-* `name` - (Required) The name of the Network Interface. Changing this forces a new resource to be created.
+* `name` - (Required) The name of the Network Interface. Changing this forces a new resource to be created. Changing this forces a new resource to be created.
 
 * `resource_group_name` - (Required) The name of the Resource Group in which to create the Network Interface. Changing this forces a new resource to be created.
 
@@ -82,7 +82,7 @@ The following arguments are supported:
 
 The `ip_configuration` block supports the following:
 
-* `name` - (Required) A name used for this IP Configuration.
+* `name` - (Required) A name used for this IP Configuration. Changing this forces a new resource to be created.
 
 * `gateway_load_balancer_frontend_ip_configuration_id` - (Optional) The Frontend IP Configuration ID of a Gateway SKU Load Balancer.
 

--- a/website/docs/r/network_security_group.html.markdown
+++ b/website/docs/r/network_security_group.html.markdown
@@ -50,7 +50,7 @@ resource "azurerm_network_security_group" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name of the network security group. Changing this forces a new resource to be created.
+* `name` - (Required) Specifies the name of the network security group. Changing this forces a new resource to be created. Changing this forces a new resource to be created.
 
 * `resource_group_name` - (Required) The name of the resource group in which to create the network security group. Changing this forces a new resource to be created.
 
@@ -64,7 +64,7 @@ The following arguments are supported:
 
 Elements of `security_rule` support:
 
-* `name` - (Required) The name of the security rule.
+* `name` - (Required) The name of the security rule. Changing this forces a new resource to be created.
 
 * `description` - (Optional) A description for this rule. Restricted to 140 characters.
 

--- a/website/docs/r/notification_hub_namespace.html.markdown
+++ b/website/docs/r/notification_hub_namespace.html.markdown
@@ -36,11 +36,11 @@ The following arguments are supported:
 
 * `resource_group_name` - (Required) The name of the Resource Group in which the Notification Hub Namespace should exist. Changing this forces a new resource to be created.
 
-* `location` - (Required) The Azure Region in which this Notification Hub Namespace should be created.
+* `location` - (Required) The Azure Region in which this Notification Hub Namespace should be created. Changing this forces a new resource to be created.
 
-* `namespace_type` - (Required) The Type of Namespace - possible values are `Messaging` or `NotificationHub`. Changing this forces a new resource to be created.
+* `namespace_type` - (Required) The Type of Namespace - possible values are `Messaging` or `NotificationHub`. 
 
-* `sku_name` - (Required) The name of the SKU to use for this Notification Hub Namespace. Possible values are `Free`, `Basic` or `Standard`. Changing this forces a new resource to be created.
+* `sku_name` - (Required) The name of the SKU to use for this Notification Hub Namespace. Possible values are `Free`, `Basic` or `Standard`. 
 
 * `enabled` - (Optional) Is this Notification Hub Namespace enabled? Defaults to `true`.
 

--- a/website/docs/r/orbital_contact_profile.html.markdown
+++ b/website/docs/r/orbital_contact_profile.html.markdown
@@ -80,15 +80,15 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the contact profile. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) The name of the Resource Group where the contact profile exists.
+* `resource_group_name` - (Required) The name of the Resource Group where the contact profile exists. Changing this forces a new resource to be created.
 
-* `location` - (Required) The location where the contact profile exists.
+* `location` - (Required) The location where the contact profile exists. Changing this forces a new resource to be created.
 
 * `minimum_variable_contact_duration` - (Required) Minimum viable contact duration in ISO 8601 format. Used for listing the available contacts with a spacecraft at a given ground station.
 
 * `auto_tracking` - (Required) Auto-tracking configurations for a spacecraft. Possible values are `disabled`, `xBand` and `sBand`.
 
-* `network_configuration_subnet_id` - (Required) ARM resource identifier of the subnet delegated to the Microsoft.Orbital/orbitalGateways. Needs to be at least a class C subnet, and should not have any IP created in it.
+* `network_configuration_subnet_id` - (Required) ARM resource identifier of the subnet delegated to the Microsoft.Orbital/orbitalGateways. Needs to be at least a class C subnet, and should not have any IP created in it. Changing this forces a new resource to be created.
 
 * `links` - (Required) A list of spacecraft links. A `links` block as defined below.
 

--- a/website/docs/r/orbital_spacecraft.html.markdown
+++ b/website/docs/r/orbital_spacecraft.html.markdown
@@ -45,11 +45,11 @@ resource "azurerm_orbital_spacecraft" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the Spacecraft. Changing this forces a new resource to be created.
+* `name` - (Required) The name of the Spacecraft. Changing this forces a new resource to be created. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) The name of the Resource Group where the Spacecraft exists.
+* `resource_group_name` - (Required) The name of the Resource Group where the Spacecraft exists. Changing this forces a new resource to be created.
 
-* `location` - (Required) The location where the Spacecraft exists.
+* `location` - (Required) The location where the Spacecraft exists. Changing this forces a new resource to be created.
 
 * `norad_id` - (Required) NORAD ID of the Spacecraft.
 
@@ -65,13 +65,13 @@ The following arguments are supported:
 
 * `polarization` - (Required) Polarization. Possible values are `RHCP`, `LHCP`, `linearVertical` and `linearHorizontal`.
 
-* `name` - (Required) Name of the link.
+* `name` - (Required) Name of the link. Changing this forces a new resource to be created.
 
 ---
 
-* `two_line_elements` - (Optional) A list of the two line elements(TLE), the first string in the list is the first line of TLE, the second one is the second line of TLE.
+* `two_line_elements` - (Required) A list of the two line elements(TLE), the first string in the list is the first line of TLE, the second one is the second line of TLE.
 
-* `title_line` - (Optional) Title of the two line elements(TLE).
+* `title_line` - (Required) Title of the two line elements(TLE).
 
 ## Attributes Reference
 

--- a/website/docs/r/orchestrated_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/orchestrated_virtual_machine_scale_set.html.markdown
@@ -81,7 +81,7 @@ resource "azurerm_orchestrated_virtual_machine_scale_set" "example" {
 
 * `identity` - (Optional) An `identity` block as defined below.
 
-* `license_type` - (Optional) Specifies the type of on-premise license (also known as Azure Hybrid Use Benefit) which should be used for this Orchestrated Virtual Machine Scale Set. Possible values are `None`, `Windows_Client` and `Windows_Server`. Changing this forces a new resource to be created.
+* `license_type` - (Optional) Specifies the type of on-premise license (also known as Azure Hybrid Use Benefit) which should be used for this Orchestrated Virtual Machine Scale Set. Possible values are `None`, `Windows_Client` and `Windows_Server`. 
 
 * `max_bid_price` - (Optional) The maximum price you're willing to pay for each Orchestrated Virtual Machine in this Scale Set, in US Dollars; which must be greater than the current spot price. If this bid price falls below the current spot price the Virtual Machines in the Scale Set will be evicted using the eviction_policy. Defaults to `-1`, which means that each Virtual Machine in the Orchestrated Scale Set should not be evicted for price reasons.
 
@@ -369,11 +369,11 @@ An `os_disk` block supports the following:
 
 * `caching` - (Required) The Type of Caching which should be used for the Internal OS Disk. Possible values are `None`, `ReadOnly` and `ReadWrite`.
 
-* `storage_account_type` - (Required) The Type of Storage Account which should back this the Internal OS Disk. Possible values include `Standard_LRS`, `StandardSSD_LRS`, `StandardSSD_ZRS`, `Premium_LRS` and `Premium_ZRS`.
+* `storage_account_type` - (Required) The Type of Storage Account which should back this the Internal OS Disk. Possible values include `Standard_LRS`, `StandardSSD_LRS`, `StandardSSD_ZRS`, `Premium_LRS` and `Premium_ZRS`. Changing this forces a new resource to be created.
 
 * `diff_disk_settings` - (Optional) A `diff_disk_settings` block as defined above.
 
-* `disk_encryption_set_id` - (Optional) The ID of the Disk Encryption Set which should be used to encrypt this OS Disk.
+* `disk_encryption_set_id` - (Optional) The ID of the Disk Encryption Set which should be used to encrypt this OS Disk. Changing this forces a new resource to be created.
 
 -> **NOTE:** Disk Encryption Sets are in Public Preview in a limited set of regions
 
@@ -435,13 +435,13 @@ A `termination_notification` block supports the following:
 
 A `source_image_reference` block supports the following:
 
-* `publisher` - (Optional) Specifies the publisher of the image used to create the virtual machines.
+* `publisher` - (Optional) Specifies the publisher of the image used to create the virtual machines. Changing this forces a new resource to be created.
 
-* `offer` - (Optional) Specifies the offer of the image used to create the virtual machines.
+* `offer` - (Optional) Specifies the offer of the image used to create the virtual machines. Changing this forces a new resource to be created.
 
-* `sku` - (Optional) Specifies the SKU of the image used to create the virtual machines.
+* `sku` - (Required) Specifies the SKU of the image used to create the virtual machines.
 
-* `version` - (Optional) Specifies the version of the image used to create the virtual machines.
+* `version` - (Required) Specifies the version of the image used to create the virtual machines.
 
 ---
 

--- a/website/docs/r/portal_dashboard.html.markdown
+++ b/website/docs/r/portal_dashboard.html.markdown
@@ -250,7 +250,7 @@ The following arguments are supported:
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 
-* `dashboard_properties` - (Required) JSON data representing dashboard body. See above for details on how to obtain this from the Portal.
+* `dashboard_properties` - (Optional) JSON data representing dashboard body. See above for details on how to obtain this from the Portal.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 

--- a/website/docs/r/postgresql_configuration.html.markdown
+++ b/website/docs/r/postgresql_configuration.html.markdown
@@ -58,7 +58,7 @@ The following arguments are supported:
 
 * `resource_group_name` - (Required) The name of the resource group in which the PostgreSQL Server exists. Changing this forces a new resource to be created.
 
-* `value` - (Required) Specifies the value of the PostgreSQL Configuration. See the PostgreSQL documentation for valid values.
+* `value` - (Required) Specifies the value of the PostgreSQL Configuration. See the PostgreSQL documentation for valid values. Changing this forces a new resource to be created.
 
 ## Attributes Reference
 

--- a/website/docs/r/private_dns_a_record.html.markdown
+++ b/website/docs/r/private_dns_a_record.html.markdown
@@ -36,7 +36,7 @@ resource "azurerm_private_dns_a_record" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the DNS A Record.
+* `name` - (Required) The name of the DNS A Record. Changing this forces a new resource to be created.
 
 * `resource_group_name` - (Required) Specifies the resource group where the Private DNS Zone exists. Changing this forces a new resource to be created.
 

--- a/website/docs/r/private_dns_aaaa_record.html.markdown
+++ b/website/docs/r/private_dns_aaaa_record.html.markdown
@@ -36,7 +36,7 @@ resource "azurerm_private_dns_aaaa_record" "test" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the DNS A Record.
+* `name` - (Required) The name of the DNS A Record. Changing this forces a new resource to be created.
 
 * `resource_group_name` - (Required) Specifies the resource group where the resource exists. Changing this forces a new resource to be created.
 

--- a/website/docs/r/private_dns_cname_record.html.markdown
+++ b/website/docs/r/private_dns_cname_record.html.markdown
@@ -36,7 +36,7 @@ resource "azurerm_private_dns_cname_record" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the DNS CNAME Record.
+* `name` - (Required) The name of the DNS CNAME Record. Changing this forces a new resource to be created.
 
 * `resource_group_name` - (Required) Specifies the resource group where the resource exists. Changing this forces a new resource to be created.
 

--- a/website/docs/r/private_dns_resolver_outbound_endpoint.html.markdown
+++ b/website/docs/r/private_dns_resolver_outbound_endpoint.html.markdown
@@ -68,7 +68,7 @@ The following arguments are supported:
 
 * `location` - (Required) Specifies the Azure Region where the Private DNS Resolver Outbound Endpoint should exist. Changing this forces a new Private DNS Resolver Outbound Endpoint to be created.
 
-* `subnet_id` - (Required)  The ID of the Subnet that is linked to the Private DNS Resolver Outbound Endpoint.
+* `subnet_id` - (Required)  The ID of the Subnet that is linked to the Private DNS Resolver Outbound Endpoint. Changing this forces a new resource to be created.
 
 * `tags` - (Optional) A mapping of tags which should be assigned to the Private DNS Resolver Outbound Endpoint.
 

--- a/website/docs/r/private_dns_resolver_virtual_network_link.html.markdown
+++ b/website/docs/r/private_dns_resolver_virtual_network_link.html.markdown
@@ -85,7 +85,7 @@ The following arguments are supported:
 
 * `dns_forwarding_ruleset_id` - (Required) Specifies the ID of the Private DNS Resolver DNS Forwarding Ruleset. Changing this forces a new Private DNS Resolver Virtual Network Link to be created.
 
-* `virtual_network_id` - (Required) The ID of the Virtual Network that is linked to the Private DNS Resolver Virtual Network Link.
+* `virtual_network_id` - (Required) The ID of the Virtual Network that is linked to the Private DNS Resolver Virtual Network Link. Changing this forces a new resource to be created.
 
 * `metadata` - (Optional) Metadata attached to the Private DNS Resolver Virtual Network Link.
 

--- a/website/docs/r/private_dns_zone.html.markdown
+++ b/website/docs/r/private_dns_zone.html.markdown
@@ -28,7 +28,7 @@ resource "azurerm_private_dns_zone" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the Private DNS Zone. Must be a valid domain name.
+* `name` - (Required) The name of the Private DNS Zone. Must be a valid domain name. Changing this forces a new resource to be created.
 
 -> **NOTE:** If you are going to be using the Private DNS Zone with a Private Endpoint the name of the Private DNS Zone must follow the **Private DNS Zone name** schema in the [product documentation](https://docs.microsoft.com/azure/private-link/private-endpoint-dns#virtual-network-and-on-premises-workloads-using-a-dns-forwarder) in order for the two resources to be connected successfully.
 

--- a/website/docs/r/private_endpoint.html.markdown
+++ b/website/docs/r/private_endpoint.html.markdown
@@ -172,7 +172,7 @@ A `private_service_connection` supports the following:
 
 * `private_connection_resource_alias` - (Optional) The Service Alias of the Private Link Enabled Remote Resource which this Private Endpoint should be connected to. One of `private_connection_resource_id` or `private_connection_resource_alias` must be specified. Changing this forces a new resource to be created.
 
-* `subresource_names` - (Required) A list of subresource names which the Private Endpoint is able to connect to. `subresource_names` corresponds to `group_id`. Changing this forces a new resource to be created.
+* `subresource_names` - (Optional) A list of subresource names which the Private Endpoint is able to connect to. `subresource_names` corresponds to `group_id`. Changing this forces a new resource to be created.
 
 -> Several possible values for this field are shown below, however this is not extensive:
 
@@ -197,11 +197,11 @@ Some resource types (such as Storage Account) only support 1 subresource per pri
 
 An `ip_configuration` supports the following:
 
-* `name` - (Required) Specifies the Name of the IP Configuration. Changing this forces a new resource to be created.
+* `name` - (Required) Specifies the Name of the IP Configuration. Changing this forces a new resource to be created. Changing this forces a new resource to be created.
 
-* `private_ip_address` - (Required) Specifies the static IP address within the private endpoint's subnet to be used. Changing this forces a new resource to be created.
+* `private_ip_address` - (Required) Specifies the static IP address within the private endpoint's subnet to be used. Changing this forces a new resource to be created. Changing this forces a new resource to be created.
 
-* `subresource_name` - (Required) Specifies the subresource this IP address applies to. `subresource_names` corresponds to `group_id` and in this context is also used for `member_name`. Changing this forces a new resource to be created.
+* `subresource_name` - (Required) Specifies the subresource this IP address applies to. `subresource_names` corresponds to `group_id` and in this context is also used for `member_name`. Changing this forces a new resource to be created. Changing this forces a new resource to be created.
 
 ## Attributes Reference
 

--- a/website/docs/r/private_link_service.html.markdown
+++ b/website/docs/r/private_link_service.html.markdown
@@ -94,7 +94,7 @@ The following arguments are supported:
 
 * `nat_ip_configuration` - (Required) One or more (up to 8) `nat_ip_configuration` block as defined below.
 
-* `load_balancer_frontend_ip_configuration_ids` - (Required) A list of Frontend IP Configuration IDs from a Standard Load Balancer, where traffic from the Private Link Service should be routed. You can use Load Balancer Rules to direct this traffic to appropriate backend pools where your applications are running.
+* `load_balancer_frontend_ip_configuration_ids` - (Required) A list of Frontend IP Configuration IDs from a Standard Load Balancer, where traffic from the Private Link Service should be routed. You can use Load Balancer Rules to direct this traffic to appropriate backend pools where your applications are running. Changing this forces a new resource to be created.
 
 ---
 
@@ -104,7 +104,7 @@ The following arguments are supported:
 
 * `fqdns` - (Optional) List of FQDNs allowed for the Private Link Service.
 
-* `tags` - (Optional) A mapping of tags to assign to the resource. Changing this forces a new resource to be created.
+* `tags` - (Optional) A mapping of tags to assign to the resource. 
 
 * `visibility_subscription_ids` - (Optional) A list of Subscription UUID/GUID's that will be able to see this Private Link Service.
 

--- a/website/docs/r/public_ip.html.markdown
+++ b/website/docs/r/public_ip.html.markdown
@@ -46,7 +46,7 @@ The following arguments are supported:
 
 ---
 
-* `zones` - (Optional) A collection containing the availability zone to allocate the Public IP in.
+* `zones` - (Optional) A collection containing the availability zone to allocate the Public IP in. Changing this forces a new resource to be created.
 
 -> **Note:** Availability Zones are only supported with a [Standard SKU](https://docs.microsoft.com/azure/virtual-network/virtual-network-ip-addresses-overview-arm#standard) and [in select regions](https://docs.microsoft.com/azure/availability-zones/az-overview) at this time. Standard SKU Public IP Addresses that do not specify a zone are **not** zone-redundant by default.
 
@@ -62,23 +62,23 @@ The following arguments are supported:
 
 * `idle_timeout_in_minutes` - (Optional) Specifies the timeout for the TCP idle connection. The value can be set between 4 and 30 minutes.
 
-* `ip_tags` - (Optional) A mapping of IP tags to assign to the public IP.
+* `ip_tags` - (Optional) A mapping of IP tags to assign to the public IP. Changing this forces a new resource to be created.
 
 -> **Note** IP Tag `RoutingPreference` requires multiple `zones` and `Standard` SKU to be set.
 
-* `ip_version` - (Optional) The IP Version to use, IPv6 or IPv4.
+* `ip_version` - (Optional) The IP Version to use, IPv6 or IPv4. Changing this forces a new resource to be created.
 
 -> **Note** Only `static` IP address allocation is supported for IPv6.
 
-* `public_ip_prefix_id` - (Optional) If specified then public IP address allocated will be provided from the public IP prefix resource.
+* `public_ip_prefix_id` - (Optional) If specified then public IP address allocated will be provided from the public IP prefix resource. Changing this forces a new resource to be created.
 
 * `reverse_fqdn` - (Optional) A fully qualified domain name that resolves to this public IP address. If the reverseFqdn is specified, then a PTR DNS record is created pointing from the IP address in the in-addr.arpa domain to the reverse FQDN.
 
-* `sku` - (Optional) The SKU of the Public IP. Accepted values are `Basic` and `Standard`. Defaults to `Basic`.
+* `sku` - (Optional) The SKU of the Public IP. Accepted values are `Basic` and `Standard`. Defaults to `Basic`. Changing this forces a new resource to be created.
 
 -> **Note** Public IP Standard SKUs require `allocation_method` to be set to `Static`.
 
-* `sku_tier` - (Optional) The SKU Tier that should be used for the Public IP. Possible values are `Regional` and `Global`. Defaults to `Regional`.
+* `sku_tier` - (Optional) The SKU Tier that should be used for the Public IP. Possible values are `Regional` and `Global`. Defaults to `Regional`. Changing this forces a new resource to be created.
 
 -> **Note** When `sku_tier` is set to `Global`, `sku` must be set to `Standard`.
 

--- a/website/docs/r/public_ip_prefix.html.markdown
+++ b/website/docs/r/public_ip_prefix.html.markdown
@@ -37,7 +37,7 @@ The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the Public IP Prefix resource . Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) The name of the resource group in which to create the Public IP Prefix.
+* `resource_group_name` - (Required) The name of the resource group in which to create the Public IP Prefix. Changing this forces a new resource to be created.
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 

--- a/website/docs/r/redis_cache.html.markdown
+++ b/website/docs/r/redis_cache.html.markdown
@@ -44,9 +44,9 @@ The following arguments are supported:
 * `name` - (Required) The name of the Redis instance. Changing this forces a
     new resource to be created.
 
-* `location` - (Required) The location of the resource group.
+* `location` - (Required) The location of the resource group. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) The name of the resource group in which to
+* `resource_group_name` - (Required) The name of the resource group in which to Changing this forces a new resource to be created.
     create the Redis instance.
 
 * `capacity` - (Required) The size of the Redis cache to deploy. Valid values for a SKU `family` of C (Basic/Standard) are `0, 1, 2, 3, 4, 5, 6`, and for P (Premium) `family` are `1, 2, 3, 4, 5`.

--- a/website/docs/r/redis_cache.html.markdown
+++ b/website/docs/r/redis_cache.html.markdown
@@ -46,8 +46,7 @@ The following arguments are supported:
 
 * `location` - (Required) The location of the resource group. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) The name of the resource group in which to Changing this forces a new resource to be created.
-    create the Redis instance.
+* `resource_group_name` - (Required) The name of the resource group in which to create the Redis instance. Changing this forces a new resource to be created.
 
 * `capacity` - (Required) The size of the Redis cache to deploy. Valid values for a SKU `family` of C (Basic/Standard) are `0, 1, 2, 3, 4, 5, 6`, and for P (Premium) `family` are `1, 2, 3, 4, 5`.
 

--- a/website/docs/r/redis_enterprise_database.html.markdown
+++ b/website/docs/r/redis_enterprise_database.html.markdown
@@ -57,7 +57,7 @@ resource "azurerm_redis_enterprise_database" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name which should be used for this Redis Enterprise Database. Currently the acceptable value for this argument is `default`. Defaults to `default`. Changing this forces a new Redis Enterprise Database to be created.
+* `name` - (Optional) The name which should be used for this Redis Enterprise Database. Currently the acceptable value for this argument is `default`. Defaults to `default`. Changing this forces a new Redis Enterprise Database to be created.
 
 * `resource_group_name` - (Required) The name of the Resource Group where the Redis Enterprise Database should exist. Changing this forces a new Redis Enterprise Database to be created.
 
@@ -87,7 +87,7 @@ An `module` block exports the following:
 
 * `name` - (Required) The name which should be used for this module. Possible values are `RediSearch`, `RedisBloom` and `RedisTimeSeries`. Changing this forces a new Redis Enterprise Database to be created.
 
-* `args` - (Optional) Configuration options for the module (e.g. `ERROR_RATE 0.00 INITIAL_SIZE 400`).
+* `args` - (Optional) Configuration options for the module (e.g. `ERROR_RATE 0.00 INITIAL_SIZE 400`). Changing this forces a new resource to be created.
 
 ---
 

--- a/website/docs/r/redis_firewall_rule.html.markdown
+++ b/website/docs/r/redis_firewall_rule.html.markdown
@@ -60,7 +60,7 @@ The following arguments are supported:
 
 * `redis_cache_name` - (Required) The name of the Redis Cache. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) The name of the resource group in which this Redis Cache exists.
+* `resource_group_name` - (Required) The name of the resource group in which this Redis Cache exists. Changing this forces a new resource to be created.
 
 * `start_ip` - (Required) The lowest IP address included in the range
 

--- a/website/docs/r/relay_namespace.html.markdown
+++ b/website/docs/r/relay_namespace.html.markdown
@@ -38,7 +38,7 @@ The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the Azure Relay Namespace. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) The name of the resource group in which to create the Azure Relay Namespace.
+* `resource_group_name` - (Required) The name of the resource group in which to create the Azure Relay Namespace. Changing this forces a new resource to be created.
 
 * `location` - (Required) Specifies the supported Azure location where the Azure Relay Namespace exists. Changing this forces a new resource to be created.
 

--- a/website/docs/r/resource_group_cost_management_export.html.markdown
+++ b/website/docs/r/resource_group_cost_management_export.html.markdown
@@ -57,7 +57,7 @@ The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the Cost Management Export. Changing this forces a new resource to be created.
 
-* `resource_group_id` - (Required) The id of the resource group on which to create an export.
+* `resource_group_id` - (Required) The id of the resource group on which to create an export. Changing this forces a new resource to be created.
 
 * `recurrence_type` - (Required) How often the requested information will be exported. Valid values include `Annually`, `Daily`, `Monthly`, `Weekly`.
 
@@ -75,9 +75,9 @@ The following arguments are supported:
 
 A `export_data_storage_location` block supports the following:
 
-* `container_id` - (Required) The Resource Manager ID of the container where exports will be uploaded.
+* `container_id` - (Required) The Resource Manager ID of the container where exports will be uploaded. Changing this forces a new resource to be created.
 
-* `root_folder_path` - (Required) The path of the directory where exports will be uploaded.
+* `root_folder_path` - (Required) The path of the directory where exports will be uploaded. Changing this forces a new resource to be created.
 
 **Note:** The Resource Manager ID of a Storage Container is exposed via the `resource_manager_id` attribute of the `azurerm_storage_container` resource.
 

--- a/website/docs/r/resource_group_policy_assignment.html.markdown
+++ b/website/docs/r/resource_group_policy_assignment.html.markdown
@@ -93,7 +93,7 @@ The following arguments are supported:
 
 A `identity` block supports the following:
 
-* `type` - (Optional) The Type of Managed Identity which should be added to this Policy Definition. Possible values are `SystemAssigned` and `UserAssigned`.
+* `type` - (Required) The Type of Managed Identity which should be added to this Policy Definition. Possible values are `SystemAssigned` and `UserAssigned`.
 
 * `identity_ids` - (Optional) A list of User Managed Identity IDs which should be assigned to the Policy Definition.
 

--- a/website/docs/r/resource_policy_assignment.html.markdown
+++ b/website/docs/r/resource_policy_assignment.html.markdown
@@ -83,7 +83,7 @@ The following arguments are supported:
 
 A `identity` block supports the following:
 
-* `type` - (Optional) The Type of Managed Identity which should be added to this Policy Definition. Possible values are `SystemAssigned` and `UserAssigned`.
+* `type` - (Required) The Type of Managed Identity which should be added to this Policy Definition. Possible values are `SystemAssigned` and `UserAssigned`.
 
 * `identity_ids` - (Optional) A list of User Managed Identity IDs which should be assigned to the Policy Definition.
 

--- a/website/docs/r/role_definition.html.markdown
+++ b/website/docs/r/role_definition.html.markdown
@@ -37,9 +37,9 @@ resource "azurerm_role_definition" "example" {
 
 The following arguments are supported:
 
-* `role_definition_id` - (Optional) A unique UUID/GUID which identifies this role - one will be generated if not specified. Changing this forces a new resource to be created.
+* `role_definition_id` - (Optional) A unique UUID/GUID which identifies this role - one will be generated if not specified. Changing this forces a new resource to be created. Changing this forces a new resource to be created.
 
-* `name` - (Required) The name of the Role Definition. Changing this forces a new resource to be created.
+* `name` - (Required) The name of the Role Definition. 
 
 * `scope` - (Required) The scope at which the Role Definition applies to, such as `/subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333`, `/subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333/resourceGroups/myGroup`, or `/subscriptions/0b1f6471-1bf0-4dda-aec3-111122223333/resourceGroups/myGroup/providers/Microsoft.Compute/virtualMachines/myVM`. It is recommended to use the first entry of the `assignable_scopes`. Changing this forces a new resource to be created.
 

--- a/website/docs/r/route_server_bgp_connection.html.markdown
+++ b/website/docs/r/route_server_bgp_connection.html.markdown
@@ -29,9 +29,9 @@ The following arguments are supported:
 
 * `route_server_id` - (Required) The ID of the Route Server within which this Bgp connection should be created. Changing this forces a new resource to be created.
 
-* `peer_asn` - (Optional) The peer autonomous system number for the Route Server Bgp Connection. Changing this forces a new resource to be created.
+* `peer_asn` - (Required) The peer autonomous system number for the Route Server Bgp Connection. Changing this forces a new resource to be created.
 
-* `peer_ip` - (Optional) The peer ip address for the Route Server Bgp Connection. Changing this forces a new resource to be created.
+* `peer_ip` - (Required) The peer ip address for the Route Server Bgp Connection. Changing this forces a new resource to be created.
 
 ## Attributes Reference
 

--- a/website/docs/r/route_table.html.markdown
+++ b/website/docs/r/route_table.html.markdown
@@ -45,7 +45,7 @@ resource "azurerm_route_table" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the route table. Changing this forces a new resource to be created.
+* `name` - (Required) The name of the route table. Changing this forces a new resource to be created. Changing this forces a new resource to be created.
 
 * `resource_group_name` - (Required) The name of the resource group in which to create the route table. Changing this forces a new resource to be created.
 
@@ -61,7 +61,7 @@ The following arguments are supported:
 
 Elements of `route` support:
 
-* `name` - (Required) The name of the route.
+* `name` - (Required) The name of the route. Changing this forces a new resource to be created.
 
 * `address_prefix` - (Required) The destination to which the route applies. Can be CIDR (such as `10.1.0.0/16`) or [Azure Service Tag](https://docs.microsoft.com/azure/virtual-network/service-tags-overview) (such as `ApiManagement`, `AzureBackup` or `AzureMonitor`) format.
 

--- a/website/docs/r/security_center_assessment_policy.html.markdown
+++ b/website/docs/r/security_center_assessment_policy.html.markdown
@@ -28,7 +28,7 @@ The following arguments are supported:
 
 * `display_name` - (Required) The user-friendly display name of the Security Center Assessment.
 
-* `severity` - (Required) The severity level of the Security Center Assessment. Possible values are `Low`, `Medium` and `High`. Defaults to `Medium`.
+* `severity` - (Optional) The severity level of the Security Center Assessment. Possible values are `Low`, `Medium` and `High`. Defaults to `Medium`.
 
 ---
 

--- a/website/docs/r/service_fabric_cluster.html.markdown
+++ b/website/docs/r/service_fabric_cluster.html.markdown
@@ -129,7 +129,7 @@ A `certificate` block supports the following:
 
 * `thumbprint` - (Required) The Thumbprint of the Certificate.
 
-* `thumbprint_secondary` - (Required) The Secondary Thumbprint of the Certificate.
+* `thumbprint_secondary` - (Optional) The Secondary Thumbprint of the Certificate.
 
 * `x509_store_name` - (Required) The X509 Store where the Certificate Exists, such as `My`.
 
@@ -139,7 +139,7 @@ A `reverse_proxy_certificate` block supports the following:
 
 * `thumbprint` - (Required) The Thumbprint of the Certificate.
 
-* `thumbprint_secondary` - (Required) The Secondary Thumbprint of the Certificate.
+* `thumbprint_secondary` - (Optional) The Secondary Thumbprint of the Certificate.
 
 * `x509_store_name` - (Required) The X509 Store where the Certificate Exists, such as `My`.
 
@@ -197,7 +197,7 @@ A `fabric_settings` block supports the following:
 
 A `node_type` block supports the following:
 
-* `name` - (Required) The name of the Node Type. Changing this forces a new resource to be created.
+* `name` - (Required) The name of the Node Type. 
 
 * `placement_properties` - (Optional) The placement tags applied to nodes in the node type, which can be used to indicate where certain services (workload) should run.
 
@@ -205,17 +205,17 @@ A `node_type` block supports the following:
 
 * `instance_count` - (Required) The number of nodes for this Node Type.
 
-* `is_primary` - (Required) Is this the Primary Node Type? Changing this forces a new resource to be created.
+* `is_primary` - (Required) Is this the Primary Node Type? 
 
 * `is_stateless` - (Optional) Should this node type run only stateless services?
 
 * `multiple_availability_zones` - (Optional) Does this node type span availability zones?
 
-* `client_endpoint_port` - (Required) The Port used for the Client Endpoint for this Node Type. Changing this forces a new resource to be created.
+* `client_endpoint_port` - (Required) The Port used for the Client Endpoint for this Node Type. 
 
-* `http_endpoint_port` - (Required) The Port used for the HTTP Endpoint for this Node Type. Changing this forces a new resource to be created.
+* `http_endpoint_port` - (Required) The Port used for the HTTP Endpoint for this Node Type. 
 
-* `durability_level` - (Optional) The Durability Level for this Node Type. Possible values include `Bronze`, `Gold` and `Silver`. Defaults to `Bronze`. Changing this forces a new resource to be created.
+* `durability_level` - (Optional) The Durability Level for this Node Type. Possible values include `Bronze`, `Gold` and `Silver`. Defaults to `Bronze`. 
 
 * `application_ports` - (Optional) A `application_ports` block as defined below.
 

--- a/website/docs/r/service_fabric_managed_cluster.html.markdown
+++ b/website/docs/r/service_fabric_managed_cluster.html.markdown
@@ -141,7 +141,7 @@ A `lb_rule` block supports the following:
 
 * `probe_protocol` - (Required) Protocol for the probe. Can be one of `tcp`, `udp`, `http`, or `https`.
 
-* `probe_request_path` - (Required) Path for the probe to check, when probe protocol is set to `http`.
+* `probe_request_path` - (Optional) Path for the probe to check, when probe protocol is set to `http`.
 
 * `protocol` - (Required) The transport protocol used in this rule. Can be one of `tcp` or `udp`.
 

--- a/website/docs/r/service_plan.html.markdown
+++ b/website/docs/r/service_plan.html.markdown
@@ -39,7 +39,7 @@ The following arguments are supported:
 
 * `location` - (Required) The Azure Region where the Service Plan should exist. Changing this forces a new AppService to be created.
 
-* `os_type` - (Required) The O/S type for the App Services to be hosted in this plan. Possible values include `Windows`, `Linux`, and `WindowsContainer`.
+* `os_type` - (Required) The O/S type for the App Services to be hosted in this plan. Possible values include `Windows`, `Linux`, and `WindowsContainer`. Changing this forces a new resource to be created.
 
 * `resource_group_name` - (Required) The name of the Resource Group where the AppService should exist. Changing this forces a new AppService to be created.
 
@@ -61,7 +61,7 @@ The following arguments are supported:
 
 * `per_site_scaling_enabled` - (Optional) Should Per Site Scaling be enabled. Defaults to `false`.
 
-* `zone_balancing_enabled` - (Optional) Should the Service Plan balance across Availability Zones in the region. Defaults to `false`.
+* `zone_balancing_enabled` - (Optional) Should the Service Plan balance across Availability Zones in the region. Defaults to `false`. Changing this forces a new resource to be created.
 
 ~> **NOTE:** If this setting is set to `true` and the `worker_count` value is specified, it should be set to a multiple of the number of availability zones in the region. Please see the Azure documentation for the number of Availability Zones in your region.
 

--- a/website/docs/r/servicebus_namespace.html.markdown
+++ b/website/docs/r/servicebus_namespace.html.markdown
@@ -41,7 +41,7 @@ The following arguments are supported:
 * `name` - (Required) Specifies the name of the ServiceBus Namespace resource . Changing this forces a
     new resource to be created.
 
-* `resource_group_name` - (Required) The name of the resource group in which to
+* `resource_group_name` - (Required) The name of the resource group in which to Changing this forces a new resource to be created.
     create the namespace.
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
@@ -60,7 +60,7 @@ The following arguments are supported:
 
 * `minimum_tls_version` - (Optional) The minimum supported TLS version for this Service Bus Namespace. Valid values are: `1.0`, `1.1` and `1.2`. The current default minimum TLS version is `1.2`.
 
-* `zone_redundant` - (Optional) Whether or not this resource is zone redundant. `sku` needs to be `Premium`. Defaults to `false`.
+* `zone_redundant` - (Optional) Whether or not this resource is zone redundant. `sku` needs to be `Premium`. Defaults to `false`. Changing this forces a new resource to be created.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
@@ -84,7 +84,7 @@ A `customer_managed_key` block supports the following:
 
 * `identity_id` - (Required) The ID of the User Assigned Identity that has access to the key.
 
-* `infrastructure_encryption_enabled` - (Optional) Used to specify whether enable Infrastructure Encryption (Double Encryption).
+* `infrastructure_encryption_enabled` - (Optional) Used to specify whether enable Infrastructure Encryption (Double Encryption). Changing this forces a new resource to be created.
 
 ## Attributes Reference
 

--- a/website/docs/r/servicebus_subscription.html.markdown
+++ b/website/docs/r/servicebus_subscription.html.markdown
@@ -83,11 +83,11 @@ The following arguments are supported:
 
 A `client_scoped_subscription` block supports the following:
 
-* `client_id` - (Optional)  Specifies the Client ID of the application that created the client-scoped subscription.
+* `client_id` - (Optional)  Specifies the Client ID of the application that created the client-scoped subscription. Changing this forces a new resource to be created.
 
 ~> **NOTE:** Client ID can be null or empty, but it must match the client ID set on the JMS client application. From the Azure Service Bus perspective, a null client ID and an empty client id have the same behavior. If the client ID is set to null or empty, it is only accessible to client applications whose client ID is also set to null or empty.
 
-* `is_client_scoped_subscription_shareable` - (Optional) Whether the client scoped subscription is shareable. Defaults to `true`
+* `is_client_scoped_subscription_shareable` - (Optional) Whether the client scoped subscription is shareable. Defaults to `true` Changing this forces a new resource to be created.
 
 * `is_client_scoped_subscription_durable` - (Optional) Whether the client scoped subscription is durable. This property can only be controlled from the application side.
 

--- a/website/docs/r/servicebus_topic.html.markdown
+++ b/website/docs/r/servicebus_topic.html.markdown
@@ -46,7 +46,7 @@ The following arguments are supported:
 * `name` - (Required) Specifies the name of the ServiceBus Topic resource. Changing this forces a
     new resource to be created.
 
-* `namespace_id` - (Required) The ID of the ServiceBus Namespace to create
+* `namespace_id` - (Required) The ID of the ServiceBus Namespace to create Changing this forces a new resource to be created.
     this topic in. Changing this forces a new resource to be created.
 
 * `status` - (Optional) The Status of the Service Bus Topic. Acceptable values are `Active` or `Disabled`. Defaults to `Active`.
@@ -67,7 +67,7 @@ The following arguments are supported:
     are enabled. An express topic holds a message in memory temporarily before writing
     it to persistent storage. Defaults to false.
 
-* `enable_partitioning` - (Optional) Boolean flag which controls whether to enable
+* `enable_partitioning` - (Optional) Boolean flag which controls whether to enable Changing this forces a new resource to be created.
     the topic to be partitioned across multiple message brokers. Defaults to false.
     Changing this forces a new resource to be created.
 
@@ -81,7 +81,7 @@ The following arguments are supported:
     memory allocated for the topic. For supported values see the "Queue/topic size"
     section of [this document](https://docs.microsoft.com/azure/service-bus-messaging/service-bus-quotas).
 
-* `requires_duplicate_detection` - (Optional) Boolean flag which controls whether
+* `requires_duplicate_detection` - (Optional) Boolean flag which controls whether Changing this forces a new resource to be created.
     the Topic requires duplicate detection. Defaults to false. Changing this forces
     a new resource to be created.
 

--- a/website/docs/r/shared_image_version.html.markdown
+++ b/website/docs/r/shared_image_version.html.markdown
@@ -45,7 +45,7 @@ resource "azurerm_shared_image_version" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The version number for this Image Version, such as `1.0.0`. Changing this forces a new resource to be created.
+* `name` - (Required) The version number for this Image Version, such as `1.0.0`. Changing this forces a new resource to be created. Changing this forces a new resource to be created.
 
 * `gallery_name` - (Required) The name of the Shared Image Gallery in which the Shared Image exists. Changing this forces a new resource to be created.
 
@@ -89,7 +89,7 @@ The following arguments are supported:
 
 The `target_region` block supports the following:
 
-* `name` - (Required) The Azure Region in which this Image Version should exist.
+* `name` - (Required) The Azure Region in which this Image Version should exist. Changing this forces a new resource to be created.
 
 * `regional_replica_count` - (Required) The number of replicas of the Image Version to be created per region.
 

--- a/website/docs/r/signalr_service.html.markdown
+++ b/website/docs/r/signalr_service.html.markdown
@@ -85,11 +85,11 @@ An `upstream_endpoint` block supports the following:
 
 * `url_template` - (Required) The upstream URL Template. This can be a url or a template such as `http://host.com/{hub}/api/{category}/{event}`.
 
-* `category_pattern` - (Optional) The categories to match on, or `*` for all.
+* `category_pattern` - (Required) The categories to match on, or `*` for all.
 
-* `event_pattern` - (Optional) The events to match on, or `*` for all.
+* `event_pattern` - (Required) The events to match on, or `*` for all.
 
-* `hub_pattern` - (Optional) The hubs to match on, or `*` for all.
+* `hub_pattern` - (Required) The hubs to match on, or `*` for all.
 
 ---
 

--- a/website/docs/r/signalr_service_network_acl.html.markdown
+++ b/website/docs/r/signalr_service_network_acl.html.markdown
@@ -98,7 +98,7 @@ A `public_network` block supports the following:
 
 **Note:** When `default_action` is `Deny`, `denied_request_types`cannot be set.
 
-**Note:** `allowed_request_types` and `denied_request_types` cannot be set together.
+**Note:** `allowed_request_types` - (Optional) and `denied_request_types` cannot be set together.
 
 ---
 
@@ -114,7 +114,7 @@ A `private_endpoint` block supports the following:
 
 **Note:** When `default_action` is `Deny`, `denied_request_types`cannot be set.
 
-**Note:** `allowed_request_types` and `denied_request_types` cannot be set together.
+**Note:** `allowed_request_types` - (Optional) and `denied_request_types` cannot be set together.
 
 ## Attributes Reference
 

--- a/website/docs/r/site_recovery_fabric.html.markdown
+++ b/website/docs/r/site_recovery_fabric.html.markdown
@@ -42,13 +42,13 @@ resource "azurerm_site_recovery_fabric" "fabric" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the network mapping.
+* `name` - (Required) The name of the network mapping. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) Name of the resource group where the vault that should be updated is located.
+* `resource_group_name` - (Required) Name of the resource group where the vault that should be updated is located. Changing this forces a new resource to be created.
 
-* `recovery_vault_name` - (Required) The name of the vault that should be updated.
+* `recovery_vault_name` - (Required) The name of the vault that should be updated. Changing this forces a new resource to be created.
 
-* `location` - (Required) In what region should the fabric be located.
+* `location` - (Required) In what region should the fabric be located. Changing this forces a new resource to be created.
 
 ## Attributes Reference
 

--- a/website/docs/r/site_recovery_network_mapping.html.markdown
+++ b/website/docs/r/site_recovery_network_mapping.html.markdown
@@ -74,19 +74,19 @@ resource "azurerm_site_recovery_network_mapping" "recovery-mapping" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the network mapping.
+* `name` - (Required) The name of the network mapping. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) Name of the resource group where the vault that should be updated is located.
+* `resource_group_name` - (Required) Name of the resource group where the vault that should be updated is located. Changing this forces a new resource to be created.
 
-* `recovery_vault_name` - (Required) The name of the vault that should be updated.
+* `recovery_vault_name` - (Required) The name of the vault that should be updated. Changing this forces a new resource to be created.
 
-* `source_recovery_fabric_name` - (Required) Specifies the ASR fabric where mapping should be created.
+* `source_recovery_fabric_name` - (Required) Specifies the ASR fabric where mapping should be created. Changing this forces a new resource to be created.
 
-* `target_recovery_fabric_name` - (Required) The Azure Site Recovery fabric object corresponding to the recovery Azure region.
+* `target_recovery_fabric_name` - (Required) The Azure Site Recovery fabric object corresponding to the recovery Azure region. Changing this forces a new resource to be created.
 
-* `source_network_id` - (Required) The id of the primary network.
+* `source_network_id` - (Required) The id of the primary network. Changing this forces a new resource to be created.
 
-* `target_network_id` - (Required) The id of the recovery network.
+* `target_network_id` - (Required) The id of the recovery network. Changing this forces a new resource to be created.
 
 ## Attributes Reference
 

--- a/website/docs/r/site_recovery_protection_container.html.markdown
+++ b/website/docs/r/site_recovery_protection_container.html.markdown
@@ -49,13 +49,13 @@ resource "azurerm_site_recovery_protection_container" "protection-container" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the protection container.
+* `name` - (Required) The name of the protection container. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) Name of the resource group where the vault that should be updated is located.
+* `resource_group_name` - (Required) Name of the resource group where the vault that should be updated is located. Changing this forces a new resource to be created.
 
-* `recovery_vault_name` - (Required) The name of the vault that should be updated.
+* `recovery_vault_name` - (Required) The name of the vault that should be updated. Changing this forces a new resource to be created.
 
-* `recovery_fabric_name` - (Required) Name of fabric that should contain this protection container.
+* `recovery_fabric_name` - (Required) Name of fabric that should contain this protection container. Changing this forces a new resource to be created.
 
 ## Attributes Reference
 

--- a/website/docs/r/site_recovery_protection_container_mapping.html.markdown
+++ b/website/docs/r/site_recovery_protection_container_mapping.html.markdown
@@ -81,19 +81,19 @@ resource "azurerm_site_recovery_protection_container_mapping" "container-mapping
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the protection container mapping.
+* `name` - (Required) The name of the protection container mapping. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) Name of the resource group where the vault that should be updated is located.
+* `resource_group_name` - (Required) Name of the resource group where the vault that should be updated is located. Changing this forces a new resource to be created.
 
-* `recovery_vault_name` - (Required) The name of the vault that should be updated.
+* `recovery_vault_name` - (Required) The name of the vault that should be updated. Changing this forces a new resource to be created.
 
-* `recovery_fabric_name` - (Required) Name of fabric that should contains the protection container to map.
+* `recovery_fabric_name` - (Required) Name of fabric that should contains the protection container to map. Changing this forces a new resource to be created.
 
-* `recovery_source_protection_container_name` - (Required) Name of the source protection container to map.
+* `recovery_source_protection_container_name` - (Required) Name of the source protection container to map. Changing this forces a new resource to be created.
 
-* `recovery_target_protection_container_id` - (Required) Id of target protection container to map to.
+* `recovery_target_protection_container_id` - (Required) Id of target protection container to map to. Changing this forces a new resource to be created.
 
-* `recovery_replication_policy_id` - (Required) Id of the policy to use for this mapping.
+* `recovery_replication_policy_id` - (Required) Id of the policy to use for this mapping. Changing this forces a new resource to be created.
 
 ## Attributes Reference
 

--- a/website/docs/r/site_recovery_replicated_vm.html.markdown
+++ b/website/docs/r/site_recovery_replicated_vm.html.markdown
@@ -222,29 +222,29 @@ resource "azurerm_site_recovery_replicated_vm" "vm-replication" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the replication for the replicated VM.
+* `name` - (Required) The name of the replication for the replicated VM. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) Name of the resource group where the vault that should be updated is located.
+* `resource_group_name` - (Required) Name of the resource group where the vault that should be updated is located. Changing this forces a new resource to be created.
 
-* `recovery_vault_name` - (Required) The name of the vault that should be updated.
+* `recovery_vault_name` - (Required) The name of the vault that should be updated. Changing this forces a new resource to be created.
 
-* `source_recovery_fabric_name` - (Required) Name of fabric that should contains this replication.
+* `source_recovery_fabric_name` - (Required) Name of fabric that should contains this replication. Changing this forces a new resource to be created.
 
-* `source_vm_id` - (Required) Id of the VM to replicate
+* `source_vm_id` - (Required) Id of the VM to replicate Changing this forces a new resource to be created.
 
-* `source_recovery_protection_container_name` - (Required) Name of the protection container to use.
+* `source_recovery_protection_container_name` - (Required) Name of the protection container to use. Changing this forces a new resource to be created.
 
-* `target_resource_group_id` - (Required) Id of resource group where the VM should be created when a failover is done.
+* `target_resource_group_id` - (Required) Id of resource group where the VM should be created when a failover is done. Changing this forces a new resource to be created.
 
-* `target_recovery_fabric_id` - (Required)  Id of fabric where the VM replication should be handled when a failover is done.
+* `target_recovery_fabric_id` - (Required)  Id of fabric where the VM replication should be handled when a failover is done. Changing this forces a new resource to be created.
 
-* `target_recovery_protection_container_id` - (Required)  Id of protection container where the VM replication should be created when a failover is done.
+* `target_recovery_protection_container_id` - (Required)  Id of protection container where the VM replication should be created when a failover is done. Changing this forces a new resource to be created.
 
 * `target_availability_set_id` - (Optional)  Id of availability set that the new VM should belong to when a failover is done.
 
-* `target_zone` - (Optional) Specifies the Availability Zone where the Failover VM should exist.
+* `target_zone` - (Optional) Specifies the Availability Zone where the Failover VM should exist. Changing this forces a new resource to be created.
 
-* `managed_disk` - (Required) One or more `managed_disk` block.
+* `managed_disk` - (Optional) One or more `managed_disk` block.
 
 * `target_network_id` - (Optional) Network to use when a failover is done (recommended to set if any network_interface is configured for failover).
 

--- a/website/docs/r/site_recovery_replication_policy.html.markdown
+++ b/website/docs/r/site_recovery_replication_policy.html.markdown
@@ -38,11 +38,11 @@ resource "azurerm_site_recovery_replication_policy" "policy" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the replication policy.
+* `name` - (Required) The name of the replication policy. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) Name of the resource group where the vault that should be updated is located.
+* `resource_group_name` - (Required) Name of the resource group where the vault that should be updated is located. Changing this forces a new resource to be created.
 
-* `recovery_vault_name` - (Required) The name of the vault that should be updated.
+* `recovery_vault_name` - (Required) The name of the vault that should be updated. Changing this forces a new resource to be created.
 
 * `recovery_point_retention_in_minutes` - (Required) The duration in minutes for which the recovery points need to be stored.
 

--- a/website/docs/r/snapshot.html.markdown
+++ b/website/docs/r/snapshot.html.markdown
@@ -47,7 +47,7 @@ The following arguments are supported:
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 
-* `create_option` - (Required) Indicates how the snapshot is to be created. Possible values are `Copy` or `Import`. Changing this forces a new resource to be created.
+* `create_option` - (Required) Indicates how the snapshot is to be created. Possible values are `Copy` or `Import`. 
 
 ~> **Note:** One of `source_uri`, `source_resource_id` or `storage_account_id` must be specified.
 

--- a/website/docs/r/spatial_anchors_account.html.markdown
+++ b/website/docs/r/spatial_anchors_account.html.markdown
@@ -31,7 +31,7 @@ The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the Spatial Anchors Account. Changing this forces a new resource to be created. Must be globally unique.
 
-* `resource_group_name` - (Required) The name of the resource group in which to create the Spatial Anchors Account.
+* `resource_group_name` - (Required) The name of the resource group in which to create the Spatial Anchors Account. Changing this forces a new resource to be created.
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 

--- a/website/docs/r/spring_cloud_connection.html.markdown
+++ b/website/docs/r/spring_cloud_connection.html.markdown
@@ -99,7 +99,7 @@ The following arguments are supported:
 
 * `type` - (Required) The authentication type. Possible values are `systemAssignedIdentity`, `userAssignedIdentity`, `servicePrincipalSecret`, `servicePrincipalCertificate`, `secret`.
 
-* `name` - (Optional) Username or account name for secret auth. `name` and `secret` should be either both specified or both not specified when `type` is set to `secret`.
+* `name` - (Required) Username or account name for secret auth. `name` and `secret` should be either both specified or both not specified when `type` is set to `secret`.
 
 * `secret` - (Optional) Password or account key for secret auth. `secret` and `name` should be either both specified or both not specified when `type` is set to `secret`.
 

--- a/website/docs/r/spring_cloud_service.html.markdown
+++ b/website/docs/r/spring_cloud_service.html.markdown
@@ -56,7 +56,7 @@ resource "azurerm_spring_cloud_service" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name of the Spring Cloud Service resource. Changing this forces a new resource to be created.
+* `name` - (Required) Specifies the name of the Spring Cloud Service resource. Changing this forces a new resource to be created. Changing this forces a new resource to be created.
 
 * `resource_group_name` - (Required) Specifies The name of the resource group in which to create the Spring Cloud Service. Changing this forces a new resource to be created.
 
@@ -66,7 +66,7 @@ The following arguments are supported:
 
 * `build_agent_pool_size` - (Optional) Specifies the size for this Spring Cloud Service's default build agent pool. Possible values are `S1`, `S2`, `S3`, `S4` and `S5`. This field is applicable only for Spring Cloud Service with enterprise tier.
 
-* `sku_name` - (Optional) Specifies the SKU Name for this Spring Cloud Service. Possible values are `B0`, `S0` and `E0`. Defaults to `S0`.
+* `sku_name` - (Optional) Specifies the SKU Name for this Spring Cloud Service. Possible values are `B0`, `S0` and `E0`. Defaults to `S0`. Changing this forces a new resource to be created.
 
 * `network` - (Optional) A `network` block as defined below. Changing this forces a new resource to be created.
 
@@ -116,7 +116,7 @@ The `config_server_git_setting` block supports the following:
 
 The `repository` block supports the following:
 
-* `name` - (Required) A name to identify on the Git repository, required only if repos exists.
+* `name` - (Required) A name to identify on the Git repository, required only if repos exists. Changing this forces a new resource to be created.
 
 * `uri` - (Required) The URI of the Git repository that's used as the Config Server back end should be started with `http://`, `https://`, `git@`, or `ssh://`.
 

--- a/website/docs/r/sql_database.html.markdown
+++ b/website/docs/r/sql_database.html.markdown
@@ -68,13 +68,13 @@ resource "azurerm_sql_database" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the database.
+* `name` - (Required) The name of the database. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) The name of the resource group in which to create the database.  This must be the same as Database Server resource group currently.
+* `resource_group_name` - (Required) The name of the resource group in which to create the database.  This must be the same as Database Server resource group currently. Changing this forces a new resource to be created.
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 
-* `server_name` - (Required) The name of the SQL Server on which to create the database.
+* `server_name` - (Required) The name of the SQL Server on which to create the database. Changing this forces a new resource to be created.
 
 * `create_mode` - (Optional) Specifies how to create the database. Valid values are: `Default`, `Copy`, `OnlineSecondary`, `NonReadableSecondary`,  `PointInTimeRestore`, `Recovery`, `Restore` or `RestoreLongTermRetentionBackup`. Must be `Default` to create a new database. Defaults to `Default`. Please see [Azure SQL Database REST API](https://docs.microsoft.com/rest/api/sql/databases/createorupdate#createmode)
 

--- a/website/docs/r/sql_elasticpool.html.markdown
+++ b/website/docs/r/sql_elasticpool.html.markdown
@@ -50,7 +50,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the elastic pool. This needs to be globally unique. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) The name of the resource group in which to create the elastic pool. This must be the same as the resource group of the underlying SQL server.
+* `resource_group_name` - (Required) The name of the resource group in which to create the elastic pool. This must be the same as the resource group of the underlying SQL server. Changing this forces a new resource to be created.
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 

--- a/website/docs/r/sql_failover_group.html.markdown
+++ b/website/docs/r/sql_failover_group.html.markdown
@@ -67,11 +67,11 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the failover group. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) The name of the resource group containing the SQL server
+* `resource_group_name` - (Required) The name of the resource group containing the SQL server Changing this forces a new resource to be created.
 
-* `server_name` - (Required) The name of the primary SQL server. Changing this forces a new resource to be created.
+* `server_name` - (Required) The name of the primary SQL server. Changing this forces a new resource to be created. Changing this forces a new resource to be created.
 
-* `databases` - A list of database ids to add to the failover group
+* `databases` - (Optional) A list of database ids to add to the failover group
 
 -> **NOTE:** The failover group will create a secondary database for each database listed in `databases`. If the secondary databases need to be managed through Terraform, they should be defined as resources and a dependency added to the failover group to ensure the secondary databases are created first. Please refer to the detailed example which can be found in [the `./examples/sql-azure/failover_group` directory within the GitHub Repository](https://github.com/hashicorp/terraform-provider-azurerm/tree/main/examples/sql-azure/failover_group)
 

--- a/website/docs/r/sql_firewall_rule.html.markdown
+++ b/website/docs/r/sql_firewall_rule.html.markdown
@@ -42,12 +42,12 @@ resource "azurerm_sql_firewall_rule" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the firewall rule.
+* `name` - (Required) The name of the firewall rule. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) The name of the resource group in which to
+* `resource_group_name` - (Required) The name of the resource group in which to Changing this forces a new resource to be created.
     create the SQL Server.
 
-* `server_name` - (Required) The name of the SQL Server on which to create the Firewall Rule.
+* `server_name` - (Required) The name of the SQL Server on which to create the Firewall Rule. Changing this forces a new resource to be created.
 
 * `start_ip_address` - (Required) The starting IP address to allow through the firewall for this rule.
 

--- a/website/docs/r/sql_firewall_rule.html.markdown
+++ b/website/docs/r/sql_firewall_rule.html.markdown
@@ -44,8 +44,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the firewall rule. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) The name of the resource group in which to Changing this forces a new resource to be created.
-    create the SQL Server.
+* `resource_group_name` - (Required) The name of the resource group in which to create the SQL Server. Changing this forces a new resource to be created.
 
 * `server_name` - (Required) The name of the SQL Server on which to create the Firewall Rule. Changing this forces a new resource to be created.
 

--- a/website/docs/r/sql_managed_instance.html.markdown
+++ b/website/docs/r/sql_managed_instance.html.markdown
@@ -207,13 +207,13 @@ resource "azurerm_sql_managed_instance" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the SQL Managed Instance. This needs to be globally unique within Azure.
+* `name` - (Required) The name of the SQL Managed Instance. This needs to be globally unique within Azure. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) The name of the resource group in which to create the SQL Server.
+* `resource_group_name` - (Required) The name of the resource group in which to create the SQL Server. Changing this forces a new resource to be created.
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 
-* `sku_name` - (Required) Specifies the SKU Name for the SQL Managed Instance. Valid values include `GP_Gen4`, `GP_Gen5`, `BC_Gen4`, `BC_Gen5`. Changing this forces a new resource to be created.
+* `sku_name` - (Required) Specifies the SKU Name for the SQL Managed Instance. Valid values include `GP_Gen4`, `GP_Gen5`, `BC_Gen4`, `BC_Gen5`. 
 
 * `vcores` - (Required) Number of cores that should be assigned to your instance. Values can be `8`, `16`, or `24` if `sku_name` is `GP_Gen4`, or `8`, `16`, `24`, `32`, or `40` if `sku_name` is `GP_Gen5`.
 
@@ -225,7 +225,7 @@ The following arguments are supported:
 
 * `administrator_login_password` - (Required) The password associated with the `administrator_login` user. Needs to comply with Azure's [Password Policy](https://msdn.microsoft.com/library/ms161959.aspx)
 
-* `subnet_id` - (Required) The subnet resource id that the SQL Managed Instance will be associated with.
+* `subnet_id` - (Required) The subnet resource id that the SQL Managed Instance will be associated with. Changing this forces a new resource to be created.
 
 * `collation` - (Optional) Specifies how the SQL Managed Instance will be collated. Default value is `SQL_Latin1_General_CP1_CI_AS`. Changing this forces a new resource to be created.
 

--- a/website/docs/r/sql_managed_instance_failover_group.html.markdown
+++ b/website/docs/r/sql_managed_instance_failover_group.html.markdown
@@ -88,9 +88,9 @@ The following arguments are supported:
 
 * `managed_instance_name` - (Required) The name of the SQL Managed Instance which will be replicated using a SQL Instance Failover Group. Changing this forces a new SQL Instance Failover Group to be created.
 
-* `location` - The Azure Region where the SQL Instance Failover Group exists.
+* `location` - The Azure Region where the SQL Instance Failover Group exists. Changing this forces a new resource to be created.
 
-* `partner_managed_instance_id` - (Required) ID of the SQL Managed Instance which will be replicated to.
+* `partner_managed_instance_id` - (Required) ID of the SQL Managed Instance which will be replicated to. Changing this forces a new resource to be created.
 
 * `read_write_endpoint_failover_policy` - (Required) A `read_write_endpoint_failover_policy` block as defined below.
 

--- a/website/docs/r/sql_server.html.markdown
+++ b/website/docs/r/sql_server.html.markdown
@@ -49,13 +49,13 @@ resource "azurerm_sql_server" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the Microsoft SQL Server. This needs to be globally unique within Azure.
+* `name` - (Required) The name of the Microsoft SQL Server. This needs to be globally unique within Azure. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) The name of the resource group in which to create the Microsoft SQL Server.
+* `resource_group_name` - (Required) The name of the resource group in which to create the Microsoft SQL Server. Changing this forces a new resource to be created.
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 
-* `version` - (Required) The version for the new server. Valid values are: 2.0 (for v11 server) and 12.0 (for v12 server).
+* `version` - (Required) The version for the new server. Valid values are: 2.0 (for v11 server) and 12.0 (for v12 server). Changing this forces a new resource to be created.
 
 * `administrator_login` - (Required) The administrator login name for the new server. Changing this forces a new resource to be created.
 

--- a/website/docs/r/static_site_custom_domain.html.markdown
+++ b/website/docs/r/static_site_custom_domain.html.markdown
@@ -82,7 +82,7 @@ The following arguments are supported:
 
 * `static_site_id` - (Required) The ID of the Static Site. Changing this forces a new Static Site Custom Domain to be created.
 
-* `validation_type` - (Required) One of `cname-delegation` or `dns-txt-token`. Changing this forces a new Static Site Custom Domain to be created.
+* `validation_type` - (Optional) One of `cname-delegation` or `dns-txt-token`. Changing this forces a new Static Site Custom Domain to be created.
 
 ## Attributes Reference
 

--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -84,7 +84,7 @@ The following arguments are supported:
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 
-* `account_kind` - (Optional) Defines the Kind of account. Valid options are `BlobStorage`, `BlockBlobStorage`, `FileStorage`, `Storage` and `StorageV2`. Changing this forces a new resource to be created. Defaults to `StorageV2`.
+* `account_kind` - (Optional) Defines the Kind of account. Valid options are `BlobStorage`, `BlockBlobStorage`, `FileStorage`, `Storage` and `StorageV2`.  Defaults to `StorageV2`.
 
 -> **NOTE:** Changing the `account_kind` value from `Storage` to `StorageV2` will not trigger a force new on the storage account, it will only upgrade the existing storage account from `Storage` to `StorageV2` keeping the existing storage account in place.
 
@@ -107,11 +107,11 @@ The following arguments are supported:
 
 -> **NOTE:** At this time `min_tls_version` is only supported in the Public Cloud, China Cloud, and US Government Cloud.
 
-* `allow_nested_items_to_be_public` - Allow or disallow nested items within this Account to opt into being public. Defaults to `true`.
+* `allow_nested_items_to_be_public` - (Optional) Allow or disallow nested items within this Account to opt into being public. Defaults to `true`.
 
 -> **NOTE:** At this time `allow_nested_items_to_be_public` is only supported in the Public Cloud, China Cloud, and US Government Cloud.
 
-* `shared_access_key_enabled` - Indicates whether the storage account permits requests to be authorized with the account access key via Shared Key. If false, then all requests, including shared access signatures, must be authorized with Azure Active Directory (Azure AD). The default value is `true`.
+* `shared_access_key_enabled` - (Optional) Indicates whether the storage account permits requests to be authorized with the account access key via Shared Key. If false, then all requests, including shared access signatures, must be authorized with Azure Active Directory (Azure AD). The default value is `true`.
 
 ~> **Note:** Terraform uses Shared Key Authorisation to provision Storage Containers, Blobs and other items - when Shared Key Access is disabled, you will need to enable [the `storage_use_azuread` flag in the Provider block](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs#storage_use_azuread) to use Azure AD for authentication, however not all Azure Storage services support Active Directory authentication.
 

--- a/website/docs/r/storage_account_customer_managed_key.html.markdown
+++ b/website/docs/r/storage_account_customer_managed_key.html.markdown
@@ -91,7 +91,7 @@ The following arguments are supported:
 
 * `storage_account_id` - (Required) The ID of the Storage Account. Changing this forces a new resource to be created.
 
-* `key_vault_id` - (Required) The ID of the Key Vault. Changing this forces a new resource to be created.
+* `key_vault_id` - (Required) The ID of the Key Vault. 
 
 * `key_name` - (Required) The name of Key Vault Key.
 

--- a/website/docs/r/storage_account_network_rules.html.markdown
+++ b/website/docs/r/storage_account_network_rules.html.markdown
@@ -65,7 +65,7 @@ resource "azurerm_storage_account_network_rules" "example" {
 
 The following arguments are supported:
 
-* `storage_account_id` - (Optional) Specifies the ID of the storage account. Changing this forces a new resource to be created.
+* `storage_account_id` - (Required) Specifies the ID of the storage account. Changing this forces a new resource to be created.
 
 * `default_action` - (Required) Specifies the default action of allow or deny when no other rules match. Valid options are `Deny` or `Allow`.
 

--- a/website/docs/r/storage_blob.html.markdown
+++ b/website/docs/r/storage_blob.html.markdown
@@ -45,16 +45,16 @@ resource "azurerm_storage_blob" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the storage blob. Must be unique within the storage container the blob is located.
+* `name` - (Required) The name of the storage blob. Must be unique within the storage container the blob is located. Changing this forces a new resource to be created.
 
-* `storage_account_name` - (Required) Specifies the storage account in which to create the storage container.
+* `storage_account_name` - (Required) Specifies the storage account in which to create the storage container. Changing this forces a new resource to be created.
  Changing this forces a new resource to be created.
 
-* `storage_container_name` - (Required) The name of the storage container in which this blob should be created.
+* `storage_container_name` - (Required) The name of the storage container in which this blob should be created. Changing this forces a new resource to be created.
 
 * `type` - (Required) The type of the storage blob to be created. Possible values are `Append`, `Block` or `Page`. Changing this forces a new resource to be created.
 
-* `size` - (Optional) Used only for `page` blobs to specify the size in bytes of the blob to be created. Must be a multiple of 512. Defaults to 0.
+* `size` - (Optional) Used only for `page` blobs to specify the size in bytes of the blob to be created. Must be a multiple of 512. Defaults to 0. Changing this forces a new resource to be created.
 
 ~> **Note:** `size` is required if `source_uri` is not set.
 
@@ -68,14 +68,14 @@ The following arguments are supported:
 
 ~> **NOTE:** This property is intended to be used with the Terraform internal [filemd5](https://www.terraform.io/docs/configuration/functions/filemd5.html) and [md5](https://www.terraform.io/docs/configuration/functions/md5.html) functions when `source` or `source_content`, respectively, are defined.
 
-* `source` - (Optional) An absolute path to a file on the local system. This field cannot be specified for Append blobs and cannot be specified if `source_content` or `source_uri` is specified.
+* `source` - (Optional) An absolute path to a file on the local system. This field cannot be specified for Append blobs and cannot be specified if `source_content` or `source_uri` is specified. Changing this forces a new resource to be created.
 
-* `source_content` - (Optional) The content for this blob which should be defined inline. This field can only be specified for Block blobs and cannot be specified if `source` or `source_uri` is specified.
+* `source_content` - (Optional) The content for this blob which should be defined inline. This field can only be specified for Block blobs and cannot be specified if `source` or `source_uri` is specified. Changing this forces a new resource to be created.
 
-* `source_uri` - (Optional) The URI of an existing blob, or a file in the Azure File service, to use as the source contents
+* `source_uri` - (Optional) The URI of an existing blob, or a file in the Azure File service, to use as the source contents Changing this forces a new resource to be created.
     for the blob to be created. Changing this forces a new resource to be created. This field cannot be specified for Append blobs and cannot be specified if `source` or `source_content` is specified.
 
-* `parallelism` - (Optional) The number of workers per CPU core to run for concurrent uploads. Defaults to `8`.
+* `parallelism` - (Optional) The number of workers per CPU core to run for concurrent uploads. Defaults to `8`. Changing this forces a new resource to be created.
 
 ~> **NOTE:** `parallelism` is only applicable for Page blobs - support for [Block Blobs is blocked on the upstream issue](https://github.com/tombuildsstuff/giovanni/issues/15).
 

--- a/website/docs/r/storage_blob.html.markdown
+++ b/website/docs/r/storage_blob.html.markdown
@@ -72,8 +72,7 @@ The following arguments are supported:
 
 * `source_content` - (Optional) The content for this blob which should be defined inline. This field can only be specified for Block blobs and cannot be specified if `source` or `source_uri` is specified. Changing this forces a new resource to be created.
 
-* `source_uri` - (Optional) The URI of an existing blob, or a file in the Azure File service, to use as the source contents Changing this forces a new resource to be created.
-    for the blob to be created. Changing this forces a new resource to be created. This field cannot be specified for Append blobs and cannot be specified if `source` or `source_content` is specified.
+* `source_uri` - (Optional) The URI of an existing blob, or a file in the Azure File service, to use as the source contents for the blob to be created. Changing this forces a new resource to be created. This field cannot be specified for Append blobs and cannot be specified if `source` or `source_content` is specified.
 
 * `parallelism` - (Optional) The number of workers per CPU core to run for concurrent uploads. Defaults to `8`. Changing this forces a new resource to be created.
 

--- a/website/docs/r/storage_container.html.markdown
+++ b/website/docs/r/storage_container.html.markdown
@@ -41,9 +41,9 @@ resource "azurerm_storage_container" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the Container which should be created within the Storage Account.
+* `name` - (Required) The name of the Container which should be created within the Storage Account. Changing this forces a new resource to be created.
 
-* `storage_account_name` - (Required) The name of the Storage Account where the Container should be created.
+* `storage_account_name` - (Required) The name of the Storage Account where the Container should be created. Changing this forces a new resource to be created.
 
 * `container_access_type` - (Optional) The Access Level configured for this Container. Possible values are `blob`, `container` or `private`. Defaults to `private`.
 

--- a/website/docs/r/storage_data_lake_gen2_path.html.markdown
+++ b/website/docs/r/storage_data_lake_gen2_path.html.markdown
@@ -53,7 +53,7 @@ The following arguments are supported:
 
 * `storage_account_id` - (Required) Specifies the ID of the Storage Account in which the Data Lake Gen2 File System should exist. Changing this forces a new resource to be created.
 
-* `resource` - (Required) Specifies the type for path to create. Currently only `directory` is supported.
+* `resource` - (Required) Specifies the type for path to create. Currently only `directory` is supported. Changing this forces a new resource to be created.
 
 * `owner` - (Optional) Specifies the Object ID of the Azure Active Directory User to make the owning user. Possible values also include `$superuser`.
 

--- a/website/docs/r/storage_encryption_scope.html.markdown
+++ b/website/docs/r/storage_encryption_scope.html.markdown
@@ -49,7 +49,7 @@ The following arguments are supported:
 
 * `storage_account_id` - (Required) The ID of the Storage Account where this Storage Encryption Scope is created. Changing this forces a new Storage Encryption Scope to be created.
 
-* `infrastructure_encryption_required` - (Optional) Is a secondary layer of encryption with Platform Managed Keys for data applied?
+* `infrastructure_encryption_required` - (Optional) Is a secondary layer of encryption with Platform Managed Keys for data applied? Changing this forces a new resource to be created.
 
 ---
 

--- a/website/docs/r/storage_management_policy.html.markdown
+++ b/website/docs/r/storage_management_policy.html.markdown
@@ -86,7 +86,7 @@ resource "azurerm_storage_management_policy" "example" {
 
 The following arguments are supported:
 
-* `storage_account_id` - (Required) Specifies the id of the storage account to apply the management policy to.
+* `storage_account_id` - (Required) Specifies the id of the storage account to apply the management policy to. Changing this forces a new resource to be created.
 
 * `rule` - (Optional) A `rule` block as documented below.
 

--- a/website/docs/r/storage_queue.html.markdown
+++ b/website/docs/r/storage_queue.html.markdown
@@ -36,7 +36,7 @@ resource "azurerm_storage_queue" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the Queue which should be created within the Storage Account. Must be unique within the storage account the queue is located.
+* `name` - (Required) The name of the Queue which should be created within the Storage Account. Must be unique within the storage account the queue is located. Changing this forces a new resource to be created.
 
 * `storage_account_name` - (Required) Specifies the Storage Account in which the Storage Queue should exist. Changing this forces a new resource to be created.
 

--- a/website/docs/r/storage_share.html.markdown
+++ b/website/docs/r/storage_share.html.markdown
@@ -49,9 +49,9 @@ resource "azurerm_storage_share" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the share. Must be unique within the storage account where the share is located.
+* `name` - (Required) The name of the share. Must be unique within the storage account where the share is located. Changing this forces a new resource to be created.
 
-* `storage_account_name` - (Required) Specifies the storage account in which to create the share.
+* `storage_account_name` - (Required) Specifies the storage account in which to create the share. Changing this forces a new resource to be created.
  Changing this forces a new resource to be created.
 
 * `access_tier` - (Optional) The access tier of the File Share. Possible values are `Hot`, `Cool` and `TransactionOptimized`, `Premium`.

--- a/website/docs/r/storage_share.html.markdown
+++ b/website/docs/r/storage_share.html.markdown
@@ -52,7 +52,6 @@ The following arguments are supported:
 * `name` - (Required) The name of the share. Must be unique within the storage account where the share is located. Changing this forces a new resource to be created.
 
 * `storage_account_name` - (Required) Specifies the storage account in which to create the share. Changing this forces a new resource to be created.
- Changing this forces a new resource to be created.
 
 * `access_tier` - (Optional) The access tier of the File Share. Possible values are `Hot`, `Cool` and `TransactionOptimized`, `Premium`.
 

--- a/website/docs/r/storage_share_file.html.markdown
+++ b/website/docs/r/storage_share_file.html.markdown
@@ -49,7 +49,7 @@ The following arguments are supported:
 
 * `path` - (Optional) The storage share directory that you would like the file placed into. Changing this forces a new resource to be created.
 
-* `source` - (Optional) An absolute path to a file on the local system.
+* `source` - (Optional) An absolute path to a file on the local system. Changing this forces a new resource to be created.
 
 * `content_type` - (Optional) The content type of the share file. Defaults to `application/octet-stream`.
 

--- a/website/docs/r/storage_table.html.markdown
+++ b/website/docs/r/storage_table.html.markdown
@@ -39,7 +39,6 @@ The following arguments are supported:
 * `name` - (Required) The name of the storage table. Only Alphanumeric characters allowed, starting with a letter. Must be unique within the storage account the table is located. Changing this forces a new resource to be created.
 
 * `storage_account_name` - (Required) Specifies the storage account in which to create the storage table. Changing this forces a new resource to be created.
- Changing this forces a new resource to be created.
 
 * `acl` - (Optional) One or more `acl` blocks as defined below.
 

--- a/website/docs/r/storage_table.html.markdown
+++ b/website/docs/r/storage_table.html.markdown
@@ -36,9 +36,9 @@ resource "azurerm_storage_table" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the storage table. Only Alphanumeric characters allowed, starting with a letter. Must be unique within the storage account the table is located.
+* `name` - (Required) The name of the storage table. Only Alphanumeric characters allowed, starting with a letter. Must be unique within the storage account the table is located. Changing this forces a new resource to be created.
 
-* `storage_account_name` - (Required) Specifies the storage account in which to create the storage table.
+* `storage_account_name` - (Required) Specifies the storage account in which to create the storage table. Changing this forces a new resource to be created.
  Changing this forces a new resource to be created.
 
 * `acl` - (Optional) One or more `acl` blocks as defined below.

--- a/website/docs/r/storage_table_entity.html.markdown
+++ b/website/docs/r/storage_table_entity.html.markdown
@@ -49,10 +49,8 @@ resource "azurerm_storage_table_entity" "example" {
 The following arguments are supported:
 
 * `storage_account_name` - (Required) Specifies the storage account in which to create the storage table entity. Changing this forces a new resource to be created.
- Changing this forces a new resource to be created.
 
 * `table_name` - (Required) The name of the storage table in which to create the storage table entity. Changing this forces a new resource to be created.
-Changing this forces a new resource to be created.
 
 * `partition_key` - (Required) The key for the partition where the entity will be inserted/merged. Changing this forces a new resource.
 

--- a/website/docs/r/storage_table_entity.html.markdown
+++ b/website/docs/r/storage_table_entity.html.markdown
@@ -48,10 +48,10 @@ resource "azurerm_storage_table_entity" "example" {
 
 The following arguments are supported:
 
-* `storage_account_name` - (Required) Specifies the storage account in which to create the storage table entity.
+* `storage_account_name` - (Required) Specifies the storage account in which to create the storage table entity. Changing this forces a new resource to be created.
  Changing this forces a new resource to be created.
 
-* `table_name` - (Required) The name of the storage table in which to create the storage table entity.
+* `table_name` - (Required) The name of the storage table in which to create the storage table entity. Changing this forces a new resource to be created.
 Changing this forces a new resource to be created.
 
 * `partition_key` - (Required) The key for the partition where the entity will be inserted/merged. Changing this forces a new resource.

--- a/website/docs/r/stream_analytics_function_javascript_uda.html.markdown
+++ b/website/docs/r/stream_analytics_function_javascript_uda.html.markdown
@@ -70,7 +70,7 @@ The following arguments are supported:
 
 An `input` block supports the following:
 
-* `type` - The input data type of this JavaScript Function. Possible values include `any`, `array`, `bigint`, `datetime`, `float`, `nvarchar(max)` and `record`.
+* `type` - (Required) The input data type of this JavaScript Function. Possible values include `any`, `array`, `bigint`, `datetime`, `float`, `nvarchar(max)` and `record`.
 
 * `configuration_parameter` - (Optional) Is this input parameter a configuration parameter? Defaults to `false`.
 
@@ -78,7 +78,7 @@ An `input` block supports the following:
 
 An `output` block supports the following:
 
-* `type` - The output data type from this JavaScript Function. Possible values include `any`, `array`, `bigint`, `datetime`, `float`, `nvarchar(max)` and `record`.
+* `type` - (Required) The output data type from this JavaScript Function. Possible values include `any`, `array`, `bigint`, `datetime`, `float`, `nvarchar(max)` and `record`.
 
 ## Attributes Reference
 

--- a/website/docs/r/stream_analytics_function_javascript_udf.html.markdown
+++ b/website/docs/r/stream_analytics_function_javascript_udf.html.markdown
@@ -64,7 +64,7 @@ The following arguments are supported:
 
 A `input` block supports the following:
 
-* `type` - The Data Type for the Input Argument of this JavaScript Function. Possible values include `array`, `any`, `bigint`, `datetime`, `float`, `nvarchar(max)` and `record`.
+* `type` - (Required) The Data Type for the Input Argument of this JavaScript Function. Possible values include `array`, `any`, `bigint`, `datetime`, `float`, `nvarchar(max)` and `record`.
 
 * `configuration_parameter` - (Optional) Is this input parameter a configuration parameter? Defaults to `false`.
 
@@ -72,7 +72,7 @@ A `input` block supports the following:
 
 A `output` block supports the following:
 
-* `type` - The Data Type output from this JavaScript Function. Possible values include `array`, `any`, `bigint`, `datetime`, `float`, `nvarchar(max)` and `record`.
+* `type` - (Required) The Data Type output from this JavaScript Function. Possible values include `array`, `any`, `bigint`, `datetime`, `float`, `nvarchar(max)` and `record`.
 
 ## Attributes Reference
 

--- a/website/docs/r/stream_analytics_job.html.markdown
+++ b/website/docs/r/stream_analytics_job.html.markdown
@@ -95,7 +95,7 @@ The following arguments are supported:
 
 * `transformation_query` - (Required) Specifies the query that will be run in the streaming job, [written in Stream Analytics Query Language (SAQL)](https://msdn.microsoft.com/library/azure/dn834998).
 
-* `tags` - A mapping of tags assigned to the resource.
+* `tags` - (Optional) A mapping of tags assigned to the resource.
 
 ---
 

--- a/website/docs/r/stream_analytics_output_mssql.html.markdown
+++ b/website/docs/r/stream_analytics_output_mssql.html.markdown
@@ -72,7 +72,7 @@ The following arguments are supported:
 
 * `database` - (Required) The MS SQL database name where the reference table exists. Changing this forces a new resource to be created.
 
-* `password` - (Required) Password used together with username, to login to the Microsoft SQL Server. Changing this forces a new resource to be created.
+* `password` - (Required) Password used together with username, to login to the Microsoft SQL Server. 
 
 * `table` - (Required) Table in the database that the output points to. Changing this forces a new resource to be created.
 

--- a/website/docs/r/stream_analytics_output_synapse.html.markdown
+++ b/website/docs/r/stream_analytics_output_synapse.html.markdown
@@ -80,7 +80,7 @@ The following arguments are supported:
 
 * `user` - (Required) The user name that will be used to connect to the Azure SQL database. Changing this forces a new resource to be created.
 
-* `password` - (Required) The password that will be used to connect to the Azure SQL database. Changing this forces a new resource to be created.
+* `password` - (Required) The password that will be used to connect to the Azure SQL database. 
 
 * `table` - (Required) The name of the table in the Azure SQL database. Changing this forces a new resource to be created.
 

--- a/website/docs/r/stream_analytics_stream_input_iothub.html.markdown
+++ b/website/docs/r/stream_analytics_stream_input_iothub.html.markdown
@@ -69,7 +69,7 @@ The following arguments are supported:
 
 * `serialization` - (Required) A `serialization` block as defined below.
 
-* `shared_access_policy_key` - (Required) The shared access policy key for the specified shared access policy.
+* `shared_access_policy_key` - (Required) The shared access policy key for the specified shared access policy. Changing this forces a new resource to be created.
 
 * `shared_access_policy_name` - (Required) The shared access policy name for the Event Hub, Service Bus Queue, Service Bus Topic, etc.
 

--- a/website/docs/r/subnet.html.markdown
+++ b/website/docs/r/subnet.html.markdown
@@ -51,11 +51,11 @@ resource "azurerm_subnet" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the subnet. Changing this forces a new resource to be created. Changing this forces a new resource to be created.
+* `name` - (Required) The name of the subnet. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) The name of the resource group in which to create the subnet. Changing this forces a new resource to be created. Changing this forces a new resource to be created.
+* `resource_group_name` - (Required) The name of the resource group in which to create the subnet. Changing this forces a new resource to be created.
 
-* `virtual_network_name` - (Required) The name of the virtual network to which to attach the subnet. Changing this forces a new resource to be created. Changing this forces a new resource to be created.
+* `virtual_network_name` - (Required) The name of the virtual network to which to attach the subnet. Changing this forces a new resource to be created.
 
 * `address_prefixes` - (Required) The address prefixes to use for the subnet.
 

--- a/website/docs/r/subnet.html.markdown
+++ b/website/docs/r/subnet.html.markdown
@@ -51,11 +51,11 @@ resource "azurerm_subnet" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the subnet. Changing this forces a new resource to be created.
+* `name` - (Required) The name of the subnet. Changing this forces a new resource to be created. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) The name of the resource group in which to create the subnet. Changing this forces a new resource to be created.
+* `resource_group_name` - (Required) The name of the resource group in which to create the subnet. Changing this forces a new resource to be created. Changing this forces a new resource to be created.
 
-* `virtual_network_name` - (Required) The name of the virtual network to which to attach the subnet. Changing this forces a new resource to be created.
+* `virtual_network_name` - (Required) The name of the virtual network to which to attach the subnet. Changing this forces a new resource to be created. Changing this forces a new resource to be created.
 
 * `address_prefixes` - (Required) The address prefixes to use for the subnet.
 

--- a/website/docs/r/subscription_cost_management_export.html.markdown
+++ b/website/docs/r/subscription_cost_management_export.html.markdown
@@ -59,7 +59,7 @@ The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the Cost Management Export. Changing this forces a new resource to be created.
 
-* `subscription_id` - (Required) The id of the subscription on which to create an export.
+* `subscription_id` - (Required) The id of the subscription on which to create an export. Changing this forces a new resource to be created.
 
 * `recurrence_type` - (Required) How often the requested information will be exported. Valid values include `Annually`, `Daily`, `Monthly`, `Weekly`.
 
@@ -77,9 +77,9 @@ The following arguments are supported:
 
 A `export_data_storage_location` block supports the following:
 
-* `container_id` - (Required) The Resource Manager ID of the container where exports will be uploaded.
+* `container_id` - (Required) The Resource Manager ID of the container where exports will be uploaded. Changing this forces a new resource to be created.
 
-* `root_folder_path` - (Required) The path of the directory where exports will be uploaded.
+* `root_folder_path` - (Required) The path of the directory where exports will be uploaded. Changing this forces a new resource to be created.
 
 **Note:** The Resource Manager ID of a Storage Container is exposed via the `resource_manager_id` attribute of the `azurerm_storage_container` resource.
 

--- a/website/docs/r/subscription_policy_assignment.html.markdown
+++ b/website/docs/r/subscription_policy_assignment.html.markdown
@@ -79,7 +79,7 @@ The following arguments are supported:
 
 A `identity` block supports the following:
 
-* `type` - (Optional) The Type of Managed Identity which should be added to this Policy Definition. Possible values are `SystemAssigned` and `UserAssigned`.
+* `type` - (Required) The Type of Managed Identity which should be added to this Policy Definition. Possible values are `SystemAssigned` and `UserAssigned`.
 
 * `identity_ids` - (Optional) A list of User Managed Identity IDs which should be assigned to the Policy Definition.
 

--- a/website/docs/r/synapse_sql_pool.html.markdown
+++ b/website/docs/r/synapse_sql_pool.html.markdown
@@ -63,7 +63,7 @@ The following arguments are supported:
 
 * `sku_name` - (Required) Specifies the SKU Name for this Synapse SQL Pool. Possible values are `DW100c`, `DW200c`, `DW300c`, `DW400c`, `DW500c`, `DW1000c`, `DW1500c`, `DW2000c`, `DW2500c`, `DW3000c`, `DW5000c`, `DW6000c`, `DW7500c`, `DW10000c`, `DW15000c` or `DW30000c`.
 
-* `create_mode` - (Optional) Specifies how to create the SQL Pool. Valid values are: `Default`, `Recovery` or `PointInTimeRestore`. Must be `Default` to create a new database. Defaults to `Default`.
+* `create_mode` - (Optional) Specifies how to create the SQL Pool. Valid values are: `Default`, `Recovery` or `PointInTimeRestore`. Must be `Default` to create a new database. Defaults to `Default`. Changing this forces a new resource to be created.
 
 * `collation` - (Optional) The name of the collation to use with this pool, only applicable when `create_mode` is set to `Default`. Azure default is `SQL_LATIN1_GENERAL_CP1_CI_AS`. Changing this forces a new resource to be created.
 

--- a/website/docs/r/synapse_workspace.html.markdown
+++ b/website/docs/r/synapse_workspace.html.markdown
@@ -187,7 +187,7 @@ The following arguments are supported:
 
 * `aad_admin` - (Optional) An `aad_admin` block as defined below. Conflicts with `customer_managed_key`.
 
-* `compute_subnet_id` - (Optional) Subnet ID used for computes in workspace
+* `compute_subnet_id` - (Optional) Subnet ID used for computes in workspace Changing this forces a new resource to be created.
 
 * `azure_devops_repo` - (Optional) An `azure_devops_repo` block as defined below.
 
@@ -199,7 +199,7 @@ The following arguments are supported:
 
 * `linking_allowed_for_aad_tenant_ids` - (Optional) Allowed AAD Tenant Ids For Linking.
 
-* `managed_resource_group_name` - (Optional) Workspace managed resource group.
+* `managed_resource_group_name` - (Optional) Workspace managed resource group. Changing this forces a new resource to be created.
 
 * `managed_virtual_network_enabled` - (Optional) Is Virtual Network enabled for all computes in this workspace? Defaults to `false`. Changing this forces a new resource to be created.
 

--- a/website/docs/r/synapse_workspace_key.html.markdown
+++ b/website/docs/r/synapse_workspace_key.html.markdown
@@ -118,7 +118,7 @@ The following arguments are supported:
 
 * `customer_managed_key_name` - (Required) Specifies the name of the workspace key. Should match the name of the key in the synapse workspace.
 
-* `customer_managed_key_versionless_id` - (Required) The Azure Key Vault Key Versionless ID to be used as the Customer Managed Key (CMK) for double encryption
+* `customer_managed_key_versionless_id` - (Optional) The Azure Key Vault Key Versionless ID to be used as the Customer Managed Key (CMK) for double encryption
 
 * `synapse_workspace_id` - (Required) The ID of the Synapse Workspace where the encryption key should be configured.
 

--- a/website/docs/r/template_deployment.html.markdown
+++ b/website/docs/r/template_deployment.html.markdown
@@ -106,8 +106,7 @@ The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the template deployment. Changing this forces a
     new resource to be created.
-* `resource_group_name` - (Required) The name of the resource group in which to Changing this forces a new resource to be created.
-    create the template deployment.
+* `resource_group_name` - (Required) The name of the resource group in which to create the template deployment. Changing this forces a new resource to be created.
 * `deployment_mode` - (Required) Specifies the mode that is used to deploy resources. This value could be either `Incremental` or `Complete`.
     Note that you will almost *always* want this to be set to `Incremental` otherwise the deployment will destroy all infrastructure not
     specified within the template, and Terraform will not be aware of this.

--- a/website/docs/r/template_deployment.html.markdown
+++ b/website/docs/r/template_deployment.html.markdown
@@ -106,7 +106,7 @@ The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the template deployment. Changing this forces a
     new resource to be created.
-* `resource_group_name` - (Required) The name of the resource group in which to
+* `resource_group_name` - (Required) The name of the resource group in which to Changing this forces a new resource to be created.
     create the template deployment.
 * `deployment_mode` - (Required) Specifies the mode that is used to deploy resources. This value could be either `Incremental` or `Complete`.
     Note that you will almost *always* want this to be set to `Incremental` otherwise the deployment will destroy all infrastructure not

--- a/website/docs/r/traffic_manager_profile.html.markdown
+++ b/website/docs/r/traffic_manager_profile.html.markdown
@@ -56,9 +56,9 @@ resource "azurerm_traffic_manager_profile" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the Traffic Manager profile. Changing this forces a new resource to be created.
+* `name` - (Required) The name of the Traffic Manager profile. Changing this forces a new resource to be created. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) The name of the resource group in which to create the Traffic Manager profile.
+* `resource_group_name` - (Required) The name of the resource group in which to create the Traffic Manager profile. Changing this forces a new resource to be created.
 
 * `profile_status` - (Optional) The status of the profile, can be set to either `Enabled` or `Disabled`. Defaults to `Enabled`.
 
@@ -108,7 +108,7 @@ The `monitor_config` block supports:
 
 A `custom_header` block supports the following:
 
-* `name` - (Required) The name of the custom header.
+* `name` - (Required) The name of the custom header. Changing this forces a new resource to be created.
 
 * `value` - (Required) The value of custom header. Applicable for HTTP and HTTPS protocol.
 

--- a/website/docs/r/virtual_desktop_application.html.markdown
+++ b/website/docs/r/virtual_desktop_application.html.markdown
@@ -72,7 +72,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the Virtual Desktop Application. Changing the name forces a new resource to be created.
 
-* `application_group_id` - (Required) Resource ID for a Virtual Desktop Application Group to associate with the
+* `application_group_id` - (Required) Resource ID for a Virtual Desktop Application Group to associate with the Changing this forces a new resource to be created.
     Virtual Desktop Application. Changing the ID forces a new resource to be created.
 
 * `friendly_name` - (Optional) Option to set a friendly name for the Virtual Desktop Application.

--- a/website/docs/r/virtual_desktop_application.html.markdown
+++ b/website/docs/r/virtual_desktop_application.html.markdown
@@ -72,8 +72,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the Virtual Desktop Application. Changing the name forces a new resource to be created.
 
-* `application_group_id` - (Required) Resource ID for a Virtual Desktop Application Group to associate with the Changing this forces a new resource to be created.
-    Virtual Desktop Application. Changing the ID forces a new resource to be created.
+* `application_group_id` - (Required) Resource ID for a Virtual Desktop Application Group to associate with the Virtual Desktop Application. Changing this forces a new resource to be created.
 
 * `friendly_name` - (Optional) Option to set a friendly name for the Virtual Desktop Application.
 

--- a/website/docs/r/virtual_desktop_application_group.html.markdown
+++ b/website/docs/r/virtual_desktop_application_group.html.markdown
@@ -70,14 +70,14 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the Virtual Desktop Application Group. Changing the name forces a new resource to be created.
 
-* `resource_group_name` - (Required) The name of the resource group in which to
+* `resource_group_name` - (Required) The name of the resource group in which to Changing this forces a new resource to be created.
     create the Virtual Desktop Application Group. Changing the resource group name forces
     a new resource to be created.
 
-* `location` - (Required) The location/region where the Virtual Desktop Application Group is
+* `location` - (Required) The location/region where the Virtual Desktop Application Group is Changing this forces a new resource to be created.
     located. Changing the location/region forces a new resource to be created.
 
-* `type` - (Required) Type of Virtual Desktop Application Group. Valid options are `RemoteApp` or `Desktop` application groups.
+* `type` - (Required) Type of Virtual Desktop Application Group. Valid options are `RemoteApp` or `Desktop` application groups. Changing this forces a new resource to be created.
 
 * `host_pool_id` - (Required) Resource ID for a Virtual Desktop Host Pool to associate with the
     Virtual Desktop Application Group.

--- a/website/docs/r/virtual_desktop_application_group.html.markdown
+++ b/website/docs/r/virtual_desktop_application_group.html.markdown
@@ -70,12 +70,9 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the Virtual Desktop Application Group. Changing the name forces a new resource to be created.
 
-* `resource_group_name` - (Required) The name of the resource group in which to Changing this forces a new resource to be created.
-    create the Virtual Desktop Application Group. Changing the resource group name forces
-    a new resource to be created.
+* `resource_group_name` - (Required) The name of the resource group in which to create the Virtual Desktop Application Group. Changing this forces a new resource to be created.
 
-* `location` - (Required) The location/region where the Virtual Desktop Application Group is Changing this forces a new resource to be created.
-    located. Changing the location/region forces a new resource to be created.
+* `location` - (Required) The location/region where the Virtual Desktop Application Group is located. Changing this forces a new resource to be created.
 
 * `type` - (Required) Type of Virtual Desktop Application Group. Valid options are `RemoteApp` or `Desktop` application groups. Changing this forces a new resource to be created.
 

--- a/website/docs/r/virtual_desktop_host_pool.html.markdown
+++ b/website/docs/r/virtual_desktop_host_pool.html.markdown
@@ -46,15 +46,11 @@ resource "azurerm_virtual_desktop_host_pool" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the Virtual Desktop Host Pool. Changing the name Changing this forces a new resource to be created.
-    forces a new resource to be created.
+* `name` - (Required) The name of the Virtual Desktop Host Pool. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) The name of the resource group in which to Changing this forces a new resource to be created.
-    create the Virtual Desktop Host Pool. Changing the resource group name forces
-    a new resource to be created.
+* `resource_group_name` - (Required) The name of the resource group in which to create the Virtual Desktop Host Pool. Changing this forces a new resource to be created.
 
-* `location` - (Required) The location/region where the Virtual Desktop Host Pool is Changing this forces a new resource to be created.
-    located. Changing the location/region forces a new resource to be created.
+* `location` - (Required) The location/region where the Virtual Desktop Host Pool is located. Changing this forces a new resource to be created.
 
 * `type` - (Required) The type of the Virtual Desktop Host Pool. Valid options are `Personal` or `Pooled`. Changing the type forces a new resource to be created.
 
@@ -72,8 +68,7 @@ The following arguments are supported:
 
 * `custom_rdp_properties` - (Optional) A valid custom RDP properties string for the Virtual Desktop Host Pool, available properties can be [found in this article](https://docs.microsoft.com/windows-server/remote/remote-desktop-services/clients/rdp-files).
 
-* `personal_desktop_assignment_type` - (Optional) `Automatic` assignment – The service will select an available host and assign it to an user. Possible values are `Automatic` and `Direct`. Changing this forces a new resource to be created.
-    `Direct` Assignment – Admin selects a specific host to assign to an user.
+* `personal_desktop_assignment_type` - (Optional) `Automatic` assignment – The service will select an available host and assign it to an user. Possible values are `Automatic` and `Direct`. `Direct` Assignment – Admin selects a specific host to assign to an user. Changing this forces a new resource to be created.
 
 ~> **NOTE:** `personal_desktop_assignment_type` is required if the `type` of your Virtual Desktop Host Pool is `Personal`
 

--- a/website/docs/r/virtual_desktop_host_pool.html.markdown
+++ b/website/docs/r/virtual_desktop_host_pool.html.markdown
@@ -46,19 +46,19 @@ resource "azurerm_virtual_desktop_host_pool" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the Virtual Desktop Host Pool. Changing the name
+* `name` - (Required) The name of the Virtual Desktop Host Pool. Changing the name Changing this forces a new resource to be created.
     forces a new resource to be created.
 
-* `resource_group_name` - (Required) The name of the resource group in which to
+* `resource_group_name` - (Required) The name of the resource group in which to Changing this forces a new resource to be created.
     create the Virtual Desktop Host Pool. Changing the resource group name forces
     a new resource to be created.
 
-* `location` - (Required) The location/region where the Virtual Desktop Host Pool is
+* `location` - (Required) The location/region where the Virtual Desktop Host Pool is Changing this forces a new resource to be created.
     located. Changing the location/region forces a new resource to be created.
 
 * `type` - (Required) The type of the Virtual Desktop Host Pool. Valid options are `Personal` or `Pooled`. Changing the type forces a new resource to be created.
 
-* `load_balancer_type` -  (Optional) `BreadthFirst` load balancing distributes new user sessions across all available session hosts in the host pool. Possible values are `BreadthFirst`, `DepthFirst` and `Persistent`.
+* `load_balancer_type` -  (Required) `BreadthFirst` load balancing distributes new user sessions across all available session hosts in the host pool. Possible values are `BreadthFirst`, `DepthFirst` and `Persistent`.
     `DepthFirst` load balancing distributes new user sessions to an available session host with the highest number of connections but has not reached its maximum session limit threshold.
     `Persistent` should be used if the host pool type is `Personal`
 
@@ -72,7 +72,7 @@ The following arguments are supported:
 
 * `custom_rdp_properties` - (Optional) A valid custom RDP properties string for the Virtual Desktop Host Pool, available properties can be [found in this article](https://docs.microsoft.com/windows-server/remote/remote-desktop-services/clients/rdp-files).
 
-* `personal_desktop_assignment_type` - (Optional) `Automatic` assignment – The service will select an available host and assign it to an user. Possible values are `Automatic` and `Direct`.
+* `personal_desktop_assignment_type` - (Optional) `Automatic` assignment – The service will select an available host and assign it to an user. Possible values are `Automatic` and `Direct`. Changing this forces a new resource to be created.
     `Direct` Assignment – Admin selects a specific host to assign to an user.
 
 ~> **NOTE:** `personal_desktop_assignment_type` is required if the `type` of your Virtual Desktop Host Pool is `Personal`
@@ -80,7 +80,7 @@ The following arguments are supported:
 * `maximum_sessions_allowed` - (Optional) A valid integer value from 0 to 999999 for the maximum number of users that have concurrent sessions on a session host.
     Should only be set if the `type` of your Virtual Desktop Host Pool is `Pooled`.
 
-* `preferred_app_group_type` - (Optional) Option to specify the preferred Application Group type for the Virtual Desktop Host Pool. Valid options are `None`, `Desktop` or `RailApplications`. Default is `None`.
+* `preferred_app_group_type` - (Optional) Option to specify the preferred Application Group type for the Virtual Desktop Host Pool. Valid options are `None`, `Desktop` or `RailApplications`. Default is `None`. Changing this forces a new resource to be created.
 
 * `scheduled_agent_updates` - (Optional) A `scheduled_agent_updates` block as defined below. This enables control of when Agent Updates will be applied to Session Hosts.
 

--- a/website/docs/r/virtual_desktop_workspace.html.markdown
+++ b/website/docs/r/virtual_desktop_workspace.html.markdown
@@ -36,12 +36,9 @@ resource "azurerm_virtual_desktop_workspace" "workspace" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the Virtual Desktop Workspace. Changing the name Changing this forces a new resource to be created.
-    forces a new resource to be created.
+* `name` - (Required) The name of the Virtual Desktop Workspace. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) The name of the resource group in which to Changing this forces a new resource to be created.
-    create the Virtual Desktop Workspace. Changing the resource group name forces
-    a new resource to be created.
+* `resource_group_name` - (Required) The name of the resource group in which to create the Virtual Desktop Workspace. Changing this forces a new resource to be created.
 
 * `location` - (Required) The location/region where the Virtual Desktop Workspace is located. Changing the location/region forces a new resource to be created.
 

--- a/website/docs/r/virtual_desktop_workspace.html.markdown
+++ b/website/docs/r/virtual_desktop_workspace.html.markdown
@@ -36,10 +36,10 @@ resource "azurerm_virtual_desktop_workspace" "workspace" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the Virtual Desktop Workspace. Changing the name
+* `name` - (Required) The name of the Virtual Desktop Workspace. Changing the name Changing this forces a new resource to be created.
     forces a new resource to be created.
 
-* `resource_group_name` - (Required) The name of the resource group in which to
+* `resource_group_name` - (Required) The name of the resource group in which to Changing this forces a new resource to be created.
     create the Virtual Desktop Workspace. Changing the resource group name forces
     a new resource to be created.
 

--- a/website/docs/r/virtual_desktop_workspace_application_group_association.html.markdown
+++ b/website/docs/r/virtual_desktop_workspace_application_group_association.html.markdown
@@ -54,9 +54,9 @@ resource "azurerm_virtual_desktop_workspace_application_group_association" "work
 
 The following arguments are supported:
 
-* `workspace_id` - (Required) The resource ID for the Virtual Desktop Workspace.
+* `workspace_id` - (Required) The resource ID for the Virtual Desktop Workspace. Changing this forces a new resource to be created.
 
-* `application_group_id` - (Required) The resource ID for the Virtual Desktop Application Group.
+* `application_group_id` - (Required) The resource ID for the Virtual Desktop Application Group. Changing this forces a new resource to be created.
 
 ## Attributes Reference
 

--- a/website/docs/r/virtual_hub_bgp_connection.html.markdown
+++ b/website/docs/r/virtual_hub_bgp_connection.html.markdown
@@ -74,9 +74,9 @@ The following arguments are supported:
 
 * `virtual_hub_id` - (Required) The ID of the Virtual Hub within which this Bgp connection should be created. Changing this forces a new resource to be created.
 
-* `peer_asn` - (Optional) The peer autonomous system number for the Virtual Hub Bgp Connection. Changing this forces a new resource to be created.
+* `peer_asn` - (Required) The peer autonomous system number for the Virtual Hub Bgp Connection. Changing this forces a new resource to be created.
 
-* `peer_ip` - (Optional) The peer IP address for the Virtual Hub Bgp Connection. Changing this forces a new resource to be created.
+* `peer_ip` - (Required) The peer IP address for the Virtual Hub Bgp Connection. Changing this forces a new resource to be created.
 
 * `virtual_network_connection_id` - (Optional) The ID of virtual network connection.
 

--- a/website/docs/r/virtual_hub_ip.html.markdown
+++ b/website/docs/r/virtual_hub_ip.html.markdown
@@ -73,7 +73,7 @@ The following arguments are supported:
 
 * `private_ip_allocation_method` - (Optional) The private IP address allocation method. Possible values are `Static` and `Dynamic` is allowed. Defaults to `Dynamic`.
 
-* `public_ip_address_id` - (Optional) The ID of the Public IP Address. This option is required since September 1st 2021. Changing this forces a new resource to be created.
+* `public_ip_address_id` - (Required) The ID of the Public IP Address. This option is required since September 1st 2021. Changing this forces a new resource to be created.
 
 ## Attributes Reference
 

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -153,7 +153,7 @@ The following arguments are supported:
 
 * `tags` - (Optional) A mapping of tags to assign to the Virtual Machine.
 
-* `zones` - (Optional) A list of a single item of the Availability Zone which the Virtual Machine should be allocated in.
+* `zones` - (Optional) A list of a single item of the Availability Zone which the Virtual Machine should be allocated in. Changing this forces a new resource to be created.
 
 -> **Please Note**: Availability Zones are [only supported in several regions at this time](https://docs.microsoft.com/azure/availability-zones/az-overview).
 
@@ -185,7 +185,7 @@ A `boot_diagnostics` block supports the following:
 
 A `additional_capabilities` block supports the following:
 
-* `ultra_ssd_enabled` - (Required) Should Ultra SSD disk be enabled for this Virtual Machine?
+* `ultra_ssd_enabled` - (Required) Should Ultra SSD disk be enabled for this Virtual Machine? Changing this forces a new resource to be created.
 
 -> **Note:** Azure Ultra Disk Storage is only available in a region that support availability zones and can only enabled on the following VM series: `ESv3`, `DSv3`, `FSv3`, `LSv2`, `M` and `Mv2`. For more information see the `Azure Ultra Disk Storage` [product documentation](https://docs.microsoft.com/azure/virtual-machines/windows/disks-enable-ultra-ssd).
 
@@ -207,11 +207,11 @@ A `identity` block supports the following:
 
 A `os_profile` block supports the following:
 
-* `computer_name` - (Required) Specifies the name of the Virtual Machine.
+* `computer_name` - (Required) Specifies the name of the Virtual Machine. Changing this forces a new resource to be created.
 
 * `admin_username` - (Required) Specifies the name of the local administrator account.
 
-* `admin_password` - (Required for Windows, Optional for Linux) The password associated with the local administrator account.
+* `admin_password` - (Optional for Windows, Optional for Linux) The password associated with the local administrator account.
 
 -> **NOTE:** If using Linux, it may be preferable to use SSH Key authentication (available in the `os_profile_linux_config` block) instead of password authentication.
 
@@ -222,7 +222,7 @@ A `os_profile` block supports the following:
 3. Contains a numeric digit
 4. Contains a special character
 
-* `custom_data` - (Optional) Specifies custom data to supply to the machine. On Linux-based systems, this can be used as a cloud-init script. On other systems, this will be copied as a file on disk. Internally, Terraform will base64 encode this value before sending it to the API. The maximum length of the binary array is 65535 bytes.
+* `custom_data` - (Optional) Specifies custom data to supply to the machine. On Linux-based systems, this can be used as a cloud-init script. On other systems, this will be copied as a file on disk. Internally, Terraform will base64 encode this value before sending it to the API. The maximum length of the binary array is 65535 bytes. Changing this forces a new resource to be created.
 
 ---
 
@@ -250,7 +250,7 @@ A `os_profile_windows_config` block supports the following:
 
 * `enable_automatic_upgrades` - (Optional) Are automatic updates enabled on this Virtual Machine? Defaults to `false.`
 
-* `timezone` - (Optional) Specifies the time zone of the virtual machine, [the possible values are defined here](https://jackstromberg.com/2017/01/list-of-time-zones-consumed-by-azure/).
+* `timezone` - (Optional) Specifies the time zone of the virtual machine, [the possible values are defined here](https://jackstromberg.com/2017/01/list-of-time-zones-consumed-by-azure/). Changing this forces a new resource to be created.
 
 * `winrm` - (Optional) One or more `winrm` blocks as defined below.
 
@@ -288,17 +288,17 @@ This block provisions the Virtual Machine from one of two sources: an Azure Plat
 
 To provision from an Azure Platform Image, the following fields are applicable:
 
-* `publisher` - (Required) Specifies the publisher of the image used to create the virtual machine. Changing this forces a new resource to be created.
+* `publisher` - (Optional) Specifies the publisher of the image used to create the virtual machine. Changing this forces a new resource to be created.
 
-* `offer` - (Required) Specifies the offer of the image used to create the virtual machine. Changing this forces a new resource to be created.
+* `offer` - (Optional) Specifies the offer of the image used to create the virtual machine. Changing this forces a new resource to be created.
 
-* `sku` - (Required) Specifies the SKU of the image used to create the virtual machine. Changing this forces a new resource to be created.
+* `sku` - (Optional) Specifies the SKU of the image used to create the virtual machine. Changing this forces a new resource to be created.
 
 * `version` - (Optional) Specifies the version of the image used to create the virtual machine. Changing this forces a new resource to be created.
 
 To provision a Custom Image, the following fields are applicable:
 
-* `id` - (Required) Specifies the ID of the Custom Image which the Virtual Machine should be created from. Changing this forces a new resource to be created.
+* `id` - (Optional) Specifies the ID of the Custom Image which the Virtual Machine should be created from. Changing this forces a new resource to be created.
 
 -> **NOTE:** An example of how to use this is available within [the `./examples/virtual-machines/virtual_machine/managed-disks/from-custom-image` directory within the GitHub Repository](https://github.com/hashicorp/terraform-provider-azurerm/tree/main/examples/virtual-machines/virtual_machine/managed-disks/from-custom-image)
 
@@ -332,7 +332,7 @@ The following properties apply when using Managed Disks:
 
 The following properties apply when using Unmanaged Disks:
 
-* `vhd_uri` - (Optional) Specifies the URI of the VHD file backing this Unmanaged Data Disk. Changing this forces a new resource to be created.
+* `vhd_uri` - (Optional) Specifies the URI of the VHD file backing this Unmanaged Data Disk. 
 
 ---
 
@@ -354,7 +354,7 @@ A `storage_os_disk` block supports the following:
 
 The following properties apply when using Managed Disks:
 
-* `managed_disk_id` - (Optional) Specifies the ID of an existing Managed Disk which should be attached as the OS Disk of this Virtual Machine. If this is set then the `create_option` must be set to `Attach`.
+* `managed_disk_id` - (Optional) Specifies the ID of an existing Managed Disk which should be attached as the OS Disk of this Virtual Machine. If this is set then the `create_option` must be set to `Attach`. Changing this forces a new resource to be created.
 
 * `managed_disk_type` - (Optional) Specifies the type of Managed Disk which should be created. Possible values are `Standard_LRS`, `StandardSSD_LRS` or `Premium_LRS`.
 

--- a/website/docs/r/virtual_machine_extension.html.markdown
+++ b/website/docs/r/virtual_machine_extension.html.markdown
@@ -128,7 +128,7 @@ SETTINGS
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the virtual machine extension peering. Changing
+* `name` - (Required) The name of the virtual machine extension peering. Changing Changing this forces a new resource to be created.
     this forces a new resource to be created.
 
 * `virtual_machine_id` - (Required) The ID of the Virtual Machine. Changing this forces a new resource to be created

--- a/website/docs/r/virtual_machine_extension.html.markdown
+++ b/website/docs/r/virtual_machine_extension.html.markdown
@@ -128,8 +128,7 @@ SETTINGS
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the virtual machine extension peering. Changing Changing this forces a new resource to be created.
-    this forces a new resource to be created.
+* `name` - (Required) The name of the virtual machine extension peering. Changing this forces a new resource to be created.
 
 * `virtual_machine_id` - (Required) The ID of the Virtual Machine. Changing this forces a new resource to be created
 

--- a/website/docs/r/virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/virtual_machine_scale_set.html.markdown
@@ -263,7 +263,7 @@ resource "azurerm_virtual_machine_scale_set" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name of the virtual machine scale set resource. Changing this forces a new resource to be created.
+* `name` - (Required) Specifies the name of the virtual machine scale set resource. Changing this forces a new resource to be created. Changing this forces a new resource to be created.
 
 * `resource_group_name` - (Required) The name of the resource group in which to create the virtual machine scale set. Changing this forces a new resource to be created.
 
@@ -293,7 +293,7 @@ The following arguments are supported:
 
 * `extension` - (Optional) Can be specified multiple times to add extension profiles to the scale set. Each `extension` block supports the fields documented below.
 
-* `eviction_policy` - (Optional) Specifies the eviction policy for Virtual Machines in this Scale Set. Possible values are `Deallocate` and `Delete`.
+* `eviction_policy` - (Optional) Specifies the eviction policy for Virtual Machines in this Scale Set. Possible values are `Deallocate` and `Delete`. Changing this forces a new resource to be created.
 
 -> **NOTE:** `eviction_policy` can only be set when `priority` is set to `Low`.
 
@@ -307,7 +307,7 @@ The following arguments are supported:
 
 * `plan` - (Optional) A plan block as documented below.
 
-* `priority` - (Optional) Specifies the priority for the Virtual Machines in the Scale Set. Defaults to `Regular`. Possible values are `Low` and `Regular`.
+* `priority` - (Optional) Specifies the priority for the Virtual Machines in the Scale Set. Defaults to `Regular`. Possible values are `Low` and `Regular`. Changing this forces a new resource to be created.
 
 * `rolling_upgrade_policy` - (Optional) A `rolling_upgrade_policy` block as defined below. This is only applicable when the `upgrade_policy_mode` is `Rolling`.
 
@@ -319,7 +319,7 @@ The following arguments are supported:
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
-* `zones` - (Optional) A collection of availability zones to spread the Virtual Machines over.
+* `zones` - (Optional) A collection of availability zones to spread the Virtual Machines over. Changing this forces a new resource to be created.
 
 -> **Please Note**: Availability Zones are [only supported in several regions at this time](https://docs.microsoft.com/azure/availability-zones/az-overview).
 
@@ -327,7 +327,7 @@ The following arguments are supported:
 
 `sku` supports the following:
 
-* `name` - (Required) Specifies the size of virtual machines in a scale set.
+* `name` - (Required) Specifies the size of virtual machines in a scale set. Changing this forces a new resource to be created.
 * `tier` - (Optional) Specifies the tier of virtual machines in a scale set. Possible values, `standard` or `basic`.
 * `capacity` - (Required) Specifies the number of virtual machines in the scale set.
 
@@ -420,7 +420,7 @@ output "principal_id" {
 
 `network_profile` supports the following:
 
-* `name` - (Required) Specifies the name of the network interface configuration.
+* `name` - (Required) Specifies the name of the network interface configuration. Changing this forces a new resource to be created.
 * `primary` - (Required) Indicates whether network interfaces created from the network interface configuration will be the primary NIC of the VM.
 * `ip_configuration` - (Required) An ip_configuration block as documented below.
 * `accelerated_networking` - (Optional) Specifies whether to enable accelerated networking or not. Defaults to `false`.
@@ -434,7 +434,7 @@ output "principal_id" {
 
 `ip_configuration` supports the following:
 
-* `name` - (Required) Specifies name of the IP configuration.
+* `name` - (Required) Specifies name of the IP configuration. Changing this forces a new resource to be created.
 * `subnet_id` - (Required) Specifies the identifier of the subnet.
 * `application_gateway_backend_address_pool_ids` - (Optional) Specifies an array of references to backend address pools of application gateways. A scale set can reference backend address pools of multiple application gateways. Multiple scale sets can use the same application gateway.
 * `load_balancer_backend_address_pool_ids` - (Optional) Specifies an array of references to backend address pools of load balancers. A scale set can reference backend address pools of one public and one internal load balancer. Multiple scale sets cannot use the same load balancer.
@@ -451,13 +451,13 @@ output "principal_id" {
 
 `public_ip_address_configuration` supports the following:
 
-* `name` - (Required) The name of the public IP address configuration
+* `name` - (Required) The name of the public IP address configuration Changing this forces a new resource to be created.
 * `idle_timeout` - (Required) The idle timeout in minutes. This value must be between 4 and 30.
 * `domain_name_label` - (Required) The domain name label for the DNS settings.
 
 `storage_profile_os_disk` supports the following:
 
-* `name` - (Optional) Specifies the disk name. Must be specified when using unmanaged disk ('managed_disk_type' property not set).
+* `name` - (Optional) Specifies the disk name. Must be specified when using unmanaged disk ('managed_disk_type' property not set). Changing this forces a new resource to be created.
 * `vhd_containers` - (Optional) Specifies the VHD URI. Cannot be used when `image` or `managed_disk_type` is specified.
 * `managed_disk_type` - (Optional) Specifies the type of managed disk to create. Value you must be either `Standard_LRS`, `StandardSSD_LRS` or `Premium_LRS`. Cannot be used when `vhd_containers` or `image` is specified.
 * `create_option` - (Required) Specifies how the virtual machine should be created. The only possible option is `FromImage`.
@@ -491,7 +491,7 @@ machine scale set, as in the [example below](#example-of-storage_profile_image_r
 
 `extension` supports the following:
 
-* `name` - (Required) Specifies the name of the extension.
+* `name` - (Required) Specifies the name of the extension. Changing this forces a new resource to be created.
 * `publisher` - (Required) The publisher of the extension, available publishers can be found by using the Azure CLI.
 * `type` - (Required) The type of extension, available types for a publisher can be found using the Azure CLI.
 * `type_handler_version` - (Required) Specifies the version of the extension to use, available versions can be found using the Azure CLI.
@@ -502,7 +502,7 @@ machine scale set, as in the [example below](#example-of-storage_profile_image_r
 
 `plan` supports the following:
 
-* `name` - (Required) Specifies the name of the image from the marketplace.
+* `name` - (Required) Specifies the name of the image from the marketplace. Changing this forces a new resource to be created.
 * `publisher` - (Required) Specifies the publisher of the image.
 * `product` - (Required) Specifies the product of the image from the marketplace.
 

--- a/website/docs/r/virtual_network.html.markdown
+++ b/website/docs/r/virtual_network.html.markdown
@@ -59,13 +59,13 @@ resource "azurerm_virtual_network" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the virtual network. Changing this forces a new resource to be created.
+* `name` - (Required) The name of the virtual network. Changing this forces a new resource to be created. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) The name of the resource group in which to create the virtual network.
+* `resource_group_name` - (Required) The name of the resource group in which to create the virtual network. Changing this forces a new resource to be created.
 
 * `address_space` - (Required) The address space that is used the virtual network. You can supply more than one address space.
 
-* `location` - (Required) The location/region where the virtual network is created. Changing this forces a new resource to be created.
+* `location` - (Required) The location/region where the virtual network is created. Changing this forces a new resource to be created. Changing this forces a new resource to be created.
 
 ---
 
@@ -101,7 +101,7 @@ A `ddos_protection_plan` block supports the following:
 
 The `subnet` block supports:
 
-* `name` - (Required) The name of the subnet.
+* `name` - (Required) The name of the subnet. Changing this forces a new resource to be created.
 
 * `address_prefix` - (Required) The address prefix to use for the subnet.
 

--- a/website/docs/r/virtual_network_dns_servers.html.markdown
+++ b/website/docs/r/virtual_network_dns_servers.html.markdown
@@ -45,7 +45,7 @@ The following arguments are supported:
 
 * `virtual_network_id` - (Required) The ID of the Virtual Network that should be linked to the DNS Zone. Changing this forces a new resource to be created.
 
-* `dns_servers` - (Required) List of IP addresses of DNS servers
+* `dns_servers` - (Optional) List of IP addresses of DNS servers
 
 ## Attributes Reference
 

--- a/website/docs/r/virtual_network_gateway.html.markdown
+++ b/website/docs/r/virtual_network_gateway.html.markdown
@@ -167,8 +167,7 @@ The following arguments are supported:
 
 The `ip_configuration` block supports:
 
-* `name` - (Optional) A user-defined name of the IP configuration. Defaults to Changing this forces a new resource to be created.
-    `vnetGatewayConfig`.
+* `name` - (Optional) A user-defined name of the IP configuration. Defaults to `vnetGatewayConfig`. Changing this forces a new resource to be created.
 
 * `private_ip_address_allocation` - (Optional) Defines how the private IP address
     of the gateways virtual interface is assigned. Valid options are `Static` or

--- a/website/docs/r/virtual_network_gateway.html.markdown
+++ b/website/docs/r/virtual_network_gateway.html.markdown
@@ -109,15 +109,11 @@ The following arguments are supported:
   an active-active gateway requires exactly two `ip_configuration` blocks whereas
   an active-active zone redundant gateway with P2S configuration requires exactly three `ip_configuration` blocks.
 
-* `location` - (Required) The location/region where the Virtual Network Gateway is Changing this forces a new resource to be created.
-  located. Changing the location/region forces a new resource to be created.
+* `location` - (Required) The location/region where the Virtual Network Gateway is located. Changing this forces a new resource to be created.
 
-* `name` - (Required) The name of the Virtual Network Gateway. Changing the name Changing this forces a new resource to be created.
-  forces a new resource to be created.
+* `name` - (Required) The name of the Virtual Network Gateway. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) The name of the resource group in which to Changing this forces a new resource to be created.
-  create the Virtual Network Gateway. Changing the resource group name forces
-  a new resource to be created.
+* `resource_group_name` - (Required) The name of the resource group in which to create the Virtual Network Gateway. Changing this forces a new resource to be created.
 
 * `sku` - (Required) Configuration of the size and capacity of the virtual network
   gateway. Valid options are `Basic`, `Standard`, `HighPerformance`, `UltraPerformance`,

--- a/website/docs/r/virtual_network_gateway.html.markdown
+++ b/website/docs/r/virtual_network_gateway.html.markdown
@@ -109,13 +109,13 @@ The following arguments are supported:
   an active-active gateway requires exactly two `ip_configuration` blocks whereas
   an active-active zone redundant gateway with P2S configuration requires exactly three `ip_configuration` blocks.
 
-* `location` - (Required) The location/region where the Virtual Network Gateway is
+* `location` - (Required) The location/region where the Virtual Network Gateway is Changing this forces a new resource to be created.
   located. Changing the location/region forces a new resource to be created.
 
-* `name` - (Required) The name of the Virtual Network Gateway. Changing the name
+* `name` - (Required) The name of the Virtual Network Gateway. Changing the name Changing this forces a new resource to be created.
   forces a new resource to be created.
 
-* `resource_group_name` - (Required) The name of the resource group in which to
+* `resource_group_name` - (Required) The name of the resource group in which to Changing this forces a new resource to be created.
   create the Virtual Network Gateway. Changing the resource group name forces
   a new resource to be created.
 
@@ -153,7 +153,7 @@ The following arguments are supported:
 
 * `bgp_settings` - (Optional) A `bgp_settings` block which is documented below. In this block the BGP specific settings can be defined.
 
-* `generation` - (Optional) The Generation of the Virtual Network gateway. Possible values include `Generation1`, `Generation2` or `None`.
+* `generation` - (Optional) The Generation of the Virtual Network gateway. Possible values include `Generation1`, `Generation2` or `None`. Changing this forces a new resource to be created.
 
 -> **NOTE:** The available values depend on the `type` and `sku` arguments - where `Generation2` is only value for a `sku` larger than `VpnGw2` or `VpnGw2AZ`.
 
@@ -165,13 +165,13 @@ The following arguments are supported:
   is documented below. In this block the Virtual Network Gateway can be configured
   to accept IPSec point-to-site connections.
 
-* `vpn_type` - (Optional) The routing type of the Virtual Network Gateway. Valid options are `RouteBased` or `PolicyBased`. Defaults to `RouteBased`.
+* `vpn_type` - (Optional) The routing type of the Virtual Network Gateway. Valid options are `RouteBased` or `PolicyBased`. Defaults to `RouteBased`. Changing this forces a new resource to be created.
 
 ---
 
 The `ip_configuration` block supports:
 
-* `name` - (Optional) A user-defined name of the IP configuration. Defaults to
+* `name` - (Optional) A user-defined name of the IP configuration. Defaults to Changing this forces a new resource to be created.
     `vnetGatewayConfig`.
 
 * `private_ip_address_allocation` - (Optional) Defines how the private IP address
@@ -253,7 +253,7 @@ A `peering_addresses` supports the following:
 
 The `root_certificate` block supports:
 
-* `name` - (Required) A user-defined name of the root certificate.
+* `name` - (Required) A user-defined name of the root certificate. Changing this forces a new resource to be created.
 
 * `public_cert_data` - (Required) The public certificate of the root certificate
     authority. The certificate must be provided in Base-64 encoded X.509 format
@@ -264,7 +264,7 @@ The `root_certificate` block supports:
 
 The `root_revoked_certificate` block supports:
 
-* `name` - (Required) A user-defined name of the revoked certificate.
+* `name` - (Required) A user-defined name of the revoked certificate. Changing this forces a new resource to be created.
 
 * `public_cert_data` - (Required) The SHA1 thumbprint of the certificate to be
     revoked.

--- a/website/docs/r/virtual_network_gateway_connection.html.markdown
+++ b/website/docs/r/virtual_network_gateway_connection.html.markdown
@@ -206,21 +206,13 @@ The following arguments are supported:
 * `name` - (Required) The name of the connection. Changing the name forces a
     new resource to be created.
 
-* `resource_group_name` - (Required) The name of the resource group in which to Changing this forces a new resource to be created.
-    create the connection Changing the name forces a new resource to be created.
+* `resource_group_name` - (Required) The name of the resource group in which to create the connection Changing this forces a new resource to be created.
 
-* `location` - (Required) The location/region where the connection is Changing this forces a new resource to be created.
-    located. Changing this forces a new resource to be created.
+* `location` - (Required) The location/region where the connection is located. Changing this forces a new resource to be created.
 
-* `type` - (Required) The type of connection. Valid options are `IPsec` Changing this forces a new resource to be created.
-    (Site-to-Site), `ExpressRoute` (ExpressRoute), and `Vnet2Vnet` (VNet-to-VNet).
-    Each connection type requires different mandatory arguments (refer to the
-    examples above). Changing the connection type will force a new connection
-    to be created.
+* `type` - (Required) The type of connection. Valid options are `IPsec` (Site-to-Site), `ExpressRoute` (ExpressRoute), and `Vnet2Vnet` (VNet-to-VNet). Each connection type requires different mandatory arguments (refer to the examples above). Changing this forces a new resource to be created.
 
-* `virtual_network_gateway_id` - (Required) The ID of the Virtual Network Gateway Changing this forces a new resource to be created.
-    in which the connection will be created. Changing the gateway forces a new
-    resource to be created.
+* `virtual_network_gateway_id` - (Required) The ID of the Virtual Network Gateway in which the connection will be created. Changing this forces a new resource to be created.
 
 * `authorization_key` - (Optional) The authorization key associated with the
     Express Route Circuit. This field is required only if the type is an
@@ -228,14 +220,9 @@ The following arguments are supported:
 
 * `dpd_timeout_seconds` - (Optional) The dead peer detection timeout of this connection in seconds. Changing this forces a new resource to be created.
 
-* `express_route_circuit_id` - (Optional) The ID of the Express Route Circuit Changing this forces a new resource to be created.
-    when creating an ExpressRoute connection (i.e. when `type` is `ExpressRoute`).
-    The Express Route Circuit can be in the same or in a different subscription.
+* `express_route_circuit_id` - (Optional) The ID of the Express Route Circuit when creating an ExpressRoute connection (i.e. when `type` is `ExpressRoute`). The Express Route Circuit can be in the same or in a different subscription. Changing this forces a new resource to be created.
 
-* `peer_virtual_network_gateway_id` - (Optional) The ID of the peer virtual Changing this forces a new resource to be created.
-    network gateway when creating a VNet-to-VNet connection (i.e. when `type`
-    is `Vnet2Vnet`). The peer Virtual Network Gateway can be in the same or
-    in a different subscription.
+* `peer_virtual_network_gateway_id` - (Optional) The ID of the peer virtual network gateway when creating a VNet-to-VNet connection (i.e. when `type` is `Vnet2Vnet`). The peer Virtual Network Gateway can be in the same or in a different subscription. Changing this forces a new resource to be created.
 
 * `local_azure_ip_address_enabled` - (Optional) Use private local Azure IP for the connection. Changing this forces a new resource to be created.
 

--- a/website/docs/r/virtual_network_gateway_connection.html.markdown
+++ b/website/docs/r/virtual_network_gateway_connection.html.markdown
@@ -206,19 +206,19 @@ The following arguments are supported:
 * `name` - (Required) The name of the connection. Changing the name forces a
     new resource to be created.
 
-* `resource_group_name` - (Required) The name of the resource group in which to
+* `resource_group_name` - (Required) The name of the resource group in which to Changing this forces a new resource to be created.
     create the connection Changing the name forces a new resource to be created.
 
-* `location` - (Required) The location/region where the connection is
+* `location` - (Required) The location/region where the connection is Changing this forces a new resource to be created.
     located. Changing this forces a new resource to be created.
 
-* `type` - (Required) The type of connection. Valid options are `IPsec`
+* `type` - (Required) The type of connection. Valid options are `IPsec` Changing this forces a new resource to be created.
     (Site-to-Site), `ExpressRoute` (ExpressRoute), and `Vnet2Vnet` (VNet-to-VNet).
     Each connection type requires different mandatory arguments (refer to the
     examples above). Changing the connection type will force a new connection
     to be created.
 
-* `virtual_network_gateway_id` - (Required) The ID of the Virtual Network Gateway
+* `virtual_network_gateway_id` - (Required) The ID of the Virtual Network Gateway Changing this forces a new resource to be created.
     in which the connection will be created. Changing the gateway forces a new
     resource to be created.
 
@@ -228,11 +228,11 @@ The following arguments are supported:
 
 * `dpd_timeout_seconds` - (Optional) The dead peer detection timeout of this connection in seconds. Changing this forces a new resource to be created.
 
-* `express_route_circuit_id` - (Optional) The ID of the Express Route Circuit
+* `express_route_circuit_id` - (Optional) The ID of the Express Route Circuit Changing this forces a new resource to be created.
     when creating an ExpressRoute connection (i.e. when `type` is `ExpressRoute`).
     The Express Route Circuit can be in the same or in a different subscription.
 
-* `peer_virtual_network_gateway_id` - (Optional) The ID of the peer virtual
+* `peer_virtual_network_gateway_id` - (Optional) The ID of the peer virtual Changing this forces a new resource to be created.
     network gateway when creating a VNet-to-VNet connection (i.e. when `type`
     is `Vnet2Vnet`). The peer Virtual Network Gateway can be in the same or
     in a different subscription.
@@ -249,7 +249,7 @@ The following arguments are supported:
 
 * `connection_mode` - (Optional) Connection mode to use. Possible values are `Default`, `InitiatorOnly` and `ResponderOnly`. Defaults to `Default`. Changing this value will force a resource to be created.
 
-* `connection_protocol` - (Optional) The IKE protocol version to use. Possible values are `IKEv1` and `IKEv2`.
+* `connection_protocol` - (Optional) The IKE protocol version to use. Possible values are `IKEv1` and `IKEv2`. Changing this forces a new resource to be created.
     values are `IKEv1` and `IKEv2`. Defaults to `IKEv2`.
     Changing this value will force a resource to be created.
 -> **Note:** Only valid for `IPSec` connections on virtual network gateways with SKU `VpnGw1`, `VpnGw2`, `VpnGw3`, `VpnGw1AZ`, `VpnGw2AZ` or `VpnGw3AZ`.

--- a/website/docs/r/virtual_network_gateway_connection.html.markdown
+++ b/website/docs/r/virtual_network_gateway_connection.html.markdown
@@ -249,9 +249,7 @@ The following arguments are supported:
 
 * `connection_mode` - (Optional) Connection mode to use. Possible values are `Default`, `InitiatorOnly` and `ResponderOnly`. Defaults to `Default`. Changing this value will force a resource to be created.
 
-* `connection_protocol` - (Optional) The IKE protocol version to use. Possible values are `IKEv1` and `IKEv2`. Changing this forces a new resource to be created.
-    values are `IKEv1` and `IKEv2`. Defaults to `IKEv2`.
-    Changing this value will force a resource to be created.
+* `connection_protocol` - (Optional) The IKE protocol version to use. Possible values are `IKEv1` and `IKEv2`, values are `IKEv1` and `IKEv2`. Defaults to `IKEv2`. Changing this forces a new resource to be created.
 -> **Note:** Only valid for `IPSec` connections on virtual network gateways with SKU `VpnGw1`, `VpnGw2`, `VpnGw3`, `VpnGw1AZ`, `VpnGw2AZ` or `VpnGw3AZ`.
 
 * `enable_bgp` - (Optional) If `true`, BGP (Border Gateway Protocol) is enabled

--- a/website/docs/r/virtual_network_peering.html.markdown
+++ b/website/docs/r/virtual_network_peering.html.markdown
@@ -114,16 +114,16 @@ resource "azurerm_virtual_network_peering" "peering" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the virtual network peering. Changing this
+* `name` - (Required) The name of the virtual network peering. Changing this Changing this forces a new resource to be created.
     forces a new resource to be created.
 
-* `virtual_network_name` - (Required) The name of the virtual network. Changing
+* `virtual_network_name` - (Required) The name of the virtual network. Changing Changing this forces a new resource to be created.
     this forces a new resource to be created.
 
-* `remote_virtual_network_id` - (Required) The full Azure resource ID of the
+* `remote_virtual_network_id` - (Required) The full Azure resource ID of the Changing this forces a new resource to be created.
     remote virtual network.  Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) The name of the resource group in which to
+* `resource_group_name` - (Required) The name of the resource group in which to Changing this forces a new resource to be created.
     create the virtual network peering. Changing this forces a new resource to be
     created.
 

--- a/website/docs/r/virtual_network_peering.html.markdown
+++ b/website/docs/r/virtual_network_peering.html.markdown
@@ -114,28 +114,20 @@ resource "azurerm_virtual_network_peering" "peering" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the virtual network peering. Changing this Changing this forces a new resource to be created.
-    forces a new resource to be created.
+* `name` - (Required) The name of the virtual network peering. Changing this forces a new resource to be created.
 
-* `virtual_network_name` - (Required) The name of the virtual network. Changing Changing this forces a new resource to be created.
-    this forces a new resource to be created.
+* `virtual_network_name` - (Required) The name of the virtual network. Changing this forces a new resource to be created.
 
-* `remote_virtual_network_id` - (Required) The full Azure resource ID of the Changing this forces a new resource to be created.
-    remote virtual network.  Changing this forces a new resource to be created.
+* `remote_virtual_network_id` - (Required) The full Azure resource ID of the remote virtual network.  Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) The name of the resource group in which to Changing this forces a new resource to be created.
-    create the virtual network peering. Changing this forces a new resource to be
+* `resource_group_name` - (Required) The name of the resource group in which to create the virtual network peering. Changing this forces a new resource to be
     created.
 
-* `allow_virtual_network_access` - (Optional) Controls if the VMs in the remote
-    virtual network can access VMs in the local virtual network. Defaults to
-    true.
+* `allow_virtual_network_access` - (Optional) Controls if the VMs in the remote virtual network can access VMs in the local virtual network. Defaults to true.
 
-* `allow_forwarded_traffic` - (Optional) Controls if forwarded traffic from  VMs
-    in the remote virtual network is allowed. Defaults to false.
+* `allow_forwarded_traffic` - (Optional) Controls if forwarded traffic from  VMs in the remote virtual network is allowed. Defaults to false.
 
-* `allow_gateway_transit` - (Optional) Controls gatewayLinks can be used in the
-    remote virtual network’s link to the local virtual network.
+* `allow_gateway_transit` - (Optional) Controls gatewayLinks can be used in the remote virtual network’s link to the local virtual network.
 
 * `use_remote_gateways` - (Optional) Controls if remote gateways can be used on
     the local virtual network. If the flag is set to `true`, and

--- a/website/docs/r/vpn_gateway.html.markdown
+++ b/website/docs/r/vpn_gateway.html.markdown
@@ -65,7 +65,7 @@ The following arguments are supported:
 
 * `bgp_settings` - (Optional) A `bgp_settings` block as defined below.
 
-* `routing_preference` - (Optional) Azure routing preference lets you to choose how your traffic routes between Azure and the internet. You can choose to route traffic either via the Microsoft network (default value, `Microsoft Network`), or via the ISP network (public internet, set to `Internet`). More context of the configuration can be found in the
+* `routing_preference` - (Optional) Azure routing preference lets you to choose how your traffic routes between Azure and the internet. You can choose to route traffic either via the Microsoft network (default value, `Microsoft Network`), or via the ISP network (public internet, set to `Internet`). More context of the configuration can be found in the Changing this forces a new resource to be created.
 [Microsoft Docs](https://docs.microsoft.com/azure/virtual-wan/virtual-wan-site-to-site-portal#gateway) to create a VPN Gateway. Changing this forces a new resource to be created.
 
 * `scale_unit` - (Optional) The Scale Unit for this VPN Gateway. Defaults to `1`.

--- a/website/docs/r/vpn_gateway.html.markdown
+++ b/website/docs/r/vpn_gateway.html.markdown
@@ -65,8 +65,7 @@ The following arguments are supported:
 
 * `bgp_settings` - (Optional) A `bgp_settings` block as defined below.
 
-* `routing_preference` - (Optional) Azure routing preference lets you to choose how your traffic routes between Azure and the internet. You can choose to route traffic either via the Microsoft network (default value, `Microsoft Network`), or via the ISP network (public internet, set to `Internet`). More context of the configuration can be found in the Changing this forces a new resource to be created.
-[Microsoft Docs](https://docs.microsoft.com/azure/virtual-wan/virtual-wan-site-to-site-portal#gateway) to create a VPN Gateway. Changing this forces a new resource to be created.
+* `routing_preference` - (Optional) Azure routing preference lets you to choose how your traffic routes between Azure and the internet. You can choose to route traffic either via the Microsoft network (default value, `Microsoft Network`), or via the ISP network (public internet, set to `Internet`). More context of the configuration can be found in the [Microsoft Docs](https://docs.microsoft.com/azure/virtual-wan/virtual-wan-site-to-site-portal#gateway) to create a VPN Gateway. Changing this forces a new resource to be created.
 
 * `scale_unit` - (Optional) The Scale Unit for this VPN Gateway. Defaults to `1`.
 

--- a/website/docs/r/vpn_gateway_nat_rule.html.markdown
+++ b/website/docs/r/vpn_gateway_nat_rule.html.markdown
@@ -74,11 +74,11 @@ The following arguments are supported:
 
 * `type` - (Optional) The type of the VPN Gateway NAT Rule. Possible values are `Dynamic` and `Static`. Defaults to `Static`. Changing this forces a new resource to be created.
 
-* `external_address_space_mappings` - (Deprecated) A list of CIDR Ranges which are used for external mapping of the VPN Gateway NAT Rule.
+* `external_address_space_mappings` - (Optional) (Deprecated) A list of CIDR Ranges which are used for external mapping of the VPN Gateway NAT Rule.
 
 ~> **NOTE:** `external_address_space_mappings` is deprecated and will be removed in favour of the property `external_mapping` in version 4.0 of the AzureRM Provider.
 
-* `internal_address_space_mappings` - (Deprecated) A list of CIDR Ranges which are used for internal mapping of the VPN Gateway NAT Rule.
+* `internal_address_space_mappings` - (Optional) (Deprecated) A list of CIDR Ranges which are used for internal mapping of the VPN Gateway NAT Rule.
 
 ~> **NOTE:** `internal_address_space_mappings` is deprecated and will be removed in favour of the property `internal_mapping` in version 4.0 of the AzureRM Provider.
 

--- a/website/docs/r/web_application_firewall_policy.html.markdown
+++ b/website/docs/r/web_application_firewall_policy.html.markdown
@@ -114,7 +114,7 @@ The following arguments are supported:
 
 * `resource_group_name` - (Required) The name of the resource group. Changing this forces a new resource to be created.
 
-* `location` - (Optional) Resource location. Changing this forces a new resource to be created.
+* `location` - (Required) Resource location. Changing this forces a new resource to be created.
 
 * `custom_rules` - (Optional) One or more `custom_rules` blocks as defined below.
 
@@ -128,7 +128,7 @@ The following arguments are supported:
 
 The `custom_rules` block supports the following:
 
-* `name` - (Optional) Gets name of the resource that is unique within a policy. This name can be used to access the resource.
+* `name` - (Required) Gets name of the resource that is unique within a policy. This name can be used to access the resource.
 
 * `priority` - (Required) Describes priority of the rule. Rules with a lower value will be evaluated before rules with a higher value.
 

--- a/website/docs/r/web_pubsub.html.markdown
+++ b/website/docs/r/web_pubsub.html.markdown
@@ -46,10 +46,10 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the Web PubSub service. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) The name of the resource group in which to create the Web PubSub service. Changing
+* `resource_group_name` - (Required) The name of the resource group in which to create the Web PubSub service. Changing Changing this forces a new resource to be created.
   this forces a new resource to be created.
 
-* `location` - (Required) Specifies the supported Azure location where the Web PubSub service exists. Changing this
+* `location` - (Required) Specifies the supported Azure location where the Web PubSub service exists. Changing this Changing this forces a new resource to be created.
   forces a new resource to be created.
 
 * `sku` - (Required) Specifies which SKU to use. Possible values are `Free_F1` and `Standard_S1`.

--- a/website/docs/r/web_pubsub.html.markdown
+++ b/website/docs/r/web_pubsub.html.markdown
@@ -46,11 +46,9 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the Web PubSub service. Changing this forces a new resource to be created.
 
-* `resource_group_name` - (Required) The name of the resource group in which to create the Web PubSub service. Changing Changing this forces a new resource to be created.
-  this forces a new resource to be created.
+* `resource_group_name` - (Required) The name of the resource group in which to create the Web PubSub service. Changing this forces a new resource to be created.
 
-* `location` - (Required) Specifies the supported Azure location where the Web PubSub service exists. Changing this Changing this forces a new resource to be created.
-  forces a new resource to be created.
+* `location` - (Required) Specifies the supported Azure location where the Web PubSub service exists. Changing this forces a new resource to be created.
 
 * `sku` - (Required) Specifies which SKU to use. Possible values are `Free_F1` and `Standard_S1`.
 

--- a/website/docs/r/web_pubsub_hub.html.markdown
+++ b/website/docs/r/web_pubsub_hub.html.markdown
@@ -62,7 +62,7 @@ resource "azurerm_web_pubsub_hub" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the Web Pubsub hub service. Changing this forces a new resource to be created.
+* `name` - (Required) The name of the Web Pubsub hub service. Changing this forces a new resource to be created. Changing this forces a new resource to be created.
 
 * `web_pubsub_id` - (Required) Specify the id of the Web Pubsub. Changing this forces a new resource to be created.
 

--- a/website/docs/r/web_pubsub_hub.html.markdown
+++ b/website/docs/r/web_pubsub_hub.html.markdown
@@ -62,7 +62,7 @@ resource "azurerm_web_pubsub_hub" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the Web Pubsub hub service. Changing this forces a new resource to be created. Changing this forces a new resource to be created.
+* `name` - (Required) The name of the Web Pubsub hub service. Changing this forces a new resource to be created.
 
 * `web_pubsub_id` - (Required) Specify the id of the Web Pubsub. Changing this forces a new resource to be created.
 

--- a/website/docs/r/web_pubsub_network_acl.html.markdown
+++ b/website/docs/r/web_pubsub_network_acl.html.markdown
@@ -81,7 +81,7 @@ The following arguments are supported:
 
 * `web_pubsub_id` - (Required) The ID of the Web Pubsub service. Changing this forces a new resource to be created.
 
-* `default_action` - (Required) The default action to control the network access when no other rule matches. Possible values are `Allow` and `Deny`. Defaults to `Deny`.
+* `default_action` - (Optional) The default action to control the network access when no other rule matches. Possible values are `Allow` and `Deny`. Defaults to `Deny`.
 
 * `public_network` - (Required) A `public_network` block as defined below.
 

--- a/website/docs/r/windows_virtual_machine.html.markdown
+++ b/website/docs/r/windows_virtual_machine.html.markdown
@@ -353,7 +353,7 @@ A `winrm_listener` block supports the following:
 
 * `Protocol` - (Required) Specifies Specifies the protocol of listener. Possible values are `Http` or `Https`
 
-* `certificate_url` - (Optional) The Secret URL of a Key Vault Certificate, which must be specified when `protocol` is set to `Https`.
+* `certificate_url` - (Optional) The Secret URL of a Key Vault Certificate, which must be specified when `protocol` is set to `Https`. Changing this forces a new resource to be created.
 
 ## Attributes Reference
 

--- a/website/docs/r/windows_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/windows_virtual_machine_scale_set.html.markdown
@@ -124,7 +124,7 @@ resource "azurerm_windows_virtual_machine_scale_set" "example" {
 
 ~> **NOTE:** `single_placement_group` must be set to `false` when `capacity_reservation_group_id` is specified.
 
-* `computer_name_prefix` - (Optional) The prefix which should be used for the name of the Virtual Machines in this Scale Set. If unspecified this defaults to the value for the `name` field. If the value of the `name` field is not a valid `computer_name_prefix`, then you must specify `computer_name_prefix`.
+* `computer_name_prefix` - (Optional) The prefix which should be used for the name of the Virtual Machines in this Scale Set. If unspecified this defaults to the value for the `name` field. If the value of the `name` field is not a valid `computer_name_prefix`, then you must specify `computer_name_prefix`. Changing this forces a new resource to be created.
 
 * `custom_data` - (Optional) The Base64-Encoded Custom Data which should be used for this Virtual Machine Scale Set.
 
@@ -212,7 +212,7 @@ resource "azurerm_windows_virtual_machine_scale_set" "example" {
 
 * `timezone` - (Optional) Specifies the time zone of the virtual machine, [the possible values are defined here](https://jackstromberg.com/2017/01/list-of-time-zones-consumed-by-azure/).
 
-* `upgrade_mode` - (Optional) Specifies how Upgrades (e.g. changing the Image/SKU) should be performed to Virtual Machine Instances. Possible values are `Automatic`, `Manual` and `Rolling`. Defaults to `Manual`.
+* `upgrade_mode` - (Optional) Specifies how Upgrades (e.g. changing the Image/SKU) should be performed to Virtual Machine Instances. Possible values are `Automatic`, `Manual` and `Rolling`. Defaults to `Manual`. Changing this forces a new resource to be created.
 
 * `user_data` - (Optional) The Base64-Encoded User Data which should be used for this Virtual Machine Scale Set.
 
@@ -292,7 +292,7 @@ A `data_disk` block supports the following:
 
 -> **NOTE:** `UltraSSD_LRS` is only supported when `ultra_ssd_enabled` within the `additional_capabilities` block is enabled.
 
-* `disk_encryption_set_id` - (Optional) The ID of the Disk Encryption Set which should be used to encrypt this Data Disk.
+* `disk_encryption_set_id` - (Optional) The ID of the Disk Encryption Set which should be used to encrypt this Data Disk. Changing this forces a new resource to be created.
 
 -> **NOTE:** The Disk Encryption Set must have the `Reader` Role Assignment scoped on the Key Vault - in addition to an Access Policy to the Key Vault
 
@@ -438,11 +438,11 @@ An `os_disk` block supports the following:
 
 * `caching` - (Required) The Type of Caching which should be used for the Internal OS Disk. Possible values are `None`, `ReadOnly` and `ReadWrite`.
 
-* `storage_account_type` - (Required) The Type of Storage Account which should back this the Internal OS Disk. Possible values include `Standard_LRS`, `StandardSSD_LRS`, `StandardSSD_ZRS`, `Premium_LRS` and `Premium_ZRS`.
+* `storage_account_type` - (Required) The Type of Storage Account which should back this the Internal OS Disk. Possible values include `Standard_LRS`, `StandardSSD_LRS`, `StandardSSD_ZRS`, `Premium_LRS` and `Premium_ZRS`. Changing this forces a new resource to be created.
 
 * `diff_disk_settings` - (Optional) A `diff_disk_settings` block as defined above. Changing this forces a new resource to be created.
 
-* `disk_encryption_set_id` - (Optional) The ID of the Disk Encryption Set which should be used to encrypt this OS Disk. Conflicts with `secure_vm_disk_encryption_set_id`.
+* `disk_encryption_set_id` - (Optional) The ID of the Disk Encryption Set which should be used to encrypt this OS Disk. Conflicts with `secure_vm_disk_encryption_set_id`. Changing this forces a new resource to be created.
 
 -> **NOTE:** The Disk Encryption Set must have the `Reader` Role Assignment scoped on the Key Vault - in addition to an Access Policy to the Key Vault
 
@@ -558,23 +558,23 @@ A `termination_notification` block supports the following:
 
 A `winrm_listener` block supports the following:
 
-* `certificate_url` - (Optional) The Secret URL of a Key Vault Certificate, which must be specified when `protocol` is set to `Https`.
+* `certificate_url` - (Optional) The Secret URL of a Key Vault Certificate, which must be specified when `protocol` is set to `Https`. Changing this forces a new resource to be created.
 
 -> **NOTE:** This can be sourced from the `secret_id` field within the `azurerm_key_vault_certificate` Resource.
 
-* `protocol` - (Required) The Protocol of the WinRM Listener. Possible values are `Http` and `Https`.
+* `protocol` - (Required) The Protocol of the WinRM Listener. Possible values are `Http` and `Https`. Changing this forces a new resource to be created.
 
 ---
 
 A `source_image_reference` block supports the following:
 
-* `publisher` - (Optional) Specifies the publisher of the image used to create the virtual machines.
+* `publisher` - (Required) Specifies the publisher of the image used to create the virtual machines.
 
-* `offer` - (Optional) Specifies the offer of the image used to create the virtual machines.
+* `offer` - (Required) Specifies the offer of the image used to create the virtual machines.
 
-* `sku` - (Optional) Specifies the SKU of the image used to create the virtual machines.
+* `sku` - (Required) Specifies the SKU of the image used to create the virtual machines.
 
-* `version` - (Optional) Specifies the version of the image used to create the virtual machines.
+* `version` - (Required) Specifies the version of the image used to create the virtual machines.
 
 ---
 


### PR DESCRIPTION
I developed a scanning tool to help check and update inconsistency `Required`, `Optional` and `ForceNew` properties between code and document. I took the code as the ground truth and update document accordingly.

1. for `Required` property in code - mark doc as `(Required)`.
2. for `Optional` property in code - mark doc as `(Optional)`.
3. for `ForceNew` property in code - mark doc as `Changing this forces a new resource to be created`.

fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/19471