### PR TITLE
New Resource : `azurerm_cognitive_deployment`

### DIFF
--- a/.teamcity/components/settings.kt
+++ b/.teamcity/components/settings.kt
@@ -44,7 +44,7 @@ var serviceTestConfigurationOverrides = mapOf(
 
         // "cognitive" is expensive - Monday, Wednesday, Friday
         // cognitive is only available in certain locations
-        "cognitive" to testConfiguration(daysOfWeek = "2,4,6", useDevTestSubscription = true, locationOverride = LocationConfiguration("westeurope", "eastus", "southcentralus", true)),
+        "cognitive" to testConfiguration(daysOfWeek = "2,4,6", locationOverride = LocationConfiguration("westeurope", "eastus", "southcentralus", true), useDevTestSubscription = true),
 
         // Cosmos is only available in certain locations
         "cosmos" to testConfiguration(locationOverride = LocationConfiguration("westus", "northeurope", "southcentralus", true), useDevTestSubscription = true),

--- a/.teamcity/components/settings.kt
+++ b/.teamcity/components/settings.kt
@@ -44,7 +44,7 @@ var serviceTestConfigurationOverrides = mapOf(
 
         // "cognitive" is expensive - Monday, Wednesday, Friday
         // cognitive is only available in certain locations
-        "cognitive" to testConfiguration(daysOfWeek = "2,4,6", locationOverride = LocationConfiguration("westeurope", "eastus", "southcentralus", true)),
+        "cognitive" to testConfiguration(daysOfWeek = "2,4,6", useDevTestSubscription = true, locationOverride = LocationConfiguration("westeurope", "eastus", "southcentralus", true)),
 
         // Cosmos is only available in certain locations
         "cosmos" to testConfiguration(locationOverride = LocationConfiguration("westus", "northeurope", "southcentralus", true)),

--- a/.teamcity/components/settings.kt
+++ b/.teamcity/components/settings.kt
@@ -43,7 +43,8 @@ var serviceTestConfigurationOverrides = mapOf(
         "cdn" to testConfiguration(locationOverride = LocationConfiguration("centralus", "eastus2", "westeurope", true)),
 
         // "cognitive" is expensive - Monday, Wednesday, Friday
-        "cognitive" to testConfiguration(daysOfWeek = "2,4,6"),
+        // cognitive is only available in certain locations
+        "cognitive" to testConfiguration(daysOfWeek = "2,4,6", locationOverride = LocationConfiguration("westeurope", "eastus", "southcentralus", true)),
 
         // Cosmos is only available in certain locations
         "cosmos" to testConfiguration(locationOverride = LocationConfiguration("westus", "northeurope", "southcentralus", true)),

--- a/internal/provider/services.go
+++ b/internal/provider/services.go
@@ -124,6 +124,7 @@ func SupportedTypedServices() []sdk.TypedServiceRegistration {
 		automation.Registration{},
 		batch.Registration{},
 		bot.Registration{},
+		cognitive.Registration{},
 		compute.Registration{},
 		consumption.Registration{},
 		cosmos.Registration{},

--- a/internal/services/cognitive/client/client.go
+++ b/internal/services/cognitive/client/client.go
@@ -2,18 +2,24 @@ package client
 
 import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2022-10-01/cognitiveservicesaccounts"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2022-10-01/deployments"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/common"
 )
 
 type Client struct {
-	AccountsClient *cognitiveservicesaccounts.CognitiveServicesAccountsClient
+	AccountsClient    *cognitiveservicesaccounts.CognitiveServicesAccountsClient
+	DeploymentsClient *deployments.DeploymentsClient
 }
 
 func NewClient(o *common.ClientOptions) *Client {
+
 	accountsClient := cognitiveservicesaccounts.NewCognitiveServicesAccountsClientWithBaseURI(o.ResourceManagerEndpoint)
 	o.ConfigureClient(&accountsClient.Client, o.ResourceManagerAuthorizer)
 
+	deploymentsClient := deployments.NewDeploymentsClientWithBaseURI(o.ResourceManagerEndpoint)
+	o.ConfigureClient(&deploymentsClient.Client, o.ResourceManagerAuthorizer)
 	return &Client{
-		AccountsClient: &accountsClient,
+		AccountsClient:    &accountsClient,
+		DeploymentsClient: &deploymentsClient,
 	}
 }

--- a/internal/services/cognitive/cognitive_deployment_resource.go
+++ b/internal/services/cognitive/cognitive_deployment_resource.go
@@ -1,0 +1,383 @@
+package cognitive
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2022-10-01/cognitiveservicesaccounts"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2022-10-01/deployments"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+type cognitiveDeploymentModel struct {
+	Name               string                         `tfschema:"name"`
+	CognitiveAccountId string                         `tfschema:"cognitive_account_id"`
+	Model              []DeploymentModelModel         `tfschema:"model"`
+	RaiPolicyName      string                         `tfschema:"rai_policy_name"`
+	ScaleSettings      []DeploymentScaleSettingsModel `tfschema:"scale_settings"`
+}
+
+type DeploymentModelModel struct {
+	Format  string `tfschema:"format"`
+	Name    string `tfschema:"name"`
+	Version string `tfschema:"version"`
+}
+
+type DeploymentScaleSettingsModel struct {
+	ScaleType deployments.DeploymentScaleType `tfschema:"scale_type"`
+}
+
+type CognitiveDeploymentResource struct{}
+
+var _ sdk.ResourceWithUpdate = CognitiveDeploymentResource{}
+
+func (r CognitiveDeploymentResource) ResourceType() string {
+	return "azurerm_cognitive_deployment"
+}
+
+func (r CognitiveDeploymentResource) ModelObject() interface{} {
+	return &cognitiveDeploymentModel{}
+}
+
+func (r CognitiveDeploymentResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+	return deployments.ValidateDeploymentID
+}
+
+func (r CognitiveDeploymentResource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"cognitive_account_id": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: cognitiveservicesaccounts.ValidateAccountID,
+		},
+
+		"model": {
+			Type:     pluginsdk.TypeList,
+			Required: true,
+			MaxItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"format": {
+						Type:     pluginsdk.TypeString,
+						Required: true,
+						ValidateFunc: validation.StringInSlice([]string{
+							"OpenAI",
+						}, false),
+					},
+
+					"name": {
+						Type:         pluginsdk.TypeString,
+						Required:     true,
+						ForceNew:     true,
+						ValidateFunc: validation.StringIsNotEmpty,
+					},
+
+					"version": {
+						Type:     pluginsdk.TypeString,
+						Required: true,
+						ValidateFunc: validation.StringInSlice([]string{
+							"1",
+						}, false),
+					},
+				},
+			},
+		},
+
+		"scale_settings": {
+			Type:     pluginsdk.TypeList,
+			Required: true,
+			MaxItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"scale_type": {
+						Type:     pluginsdk.TypeString,
+						Required: true,
+						ForceNew: true,
+						ValidateFunc: validation.StringInSlice([]string{
+							string(deployments.DeploymentScaleTypeStandard),
+						}, false),
+					},
+				},
+			},
+		},
+
+		"rai_policy_name": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+	}
+}
+
+func (r CognitiveDeploymentResource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{}
+}
+
+func (r CognitiveDeploymentResource) Create() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			var model cognitiveDeploymentModel
+			if err := metadata.Decode(&model); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			client := metadata.Client.Cognitive.DeploymentsClient
+			accountId, err := cognitiveservicesaccounts.ParseAccountID(model.CognitiveAccountId)
+			if err != nil {
+				return err
+			}
+
+			id := deployments.NewDeploymentID(accountId.SubscriptionId, accountId.ResourceGroupName, accountId.AccountName, model.Name)
+			existing, err := client.Get(ctx, id)
+			if err != nil && !response.WasNotFound(existing.HttpResponse) {
+				return fmt.Errorf("checking for existing %s: %+v", id, err)
+			}
+
+			if !response.WasNotFound(existing.HttpResponse) {
+				return metadata.ResourceRequiresImport(r.ResourceType(), id)
+			}
+
+			properties := &deployments.Deployment{
+				Properties: &deployments.DeploymentProperties{},
+			}
+
+			modelValue, err := expandDeploymentModelModel(model.Model)
+			if err != nil {
+				return err
+			}
+
+			properties.Properties.Model = modelValue
+
+			if model.RaiPolicyName != "" {
+				properties.Properties.RaiPolicyName = &model.RaiPolicyName
+			}
+
+			scaleSettingsValue, err := expandDeploymentScaleSettingsModel(model.ScaleSettings)
+			if err != nil {
+				return err
+			}
+
+			properties.Properties.ScaleSettings = scaleSettingsValue
+
+			if err := client.CreateOrUpdateThenPoll(ctx, id, *properties); err != nil {
+				return fmt.Errorf("creating %s: %+v", id, err)
+			}
+
+			metadata.SetID(id)
+			return nil
+		},
+	}
+}
+
+func (r CognitiveDeploymentResource) Update() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Cognitive.DeploymentsClient
+
+			id, err := deployments.ParseDeploymentID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			var model cognitiveDeploymentModel
+			if err := metadata.Decode(&model); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			resp, err := client.Get(ctx, *id)
+			if err != nil {
+				return fmt.Errorf("retrieving %s: %+v", *id, err)
+			}
+
+			properties := resp.Model
+			if properties == nil {
+				return fmt.Errorf("retrieving %s: properties was nil", id)
+			}
+
+			if metadata.ResourceData.HasChange("format") {
+				properties.Properties.Model.Format = &model.Model[0].Format
+			}
+
+			if metadata.ResourceData.HasChange("model.0.version") {
+				properties.Properties.Model.Version = &model.Model[0].Version
+			}
+
+			properties.SystemData = nil
+
+			if err := client.CreateOrUpdateThenPoll(ctx, *id, *properties); err != nil {
+				return fmt.Errorf("updating %s: %+v", *id, err)
+			}
+
+			return nil
+		},
+	}
+}
+
+func (r CognitiveDeploymentResource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Cognitive.DeploymentsClient
+
+			id, err := deployments.ParseDeploymentID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.Get(ctx, *id)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return metadata.MarkAsGone(id)
+				}
+
+				return fmt.Errorf("retrieving %s: %+v", *id, err)
+			}
+
+			model := resp.Model
+			if model == nil {
+				return fmt.Errorf("retrieving %s: model was nil", id)
+			}
+
+			state := cognitiveDeploymentModel{
+				Name:               id.DeploymentName,
+				CognitiveAccountId: cognitiveservicesaccounts.NewAccountID(id.SubscriptionId, id.ResourceGroupName, id.AccountName).ID(),
+			}
+
+			if properties := model.Properties; properties != nil {
+				modelValue, err := flattenDeploymentModelModel(properties.Model)
+				if err != nil {
+					return err
+				}
+
+				state.Model = modelValue
+
+				scaleSettingsValue, err := flattenDeploymentScaleSettingsModel(properties.ScaleSettings)
+				if err != nil {
+					return err
+				}
+
+				state.ScaleSettings = scaleSettingsValue
+
+				if v := properties.RaiPolicyName; v != nil {
+					state.RaiPolicyName = *v
+				}
+			}
+
+			return metadata.Encode(&state)
+		},
+	}
+}
+
+func (r CognitiveDeploymentResource) Delete() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Cognitive.DeploymentsClient
+
+			id, err := deployments.ParseDeploymentID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			if err := client.DeleteThenPoll(ctx, *id); err != nil {
+				return fmt.Errorf("deleting %s: %+v", id, err)
+			}
+
+			return nil
+		},
+	}
+}
+
+func expandDeploymentModelModel(inputList []DeploymentModelModel) (*deployments.DeploymentModel, error) {
+	if len(inputList) == 0 {
+		return nil, nil
+	}
+
+	input := &inputList[0]
+	output := deployments.DeploymentModel{}
+
+	if input.Format != "" {
+		output.Format = &input.Format
+	}
+
+	if input.Name != "" {
+		output.Name = &input.Name
+	}
+
+	if input.Version != "" {
+		output.Version = &input.Version
+	}
+
+	return &output, nil
+}
+
+func expandDeploymentScaleSettingsModel(inputList []DeploymentScaleSettingsModel) (*deployments.DeploymentScaleSettings, error) {
+	if len(inputList) == 0 {
+		return nil, nil
+	}
+
+	input := &inputList[0]
+	output := deployments.DeploymentScaleSettings{
+		ScaleType: &input.ScaleType,
+	}
+
+	return &output, nil
+}
+
+func flattenDeploymentModelModel(input *deployments.DeploymentModel) ([]DeploymentModelModel, error) {
+	var outputList []DeploymentModelModel
+	if input == nil {
+		return outputList, nil
+	}
+
+	output := DeploymentModelModel{}
+	format := ""
+	if input.Format != nil {
+		format = *input.Format
+	}
+	output.Format = format
+
+	name := ""
+	if input.Name != nil {
+		name = *input.Name
+	}
+	output.Name = name
+
+	version := ""
+	if input.Version != nil {
+		version = *input.Version
+	}
+	output.Version = version
+
+	return append(outputList, output), nil
+}
+
+func flattenDeploymentScaleSettingsModel(input *deployments.DeploymentScaleSettings) ([]DeploymentScaleSettingsModel, error) {
+	var outputList []DeploymentScaleSettingsModel
+	if input == nil {
+		return outputList, nil
+	}
+
+	output := DeploymentScaleSettingsModel{}
+
+	if input.ScaleType != nil {
+		output.ScaleType = *input.ScaleType
+	}
+
+	return append(outputList, output), nil
+}

