### PR TITLE
`azurerm_lb_probe` - Support property `probe_threshold` 

### DIFF
--- a/internal/services/loadbalancer/loadbalancer_probe_resource_test.go
+++ b/internal/services/loadbalancer/loadbalancer_probe_resource_test.go
@@ -85,6 +85,7 @@ func TestAccAzureRMLoadBalancerProbe_update(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data2.ResourceName).ExistsInAzure(r),
 				check.That(data2.ResourceName).Key("port").HasValue("80"),
+				check.That(data2.ResourceName).Key("probe_threshold").HasValue("3"),
 			),
 		},
 		data.ImportStep(),
@@ -264,6 +265,7 @@ resource "azurerm_lb_probe" "test" {
   port                = 22
   interval_in_seconds = 5
   number_of_probes    = 2
+  probe_threshold     = 2
 }
 `, data.RandomInteger, data.Locations.Primary)
 }
@@ -314,12 +316,14 @@ resource "azurerm_lb_probe" "test" {
   loadbalancer_id = azurerm_lb.test.id
   name            = "probe-%d"
   port            = 22
+  probe_threshold = 2
 }
 
 resource "azurerm_lb_probe" "test2" {
   loadbalancer_id = azurerm_lb.test.id
   name            = "probe-%d"
   port            = 80
+  probe_threshold = 3
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data2.RandomInteger)
 }

--- a/internal/services/loadbalancer/probe_resource.go
+++ b/internal/services/loadbalancer/probe_resource.go
@@ -136,9 +136,6 @@ func resourceArmLoadBalancerProbeCreateUpdate(d *pluginsdk.ResourceData, meta in
 		}
 		return fmt.Errorf("failed to retrieve Load Balancer %q (resource group %q) for Probe %q: %+v", id.LoadBalancerName, id.ResourceGroup, id.ProbeName, err)
 	}
-	if d.IsNewResource() {
-		log.Printf("is new resource")
-	}
 
 	newProbe := expandAzureRmLoadBalancerProbe(d)
 	probes := append(*loadBalancer.LoadBalancerPropertiesFormat.Probes, *newProbe)

--- a/website/docs/r/lb_probe.html.markdown
+++ b/website/docs/r/lb_probe.html.markdown
@@ -53,6 +53,7 @@ The following arguments are supported:
 * `loadbalancer_id` - (Required) The ID of the LoadBalancer in which to create the NAT Rule. Changing this forces a new resource to be created.
 * `protocol` - (Optional) Specifies the protocol of the end point. Possible values are `Http`, `Https` or `Tcp`. If TCP is specified, a received ACK is required for the probe to be successful. If HTTP is specified, a 200 OK response from the specified URI is required for the probe to be successful.
 * `port` - (Required) Port on which the Probe queries the backend endpoint. Possible values range from 1 to 65535, inclusive.
+* `probe_threshold` -  (Optional) The number of consecutive successful or failed probes that allow or deny traffic to this endpoint. Possible values range from `1` to `100`. The default value is `1`.
 * `request_path` - (Optional) The URI used for requesting health status from the backend endpoint. Required if protocol is set to `Http` or `Https`. Otherwise, it is not allowed.
 * `interval_in_seconds` - (Optional) The interval, in seconds between probes to the backend endpoint for health status. The default value is 15, the minimum value is 5.
 * `number_of_probes` - (Optional) The number of failed probe attempts after which the backend endpoint is removed from rotation. The default value is 2. NumberOfProbes multiplied by intervalInSeconds value must be greater or equal to 10.Endpoints are returned to rotation when at least one probe is successful.


### PR DESCRIPTION
Support property `probe_threshold` for resource `azurerm_lb_probe`.

Test Results:
PASS: TestAccAzureRMLoadBalancerProbe_basic (391.24s)
PASS: TestAccAzureRMLoadBalancerProbe_update (478.81s)