### PR TITLE
doc enhancement for `azurerm_site_recovery_replication_policy`

### DIFF
--- a/internal/services/recoveryservices/site_recovery_replication_policy_resource.go
+++ b/internal/services/recoveryservices/site_recovery_replication_policy_resource.go
@@ -92,6 +92,10 @@ func resourceSiteRecoveryReplicationPolicyCreate(d *pluginsdk.ResourceData, meta
 
 	recoveryPoint := int32(d.Get("recovery_point_retention_in_minutes").(int))
 	appConsitency := int32(d.Get("application_consistent_snapshot_frequency_in_minutes").(int))
+	if appConsitency > recoveryPoint {
+		return fmt.Errorf("the value of `application_consistent_snapshot_frequency_in_minutes` must be less than or equal to the value of `recovery_point_retention_in_minutes`")
+	}
+
 	parameters := siterecovery.CreatePolicyInput{
 		Properties: &siterecovery.CreatePolicyInputProperties{
 			ProviderSpecificInput: &siterecovery.A2APolicyCreationInput{
@@ -131,6 +135,10 @@ func resourceSiteRecoveryReplicationPolicyUpdate(d *pluginsdk.ResourceData, meta
 
 	recoveryPoint := int32(d.Get("recovery_point_retention_in_minutes").(int))
 	appConsitency := int32(d.Get("application_consistent_snapshot_frequency_in_minutes").(int))
+	if appConsitency > recoveryPoint {
+		return fmt.Errorf("the value of `application_consistent_snapshot_frequency_in_minutes` must be less than or equal to the value of `recovery_point_retention_in_minutes`")
+	}
+
 	parameters := siterecovery.UpdatePolicyInput{
 		Properties: &siterecovery.UpdatePolicyInputProperties{
 			ReplicationProviderSettings: &siterecovery.A2APolicyCreationInput{

--- a/website/docs/r/site_recovery_replication_policy.html.markdown
+++ b/website/docs/r/site_recovery_replication_policy.html.markdown
@@ -48,6 +48,8 @@ The following arguments are supported:
 
 * `application_consistent_snapshot_frequency_in_minutes` - (Required) Specifies the frequency(in minutes) at which to create application consistent recovery points.
 
+-> **Note:** The value of `application_consistent_snapshot_frequency_in_minutes` must be less than or equal to the value of `recovery_point_retention_in_minutes`.
+
 ## Attributes Reference
 
 In addition to the arguments above, the following attributes are exported:


### PR DESCRIPTION
fixes #19505

add a note and runtime check for these properties.

Test
---
```
TF_ACC=1 go test -v ./internal/services/recoveryservices -run=TestAccSiteRecoveryReplicationPolicy -timeout=600m                                  
=== RUN   TestAccSiteRecoveryReplicationPolicy_basic
=== PAUSE TestAccSiteRecoveryReplicationPolicy_basic
=== RUN   TestAccSiteRecoveryReplicationPolicy_noSnapshots
=== PAUSE TestAccSiteRecoveryReplicationPolicy_noSnapshots
=== RUN   TestAccSiteRecoveryReplicationPolicy_wrongSettings
=== PAUSE TestAccSiteRecoveryReplicationPolicy_wrongSettings
=== CONT  TestAccSiteRecoveryReplicationPolicy_basic
=== CONT  TestAccSiteRecoveryReplicationPolicy_wrongSettings
=== CONT  TestAccSiteRecoveryReplicationPolicy_noSnapshots
--- PASS: TestAccSiteRecoveryReplicationPolicy_wrongSettings (32.85s)
--- PASS: TestAccSiteRecoveryReplicationPolicy_basic (550.01s)
--- PASS: TestAccSiteRecoveryReplicationPolicy_noSnapshots (566.43s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/recoveryservices      567.601s
```