### PR TITLE
`azurerm_key_vault_certificate`, `azurerm_key_vault_key`, `azurerm_key_vault_managed_hardware_security_module`, `azurerm_key_vault_secret` - skip purging if `purge_protection` enabled

### DIFF
--- a/internal/services/keyvault/key_vault_certificate_resource.go
+++ b/internal/services/keyvault/key_vault_certificate_resource.go
@@ -509,8 +509,15 @@ func resourceKeyVaultCertificateCreate(d *pluginsdk.ResourceData, meta interface
 	if err != nil {
 		return err
 	}
+	if resp.ID == nil {
+		return fmt.Errorf("error: Certificate %q in Vault %q get nil ID from server", name, *keyVaultBaseUrl)
+	}
 
-	d.SetId(*resp.ID)
+	certificateId, err := parse.ParseNestedItemID(*resp.ID)
+	if err != nil {
+		return err
+	}
+	d.SetId(certificateId.ID())
 
 	return resourceKeyVaultCertificateRead(d, meta)
 }
@@ -564,7 +571,7 @@ func resourceKeyVaultCertificateUpdate(d *schema.ResourceData, meta interface{})
 				return err
 			}
 			if resp.ID != nil {
-				d.SetId(*resp.ID)
+				d.SetId(id.ID())
 			}
 		}
 	}

--- a/internal/services/keyvault/key_vault_certificate_resource.go
+++ b/internal/services/keyvault/key_vault_certificate_resource.go
@@ -510,7 +510,7 @@ func resourceKeyVaultCertificateCreate(d *pluginsdk.ResourceData, meta interface
 		return err
 	}
 	if resp.ID == nil {
-		return fmt.Errorf("error: Certificate %q in Vault %q get nil ID from server", name, *keyVaultBaseUrl)
+		return fmt.Errorf("cannot read KeyVault Certificate '%s' (in key vault '%s')", name, *keyVaultBaseUrl)
 	}
 
 	certificateId, err := parse.ParseNestedItemID(*resp.ID)

--- a/internal/services/keyvault/key_vault_certificate_resource.go
+++ b/internal/services/keyvault/key_vault_certificate_resource.go
@@ -740,7 +740,7 @@ func resourceKeyVaultCertificateDelete(d *pluginsdk.ResourceData, meta interface
 	shouldPurge := meta.(*clients.Client).Features.KeyVault.PurgeSoftDeletedCertsOnDestroy
 	if shouldPurge && kv.Properties != nil && utils.NormaliseNilableBool(kv.Properties.EnablePurgeProtection) {
 		log.Printf("[DEBUG] cannot purge certificate %q because vault %q has purge protection enabled", id.Name, keyVaultId.String())
-		return nil
+		shouldPurge = false
 	}
 
 	description := fmt.Sprintf("Certificate %q (Key Vault %q)", id.Name, id.KeyVaultBaseUrl)

--- a/internal/services/keyvault/key_vault_key_resource.go
+++ b/internal/services/keyvault/key_vault_key_resource.go
@@ -543,7 +543,8 @@ func resourceKeyVaultKeyDelete(d *pluginsdk.ResourceData, meta interface{}) erro
 
 	shouldPurge := meta.(*clients.Client).Features.KeyVault.PurgeSoftDeletedKeysOnDestroy
 	if shouldPurge && kv.Properties != nil && utils.NormaliseNilableBool(kv.Properties.EnablePurgeProtection) {
-		return fmt.Errorf("cannot purge key %q because vault %q has purge protection enabled", id.Name, keyVaultId.String())
+		log.Printf("[DEBUG] cannot purge key %q because vault %q has purge protection enabled", id.Name, keyVaultId.String())
+		return nil
 	}
 
 	description := fmt.Sprintf("Key %q (Key Vault %q)", id.Name, id.KeyVaultBaseUrl)

--- a/internal/services/keyvault/key_vault_key_resource.go
+++ b/internal/services/keyvault/key_vault_key_resource.go
@@ -297,7 +297,14 @@ func resourceKeyVaultKeyCreate(d *pluginsdk.ResourceData, meta interface{}) erro
 		return err
 	}
 
-	d.SetId(*read.Key.Kid)
+	if read.Key == nil || read.Key.Kid == nil {
+		return fmt.Errorf("cannot read KeyVault Key '%s' (in key vault '%s')", name, *keyVaultBaseUri)
+	}
+	keyId, err := parse.ParseNestedItemID(*read.Key.Kid)
+	if err != nil {
+		return err
+	}
+	d.SetId(keyId.ID())
 
 	return resourceKeyVaultKeyRead(d, meta)
 }

