### PR TITLE
`azurerm_key_vault` - fix two kv in different sub issue

### DIFF
--- a/internal/services/keyvault/client/helpers.go
+++ b/internal/services/keyvault/client/helpers.go
@@ -45,11 +45,12 @@ func (c *Client) BaseUriForKeyVault(ctx context.Context, keyVaultId parse.VaultI
 	lock[cacheKey].Lock()
 	defer lock[cacheKey].Unlock()
 
+	vaultsClient := c.VaultsClient
 	if keyVaultId.SubscriptionId != c.VaultsClient.SubscriptionID {
-		c.VaultsClient = c.KeyVaultClientForSubscription(keyVaultId.SubscriptionId)
+		vaultsClient = c.KeyVaultClientForSubscription(keyVaultId.SubscriptionId)
 	}
 
-	resp, err := c.VaultsClient.Get(ctx, keyVaultId.ResourceGroup, keyVaultId.Name)
+	resp, err := vaultsClient.Get(ctx, keyVaultId.ResourceGroup, keyVaultId.Name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
 			return nil, fmt.Errorf("%s was not found", keyVaultId)


### PR DESCRIPTION
resolves #19509
## background
Assume we have
- kv1 in subscription1
- kv2 in subscription2
- a resource or data source (e.g. `azurerm_key_vault_secret` or `azurerm_storage_account`) in subscription1 depends on the kv2

the config is like:
```hcl
provider "azurerm" {
  features {}
  alias           = "sub1"
  subscription_id = "11111111-1111-1111-1111-111111111111"
}
data "azurerm_client_config" "current" {}

resource "azurerm_resource_group" "test" {
  provider = azurerm.sub1
  name     = "wt-test-resources"
  location = "West Europe"
}

resource "azurerm_key_vault" "kv1" {
  provider                    = azurerm.sub1
  name                        = "wtttmplekeyvault1"
  location                    = azurerm_resource_group.test.location
  resource_group_name         = azurerm_resource_group.test.name
  enabled_for_disk_encryption = true
  tenant_id                   = data.azurerm_client_config.current.tenant_id
  soft_delete_retention_days  = 7
  purge_protection_enabled    = false

  sku_name   = "standard"
  # intentionally let the datasource refresh before this kv, and this kv will be removed from state.
  depends_on = [data.azurerm_key_vault_secret.test]
}

data "azurerm_key_vault_secret" "test" {
  provider     = azurerm.sub1
  key_vault_id = azurerm_key_vault.kv2.id
  name         = azurerm_key_vault_secret.test.name
}

####

provider "azurerm" {
  features {}
  alias           = "sub2"
  subscription_id = "22222222-2222-2222-2222-222222222222"
}

resource "azurerm_resource_group" "test2" {
  provider = azurerm.sub2
  name     = "wt-test-resources2"
  location = "West Europe"
}

resource "azurerm_key_vault" "kv2" {
  provider                   = azurerm.sub2
  name                       = "wtttmplekeyvault2"
  location                   = azurerm_resource_group.test2.location
  resource_group_name        = azurerm_resource_group.test2.name
  tenant_id                  = data.azurerm_client_config.current.tenant_id
  sku_name                   = "standard"
  soft_delete_retention_days = 7

  access_policy {
    tenant_id = data.azurerm_client_config.current.tenant_id
    object_id = data.azurerm_client_config.current.object_id
    secret_permissions = [
      "Set",
      "Get",
      "Delete",
      "Purge",
      "Recover",
      "List"
    ]
  }
}

resource "azurerm_key_vault_secret" "test" {
  provider     = azurerm.sub2
  name         = "test"
  value        = "szechuan"
  key_vault_id = azurerm_key_vault.kv2.id
}
```
Replace two real subscription ids the above config, and run `terraform apply -auto-approve` twice.

During the refresh step before the second apply, `data.azurerm_key_vault_secret.test` calls the `BaseUriForKeyVault` function, which will modify the subscription_id of KeyVaultsClient within the provider scope. After that the KeyVaultsClient cannot reach  `azurerm_key_vault.kv1`, and the `azurerm_key_vault.kv1` will be removed from state. 

But later apply will try to recreate the kv1 in another thread in sub1, returns the resource already exists error.