### PR TITLE
Typo in sftp_enabled of `azurerm_storage_account` documentation

### DIFF
--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -166,7 +166,7 @@ The following arguments are supported:
 
 * `sas_policy` - (Optional) A `sas_policy` block as defined below.
 
-* `stfp_enabled` - (Optional) Boolean, enable SFTP for the storage account
+* `sftp_enabled` - (Optional) Boolean, enable SFTP for the storage account
 
 -> **NOTE:** SFTP support requires `is_hns_enabled` set to `true`. [More information on SFTP support can be found here](https://learn.microsoft.com/azure/storage/blobs/secure-file-transfer-protocol-support). Defaults to `false`
 


### PR DESCRIPTION
Really small thing, but the F and T in `sftp_enabled` are swapped around