### PR TITLE
Correct field name from `auth_config` to `authentication` on documentation example for `azurerm_postgresql_flexible_server_active_directory_administrator`

### DIFF
--- a/website/docs/r/postgresql_flexible_server_active_directory_administrator.html.markdown
+++ b/website/docs/r/postgresql_flexible_server_active_directory_administrator.html.markdown
@@ -30,7 +30,7 @@ resource "azurerm_postgresql_flexible_server" "example" {
   sku_name                     = "GP_Standard_D2s_v3"
   zone                         = "2"
 
-  auth_config {
+  authentication {
     active_directory_auth_enabled = true
     tenant_id                     = data.azurerm_client_config.current.tenant_id
   }


### PR DESCRIPTION
During the pull request when AAD auth was implemented (#19269) the field changed name from `auth_config` to `authentication` but it seems one instance got left behind in the documentation, leading to a little confusion when trying to use the resource.