--- a/internal/services/cognitive/cognitive_deployment_resource.go
+++ b/internal/services/cognitive/cognitive_deployment_resource.go
@@ -18,7 +18,7 @@ type cognitiveDeploymentModel struct {
 	CognitiveAccountId string                         `tfschema:"cognitive_account_id"`
 	Model              []DeploymentModelModel         `tfschema:"model"`
 	RaiPolicyName      string                         `tfschema:"rai_policy_name"`
-	ScaleSettings      []DeploymentScaleSettingsModel `tfschema:"scale_settings"`
+	ScaleSettings      []DeploymentScaleSettingsModel `tfschema:"scale"`
 }
 
 type DeploymentModelModel struct {
@@ -28,7 +28,7 @@ type DeploymentModelModel struct {
 }
 
 type DeploymentScaleSettingsModel struct {
-	ScaleType deployments.DeploymentScaleType `tfschema:"scale_type"`
+	ScaleType deployments.DeploymentScaleType `tfschema:"type"`
 }
 
 type CognitiveDeploymentResource struct{}
@@ -94,14 +94,14 @@ func (r CognitiveDeploymentResource) Arguments() map[string]*pluginsdk.Schema {
 			},
 		},
 
-		"scale_settings": {
+		"scale": {
 			Type:     pluginsdk.TypeList,
 			Required: true,
 			ForceNew: true,
 			MaxItems: 1,
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*pluginsdk.Schema{
-					"scale_type": {
+					"type": {
 						Type:     pluginsdk.TypeString,
 						Required: true,
 						ForceNew: true,

--- a/internal/services/cognitive/cognitive_deployment_resource_test.go
+++ b/internal/services/cognitive/cognitive_deployment_resource_test.go
@@ -1,0 +1,166 @@
+package cognitive_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2022-10-01/deployments"
+
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+type CognitiveDeploymentTestResource struct{}
+
+func TestAccCognitiveDeployment_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cognitive_deployment", "test")
+	r := CognitiveDeploymentTestResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccCognitiveDeployment_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cognitive_deployment", "test")
+
+	r := CognitiveDeploymentTestResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.RequiresImportErrorStep(r.requiresImport),
+	})
+}
+
+func TestAccCognitiveDeployment_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cognitive_deployment", "test")
+	r := CognitiveDeploymentTestResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func (r CognitiveDeploymentTestResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := deployments.ParseDeploymentID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	client := clients.Cognitive.DeploymentsClient
+	resp, err := client.Get(ctx, *id)
+	if err != nil {
+		if response.WasNotFound(resp.HttpResponse) {
+			return utils.Bool(false), nil
+		}
+		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+	return utils.Bool(resp.Model != nil), nil
+}
+
+func (r CognitiveDeploymentTestResource) template(data acceptance.TestData, kind string) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctest-rg-%d"
+  location = "%s"
+}
+resource "azurerm_cognitive_account" "test" {
+  name                = "acctest-ca-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  kind                = "%s"
+  sku_name            = "S0"
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, kind)
+}
+
+func (r CognitiveDeploymentTestResource) basic(data acceptance.TestData) string {
+	template := r.template(data, "OpenAI")
+
+	return fmt.Sprintf(`
+
+%s
+
+resource "azurerm_cognitive_deployment" "test" {
+  name                 = "acctest-cd-%d"
+  cognitive_account_id = azurerm_cognitive_account.test.id
+  model {
+    format  = "OpenAI"
+    name    = "text-curie-001"
+    version = "1"
+  }
+
+  scale_settings {
+    scale_type = "Standard"
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func (r CognitiveDeploymentTestResource) requiresImport(data acceptance.TestData) string {
+	config := r.basic(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_cognitive_deployment" "import" {
+  name                 = azurerm_cognitive_deployment.test.name
+  cognitive_account_id = azurerm_cognitive_account.test.id
+  model {
+    format  = "OpenAI"
+    name    = "text-curie-001"
+    version = "1"
+  }
+  scale_settings {
+    scale_type = "Standard"
+  }
+}
+`, config)
+}
+
+func (r CognitiveDeploymentTestResource) complete(data acceptance.TestData) string {
+	template := r.template(data, "OpenAI")
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_cognitive_deployment" "test" {
+  name                 = "acctest-cd-%d"
+  cognitive_account_id = azurerm_cognitive_account.test.id
+
+  model {
+    format  = "OpenAI"
+    name    = "text-davinci-002"
+    version = "1"
+  }
+
+  scale_settings {
+    scale_type = "Standard"
+  }
+
+  rai_policy_name = "RAI policy"
+}
+`, template, data.RandomInteger)
+}

--- a/internal/services/cognitive/cognitive_deployment_resource_test.go
+++ b/internal/services/cognitive/cognitive_deployment_resource_test.go
@@ -126,8 +126,8 @@ resource "azurerm_cognitive_deployment" "test" {
     version = "1"
   }
 
-  scale_settings {
-    scale_type = "Standard"
+  scale {
+    type = "Standard"
   }
 }
 `, template, data.RandomInteger)
