### PR TITLE
azurerm_vmware_private_cloud and azurerm_vmware_cluster adding new skus to validation - #19

### DIFF
--- a/internal/services/vmware/vmware_cluster_resource.go
+++ b/internal/services/vmware/vmware_cluster_resource.go
@@ -65,6 +65,8 @@ func resourceVmwareCluster() *pluginsdk.Resource {
 					"av20",
 					"av36",
 					"av36t",
+					"av36p",
+					"av52",
 				}, false),
 			},
 

--- a/internal/services/vmware/vmware_private_cloud_resource.go
+++ b/internal/services/vmware/vmware_private_cloud_resource.go
@@ -57,6 +57,8 @@ func resourceVmwarePrivateCloud() *pluginsdk.Resource {
 					"av20",
 					"av36",
 					"av36t",
+					"av36p",
+					"av52",
 				}, false),
 			},
 


### PR DESCRIPTION
Updated the azurerm_vmware_private_cloud and azurerm_vmware_cluster sku validation lists to include the latest skus that have been released.

As AVS is a very expensive resource and requires quota for deployments, I don't have a subscription where I can do acceptance testing on the changes. Since the test deploys the av36 test they won't properly test the new sku's anyway.  These were simple list updates on the two provider files to ensure the new skus pass validation.

This addresses issue https://github.com/hashicorp/terraform-provider-azurerm/issues/19538