--- a/internal/services/keyvault/key_vault_key_resource.go
+++ b/internal/services/keyvault/key_vault_key_resource.go
@@ -544,7 +544,7 @@ func resourceKeyVaultKeyDelete(d *pluginsdk.ResourceData, meta interface{}) erro
 	shouldPurge := meta.(*clients.Client).Features.KeyVault.PurgeSoftDeletedKeysOnDestroy
 	if shouldPurge && kv.Properties != nil && utils.NormaliseNilableBool(kv.Properties.EnablePurgeProtection) {
 		log.Printf("[DEBUG] cannot purge key %q because vault %q has purge protection enabled", id.Name, keyVaultId.String())
-		return nil
+		shouldPurge = false
 	}
 
 	description := fmt.Sprintf("Key %q (Key Vault %q)", id.Name, id.KeyVaultBaseUrl)

--- a/internal/services/keyvault/key_vault_managed_hardware_security_module_resource.go
+++ b/internal/services/keyvault/key_vault_managed_hardware_security_module_resource.go
@@ -235,7 +235,7 @@ func resourceArmKeyVaultManagedHardwareSecurityModuleDelete(d *pluginsdk.Resourc
 
 	shouldPurge := meta.(*clients.Client).Features.KeyVault.PurgeSoftDeletedHSMsOnDestroy
 	if shouldPurge && resp.Properties != nil && utils.NormaliseNilableBool(resp.Properties.EnablePurgeProtection) {
-		log.Printf("cannot purge %s because purge protection is enabled", id)
+		log.Printf("[DEBUG] cannot purge %s because purge protection is enabled", id)
 		return nil
 	}
 

--- a/internal/services/keyvault/key_vault_managed_hardware_security_module_resource.go
+++ b/internal/services/keyvault/key_vault_managed_hardware_security_module_resource.go
@@ -235,7 +235,8 @@ func resourceArmKeyVaultManagedHardwareSecurityModuleDelete(d *pluginsdk.Resourc
 
 	shouldPurge := meta.(*clients.Client).Features.KeyVault.PurgeSoftDeletedHSMsOnDestroy
 	if shouldPurge && resp.Properties != nil && utils.NormaliseNilableBool(resp.Properties.EnablePurgeProtection) {
-		return fmt.Errorf("cannot purge %s because purge protection is enabled", id)
+		log.Printf("cannot purge %s because purge protection is enabled", id)
+		return nil
 	}
 
 	purgeFuture, err := client.PurgeDeleted(ctx, id.Name, *resp.Location)

--- a/internal/services/keyvault/key_vault_managed_hardware_security_module_resource.go
+++ b/internal/services/keyvault/key_vault_managed_hardware_security_module_resource.go
@@ -236,7 +236,7 @@ func resourceArmKeyVaultManagedHardwareSecurityModuleDelete(d *pluginsdk.Resourc
 	shouldPurge := meta.(*clients.Client).Features.KeyVault.PurgeSoftDeletedHSMsOnDestroy
 	if shouldPurge && resp.Properties != nil && utils.NormaliseNilableBool(resp.Properties.EnablePurgeProtection) {
 		log.Printf("[DEBUG] cannot purge %s because purge protection is enabled", id)
-		shouldPurge = false
+		return nil
 	}
 
 	purgeFuture, err := client.PurgeDeleted(ctx, id.Name, *resp.Location)

--- a/internal/services/keyvault/key_vault_managed_hardware_security_module_resource.go
+++ b/internal/services/keyvault/key_vault_managed_hardware_security_module_resource.go
@@ -236,7 +236,7 @@ func resourceArmKeyVaultManagedHardwareSecurityModuleDelete(d *pluginsdk.Resourc
 	shouldPurge := meta.(*clients.Client).Features.KeyVault.PurgeSoftDeletedHSMsOnDestroy
 	if shouldPurge && resp.Properties != nil && utils.NormaliseNilableBool(resp.Properties.EnablePurgeProtection) {
 		log.Printf("[DEBUG] cannot purge %s because purge protection is enabled", id)
-		return nil
+		shouldPurge = false
 	}
 
 	purgeFuture, err := client.PurgeDeleted(ctx, id.Name, *resp.Location)

--- a/internal/services/keyvault/key_vault_secret_resource.go
+++ b/internal/services/keyvault/key_vault_secret_resource.go
@@ -412,7 +412,8 @@ func resourceKeyVaultSecretDelete(d *pluginsdk.ResourceData, meta interface{}) e
 	shouldPurge := meta.(*clients.Client).Features.KeyVault.PurgeSoftDeletedSecretsOnDestroy
 	if shouldPurge && kv.Properties != nil && utils.NormaliseNilableBool(kv.Properties.EnablePurgeProtection) {
 		log.Printf("[DEBUG] cannot purge secret %q because vault %q has purge protection enabled", id.Name, keyVaultId.String())
-		return nil
+		shouldPurge = false
+
 	}
 
 	description := fmt.Sprintf("Secret %q (Key Vault %q)", id.Name, id.KeyVaultBaseUrl)

--- a/internal/services/keyvault/key_vault_secret_resource.go
+++ b/internal/services/keyvault/key_vault_secret_resource.go
@@ -199,10 +199,15 @@ func resourceKeyVaultSecretCreate(d *pluginsdk.ResourceData, meta interface{}) e
 	}
 
 	if read.ID == nil {
-		return fmt.Errorf("Cannot read KeyVault Secret '%s' (in key vault '%s')", name, *keyVaultBaseUrl)
+		return fmt.Errorf("cannot read KeyVault Secret '%s' (in key vault '%s')", name, *keyVaultBaseUrl)
 	}
 
-	d.SetId(*read.ID)
+	secretId, err := parse.ParseNestedItemID(*read.ID)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(secretId.ID())
 
 	return resourceKeyVaultSecretRead(d, meta)
 }
@@ -290,12 +295,13 @@ func resourceKeyVaultSecretUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 		return fmt.Errorf("getting Key Vault Secret %q : %+v", id.Name, err)
 	}
 
-	if _, err = parse.ParseNestedItemID(*read.ID); err != nil {
+	secretId, err := parse.ParseNestedItemID(*read.ID)
+	if err != nil {
 		return err
 	}
 
 	// the ID is suffixed with the secret version
-	d.SetId(*read.ID)
+	d.SetId(secretId.ID())
 
 	return resourceKeyVaultSecretRead(d, meta)
 }

--- a/internal/services/keyvault/key_vault_secret_resource.go
+++ b/internal/services/keyvault/key_vault_secret_resource.go
@@ -399,17 +399,22 @@ func resourceKeyVaultSecretDelete(d *pluginsdk.ResourceData, meta interface{}) e
 		return err
 	}
 
