### PR TITLE
Docs: azurerm_redis_cache - private_static_ip_address requires subnet_id

### DIFF
--- a/website/docs/r/redis_cache.html.markdown
+++ b/website/docs/r/redis_cache.html.markdown
@@ -67,7 +67,7 @@ The following arguments are supported:
 
 * `patch_schedule` - (Optional) A list of `patch_schedule` blocks as defined below.
 
-* `private_static_ip_address` - (Optional) The Static IP Address to assign to the Redis Cache when hosted inside the Virtual Network. Changing this forces a new resource to be created.
+* `private_static_ip_address` - (Optional) The Static IP Address to assign to the Redis Cache when hosted inside the Virtual Network. This argument implies the use of the `subnet_id`. Changing this forces a new resource to be created.
 
 * `public_network_access_enabled` - (Optional) Whether or not public network access is allowed for this Redis Cache. `true` means this resource could be accessed by both public and private endpoint. `false` means only private endpoint access is allowed. Defaults to `true`.
 

--- a/website/docs/r/redis_cache.html.markdown
+++ b/website/docs/r/redis_cache.html.markdown
@@ -67,7 +67,7 @@ The following arguments are supported:
 
 * `patch_schedule` - (Optional) A list of `patch_schedule` blocks as defined below.
 
-* `private_static_ip_address` - (Optional) The Static IP Address to assign to the Redis Cache when hosted inside the Virtual Network. This argument implies the use of the `subnet_id`. Changing this forces a new resource to be created.
+* `private_static_ip_address` - (Optional) The Static IP Address to assign to the Redis Cache when hosted inside the Virtual Network. This argument implies the use of `subnet_id`. Changing this forces a new resource to be created.
 
 * `public_network_access_enabled` - (Optional) Whether or not public network access is allowed for this Redis Cache. `true` means this resource could be accessed by both public and private endpoint. `false` means only private endpoint access is allowed. Defaults to `true`.
 


### PR DESCRIPTION
Updated the docs to mention the relationship between `subnet_id` and `private_static_ip_address` arguments.

refers #18877