### PR TITLE
Fix wrong Azure FrontDoor SP name to `Microsoft.Azure.Cdn`

### DIFF
--- a/examples/cdn/frontdoor/frontdoor-cmk-byoc-custom-domain/README.md
+++ b/examples/cdn/frontdoor/frontdoor-cmk-byoc-custom-domain/README.md
@@ -30,11 +30,11 @@ For this example you will need to look up the object IDs of the Frontdoor servic
 
 * From the left hand menu select `Azure Active Directory`.
 
-* In the search filter box, near the top of the page, type `Microsoft.AzureFrontDoor-Cdn`.
+* In the search filter box, near the top of the page, type `Microsoft.Azure.Cdn`.
 
-* Click on the `Microsoft.AzureFrontDoor-Cdn` entry in the `Enterprise Applications` results view.
+* Click on the `Microsoft.Azure.Cdn` entry in the `Enterprise Applications` results view.
 
-* This will open the `Enterprise Applications Properties`, copy the `Object ID` and paste it into the examples `main.tf` file where is says `<- Object Id for the Microsoft.AzureFrontDoor-Cdn Enterprise Application.`.
+* This will open the `Enterprise Applications Properties`, copy the `Object ID` and paste it into the examples `main.tf` file where is says `<- Object Id for the Microsoft.Azure.Cdn Enterprise Application.`.
 
 Repeat the above steps for all of the object IDs needed for this example.
 
@@ -44,7 +44,7 @@ The following Key Vault permission are granted by this example:
 
 | Object ID                                | Key Permissions | Secret Permissions   | Certificate Permissions                       |
 |:-----------------------------------------|:---------------:|:--------------------:|:---------------------------------------------:|
-| `Microsoft.AzureFrontDoor-Cdn` Object ID | -               | **Get**              | -                                             |
+| `Microsoft.Azure.Cdn` Object ID | -               | **Get**              | -                                             |
 | Your Personal AAD Object ID              | -               | **Get** and **List** | **Get**, **List**, **Purge** and **Recover**  |
 | Terraform Service Principal              | -               | **Get**              | **Get**, **Import**, **Delete** and **Purge** |
 

--- a/examples/cdn/frontdoor/frontdoor-cmk-byoc-custom-domain/main.tf
+++ b/examples/cdn/frontdoor/frontdoor-cmk-byoc-custom-domain/main.tf
@@ -23,10 +23,10 @@ resource "azurerm_key_vault" "example" {
     ip_rules       = ["10.0.1.0/24"] # <- this should be the CIDR for your clients IP to allow it through the Key Vault Firewall Policy
   }
 
-  # Grant access to the Frontdoor Enterprise Application(e.g. Microsoft.AzureFrontDoor-Cdn) to the Key Vaults Certificates
+  # Grant access to the Frontdoor Enterprise Application(e.g. Microsoft.Azure.Cdn) to the Key Vaults Certificates
   access_policy {
     tenant_id = data.azurerm_client_config.current.tenant_id
-    object_id = "00000000-0000-0000-0000-000000000000" # <- Object Id for the Microsoft.AzureFrontDoor-Cdn Enterprise Application.
+    object_id = "00000000-0000-0000-0000-000000000000" # <- Object Id for the Microsoft.Azure.Cdn Enterprise Application.
 
     secret_permissions = [
       "Get",

--- a/internal/services/cdn/cdn_endpoint_custom_domain_resource_test.go
+++ b/internal/services/cdn/cdn_endpoint_custom_domain_resource_test.go
@@ -292,7 +292,7 @@ data "azurerm_client_config" "test" {
 }
 
 data "azuread_service_principal" "test" {
-  display_name = "Microsoft.AzureFrontDoor-Cdn"
+  display_name = "Microsoft.Azure.Cdn"
 }
 
 resource "azurerm_key_vault" "test" {

--- a/website/docs/r/cdn_frontdoor_secret.html.markdown
+++ b/website/docs/r/cdn_frontdoor_secret.html.markdown
@@ -12,11 +12,11 @@ Manages a Front Door (standard/premium) Secret.
 
 ## Required Key Vault Permissions
 
-!>**IMPORTANT:** You must add an `Access Policy` to your `azurerm_key_vault` for the `Microsoft.AzureFrontDoor-Cdn` Enterprise Application Object ID.
+!>**IMPORTANT:** You must add an `Access Policy` to your `azurerm_key_vault` for the `Microsoft.Azure.Cdn` Enterprise Application Object ID.
 
 | Object ID                                | Key Permissions | Secret Permissions   | Certificate Permissions                       |
 |:-----------------------------------------|:---------------:|:--------------------:|:---------------------------------------------:|
-| `Microsoft.AzureFrontDoor-Cdn` Object ID | -               | **Get**              | -                                             |
+| `Microsoft.Azure.Cdn` Object ID          | -               | **Get**              | -                                             |
 | Your Personal AAD Object ID              | -               | **Get** and **List** | **Get**, **List**, **Purge** and **Recover**  |
 | Terraform Service Principal              | -               | **Get**              | **Get**, **Import**, **Delete** and **Purge** |
 
@@ -27,7 +27,7 @@ Manages a Front Door (standard/premium) Secret.
 ```hcl
 data "azurerm_client_config" "current" {}
 data "azuread_service_principal" "frontdoor" {
-  display_name = "Microsoft.AzureFrontDoor-Cdn"
+  display_name = "Microsoft.Azure.Cdn"
 }
 
 resource "azurerm_key_vault" "example" {
@@ -44,7 +44,7 @@ resource "azurerm_key_vault" "example" {
     ip_rules       = ["10.0.0.0/24"]
   }
 
-  # CDN Front Door Enterprise Application Object ID(e.g. Microsoft.AzureFrontDoor-Cdn)
+  # CDN Front Door Enterprise Application Object ID(e.g. Microsoft.Azure.Cdn)
   access_policy {
     tenant_id = data.azurerm_client_config.current.tenant_id
     object_id = data.azuread_service_principal.frontdoor.object_id


### PR DESCRIPTION
Fix wrong SP name from `Microsoft.AzureFrontDoor-Cdn` to `Microsoft.Azure.Cdn` as the old name cannot be found on the Azure AD. PR for changing the original docs is already provided here https://github.com/MicrosoftDocs/azure-docs/pull/102276.

Not sure how the test was running.

<sub>Daniel Schniepp [daniel.schniepp@mercedes-benz.com](mailto:daniel.schniepp@mercedes-benz.com), Mercedes-Benz Mobility AG on behalf of Mercedes-Benz Tech Innovation GmbH.</sub>