@@ -146,8 +146,8 @@ resource "azurerm_cognitive_deployment" "import" {
     name    = "text-curie-001"
     version = "1"
   }
-  scale_settings {
-    scale_type = "Standard"
+  scale {
+    type = "Standard"
   }
 }
 `, config)
@@ -168,8 +168,8 @@ resource "azurerm_cognitive_deployment" "test" {
     version = "1"
   }
 
-  scale_settings {
-    scale_type = "Standard"
+  scale {
+    type = "Standard"
   }
 
   rai_policy_name = "RAI policy"

--- a/internal/services/cognitive/cognitive_deployment_resource_test.go
+++ b/internal/services/cognitive/cognitive_deployment_resource_test.go
@@ -17,11 +17,23 @@ import (
 
 type CognitiveDeploymentTestResource struct{}
 
-func TestAccCognitiveDeployment_basic(t *testing.T) {
+func TestAccCognitiveDeploymentSequential(t *testing.T) {
+	// Only two OpenAI resources could be created per region, so run the tests sequentially.
+	// Refer to : https://learn.microsoft.com/en-us/azure/cognitive-services/openai/quotas-limits
+	acceptance.RunTestsInSequence(t, map[string]map[string]func(t *testing.T){
+		"deployment": {
+			"basic":          testAccCognitiveDeployment_basic,
+			"requiresImport": testAccCognitiveDeployment_requiresImport,
+			"complete":       testAccCognitiveDeployment_complete,
+		},
+	})
+}
+
+func testAccCognitiveDeployment_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_cognitive_deployment", "test")
 	r := CognitiveDeploymentTestResource{}
 
-	data.ResourceTest(t, r, []acceptance.TestStep{
+	data.ResourceSequentialTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -32,11 +44,11 @@ func TestAccCognitiveDeployment_basic(t *testing.T) {
 	})
 }
 
-func TestAccCognitiveDeployment_requiresImport(t *testing.T) {
+func testAccCognitiveDeployment_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_cognitive_deployment", "test")
 
 	r := CognitiveDeploymentTestResource{}
-	data.ResourceTest(t, r, []acceptance.TestStep{
+	data.ResourceSequentialTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -47,10 +59,10 @@ func TestAccCognitiveDeployment_requiresImport(t *testing.T) {
 	})
 }
 
-func TestAccCognitiveDeployment_complete(t *testing.T) {
+func testAccCognitiveDeployment_complete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_cognitive_deployment", "test")
 	r := CognitiveDeploymentTestResource{}
-	data.ResourceTest(t, r, []acceptance.TestStep{
+	data.ResourceSequentialTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.complete(data),
 			Check: acceptance.ComposeTestCheckFunc(

--- a/internal/services/cognitive/registration.go
+++ b/internal/services/cognitive/registration.go
@@ -7,7 +7,10 @@ import (
 
 type Registration struct{}
 
-var _ sdk.UntypedServiceRegistrationWithAGitHubLabel = Registration{}
+var (
+	_ sdk.TypedServiceRegistration                   = Registration{}
+	_ sdk.UntypedServiceRegistrationWithAGitHubLabel = Registration{}
+)
 
 func (r Registration) AssociatedGitHubLabel() string {
 	return "service/cognitive-services"
@@ -37,5 +40,17 @@ func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 	return map[string]*pluginsdk.Resource{
 		"azurerm_cognitive_account":                      resourceCognitiveAccount(),
 		"azurerm_cognitive_account_customer_managed_key": resourceCognitiveAccountCustomerManagedKey(),
+	}
+}
+
+// DataSources returns a list of Data Sources supported by this Service
+func (r Registration) DataSources() []sdk.DataSource {
+	return []sdk.DataSource{}
+}
+
+// Resources returns a list of Resources supported by this Service
+func (r Registration) Resources() []sdk.Resource {
+	return []sdk.Resource{
+		CognitiveDeploymentResource{},
 	}
 }

--- a/internal/services/loadbalancer/loadbalancer_resource.go
+++ b/internal/services/loadbalancer/loadbalancer_resource.go
@@ -86,7 +86,6 @@ func resourceArmLoadBalancerCreateUpdate(d *pluginsdk.ResourceData, meta interfa
 
 	id := parse.NewLoadBalancerID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 
-	log.Printf("elena: is new resource : %t", d.IsNewResource())
 	if d.IsNewResource() {
 		existing, err := client.Get(ctx, id.ResourceGroup, id.Name, "")
 		if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2022-10-01/deployments/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2022-10-01/deployments/README.md
@@ -1,0 +1,82 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2022-10-01/deployments` Documentation
+
+The `deployments` SDK allows for interaction with the Azure Resource Manager Service `cognitive` (API Version `2022-10-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2022-10-01/deployments"
+```
+
+
+### Client Initialization
+
+```go
+client := deployments.NewDeploymentsClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `DeploymentsClient.CreateOrUpdate`
+
+```go
+ctx := context.TODO()
+id := deployments.NewDeploymentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "accountValue", "deploymentValue")
+
+payload := deployments.Deployment{
+	// ...
+}
+
+
+if err := client.CreateOrUpdateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `DeploymentsClient.Delete`
+
+```go
+ctx := context.TODO()
+id := deployments.NewDeploymentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "accountValue", "deploymentValue")
+
+if err := client.DeleteThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `DeploymentsClient.Get`
+
+```go
+ctx := context.TODO()
+id := deployments.NewDeploymentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "accountValue", "deploymentValue")
+
+read, err := client.Get(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `DeploymentsClient.List`
+
+```go
+ctx := context.TODO()
+id := deployments.NewAccountID("12345678-1234-9876-4563-123456789012", "example-resource-group", "accountValue")
+
+// alternatively `client.List(ctx, id)` can be used to do batched pagination
+items, err := client.ListComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2022-10-01/deployments/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2022-10-01/deployments/client.go
@@ -1,0 +1,18 @@
+package deployments
+
+import "github.com/Azure/go-autorest/autorest"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DeploymentsClient struct {
+	Client  autorest.Client
+	baseUri string
+}
+
+func NewDeploymentsClientWithBaseURI(endpoint string) DeploymentsClient {
+	return DeploymentsClient{
+		Client:  autorest.NewClientWithUserAgent(userAgent()),
+		baseUri: endpoint,
+	}
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2022-10-01/deployments/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2022-10-01/deployments/constants.go
@@ -1,0 +1,74 @@
+package deployments
+
+import "strings"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DeploymentProvisioningState string
+
+const (
+	DeploymentProvisioningStateAccepted  DeploymentProvisioningState = "Accepted"
+	DeploymentProvisioningStateCreating  DeploymentProvisioningState = "Creating"
+	DeploymentProvisioningStateDeleting  DeploymentProvisioningState = "Deleting"
+	DeploymentProvisioningStateFailed    DeploymentProvisioningState = "Failed"
+	DeploymentProvisioningStateMoving    DeploymentProvisioningState = "Moving"
+	DeploymentProvisioningStateSucceeded DeploymentProvisioningState = "Succeeded"
+)
+
+func PossibleValuesForDeploymentProvisioningState() []string {
+	return []string{
+		string(DeploymentProvisioningStateAccepted),
+		string(DeploymentProvisioningStateCreating),
+		string(DeploymentProvisioningStateDeleting),
+		string(DeploymentProvisioningStateFailed),
+		string(DeploymentProvisioningStateMoving),
+		string(DeploymentProvisioningStateSucceeded),
+	}
+}
+
+func parseDeploymentProvisioningState(input string) (*DeploymentProvisioningState, error) {
+	vals := map[string]DeploymentProvisioningState{
+		"accepted":  DeploymentProvisioningStateAccepted,
+		"creating":  DeploymentProvisioningStateCreating,
+		"deleting":  DeploymentProvisioningStateDeleting,
+		"failed":    DeploymentProvisioningStateFailed,
+		"moving":    DeploymentProvisioningStateMoving,
+		"succeeded": DeploymentProvisioningStateSucceeded,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := DeploymentProvisioningState(input)
+	return &out, nil
+}
+
+type DeploymentScaleType string
+
+const (
+	DeploymentScaleTypeManual   DeploymentScaleType = "Manual"
+	DeploymentScaleTypeStandard DeploymentScaleType = "Standard"
+)
+
+func PossibleValuesForDeploymentScaleType() []string {
+	return []string{
+		string(DeploymentScaleTypeManual),
+		string(DeploymentScaleTypeStandard),
+	}
+}
+
+func parseDeploymentScaleType(input string) (*DeploymentScaleType, error) {
+	vals := map[string]DeploymentScaleType{
+		"manual":   DeploymentScaleTypeManual,
+		"standard": DeploymentScaleTypeStandard,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := DeploymentScaleType(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2022-10-01/deployments/id_account.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2022-10-01/deployments/id_account.go
@@ -1,0 +1,124 @@
+package deployments
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = AccountId{}
+
+// AccountId is a struct representing the Resource ID for a Account
+type AccountId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	AccountName       string
+}
+
+// NewAccountID returns a new AccountId struct
+func NewAccountID(subscriptionId string, resourceGroupName string, accountName string) AccountId {
+	return AccountId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		AccountName:       accountName,
+	}
+}
+
+// ParseAccountID parses 'input' into a AccountId
+func ParseAccountID(input string) (*AccountId, error) {
+	parser := resourceids.NewParserFromResourceIdType(AccountId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := AccountId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.AccountName, ok = parsed.Parsed["accountName"]; !ok {
+		return nil, fmt.Errorf("the segment 'accountName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ParseAccountIDInsensitively parses 'input' case-insensitively into a AccountId
+// note: this method should only be used for API response data and not user input
+func ParseAccountIDInsensitively(input string) (*AccountId, error) {
+	parser := resourceids.NewParserFromResourceIdType(AccountId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := AccountId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.AccountName, ok = parsed.Parsed["accountName"]; !ok {
+		return nil, fmt.Errorf("the segment 'accountName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ValidateAccountID checks that 'input' can be parsed as a Account ID
+func ValidateAccountID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseAccountID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Account ID
+func (id AccountId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.CognitiveServices/accounts/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.AccountName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Account ID
+func (id AccountId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftCognitiveServices", "Microsoft.CognitiveServices", "Microsoft.CognitiveServices"),
+		resourceids.StaticSegment("staticAccounts", "accounts", "accounts"),
+		resourceids.UserSpecifiedSegment("accountName", "accountValue"),
+	}
+}
+
+// String returns a human-readable description of this Account ID
+func (id AccountId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Account Name: %q", id.AccountName),
+	}
+	return fmt.Sprintf("Account (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2022-10-01/deployments/id_deployment.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2022-10-01/deployments/id_deployment.go
@@ -1,0 +1,137 @@
+package deployments
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = DeploymentId{}
+
+// DeploymentId is a struct representing the Resource ID for a Deployment
+type DeploymentId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	AccountName       string
+	DeploymentName    string
+}
+
+// NewDeploymentID returns a new DeploymentId struct
+func NewDeploymentID(subscriptionId string, resourceGroupName string, accountName string, deploymentName string) DeploymentId {
+	return DeploymentId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		AccountName:       accountName,
+		DeploymentName:    deploymentName,
+	}
+}
+
+// ParseDeploymentID parses 'input' into a DeploymentId
+func ParseDeploymentID(input string) (*DeploymentId, error) {
+	parser := resourceids.NewParserFromResourceIdType(DeploymentId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := DeploymentId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.AccountName, ok = parsed.Parsed["accountName"]; !ok {
+		return nil, fmt.Errorf("the segment 'accountName' was not found in the resource id %q", input)
+	}
+
+	if id.DeploymentName, ok = parsed.Parsed["deploymentName"]; !ok {
+		return nil, fmt.Errorf("the segment 'deploymentName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ParseDeploymentIDInsensitively parses 'input' case-insensitively into a DeploymentId
+// note: this method should only be used for API response data and not user input
+func ParseDeploymentIDInsensitively(input string) (*DeploymentId, error) {
+	parser := resourceids.NewParserFromResourceIdType(DeploymentId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := DeploymentId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.AccountName, ok = parsed.Parsed["accountName"]; !ok {
+		return nil, fmt.Errorf("the segment 'accountName' was not found in the resource id %q", input)
+	}
+
+	if id.DeploymentName, ok = parsed.Parsed["deploymentName"]; !ok {
+		return nil, fmt.Errorf("the segment 'deploymentName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ValidateDeploymentID checks that 'input' can be parsed as a Deployment ID
+func ValidateDeploymentID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseDeploymentID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Deployment ID
+func (id DeploymentId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.CognitiveServices/accounts/%s/deployments/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.AccountName, id.DeploymentName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Deployment ID
+func (id DeploymentId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftCognitiveServices", "Microsoft.CognitiveServices", "Microsoft.CognitiveServices"),
+		resourceids.StaticSegment("staticAccounts", "accounts", "accounts"),
+		resourceids.UserSpecifiedSegment("accountName", "accountValue"),
+		resourceids.StaticSegment("staticDeployments", "deployments", "deployments"),
+		resourceids.UserSpecifiedSegment("deploymentName", "deploymentValue"),
+	}
+}
+
+// String returns a human-readable description of this Deployment ID
+func (id DeploymentId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Account Name: %q", id.AccountName),
+		fmt.Sprintf("Deployment Name: %q", id.DeploymentName),
+	}
+	return fmt.Sprintf("Deployment (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2022-10-01/deployments/method_createorupdate_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2022-10-01/deployments/method_createorupdate_autorest.go
@@ -1,0 +1,79 @@
+package deployments
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CreateOrUpdateOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// CreateOrUpdate ...
+func (c DeploymentsClient) CreateOrUpdate(ctx context.Context, id DeploymentId, input Deployment) (result CreateOrUpdateOperationResponse, err error) {
+	req, err := c.preparerForCreateOrUpdate(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "deployments.DeploymentsClient", "CreateOrUpdate", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForCreateOrUpdate(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "deployments.DeploymentsClient", "CreateOrUpdate", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// CreateOrUpdateThenPoll performs CreateOrUpdate then polls until it's completed
+func (c DeploymentsClient) CreateOrUpdateThenPoll(ctx context.Context, id DeploymentId, input Deployment) error {
+	result, err := c.CreateOrUpdate(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing CreateOrUpdate: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after CreateOrUpdate: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForCreateOrUpdate prepares the CreateOrUpdate request.
+func (c DeploymentsClient) preparerForCreateOrUpdate(ctx context.Context, id DeploymentId, input Deployment) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPut(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForCreateOrUpdate sends the CreateOrUpdate request. The method will close the
+// http.Response Body if it receives an error.
+func (c DeploymentsClient) senderForCreateOrUpdate(ctx context.Context, req *http.Request) (future CreateOrUpdateOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2022-10-01/deployments/method_delete_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2022-10-01/deployments/method_delete_autorest.go
@@ -1,0 +1,78 @@
+package deployments
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DeleteOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// Delete ...
+func (c DeploymentsClient) Delete(ctx context.Context, id DeploymentId) (result DeleteOperationResponse, err error) {
+	req, err := c.preparerForDelete(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "deployments.DeploymentsClient", "Delete", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForDelete(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "deployments.DeploymentsClient", "Delete", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// DeleteThenPoll performs Delete then polls until it's completed
+func (c DeploymentsClient) DeleteThenPoll(ctx context.Context, id DeploymentId) error {
+	result, err := c.Delete(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing Delete: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after Delete: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForDelete prepares the Delete request.
+func (c DeploymentsClient) preparerForDelete(ctx context.Context, id DeploymentId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsDelete(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForDelete sends the Delete request. The method will close the
+// http.Response Body if it receives an error.
+func (c DeploymentsClient) senderForDelete(ctx context.Context, req *http.Request) (future DeleteOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2022-10-01/deployments/method_get_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2022-10-01/deployments/method_get_autorest.go
@@ -1,0 +1,68 @@
+package deployments
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *Deployment
+}
+
+// Get ...
+func (c DeploymentsClient) Get(ctx context.Context, id DeploymentId) (result GetOperationResponse, err error) {
+	req, err := c.preparerForGet(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "deployments.DeploymentsClient", "Get", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "deployments.DeploymentsClient", "Get", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForGet(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "deployments.DeploymentsClient", "Get", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForGet prepares the Get request.
+func (c DeploymentsClient) preparerForGet(ctx context.Context, id DeploymentId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForGet handles the response to the Get request. The method always
+// closes the http.Response Body.
+func (c DeploymentsClient) responderForGet(resp *http.Response) (result GetOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2022-10-01/deployments/method_list_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2022-10-01/deployments/method_list_autorest.go
@@ -1,0 +1,186 @@
+package deployments
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *[]Deployment
+
+	nextLink     *string
+	nextPageFunc func(ctx context.Context, nextLink string) (ListOperationResponse, error)
+}
+
+type ListCompleteResult struct {
+	Items []Deployment
+}
+
+func (r ListOperationResponse) HasMore() bool {
+	return r.nextLink != nil
+}
+
+func (r ListOperationResponse) LoadMore(ctx context.Context) (resp ListOperationResponse, err error) {
+	if !r.HasMore() {
+		err = fmt.Errorf("no more pages returned")
+		return
+	}
+	return r.nextPageFunc(ctx, *r.nextLink)
+}
+
+// List ...
+func (c DeploymentsClient) List(ctx context.Context, id AccountId) (resp ListOperationResponse, err error) {
+	req, err := c.preparerForList(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "deployments.DeploymentsClient", "List", nil, "Failure preparing request")
+		return
+	}
+
+	resp.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "deployments.DeploymentsClient", "List", resp.HttpResponse, "Failure sending request")
+		return
+	}
+
+	resp, err = c.responderForList(resp.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "deployments.DeploymentsClient", "List", resp.HttpResponse, "Failure responding to request")
+		return
+	}
+	return
+}
+
+// preparerForList prepares the List request.
+func (c DeploymentsClient) preparerForList(ctx context.Context, id AccountId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/deployments", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// preparerForListWithNextLink prepares the List request with the given nextLink token.
+func (c DeploymentsClient) preparerForListWithNextLink(ctx context.Context, nextLink string) (*http.Request, error) {
+	uri, err := url.Parse(nextLink)
+	if err != nil {
+		return nil, fmt.Errorf("parsing nextLink %q: %+v", nextLink, err)
+	}
+	queryParameters := map[string]interface{}{}
+	for k, v := range uri.Query() {
+		if len(v) == 0 {
+			continue
+		}
+		val := v[0]
+		val = autorest.Encode("query", val)
+		queryParameters[k] = val
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(uri.Path),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForList handles the response to the List request. The method always
+// closes the http.Response Body.
+func (c DeploymentsClient) responderForList(resp *http.Response) (result ListOperationResponse, err error) {
+	type page struct {
+		Values   []Deployment `json:"value"`
+		NextLink *string      `json:"nextLink"`
+	}
+	var respObj page
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&respObj),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	result.Model = &respObj.Values
+	result.nextLink = respObj.NextLink
+	if respObj.NextLink != nil {
+		result.nextPageFunc = func(ctx context.Context, nextLink string) (result ListOperationResponse, err error) {
+			req, err := c.preparerForListWithNextLink(ctx, nextLink)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "deployments.DeploymentsClient", "List", nil, "Failure preparing request")
+				return
+			}
+
+			result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "deployments.DeploymentsClient", "List", result.HttpResponse, "Failure sending request")
+				return
+			}
+
+			result, err = c.responderForList(result.HttpResponse)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "deployments.DeploymentsClient", "List", result.HttpResponse, "Failure responding to request")
+				return
+			}
+
+			return
+		}
+	}
+	return
+}
+
+// ListComplete retrieves all of the results into a single object
+func (c DeploymentsClient) ListComplete(ctx context.Context, id AccountId) (ListCompleteResult, error) {
+	return c.ListCompleteMatchingPredicate(ctx, id, DeploymentOperationPredicate{})
+}
+
+// ListCompleteMatchingPredicate retrieves all of the results and then applied the predicate
+func (c DeploymentsClient) ListCompleteMatchingPredicate(ctx context.Context, id AccountId, predicate DeploymentOperationPredicate) (resp ListCompleteResult, err error) {
+	items := make([]Deployment, 0)
+
+	page, err := c.List(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading the initial page: %+v", err)
+		return
+	}
+	if page.Model != nil {
+		for _, v := range *page.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	for page.HasMore() {
+		page, err = page.LoadMore(ctx)
+		if err != nil {
+			err = fmt.Errorf("loading the next page: %+v", err)
+			return
+		}
+
+		if page.Model != nil {
+			for _, v := range *page.Model {
+				if predicate.Matches(v) {
+					items = append(items, v)
+				}
+			}
+		}
+	}
+
+	out := ListCompleteResult{
+		Items: items,
+	}
+	return out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2022-10-01/deployments/model_callratelimit.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2022-10-01/deployments/model_callratelimit.go
@@ -1,0 +1,10 @@
+package deployments
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CallRateLimit struct {
+	Count         *float64          `json:"count,omitempty"`
+	RenewalPeriod *float64          `json:"renewalPeriod,omitempty"`
+	Rules         *[]ThrottlingRule `json:"rules,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2022-10-01/deployments/model_deployment.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2022-10-01/deployments/model_deployment.go
@@ -1,0 +1,17 @@
+package deployments
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/systemdata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type Deployment struct {
+	Etag       *string                `json:"etag,omitempty"`
+	Id         *string                `json:"id,omitempty"`
+	Name       *string                `json:"name,omitempty"`
+	Properties *DeploymentProperties  `json:"properties,omitempty"`
+	SystemData *systemdata.SystemData `json:"systemData,omitempty"`
+	Type       *string                `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2022-10-01/deployments/model_deploymentmodel.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2022-10-01/deployments/model_deploymentmodel.go
@@ -1,0 +1,11 @@
+package deployments
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DeploymentModel struct {
+	CallRateLimit *CallRateLimit `json:"callRateLimit,omitempty"`
+	Format        *string        `json:"format,omitempty"`
+	Name          *string        `json:"name,omitempty"`
+	Version       *string        `json:"version,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2022-10-01/deployments/model_deploymentproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2022-10-01/deployments/model_deploymentproperties.go
@@ -1,0 +1,13 @@
+package deployments
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DeploymentProperties struct {
+	CallRateLimit     *CallRateLimit               `json:"callRateLimit,omitempty"`
+	Capabilities      *map[string]string           `json:"capabilities,omitempty"`
+	Model             *DeploymentModel             `json:"model,omitempty"`
+	ProvisioningState *DeploymentProvisioningState `json:"provisioningState,omitempty"`
+	RaiPolicyName     *string                      `json:"raiPolicyName,omitempty"`
+	ScaleSettings     *DeploymentScaleSettings     `json:"scaleSettings,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2022-10-01/deployments/model_deploymentscalesettings.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2022-10-01/deployments/model_deploymentscalesettings.go
@@ -1,0 +1,10 @@
+package deployments
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DeploymentScaleSettings struct {
+	ActiveCapacity *int64               `json:"activeCapacity,omitempty"`
+	Capacity       *int64               `json:"capacity,omitempty"`
+	ScaleType      *DeploymentScaleType `json:"scaleType,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2022-10-01/deployments/model_requestmatchpattern.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2022-10-01/deployments/model_requestmatchpattern.go
@@ -1,0 +1,9 @@
+package deployments
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RequestMatchPattern struct {
+	Method *string `json:"method,omitempty"`
+	Path   *string `json:"path,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2022-10-01/deployments/model_throttlingrule.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2022-10-01/deployments/model_throttlingrule.go
@@ -1,0 +1,13 @@
+package deployments
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ThrottlingRule struct {
+	Count                    *float64               `json:"count,omitempty"`
+	DynamicThrottlingEnabled *bool                  `json:"dynamicThrottlingEnabled,omitempty"`
+	Key                      *string                `json:"key,omitempty"`
+	MatchPatterns            *[]RequestMatchPattern `json:"matchPatterns,omitempty"`
+	MinCount                 *float64               `json:"minCount,omitempty"`
+	RenewalPeriod            *float64               `json:"renewalPeriod,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2022-10-01/deployments/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2022-10-01/deployments/predicates.go
@@ -1,0 +1,29 @@
+package deployments
+
+type DeploymentOperationPredicate struct {
+	Etag *string
+	Id   *string
+	Name *string
+	Type *string
+}
+
+func (p DeploymentOperationPredicate) Matches(input Deployment) bool {
+
+	if p.Etag != nil && (input.Etag == nil && *p.Etag != *input.Etag) {
+		return false
+	}
+
+	if p.Id != nil && (input.Id == nil && *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil && *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil && *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2022-10-01/deployments/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2022-10-01/deployments/version.go
@@ -1,0 +1,12 @@
+package deployments
+
+import "fmt"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2022-10-01"
+
+func userAgent() string {
+	return fmt.Sprintf("hashicorp/go-azure-sdk/deployments/%s", defaultApiVersion)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -197,6 +197,7 @@ github.com/hashicorp/go-azure-sdk/resource-manager/automation/2021-06-22/hybridr
 github.com/hashicorp/go-azure-sdk/resource-manager/automation/2021-06-22/hybridrunbookworkergroup
 github.com/hashicorp/go-azure-sdk/resource-manager/azurestackhci/2022-09-01/clusters
 github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2022-10-01/cognitiveservicesaccounts
+github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2022-10-01/deployments
 github.com/hashicorp/go-azure-sdk/resource-manager/communication/2020-08-20/communicationservice
 github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-07-01/skus
 github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-11-01/availabilitysets

--- a/website/docs/r/cognitive_deployment.html.markdown
+++ b/website/docs/r/cognitive_deployment.html.markdown
@@ -60,17 +60,17 @@ The following arguments are supported:
 
 A `model` block supports the following:
 
-* `format` - (Required) The format of the Cognitive Services Account Deployment model. Possible value is `OpenAI`.
+* `format` - (Required) The format of the Cognitive Services Account Deployment model. Changing this forces a new resource to be created. Possible value is `OpenAI`.
 
 * `name` - (Required) The name of the Cognitive Services Account Deployment model. Changing this forces a new resource to be created.
 
-* `version` - (Required) The version of Cognitive Services Account Deployment model. Possible value is `1`.
+* `version` - (Required) The version of Cognitive Services Account Deployment model.
 
 ---
 
 A `scale_settings` block supports the following:
 
-* `scale_type` - (Required) Deployment scale type. Possible value is `Standard`.
+* `scale_type` - (Required) Deployment scale type. Possible value is `Standard`. Changing this forces a new resource to be created.
 
 ## Attributes Reference
 

--- a/website/docs/r/cognitive_deployment.html.markdown
+++ b/website/docs/r/cognitive_deployment.html.markdown
@@ -1,0 +1,96 @@
+---
+subcategory: "Cognitive Services"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_cognitive_deployment"
+description: |-
+  Manages a Cognitive Services Account Deployment.
+---
+
+# azurerm_cognitive_deployment
+
+Manages a Cognitive Services Account Deployment.
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_cognitive_account" "example" {
+  name                = "example-ca"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  kind                = "OpenAI"
+  sku_name            = "S0"
+}
+
+resource "azurerm_cognitive_deployment" "example" {
+  name                 = "example-cd"
+  cognitive_account_id = azurerm_cognitive_account.example.id
+  model {
+    format  = "OpenAI"
+    name    = "text-curie-001"
+    version = "1"
+  }
+
+  scale_settings {
+    scale_type = "Standard"
+  }
+}
+
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the Cognitive Services Account Deployment. Changing this forces a new resource to be created.
+
+* `cognitive_account_id` - (Required) The ID of the Cognitive Services Account. Changing this forces a new resource to be created.
+
+* `model` - (Required) A `model` block as defined below.
+
+* `scale_settings` - (Required) A `scale_settings` block as defined below.
+
+* `rai_policy_name` - (Optional) The name of RAI policy. Changing this forces a new resource to be created.
+
+---
+
+A `model` block supports the following:
+
+* `format` - (Required) The format of the Cognitive Services Account Deployment model. Possible value is `OpenAI`.
+
+* `name` - (Required) The name of the Cognitive Services Account Deployment model. Changing this forces a new resource to be created.
+
+* `version` - (Required) The version of Cognitive Services Account Deployment model. Possible value is `1`.
+
+---
+
+A `scale_settings` block supports the following:
+
+* `scale_type` - (Required) Deployment scale type. Possible value is `Standard`.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `id` - The ID of the Deployment for Azure Cognitive Services Account.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Cognitive Services Account Deployment.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Cognitive Services Account Deployment.
+* `update` - (Defaults to 30 minutes) Used when updating the Cognitive Services Account Deployment.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Cognitive Services Account Deployment.
+
+## Import
+
+Cognitive Services Account Deployment can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_cognitive_deployment.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup1/providers/Microsoft.CognitiveServices/accounts/account1/deployments/deployment1
+```

--- a/website/docs/r/cognitive_deployment.html.markdown
+++ b/website/docs/r/cognitive_deployment.html.markdown
@@ -35,8 +35,8 @@ resource "azurerm_cognitive_deployment" "example" {
     version = "1"
   }
 
-  scale_settings {
-    scale_type = "Standard"
+  scale {
+    type = "Standard"
   }
 }
 
@@ -52,7 +52,7 @@ The following arguments are supported:
 
 * `model` - (Required) A `model` block as defined below.
 
-* `scale_settings` - (Required) A `scale_settings` block as defined below.
+* `scale` - (Required) A `scale` block as defined below.
 
 * `rai_policy_name` - (Optional) The name of RAI policy. Changing this forces a new resource to be created.
 
@@ -68,9 +68,9 @@ A `model` block supports the following:
 
 ---
 
-A `scale_settings` block supports the following:
+A `scale` block supports the following:
 
-* `scale_type` - (Required) Deployment scale type. Possible value is `Standard`. Changing this forces a new resource to be created.
+* `type` - (Required) Deployment scale type. Possible value is `Standard`. Changing this forces a new resource to be created.
 
 ## Attributes Reference
 


### PR DESCRIPTION
I would like to explain that for property`scale_settings` , it should contain two properties [capacity](https://github.com/Azure/azure-rest-api-specs/blob/83cde4fa7d6c820f574b9aec973fd9597385e312/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/stable/2022-10-01/cognitiveservices.json#L2790) and [scaleType](https://github.com/Azure/azure-rest-api-specs/blob/83cde4fa7d6c820f574b9aec973fd9597385e312/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/stable/2022-10-01/cognitiveservices.json#L2778). After confirming with the service team, the `capacity` is not support at this time (GA date 2022-12-15). For convenience of future expansion, I reserved the `scale_settings` property, although it only has one property  `scaleType`.




Overview doc link : https://learn.microsoft.com/en-us/azure/cognitive-services/openai/overview