-	ok, err := keyVaultsClient.Exists(ctx, *keyVaultId)
+	kv, err := keyVaultsClient.VaultsClient.Get(ctx, keyVaultId.ResourceGroup, keyVaultId.Name)
 	if err != nil {
+		if utils.ResponseWasNotFound(kv.Response) {
+			log.Printf("[DEBUG] Secret %q Key Vault %q was not found in Key Vault at URI %q - removing from state", id.Name, *keyVaultId, id.KeyVaultBaseUrl)
+			d.SetId("")
+			return nil
+		}
 		return fmt.Errorf("checking if key vault %q for Secret %q in Vault at url %q exists: %v", *keyVaultId, id.Name, id.KeyVaultBaseUrl, err)
-	}
-	if !ok {
-		log.Printf("[DEBUG] Secret %q Key Vault %q was not found in Key Vault at URI %q - removing from state", id.Name, *keyVaultId, id.KeyVaultBaseUrl)
-		d.SetId("")
-		return nil
 	}
 
 	shouldPurge := meta.(*clients.Client).Features.KeyVault.PurgeSoftDeletedSecretsOnDestroy
+	if shouldPurge && kv.Properties != nil && utils.NormaliseNilableBool(kv.Properties.EnablePurgeProtection) {
+		log.Printf("[DEBUG] cannot purge secret %q because vault %q has purge protection enabled", id.Name, keyVaultId.String())
+		return nil
+	}
+
 	description := fmt.Sprintf("Secret %q (Key Vault %q)", id.Name, id.KeyVaultBaseUrl)
 	deleter := deleteAndPurgeSecret{
 		client:      client,

--- a/website/docs/r/key_vault.html.markdown
+++ b/website/docs/r/key_vault.html.markdown
@@ -22,7 +22,8 @@ Manages a Key Vault.
 provider "azurerm" {
   features {
     key_vault {
-      purge_soft_delete_on_destroy = true
+      purge_soft_delete_on_destroy    = true
+      recover_soft_deleted_key_vaults = true
     }
   }
 }

--- a/website/docs/r/key_vault_certificate.html.markdown
+++ b/website/docs/r/key_vault_certificate.html.markdown
@@ -11,13 +11,22 @@ description: |-
 
 Manages a Key Vault Certificate.
 
+~> **Note:** the Azure Provider includes a Feature Toggle which will purge a Key Vault Certificate resource on destroy, rather than the default soft-delete. See [`purge_soft_deleted_certificates_on_destroy`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/features-block#purge_soft_deleted_certificates_on_destroy) for more information. 
+
 ## Example Usage (Importing a PFX)
 
 ~> **Note:** this example assumed the PFX file is located in the same directory at `certificate-to-import.pfx`.
 
-~> **Note:** the Azure Provider includes a Feature Toggle which will purge a Key Vault Certificate resource on destroy, rather than the default soft-delete. See [`purge_soft_deleted_certificates_on_destroy`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/features-block#purge_soft_deleted_certificates_on_destroy) for more information.
-
 ```hcl
+provider "azurerm" {
+  features {
+    key_vault {
+      purge_soft_deleted_certificates_on_destroy = true
+      recover_soft_deleted_certificates          = true
+    }
+  }
+}
+
 data "azurerm_client_config" "current" {}
 
 resource "azurerm_resource_group" "example" {

--- a/website/docs/r/key_vault_key.html.markdown
+++ b/website/docs/r/key_vault_key.html.markdown
@@ -11,11 +11,20 @@ description: |-
 
 Manages a Key Vault Key.
 
-## Example Usage
-
 ~> **Note:** the Azure Provider includes a Feature Toggle which will purge a Key Vault Key resource on destroy, rather than the default soft-delete. See [`purge_soft_deleted_keys_on_destroy`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/features-block#purge_soft_deleted_keys_on_destroy) for more information.
 
+## Example Usage
+
 ```hcl
+provider "azurerm" {
+  features {
+    key_vault {
+      purge_soft_deleted_keys_on_destroy = true
+      recover_soft_deleted_keys          = true
+    }
+  }
+}
+
 data "azurerm_client_config" "current" {}
 
 resource "azurerm_resource_group" "example" {

--- a/website/docs/r/key_vault_managed_hardware_security_module.html.markdown
+++ b/website/docs/r/key_vault_managed_hardware_security_module.html.markdown
@@ -10,11 +10,18 @@ description: |-
 
 Manages a Key Vault Managed Hardware Security Module.
 
-## Example Usage
-
 ~> **Note:** the Azure Provider includes a Feature Toggle which will purge a Key Vault Managed Hardware Security Module resource on destroy, rather than the default soft-delete. See [`purge_soft_deleted_hardware_security_modules_on_destroy`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/features-block#purge_soft_deleted_hardware_security_modules_on_destroy) for more information.
 
+## Example Usage
+
 ```hcl
+provider "azurerm" {
+  features {
+    key_vault {
+      purge_soft_deleted_hardware_security_modules_on_destroy = true
+    }
+  }
+}
 data "azurerm_client_config" "current" {
 }
 

--- a/website/docs/r/key_vault_secret.html.markdown
+++ b/website/docs/r/key_vault_secret.html.markdown
@@ -19,6 +19,15 @@ Manages a Key Vault Secret.
 ## Example Usage
 
 ```hcl
+provider "azurerm" {
+  features {
+    key_vault {
+      purge_soft_deleted_secrets_on_destroy = true
+      recover_soft_deleted_secrets          = true
+    }
+  }
+}
+
 data "azurerm_client_config" "current" {}
 
 resource "azurerm_resource_group" "example" {


### PR DESCRIPTION
resolves #19502 

__Current__: If `purge_protection` is enabled and the provider will try to purge the soft-deleted key vault resource at default, which will return an error.

__This PR__: If Key Vault has `purge_protection` enabled, skip purging the soft-deleted resource, so that users don't need to explicitly set `purge_soft_deleted` to `false` in features block. This is also to align with [logics](https://github.com/hashicorp/terraform-provider-azurerm/blob/e52408cf7cfecd7c219f70dfcb9c5ff9eaa45a08/internal/services/keyvault/key_vault_resource.go#L796-L801) in  `azurerm_key_vault` resource.