### PR TITLE
media: fixing the state migration to parse case-insensitively

### DIFF
--- a/internal/services/media/migration/service_v0_to_v1.go
+++ b/internal/services/media/migration/service_v0_to_v1.go
@@ -117,7 +117,7 @@ func (ServiceV0ToV1) Schema() map[string]*pluginsdk.Schema {
 func (ServiceV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
 	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
 		oldIdRaw := rawState["id"].(string)
-		oldId, err := accounts.ParseMediaServiceID(oldIdRaw)
+		oldId, err := accounts.ParseMediaServiceIDInsensitively(oldIdRaw)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This should be case-insensitive parsing the old ID, as such this isn't guaranteed to have been successful (culminating in #19556, which also occurs via a state upgrade) as such this fixes this state migration.