### PR TITLE
Bug Fix - `azurerm_virtual_desktop_workspace_application_group_association`- Association should not remove the tags

### DIFF
--- a/internal/services/desktopvirtualization/virtual_desktop_workspace_application_group_association_resource.go
+++ b/internal/services/desktopvirtualization/virtual_desktop_workspace_application_group_association_resource.go
@@ -201,6 +201,7 @@ func resourceVirtualDesktopWorkspaceApplicationGroupAssociationDelete(d *plugins
 		Properties: &workspace.WorkspacePatchProperties{
 			ApplicationGroupReferences: &applicationGroupReferences,
 		},
+		Tags: model.Tags,
 	}
 	if _, err = client.Update(ctx, id.Workspace, payload); err != nil {
 		return fmt.Errorf("removing association between %s and %s: %+v", id.Workspace, id.ApplicationGroup, err)

--- a/internal/services/desktopvirtualization/virtual_desktop_workspace_application_group_association_resource.go
+++ b/internal/services/desktopvirtualization/virtual_desktop_workspace_application_group_association_resource.go
@@ -109,6 +109,7 @@ func resourceVirtualDesktopWorkspaceApplicationGroupAssociationCreate(d *plugins
 		Properties: &workspace.WorkspacePatchProperties{
 			ApplicationGroupReferences: &applicationGroupAssociations,
 		},
+		Tags: model.Tags,
 	}
 	if _, err = client.Update(ctx, *workspaceId, payload); err != nil {
 		return fmt.Errorf("creating association between %s and %s: %+v", *workspaceId, *applicationGroupId, err)

--- a/internal/services/desktopvirtualization/virtual_desktop_workspace_application_group_association_resource_test.go
+++ b/internal/services/desktopvirtualization/virtual_desktop_workspace_application_group_association_resource_test.go
@@ -125,6 +125,9 @@ resource "azurerm_virtual_desktop_workspace" "test" {
   name                = "acctestWS%d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
+  tags = {
+    environment = "test"
+  }
 }
 
 resource "azurerm_virtual_desktop_host_pool" "test" {
@@ -168,6 +171,9 @@ resource "azurerm_virtual_desktop_workspace" "test" {
   name                = "acctestWS%d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
+  tags = {
+    environment = "test"
+  }
 }
 
 resource "azurerm_virtual_desktop_host_pool" "test" {


### PR DESCRIPTION
Fixes: #18677 
Association update should not remove the workspace tags.