### PR TITLE
azurerm_site_recovery_replicated_vm - support for the   `unmanaged_disk`,`target_proximity_placement_group_id`, `target_boot_diag_storage_account_id`, `target_capacity_reservation_group_id`, `target_virtual_machine_scale_set_id`,`multi_vm_group_name`,`target_edge_zone` properties

### DIFF
--- a/internal/services/recoveryservices/client/client.go
+++ b/internal/services/recoveryservices/client/client.go
@@ -1,9 +1,15 @@
 package client
 
 import (
-	"github.com/Azure/azure-sdk-for-go/services/recoveryservices/mgmt/2018-07-10/siterecovery"
 	"github.com/Azure/azure-sdk-for-go/services/recoveryservices/mgmt/2021-08-01/recoveryservices"
 	"github.com/Azure/azure-sdk-for-go/services/recoveryservices/mgmt/2021-12-01/backup"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/common"
 )
 
@@ -18,12 +24,13 @@ type Client struct {
 	VaultsClient                              *recoveryservices.VaultsClient
 	VaultsConfigsClient                       *backup.ResourceVaultConfigsClient // Not sure why this is in backup, but https://github.com/Azure/azure-sdk-for-go/issues/7279
 	StorageConfigsClient                      *backup.ResourceStorageConfigsNonCRRClient
-	FabricClient                              func(resourceGroupName string, vaultName string) siterecovery.ReplicationFabricsClient
-	ProtectionContainerClient                 func(resourceGroupName string, vaultName string) siterecovery.ReplicationProtectionContainersClient
-	ReplicationPoliciesClient                 func(resourceGroupName string, vaultName string) siterecovery.ReplicationPoliciesClient
-	ContainerMappingClient                    func(resourceGroupName string, vaultName string) siterecovery.ReplicationProtectionContainerMappingsClient
-	NetworkMappingClient                      func(resourceGroupName string, vaultName string) siterecovery.ReplicationNetworkMappingsClient
-	ReplicationMigrationItemsClient           func(resourceGroupName string, vaultName string) siterecovery.ReplicationProtectedItemsClient
+	FabricClient                              *replicationfabrics.ReplicationFabricsClient
+	ProtectionContainerClient                 *replicationprotectioncontainers.ReplicationProtectionContainersClient
+	ReplicationPoliciesClient                 *replicationpolicies.ReplicationPoliciesClient
+	ContainerMappingClient                    *replicationprotectioncontainermappings.ReplicationProtectionContainerMappingsClient
+	NetworkMappingClient                      *replicationnetworkmappings.ReplicationNetworkMappingsClient
+	ReplicationProtectedItemsClient           *replicationprotecteditems.ReplicationProtectedItemsClient
+	ReplicationRecoveryPlansClient            *replicationrecoveryplans.ReplicationRecoveryPlansClient
 }
 
 func NewClient(o *common.ClientOptions) *Client {
@@ -57,41 +64,26 @@ func NewClient(o *common.ClientOptions) *Client {
 	backupProtectionContainerOperationResultsClient := backup.NewProtectionContainerOperationResultsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&backupProtectionContainerOperationResultsClient.Client, o.ResourceManagerAuthorizer)
 
-	fabricClient := func(resourceGroupName string, vaultName string) siterecovery.ReplicationFabricsClient {
-		client := siterecovery.NewReplicationFabricsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId, resourceGroupName, vaultName)
-		o.ConfigureClient(&client.Client, o.ResourceManagerAuthorizer)
-		return client
-	}
+	fabricClient := replicationfabrics.NewReplicationFabricsClientWithBaseURI(o.ResourceManagerEndpoint)
+	o.ConfigureClient(&fabricClient.Client, o.ResourceManagerAuthorizer)
 
-	protectionContainerClient := func(resourceGroupName string, vaultName string) siterecovery.ReplicationProtectionContainersClient {
-		client := siterecovery.NewReplicationProtectionContainersClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId, resourceGroupName, vaultName)
-		o.ConfigureClient(&client.Client, o.ResourceManagerAuthorizer)
-		return client
-	}
+	protectionContainerClient := replicationprotectioncontainers.NewReplicationProtectionContainersClientWithBaseURI(o.ResourceManagerEndpoint)
+	o.ConfigureClient(&protectionContainerClient.Client, o.ResourceManagerAuthorizer)
 
-	replicationPoliciesClient := func(resourceGroupName string, vaultName string) siterecovery.ReplicationPoliciesClient {
-		client := siterecovery.NewReplicationPoliciesClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId, resourceGroupName, vaultName)
-		o.ConfigureClient(&client.Client, o.ResourceManagerAuthorizer)
-		return client
-	}
+	replicationPoliciesClient := replicationpolicies.NewReplicationPoliciesClientWithBaseURI(o.ResourceManagerEndpoint)
+	o.ConfigureClient(&replicationPoliciesClient.Client, o.ResourceManagerAuthorizer)
 
-	containerMappingClient := func(resourceGroupName string, vaultName string) siterecovery.ReplicationProtectionContainerMappingsClient {
-		client := siterecovery.NewReplicationProtectionContainerMappingsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId, resourceGroupName, vaultName)
-		o.ConfigureClient(&client.Client, o.ResourceManagerAuthorizer)
-		return client
-	}
+	containerMappingClient := replicationprotectioncontainermappings.NewReplicationProtectionContainerMappingsClientWithBaseURI(o.ResourceManagerEndpoint)
+	o.ConfigureClient(&containerMappingClient.Client, o.ResourceManagerAuthorizer)
 
-	networkMappingClient := func(resourceGroupName string, vaultName string) siterecovery.ReplicationNetworkMappingsClient {
-		client := siterecovery.NewReplicationNetworkMappingsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId, resourceGroupName, vaultName)
-		o.ConfigureClient(&client.Client, o.ResourceManagerAuthorizer)
-		return client
-	}
+	networkMappingClient := replicationnetworkmappings.NewReplicationNetworkMappingsClientWithBaseURI(o.ResourceManagerEndpoint)
+	o.ConfigureClient(&networkMappingClient.Client, o.ResourceManagerAuthorizer)
 
-	replicationMigrationItemsClient := func(resourceGroupName string, vaultName string) siterecovery.ReplicationProtectedItemsClient {
-		client := siterecovery.NewReplicationProtectedItemsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId, resourceGroupName, vaultName)
-		o.ConfigureClient(&client.Client, o.ResourceManagerAuthorizer)
-		return client
-	}
+	replicationMigrationItemsClient := replicationprotecteditems.NewReplicationProtectedItemsClientWithBaseURI(o.ResourceManagerEndpoint)
+	o.ConfigureClient(&replicationMigrationItemsClient.Client, o.ResourceManagerAuthorizer)
+
+	replicationRecoveryPlanClient := replicationrecoveryplans.NewReplicationRecoveryPlansClientWithBaseURI(o.ResourceManagerEndpoint)
+	o.ConfigureClient(&replicationRecoveryPlanClient.Client, o.ResourceManagerAuthorizer)
 
 	return &Client{
 		ProtectableItemsClient:                    &protectableItemsClient,
@@ -104,11 +96,12 @@ func NewClient(o *common.ClientOptions) *Client {
 		VaultsClient:                              &vaultsClient,
 		VaultsConfigsClient:                       &vaultConfigsClient,
 		StorageConfigsClient:                      &storageConfigsClient,
-		FabricClient:                              fabricClient,
-		ProtectionContainerClient:                 protectionContainerClient,
-		ReplicationPoliciesClient:                 replicationPoliciesClient,
-		ContainerMappingClient:                    containerMappingClient,
-		NetworkMappingClient:                      networkMappingClient,
-		ReplicationMigrationItemsClient:           replicationMigrationItemsClient,
+		FabricClient:                              &fabricClient,
+		ProtectionContainerClient:                 &protectionContainerClient,
+		ReplicationPoliciesClient:                 &replicationPoliciesClient,
+		ContainerMappingClient:                    &containerMappingClient,
+		NetworkMappingClient:                      &networkMappingClient,
+		ReplicationProtectedItemsClient:           &replicationMigrationItemsClient,
+		ReplicationRecoveryPlansClient:            &replicationRecoveryPlanClient,
 	}
 }

--- a/internal/services/recoveryservices/helpers.go
+++ b/internal/services/recoveryservices/helpers.go
@@ -1,10 +1,38 @@
 package recoveryservices
 
 import (
+	"net/http"
 	"strings"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
 )
 
 // This code is a workaround for this bug https://github.com/Azure/azure-sdk-for-go/issues/2824
 func handleAzureSdkForGoBug2824(id string) string {
 	return strings.Replace(id, "/Subscriptions/", "/subscriptions/", 1)
+}
+
+func wasBadRequestWithNotExist(resp *http.Response, err error) bool {
+	e, ok := err.(autorest.DetailedError)
+	if !ok {
+		return false
+	}
+
+	r, ok := e.Original.(*azure.RequestError)
+	if !ok {
+		return false
+	}
+
+	if r.ServiceError == nil || len(r.ServiceError.Details) == 0 {
+		return false
+	}
+
+	sc, ok := r.ServiceError.Details[0]["code"]
+	if !ok {
+		return false
+	}
+
+	return response.WasBadRequest(resp) && sc == "SubscriptionIdNotRegisteredWithSrs"
 }

--- a/internal/services/recoveryservices/site_recovery_fabric_data_source.go
+++ b/internal/services/recoveryservices/site_recovery_fabric_data_source.go
@@ -4,15 +4,15 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/recoveryservices/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/recoveryservices/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func dataSourceSiteRecoveryFabric() *pluginsdk.Resource {
@@ -43,30 +43,33 @@ func dataSourceSiteRecoveryFabric() *pluginsdk.Resource {
 
 func dataSourceSiteRecoveryFabricRead(d *pluginsdk.ResourceData, meta interface{}) error {
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
-	id := parse.NewReplicationFabricID(subscriptionId, d.Get("resource_group_name").(string), d.Get("recovery_vault_name").(string), d.Get("name").(string))
+	id := replicationfabrics.NewReplicationFabricID(subscriptionId, d.Get("resource_group_name").(string), d.Get("recovery_vault_name").(string), d.Get("name").(string))
 
-	client := meta.(*clients.Client).RecoveryServices.FabricClient(id.ResourceGroup, id.VaultName)
+	client := meta.(*clients.Client).RecoveryServices.FabricClient
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	resp, err := client.Get(ctx, id.Name)
+	resp, err := client.Get(ctx, id, replicationfabrics.DefaultGetOperationOptions())
 	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
+		if response.WasNotFound(resp.HttpResponse) {
 			return fmt.Errorf("%s was not found", id)
 		}
 		return fmt.Errorf("making read request on site recovery fabric %s: %+v", id.String(), err)
 	}
 
+	model := resp.Model
+	if model == nil {
+		return fmt.Errorf("making read request on site recovery fabric %s: model is nil", id.String())
+	}
+
 	d.SetId(id.ID())
-	d.Set("name", id.Name)
-	d.Set("resource_group_name", id.ResourceGroup)
-	d.Set("recovery_vault_name", id.VaultName)
+	d.Set("name", id.FabricName)
+	d.Set("resource_group_name", id.ResourceGroupName)
+	d.Set("recovery_vault_name", id.ResourceName)
 
 	normalizedLocation := ""
-	if props := resp.Properties; props != nil {
-		if azureDetails, isAzureDetails := props.CustomDetails.AsAzureFabricSpecificDetails(); isAzureDetails {
-			normalizedLocation = location.NormalizeNilable(azureDetails.Location)
-		}
+	if l := model.Location; l != nil {
+		normalizedLocation = location.NormalizeNilable(l)
 	}
 	d.Set("location", normalizedLocation)
 

--- a/internal/services/recoveryservices/site_recovery_fabric_resource.go
+++ b/internal/services/recoveryservices/site_recovery_fabric_resource.go
@@ -4,8 +4,10 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/recoveryservices/mgmt/2018-07-10/siterecovery"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -14,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceSiteRecoveryFabric() *pluginsdk.Resource {
@@ -56,104 +57,98 @@ func resourceSiteRecoveryFabric() *pluginsdk.Resource {
 }
 
 func resourceSiteRecoveryFabricCreate(d *pluginsdk.ResourceData, meta interface{}) error {
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	resGroup := d.Get("resource_group_name").(string)
 	vaultName := d.Get("recovery_vault_name").(string)
 	location := azure.NormalizeLocation(d.Get("location").(string))
 	name := d.Get("name").(string)
 
-	client := meta.(*clients.Client).RecoveryServices.FabricClient(resGroup, vaultName)
+	client := meta.(*clients.Client).RecoveryServices.FabricClient
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
+	id := replicationfabrics.NewReplicationFabricID(subscriptionId, resGroup, vaultName, name)
+
 	if d.IsNewResource() {
-		existing, err := client.Get(ctx, name)
+		existing, err := client.Get(ctx, id, replicationfabrics.DefaultGetOperationOptions())
 		if err != nil {
 			// NOTE: Bad Request due to https://github.com/Azure/azure-rest-api-specs/issues/12759
-			if !utils.ResponseWasNotFound(existing.Response) && !utils.ResponseWasBadRequestWithServiceCode(existing.Response, err, "SubscriptionIdNotRegisteredWithSrs") {
+			if !response.WasNotFound(existing.HttpResponse) && !wasBadRequestWithNotExist(existing.HttpResponse, err) {
 				return fmt.Errorf("checking for presence of existing site recovery fabric %s (vault %s): %+v", name, vaultName, err)
 			}
 		}
 
-		if existing.ID != nil && *existing.ID != "" {
-			return tf.ImportAsExistsError("azurerm_site_recovery_fabric", handleAzureSdkForGoBug2824(*existing.ID))
+		if model := existing.Model; model != nil && model.Id != nil && *model.Id != "" {
+			return tf.ImportAsExistsError("azurerm_site_recovery_fabric", handleAzureSdkForGoBug2824(*model.Id))
 		}
 	}
 
-	parameters := siterecovery.FabricCreationInput{
-		Properties: &siterecovery.FabricCreationInputProperties{
-			CustomDetails: siterecovery.AzureFabricCreationInput{
-				InstanceType: "Azure",
-				Location:     &location,
+	parameters := replicationfabrics.FabricCreationInput{
+		Properties: &replicationfabrics.FabricCreationInputProperties{
+			CustomDetails: replicationfabrics.AzureFabricCreationInput{
+				Location: &location,
 			},
 		},
 	}
 
-	future, err := client.Create(ctx, name, parameters)
+	err := client.CreateThenPoll(ctx, id, parameters)
 	if err != nil {
 		return fmt.Errorf("creating site recovery fabric %s (vault %s): %+v", name, vaultName, err)
 	}
-	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("creating site recovery fabric %s (vault %s): %+v", name, vaultName, err)
-	}
 
-	resp, err := client.Get(ctx, name)
-	if err != nil {
-		return fmt.Errorf("retrieving site recovery fabric %s (vault %s): %+v", name, vaultName, err)
-	}
-
-	d.SetId(handleAzureSdkForGoBug2824(*resp.ID))
+	d.SetId(id.ID())
 
 	return resourceSiteRecoveryFabricRead(d, meta)
 }
 
 func resourceSiteRecoveryFabricRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	id, err := parse.ReplicationFabricID(d.Id())
+	id, err := replicationfabrics.ParseReplicationFabricID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	fabricClient := meta.(*clients.Client).RecoveryServices.FabricClient(id.ResourceGroup, id.VaultName)
+	fabricClient := meta.(*clients.Client).RecoveryServices.FabricClient
 	client := fabricClient
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	resp, err := client.Get(ctx, id.Name)
+	resp, err := client.Get(ctx, *id, replicationfabrics.DefaultGetOperationOptions())
 	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
+		if response.WasNotFound(resp.HttpResponse) {
 			d.SetId("")
 			return nil
 		}
 		return fmt.Errorf("making read request on site recovery fabric %s: %+v", id.String(), err)
 	}
 
-	d.Set("name", resp.Name)
-	d.Set("resource_group_name", id.ResourceGroup)
-	if props := resp.Properties; props != nil {
-		if azureDetails, isAzureDetails := props.CustomDetails.AsAzureFabricSpecificDetails(); isAzureDetails {
-			d.Set("location", azureDetails.Location)
-		}
+	model := resp.Model
+	if model == nil {
+		return fmt.Errorf("making read request on site recovery fabric %s: model is nil", id.String())
 	}
-	d.Set("recovery_vault_name", id.VaultName)
+
+	d.Set("name", model.Name)
+	d.Set("resource_group_name", id.ResourceGroupName)
+	if model.Properties.CustomDetails != nil {
+		loc := *model.Properties.CustomDetails.(replicationfabrics.AzureFabricSpecificDetails).Location
+		d.Set("location", location.Normalize(loc))
+	}
+	d.Set("recovery_vault_name", id.ResourceName)
 	return nil
 }
 
 func resourceSiteRecoveryFabricDelete(d *pluginsdk.ResourceData, meta interface{}) error {
-	id, err := parse.ReplicationFabricID(d.Id())
+	id, err := replicationfabrics.ParseReplicationFabricID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	client := meta.(*clients.Client).RecoveryServices.FabricClient(id.ResourceGroup, id.VaultName)
+	client := meta.(*clients.Client).RecoveryServices.FabricClient
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	future, err := client.Delete(ctx, id.Name)
+	err = client.DeleteThenPoll(ctx, *id)
 	if err != nil {
 		return fmt.Errorf("deleting site recovery fabric %s : %+v", id.String(), err)
-	}
-
-	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting for deletion of site recovery fabric %s : %+v", id.String(), err)
 	}
 
 	return nil

--- a/internal/services/recoveryservices/site_recovery_fabric_resource_test.go
+++ b/internal/services/recoveryservices/site_recovery_fabric_resource_test.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/recoveryservices/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
@@ -60,15 +60,20 @@ resource "azurerm_site_recovery_fabric" "test" {
 }
 
 func (t SiteRecoveryFabricResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
-	id, err := parse.ReplicationFabricID(state.ID)
+	id, err := replicationfabrics.ParseReplicationFabricID(state.ID)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := clients.RecoveryServices.FabricClient(id.ResourceGroup, id.VaultName).Get(ctx, id.Name)
+	resp, err := clients.RecoveryServices.FabricClient.Get(ctx, *id, replicationfabrics.DefaultGetOperationOptions())
 	if err != nil {
 		return nil, fmt.Errorf("reading Recovery Service Vault (%s): %+v", id.String(), err)
 	}
 
-	return utils.Bool(resp.ID != nil), nil
+	model := resp.Model
+	if model == nil {
+		return nil, fmt.Errorf("reading Recovery Service Vault (%s): model is nil", id.String())
+	}
+
+	return utils.Bool(model.Id != nil), nil
 }

--- a/internal/services/recoveryservices/site_recovery_network_mapping_resource.go
+++ b/internal/services/recoveryservices/site_recovery_network_mapping_resource.go
@@ -2,11 +2,11 @@ package recoveryservices
 
 import (
 	"fmt"
-	"net/http"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/recoveryservices/mgmt/2018-07-10/siterecovery"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -17,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceSiteRecoveryNetworkMapping() *pluginsdk.Resource {
@@ -26,7 +25,7 @@ func resourceSiteRecoveryNetworkMapping() *pluginsdk.Resource {
 		Read:   resourceSiteRecoveryNetworkMappingRead,
 		Delete: resourceSiteRecoveryNetworkMappingDelete,
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
-			_, err := parse.ReplicationNetworkMappingID(id)
+			_, err := replicationnetworkmappings.ParseReplicationNetworkMappingID(id)
 			return err
 		}),
 
@@ -83,6 +82,7 @@ func resourceSiteRecoveryNetworkMapping() *pluginsdk.Resource {
 }
 
 func resourceSiteRecoveryNetworkMappingCreate(d *pluginsdk.ResourceData, meta interface{}) error {
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	resGroup := d.Get("resource_group_name").(string)
 	vaultName := d.Get("recovery_vault_name").(string)
 	fabricName := d.Get("source_recovery_fabric_name").(string)
@@ -91,7 +91,7 @@ func resourceSiteRecoveryNetworkMappingCreate(d *pluginsdk.ResourceData, meta in
 	targetNetworkId := d.Get("target_network_id").(string)
 	name := d.Get("name").(string)
 
-	client := meta.(*clients.Client).RecoveryServices.NetworkMappingClient(resGroup, vaultName)
+	client := meta.(*clients.Client).RecoveryServices.NetworkMappingClient
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -101,77 +101,74 @@ func resourceSiteRecoveryNetworkMappingCreate(d *pluginsdk.ResourceData, meta in
 		return fmt.Errorf("[ERROR] Unable to parse source_network_id '%s' (network mapping %s): %+v", sourceNetworkId, name, err)
 	}
 
+	id := replicationnetworkmappings.NewReplicationNetworkMappingID(subscriptionId, resGroup, vaultName, fabricName, parsedSourceNetworkId.Name, name)
+
 	if d.IsNewResource() {
-		existing, err := client.Get(ctx, fabricName, parsedSourceNetworkId.Name, name)
+		existing, err := client.Get(ctx, id)
 		if err != nil {
-			if !utils.ResponseWasNotFound(existing.Response) &&
-				// todo this workaround can be removed when this bug is fixed
-				// https://github.com/Azure/azure-sdk-for-go/issues/8705
-				!utils.ResponseWasStatusCode(existing.Response, http.StatusBadRequest) {
+			if !response.WasNotFound(existing.HttpResponse) && !wasBadRequestWithNotExist(existing.HttpResponse, err) {
 				return fmt.Errorf("checking for presence of existing site recovery network mapping %s (vault %s): %+v", name, vaultName, err)
 			}
 		}
 
-		if existing.ID != nil && *existing.ID != "" {
-			return tf.ImportAsExistsError("azurerm_site_recovery_network_mapping", handleAzureSdkForGoBug2824(*existing.ID))
+		if existing.Model != nil && existing.Model.Id != nil && *existing.Model.Id != "" {
+			return tf.ImportAsExistsError("azurerm_site_recovery_network_mapping", *existing.Model.Id)
 		}
 	}
 
-	parameters := siterecovery.CreateNetworkMappingInput{
-		Properties: &siterecovery.CreateNetworkMappingInputProperties{
-			RecoveryNetworkID:  &targetNetworkId,
+	parameters := replicationnetworkmappings.CreateNetworkMappingInput{
+		Properties: replicationnetworkmappings.CreateNetworkMappingInputProperties{
+			RecoveryNetworkId:  targetNetworkId,
 			RecoveryFabricName: &targetFabricName,
-			FabricSpecificDetails: siterecovery.AzureToAzureCreateNetworkMappingInput{
-				PrimaryNetworkID: &sourceNetworkId,
+			FabricSpecificDetails: replicationnetworkmappings.AzureToAzureCreateNetworkMappingInput{
+				PrimaryNetworkId: sourceNetworkId,
 			},
 		},
 	}
-	future, err := client.Create(ctx, fabricName, parsedSourceNetworkId.Name, name, parameters)
+
+	err = client.CreateThenPoll(ctx, id, parameters)
 	if err != nil {
 		return fmt.Errorf("creating site recovery network mapping %s (vault %s): %+v", name, vaultName, err)
 	}
-	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("creating site recovery network mapping %s (vault %s): %+v", name, vaultName, err)
-	}
 
-	resp, err := client.Get(ctx, fabricName, parsedSourceNetworkId.Name, name)
-	if err != nil {
-		return fmt.Errorf("retrieving site recovery network mapping %s (vault %s): %+v", name, vaultName, err)
-	}
-
-	d.SetId(handleAzureSdkForGoBug2824(*resp.ID))
+	d.SetId(id.ID())
 
 	return resourceSiteRecoveryNetworkMappingRead(d, meta)
 }
 
 func resourceSiteRecoveryNetworkMappingRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	id, err := parse.ReplicationNetworkMappingID(d.Id())
+	id, err := replicationnetworkmappings.ParseReplicationNetworkMappingID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	client := meta.(*clients.Client).RecoveryServices.NetworkMappingClient(id.ResourceGroup, id.VaultName)
+	client := meta.(*clients.Client).RecoveryServices.NetworkMappingClient
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	resp, err := client.Get(ctx, id.ReplicationFabricName, id.ReplicationNetworkName, id.Name)
+	resp, err := client.Get(ctx, *id)
 	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
+		if response.WasNotFound(resp.HttpResponse) {
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("making Read request on site recovery network mapping %s (vault %s): %+v", id.Name, id.VaultName, err)
+		return fmt.Errorf("making Read request on site recovery network mapping %q: %+v", id, err)
 	}
 
-	d.Set("resource_group_name", id.ResourceGroup)
-	d.Set("recovery_vault_name", id.VaultName)
-	d.Set("source_recovery_fabric_name", id.ReplicationFabricName)
-	d.Set("name", resp.Name)
-	if props := resp.Properties; props != nil {
-		d.Set("source_network_id", props.PrimaryNetworkID)
-		d.Set("target_network_id", props.RecoveryNetworkID)
+	if resp.Model == nil {
+		return fmt.Errorf("retrieving site recovery network mapping %q: `model` was nil", id)
+	}
+	model := resp.Model
 
-		targetFabricId, err := parse.ReplicationFabricID(handleAzureSdkForGoBug2824(*resp.Properties.RecoveryFabricArmID))
+	d.Set("resource_group_name", id.ResourceGroupName)
+	d.Set("recovery_vault_name", id.ResourceName)
+	d.Set("source_recovery_fabric_name", id.FabricName)
+	d.Set("name", id.NetworkMappingName)
+	if props := model.Properties; props != nil {
+		d.Set("source_network_id", props.PrimaryNetworkId)
+		d.Set("target_network_id", props.RecoveryNetworkId)
+
+		targetFabricId, err := parse.ReplicationFabricID(handleAzureSdkForGoBug2824(*props.RecoveryFabricArmId))
 		if err != nil {
 			return err
 		}
@@ -182,22 +179,18 @@ func resourceSiteRecoveryNetworkMappingRead(d *pluginsdk.ResourceData, meta inte
 }
 
 func resourceSiteRecoveryNetworkMappingDelete(d *pluginsdk.ResourceData, meta interface{}) error {
-	id, err := parse.ReplicationNetworkMappingID(d.Id())
+	id, err := replicationnetworkmappings.ParseReplicationNetworkMappingID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	client := meta.(*clients.Client).RecoveryServices.NetworkMappingClient(id.ResourceGroup, id.VaultName)
+	client := meta.(*clients.Client).RecoveryServices.NetworkMappingClient
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	future, err := client.Delete(ctx, id.ReplicationFabricName, id.ReplicationNetworkName, id.Name)
+	err = client.DeleteThenPoll(ctx, *id)
 	if err != nil {
-		return fmt.Errorf("deleting site recovery network mapping %s (vault %s): %+v", id.Name, id.VaultName, err)
-	}
-
-	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting for deletion of site recovery network mapping  %s (vault %s): %+v", id.Name, id.VaultName, err)
+		return fmt.Errorf("deleting site recovery network mapping %q: %+v", id, err)
 	}
 
 	return nil

--- a/internal/services/recoveryservices/site_recovery_network_mapping_resource_test.go
+++ b/internal/services/recoveryservices/site_recovery_network_mapping_resource_test.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/recoveryservices/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
@@ -92,15 +92,18 @@ resource "azurerm_site_recovery_network_mapping" "test" {
 }
 
 func (t SiteRecoveryNetworkMappingResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
-	id, err := parse.ReplicationNetworkMappingID(state.ID)
+	id, err := replicationnetworkmappings.ParseReplicationNetworkMappingID(state.ID)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := clients.RecoveryServices.NetworkMappingClient(id.ResourceGroup, id.VaultName).Get(ctx, id.ReplicationFabricName, id.ReplicationNetworkName, id.Name)
+	resp, err := clients.RecoveryServices.NetworkMappingClient.Get(ctx, *id)
 	if err != nil {
-		return nil, fmt.Errorf("reading Recovery Service Vault (%s): %+v", id.String(), err)
+		return nil, fmt.Errorf("reading Recovery Service Network Mapping %q: %+v", id, err)
+	}
+	if resp.Model == nil {
+		return nil, fmt.Errorf("retrieving Recovery Service Network Mapping %q: `model` was nil", id)
 	}
 
-	return utils.Bool(resp.ID != nil), nil
+	return utils.Bool(resp.Model.Id != nil), nil
 }

--- a/internal/services/recoveryservices/site_recovery_protection_container_data_source.go
+++ b/internal/services/recoveryservices/site_recovery_protection_container_data_source.go
@@ -4,14 +4,14 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/recoveryservices/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/recoveryservices/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func dataSourceSiteRecoveryProtectionContainer() *pluginsdk.Resource {
@@ -46,25 +46,25 @@ func dataSourceSiteRecoveryProtectionContainer() *pluginsdk.Resource {
 
 func dataSourceSiteRecoveryProtectionContainerRead(d *pluginsdk.ResourceData, meta interface{}) error {
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
-	id := parse.NewReplicationProtectionContainerID(subscriptionId, d.Get("resource_group_name").(string), d.Get("recovery_vault_name").(string), d.Get("recovery_fabric_name").(string), d.Get("name").(string))
+	id := replicationprotectioncontainers.NewReplicationProtectionContainerID(subscriptionId, d.Get("resource_group_name").(string), d.Get("recovery_vault_name").(string), d.Get("recovery_fabric_name").(string), d.Get("name").(string))
 
-	client := meta.(*clients.Client).RecoveryServices.ProtectionContainerClient(id.ResourceGroup, id.VaultName)
+	client := meta.(*clients.Client).RecoveryServices.ProtectionContainerClient
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	resp, err := client.Get(ctx, id.ReplicationFabricName, id.Name)
+	resp, err := client.Get(ctx, id)
 	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
+		if response.WasNotFound(resp.HttpResponse) {
 			return fmt.Errorf("%s was not found", id)
 		}
 		return fmt.Errorf("making Read request on site recovery protection container %s : %+v", id.String(), err)
 	}
 
-	d.SetId(id.ID())
-	d.Set("name", id.Name)
-	d.Set("resource_group_name", id.ResourceGroup)
-	d.Set("recovery_vault_name", id.VaultName)
-	d.Set("recovery_fabric_name", id.ReplicationFabricName)
+	d.SetId(handleAzureSdkForGoBug2824(id.ID()))
+	d.Set("name", id.ProtectionContainerName)
+	d.Set("resource_group_name", id.ResourceGroupName)
+	d.Set("recovery_vault_name", id.ResourceName)
+	d.Set("recovery_fabric_name", id.FabricName)
 
 	return nil
 }

--- a/internal/services/recoveryservices/site_recovery_protection_container_mapping_resource.go
+++ b/internal/services/recoveryservices/site_recovery_protection_container_mapping_resource.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/recoveryservices/mgmt/2018-07-10/siterecovery"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -15,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceSiteRecoveryProtectionContainerMapping() *pluginsdk.Resource {
@@ -82,6 +82,7 @@ func resourceSiteRecoveryProtectionContainerMapping() *pluginsdk.Resource {
 }
 
 func resourceSiteRecoveryContainerMappingCreate(d *pluginsdk.ResourceData, meta interface{}) error {
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	resGroup := d.Get("resource_group_name").(string)
 	vaultName := d.Get("recovery_vault_name").(string)
 	fabricName := d.Get("recovery_fabric_name").(string)
@@ -90,104 +91,102 @@ func resourceSiteRecoveryContainerMappingCreate(d *pluginsdk.ResourceData, meta 
 	targetContainerId := d.Get("recovery_target_protection_container_id").(string)
 	name := d.Get("name").(string)
 
-	client := meta.(*clients.Client).RecoveryServices.ContainerMappingClient(resGroup, vaultName)
+	client := meta.(*clients.Client).RecoveryServices.ContainerMappingClient
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
+	id := replicationprotectioncontainermappings.NewReplicationProtectionContainerMappingID(subscriptionId, resGroup, vaultName, fabricName, protectionContainerName, name)
+
 	if d.IsNewResource() {
-		existing, err := client.Get(ctx, fabricName, protectionContainerName, name)
+		existing, err := client.Get(ctx, id)
 		if err != nil {
-			if !utils.ResponseWasNotFound(existing.Response) {
+			if !response.WasNotFound(existing.HttpResponse) {
 				return fmt.Errorf("checking for presence of existing site recovery protection container mapping %s (fabric %s, container %s): %+v", name, fabricName, protectionContainerName, err)
 			}
 		}
 
-		if existing.ID != nil && *existing.ID != "" {
-			return tf.ImportAsExistsError("azurerm_site_recovery_protection_container_mapping", handleAzureSdkForGoBug2824(*existing.ID))
+		if existing.Model != nil && existing.Model.Id != nil && *existing.Model.Id != "" {
+			return tf.ImportAsExistsError("azurerm_site_recovery_protection_container_mapping", *existing.Model.Id)
 		}
 	}
 
-	parameters := siterecovery.CreateProtectionContainerMappingInput{
-		Properties: &siterecovery.CreateProtectionContainerMappingInputProperties{
-			TargetProtectionContainerID: &targetContainerId,
-			PolicyID:                    &policyId,
-			ProviderSpecificInput:       siterecovery.ReplicationProviderSpecificContainerMappingInput{},
+	parameters := replicationprotectioncontainermappings.CreateProtectionContainerMappingInput{
+		Properties: &replicationprotectioncontainermappings.CreateProtectionContainerMappingInputProperties{
+			TargetProtectionContainerId: &targetContainerId,
+			PolicyId:                    &policyId,
+			ProviderSpecificInput:       replicationprotectioncontainermappings.A2AContainerMappingInput{},
 		},
 	}
-	future, err := client.Create(ctx, fabricName, protectionContainerName, name, parameters)
+	err := client.CreateThenPoll(ctx, id, parameters)
 	if err != nil {
 		return fmt.Errorf("creating site recovery protection container mapping %s (vault %s): %+v", name, vaultName, err)
 	}
-	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("creating site recovery protection container mapping %s (vault %s): %+v", name, vaultName, err)
-	}
 
-	resp, err := client.Get(ctx, fabricName, protectionContainerName, name)
-	if err != nil {
-		return fmt.Errorf("retrieving site recovery protection container mapping %s (vault %s): %+v", name, vaultName, err)
-	}
-
-	d.SetId(handleAzureSdkForGoBug2824(*resp.ID))
+	d.SetId(id.ID())
 
 	return resourceSiteRecoveryContainerMappingRead(d, meta)
 }
 
 func resourceSiteRecoveryContainerMappingRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	id, err := parse.ReplicationProtectionContainerMappingsID(d.Id())
+	id, err := replicationprotectioncontainermappings.ParseReplicationProtectionContainerMappingID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	client := meta.(*clients.Client).RecoveryServices.ContainerMappingClient(id.ResourceGroup, id.VaultName)
+	client := meta.(*clients.Client).RecoveryServices.ContainerMappingClient
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	resp, err := client.Get(ctx, id.ReplicationFabricName, id.ReplicationProtectionContainerName, id.ReplicationProtectionContainerMappingName)
+	resp, err := client.Get(ctx, *id)
 	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
+		if response.WasNotFound(resp.HttpResponse) {
 			d.SetId("")
 			return nil
 		}
 		return fmt.Errorf("making Read request on site recovery protection container mapping %s : %+v", id.String(), err)
 	}
 
-	d.Set("resource_group_name", id.ResourceGroup)
-	d.Set("recovery_vault_name", id.VaultName)
-	d.Set("recovery_fabric_name", id.ReplicationFabricName)
-	d.Set("recovery_source_protection_container_name", resp.Properties.SourceProtectionContainerFriendlyName)
-	d.Set("name", resp.Name)
-	d.Set("recovery_replication_policy_id", resp.Properties.PolicyID)
-	d.Set("recovery_target_protection_container_id", resp.Properties.TargetProtectionContainerID)
+	model := resp.Model
+	if model == nil {
+		return fmt.Errorf("retrieving site recovery protection container mapping %s (vault %s): model is nil", id.MappingName, id.ResourceName)
+	}
+
+	d.Set("resource_group_name", id.ResourceGroupName)
+	d.Set("recovery_vault_name", id.ResourceName)
+	d.Set("recovery_fabric_name", id.FabricName)
+	d.Set("name", model.Name)
+	if prop := model.Properties; prop != nil {
+		d.Set("recovery_source_protection_container_name", model.Properties.SourceProtectionContainerFriendlyName)
+		d.Set("recovery_replication_policy_id", model.Properties.PolicyId)
+		d.Set("recovery_target_protection_container_id", model.Properties.TargetProtectionContainerId)
+	}
+
 	return nil
 }
 
 func resourceSiteRecoveryServicesContainerMappingDelete(d *pluginsdk.ResourceData, meta interface{}) error {
-	id, err := parse.ReplicationProtectionContainerMappingsID(d.Id())
+	id, err := replicationprotectioncontainermappings.ParseReplicationProtectionContainerMappingID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	instanceType := string(siterecovery.InstanceTypeBasicReplicationProviderSpecificContainerMappingInputInstanceTypeA2A)
+	instanceType := "A2A"
 
-	client := meta.(*clients.Client).RecoveryServices.ContainerMappingClient(id.ResourceGroup, id.VaultName)
+	client := meta.(*clients.Client).RecoveryServices.ContainerMappingClient
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	input := siterecovery.RemoveProtectionContainerMappingInput{
-		Properties: &siterecovery.RemoveProtectionContainerMappingInputProperties{
-			ProviderSpecificInput: &siterecovery.ReplicationProviderContainerUnmappingInput{
+	input := replicationprotectioncontainermappings.RemoveProtectionContainerMappingInput{
+		Properties: &replicationprotectioncontainermappings.RemoveProtectionContainerMappingInputProperties{
+			ProviderSpecificInput: &replicationprotectioncontainermappings.ReplicationProviderContainerUnmappingInput{
 				InstanceType: &instanceType,
 			},
 		},
 	}
 
-	future, err := client.Delete(ctx, id.ReplicationFabricName, id.ReplicationProtectionContainerName, id.ReplicationProtectionContainerMappingName, input)
+	err = client.DeleteThenPoll(ctx, *id, input)
 	if err != nil {
 		return fmt.Errorf("deleting site recovery protection container mapping %s : %+v", id.String(), err)
-	}
-
-	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting for deletion of site recovery protection container mapping %s : %+v", id.String(), err)
 	}
 
 	return nil

--- a/internal/services/recoveryservices/site_recovery_protection_container_mapping_resource_test.go
+++ b/internal/services/recoveryservices/site_recovery_protection_container_mapping_resource_test.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/recoveryservices/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
@@ -100,15 +100,20 @@ resource "azurerm_site_recovery_protection_container_mapping" "test" {
 }
 
 func (t SiteRecoveryProtectionContainerMappingResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
-	id, err := parse.ReplicationProtectionContainerMappingsID(state.ID)
+	id, err := replicationprotectioncontainermappings.ParseReplicationProtectionContainerMappingID(state.ID)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := clients.RecoveryServices.ContainerMappingClient(id.ResourceGroup, id.VaultName).Get(ctx, id.ReplicationFabricName, id.ReplicationProtectionContainerName, id.ReplicationProtectionContainerMappingName)
+	resp, err := clients.RecoveryServices.ContainerMappingClient.Get(ctx, *id)
 	if err != nil {
 		return nil, fmt.Errorf("reading site recovery protection container mapping (%s): %+v", id.String(), err)
 	}
 
-	return utils.Bool(resp.ID != nil), nil
+	model := resp.Model
+	if model == nil {
+		return nil, fmt.Errorf("reading site recovery protection container mapping (%s): model is nil", id.String())
+	}
+
+	return utils.Bool(model.Id != nil), nil
 }

--- a/internal/services/recoveryservices/site_recovery_protection_container_resource.go
+++ b/internal/services/recoveryservices/site_recovery_protection_container_resource.go
@@ -4,16 +4,15 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/recoveryservices/mgmt/2018-07-10/siterecovery"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/recoveryservices/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/recoveryservices/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceSiteRecoveryProtectionContainer() *pluginsdk.Resource {
@@ -23,7 +22,7 @@ func resourceSiteRecoveryProtectionContainer() *pluginsdk.Resource {
 		Update: nil,
 		Delete: resourceSiteRecoveryProtectionContainerDelete,
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
-			_, err := parse.ReplicationProtectionContainerID(id)
+			_, err := replicationprotectioncontainers.ParseReplicationProtectionContainerID(id)
 			return err
 		}),
 
@@ -60,93 +59,84 @@ func resourceSiteRecoveryProtectionContainer() *pluginsdk.Resource {
 }
 
 func resourceSiteRecoveryProtectionContainerCreate(d *pluginsdk.ResourceData, meta interface{}) error {
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	resGroup := d.Get("resource_group_name").(string)
 	vaultName := d.Get("recovery_vault_name").(string)
 	fabricName := d.Get("recovery_fabric_name").(string)
 	name := d.Get("name").(string)
 
-	client := meta.(*clients.Client).RecoveryServices.ProtectionContainerClient(resGroup, vaultName)
+	client := meta.(*clients.Client).RecoveryServices.ProtectionContainerClient
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
+	id := replicationprotectioncontainers.NewReplicationProtectionContainerID(subscriptionId, resGroup, vaultName, fabricName, name)
+
 	if d.IsNewResource() {
-		existing, err := client.Get(ctx, fabricName, name)
+		existing, err := client.Get(ctx, id)
 		if err != nil {
-			if !utils.ResponseWasNotFound(existing.Response) {
+			if !response.WasNotFound(existing.HttpResponse) {
 				return fmt.Errorf("checking for presence of existing site recovery protection container %s (fabric %s): %+v", name, fabricName, err)
 			}
 		}
 
-		if existing.ID != nil && *existing.ID != "" {
-			return tf.ImportAsExistsError("azurerm_site_recovery_protection_container", handleAzureSdkForGoBug2824(*existing.ID))
+		if existing.Model != nil && existing.Model.Id != nil && *existing.Model.Id != "" {
+			return tf.ImportAsExistsError("azurerm_site_recovery_protection_container", *existing.Model.Id)
 		}
 	}
 
-	parameters := siterecovery.CreateProtectionContainerInput{
-		Properties: &siterecovery.CreateProtectionContainerInputProperties{},
+	parameters := replicationprotectioncontainers.CreateProtectionContainerInput{
+		Properties: &replicationprotectioncontainers.CreateProtectionContainerInputProperties{},
 	}
 
-	future, err := client.Create(ctx, fabricName, name, parameters)
+	err := client.CreateThenPoll(ctx, id, parameters)
 	if err != nil {
 		return fmt.Errorf("creating site recovery protection container %s (fabric %s): %+v", name, fabricName, err)
 	}
-	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("creating site recovery protection container %s (fabric %s): %+v", name, fabricName, err)
-	}
 
-	resp, err := client.Get(ctx, fabricName, name)
-	if err != nil {
-		return fmt.Errorf("retrieving site recovery protection container %s (fabric %s): %+v", name, fabricName, err)
-	}
-
-	d.SetId(handleAzureSdkForGoBug2824(*resp.ID))
+	d.SetId(id.ID())
 
 	return resourceSiteRecoveryProtectionContainerRead(d, meta)
 }
 
 func resourceSiteRecoveryProtectionContainerRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	id, err := parse.ReplicationProtectionContainerID(d.Id())
+	id, err := replicationprotectioncontainers.ParseReplicationProtectionContainerID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	client := meta.(*clients.Client).RecoveryServices.ProtectionContainerClient(id.ResourceGroup, id.VaultName)
+	client := meta.(*clients.Client).RecoveryServices.ProtectionContainerClient
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	resp, err := client.Get(ctx, id.ReplicationFabricName, id.Name)
+	resp, err := client.Get(ctx, *id)
 	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
+		if response.WasNotFound(resp.HttpResponse) {
 			d.SetId("")
 			return nil
 		}
 		return fmt.Errorf("making Read request on site recovery protection container %s : %+v", id.String(), err)
 	}
 
-	d.Set("name", resp.Name)
-	d.Set("resource_group_name", id.ResourceGroup)
-	d.Set("recovery_vault_name", id.VaultName)
-	d.Set("recovery_fabric_name", id.ReplicationFabricName)
+	d.Set("name", id.ProtectionContainerName)
+	d.Set("resource_group_name", id.ResourceGroupName)
+	d.Set("recovery_vault_name", id.ResourceName)
+	d.Set("recovery_fabric_name", id.FabricName)
 	return nil
 }
 
 func resourceSiteRecoveryProtectionContainerDelete(d *pluginsdk.ResourceData, meta interface{}) error {
-	id, err := parse.ReplicationProtectionContainerID(d.Id())
+	id, err := replicationprotectioncontainers.ParseReplicationProtectionContainerID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	client := meta.(*clients.Client).RecoveryServices.ProtectionContainerClient(id.ResourceGroup, id.VaultName)
+	client := meta.(*clients.Client).RecoveryServices.ProtectionContainerClient
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	future, err := client.Delete(ctx, id.ReplicationFabricName, id.Name)
+	err = client.DeleteThenPoll(ctx, *id)
 	if err != nil {
 		return fmt.Errorf("deleting site recovery protection container %s : %+v", id.String(), err)
-	}
-
-	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting for deletion of site recovery protection container %s : %+v", id.String(), err)
 	}
 
 	return nil

--- a/internal/services/recoveryservices/site_recovery_protection_container_resource_test.go
+++ b/internal/services/recoveryservices/site_recovery_protection_container_resource_test.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/recoveryservices/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
@@ -67,15 +67,20 @@ resource "azurerm_site_recovery_protection_container" "test" {
 }
 
 func (t SiteRecoveryProtectionContainerResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
-	id, err := parse.ReplicationProtectionContainerID(state.ID)
+	id, err := replicationprotectioncontainers.ParseReplicationProtectionContainerID(state.ID)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := clients.RecoveryServices.ProtectionContainerClient(id.ResourceGroup, id.VaultName).Get(ctx, id.ReplicationFabricName, id.Name)
+	resp, err := clients.RecoveryServices.ProtectionContainerClient.Get(ctx, *id)
 	if err != nil {
 		return nil, fmt.Errorf("reading site recovery protection container (%s): %+v", id.String(), err)
 	}
 
-	return utils.Bool(resp.ID != nil), nil
+	model := resp.Model
+	if model == nil {
+		return nil, fmt.Errorf("reading site recovery protection container (%s): model is nil", id.String())
+	}
+
+	return utils.Bool(model.Id != nil), nil
 }

--- a/internal/services/recoveryservices/site_recovery_replicated_vm_resource_test.go
+++ b/internal/services/recoveryservices/site_recovery_replicated_vm_resource_test.go
@@ -31,6 +31,81 @@ func TestAccSiteRecoveryReplicatedVm_basic(t *testing.T) {
 	})
 }
 
+func TestAccSiteRecoveryReplicatedVm_withProximityPlacementGroup(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_site_recovery_replicated_vm", "test")
+	r := SiteRecoveryReplicatedVmResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.withProximityPlacementGroup(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccSiteRecoveryReplicatedVm_withBootDiagStorageAccount(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_site_recovery_replicated_vm", "test")
+	r := SiteRecoveryReplicatedVmResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.withBootDiagStorageAccount(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccSiteRecoveryReplicatedVm_withCapacityReservationGroup(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_site_recovery_replicated_vm", "test")
+	r := SiteRecoveryReplicatedVmResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.withCapacityReservationGroup(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccSiteRecoveryReplicatedVm_withVMSS(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_site_recovery_replicated_vm", "test")
+	r := SiteRecoveryReplicatedVmResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.withVMSS(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccSiteRecoveryReplicatedVm_withUnManagedDisks(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_site_recovery_replicated_vm", "test")
+	r := SiteRecoveryReplicatedVmResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.withUnManagedVmDisks(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccSiteRecoveryReplicatedVm_des(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_site_recovery_replicated_vm", "test")
 	r := SiteRecoveryReplicatedVmResource{}
@@ -1157,6 +1232,527 @@ resource "azurerm_site_recovery_replicated_vm" "test" {
   ]
 }
 `, data.RandomInteger, data.Locations.Primary, data.Locations.Secondary, data.RandomString)
+}
+
+func (r SiteRecoveryReplicatedVmResource) withProximityPlacementGroup(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_proximity_placement_group" "test" {
+  name                = "acctest-replication-%[2]d"
+  location            = azurerm_resource_group.test2.location
+  resource_group_name = azurerm_resource_group.test2.name
+}
+
+resource "azurerm_site_recovery_replicated_vm" "test" {
+  name                                      = "repl-%[2]d"
+  resource_group_name                       = azurerm_resource_group.test2.name
+  recovery_vault_name                       = azurerm_recovery_services_vault.test.name
+  source_vm_id                              = azurerm_virtual_machine.test.id
+  source_recovery_fabric_name               = azurerm_site_recovery_fabric.test1.name
+  recovery_replication_policy_id            = azurerm_site_recovery_replication_policy.test.id
+  source_recovery_protection_container_name = azurerm_site_recovery_protection_container.test1.name
+
+  target_resource_group_id                = azurerm_resource_group.test2.id
+  target_recovery_fabric_id               = azurerm_site_recovery_fabric.test2.id
+  target_recovery_protection_container_id = azurerm_site_recovery_protection_container.test2.id
+  target_proximity_placement_group_id     = azurerm_proximity_placement_group.test.id
+
+  managed_disk {
+    disk_id                    = azurerm_virtual_machine.test.storage_os_disk[0].managed_disk_id
+    staging_storage_account_id = azurerm_storage_account.test.id
+    target_resource_group_id   = azurerm_resource_group.test2.id
+    target_disk_type           = "Premium_LRS"
+    target_replica_disk_type   = "Premium_LRS"
+  }
+
+  network_interface {
+    source_network_interface_id   = azurerm_network_interface.test.id
+    target_subnet_name            = azurerm_subnet.test2.name
+    recovery_public_ip_address_id = azurerm_public_ip.test-recovery.id
+  }
+
+  depends_on = [
+    azurerm_site_recovery_protection_container_mapping.test,
+    azurerm_site_recovery_network_mapping.test,
+  ]
+}
+
+
+`, r.template(data), data.RandomInteger, data.Locations.Primary, data.Locations.Secondary)
+}
+
+func (r SiteRecoveryReplicatedVmResource) withBootDiagStorageAccount(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_storage_account" "test2" {
+  name                     = "acctre%[2]d"
+  location                 = azurerm_resource_group.test2.location
+  resource_group_name      = azurerm_resource_group.test2.name
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_site_recovery_replicated_vm" "test" {
+  name                                      = "repl-%[2]d"
+  resource_group_name                       = azurerm_resource_group.test2.name
+  recovery_vault_name                       = azurerm_recovery_services_vault.test.name
+  source_vm_id                              = azurerm_virtual_machine.test.id
+  source_recovery_fabric_name               = azurerm_site_recovery_fabric.test1.name
+  recovery_replication_policy_id            = azurerm_site_recovery_replication_policy.test.id
+  source_recovery_protection_container_name = azurerm_site_recovery_protection_container.test1.name
+
+  target_resource_group_id                = azurerm_resource_group.test2.id
+  target_recovery_fabric_id               = azurerm_site_recovery_fabric.test2.id
+  target_recovery_protection_container_id = azurerm_site_recovery_protection_container.test2.id
+  target_boot_diag_storage_account_id     = azurerm_storage_account.test2.id
+
+  managed_disk {
+    disk_id                    = azurerm_virtual_machine.test.storage_os_disk[0].managed_disk_id
+    staging_storage_account_id = azurerm_storage_account.test.id
+    target_resource_group_id   = azurerm_resource_group.test2.id
+    target_disk_type           = "Premium_LRS"
+    target_replica_disk_type   = "Premium_LRS"
+  }
+
+  network_interface {
+    source_network_interface_id   = azurerm_network_interface.test.id
+    target_subnet_name            = azurerm_subnet.test2.name
+    recovery_public_ip_address_id = azurerm_public_ip.test-recovery.id
+  }
+
+  depends_on = [
+    azurerm_site_recovery_protection_container_mapping.test,
+    azurerm_site_recovery_network_mapping.test,
+  ]
+}
+
+
+`, r.template(data), data.RandomInteger, data.Locations.Primary, data.Locations.Secondary)
+}
+
+func (r SiteRecoveryReplicatedVmResource) withUnManagedVmDisks(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy       = false
+      purge_soft_deleted_keys_on_destroy = false
+    }
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+}
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-recovery-%[1]d-1"
+  location = "%[2]s"
+}
+
+resource "azurerm_resource_group" "test2" {
+  name     = "acctestRG-recovery-%[1]d-2"
+  location = "%[3]s"
+}
+
+resource "azurerm_managed_disk" "test" {
+  name                 = "acctestd-%[1]d"
+  location             = azurerm_resource_group.test.location
+  resource_group_name  = azurerm_resource_group.test.name
+  storage_account_type = "Standard_LRS"
+  create_option        = "Empty"
+  disk_size_gb         = 1
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctvn-%[1]d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctsub-%[1]d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.2.0/24"]
+}
+
+resource "azurerm_network_interface" "test" {
+  name                = "acctni-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  ip_configuration {
+    name                          = "testconfiguration1"
+    subnet_id                     = azurerm_subnet.test.id
+    private_ip_address_allocation = "Dynamic"
+  }
+}
+
+
+resource "azurerm_virtual_machine" "test" {
+  name                  = "acctvm-%[1]d"
+  location              = azurerm_resource_group.test.location
+  resource_group_name   = azurerm_resource_group.test.name
+  network_interface_ids = [azurerm_network_interface.test.id]
+  vm_size               = "Standard_D1_v2"
+
+  delete_os_disk_on_termination    = true
+  delete_data_disks_on_termination = true
+
+  storage_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+
+  storage_os_disk {
+    name          = "myosdisk1"
+    vhd_uri       = "${azurerm_storage_account.test.primary_blob_endpoint}${azurerm_storage_container.test.name}/myosdisk1.vhd"
+    caching       = "ReadWrite"
+    create_option = "FromImage"
+  }
+
+  os_profile {
+    computer_name  = "hn%[1]d"
+    admin_username = "testadmin"
+    admin_password = "Password1234!"
+  }
+
+  os_profile_linux_config {
+    disable_password_authentication = false
+  }
+
+  tags = {
+    environment = "Production"
+    cost-center = "Ops"
+  }
+}
+
+resource "azurerm_recovery_services_vault" "test" {
+  name                = "acctest-vault-%[1]d"
+  location            = azurerm_resource_group.test2.location
+  resource_group_name = azurerm_resource_group.test2.name
+  sku                 = "Standard"
+
+  soft_delete_enabled = false
+}
+
+resource "azurerm_site_recovery_fabric" "test1" {
+  resource_group_name = azurerm_resource_group.test2.name
+  recovery_vault_name = azurerm_recovery_services_vault.test.name
+  name                = "acctest-fabric1-%[1]d"
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_site_recovery_fabric" "test2" {
+  resource_group_name = azurerm_resource_group.test2.name
+  recovery_vault_name = azurerm_recovery_services_vault.test.name
+  name                = "acctest-fabric2-%[1]d"
+  location            = azurerm_resource_group.test2.location
+  depends_on          = [azurerm_site_recovery_fabric.test1]
+}
+
+resource "azurerm_site_recovery_protection_container" "test1" {
+  resource_group_name  = azurerm_resource_group.test2.name
+  recovery_vault_name  = azurerm_recovery_services_vault.test.name
+  recovery_fabric_name = azurerm_site_recovery_fabric.test1.name
+  name                 = "acctest-protection-cont1-%[1]d"
+}
+
+resource "azurerm_site_recovery_protection_container" "test2" {
+  resource_group_name  = azurerm_resource_group.test2.name
+  recovery_vault_name  = azurerm_recovery_services_vault.test.name
+  recovery_fabric_name = azurerm_site_recovery_fabric.test2.name
+  name                 = "acctest-protection-cont2-%[1]d"
+}
+
+resource "azurerm_site_recovery_replication_policy" "test" {
+  resource_group_name                                  = azurerm_resource_group.test2.name
+  recovery_vault_name                                  = azurerm_recovery_services_vault.test.name
+  name                                                 = "acctest-policy-%[1]d"
+  recovery_point_retention_in_minutes                  = 24 * 60
+  application_consistent_snapshot_frequency_in_minutes = 4 * 60
+}
+
+resource "azurerm_site_recovery_protection_container_mapping" "test" {
+  resource_group_name                       = azurerm_resource_group.test2.name
+  recovery_vault_name                       = azurerm_recovery_services_vault.test.name
+  recovery_fabric_name                      = azurerm_site_recovery_fabric.test1.name
+  recovery_source_protection_container_name = azurerm_site_recovery_protection_container.test1.name
+  recovery_target_protection_container_id   = azurerm_site_recovery_protection_container.test2.id
+  recovery_replication_policy_id            = azurerm_site_recovery_replication_policy.test.id
+  name                                      = "mapping-%[1]d"
+}
+
+resource "azurerm_virtual_network" "test2" {
+  name                = "net-%[1]d-2"
+  resource_group_name = azurerm_resource_group.test2.name
+  address_space       = ["192.168.2.0/24"]
+  location            = azurerm_site_recovery_fabric.test2.location
+}
+
+resource "azurerm_site_recovery_network_mapping" "test" {
+  resource_group_name         = azurerm_resource_group.test2.name
+  recovery_vault_name         = azurerm_recovery_services_vault.test.name
+  name                        = "mapping-%[1]d"
+  source_recovery_fabric_name = azurerm_site_recovery_fabric.test1.name
+  target_recovery_fabric_name = azurerm_site_recovery_fabric.test2.name
+  source_network_id           = azurerm_virtual_network.test.id
+  target_network_id           = azurerm_virtual_network.test2.id
+}
+
+resource "azurerm_public_ip" "test-recovery" {
+  name                = "pubip%[1]d-recovery"
+  allocation_method   = "Static"
+  location            = azurerm_resource_group.test2.location
+  resource_group_name = azurerm_resource_group.test2.name
+  sku                 = "Basic"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "acct%[1]d"
+  location                 = azurerm_resource_group.test.location
+  resource_group_name      = azurerm_resource_group.test.name
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_storage_container" "test" {
+  name                  = "vhds"
+  storage_account_name  = azurerm_storage_account.test.name
+  container_access_type = "blob"
+}
+
+resource "azurerm_storage_account" "test2" {
+  name                     = "acctre%[1]d"
+  location                 = azurerm_resource_group.test2.location
+  resource_group_name      = azurerm_resource_group.test.name
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+
+resource "azurerm_site_recovery_replicated_vm" "test" {
+  name                                      = "repl-%[1]d"
+  resource_group_name                       = azurerm_resource_group.test2.name
+  recovery_vault_name                       = azurerm_recovery_services_vault.test.name
+  source_vm_id                              = azurerm_virtual_machine.test.id
+  source_recovery_fabric_name               = azurerm_site_recovery_fabric.test1.name
+  recovery_replication_policy_id            = azurerm_site_recovery_replication_policy.test.id
+  source_recovery_protection_container_name = azurerm_site_recovery_protection_container.test1.name
+
+  target_resource_group_id                = azurerm_resource_group.test2.id
+  target_recovery_fabric_id               = azurerm_site_recovery_fabric.test2.id
+  target_recovery_protection_container_id = azurerm_site_recovery_protection_container.test2.id
+
+  unmanaged_disk {
+    disk_uri                   = azurerm_virtual_machine.test.storage_os_disk[0].vhd_uri
+    staging_storage_account_id = azurerm_storage_account.test.id
+    target_storage_account_id  = azurerm_storage_account.test2.id
+  }
+
+  depends_on = [
+    azurerm_site_recovery_protection_container_mapping.test,
+    azurerm_site_recovery_network_mapping.test,
+  ]
+}
+`, data.RandomInteger, data.Locations.Primary, data.Locations.Secondary)
+}
+
+func (r SiteRecoveryReplicatedVmResource) withCapacityReservationGroup(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_capacity_reservation_group" "test" {
+  name                = "acctest-crg-%[2]d"
+  location            = azurerm_resource_group.test2.location
+  resource_group_name = azurerm_resource_group.test2.name
+}
+
+resource "azurerm_capacity_reservation" "test" {
+  name                          = "acctest-ccr-%[2]d"
+  capacity_reservation_group_id = azurerm_capacity_reservation_group.test.id
+
+  sku {
+    name     = "Standard_B1s"
+    capacity = 1
+  }
+}
+
+resource "azurerm_site_recovery_replicated_vm" "test" {
+  name                                      = "repl-%[2]d"
+  resource_group_name                       = azurerm_resource_group.test2.name
+  recovery_vault_name                       = azurerm_recovery_services_vault.test.name
+  source_vm_id                              = azurerm_virtual_machine.test.id
+  source_recovery_fabric_name               = azurerm_site_recovery_fabric.test1.name
+  recovery_replication_policy_id            = azurerm_site_recovery_replication_policy.test.id
+  source_recovery_protection_container_name = azurerm_site_recovery_protection_container.test1.name
+
+  target_resource_group_id                = azurerm_resource_group.test2.id
+  target_recovery_fabric_id               = azurerm_site_recovery_fabric.test2.id
+  target_recovery_protection_container_id = azurerm_site_recovery_protection_container.test2.id
+  target_capacity_reservation_group_id    = azurerm_capacity_reservation_group.test.id
+
+  managed_disk {
+    disk_id                    = azurerm_virtual_machine.test.storage_os_disk[0].managed_disk_id
+    staging_storage_account_id = azurerm_storage_account.test.id
+    target_resource_group_id   = azurerm_resource_group.test2.id
+    target_disk_type           = "Premium_LRS"
+    target_replica_disk_type   = "Premium_LRS"
+  }
+
+  network_interface {
+    source_network_interface_id   = azurerm_network_interface.test.id
+    target_subnet_name            = azurerm_subnet.test2.name
+    recovery_public_ip_address_id = azurerm_public_ip.test-recovery.id
+  }
+
+  depends_on = [
+    azurerm_site_recovery_protection_container_mapping.test,
+    azurerm_site_recovery_network_mapping.test,
+    azurerm_capacity_reservation.test,
+  ]
+}
+
+`, r.template(data), data.RandomInteger, data.Locations.Primary, data.Locations.Secondary)
+}
+
+func (r SiteRecoveryReplicatedVmResource) withVMSS(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_orchestrated_virtual_machine_scale_set" "test" {
+  name                = "acctestOVMSS-%[2]d"
+  location            = azurerm_resource_group.test2.location
+  resource_group_name = azurerm_resource_group.test2.name
+
+  sku_name                    = "Standard_B1s"
+  instances                   = 2
+  platform_fault_domain_count = 2
+
+  network_interface {
+    name    = "TestNetworkProfile-%[2]d"
+    primary = true
+
+    ip_configuration {
+      name      = "TestIPConfiguration"
+      primary   = true
+      subnet_id = azurerm_subnet.test2.id
+
+      public_ip_address {
+        name                    = "TestPublicIPConfiguration"
+        domain_name_label       = "test-domain-label"
+        idle_timeout_in_minutes = 4
+      }
+    }
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+
+  os_profile {
+    linux_configuration {
+      computer_name_prefix = "testvm-%[2]d"
+      admin_username       = "myadmin"
+      admin_password       = "Passwword1234"
+
+      disable_password_authentication = false
+    }
+  }
+
+}
+
+resource "azurerm_site_recovery_replicated_vm" "test" {
+  name                                      = "repl-%[2]d"
+  resource_group_name                       = azurerm_resource_group.test2.name
+  recovery_vault_name                       = azurerm_recovery_services_vault.test.name
+  source_vm_id                              = azurerm_virtual_machine.test.id
+  source_recovery_fabric_name               = azurerm_site_recovery_fabric.test1.name
+  recovery_replication_policy_id            = azurerm_site_recovery_replication_policy.test.id
+  source_recovery_protection_container_name = azurerm_site_recovery_protection_container.test1.name
+
+  target_resource_group_id                = azurerm_resource_group.test2.id
+  target_recovery_fabric_id               = azurerm_site_recovery_fabric.test2.id
+  target_recovery_protection_container_id = azurerm_site_recovery_protection_container.test2.id
+  target_virtual_machine_scale_set_id     = azurerm_orchestrated_virtual_machine_scale_set.test.id
+
+  managed_disk {
+    disk_id                    = azurerm_virtual_machine.test.storage_os_disk[0].managed_disk_id
+    staging_storage_account_id = azurerm_storage_account.test.id
+    target_resource_group_id   = azurerm_resource_group.test2.id
+    target_disk_type           = "Premium_LRS"
+    target_replica_disk_type   = "Premium_LRS"
+  }
+
+  network_interface {
+    source_network_interface_id   = azurerm_network_interface.test.id
+    target_subnet_name            = azurerm_subnet.test2.name
+    recovery_public_ip_address_id = azurerm_public_ip.test-recovery.id
+  }
+
+  depends_on = [
+    azurerm_site_recovery_protection_container_mapping.test,
+    azurerm_site_recovery_network_mapping.test,
+  ]
+}
+
+
+`, r.template(data), data.RandomInteger, data.RandomString)
+}
+
+func (r SiteRecoveryReplicatedVmResource) withMultiVmGroup(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_site_recovery_replicated_vm" "test" {
+  name                                      = "repl-%[2]d"
+  resource_group_name                       = azurerm_resource_group.test2.name
+  recovery_vault_name                       = azurerm_recovery_services_vault.test.name
+  source_vm_id                              = azurerm_virtual_machine.test.id
+  source_recovery_fabric_name               = azurerm_site_recovery_fabric.test1.name
+  recovery_replication_policy_id            = azurerm_site_recovery_replication_policy.test.id
+  source_recovery_protection_container_name = azurerm_site_recovery_protection_container.test1.name
+  multi_vm_group_name                       = "accmultivmgroup"
+
+  target_resource_group_id                = azurerm_resource_group.test2.id
+  target_recovery_fabric_id               = azurerm_site_recovery_fabric.test2.id
+  target_recovery_protection_container_id = azurerm_site_recovery_protection_container.test2.id
+
+  managed_disk {
+    disk_id                    = azurerm_virtual_machine.test.storage_os_disk[0].managed_disk_id
+    staging_storage_account_id = azurerm_storage_account.test.id
+    target_resource_group_id   = azurerm_resource_group.test2.id
+    target_disk_type           = "Premium_LRS"
+    target_replica_disk_type   = "Premium_LRS"
+  }
+
+  network_interface {
+    source_network_interface_id   = azurerm_network_interface.test.id
+    target_subnet_name            = azurerm_subnet.test2.name
+    recovery_public_ip_address_id = azurerm_public_ip.test-recovery.id
+  }
+
+  depends_on = [
+    azurerm_site_recovery_protection_container_mapping.test,
+    azurerm_site_recovery_network_mapping.test,
+  ]
+}
+`, r.template(data), data.RandomInteger)
 }
 
 func (r SiteRecoveryReplicatedVmResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {

--- a/internal/services/recoveryservices/site_recovery_replication_policy_resource.go
+++ b/internal/services/recoveryservices/site_recovery_replication_policy_resource.go
@@ -5,8 +5,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/recoveryservices/mgmt/2018-07-10/siterecovery"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/recoveryservices/parse"
@@ -14,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func resourceSiteRecoveryReplicationPolicy() *pluginsdk.Resource {
@@ -68,143 +68,128 @@ func resourceSiteRecoveryReplicationPolicy() *pluginsdk.Resource {
 }
 
 func resourceSiteRecoveryReplicationPolicyCreate(d *pluginsdk.ResourceData, meta interface{}) error {
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	resGroup := d.Get("resource_group_name").(string)
 	vaultName := d.Get("recovery_vault_name").(string)
 	name := d.Get("name").(string)
 
-	client := meta.(*clients.Client).RecoveryServices.ReplicationPoliciesClient(resGroup, vaultName)
+	client := meta.(*clients.Client).RecoveryServices.ReplicationPoliciesClient
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
+	id := replicationpolicies.NewReplicationPolicyID(subscriptionId, resGroup, vaultName, name)
+
 	if d.IsNewResource() {
-		existing, err := client.Get(ctx, name)
+		existing, err := client.Get(ctx, id)
 		if err != nil {
 			// NOTE: Bad Request due to https://github.com/Azure/azure-rest-api-specs/issues/12759
-			if !utils.ResponseWasNotFound(existing.Response) && !utils.ResponseWasBadRequestWithServiceCode(existing.Response, err, "SubscriptionIdNotRegisteredWithSrs") {
+			if !response.WasNotFound(existing.HttpResponse) && !wasBadRequestWithNotExist(existing.HttpResponse, err) {
 				return fmt.Errorf("checking for presence of existing site recovery replication policy %s: %+v", name, err)
 			}
 		}
 
-		if existing.ID != nil && *existing.ID != "" {
-			return tf.ImportAsExistsError("azurerm_site_recovery_replication_policy", handleAzureSdkForGoBug2824(*existing.ID))
+		if existing.Model != nil && existing.Model.Id != nil && *existing.Model.Id != "" {
+			return tf.ImportAsExistsError("azurerm_site_recovery_replication_policy", *existing.Model.Id)
 		}
 	}
 
-	recoveryPoint := int32(d.Get("recovery_point_retention_in_minutes").(int))
-	appConsitency := int32(d.Get("application_consistent_snapshot_frequency_in_minutes").(int))
-	parameters := siterecovery.CreatePolicyInput{
-		Properties: &siterecovery.CreatePolicyInputProperties{
-			ProviderSpecificInput: &siterecovery.A2APolicyCreationInput{
+	recoveryPoint := int64(d.Get("recovery_point_retention_in_minutes").(int))
+	appConsistency := int64(d.Get("application_consistent_snapshot_frequency_in_minutes").(int))
+	parameters := replicationpolicies.CreatePolicyInput{
+		Properties: &replicationpolicies.CreatePolicyInputProperties{
+			ProviderSpecificInput: &replicationpolicies.A2APolicyCreationInput{
 				RecoveryPointHistory:            &recoveryPoint,
-				AppConsistentFrequencyInMinutes: &appConsitency,
-				MultiVMSyncStatus:               siterecovery.Enable,
-				InstanceType:                    siterecovery.InstanceTypeBasicPolicyProviderSpecificInputInstanceTypeA2A,
+				AppConsistentFrequencyInMinutes: &appConsistency,
+				MultiVmSyncStatus:               replicationpolicies.SetMultiVmSyncStatusEnable,
 			},
 		},
 	}
-	future, err := client.Create(ctx, name, parameters)
+	err := client.CreateThenPoll(ctx, id, parameters)
 	if err != nil {
 		return fmt.Errorf("creating site recovery replication policy %s (vault %s): %+v", name, vaultName, err)
 	}
-	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("creating site recovery replication policy %s (vault %s): %+v", name, vaultName, err)
-	}
 
-	resp, err := client.Get(ctx, name)
-	if err != nil {
-		return fmt.Errorf("retrieving site recovery replication policy %s (vault %s): %+v", name, vaultName, err)
-	}
-
-	d.SetId(handleAzureSdkForGoBug2824(*resp.ID))
+	d.SetId(id.ID())
 
 	return resourceSiteRecoveryReplicationPolicyRead(d, meta)
 }
 
 func resourceSiteRecoveryReplicationPolicyUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	resGroup := d.Get("resource_group_name").(string)
 	vaultName := d.Get("recovery_vault_name").(string)
 	name := d.Get("name").(string)
 
-	client := meta.(*clients.Client).RecoveryServices.ReplicationPoliciesClient(resGroup, vaultName)
+	client := meta.(*clients.Client).RecoveryServices.ReplicationPoliciesClient
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	recoveryPoint := int32(d.Get("recovery_point_retention_in_minutes").(int))
-	appConsitency := int32(d.Get("application_consistent_snapshot_frequency_in_minutes").(int))
-	parameters := siterecovery.UpdatePolicyInput{
-		Properties: &siterecovery.UpdatePolicyInputProperties{
-			ReplicationProviderSettings: &siterecovery.A2APolicyCreationInput{
+	id := replicationpolicies.NewReplicationPolicyID(subscriptionId, resGroup, vaultName, name)
+
+	recoveryPoint := int64(d.Get("recovery_point_retention_in_minutes").(int))
+	appConsistency := int64(d.Get("application_consistent_snapshot_frequency_in_minutes").(int))
+	parameters := replicationpolicies.UpdatePolicyInput{
+		Properties: &replicationpolicies.UpdatePolicyInputProperties{
+			ReplicationProviderSettings: &replicationpolicies.A2APolicyCreationInput{
 				RecoveryPointHistory:            &recoveryPoint,
-				AppConsistentFrequencyInMinutes: &appConsitency,
-				MultiVMSyncStatus:               siterecovery.Enable,
-				InstanceType:                    siterecovery.InstanceTypeBasicPolicyProviderSpecificInputInstanceTypeA2A,
+				AppConsistentFrequencyInMinutes: &appConsistency,
+				MultiVmSyncStatus:               replicationpolicies.SetMultiVmSyncStatusEnable,
 			},
 		},
 	}
-	future, err := client.Update(ctx, name, parameters)
+	err := client.UpdateThenPoll(ctx, id, parameters)
 	if err != nil {
 		return fmt.Errorf("updating site recovery replication policy %s (vault %s): %+v", name, vaultName, err)
 	}
-	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("updating site recovery replication policy %s (vault %s): %+v", name, vaultName, err)
-	}
-
-	resp, err := client.Get(ctx, name)
-	if err != nil {
-		return fmt.Errorf("retrieving site recovery replication policy %s (vault %s): %+v", name, vaultName, err)
-	}
-
-	d.SetId(handleAzureSdkForGoBug2824(*resp.ID))
 
 	return resourceSiteRecoveryReplicationPolicyRead(d, meta)
 }
 
 func resourceSiteRecoveryReplicationPolicyRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	id, err := parse.ReplicationPolicyID(d.Id())
+	id, err := replicationpolicies.ParseReplicationPolicyID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	client := meta.(*clients.Client).RecoveryServices.ReplicationPoliciesClient(id.ResourceGroup, id.VaultName)
+	client := meta.(*clients.Client).RecoveryServices.ReplicationPoliciesClient
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	resp, err := client.Get(ctx, id.Name)
+	resp, err := client.Get(ctx, *id)
 	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
+		if response.WasNotFound(resp.HttpResponse) {
 			d.SetId("")
 			return nil
 		}
 		return fmt.Errorf("making Read request on site recovery replication policy %s : %+v", id.String(), err)
 	}
 
-	d.Set("name", resp.Name)
-	d.Set("resource_group_name", id.ResourceGroup)
-	d.Set("recovery_vault_name", id.VaultName)
-	if a2APolicyDetails, isA2A := resp.Properties.ProviderSpecificDetails.AsA2APolicyDetails(); isA2A {
-		d.Set("recovery_point_retention_in_minutes", a2APolicyDetails.RecoveryPointHistory)
-		d.Set("application_consistent_snapshot_frequency_in_minutes", a2APolicyDetails.AppConsistentFrequencyInMinutes)
+	d.Set("name", id.PolicyName)
+	d.Set("resource_group_name", id.ResourceGroupName)
+	d.Set("recovery_vault_name", id.ResourceName)
+
+	if model := resp.Model; model != nil {
+		if a2APolicyDetails, isA2A := expandA2APolicyDetail(resp.Model); isA2A {
+			d.Set("recovery_point_retention_in_minutes", a2APolicyDetails.RecoveryPointHistory)
+			d.Set("application_consistent_snapshot_frequency_in_minutes", a2APolicyDetails.AppConsistentFrequencyInMinutes)
+		}
 	}
 	return nil
 }
 
 func resourceSiteRecoveryReplicationPolicyDelete(d *pluginsdk.ResourceData, meta interface{}) error {
-	id, err := parse.ReplicationPolicyID(d.Id())
+	id, err := replicationpolicies.ParseReplicationPolicyID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	client := meta.(*clients.Client).RecoveryServices.ReplicationPoliciesClient(id.ResourceGroup, id.VaultName)
+	client := meta.(*clients.Client).RecoveryServices.ReplicationPoliciesClient
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	future, err := client.Delete(ctx, id.Name)
+	err = client.DeleteThenPoll(ctx, *id)
 	if err != nil {
 		return fmt.Errorf("deleting site recovery replication policy %s : %+v", id.String(), err)
-	}
-
-	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting for deletion of site recovery replication policy %s : %+v", id.String(), err)
 	}
 
 	return nil
@@ -219,4 +204,18 @@ func resourceSiteRecoveryReplicationPolicyCustomDiff(ctx context.Context, d *plu
 	}
 
 	return nil
+}
+
+func expandA2APolicyDetail(input *replicationpolicies.Policy) (out *replicationpolicies.A2APolicyDetails, isA2A bool) {
+	if input.Properties == nil {
+		return nil, false
+	}
+	if input.Properties.ProviderSpecificDetails == nil {
+		return nil, false
+	}
+	detail, isA2A := input.Properties.ProviderSpecificDetails.(replicationpolicies.A2APolicyDetails)
+	if isA2A {
+		out = &detail
+	}
+	return
 }

--- a/internal/services/recoveryservices/site_recovery_replication_policy_resource_test.go
+++ b/internal/services/recoveryservices/site_recovery_replication_policy_resource_test.go
@@ -6,10 +6,11 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies"
+
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/recoveryservices/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
@@ -91,15 +92,20 @@ resource "azurerm_site_recovery_replication_policy" "test" {
 }
 
 func (t SiteRecoveryReplicationPolicyResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
-	id, err := parse.ReplicationPolicyID(state.ID)
+	id, err := replicationpolicies.ParseReplicationPolicyID(state.ID)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := clients.RecoveryServices.ReplicationPoliciesClient(id.ResourceGroup, id.VaultName).Get(ctx, id.Name)
+	resp, err := clients.RecoveryServices.ReplicationPoliciesClient.Get(ctx, *id)
 	if err != nil {
 		return nil, fmt.Errorf("reading site recovery replication policy (%s): %+v", id.String(), err)
 	}
 
-	return utils.Bool(resp.ID != nil), nil
+	model := resp.Model
+	if model == nil {
+		return nil, fmt.Errorf("reading site recovery replication policy (%s): model is nil", id.String())
+	}
+
+	return utils.Bool(model.Id != nil), nil
 }

--- a/utils/response.go
+++ b/utils/response.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/azure"
 )
 
 func ResponseWasNotFound(resp autorest.Response) bool {
@@ -48,27 +47,4 @@ func ResponseWasStatusCode(resp autorest.Response, statusCode int) bool { // nol
 	}
 
 	return false
-}
-
-func ResponseWasBadRequestWithServiceCode(resp autorest.Response, err error, serviceCode string) bool {
-	e, ok := err.(autorest.DetailedError)
-	if !ok {
-		return false
-	}
-
-	r, ok := e.Original.(*azure.RequestError)
-	if !ok {
-		return false
-	}
-
-	if r.ServiceError == nil || len(r.ServiceError.Details) == 0 {
-		return false
-	}
-
-	sc, ok := r.ServiceError.Details[0]["code"]
-	if !ok {
-		return false
-	}
-
-	return ResponseWasStatusCode(resp, http.StatusBadRequest) && sc == serviceCode
 }

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/README.md
@@ -1,0 +1,152 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics` Documentation
+
+The `replicationfabrics` SDK allows for interaction with the Azure Resource Manager Service `recoveryservicessiterecovery` (API Version `2022-10-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics"
+```
+
+
+### Client Initialization
+
+```go
+client := replicationfabrics.NewReplicationFabricsClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `ReplicationFabricsClient.CheckConsistency`
+
+```go
+ctx := context.TODO()
+id := replicationfabrics.NewReplicationFabricID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue", "fabricValue")
+
+if err := client.CheckConsistencyThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `ReplicationFabricsClient.Create`
+
+```go
+ctx := context.TODO()
+id := replicationfabrics.NewReplicationFabricID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue", "fabricValue")
+
+payload := replicationfabrics.FabricCreationInput{
+	// ...
+}
+
+
+if err := client.CreateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `ReplicationFabricsClient.Delete`
+
+```go
+ctx := context.TODO()
+id := replicationfabrics.NewReplicationFabricID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue", "fabricValue")
+
+if err := client.DeleteThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `ReplicationFabricsClient.Get`
+
+```go
+ctx := context.TODO()
+id := replicationfabrics.NewReplicationFabricID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue", "fabricValue")
+
+read, err := client.Get(ctx, id, replicationfabrics.DefaultGetOperationOptions())
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `ReplicationFabricsClient.List`
+
+```go
+ctx := context.TODO()
+id := replicationfabrics.NewVaultID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue")
+
+// alternatively `client.List(ctx, id)` can be used to do batched pagination
+items, err := client.ListComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `ReplicationFabricsClient.MigrateToAad`
+
+```go
+ctx := context.TODO()
+id := replicationfabrics.NewReplicationFabricID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue", "fabricValue")
+
+if err := client.MigrateToAadThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `ReplicationFabricsClient.Purge`
+
+```go
+ctx := context.TODO()
+id := replicationfabrics.NewReplicationFabricID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue", "fabricValue")
+
+if err := client.PurgeThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `ReplicationFabricsClient.ReassociateGateway`
+
+```go
+ctx := context.TODO()
+id := replicationfabrics.NewReplicationFabricID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue", "fabricValue")
+
+payload := replicationfabrics.FailoverProcessServerRequest{
+	// ...
+}
+
+
+if err := client.ReassociateGatewayThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `ReplicationFabricsClient.RenewCertificate`
+
+```go
+ctx := context.TODO()
+id := replicationfabrics.NewReplicationFabricID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue", "fabricValue")
+
+payload := replicationfabrics.RenewCertificateInput{
+	// ...
+}
+
+
+if err := client.RenewCertificateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/client.go
@@ -1,0 +1,18 @@
+package replicationfabrics
+
+import "github.com/Azure/go-autorest/autorest"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ReplicationFabricsClient struct {
+	Client  autorest.Client
+	baseUri string
+}
+
+func NewReplicationFabricsClientWithBaseURI(endpoint string) ReplicationFabricsClient {
+	return ReplicationFabricsClient{
+		Client:  autorest.NewClientWithUserAgent(userAgent()),
+		baseUri: endpoint,
+	}
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/constants.go
@@ -1,0 +1,139 @@
+package replicationfabrics
+
+import "strings"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AgentVersionStatus string
+
+const (
+	AgentVersionStatusDeprecated             AgentVersionStatus = "Deprecated"
+	AgentVersionStatusNotSupported           AgentVersionStatus = "NotSupported"
+	AgentVersionStatusSecurityUpdateRequired AgentVersionStatus = "SecurityUpdateRequired"
+	AgentVersionStatusSupported              AgentVersionStatus = "Supported"
+	AgentVersionStatusUpdateRequired         AgentVersionStatus = "UpdateRequired"
+)
+
+func PossibleValuesForAgentVersionStatus() []string {
+	return []string{
+		string(AgentVersionStatusDeprecated),
+		string(AgentVersionStatusNotSupported),
+		string(AgentVersionStatusSecurityUpdateRequired),
+		string(AgentVersionStatusSupported),
+		string(AgentVersionStatusUpdateRequired),
+	}
+}
+
+func parseAgentVersionStatus(input string) (*AgentVersionStatus, error) {
+	vals := map[string]AgentVersionStatus{
+		"deprecated":             AgentVersionStatusDeprecated,
+		"notsupported":           AgentVersionStatusNotSupported,
+		"securityupdaterequired": AgentVersionStatusSecurityUpdateRequired,
+		"supported":              AgentVersionStatusSupported,
+		"updaterequired":         AgentVersionStatusUpdateRequired,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := AgentVersionStatus(input)
+	return &out, nil
+}
+
+type HealthErrorCustomerResolvability string
+
+const (
+	HealthErrorCustomerResolvabilityAllowed    HealthErrorCustomerResolvability = "Allowed"
+	HealthErrorCustomerResolvabilityNotAllowed HealthErrorCustomerResolvability = "NotAllowed"
+)
+
+func PossibleValuesForHealthErrorCustomerResolvability() []string {
+	return []string{
+		string(HealthErrorCustomerResolvabilityAllowed),
+		string(HealthErrorCustomerResolvabilityNotAllowed),
+	}
+}
+
+func parseHealthErrorCustomerResolvability(input string) (*HealthErrorCustomerResolvability, error) {
+	vals := map[string]HealthErrorCustomerResolvability{
+		"allowed":    HealthErrorCustomerResolvabilityAllowed,
+		"notallowed": HealthErrorCustomerResolvabilityNotAllowed,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := HealthErrorCustomerResolvability(input)
+	return &out, nil
+}
+
+type ProtectionHealth string
+
+const (
+	ProtectionHealthCritical ProtectionHealth = "Critical"
+	ProtectionHealthNone     ProtectionHealth = "None"
+	ProtectionHealthNormal   ProtectionHealth = "Normal"
+	ProtectionHealthWarning  ProtectionHealth = "Warning"
+)
+
+func PossibleValuesForProtectionHealth() []string {
+	return []string{
+		string(ProtectionHealthCritical),
+		string(ProtectionHealthNone),
+		string(ProtectionHealthNormal),
+		string(ProtectionHealthWarning),
+	}
+}
+
+func parseProtectionHealth(input string) (*ProtectionHealth, error) {
+	vals := map[string]ProtectionHealth{
+		"critical": ProtectionHealthCritical,
+		"none":     ProtectionHealthNone,
+		"normal":   ProtectionHealthNormal,
+		"warning":  ProtectionHealthWarning,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ProtectionHealth(input)
+	return &out, nil
+}
+
+type RcmComponentStatus string
+
+const (
+	RcmComponentStatusCritical RcmComponentStatus = "Critical"
+	RcmComponentStatusHealthy  RcmComponentStatus = "Healthy"
+	RcmComponentStatusUnknown  RcmComponentStatus = "Unknown"
+	RcmComponentStatusWarning  RcmComponentStatus = "Warning"
+)
+
+func PossibleValuesForRcmComponentStatus() []string {
+	return []string{
+		string(RcmComponentStatusCritical),
+		string(RcmComponentStatusHealthy),
+		string(RcmComponentStatusUnknown),
+		string(RcmComponentStatusWarning),
+	}
+}
+
+func parseRcmComponentStatus(input string) (*RcmComponentStatus, error) {
+	vals := map[string]RcmComponentStatus{
+		"critical": RcmComponentStatusCritical,
+		"healthy":  RcmComponentStatusHealthy,
+		"unknown":  RcmComponentStatusUnknown,
+		"warning":  RcmComponentStatusWarning,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := RcmComponentStatus(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/id_replicationfabric.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/id_replicationfabric.go
@@ -1,0 +1,137 @@
+package replicationfabrics
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = ReplicationFabricId{}
+
+// ReplicationFabricId is a struct representing the Resource ID for a Replication Fabric
+type ReplicationFabricId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	ResourceName      string
+	FabricName        string
+}
+
+// NewReplicationFabricID returns a new ReplicationFabricId struct
+func NewReplicationFabricID(subscriptionId string, resourceGroupName string, resourceName string, fabricName string) ReplicationFabricId {
+	return ReplicationFabricId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		ResourceName:      resourceName,
+		FabricName:        fabricName,
+	}
+}
+
+// ParseReplicationFabricID parses 'input' into a ReplicationFabricId
+func ParseReplicationFabricID(input string) (*ReplicationFabricId, error) {
+	parser := resourceids.NewParserFromResourceIdType(ReplicationFabricId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := ReplicationFabricId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceName, ok = parsed.Parsed["resourceName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceName' was not found in the resource id %q", input)
+	}
+
+	if id.FabricName, ok = parsed.Parsed["fabricName"]; !ok {
+		return nil, fmt.Errorf("the segment 'fabricName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ParseReplicationFabricIDInsensitively parses 'input' case-insensitively into a ReplicationFabricId
+// note: this method should only be used for API response data and not user input
+func ParseReplicationFabricIDInsensitively(input string) (*ReplicationFabricId, error) {
+	parser := resourceids.NewParserFromResourceIdType(ReplicationFabricId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := ReplicationFabricId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceName, ok = parsed.Parsed["resourceName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceName' was not found in the resource id %q", input)
+	}
+
+	if id.FabricName, ok = parsed.Parsed["fabricName"]; !ok {
+		return nil, fmt.Errorf("the segment 'fabricName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ValidateReplicationFabricID checks that 'input' can be parsed as a Replication Fabric ID
+func ValidateReplicationFabricID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseReplicationFabricID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Replication Fabric ID
+func (id ReplicationFabricId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.RecoveryServices/vaults/%s/replicationFabrics/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.ResourceName, id.FabricName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Replication Fabric ID
+func (id ReplicationFabricId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftRecoveryServices", "Microsoft.RecoveryServices", "Microsoft.RecoveryServices"),
+		resourceids.StaticSegment("staticVaults", "vaults", "vaults"),
+		resourceids.UserSpecifiedSegment("resourceName", "resourceValue"),
+		resourceids.StaticSegment("staticReplicationFabrics", "replicationFabrics", "replicationFabrics"),
+		resourceids.UserSpecifiedSegment("fabricName", "fabricValue"),
+	}
+}
+
+// String returns a human-readable description of this Replication Fabric ID
+func (id ReplicationFabricId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Resource Name: %q", id.ResourceName),
+		fmt.Sprintf("Fabric Name: %q", id.FabricName),
+	}
+	return fmt.Sprintf("Replication Fabric (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/id_vault.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/id_vault.go
@@ -1,0 +1,124 @@
+package replicationfabrics
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = VaultId{}
+
+// VaultId is a struct representing the Resource ID for a Vault
+type VaultId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	ResourceName      string
+}
+
+// NewVaultID returns a new VaultId struct
+func NewVaultID(subscriptionId string, resourceGroupName string, resourceName string) VaultId {
+	return VaultId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		ResourceName:      resourceName,
+	}
+}
+
+// ParseVaultID parses 'input' into a VaultId
+func ParseVaultID(input string) (*VaultId, error) {
+	parser := resourceids.NewParserFromResourceIdType(VaultId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := VaultId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceName, ok = parsed.Parsed["resourceName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ParseVaultIDInsensitively parses 'input' case-insensitively into a VaultId
+// note: this method should only be used for API response data and not user input
+func ParseVaultIDInsensitively(input string) (*VaultId, error) {
+	parser := resourceids.NewParserFromResourceIdType(VaultId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := VaultId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceName, ok = parsed.Parsed["resourceName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ValidateVaultID checks that 'input' can be parsed as a Vault ID
+func ValidateVaultID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseVaultID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Vault ID
+func (id VaultId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.RecoveryServices/vaults/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.ResourceName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Vault ID
+func (id VaultId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftRecoveryServices", "Microsoft.RecoveryServices", "Microsoft.RecoveryServices"),
+		resourceids.StaticSegment("staticVaults", "vaults", "vaults"),
+		resourceids.UserSpecifiedSegment("resourceName", "resourceValue"),
+	}
+}
+
+// String returns a human-readable description of this Vault ID
+func (id VaultId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Resource Name: %q", id.ResourceName),
+	}
+	return fmt.Sprintf("Vault (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/method_checkconsistency_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/method_checkconsistency_autorest.go
@@ -1,0 +1,78 @@
+package replicationfabrics
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CheckConsistencyOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// CheckConsistency ...
+func (c ReplicationFabricsClient) CheckConsistency(ctx context.Context, id ReplicationFabricId) (result CheckConsistencyOperationResponse, err error) {
+	req, err := c.preparerForCheckConsistency(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationfabrics.ReplicationFabricsClient", "CheckConsistency", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForCheckConsistency(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationfabrics.ReplicationFabricsClient", "CheckConsistency", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// CheckConsistencyThenPoll performs CheckConsistency then polls until it's completed
+func (c ReplicationFabricsClient) CheckConsistencyThenPoll(ctx context.Context, id ReplicationFabricId) error {
+	result, err := c.CheckConsistency(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing CheckConsistency: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after CheckConsistency: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForCheckConsistency prepares the CheckConsistency request.
+func (c ReplicationFabricsClient) preparerForCheckConsistency(ctx context.Context, id ReplicationFabricId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/checkConsistency", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForCheckConsistency sends the CheckConsistency request. The method will close the
+// http.Response Body if it receives an error.
+func (c ReplicationFabricsClient) senderForCheckConsistency(ctx context.Context, req *http.Request) (future CheckConsistencyOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/method_create_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/method_create_autorest.go
@@ -1,0 +1,79 @@
+package replicationfabrics
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CreateOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// Create ...
+func (c ReplicationFabricsClient) Create(ctx context.Context, id ReplicationFabricId, input FabricCreationInput) (result CreateOperationResponse, err error) {
+	req, err := c.preparerForCreate(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationfabrics.ReplicationFabricsClient", "Create", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForCreate(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationfabrics.ReplicationFabricsClient", "Create", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// CreateThenPoll performs Create then polls until it's completed
+func (c ReplicationFabricsClient) CreateThenPoll(ctx context.Context, id ReplicationFabricId, input FabricCreationInput) error {
+	result, err := c.Create(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing Create: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after Create: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForCreate prepares the Create request.
+func (c ReplicationFabricsClient) preparerForCreate(ctx context.Context, id ReplicationFabricId, input FabricCreationInput) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPut(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForCreate sends the Create request. The method will close the
+// http.Response Body if it receives an error.
+func (c ReplicationFabricsClient) senderForCreate(ctx context.Context, req *http.Request) (future CreateOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/method_delete_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/method_delete_autorest.go
@@ -1,0 +1,78 @@
+package replicationfabrics
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DeleteOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// Delete ...
+func (c ReplicationFabricsClient) Delete(ctx context.Context, id ReplicationFabricId) (result DeleteOperationResponse, err error) {
+	req, err := c.preparerForDelete(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationfabrics.ReplicationFabricsClient", "Delete", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForDelete(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationfabrics.ReplicationFabricsClient", "Delete", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// DeleteThenPoll performs Delete then polls until it's completed
+func (c ReplicationFabricsClient) DeleteThenPoll(ctx context.Context, id ReplicationFabricId) error {
+	result, err := c.Delete(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing Delete: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after Delete: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForDelete prepares the Delete request.
+func (c ReplicationFabricsClient) preparerForDelete(ctx context.Context, id ReplicationFabricId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/remove", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForDelete sends the Delete request. The method will close the
+// http.Response Body if it receives an error.
+func (c ReplicationFabricsClient) senderForDelete(ctx context.Context, req *http.Request) (future DeleteOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/method_get_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/method_get_autorest.go
@@ -1,0 +1,97 @@
+package replicationfabrics
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *Fabric
+}
+
+type GetOperationOptions struct {
+	Filter *string
+}
+
+func DefaultGetOperationOptions() GetOperationOptions {
+	return GetOperationOptions{}
+}
+
+func (o GetOperationOptions) toHeaders() map[string]interface{} {
+	out := make(map[string]interface{})
+
+	return out
+}
+
+func (o GetOperationOptions) toQueryString() map[string]interface{} {
+	out := make(map[string]interface{})
+
+	if o.Filter != nil {
+		out["$filter"] = *o.Filter
+	}
+
+	return out
+}
+
+// Get ...
+func (c ReplicationFabricsClient) Get(ctx context.Context, id ReplicationFabricId, options GetOperationOptions) (result GetOperationResponse, err error) {
+	req, err := c.preparerForGet(ctx, id, options)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationfabrics.ReplicationFabricsClient", "Get", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationfabrics.ReplicationFabricsClient", "Get", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForGet(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationfabrics.ReplicationFabricsClient", "Get", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForGet prepares the Get request.
+func (c ReplicationFabricsClient) preparerForGet(ctx context.Context, id ReplicationFabricId, options GetOperationOptions) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	for k, v := range options.toQueryString() {
+		queryParameters[k] = autorest.Encode("query", v)
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithHeaders(options.toHeaders()),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForGet handles the response to the Get request. The method always
+// closes the http.Response Body.
+func (c ReplicationFabricsClient) responderForGet(resp *http.Response) (result GetOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/method_list_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/method_list_autorest.go
@@ -1,0 +1,186 @@
+package replicationfabrics
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *[]Fabric
+
+	nextLink     *string
+	nextPageFunc func(ctx context.Context, nextLink string) (ListOperationResponse, error)
+}
+
+type ListCompleteResult struct {
+	Items []Fabric
+}
+
+func (r ListOperationResponse) HasMore() bool {
+	return r.nextLink != nil
+}
+
+func (r ListOperationResponse) LoadMore(ctx context.Context) (resp ListOperationResponse, err error) {
+	if !r.HasMore() {
+		err = fmt.Errorf("no more pages returned")
+		return
+	}
+	return r.nextPageFunc(ctx, *r.nextLink)
+}
+
+// List ...
+func (c ReplicationFabricsClient) List(ctx context.Context, id VaultId) (resp ListOperationResponse, err error) {
+	req, err := c.preparerForList(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationfabrics.ReplicationFabricsClient", "List", nil, "Failure preparing request")
+		return
+	}
+
+	resp.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationfabrics.ReplicationFabricsClient", "List", resp.HttpResponse, "Failure sending request")
+		return
+	}
+
+	resp, err = c.responderForList(resp.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationfabrics.ReplicationFabricsClient", "List", resp.HttpResponse, "Failure responding to request")
+		return
+	}
+	return
+}
+
+// preparerForList prepares the List request.
+func (c ReplicationFabricsClient) preparerForList(ctx context.Context, id VaultId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/replicationFabrics", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// preparerForListWithNextLink prepares the List request with the given nextLink token.
+func (c ReplicationFabricsClient) preparerForListWithNextLink(ctx context.Context, nextLink string) (*http.Request, error) {
+	uri, err := url.Parse(nextLink)
+	if err != nil {
+		return nil, fmt.Errorf("parsing nextLink %q: %+v", nextLink, err)
+	}
+	queryParameters := map[string]interface{}{}
+	for k, v := range uri.Query() {
+		if len(v) == 0 {
+			continue
+		}
+		val := v[0]
+		val = autorest.Encode("query", val)
+		queryParameters[k] = val
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(uri.Path),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForList handles the response to the List request. The method always
+// closes the http.Response Body.
+func (c ReplicationFabricsClient) responderForList(resp *http.Response) (result ListOperationResponse, err error) {
+	type page struct {
+		Values   []Fabric `json:"value"`
+		NextLink *string  `json:"nextLink"`
+	}
+	var respObj page
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&respObj),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	result.Model = &respObj.Values
+	result.nextLink = respObj.NextLink
+	if respObj.NextLink != nil {
+		result.nextPageFunc = func(ctx context.Context, nextLink string) (result ListOperationResponse, err error) {
+			req, err := c.preparerForListWithNextLink(ctx, nextLink)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "replicationfabrics.ReplicationFabricsClient", "List", nil, "Failure preparing request")
+				return
+			}
+
+			result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "replicationfabrics.ReplicationFabricsClient", "List", result.HttpResponse, "Failure sending request")
+				return
+			}
+
+			result, err = c.responderForList(result.HttpResponse)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "replicationfabrics.ReplicationFabricsClient", "List", result.HttpResponse, "Failure responding to request")
+				return
+			}
+
+			return
+		}
+	}
+	return
+}
+
+// ListComplete retrieves all of the results into a single object
+func (c ReplicationFabricsClient) ListComplete(ctx context.Context, id VaultId) (ListCompleteResult, error) {
+	return c.ListCompleteMatchingPredicate(ctx, id, FabricOperationPredicate{})
+}
+
+// ListCompleteMatchingPredicate retrieves all of the results and then applied the predicate
+func (c ReplicationFabricsClient) ListCompleteMatchingPredicate(ctx context.Context, id VaultId, predicate FabricOperationPredicate) (resp ListCompleteResult, err error) {
+	items := make([]Fabric, 0)
+
+	page, err := c.List(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading the initial page: %+v", err)
+		return
+	}
+	if page.Model != nil {
+		for _, v := range *page.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	for page.HasMore() {
+		page, err = page.LoadMore(ctx)
+		if err != nil {
+			err = fmt.Errorf("loading the next page: %+v", err)
+			return
+		}
+
+		if page.Model != nil {
+			for _, v := range *page.Model {
+				if predicate.Matches(v) {
+					items = append(items, v)
+				}
+			}
+		}
+	}
+
+	out := ListCompleteResult{
+		Items: items,
+	}
+	return out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/method_migratetoaad_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/method_migratetoaad_autorest.go
@@ -1,0 +1,78 @@
+package replicationfabrics
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type MigrateToAadOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// MigrateToAad ...
+func (c ReplicationFabricsClient) MigrateToAad(ctx context.Context, id ReplicationFabricId) (result MigrateToAadOperationResponse, err error) {
+	req, err := c.preparerForMigrateToAad(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationfabrics.ReplicationFabricsClient", "MigrateToAad", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForMigrateToAad(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationfabrics.ReplicationFabricsClient", "MigrateToAad", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// MigrateToAadThenPoll performs MigrateToAad then polls until it's completed
+func (c ReplicationFabricsClient) MigrateToAadThenPoll(ctx context.Context, id ReplicationFabricId) error {
+	result, err := c.MigrateToAad(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing MigrateToAad: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after MigrateToAad: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForMigrateToAad prepares the MigrateToAad request.
+func (c ReplicationFabricsClient) preparerForMigrateToAad(ctx context.Context, id ReplicationFabricId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/migratetoaad", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForMigrateToAad sends the MigrateToAad request. The method will close the
+// http.Response Body if it receives an error.
+func (c ReplicationFabricsClient) senderForMigrateToAad(ctx context.Context, req *http.Request) (future MigrateToAadOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/method_purge_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/method_purge_autorest.go
@@ -1,0 +1,78 @@
+package replicationfabrics
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PurgeOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// Purge ...
+func (c ReplicationFabricsClient) Purge(ctx context.Context, id ReplicationFabricId) (result PurgeOperationResponse, err error) {
+	req, err := c.preparerForPurge(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationfabrics.ReplicationFabricsClient", "Purge", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForPurge(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationfabrics.ReplicationFabricsClient", "Purge", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// PurgeThenPoll performs Purge then polls until it's completed
+func (c ReplicationFabricsClient) PurgeThenPoll(ctx context.Context, id ReplicationFabricId) error {
+	result, err := c.Purge(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing Purge: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after Purge: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForPurge prepares the Purge request.
+func (c ReplicationFabricsClient) preparerForPurge(ctx context.Context, id ReplicationFabricId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsDelete(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForPurge sends the Purge request. The method will close the
+// http.Response Body if it receives an error.
+func (c ReplicationFabricsClient) senderForPurge(ctx context.Context, req *http.Request) (future PurgeOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/method_reassociategateway_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/method_reassociategateway_autorest.go
@@ -1,0 +1,79 @@
+package replicationfabrics
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ReassociateGatewayOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// ReassociateGateway ...
+func (c ReplicationFabricsClient) ReassociateGateway(ctx context.Context, id ReplicationFabricId, input FailoverProcessServerRequest) (result ReassociateGatewayOperationResponse, err error) {
+	req, err := c.preparerForReassociateGateway(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationfabrics.ReplicationFabricsClient", "ReassociateGateway", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForReassociateGateway(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationfabrics.ReplicationFabricsClient", "ReassociateGateway", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// ReassociateGatewayThenPoll performs ReassociateGateway then polls until it's completed
+func (c ReplicationFabricsClient) ReassociateGatewayThenPoll(ctx context.Context, id ReplicationFabricId, input FailoverProcessServerRequest) error {
+	result, err := c.ReassociateGateway(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing ReassociateGateway: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after ReassociateGateway: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForReassociateGateway prepares the ReassociateGateway request.
+func (c ReplicationFabricsClient) preparerForReassociateGateway(ctx context.Context, id ReplicationFabricId, input FailoverProcessServerRequest) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/reassociateGateway", id.ID())),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForReassociateGateway sends the ReassociateGateway request. The method will close the
+// http.Response Body if it receives an error.
+func (c ReplicationFabricsClient) senderForReassociateGateway(ctx context.Context, req *http.Request) (future ReassociateGatewayOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/method_renewcertificate_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/method_renewcertificate_autorest.go
@@ -1,0 +1,79 @@
+package replicationfabrics
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RenewCertificateOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// RenewCertificate ...
+func (c ReplicationFabricsClient) RenewCertificate(ctx context.Context, id ReplicationFabricId, input RenewCertificateInput) (result RenewCertificateOperationResponse, err error) {
+	req, err := c.preparerForRenewCertificate(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationfabrics.ReplicationFabricsClient", "RenewCertificate", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForRenewCertificate(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationfabrics.ReplicationFabricsClient", "RenewCertificate", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// RenewCertificateThenPoll performs RenewCertificate then polls until it's completed
+func (c ReplicationFabricsClient) RenewCertificateThenPoll(ctx context.Context, id ReplicationFabricId, input RenewCertificateInput) error {
+	result, err := c.RenewCertificate(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing RenewCertificate: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after RenewCertificate: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForRenewCertificate prepares the RenewCertificate request.
+func (c ReplicationFabricsClient) preparerForRenewCertificate(ctx context.Context, id ReplicationFabricId, input RenewCertificateInput) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/renewCertificate", id.ID())),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForRenewCertificate sends the RenewCertificate request. The method will close the
+// http.Response Body if it receives an error.
+func (c ReplicationFabricsClient) senderForRenewCertificate(ctx context.Context, req *http.Request) (future RenewCertificateOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_a2aextendedlocationdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_a2aextendedlocationdetails.go
@@ -1,0 +1,13 @@
+package replicationfabrics
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/edgezones"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type A2AExtendedLocationDetails struct {
+	PrimaryExtendedLocation  *edgezones.Model `json:"primaryExtendedLocation,omitempty"`
+	RecoveryExtendedLocation *edgezones.Model `json:"recoveryExtendedLocation,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_a2azonedetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_a2azonedetails.go
@@ -1,0 +1,9 @@
+package replicationfabrics
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type A2AZoneDetails struct {
+	Source *string `json:"source,omitempty"`
+	Target *string `json:"target,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_agentdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_agentdetails.go
@@ -1,0 +1,12 @@
+package replicationfabrics
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AgentDetails struct {
+	AgentId   *string             `json:"agentId,omitempty"`
+	BiosId    *string             `json:"biosId,omitempty"`
+	Disks     *[]AgentDiskDetails `json:"disks,omitempty"`
+	Fqdn      *string             `json:"fqdn,omitempty"`
+	MachineId *string             `json:"machineId,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_agentdiskdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_agentdiskdetails.go
@@ -1,0 +1,12 @@
+package replicationfabrics
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AgentDiskDetails struct {
+	CapacityInBytes *int64  `json:"capacityInBytes,omitempty"`
+	DiskId          *string `json:"diskId,omitempty"`
+	DiskName        *string `json:"diskName,omitempty"`
+	IsOSDisk        *string `json:"isOSDisk,omitempty"`
+	LunId           *int64  `json:"lunId,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_azurefabriccreationinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_azurefabriccreationinput.go
@@ -1,0 +1,41 @@
+package replicationfabrics
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ FabricSpecificCreationInput = AzureFabricCreationInput{}
+
+type AzureFabricCreationInput struct {
+	Location *string `json:"location,omitempty"`
+
+	// Fields inherited from FabricSpecificCreationInput
+}
+
+var _ json.Marshaler = AzureFabricCreationInput{}
+
+func (s AzureFabricCreationInput) MarshalJSON() ([]byte, error) {
+	type wrapper AzureFabricCreationInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling AzureFabricCreationInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling AzureFabricCreationInput: %+v", err)
+	}
+	decoded["instanceType"] = "Azure"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling AzureFabricCreationInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_azurefabricspecificdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_azurefabricspecificdetails.go
@@ -1,0 +1,44 @@
+package replicationfabrics
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ FabricSpecificDetails = AzureFabricSpecificDetails{}
+
+type AzureFabricSpecificDetails struct {
+	ContainerIds      *[]string                     `json:"containerIds,omitempty"`
+	ExtendedLocations *[]A2AExtendedLocationDetails `json:"extendedLocations,omitempty"`
+	Location          *string                       `json:"location,omitempty"`
+	Zones             *[]A2AZoneDetails             `json:"zones,omitempty"`
+
+	// Fields inherited from FabricSpecificDetails
+}
+
+var _ json.Marshaler = AzureFabricSpecificDetails{}
+
+func (s AzureFabricSpecificDetails) MarshalJSON() ([]byte, error) {
+	type wrapper AzureFabricSpecificDetails
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling AzureFabricSpecificDetails: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling AzureFabricSpecificDetails: %+v", err)
+	}
+	decoded["instanceType"] = "Azure"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling AzureFabricSpecificDetails: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_datastore.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_datastore.go
@@ -1,0 +1,12 @@
+package replicationfabrics
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DataStore struct {
+	Capacity     *string `json:"capacity,omitempty"`
+	FreeSpace    *string `json:"freeSpace,omitempty"`
+	SymbolicName *string `json:"symbolicName,omitempty"`
+	Type         *string `json:"type,omitempty"`
+	Uuid         *string `json:"uuid,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_dradetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_dradetails.go
@@ -1,0 +1,34 @@
+package replicationfabrics
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DraDetails struct {
+	BiosId                    *string           `json:"biosId,omitempty"`
+	ForwardProtectedItemCount *int64            `json:"forwardProtectedItemCount,omitempty"`
+	Health                    *ProtectionHealth `json:"health,omitempty"`
+	HealthErrors              *[]HealthError    `json:"healthErrors,omitempty"`
+	Id                        *string           `json:"id,omitempty"`
+	LastHeartbeatUtc          *string           `json:"lastHeartbeatUtc,omitempty"`
+	Name                      *string           `json:"name,omitempty"`
+	ReverseProtectedItemCount *int64            `json:"reverseProtectedItemCount,omitempty"`
+	Version                   *string           `json:"version,omitempty"`
+}
+
+func (o *DraDetails) GetLastHeartbeatUtcAsTime() (*time.Time, error) {
+	if o.LastHeartbeatUtc == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.LastHeartbeatUtc, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *DraDetails) SetLastHeartbeatUtcAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.LastHeartbeatUtc = &formatted
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_encryptiondetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_encryptiondetails.go
@@ -1,0 +1,28 @@
+package replicationfabrics
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type EncryptionDetails struct {
+	KekCertExpiryDate *string `json:"kekCertExpiryDate,omitempty"`
+	KekCertThumbprint *string `json:"kekCertThumbprint,omitempty"`
+	KekState          *string `json:"kekState,omitempty"`
+}
+
+func (o *EncryptionDetails) GetKekCertExpiryDateAsTime() (*time.Time, error) {
+	if o.KekCertExpiryDate == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.KekCertExpiryDate, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *EncryptionDetails) SetKekCertExpiryDateAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.KekCertExpiryDate = &formatted
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_fabric.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_fabric.go
@@ -1,0 +1,12 @@
+package replicationfabrics
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type Fabric struct {
+	Id         *string           `json:"id,omitempty"`
+	Location   *string           `json:"location,omitempty"`
+	Name       *string           `json:"name,omitempty"`
+	Properties *FabricProperties `json:"properties,omitempty"`
+	Type       *string           `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_fabriccreationinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_fabriccreationinput.go
@@ -1,0 +1,8 @@
+package replicationfabrics
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type FabricCreationInput struct {
+	Properties *FabricCreationInputProperties `json:"properties,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_fabriccreationinputproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_fabriccreationinputproperties.go
@@ -1,0 +1,32 @@
+package replicationfabrics
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type FabricCreationInputProperties struct {
+	CustomDetails FabricSpecificCreationInput `json:"customDetails"`
+}
+
+var _ json.Unmarshaler = &FabricCreationInputProperties{}
+
+func (s *FabricCreationInputProperties) UnmarshalJSON(bytes []byte) error {
+
+	var temp map[string]json.RawMessage
+	if err := json.Unmarshal(bytes, &temp); err != nil {
+		return fmt.Errorf("unmarshaling FabricCreationInputProperties into map[string]json.RawMessage: %+v", err)
+	}
+
+	if v, ok := temp["customDetails"]; ok {
+		impl, err := unmarshalFabricSpecificCreationInputImplementation(v)
+		if err != nil {
+			return fmt.Errorf("unmarshaling field 'CustomDetails' for 'FabricCreationInputProperties': %+v", err)
+		}
+		s.CustomDetails = impl
+	}
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_fabricproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_fabricproperties.go
@@ -1,0 +1,52 @@
+package replicationfabrics
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type FabricProperties struct {
+	BcdrState                 *string               `json:"bcdrState,omitempty"`
+	CustomDetails             FabricSpecificDetails `json:"customDetails"`
+	EncryptionDetails         *EncryptionDetails    `json:"encryptionDetails,omitempty"`
+	FriendlyName              *string               `json:"friendlyName,omitempty"`
+	Health                    *string               `json:"health,omitempty"`
+	HealthErrorDetails        *[]HealthError        `json:"healthErrorDetails,omitempty"`
+	InternalIdentifier        *string               `json:"internalIdentifier,omitempty"`
+	RolloverEncryptionDetails *EncryptionDetails    `json:"rolloverEncryptionDetails,omitempty"`
+}
+
+var _ json.Unmarshaler = &FabricProperties{}
+
+func (s *FabricProperties) UnmarshalJSON(bytes []byte) error {
+	type alias FabricProperties
+	var decoded alias
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling into FabricProperties: %+v", err)
+	}
+
+	s.BcdrState = decoded.BcdrState
+	s.EncryptionDetails = decoded.EncryptionDetails
+	s.FriendlyName = decoded.FriendlyName
+	s.Health = decoded.Health
+	s.HealthErrorDetails = decoded.HealthErrorDetails
+	s.InternalIdentifier = decoded.InternalIdentifier
+	s.RolloverEncryptionDetails = decoded.RolloverEncryptionDetails
+
+	var temp map[string]json.RawMessage
+	if err := json.Unmarshal(bytes, &temp); err != nil {
+		return fmt.Errorf("unmarshaling FabricProperties into map[string]json.RawMessage: %+v", err)
+	}
+
+	if v, ok := temp["customDetails"]; ok {
+		impl, err := unmarshalFabricSpecificDetailsImplementation(v)
+		if err != nil {
+			return fmt.Errorf("unmarshaling field 'CustomDetails' for 'FabricProperties': %+v", err)
+		}
+		s.CustomDetails = impl
+	}
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_fabricspecificcreationinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_fabricspecificcreationinput.go
@@ -1,0 +1,64 @@
+package replicationfabrics
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type FabricSpecificCreationInput interface {
+}
+
+func unmarshalFabricSpecificCreationInputImplementation(input []byte) (FabricSpecificCreationInput, error) {
+	if input == nil {
+		return nil, nil
+	}
+
+	var temp map[string]interface{}
+	if err := json.Unmarshal(input, &temp); err != nil {
+		return nil, fmt.Errorf("unmarshaling FabricSpecificCreationInput into map[string]interface: %+v", err)
+	}
+
+	value, ok := temp["instanceType"].(string)
+	if !ok {
+		return nil, nil
+	}
+
+	if strings.EqualFold(value, "Azure") {
+		var out AzureFabricCreationInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into AzureFabricCreationInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "InMageRcm") {
+		var out InMageRcmFabricCreationInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into InMageRcmFabricCreationInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "VMwareV2") {
+		var out VMwareV2FabricCreationInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into VMwareV2FabricCreationInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	type RawFabricSpecificCreationInputImpl struct {
+		Type   string                 `json:"-"`
+		Values map[string]interface{} `json:"-"`
+	}
+	out := RawFabricSpecificCreationInputImpl{
+		Type:   value,
+		Values: temp,
+	}
+	return out, nil
+
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_fabricspecificdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_fabricspecificdetails.go
@@ -1,0 +1,88 @@
+package replicationfabrics
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type FabricSpecificDetails interface {
+}
+
+func unmarshalFabricSpecificDetailsImplementation(input []byte) (FabricSpecificDetails, error) {
+	if input == nil {
+		return nil, nil
+	}
+
+	var temp map[string]interface{}
+	if err := json.Unmarshal(input, &temp); err != nil {
+		return nil, fmt.Errorf("unmarshaling FabricSpecificDetails into map[string]interface: %+v", err)
+	}
+
+	value, ok := temp["instanceType"].(string)
+	if !ok {
+		return nil, nil
+	}
+
+	if strings.EqualFold(value, "Azure") {
+		var out AzureFabricSpecificDetails
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into AzureFabricSpecificDetails: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "HyperVSite") {
+		var out HyperVSiteDetails
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into HyperVSiteDetails: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "InMageRcm") {
+		var out InMageRcmFabricSpecificDetails
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into InMageRcmFabricSpecificDetails: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "VMware") {
+		var out VMwareDetails
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into VMwareDetails: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "VMwareV2") {
+		var out VMwareV2FabricSpecificDetails
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into VMwareV2FabricSpecificDetails: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "VMM") {
+		var out VmmDetails
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into VmmDetails: %+v", err)
+		}
+		return out, nil
+	}
+
+	type RawFabricSpecificDetailsImpl struct {
+		Type   string                 `json:"-"`
+		Values map[string]interface{} `json:"-"`
+	}
+	out := RawFabricSpecificDetailsImpl{
+		Type:   value,
+		Values: temp,
+	}
+	return out, nil
+
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_failoverprocessserverrequest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_failoverprocessserverrequest.go
@@ -1,0 +1,8 @@
+package replicationfabrics
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type FailoverProcessServerRequest struct {
+	Properties *FailoverProcessServerRequestProperties `json:"properties,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_failoverprocessserverrequestproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_failoverprocessserverrequestproperties.go
@@ -1,0 +1,12 @@
+package replicationfabrics
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type FailoverProcessServerRequestProperties struct {
+	ContainerName         *string   `json:"containerName,omitempty"`
+	SourceProcessServerId *string   `json:"sourceProcessServerId,omitempty"`
+	TargetProcessServerId *string   `json:"targetProcessServerId,omitempty"`
+	UpdateType            *string   `json:"updateType,omitempty"`
+	VmsToMigrate          *[]string `json:"vmsToMigrate,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_healtherror.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_healtherror.go
@@ -1,0 +1,40 @@
+package replicationfabrics
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type HealthError struct {
+	CreationTimeUtc              *string                           `json:"creationTimeUtc,omitempty"`
+	CustomerResolvability        *HealthErrorCustomerResolvability `json:"customerResolvability,omitempty"`
+	EntityId                     *string                           `json:"entityId,omitempty"`
+	ErrorCategory                *string                           `json:"errorCategory,omitempty"`
+	ErrorCode                    *string                           `json:"errorCode,omitempty"`
+	ErrorId                      *string                           `json:"errorId,omitempty"`
+	ErrorLevel                   *string                           `json:"errorLevel,omitempty"`
+	ErrorMessage                 *string                           `json:"errorMessage,omitempty"`
+	ErrorSource                  *string                           `json:"errorSource,omitempty"`
+	ErrorType                    *string                           `json:"errorType,omitempty"`
+	InnerHealthErrors            *[]InnerHealthError               `json:"innerHealthErrors,omitempty"`
+	PossibleCauses               *string                           `json:"possibleCauses,omitempty"`
+	RecommendedAction            *string                           `json:"recommendedAction,omitempty"`
+	RecoveryProviderErrorMessage *string                           `json:"recoveryProviderErrorMessage,omitempty"`
+	SummaryMessage               *string                           `json:"summaryMessage,omitempty"`
+}
+
+func (o *HealthError) GetCreationTimeUtcAsTime() (*time.Time, error) {
+	if o.CreationTimeUtc == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.CreationTimeUtc, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *HealthError) SetCreationTimeUtcAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.CreationTimeUtc = &formatted
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_hypervhostdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_hypervhostdetails.go
@@ -1,0 +1,10 @@
+package replicationfabrics
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type HyperVHostDetails struct {
+	Id               *string `json:"id,omitempty"`
+	MarsAgentVersion *string `json:"marsAgentVersion,omitempty"`
+	Name             *string `json:"name,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_hypervsitedetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_hypervsitedetails.go
@@ -1,0 +1,41 @@
+package replicationfabrics
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ FabricSpecificDetails = HyperVSiteDetails{}
+
+type HyperVSiteDetails struct {
+	HyperVHosts *[]HyperVHostDetails `json:"hyperVHosts,omitempty"`
+
+	// Fields inherited from FabricSpecificDetails
+}
+
+var _ json.Marshaler = HyperVSiteDetails{}
+
+func (s HyperVSiteDetails) MarshalJSON() ([]byte, error) {
+	type wrapper HyperVSiteDetails
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling HyperVSiteDetails: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling HyperVSiteDetails: %+v", err)
+	}
+	decoded["instanceType"] = "HyperVSite"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling HyperVSiteDetails: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_identityproviderdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_identityproviderdetails.go
@@ -1,0 +1,12 @@
+package replicationfabrics
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type IdentityProviderDetails struct {
+	AadAuthority  *string `json:"aadAuthority,omitempty"`
+	ApplicationId *string `json:"applicationId,omitempty"`
+	Audience      *string `json:"audience,omitempty"`
+	ObjectId      *string `json:"objectId,omitempty"`
+	TenantId      *string `json:"tenantId,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_identityproviderinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_identityproviderinput.go
@@ -1,0 +1,12 @@
+package replicationfabrics
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type IdentityProviderInput struct {
+	AadAuthority  string `json:"aadAuthority"`
+	ApplicationId string `json:"applicationId"`
+	Audience      string `json:"audience"`
+	ObjectId      string `json:"objectId"`
+	TenantId      string `json:"tenantId"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_inmagefabricswitchproviderblockingerrordetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_inmagefabricswitchproviderblockingerrordetails.go
@@ -1,0 +1,13 @@
+package replicationfabrics
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type InMageFabricSwitchProviderBlockingErrorDetails struct {
+	ErrorCode              *string            `json:"errorCode,omitempty"`
+	ErrorMessage           *string            `json:"errorMessage,omitempty"`
+	ErrorMessageParameters *map[string]string `json:"errorMessageParameters,omitempty"`
+	ErrorTags              *map[string]string `json:"errorTags,omitempty"`
+	PossibleCauses         *string            `json:"possibleCauses,omitempty"`
+	RecommendedAction      *string            `json:"recommendedAction,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_inmagercmfabriccreationinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_inmagercmfabriccreationinput.go
@@ -1,0 +1,43 @@
+package replicationfabrics
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ FabricSpecificCreationInput = InMageRcmFabricCreationInput{}
+
+type InMageRcmFabricCreationInput struct {
+	PhysicalSiteId      string                `json:"physicalSiteId"`
+	SourceAgentIdentity IdentityProviderInput `json:"sourceAgentIdentity"`
+	VmwareSiteId        string                `json:"vmwareSiteId"`
+
+	// Fields inherited from FabricSpecificCreationInput
+}
+
+var _ json.Marshaler = InMageRcmFabricCreationInput{}
+
+func (s InMageRcmFabricCreationInput) MarshalJSON() ([]byte, error) {
+	type wrapper InMageRcmFabricCreationInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling InMageRcmFabricCreationInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling InMageRcmFabricCreationInput: %+v", err)
+	}
+	decoded["instanceType"] = "InMageRcm"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling InMageRcmFabricCreationInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_inmagercmfabricspecificdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_inmagercmfabricspecificdetails.go
@@ -1,0 +1,56 @@
+package replicationfabrics
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ FabricSpecificDetails = InMageRcmFabricSpecificDetails{}
+
+type InMageRcmFabricSpecificDetails struct {
+	AgentDetails               *[]AgentDetails            `json:"agentDetails,omitempty"`
+	ControlPlaneUri            *string                    `json:"controlPlaneUri,omitempty"`
+	DataPlaneUri               *string                    `json:"dataPlaneUri,omitempty"`
+	Dras                       *[]DraDetails              `json:"dras,omitempty"`
+	MarsAgents                 *[]MarsAgentDetails        `json:"marsAgents,omitempty"`
+	PhysicalSiteId             *string                    `json:"physicalSiteId,omitempty"`
+	ProcessServers             *[]ProcessServerDetails    `json:"processServers,omitempty"`
+	PushInstallers             *[]PushInstallerDetails    `json:"pushInstallers,omitempty"`
+	RcmProxies                 *[]RcmProxyDetails         `json:"rcmProxies,omitempty"`
+	ReplicationAgents          *[]ReplicationAgentDetails `json:"replicationAgents,omitempty"`
+	ReprotectAgents            *[]ReprotectAgentDetails   `json:"reprotectAgents,omitempty"`
+	ServiceContainerId         *string                    `json:"serviceContainerId,omitempty"`
+	ServiceEndpoint            *string                    `json:"serviceEndpoint,omitempty"`
+	ServiceResourceId          *string                    `json:"serviceResourceId,omitempty"`
+	SourceAgentIdentityDetails *IdentityProviderDetails   `json:"sourceAgentIdentityDetails,omitempty"`
+	VmwareSiteId               *string                    `json:"vmwareSiteId,omitempty"`
+
+	// Fields inherited from FabricSpecificDetails
+}
+
+var _ json.Marshaler = InMageRcmFabricSpecificDetails{}
+
+func (s InMageRcmFabricSpecificDetails) MarshalJSON() ([]byte, error) {
+	type wrapper InMageRcmFabricSpecificDetails
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling InMageRcmFabricSpecificDetails: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling InMageRcmFabricSpecificDetails: %+v", err)
+	}
+	decoded["instanceType"] = "InMageRcm"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling InMageRcmFabricSpecificDetails: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_innerhealtherror.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_innerhealtherror.go
@@ -1,0 +1,39 @@
+package replicationfabrics
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type InnerHealthError struct {
+	CreationTimeUtc              *string                           `json:"creationTimeUtc,omitempty"`
+	CustomerResolvability        *HealthErrorCustomerResolvability `json:"customerResolvability,omitempty"`
+	EntityId                     *string                           `json:"entityId,omitempty"`
+	ErrorCategory                *string                           `json:"errorCategory,omitempty"`
+	ErrorCode                    *string                           `json:"errorCode,omitempty"`
+	ErrorId                      *string                           `json:"errorId,omitempty"`
+	ErrorLevel                   *string                           `json:"errorLevel,omitempty"`
+	ErrorMessage                 *string                           `json:"errorMessage,omitempty"`
+	ErrorSource                  *string                           `json:"errorSource,omitempty"`
+	ErrorType                    *string                           `json:"errorType,omitempty"`
+	PossibleCauses               *string                           `json:"possibleCauses,omitempty"`
+	RecommendedAction            *string                           `json:"recommendedAction,omitempty"`
+	RecoveryProviderErrorMessage *string                           `json:"recoveryProviderErrorMessage,omitempty"`
+	SummaryMessage               *string                           `json:"summaryMessage,omitempty"`
+}
+
+func (o *InnerHealthError) GetCreationTimeUtcAsTime() (*time.Time, error) {
+	if o.CreationTimeUtc == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.CreationTimeUtc, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *InnerHealthError) SetCreationTimeUtcAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.CreationTimeUtc = &formatted
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_marsagentdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_marsagentdetails.go
@@ -1,0 +1,34 @@
+package replicationfabrics
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type MarsAgentDetails struct {
+	BiosId           *string           `json:"biosId,omitempty"`
+	FabricObjectId   *string           `json:"fabricObjectId,omitempty"`
+	Fqdn             *string           `json:"fqdn,omitempty"`
+	Health           *ProtectionHealth `json:"health,omitempty"`
+	HealthErrors     *[]HealthError    `json:"healthErrors,omitempty"`
+	Id               *string           `json:"id,omitempty"`
+	LastHeartbeatUtc *string           `json:"lastHeartbeatUtc,omitempty"`
+	Name             *string           `json:"name,omitempty"`
+	Version          *string           `json:"version,omitempty"`
+}
+
+func (o *MarsAgentDetails) GetLastHeartbeatUtcAsTime() (*time.Time, error) {
+	if o.LastHeartbeatUtc == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.LastHeartbeatUtc, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *MarsAgentDetails) SetLastHeartbeatUtcAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.LastHeartbeatUtc = &formatted
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_mastertargetserver.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_mastertargetserver.go
@@ -1,0 +1,67 @@
+package replicationfabrics
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type MasterTargetServer struct {
+	AgentExpiryDate         *string            `json:"agentExpiryDate,omitempty"`
+	AgentVersion            *string            `json:"agentVersion,omitempty"`
+	AgentVersionDetails     *VersionDetails    `json:"agentVersionDetails,omitempty"`
+	DataStores              *[]DataStore       `json:"dataStores,omitempty"`
+	DiskCount               *int64             `json:"diskCount,omitempty"`
+	HealthErrors            *[]HealthError     `json:"healthErrors,omitempty"`
+	IPAddress               *string            `json:"ipAddress,omitempty"`
+	Id                      *string            `json:"id,omitempty"`
+	LastHeartbeat           *string            `json:"lastHeartbeat,omitempty"`
+	MarsAgentExpiryDate     *string            `json:"marsAgentExpiryDate,omitempty"`
+	MarsAgentVersion        *string            `json:"marsAgentVersion,omitempty"`
+	MarsAgentVersionDetails *VersionDetails    `json:"marsAgentVersionDetails,omitempty"`
+	Name                    *string            `json:"name,omitempty"`
+	OsType                  *string            `json:"osType,omitempty"`
+	OsVersion               *string            `json:"osVersion,omitempty"`
+	RetentionVolumes        *[]RetentionVolume `json:"retentionVolumes,omitempty"`
+	ValidationErrors        *[]HealthError     `json:"validationErrors,omitempty"`
+	VersionStatus           *string            `json:"versionStatus,omitempty"`
+}
+
+func (o *MasterTargetServer) GetAgentExpiryDateAsTime() (*time.Time, error) {
+	if o.AgentExpiryDate == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.AgentExpiryDate, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *MasterTargetServer) SetAgentExpiryDateAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.AgentExpiryDate = &formatted
+}
+
+func (o *MasterTargetServer) GetLastHeartbeatAsTime() (*time.Time, error) {
+	if o.LastHeartbeat == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.LastHeartbeat, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *MasterTargetServer) SetLastHeartbeatAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.LastHeartbeat = &formatted
+}
+
+func (o *MasterTargetServer) GetMarsAgentExpiryDateAsTime() (*time.Time, error) {
+	if o.MarsAgentExpiryDate == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.MarsAgentExpiryDate, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *MasterTargetServer) SetMarsAgentExpiryDateAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.MarsAgentExpiryDate = &formatted
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_mobilityserviceupdate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_mobilityserviceupdate.go
@@ -1,0 +1,10 @@
+package replicationfabrics
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type MobilityServiceUpdate struct {
+	OsType       *string `json:"osType,omitempty"`
+	RebootStatus *string `json:"rebootStatus,omitempty"`
+	Version      *string `json:"version,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_processserver.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_processserver.go
@@ -1,0 +1,97 @@
+package replicationfabrics
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ProcessServer struct {
+	AgentExpiryDate                    *string                  `json:"agentExpiryDate,omitempty"`
+	AgentVersion                       *string                  `json:"agentVersion,omitempty"`
+	AgentVersionDetails                *VersionDetails          `json:"agentVersionDetails,omitempty"`
+	AvailableMemoryInBytes             *int64                   `json:"availableMemoryInBytes,omitempty"`
+	AvailableSpaceInBytes              *int64                   `json:"availableSpaceInBytes,omitempty"`
+	CpuLoad                            *string                  `json:"cpuLoad,omitempty"`
+	CpuLoadStatus                      *string                  `json:"cpuLoadStatus,omitempty"`
+	FriendlyName                       *string                  `json:"friendlyName,omitempty"`
+	Health                             *ProtectionHealth        `json:"health,omitempty"`
+	HealthErrors                       *[]HealthError           `json:"healthErrors,omitempty"`
+	HostId                             *string                  `json:"hostId,omitempty"`
+	IPAddress                          *string                  `json:"ipAddress,omitempty"`
+	Id                                 *string                  `json:"id,omitempty"`
+	LastHeartbeat                      *string                  `json:"lastHeartbeat,omitempty"`
+	MachineCount                       *string                  `json:"machineCount,omitempty"`
+	MarsCommunicationStatus            *string                  `json:"marsCommunicationStatus,omitempty"`
+	MarsRegistrationStatus             *string                  `json:"marsRegistrationStatus,omitempty"`
+	MemoryUsageStatus                  *string                  `json:"memoryUsageStatus,omitempty"`
+	MobilityServiceUpdates             *[]MobilityServiceUpdate `json:"mobilityServiceUpdates,omitempty"`
+	OsType                             *string                  `json:"osType,omitempty"`
+	OsVersion                          *string                  `json:"osVersion,omitempty"`
+	PsServiceStatus                    *string                  `json:"psServiceStatus,omitempty"`
+	PsStatsRefreshTime                 *string                  `json:"psStatsRefreshTime,omitempty"`
+	ReplicationPairCount               *string                  `json:"replicationPairCount,omitempty"`
+	SpaceUsageStatus                   *string                  `json:"spaceUsageStatus,omitempty"`
+	SslCertExpiryDate                  *string                  `json:"sslCertExpiryDate,omitempty"`
+	SslCertExpiryRemainingDays         *int64                   `json:"sslCertExpiryRemainingDays,omitempty"`
+	SystemLoad                         *string                  `json:"systemLoad,omitempty"`
+	SystemLoadStatus                   *string                  `json:"systemLoadStatus,omitempty"`
+	ThroughputInBytes                  *int64                   `json:"throughputInBytes,omitempty"`
+	ThroughputInMBps                   *int64                   `json:"throughputInMBps,omitempty"`
+	ThroughputStatus                   *string                  `json:"throughputStatus,omitempty"`
+	ThroughputUploadPendingDataInBytes *int64                   `json:"throughputUploadPendingDataInBytes,omitempty"`
+	TotalMemoryInBytes                 *int64                   `json:"totalMemoryInBytes,omitempty"`
+	TotalSpaceInBytes                  *int64                   `json:"totalSpaceInBytes,omitempty"`
+	VersionStatus                      *string                  `json:"versionStatus,omitempty"`
+}
+
+func (o *ProcessServer) GetAgentExpiryDateAsTime() (*time.Time, error) {
+	if o.AgentExpiryDate == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.AgentExpiryDate, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *ProcessServer) SetAgentExpiryDateAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.AgentExpiryDate = &formatted
+}
+
+func (o *ProcessServer) GetLastHeartbeatAsTime() (*time.Time, error) {
+	if o.LastHeartbeat == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.LastHeartbeat, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *ProcessServer) SetLastHeartbeatAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.LastHeartbeat = &formatted
+}
+
+func (o *ProcessServer) GetPsStatsRefreshTimeAsTime() (*time.Time, error) {
+	if o.PsStatsRefreshTime == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.PsStatsRefreshTime, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *ProcessServer) SetPsStatsRefreshTimeAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.PsStatsRefreshTime = &formatted
+}
+
+func (o *ProcessServer) GetSslCertExpiryDateAsTime() (*time.Time, error) {
+	if o.SslCertExpiryDate == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.SslCertExpiryDate, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *ProcessServer) SetSslCertExpiryDateAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.SslCertExpiryDate = &formatted
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_processserverdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_processserverdetails.go
@@ -1,0 +1,54 @@
+package replicationfabrics
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ProcessServerDetails struct {
+	AvailableMemoryInBytes             *int64              `json:"availableMemoryInBytes,omitempty"`
+	AvailableSpaceInBytes              *int64              `json:"availableSpaceInBytes,omitempty"`
+	BiosId                             *string             `json:"biosId,omitempty"`
+	DiskUsageStatus                    *RcmComponentStatus `json:"diskUsageStatus,omitempty"`
+	FabricObjectId                     *string             `json:"fabricObjectId,omitempty"`
+	Fqdn                               *string             `json:"fqdn,omitempty"`
+	FreeSpacePercentage                *float64            `json:"freeSpacePercentage,omitempty"`
+	Health                             *ProtectionHealth   `json:"health,omitempty"`
+	HealthErrors                       *[]HealthError      `json:"healthErrors,omitempty"`
+	HistoricHealth                     *ProtectionHealth   `json:"historicHealth,omitempty"`
+	IPAddresses                        *[]string           `json:"ipAddresses,omitempty"`
+	Id                                 *string             `json:"id,omitempty"`
+	LastHeartbeatUtc                   *string             `json:"lastHeartbeatUtc,omitempty"`
+	MemoryUsagePercentage              *float64            `json:"memoryUsagePercentage,omitempty"`
+	MemoryUsageStatus                  *RcmComponentStatus `json:"memoryUsageStatus,omitempty"`
+	Name                               *string             `json:"name,omitempty"`
+	ProcessorUsagePercentage           *float64            `json:"processorUsagePercentage,omitempty"`
+	ProcessorUsageStatus               *RcmComponentStatus `json:"processorUsageStatus,omitempty"`
+	ProtectedItemCount                 *int64              `json:"protectedItemCount,omitempty"`
+	SystemLoad                         *int64              `json:"systemLoad,omitempty"`
+	SystemLoadStatus                   *RcmComponentStatus `json:"systemLoadStatus,omitempty"`
+	ThroughputInBytes                  *int64              `json:"throughputInBytes,omitempty"`
+	ThroughputStatus                   *RcmComponentStatus `json:"throughputStatus,omitempty"`
+	ThroughputUploadPendingDataInBytes *int64              `json:"throughputUploadPendingDataInBytes,omitempty"`
+	TotalMemoryInBytes                 *int64              `json:"totalMemoryInBytes,omitempty"`
+	TotalSpaceInBytes                  *int64              `json:"totalSpaceInBytes,omitempty"`
+	UsedMemoryInBytes                  *int64              `json:"usedMemoryInBytes,omitempty"`
+	UsedSpaceInBytes                   *int64              `json:"usedSpaceInBytes,omitempty"`
+	Version                            *string             `json:"version,omitempty"`
+}
+
+func (o *ProcessServerDetails) GetLastHeartbeatUtcAsTime() (*time.Time, error) {
+	if o.LastHeartbeatUtc == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.LastHeartbeatUtc, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *ProcessServerDetails) SetLastHeartbeatUtcAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.LastHeartbeatUtc = &formatted
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_pushinstallerdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_pushinstallerdetails.go
@@ -1,0 +1,34 @@
+package replicationfabrics
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PushInstallerDetails struct {
+	BiosId           *string           `json:"biosId,omitempty"`
+	FabricObjectId   *string           `json:"fabricObjectId,omitempty"`
+	Fqdn             *string           `json:"fqdn,omitempty"`
+	Health           *ProtectionHealth `json:"health,omitempty"`
+	HealthErrors     *[]HealthError    `json:"healthErrors,omitempty"`
+	Id               *string           `json:"id,omitempty"`
+	LastHeartbeatUtc *string           `json:"lastHeartbeatUtc,omitempty"`
+	Name             *string           `json:"name,omitempty"`
+	Version          *string           `json:"version,omitempty"`
+}
+
+func (o *PushInstallerDetails) GetLastHeartbeatUtcAsTime() (*time.Time, error) {
+	if o.LastHeartbeatUtc == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.LastHeartbeatUtc, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *PushInstallerDetails) SetLastHeartbeatUtcAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.LastHeartbeatUtc = &formatted
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_rcmproxydetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_rcmproxydetails.go
@@ -1,0 +1,35 @@
+package replicationfabrics
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RcmProxyDetails struct {
+	BiosId                   *string           `json:"biosId,omitempty"`
+	ClientAuthenticationType *string           `json:"clientAuthenticationType,omitempty"`
+	FabricObjectId           *string           `json:"fabricObjectId,omitempty"`
+	Fqdn                     *string           `json:"fqdn,omitempty"`
+	Health                   *ProtectionHealth `json:"health,omitempty"`
+	HealthErrors             *[]HealthError    `json:"healthErrors,omitempty"`
+	Id                       *string           `json:"id,omitempty"`
+	LastHeartbeatUtc         *string           `json:"lastHeartbeatUtc,omitempty"`
+	Name                     *string           `json:"name,omitempty"`
+	Version                  *string           `json:"version,omitempty"`
+}
+
+func (o *RcmProxyDetails) GetLastHeartbeatUtcAsTime() (*time.Time, error) {
+	if o.LastHeartbeatUtc == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.LastHeartbeatUtc, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *RcmProxyDetails) SetLastHeartbeatUtcAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.LastHeartbeatUtc = &formatted
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_renewcertificateinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_renewcertificateinput.go
@@ -1,0 +1,8 @@
+package replicationfabrics
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RenewCertificateInput struct {
+	Properties *RenewCertificateInputProperties `json:"properties,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_renewcertificateinputproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_renewcertificateinputproperties.go
@@ -1,0 +1,8 @@
+package replicationfabrics
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RenewCertificateInputProperties struct {
+	RenewCertificateType *string `json:"renewCertificateType,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_replicationagentdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_replicationagentdetails.go
@@ -1,0 +1,34 @@
+package replicationfabrics
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ReplicationAgentDetails struct {
+	BiosId           *string           `json:"biosId,omitempty"`
+	FabricObjectId   *string           `json:"fabricObjectId,omitempty"`
+	Fqdn             *string           `json:"fqdn,omitempty"`
+	Health           *ProtectionHealth `json:"health,omitempty"`
+	HealthErrors     *[]HealthError    `json:"healthErrors,omitempty"`
+	Id               *string           `json:"id,omitempty"`
+	LastHeartbeatUtc *string           `json:"lastHeartbeatUtc,omitempty"`
+	Name             *string           `json:"name,omitempty"`
+	Version          *string           `json:"version,omitempty"`
+}
+
+func (o *ReplicationAgentDetails) GetLastHeartbeatUtcAsTime() (*time.Time, error) {
+	if o.LastHeartbeatUtc == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.LastHeartbeatUtc, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *ReplicationAgentDetails) SetLastHeartbeatUtcAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.LastHeartbeatUtc = &formatted
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_reprotectagentdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_reprotectagentdetails.go
@@ -1,0 +1,50 @@
+package replicationfabrics
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ReprotectAgentDetails struct {
+	AccessibleDatastores *[]string         `json:"accessibleDatastores,omitempty"`
+	BiosId               *string           `json:"biosId,omitempty"`
+	FabricObjectId       *string           `json:"fabricObjectId,omitempty"`
+	Fqdn                 *string           `json:"fqdn,omitempty"`
+	Health               *ProtectionHealth `json:"health,omitempty"`
+	HealthErrors         *[]HealthError    `json:"healthErrors,omitempty"`
+	Id                   *string           `json:"id,omitempty"`
+	LastDiscoveryInUtc   *string           `json:"lastDiscoveryInUtc,omitempty"`
+	LastHeartbeatUtc     *string           `json:"lastHeartbeatUtc,omitempty"`
+	Name                 *string           `json:"name,omitempty"`
+	ProtectedItemCount   *int64            `json:"protectedItemCount,omitempty"`
+	VcenterId            *string           `json:"vcenterId,omitempty"`
+	Version              *string           `json:"version,omitempty"`
+}
+
+func (o *ReprotectAgentDetails) GetLastDiscoveryInUtcAsTime() (*time.Time, error) {
+	if o.LastDiscoveryInUtc == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.LastDiscoveryInUtc, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *ReprotectAgentDetails) SetLastDiscoveryInUtcAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.LastDiscoveryInUtc = &formatted
+}
+
+func (o *ReprotectAgentDetails) GetLastHeartbeatUtcAsTime() (*time.Time, error) {
+	if o.LastHeartbeatUtc == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.LastHeartbeatUtc, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *ReprotectAgentDetails) SetLastHeartbeatUtcAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.LastHeartbeatUtc = &formatted
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_retentionvolume.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_retentionvolume.go
@@ -1,0 +1,11 @@
+package replicationfabrics
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RetentionVolume struct {
+	CapacityInBytes     *int64  `json:"capacityInBytes,omitempty"`
+	FreeSpaceInBytes    *int64  `json:"freeSpaceInBytes,omitempty"`
+	ThresholdPercentage *int64  `json:"thresholdPercentage,omitempty"`
+	VolumeName          *string `json:"volumeName,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_runasaccount.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_runasaccount.go
@@ -1,0 +1,9 @@
+package replicationfabrics
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RunAsAccount struct {
+	AccountId   *string `json:"accountId,omitempty"`
+	AccountName *string `json:"accountName,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_versiondetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_versiondetails.go
@@ -1,0 +1,28 @@
+package replicationfabrics
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VersionDetails struct {
+	ExpiryDate *string             `json:"expiryDate,omitempty"`
+	Status     *AgentVersionStatus `json:"status,omitempty"`
+	Version    *string             `json:"version,omitempty"`
+}
+
+func (o *VersionDetails) GetExpiryDateAsTime() (*time.Time, error) {
+	if o.ExpiryDate == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.ExpiryDate, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *VersionDetails) SetExpiryDateAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.ExpiryDate = &formatted
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_vmmdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_vmmdetails.go
@@ -1,0 +1,40 @@
+package replicationfabrics
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ FabricSpecificDetails = VmmDetails{}
+
+type VmmDetails struct {
+
+	// Fields inherited from FabricSpecificDetails
+}
+
+var _ json.Marshaler = VmmDetails{}
+
+func (s VmmDetails) MarshalJSON() ([]byte, error) {
+	type wrapper VmmDetails
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling VmmDetails: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling VmmDetails: %+v", err)
+	}
+	decoded["instanceType"] = "VMM"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling VmmDetails: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_vmwaredetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_vmwaredetails.go
@@ -1,0 +1,73 @@
+package replicationfabrics
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ FabricSpecificDetails = VMwareDetails{}
+
+type VMwareDetails struct {
+	AgentCount                         *string                                           `json:"agentCount,omitempty"`
+	AgentExpiryDate                    *string                                           `json:"agentExpiryDate,omitempty"`
+	AgentVersion                       *string                                           `json:"agentVersion,omitempty"`
+	AgentVersionDetails                *VersionDetails                                   `json:"agentVersionDetails,omitempty"`
+	AvailableMemoryInBytes             *int64                                            `json:"availableMemoryInBytes,omitempty"`
+	AvailableSpaceInBytes              *int64                                            `json:"availableSpaceInBytes,omitempty"`
+	CpuLoad                            *string                                           `json:"cpuLoad,omitempty"`
+	CpuLoadStatus                      *string                                           `json:"cpuLoadStatus,omitempty"`
+	CsServiceStatus                    *string                                           `json:"csServiceStatus,omitempty"`
+	DatabaseServerLoad                 *string                                           `json:"databaseServerLoad,omitempty"`
+	DatabaseServerLoadStatus           *string                                           `json:"databaseServerLoadStatus,omitempty"`
+	HostName                           *string                                           `json:"hostName,omitempty"`
+	IPAddress                          *string                                           `json:"ipAddress,omitempty"`
+	LastHeartbeat                      *string                                           `json:"lastHeartbeat,omitempty"`
+	MasterTargetServers                *[]MasterTargetServer                             `json:"masterTargetServers,omitempty"`
+	MemoryUsageStatus                  *string                                           `json:"memoryUsageStatus,omitempty"`
+	ProcessServerCount                 *string                                           `json:"processServerCount,omitempty"`
+	ProcessServers                     *[]ProcessServer                                  `json:"processServers,omitempty"`
+	ProtectedServers                   *string                                           `json:"protectedServers,omitempty"`
+	PsTemplateVersion                  *string                                           `json:"psTemplateVersion,omitempty"`
+	ReplicationPairCount               *string                                           `json:"replicationPairCount,omitempty"`
+	RunAsAccounts                      *[]RunAsAccount                                   `json:"runAsAccounts,omitempty"`
+	SpaceUsageStatus                   *string                                           `json:"spaceUsageStatus,omitempty"`
+	SslCertExpiryDate                  *string                                           `json:"sslCertExpiryDate,omitempty"`
+	SslCertExpiryRemainingDays         *int64                                            `json:"sslCertExpiryRemainingDays,omitempty"`
+	SwitchProviderBlockingErrorDetails *[]InMageFabricSwitchProviderBlockingErrorDetails `json:"switchProviderBlockingErrorDetails,omitempty"`
+	SystemLoad                         *string                                           `json:"systemLoad,omitempty"`
+	SystemLoadStatus                   *string                                           `json:"systemLoadStatus,omitempty"`
+	TotalMemoryInBytes                 *int64                                            `json:"totalMemoryInBytes,omitempty"`
+	TotalSpaceInBytes                  *int64                                            `json:"totalSpaceInBytes,omitempty"`
+	VersionStatus                      *string                                           `json:"versionStatus,omitempty"`
+	WebLoad                            *string                                           `json:"webLoad,omitempty"`
+	WebLoadStatus                      *string                                           `json:"webLoadStatus,omitempty"`
+
+	// Fields inherited from FabricSpecificDetails
+}
+
+var _ json.Marshaler = VMwareDetails{}
+
+func (s VMwareDetails) MarshalJSON() ([]byte, error) {
+	type wrapper VMwareDetails
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling VMwareDetails: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling VMwareDetails: %+v", err)
+	}
+	decoded["instanceType"] = "VMware"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling VMwareDetails: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_vmwarev2fabriccreationinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_vmwarev2fabriccreationinput.go
@@ -1,0 +1,43 @@
+package replicationfabrics
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ FabricSpecificCreationInput = VMwareV2FabricCreationInput{}
+
+type VMwareV2FabricCreationInput struct {
+	MigrationSolutionId string  `json:"migrationSolutionId"`
+	PhysicalSiteId      *string `json:"physicalSiteId,omitempty"`
+	VmwareSiteId        *string `json:"vmwareSiteId,omitempty"`
+
+	// Fields inherited from FabricSpecificCreationInput
+}
+
+var _ json.Marshaler = VMwareV2FabricCreationInput{}
+
+func (s VMwareV2FabricCreationInput) MarshalJSON() ([]byte, error) {
+	type wrapper VMwareV2FabricCreationInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling VMwareV2FabricCreationInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling VMwareV2FabricCreationInput: %+v", err)
+	}
+	decoded["instanceType"] = "VMwareV2"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling VMwareV2FabricCreationInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_vmwarev2fabricspecificdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_vmwarev2fabricspecificdetails.go
@@ -1,0 +1,47 @@
+package replicationfabrics
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ FabricSpecificDetails = VMwareV2FabricSpecificDetails{}
+
+type VMwareV2FabricSpecificDetails struct {
+	MigrationSolutionId *string                 `json:"migrationSolutionId,omitempty"`
+	PhysicalSiteId      *string                 `json:"physicalSiteId,omitempty"`
+	ProcessServers      *[]ProcessServerDetails `json:"processServers,omitempty"`
+	ServiceContainerId  *string                 `json:"serviceContainerId,omitempty"`
+	ServiceEndpoint     *string                 `json:"serviceEndpoint,omitempty"`
+	ServiceResourceId   *string                 `json:"serviceResourceId,omitempty"`
+	VmwareSiteId        *string                 `json:"vmwareSiteId,omitempty"`
+
+	// Fields inherited from FabricSpecificDetails
+}
+
+var _ json.Marshaler = VMwareV2FabricSpecificDetails{}
+
+func (s VMwareV2FabricSpecificDetails) MarshalJSON() ([]byte, error) {
+	type wrapper VMwareV2FabricSpecificDetails
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling VMwareV2FabricSpecificDetails: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling VMwareV2FabricSpecificDetails: %+v", err)
+	}
+	decoded["instanceType"] = "VMwareV2"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling VMwareV2FabricSpecificDetails: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/predicates.go
@@ -1,0 +1,29 @@
+package replicationfabrics
+
+type FabricOperationPredicate struct {
+	Id       *string
+	Location *string
+	Name     *string
+	Type     *string
+}
+
+func (p FabricOperationPredicate) Matches(input Fabric) bool {
+
+	if p.Id != nil && (input.Id == nil && *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Location != nil && (input.Location == nil && *p.Location != *input.Location) {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil && *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil && *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/version.go
@@ -1,0 +1,12 @@
+package replicationfabrics
+
+import "fmt"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2022-10-01"
+
+func userAgent() string {
+	return fmt.Sprintf("hashicorp/go-azure-sdk/replicationfabrics/%s", defaultApiVersion)
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/README.md
@@ -1,0 +1,116 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings` Documentation
+
+The `replicationnetworkmappings` SDK allows for interaction with the Azure Resource Manager Service `recoveryservicessiterecovery` (API Version `2022-10-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings"
+```
+
+
+### Client Initialization
+
+```go
+client := replicationnetworkmappings.NewReplicationNetworkMappingsClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `ReplicationNetworkMappingsClient.Create`
+
+```go
+ctx := context.TODO()
+id := replicationnetworkmappings.NewReplicationNetworkMappingID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue", "fabricValue", "networkValue", "networkMappingValue")
+
+payload := replicationnetworkmappings.CreateNetworkMappingInput{
+	// ...
+}
+
+
+if err := client.CreateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `ReplicationNetworkMappingsClient.Delete`
+
+```go
+ctx := context.TODO()
+id := replicationnetworkmappings.NewReplicationNetworkMappingID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue", "fabricValue", "networkValue", "networkMappingValue")
+
+if err := client.DeleteThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `ReplicationNetworkMappingsClient.Get`
+
+```go
+ctx := context.TODO()
+id := replicationnetworkmappings.NewReplicationNetworkMappingID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue", "fabricValue", "networkValue", "networkMappingValue")
+
+read, err := client.Get(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `ReplicationNetworkMappingsClient.List`
+
+```go
+ctx := context.TODO()
+id := replicationnetworkmappings.NewVaultID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue")
+
+// alternatively `client.List(ctx, id)` can be used to do batched pagination
+items, err := client.ListComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `ReplicationNetworkMappingsClient.ListByReplicationNetworks`
+
+```go
+ctx := context.TODO()
+id := replicationnetworkmappings.NewReplicationNetworkID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue", "fabricValue", "networkValue")
+
+// alternatively `client.ListByReplicationNetworks(ctx, id)` can be used to do batched pagination
+items, err := client.ListByReplicationNetworksComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `ReplicationNetworkMappingsClient.Update`
+
+```go
+ctx := context.TODO()
+id := replicationnetworkmappings.NewReplicationNetworkMappingID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue", "fabricValue", "networkValue", "networkMappingValue")
+
+payload := replicationnetworkmappings.UpdateNetworkMappingInput{
+	// ...
+}
+
+
+if err := client.UpdateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/client.go
@@ -1,0 +1,18 @@
+package replicationnetworkmappings
+
+import "github.com/Azure/go-autorest/autorest"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ReplicationNetworkMappingsClient struct {
+	Client  autorest.Client
+	baseUri string
+}
+
+func NewReplicationNetworkMappingsClientWithBaseURI(endpoint string) ReplicationNetworkMappingsClient {
+	return ReplicationNetworkMappingsClient{
+		Client:  autorest.NewClientWithUserAgent(userAgent()),
+		baseUri: endpoint,
+	}
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/id_replicationnetwork.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/id_replicationnetwork.go
@@ -1,0 +1,150 @@
+package replicationnetworkmappings
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = ReplicationNetworkId{}
+
+// ReplicationNetworkId is a struct representing the Resource ID for a Replication Network
+type ReplicationNetworkId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	ResourceName      string
+	FabricName        string
+	NetworkName       string
+}
+
+// NewReplicationNetworkID returns a new ReplicationNetworkId struct
+func NewReplicationNetworkID(subscriptionId string, resourceGroupName string, resourceName string, fabricName string, networkName string) ReplicationNetworkId {
+	return ReplicationNetworkId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		ResourceName:      resourceName,
+		FabricName:        fabricName,
+		NetworkName:       networkName,
+	}
+}
+
+// ParseReplicationNetworkID parses 'input' into a ReplicationNetworkId
+func ParseReplicationNetworkID(input string) (*ReplicationNetworkId, error) {
+	parser := resourceids.NewParserFromResourceIdType(ReplicationNetworkId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := ReplicationNetworkId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceName, ok = parsed.Parsed["resourceName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceName' was not found in the resource id %q", input)
+	}
+
+	if id.FabricName, ok = parsed.Parsed["fabricName"]; !ok {
+		return nil, fmt.Errorf("the segment 'fabricName' was not found in the resource id %q", input)
+	}
+
+	if id.NetworkName, ok = parsed.Parsed["networkName"]; !ok {
+		return nil, fmt.Errorf("the segment 'networkName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ParseReplicationNetworkIDInsensitively parses 'input' case-insensitively into a ReplicationNetworkId
+// note: this method should only be used for API response data and not user input
+func ParseReplicationNetworkIDInsensitively(input string) (*ReplicationNetworkId, error) {
+	parser := resourceids.NewParserFromResourceIdType(ReplicationNetworkId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := ReplicationNetworkId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceName, ok = parsed.Parsed["resourceName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceName' was not found in the resource id %q", input)
+	}
+
+	if id.FabricName, ok = parsed.Parsed["fabricName"]; !ok {
+		return nil, fmt.Errorf("the segment 'fabricName' was not found in the resource id %q", input)
+	}
+
+	if id.NetworkName, ok = parsed.Parsed["networkName"]; !ok {
+		return nil, fmt.Errorf("the segment 'networkName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ValidateReplicationNetworkID checks that 'input' can be parsed as a Replication Network ID
+func ValidateReplicationNetworkID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseReplicationNetworkID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Replication Network ID
+func (id ReplicationNetworkId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.RecoveryServices/vaults/%s/replicationFabrics/%s/replicationNetworks/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.ResourceName, id.FabricName, id.NetworkName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Replication Network ID
+func (id ReplicationNetworkId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftRecoveryServices", "Microsoft.RecoveryServices", "Microsoft.RecoveryServices"),
+		resourceids.StaticSegment("staticVaults", "vaults", "vaults"),
+		resourceids.UserSpecifiedSegment("resourceName", "resourceValue"),
+		resourceids.StaticSegment("staticReplicationFabrics", "replicationFabrics", "replicationFabrics"),
+		resourceids.UserSpecifiedSegment("fabricName", "fabricValue"),
+		resourceids.StaticSegment("staticReplicationNetworks", "replicationNetworks", "replicationNetworks"),
+		resourceids.UserSpecifiedSegment("networkName", "networkValue"),
+	}
+}
+
+// String returns a human-readable description of this Replication Network ID
+func (id ReplicationNetworkId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Resource Name: %q", id.ResourceName),
+		fmt.Sprintf("Fabric Name: %q", id.FabricName),
+		fmt.Sprintf("Network Name: %q", id.NetworkName),
+	}
+	return fmt.Sprintf("Replication Network (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/id_replicationnetworkmapping.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/id_replicationnetworkmapping.go
@@ -1,0 +1,163 @@
+package replicationnetworkmappings
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = ReplicationNetworkMappingId{}
+
+// ReplicationNetworkMappingId is a struct representing the Resource ID for a Replication Network Mapping
+type ReplicationNetworkMappingId struct {
+	SubscriptionId     string
+	ResourceGroupName  string
+	ResourceName       string
+	FabricName         string
+	NetworkName        string
+	NetworkMappingName string
+}
+
+// NewReplicationNetworkMappingID returns a new ReplicationNetworkMappingId struct
+func NewReplicationNetworkMappingID(subscriptionId string, resourceGroupName string, resourceName string, fabricName string, networkName string, networkMappingName string) ReplicationNetworkMappingId {
+	return ReplicationNetworkMappingId{
+		SubscriptionId:     subscriptionId,
+		ResourceGroupName:  resourceGroupName,
+		ResourceName:       resourceName,
+		FabricName:         fabricName,
+		NetworkName:        networkName,
+		NetworkMappingName: networkMappingName,
+	}
+}
+
+// ParseReplicationNetworkMappingID parses 'input' into a ReplicationNetworkMappingId
+func ParseReplicationNetworkMappingID(input string) (*ReplicationNetworkMappingId, error) {
+	parser := resourceids.NewParserFromResourceIdType(ReplicationNetworkMappingId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := ReplicationNetworkMappingId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceName, ok = parsed.Parsed["resourceName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceName' was not found in the resource id %q", input)
+	}
+
+	if id.FabricName, ok = parsed.Parsed["fabricName"]; !ok {
+		return nil, fmt.Errorf("the segment 'fabricName' was not found in the resource id %q", input)
+	}
+
+	if id.NetworkName, ok = parsed.Parsed["networkName"]; !ok {
+		return nil, fmt.Errorf("the segment 'networkName' was not found in the resource id %q", input)
+	}
+
+	if id.NetworkMappingName, ok = parsed.Parsed["networkMappingName"]; !ok {
+		return nil, fmt.Errorf("the segment 'networkMappingName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ParseReplicationNetworkMappingIDInsensitively parses 'input' case-insensitively into a ReplicationNetworkMappingId
+// note: this method should only be used for API response data and not user input
+func ParseReplicationNetworkMappingIDInsensitively(input string) (*ReplicationNetworkMappingId, error) {
+	parser := resourceids.NewParserFromResourceIdType(ReplicationNetworkMappingId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := ReplicationNetworkMappingId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceName, ok = parsed.Parsed["resourceName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceName' was not found in the resource id %q", input)
+	}
+
+	if id.FabricName, ok = parsed.Parsed["fabricName"]; !ok {
+		return nil, fmt.Errorf("the segment 'fabricName' was not found in the resource id %q", input)
+	}
+
+	if id.NetworkName, ok = parsed.Parsed["networkName"]; !ok {
+		return nil, fmt.Errorf("the segment 'networkName' was not found in the resource id %q", input)
+	}
+
+	if id.NetworkMappingName, ok = parsed.Parsed["networkMappingName"]; !ok {
+		return nil, fmt.Errorf("the segment 'networkMappingName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ValidateReplicationNetworkMappingID checks that 'input' can be parsed as a Replication Network Mapping ID
+func ValidateReplicationNetworkMappingID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseReplicationNetworkMappingID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Replication Network Mapping ID
+func (id ReplicationNetworkMappingId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.RecoveryServices/vaults/%s/replicationFabrics/%s/replicationNetworks/%s/replicationNetworkMappings/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.ResourceName, id.FabricName, id.NetworkName, id.NetworkMappingName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Replication Network Mapping ID
+func (id ReplicationNetworkMappingId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftRecoveryServices", "Microsoft.RecoveryServices", "Microsoft.RecoveryServices"),
+		resourceids.StaticSegment("staticVaults", "vaults", "vaults"),
+		resourceids.UserSpecifiedSegment("resourceName", "resourceValue"),
+		resourceids.StaticSegment("staticReplicationFabrics", "replicationFabrics", "replicationFabrics"),
+		resourceids.UserSpecifiedSegment("fabricName", "fabricValue"),
+		resourceids.StaticSegment("staticReplicationNetworks", "replicationNetworks", "replicationNetworks"),
+		resourceids.UserSpecifiedSegment("networkName", "networkValue"),
+		resourceids.StaticSegment("staticReplicationNetworkMappings", "replicationNetworkMappings", "replicationNetworkMappings"),
+		resourceids.UserSpecifiedSegment("networkMappingName", "networkMappingValue"),
+	}
+}
+
+// String returns a human-readable description of this Replication Network Mapping ID
+func (id ReplicationNetworkMappingId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Resource Name: %q", id.ResourceName),
+		fmt.Sprintf("Fabric Name: %q", id.FabricName),
+		fmt.Sprintf("Network Name: %q", id.NetworkName),
+		fmt.Sprintf("Network Mapping Name: %q", id.NetworkMappingName),
+	}
+	return fmt.Sprintf("Replication Network Mapping (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/id_vault.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/id_vault.go
@@ -1,0 +1,124 @@
+package replicationnetworkmappings
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = VaultId{}
+
+// VaultId is a struct representing the Resource ID for a Vault
+type VaultId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	ResourceName      string
+}
+
+// NewVaultID returns a new VaultId struct
+func NewVaultID(subscriptionId string, resourceGroupName string, resourceName string) VaultId {
+	return VaultId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		ResourceName:      resourceName,
+	}
+}
+
+// ParseVaultID parses 'input' into a VaultId
+func ParseVaultID(input string) (*VaultId, error) {
+	parser := resourceids.NewParserFromResourceIdType(VaultId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := VaultId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceName, ok = parsed.Parsed["resourceName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ParseVaultIDInsensitively parses 'input' case-insensitively into a VaultId
+// note: this method should only be used for API response data and not user input
+func ParseVaultIDInsensitively(input string) (*VaultId, error) {
+	parser := resourceids.NewParserFromResourceIdType(VaultId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := VaultId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceName, ok = parsed.Parsed["resourceName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ValidateVaultID checks that 'input' can be parsed as a Vault ID
+func ValidateVaultID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseVaultID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Vault ID
+func (id VaultId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.RecoveryServices/vaults/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.ResourceName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Vault ID
+func (id VaultId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftRecoveryServices", "Microsoft.RecoveryServices", "Microsoft.RecoveryServices"),
+		resourceids.StaticSegment("staticVaults", "vaults", "vaults"),
+		resourceids.UserSpecifiedSegment("resourceName", "resourceValue"),
+	}
+}
+
+// String returns a human-readable description of this Vault ID
+func (id VaultId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Resource Name: %q", id.ResourceName),
+	}
+	return fmt.Sprintf("Vault (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/method_create_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/method_create_autorest.go
@@ -1,0 +1,79 @@
+package replicationnetworkmappings
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CreateOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// Create ...
+func (c ReplicationNetworkMappingsClient) Create(ctx context.Context, id ReplicationNetworkMappingId, input CreateNetworkMappingInput) (result CreateOperationResponse, err error) {
+	req, err := c.preparerForCreate(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationnetworkmappings.ReplicationNetworkMappingsClient", "Create", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForCreate(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationnetworkmappings.ReplicationNetworkMappingsClient", "Create", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// CreateThenPoll performs Create then polls until it's completed
+func (c ReplicationNetworkMappingsClient) CreateThenPoll(ctx context.Context, id ReplicationNetworkMappingId, input CreateNetworkMappingInput) error {
+	result, err := c.Create(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing Create: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after Create: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForCreate prepares the Create request.
+func (c ReplicationNetworkMappingsClient) preparerForCreate(ctx context.Context, id ReplicationNetworkMappingId, input CreateNetworkMappingInput) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPut(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForCreate sends the Create request. The method will close the
+// http.Response Body if it receives an error.
+func (c ReplicationNetworkMappingsClient) senderForCreate(ctx context.Context, req *http.Request) (future CreateOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/method_delete_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/method_delete_autorest.go
@@ -1,0 +1,78 @@
+package replicationnetworkmappings
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DeleteOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// Delete ...
+func (c ReplicationNetworkMappingsClient) Delete(ctx context.Context, id ReplicationNetworkMappingId) (result DeleteOperationResponse, err error) {
+	req, err := c.preparerForDelete(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationnetworkmappings.ReplicationNetworkMappingsClient", "Delete", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForDelete(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationnetworkmappings.ReplicationNetworkMappingsClient", "Delete", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// DeleteThenPoll performs Delete then polls until it's completed
+func (c ReplicationNetworkMappingsClient) DeleteThenPoll(ctx context.Context, id ReplicationNetworkMappingId) error {
+	result, err := c.Delete(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing Delete: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after Delete: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForDelete prepares the Delete request.
+func (c ReplicationNetworkMappingsClient) preparerForDelete(ctx context.Context, id ReplicationNetworkMappingId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsDelete(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForDelete sends the Delete request. The method will close the
+// http.Response Body if it receives an error.
+func (c ReplicationNetworkMappingsClient) senderForDelete(ctx context.Context, req *http.Request) (future DeleteOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/method_get_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/method_get_autorest.go
@@ -1,0 +1,68 @@
+package replicationnetworkmappings
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *NetworkMapping
+}
+
+// Get ...
+func (c ReplicationNetworkMappingsClient) Get(ctx context.Context, id ReplicationNetworkMappingId) (result GetOperationResponse, err error) {
+	req, err := c.preparerForGet(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationnetworkmappings.ReplicationNetworkMappingsClient", "Get", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationnetworkmappings.ReplicationNetworkMappingsClient", "Get", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForGet(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationnetworkmappings.ReplicationNetworkMappingsClient", "Get", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForGet prepares the Get request.
+func (c ReplicationNetworkMappingsClient) preparerForGet(ctx context.Context, id ReplicationNetworkMappingId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForGet handles the response to the Get request. The method always
+// closes the http.Response Body.
+func (c ReplicationNetworkMappingsClient) responderForGet(resp *http.Response) (result GetOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/method_list_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/method_list_autorest.go
@@ -1,0 +1,186 @@
+package replicationnetworkmappings
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *[]NetworkMapping
+
+	nextLink     *string
+	nextPageFunc func(ctx context.Context, nextLink string) (ListOperationResponse, error)
+}
+
+type ListCompleteResult struct {
+	Items []NetworkMapping
+}
+
+func (r ListOperationResponse) HasMore() bool {
+	return r.nextLink != nil
+}
+
+func (r ListOperationResponse) LoadMore(ctx context.Context) (resp ListOperationResponse, err error) {
+	if !r.HasMore() {
+		err = fmt.Errorf("no more pages returned")
+		return
+	}
+	return r.nextPageFunc(ctx, *r.nextLink)
+}
+
+// List ...
+func (c ReplicationNetworkMappingsClient) List(ctx context.Context, id VaultId) (resp ListOperationResponse, err error) {
+	req, err := c.preparerForList(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationnetworkmappings.ReplicationNetworkMappingsClient", "List", nil, "Failure preparing request")
+		return
+	}
+
+	resp.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationnetworkmappings.ReplicationNetworkMappingsClient", "List", resp.HttpResponse, "Failure sending request")
+		return
+	}
+
+	resp, err = c.responderForList(resp.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationnetworkmappings.ReplicationNetworkMappingsClient", "List", resp.HttpResponse, "Failure responding to request")
+		return
+	}
+	return
+}
+
+// preparerForList prepares the List request.
+func (c ReplicationNetworkMappingsClient) preparerForList(ctx context.Context, id VaultId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/replicationNetworkMappings", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// preparerForListWithNextLink prepares the List request with the given nextLink token.
+func (c ReplicationNetworkMappingsClient) preparerForListWithNextLink(ctx context.Context, nextLink string) (*http.Request, error) {
+	uri, err := url.Parse(nextLink)
+	if err != nil {
+		return nil, fmt.Errorf("parsing nextLink %q: %+v", nextLink, err)
+	}
+	queryParameters := map[string]interface{}{}
+	for k, v := range uri.Query() {
+		if len(v) == 0 {
+			continue
+		}
+		val := v[0]
+		val = autorest.Encode("query", val)
+		queryParameters[k] = val
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(uri.Path),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForList handles the response to the List request. The method always
+// closes the http.Response Body.
+func (c ReplicationNetworkMappingsClient) responderForList(resp *http.Response) (result ListOperationResponse, err error) {
+	type page struct {
+		Values   []NetworkMapping `json:"value"`
+		NextLink *string          `json:"nextLink"`
+	}
+	var respObj page
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&respObj),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	result.Model = &respObj.Values
+	result.nextLink = respObj.NextLink
+	if respObj.NextLink != nil {
+		result.nextPageFunc = func(ctx context.Context, nextLink string) (result ListOperationResponse, err error) {
+			req, err := c.preparerForListWithNextLink(ctx, nextLink)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "replicationnetworkmappings.ReplicationNetworkMappingsClient", "List", nil, "Failure preparing request")
+				return
+			}
+
+			result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "replicationnetworkmappings.ReplicationNetworkMappingsClient", "List", result.HttpResponse, "Failure sending request")
+				return
+			}
+
+			result, err = c.responderForList(result.HttpResponse)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "replicationnetworkmappings.ReplicationNetworkMappingsClient", "List", result.HttpResponse, "Failure responding to request")
+				return
+			}
+
+			return
+		}
+	}
+	return
+}
+
+// ListComplete retrieves all of the results into a single object
+func (c ReplicationNetworkMappingsClient) ListComplete(ctx context.Context, id VaultId) (ListCompleteResult, error) {
+	return c.ListCompleteMatchingPredicate(ctx, id, NetworkMappingOperationPredicate{})
+}
+
+// ListCompleteMatchingPredicate retrieves all of the results and then applied the predicate
+func (c ReplicationNetworkMappingsClient) ListCompleteMatchingPredicate(ctx context.Context, id VaultId, predicate NetworkMappingOperationPredicate) (resp ListCompleteResult, err error) {
+	items := make([]NetworkMapping, 0)
+
+	page, err := c.List(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading the initial page: %+v", err)
+		return
+	}
+	if page.Model != nil {
+		for _, v := range *page.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	for page.HasMore() {
+		page, err = page.LoadMore(ctx)
+		if err != nil {
+			err = fmt.Errorf("loading the next page: %+v", err)
+			return
+		}
+
+		if page.Model != nil {
+			for _, v := range *page.Model {
+				if predicate.Matches(v) {
+					items = append(items, v)
+				}
+			}
+		}
+	}
+
+	out := ListCompleteResult{
+		Items: items,
+	}
+	return out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/method_listbyreplicationnetworks_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/method_listbyreplicationnetworks_autorest.go
@@ -1,0 +1,186 @@
+package replicationnetworkmappings
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListByReplicationNetworksOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *[]NetworkMapping
+
+	nextLink     *string
+	nextPageFunc func(ctx context.Context, nextLink string) (ListByReplicationNetworksOperationResponse, error)
+}
+
+type ListByReplicationNetworksCompleteResult struct {
+	Items []NetworkMapping
+}
+
+func (r ListByReplicationNetworksOperationResponse) HasMore() bool {
+	return r.nextLink != nil
+}
+
+func (r ListByReplicationNetworksOperationResponse) LoadMore(ctx context.Context) (resp ListByReplicationNetworksOperationResponse, err error) {
+	if !r.HasMore() {
+		err = fmt.Errorf("no more pages returned")
+		return
+	}
+	return r.nextPageFunc(ctx, *r.nextLink)
+}
+
+// ListByReplicationNetworks ...
+func (c ReplicationNetworkMappingsClient) ListByReplicationNetworks(ctx context.Context, id ReplicationNetworkId) (resp ListByReplicationNetworksOperationResponse, err error) {
+	req, err := c.preparerForListByReplicationNetworks(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationnetworkmappings.ReplicationNetworkMappingsClient", "ListByReplicationNetworks", nil, "Failure preparing request")
+		return
+	}
+
+	resp.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationnetworkmappings.ReplicationNetworkMappingsClient", "ListByReplicationNetworks", resp.HttpResponse, "Failure sending request")
+		return
+	}
+
+	resp, err = c.responderForListByReplicationNetworks(resp.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationnetworkmappings.ReplicationNetworkMappingsClient", "ListByReplicationNetworks", resp.HttpResponse, "Failure responding to request")
+		return
+	}
+	return
+}
+
+// preparerForListByReplicationNetworks prepares the ListByReplicationNetworks request.
+func (c ReplicationNetworkMappingsClient) preparerForListByReplicationNetworks(ctx context.Context, id ReplicationNetworkId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/replicationNetworkMappings", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// preparerForListByReplicationNetworksWithNextLink prepares the ListByReplicationNetworks request with the given nextLink token.
+func (c ReplicationNetworkMappingsClient) preparerForListByReplicationNetworksWithNextLink(ctx context.Context, nextLink string) (*http.Request, error) {
+	uri, err := url.Parse(nextLink)
+	if err != nil {
+		return nil, fmt.Errorf("parsing nextLink %q: %+v", nextLink, err)
+	}
+	queryParameters := map[string]interface{}{}
+	for k, v := range uri.Query() {
+		if len(v) == 0 {
+			continue
+		}
+		val := v[0]
+		val = autorest.Encode("query", val)
+		queryParameters[k] = val
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(uri.Path),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForListByReplicationNetworks handles the response to the ListByReplicationNetworks request. The method always
+// closes the http.Response Body.
+func (c ReplicationNetworkMappingsClient) responderForListByReplicationNetworks(resp *http.Response) (result ListByReplicationNetworksOperationResponse, err error) {
+	type page struct {
+		Values   []NetworkMapping `json:"value"`
+		NextLink *string          `json:"nextLink"`
+	}
+	var respObj page
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&respObj),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	result.Model = &respObj.Values
+	result.nextLink = respObj.NextLink
+	if respObj.NextLink != nil {
+		result.nextPageFunc = func(ctx context.Context, nextLink string) (result ListByReplicationNetworksOperationResponse, err error) {
+			req, err := c.preparerForListByReplicationNetworksWithNextLink(ctx, nextLink)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "replicationnetworkmappings.ReplicationNetworkMappingsClient", "ListByReplicationNetworks", nil, "Failure preparing request")
+				return
+			}
+
+			result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "replicationnetworkmappings.ReplicationNetworkMappingsClient", "ListByReplicationNetworks", result.HttpResponse, "Failure sending request")
+				return
+			}
+
+			result, err = c.responderForListByReplicationNetworks(result.HttpResponse)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "replicationnetworkmappings.ReplicationNetworkMappingsClient", "ListByReplicationNetworks", result.HttpResponse, "Failure responding to request")
+				return
+			}
+
+			return
+		}
+	}
+	return
+}
+
+// ListByReplicationNetworksComplete retrieves all of the results into a single object
+func (c ReplicationNetworkMappingsClient) ListByReplicationNetworksComplete(ctx context.Context, id ReplicationNetworkId) (ListByReplicationNetworksCompleteResult, error) {
+	return c.ListByReplicationNetworksCompleteMatchingPredicate(ctx, id, NetworkMappingOperationPredicate{})
+}
+
+// ListByReplicationNetworksCompleteMatchingPredicate retrieves all of the results and then applied the predicate
+func (c ReplicationNetworkMappingsClient) ListByReplicationNetworksCompleteMatchingPredicate(ctx context.Context, id ReplicationNetworkId, predicate NetworkMappingOperationPredicate) (resp ListByReplicationNetworksCompleteResult, err error) {
+	items := make([]NetworkMapping, 0)
+
+	page, err := c.ListByReplicationNetworks(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading the initial page: %+v", err)
+		return
+	}
+	if page.Model != nil {
+		for _, v := range *page.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	for page.HasMore() {
+		page, err = page.LoadMore(ctx)
+		if err != nil {
+			err = fmt.Errorf("loading the next page: %+v", err)
+			return
+		}
+
+		if page.Model != nil {
+			for _, v := range *page.Model {
+				if predicate.Matches(v) {
+					items = append(items, v)
+				}
+			}
+		}
+	}
+
+	out := ListByReplicationNetworksCompleteResult{
+		Items: items,
+	}
+	return out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/method_update_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/method_update_autorest.go
@@ -1,0 +1,79 @@
+package replicationnetworkmappings
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UpdateOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// Update ...
+func (c ReplicationNetworkMappingsClient) Update(ctx context.Context, id ReplicationNetworkMappingId, input UpdateNetworkMappingInput) (result UpdateOperationResponse, err error) {
+	req, err := c.preparerForUpdate(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationnetworkmappings.ReplicationNetworkMappingsClient", "Update", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForUpdate(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationnetworkmappings.ReplicationNetworkMappingsClient", "Update", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// UpdateThenPoll performs Update then polls until it's completed
+func (c ReplicationNetworkMappingsClient) UpdateThenPoll(ctx context.Context, id ReplicationNetworkMappingId, input UpdateNetworkMappingInput) error {
+	result, err := c.Update(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing Update: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after Update: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForUpdate prepares the Update request.
+func (c ReplicationNetworkMappingsClient) preparerForUpdate(ctx context.Context, id ReplicationNetworkMappingId, input UpdateNetworkMappingInput) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPatch(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForUpdate sends the Update request. The method will close the
+// http.Response Body if it receives an error.
+func (c ReplicationNetworkMappingsClient) senderForUpdate(ctx context.Context, req *http.Request) (future UpdateOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/model_azuretoazurecreatenetworkmappinginput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/model_azuretoazurecreatenetworkmappinginput.go
@@ -1,0 +1,41 @@
+package replicationnetworkmappings
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ FabricSpecificCreateNetworkMappingInput = AzureToAzureCreateNetworkMappingInput{}
+
+type AzureToAzureCreateNetworkMappingInput struct {
+	PrimaryNetworkId string `json:"primaryNetworkId"`
+
+	// Fields inherited from FabricSpecificCreateNetworkMappingInput
+}
+
+var _ json.Marshaler = AzureToAzureCreateNetworkMappingInput{}
+
+func (s AzureToAzureCreateNetworkMappingInput) MarshalJSON() ([]byte, error) {
+	type wrapper AzureToAzureCreateNetworkMappingInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling AzureToAzureCreateNetworkMappingInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling AzureToAzureCreateNetworkMappingInput: %+v", err)
+	}
+	decoded["instanceType"] = "AzureToAzure"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling AzureToAzureCreateNetworkMappingInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/model_azuretoazurenetworkmappingsettings.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/model_azuretoazurenetworkmappingsettings.go
@@ -1,0 +1,42 @@
+package replicationnetworkmappings
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ NetworkMappingFabricSpecificSettings = AzureToAzureNetworkMappingSettings{}
+
+type AzureToAzureNetworkMappingSettings struct {
+	PrimaryFabricLocation  *string `json:"primaryFabricLocation,omitempty"`
+	RecoveryFabricLocation *string `json:"recoveryFabricLocation,omitempty"`
+
+	// Fields inherited from NetworkMappingFabricSpecificSettings
+}
+
+var _ json.Marshaler = AzureToAzureNetworkMappingSettings{}
+
+func (s AzureToAzureNetworkMappingSettings) MarshalJSON() ([]byte, error) {
+	type wrapper AzureToAzureNetworkMappingSettings
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling AzureToAzureNetworkMappingSettings: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling AzureToAzureNetworkMappingSettings: %+v", err)
+	}
+	decoded["instanceType"] = "AzureToAzure"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling AzureToAzureNetworkMappingSettings: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/model_azuretoazureupdatenetworkmappinginput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/model_azuretoazureupdatenetworkmappinginput.go
@@ -1,0 +1,41 @@
+package replicationnetworkmappings
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ FabricSpecificUpdateNetworkMappingInput = AzureToAzureUpdateNetworkMappingInput{}
+
+type AzureToAzureUpdateNetworkMappingInput struct {
+	PrimaryNetworkId *string `json:"primaryNetworkId,omitempty"`
+
+	// Fields inherited from FabricSpecificUpdateNetworkMappingInput
+}
+
+var _ json.Marshaler = AzureToAzureUpdateNetworkMappingInput{}
+
+func (s AzureToAzureUpdateNetworkMappingInput) MarshalJSON() ([]byte, error) {
+	type wrapper AzureToAzureUpdateNetworkMappingInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling AzureToAzureUpdateNetworkMappingInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling AzureToAzureUpdateNetworkMappingInput: %+v", err)
+	}
+	decoded["instanceType"] = "AzureToAzure"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling AzureToAzureUpdateNetworkMappingInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/model_createnetworkmappinginput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/model_createnetworkmappinginput.go
@@ -1,0 +1,8 @@
+package replicationnetworkmappings
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CreateNetworkMappingInput struct {
+	Properties CreateNetworkMappingInputProperties `json:"properties"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/model_createnetworkmappinginputproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/model_createnetworkmappinginputproperties.go
@@ -1,0 +1,42 @@
+package replicationnetworkmappings
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CreateNetworkMappingInputProperties struct {
+	FabricSpecificDetails FabricSpecificCreateNetworkMappingInput `json:"fabricSpecificDetails"`
+	RecoveryFabricName    *string                                 `json:"recoveryFabricName,omitempty"`
+	RecoveryNetworkId     string                                  `json:"recoveryNetworkId"`
+}
+
+var _ json.Unmarshaler = &CreateNetworkMappingInputProperties{}
+
+func (s *CreateNetworkMappingInputProperties) UnmarshalJSON(bytes []byte) error {
+	type alias CreateNetworkMappingInputProperties
+	var decoded alias
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling into CreateNetworkMappingInputProperties: %+v", err)
+	}
+
+	s.RecoveryFabricName = decoded.RecoveryFabricName
+	s.RecoveryNetworkId = decoded.RecoveryNetworkId
+
+	var temp map[string]json.RawMessage
+	if err := json.Unmarshal(bytes, &temp); err != nil {
+		return fmt.Errorf("unmarshaling CreateNetworkMappingInputProperties into map[string]json.RawMessage: %+v", err)
+	}
+
+	if v, ok := temp["fabricSpecificDetails"]; ok {
+		impl, err := unmarshalFabricSpecificCreateNetworkMappingInputImplementation(v)
+		if err != nil {
+			return fmt.Errorf("unmarshaling field 'FabricSpecificDetails' for 'CreateNetworkMappingInputProperties': %+v", err)
+		}
+		s.FabricSpecificDetails = impl
+	}
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/model_fabricspecificcreatenetworkmappinginput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/model_fabricspecificcreatenetworkmappinginput.go
@@ -1,0 +1,64 @@
+package replicationnetworkmappings
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type FabricSpecificCreateNetworkMappingInput interface {
+}
+
+func unmarshalFabricSpecificCreateNetworkMappingInputImplementation(input []byte) (FabricSpecificCreateNetworkMappingInput, error) {
+	if input == nil {
+		return nil, nil
+	}
+
+	var temp map[string]interface{}
+	if err := json.Unmarshal(input, &temp); err != nil {
+		return nil, fmt.Errorf("unmarshaling FabricSpecificCreateNetworkMappingInput into map[string]interface: %+v", err)
+	}
+
+	value, ok := temp["instanceType"].(string)
+	if !ok {
+		return nil, nil
+	}
+
+	if strings.EqualFold(value, "AzureToAzure") {
+		var out AzureToAzureCreateNetworkMappingInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into AzureToAzureCreateNetworkMappingInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "VmmToAzure") {
+		var out VmmToAzureCreateNetworkMappingInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into VmmToAzureCreateNetworkMappingInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "VmmToVmm") {
+		var out VmmToVmmCreateNetworkMappingInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into VmmToVmmCreateNetworkMappingInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	type RawFabricSpecificCreateNetworkMappingInputImpl struct {
+		Type   string                 `json:"-"`
+		Values map[string]interface{} `json:"-"`
+	}
+	out := RawFabricSpecificCreateNetworkMappingInputImpl{
+		Type:   value,
+		Values: temp,
+	}
+	return out, nil
+
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/model_fabricspecificupdatenetworkmappinginput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/model_fabricspecificupdatenetworkmappinginput.go
@@ -1,0 +1,64 @@
+package replicationnetworkmappings
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type FabricSpecificUpdateNetworkMappingInput interface {
+}
+
+func unmarshalFabricSpecificUpdateNetworkMappingInputImplementation(input []byte) (FabricSpecificUpdateNetworkMappingInput, error) {
+	if input == nil {
+		return nil, nil
+	}
+
+	var temp map[string]interface{}
+	if err := json.Unmarshal(input, &temp); err != nil {
+		return nil, fmt.Errorf("unmarshaling FabricSpecificUpdateNetworkMappingInput into map[string]interface: %+v", err)
+	}
+
+	value, ok := temp["instanceType"].(string)
+	if !ok {
+		return nil, nil
+	}
+
+	if strings.EqualFold(value, "AzureToAzure") {
+		var out AzureToAzureUpdateNetworkMappingInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into AzureToAzureUpdateNetworkMappingInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "VmmToAzure") {
+		var out VmmToAzureUpdateNetworkMappingInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into VmmToAzureUpdateNetworkMappingInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "VmmToVmm") {
+		var out VmmToVmmUpdateNetworkMappingInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into VmmToVmmUpdateNetworkMappingInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	type RawFabricSpecificUpdateNetworkMappingInputImpl struct {
+		Type   string                 `json:"-"`
+		Values map[string]interface{} `json:"-"`
+	}
+	out := RawFabricSpecificUpdateNetworkMappingInputImpl{
+		Type:   value,
+		Values: temp,
+	}
+	return out, nil
+
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/model_networkmapping.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/model_networkmapping.go
@@ -1,0 +1,12 @@
+package replicationnetworkmappings
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type NetworkMapping struct {
+	Id         *string                   `json:"id,omitempty"`
+	Location   *string                   `json:"location,omitempty"`
+	Name       *string                   `json:"name,omitempty"`
+	Properties *NetworkMappingProperties `json:"properties,omitempty"`
+	Type       *string                   `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/model_networkmappingfabricspecificsettings.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/model_networkmappingfabricspecificsettings.go
@@ -1,0 +1,64 @@
+package replicationnetworkmappings
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type NetworkMappingFabricSpecificSettings interface {
+}
+
+func unmarshalNetworkMappingFabricSpecificSettingsImplementation(input []byte) (NetworkMappingFabricSpecificSettings, error) {
+	if input == nil {
+		return nil, nil
+	}
+
+	var temp map[string]interface{}
+	if err := json.Unmarshal(input, &temp); err != nil {
+		return nil, fmt.Errorf("unmarshaling NetworkMappingFabricSpecificSettings into map[string]interface: %+v", err)
+	}
+
+	value, ok := temp["instanceType"].(string)
+	if !ok {
+		return nil, nil
+	}
+
+	if strings.EqualFold(value, "AzureToAzure") {
+		var out AzureToAzureNetworkMappingSettings
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into AzureToAzureNetworkMappingSettings: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "VmmToAzure") {
+		var out VmmToAzureNetworkMappingSettings
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into VmmToAzureNetworkMappingSettings: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "VmmToVmm") {
+		var out VmmToVmmNetworkMappingSettings
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into VmmToVmmNetworkMappingSettings: %+v", err)
+		}
+		return out, nil
+	}
+
+	type RawNetworkMappingFabricSpecificSettingsImpl struct {
+		Type   string                 `json:"-"`
+		Values map[string]interface{} `json:"-"`
+	}
+	out := RawNetworkMappingFabricSpecificSettingsImpl{
+		Type:   value,
+		Values: temp,
+	}
+	return out, nil
+
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/model_networkmappingproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/model_networkmappingproperties.go
@@ -1,0 +1,54 @@
+package replicationnetworkmappings
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type NetworkMappingProperties struct {
+	FabricSpecificSettings      NetworkMappingFabricSpecificSettings `json:"fabricSpecificSettings"`
+	PrimaryFabricFriendlyName   *string                              `json:"primaryFabricFriendlyName,omitempty"`
+	PrimaryNetworkFriendlyName  *string                              `json:"primaryNetworkFriendlyName,omitempty"`
+	PrimaryNetworkId            *string                              `json:"primaryNetworkId,omitempty"`
+	RecoveryFabricArmId         *string                              `json:"recoveryFabricArmId,omitempty"`
+	RecoveryFabricFriendlyName  *string                              `json:"recoveryFabricFriendlyName,omitempty"`
+	RecoveryNetworkFriendlyName *string                              `json:"recoveryNetworkFriendlyName,omitempty"`
+	RecoveryNetworkId           *string                              `json:"recoveryNetworkId,omitempty"`
+	State                       *string                              `json:"state,omitempty"`
+}
+
+var _ json.Unmarshaler = &NetworkMappingProperties{}
+
+func (s *NetworkMappingProperties) UnmarshalJSON(bytes []byte) error {
+	type alias NetworkMappingProperties
+	var decoded alias
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling into NetworkMappingProperties: %+v", err)
+	}
+
+	s.PrimaryFabricFriendlyName = decoded.PrimaryFabricFriendlyName
+	s.PrimaryNetworkFriendlyName = decoded.PrimaryNetworkFriendlyName
+	s.PrimaryNetworkId = decoded.PrimaryNetworkId
+	s.RecoveryFabricArmId = decoded.RecoveryFabricArmId
+	s.RecoveryFabricFriendlyName = decoded.RecoveryFabricFriendlyName
+	s.RecoveryNetworkFriendlyName = decoded.RecoveryNetworkFriendlyName
+	s.RecoveryNetworkId = decoded.RecoveryNetworkId
+	s.State = decoded.State
+
+	var temp map[string]json.RawMessage
+	if err := json.Unmarshal(bytes, &temp); err != nil {
+		return fmt.Errorf("unmarshaling NetworkMappingProperties into map[string]json.RawMessage: %+v", err)
+	}
+
+	if v, ok := temp["fabricSpecificSettings"]; ok {
+		impl, err := unmarshalNetworkMappingFabricSpecificSettingsImplementation(v)
+		if err != nil {
+			return fmt.Errorf("unmarshaling field 'FabricSpecificSettings' for 'NetworkMappingProperties': %+v", err)
+		}
+		s.FabricSpecificSettings = impl
+	}
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/model_updatenetworkmappinginput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/model_updatenetworkmappinginput.go
@@ -1,0 +1,8 @@
+package replicationnetworkmappings
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UpdateNetworkMappingInput struct {
+	Properties *UpdateNetworkMappingInputProperties `json:"properties,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/model_updatenetworkmappinginputproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/model_updatenetworkmappinginputproperties.go
@@ -1,0 +1,42 @@
+package replicationnetworkmappings
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UpdateNetworkMappingInputProperties struct {
+	FabricSpecificDetails FabricSpecificUpdateNetworkMappingInput `json:"fabricSpecificDetails"`
+	RecoveryFabricName    *string                                 `json:"recoveryFabricName,omitempty"`
+	RecoveryNetworkId     *string                                 `json:"recoveryNetworkId,omitempty"`
+}
+
+var _ json.Unmarshaler = &UpdateNetworkMappingInputProperties{}
+
+func (s *UpdateNetworkMappingInputProperties) UnmarshalJSON(bytes []byte) error {
+	type alias UpdateNetworkMappingInputProperties
+	var decoded alias
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling into UpdateNetworkMappingInputProperties: %+v", err)
+	}
+
+	s.RecoveryFabricName = decoded.RecoveryFabricName
+	s.RecoveryNetworkId = decoded.RecoveryNetworkId
+
+	var temp map[string]json.RawMessage
+	if err := json.Unmarshal(bytes, &temp); err != nil {
+		return fmt.Errorf("unmarshaling UpdateNetworkMappingInputProperties into map[string]json.RawMessage: %+v", err)
+	}
+
+	if v, ok := temp["fabricSpecificDetails"]; ok {
+		impl, err := unmarshalFabricSpecificUpdateNetworkMappingInputImplementation(v)
+		if err != nil {
+			return fmt.Errorf("unmarshaling field 'FabricSpecificDetails' for 'UpdateNetworkMappingInputProperties': %+v", err)
+		}
+		s.FabricSpecificDetails = impl
+	}
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/model_vmmtoazurecreatenetworkmappinginput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/model_vmmtoazurecreatenetworkmappinginput.go
@@ -1,0 +1,40 @@
+package replicationnetworkmappings
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ FabricSpecificCreateNetworkMappingInput = VmmToAzureCreateNetworkMappingInput{}
+
+type VmmToAzureCreateNetworkMappingInput struct {
+
+	// Fields inherited from FabricSpecificCreateNetworkMappingInput
+}
+
+var _ json.Marshaler = VmmToAzureCreateNetworkMappingInput{}
+
+func (s VmmToAzureCreateNetworkMappingInput) MarshalJSON() ([]byte, error) {
+	type wrapper VmmToAzureCreateNetworkMappingInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling VmmToAzureCreateNetworkMappingInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling VmmToAzureCreateNetworkMappingInput: %+v", err)
+	}
+	decoded["instanceType"] = "VmmToAzure"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling VmmToAzureCreateNetworkMappingInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/model_vmmtoazurenetworkmappingsettings.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/model_vmmtoazurenetworkmappingsettings.go
@@ -1,0 +1,40 @@
+package replicationnetworkmappings
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ NetworkMappingFabricSpecificSettings = VmmToAzureNetworkMappingSettings{}
+
+type VmmToAzureNetworkMappingSettings struct {
+
+	// Fields inherited from NetworkMappingFabricSpecificSettings
+}
+
+var _ json.Marshaler = VmmToAzureNetworkMappingSettings{}
+
+func (s VmmToAzureNetworkMappingSettings) MarshalJSON() ([]byte, error) {
+	type wrapper VmmToAzureNetworkMappingSettings
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling VmmToAzureNetworkMappingSettings: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling VmmToAzureNetworkMappingSettings: %+v", err)
+	}
+	decoded["instanceType"] = "VmmToAzure"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling VmmToAzureNetworkMappingSettings: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/model_vmmtoazureupdatenetworkmappinginput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/model_vmmtoazureupdatenetworkmappinginput.go
@@ -1,0 +1,40 @@
+package replicationnetworkmappings
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ FabricSpecificUpdateNetworkMappingInput = VmmToAzureUpdateNetworkMappingInput{}
+
+type VmmToAzureUpdateNetworkMappingInput struct {
+
+	// Fields inherited from FabricSpecificUpdateNetworkMappingInput
+}
+
+var _ json.Marshaler = VmmToAzureUpdateNetworkMappingInput{}
+
+func (s VmmToAzureUpdateNetworkMappingInput) MarshalJSON() ([]byte, error) {
+	type wrapper VmmToAzureUpdateNetworkMappingInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling VmmToAzureUpdateNetworkMappingInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling VmmToAzureUpdateNetworkMappingInput: %+v", err)
+	}
+	decoded["instanceType"] = "VmmToAzure"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling VmmToAzureUpdateNetworkMappingInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/model_vmmtovmmcreatenetworkmappinginput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/model_vmmtovmmcreatenetworkmappinginput.go
@@ -1,0 +1,40 @@
+package replicationnetworkmappings
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ FabricSpecificCreateNetworkMappingInput = VmmToVmmCreateNetworkMappingInput{}
+
+type VmmToVmmCreateNetworkMappingInput struct {
+
+	// Fields inherited from FabricSpecificCreateNetworkMappingInput
+}
+
+var _ json.Marshaler = VmmToVmmCreateNetworkMappingInput{}
+
+func (s VmmToVmmCreateNetworkMappingInput) MarshalJSON() ([]byte, error) {
+	type wrapper VmmToVmmCreateNetworkMappingInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling VmmToVmmCreateNetworkMappingInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling VmmToVmmCreateNetworkMappingInput: %+v", err)
+	}
+	decoded["instanceType"] = "VmmToVmm"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling VmmToVmmCreateNetworkMappingInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/model_vmmtovmmnetworkmappingsettings.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/model_vmmtovmmnetworkmappingsettings.go
@@ -1,0 +1,40 @@
+package replicationnetworkmappings
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ NetworkMappingFabricSpecificSettings = VmmToVmmNetworkMappingSettings{}
+
+type VmmToVmmNetworkMappingSettings struct {
+
+	// Fields inherited from NetworkMappingFabricSpecificSettings
+}
+
+var _ json.Marshaler = VmmToVmmNetworkMappingSettings{}
+
+func (s VmmToVmmNetworkMappingSettings) MarshalJSON() ([]byte, error) {
+	type wrapper VmmToVmmNetworkMappingSettings
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling VmmToVmmNetworkMappingSettings: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling VmmToVmmNetworkMappingSettings: %+v", err)
+	}
+	decoded["instanceType"] = "VmmToVmm"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling VmmToVmmNetworkMappingSettings: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/model_vmmtovmmupdatenetworkmappinginput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/model_vmmtovmmupdatenetworkmappinginput.go
@@ -1,0 +1,40 @@
+package replicationnetworkmappings
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ FabricSpecificUpdateNetworkMappingInput = VmmToVmmUpdateNetworkMappingInput{}
+
+type VmmToVmmUpdateNetworkMappingInput struct {
+
+	// Fields inherited from FabricSpecificUpdateNetworkMappingInput
+}
+
+var _ json.Marshaler = VmmToVmmUpdateNetworkMappingInput{}
+
+func (s VmmToVmmUpdateNetworkMappingInput) MarshalJSON() ([]byte, error) {
+	type wrapper VmmToVmmUpdateNetworkMappingInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling VmmToVmmUpdateNetworkMappingInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling VmmToVmmUpdateNetworkMappingInput: %+v", err)
+	}
+	decoded["instanceType"] = "VmmToVmm"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling VmmToVmmUpdateNetworkMappingInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/predicates.go
@@ -1,0 +1,29 @@
+package replicationnetworkmappings
+
+type NetworkMappingOperationPredicate struct {
+	Id       *string
+	Location *string
+	Name     *string
+	Type     *string
+}
+
+func (p NetworkMappingOperationPredicate) Matches(input NetworkMapping) bool {
+
+	if p.Id != nil && (input.Id == nil && *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Location != nil && (input.Location == nil && *p.Location != *input.Location) {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil && *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil && *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/version.go
@@ -1,0 +1,12 @@
+package replicationnetworkmappings
+
+import "fmt"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2022-10-01"
+
+func userAgent() string {
+	return fmt.Sprintf("hashicorp/go-azure-sdk/replicationnetworkmappings/%s", defaultApiVersion)
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/README.md
@@ -1,0 +1,99 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies` Documentation
+
+The `replicationpolicies` SDK allows for interaction with the Azure Resource Manager Service `recoveryservicessiterecovery` (API Version `2022-10-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies"
+```
+
+
+### Client Initialization
+
+```go
+client := replicationpolicies.NewReplicationPoliciesClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `ReplicationPoliciesClient.Create`
+
+```go
+ctx := context.TODO()
+id := replicationpolicies.NewReplicationPolicyID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue", "policyValue")
+
+payload := replicationpolicies.CreatePolicyInput{
+	// ...
+}
+
+
+if err := client.CreateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `ReplicationPoliciesClient.Delete`
+
+```go
+ctx := context.TODO()
+id := replicationpolicies.NewReplicationPolicyID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue", "policyValue")
+
+if err := client.DeleteThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `ReplicationPoliciesClient.Get`
+
+```go
+ctx := context.TODO()
+id := replicationpolicies.NewReplicationPolicyID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue", "policyValue")
+
+read, err := client.Get(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `ReplicationPoliciesClient.List`
+
+```go
+ctx := context.TODO()
+id := replicationpolicies.NewVaultID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue")
+
+// alternatively `client.List(ctx, id)` can be used to do batched pagination
+items, err := client.ListComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `ReplicationPoliciesClient.Update`
+
+```go
+ctx := context.TODO()
+id := replicationpolicies.NewReplicationPolicyID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue", "policyValue")
+
+payload := replicationpolicies.UpdatePolicyInput{
+	// ...
+}
+
+
+if err := client.UpdateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/client.go
@@ -1,0 +1,18 @@
+package replicationpolicies
+
+import "github.com/Azure/go-autorest/autorest"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ReplicationPoliciesClient struct {
+	Client  autorest.Client
+	baseUri string
+}
+
+func NewReplicationPoliciesClientWithBaseURI(endpoint string) ReplicationPoliciesClient {
+	return ReplicationPoliciesClient{
+		Client:  autorest.NewClientWithUserAgent(userAgent()),
+		baseUri: endpoint,
+	}
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/constants.go
@@ -1,0 +1,34 @@
+package replicationpolicies
+
+import "strings"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SetMultiVmSyncStatus string
+
+const (
+	SetMultiVmSyncStatusDisable SetMultiVmSyncStatus = "Disable"
+	SetMultiVmSyncStatusEnable  SetMultiVmSyncStatus = "Enable"
+)
+
+func PossibleValuesForSetMultiVmSyncStatus() []string {
+	return []string{
+		string(SetMultiVmSyncStatusDisable),
+		string(SetMultiVmSyncStatusEnable),
+	}
+}
+
+func parseSetMultiVmSyncStatus(input string) (*SetMultiVmSyncStatus, error) {
+	vals := map[string]SetMultiVmSyncStatus{
+		"disable": SetMultiVmSyncStatusDisable,
+		"enable":  SetMultiVmSyncStatusEnable,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := SetMultiVmSyncStatus(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/id_replicationpolicy.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/id_replicationpolicy.go
@@ -1,0 +1,137 @@
+package replicationpolicies
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = ReplicationPolicyId{}
+
+// ReplicationPolicyId is a struct representing the Resource ID for a Replication Policy
+type ReplicationPolicyId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	ResourceName      string
+	PolicyName        string
+}
+
+// NewReplicationPolicyID returns a new ReplicationPolicyId struct
+func NewReplicationPolicyID(subscriptionId string, resourceGroupName string, resourceName string, policyName string) ReplicationPolicyId {
+	return ReplicationPolicyId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		ResourceName:      resourceName,
+		PolicyName:        policyName,
+	}
+}
+
+// ParseReplicationPolicyID parses 'input' into a ReplicationPolicyId
+func ParseReplicationPolicyID(input string) (*ReplicationPolicyId, error) {
+	parser := resourceids.NewParserFromResourceIdType(ReplicationPolicyId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := ReplicationPolicyId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceName, ok = parsed.Parsed["resourceName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceName' was not found in the resource id %q", input)
+	}
+
+	if id.PolicyName, ok = parsed.Parsed["policyName"]; !ok {
+		return nil, fmt.Errorf("the segment 'policyName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ParseReplicationPolicyIDInsensitively parses 'input' case-insensitively into a ReplicationPolicyId
+// note: this method should only be used for API response data and not user input
+func ParseReplicationPolicyIDInsensitively(input string) (*ReplicationPolicyId, error) {
+	parser := resourceids.NewParserFromResourceIdType(ReplicationPolicyId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := ReplicationPolicyId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceName, ok = parsed.Parsed["resourceName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceName' was not found in the resource id %q", input)
+	}
+
+	if id.PolicyName, ok = parsed.Parsed["policyName"]; !ok {
+		return nil, fmt.Errorf("the segment 'policyName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ValidateReplicationPolicyID checks that 'input' can be parsed as a Replication Policy ID
+func ValidateReplicationPolicyID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseReplicationPolicyID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Replication Policy ID
+func (id ReplicationPolicyId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.RecoveryServices/vaults/%s/replicationPolicies/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.ResourceName, id.PolicyName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Replication Policy ID
+func (id ReplicationPolicyId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftRecoveryServices", "Microsoft.RecoveryServices", "Microsoft.RecoveryServices"),
+		resourceids.StaticSegment("staticVaults", "vaults", "vaults"),
+		resourceids.UserSpecifiedSegment("resourceName", "resourceValue"),
+		resourceids.StaticSegment("staticReplicationPolicies", "replicationPolicies", "replicationPolicies"),
+		resourceids.UserSpecifiedSegment("policyName", "policyValue"),
+	}
+}
+
+// String returns a human-readable description of this Replication Policy ID
+func (id ReplicationPolicyId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Resource Name: %q", id.ResourceName),
+		fmt.Sprintf("Policy Name: %q", id.PolicyName),
+	}
+	return fmt.Sprintf("Replication Policy (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/id_vault.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/id_vault.go
@@ -1,0 +1,124 @@
+package replicationpolicies
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = VaultId{}
+
+// VaultId is a struct representing the Resource ID for a Vault
+type VaultId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	ResourceName      string
+}
+
+// NewVaultID returns a new VaultId struct
+func NewVaultID(subscriptionId string, resourceGroupName string, resourceName string) VaultId {
+	return VaultId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		ResourceName:      resourceName,
+	}
+}
+
+// ParseVaultID parses 'input' into a VaultId
+func ParseVaultID(input string) (*VaultId, error) {
+	parser := resourceids.NewParserFromResourceIdType(VaultId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := VaultId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceName, ok = parsed.Parsed["resourceName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ParseVaultIDInsensitively parses 'input' case-insensitively into a VaultId
+// note: this method should only be used for API response data and not user input
+func ParseVaultIDInsensitively(input string) (*VaultId, error) {
+	parser := resourceids.NewParserFromResourceIdType(VaultId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := VaultId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceName, ok = parsed.Parsed["resourceName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ValidateVaultID checks that 'input' can be parsed as a Vault ID
+func ValidateVaultID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseVaultID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Vault ID
+func (id VaultId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.RecoveryServices/vaults/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.ResourceName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Vault ID
+func (id VaultId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftRecoveryServices", "Microsoft.RecoveryServices", "Microsoft.RecoveryServices"),
+		resourceids.StaticSegment("staticVaults", "vaults", "vaults"),
+		resourceids.UserSpecifiedSegment("resourceName", "resourceValue"),
+	}
+}
+
+// String returns a human-readable description of this Vault ID
+func (id VaultId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Resource Name: %q", id.ResourceName),
+	}
+	return fmt.Sprintf("Vault (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/method_create_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/method_create_autorest.go
@@ -1,0 +1,79 @@
+package replicationpolicies
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CreateOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// Create ...
+func (c ReplicationPoliciesClient) Create(ctx context.Context, id ReplicationPolicyId, input CreatePolicyInput) (result CreateOperationResponse, err error) {
+	req, err := c.preparerForCreate(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationpolicies.ReplicationPoliciesClient", "Create", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForCreate(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationpolicies.ReplicationPoliciesClient", "Create", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// CreateThenPoll performs Create then polls until it's completed
+func (c ReplicationPoliciesClient) CreateThenPoll(ctx context.Context, id ReplicationPolicyId, input CreatePolicyInput) error {
+	result, err := c.Create(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing Create: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after Create: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForCreate prepares the Create request.
+func (c ReplicationPoliciesClient) preparerForCreate(ctx context.Context, id ReplicationPolicyId, input CreatePolicyInput) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPut(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForCreate sends the Create request. The method will close the
+// http.Response Body if it receives an error.
+func (c ReplicationPoliciesClient) senderForCreate(ctx context.Context, req *http.Request) (future CreateOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/method_delete_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/method_delete_autorest.go
@@ -1,0 +1,78 @@
+package replicationpolicies
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DeleteOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// Delete ...
+func (c ReplicationPoliciesClient) Delete(ctx context.Context, id ReplicationPolicyId) (result DeleteOperationResponse, err error) {
+	req, err := c.preparerForDelete(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationpolicies.ReplicationPoliciesClient", "Delete", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForDelete(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationpolicies.ReplicationPoliciesClient", "Delete", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// DeleteThenPoll performs Delete then polls until it's completed
+func (c ReplicationPoliciesClient) DeleteThenPoll(ctx context.Context, id ReplicationPolicyId) error {
+	result, err := c.Delete(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing Delete: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after Delete: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForDelete prepares the Delete request.
+func (c ReplicationPoliciesClient) preparerForDelete(ctx context.Context, id ReplicationPolicyId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsDelete(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForDelete sends the Delete request. The method will close the
+// http.Response Body if it receives an error.
+func (c ReplicationPoliciesClient) senderForDelete(ctx context.Context, req *http.Request) (future DeleteOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/method_get_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/method_get_autorest.go
@@ -1,0 +1,68 @@
+package replicationpolicies
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *Policy
+}
+
+// Get ...
+func (c ReplicationPoliciesClient) Get(ctx context.Context, id ReplicationPolicyId) (result GetOperationResponse, err error) {
+	req, err := c.preparerForGet(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationpolicies.ReplicationPoliciesClient", "Get", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationpolicies.ReplicationPoliciesClient", "Get", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForGet(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationpolicies.ReplicationPoliciesClient", "Get", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForGet prepares the Get request.
+func (c ReplicationPoliciesClient) preparerForGet(ctx context.Context, id ReplicationPolicyId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForGet handles the response to the Get request. The method always
+// closes the http.Response Body.
+func (c ReplicationPoliciesClient) responderForGet(resp *http.Response) (result GetOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/method_list_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/method_list_autorest.go
@@ -1,0 +1,186 @@
+package replicationpolicies
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *[]Policy
+
+	nextLink     *string
+	nextPageFunc func(ctx context.Context, nextLink string) (ListOperationResponse, error)
+}
+
+type ListCompleteResult struct {
+	Items []Policy
+}
+
+func (r ListOperationResponse) HasMore() bool {
+	return r.nextLink != nil
+}
+
+func (r ListOperationResponse) LoadMore(ctx context.Context) (resp ListOperationResponse, err error) {
+	if !r.HasMore() {
+		err = fmt.Errorf("no more pages returned")
+		return
+	}
+	return r.nextPageFunc(ctx, *r.nextLink)
+}
+
+// List ...
+func (c ReplicationPoliciesClient) List(ctx context.Context, id VaultId) (resp ListOperationResponse, err error) {
+	req, err := c.preparerForList(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationpolicies.ReplicationPoliciesClient", "List", nil, "Failure preparing request")
+		return
+	}
+
+	resp.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationpolicies.ReplicationPoliciesClient", "List", resp.HttpResponse, "Failure sending request")
+		return
+	}
+
+	resp, err = c.responderForList(resp.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationpolicies.ReplicationPoliciesClient", "List", resp.HttpResponse, "Failure responding to request")
+		return
+	}
+	return
+}
+
+// preparerForList prepares the List request.
+func (c ReplicationPoliciesClient) preparerForList(ctx context.Context, id VaultId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/replicationPolicies", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// preparerForListWithNextLink prepares the List request with the given nextLink token.
+func (c ReplicationPoliciesClient) preparerForListWithNextLink(ctx context.Context, nextLink string) (*http.Request, error) {
+	uri, err := url.Parse(nextLink)
+	if err != nil {
+		return nil, fmt.Errorf("parsing nextLink %q: %+v", nextLink, err)
+	}
+	queryParameters := map[string]interface{}{}
+	for k, v := range uri.Query() {
+		if len(v) == 0 {
+			continue
+		}
+		val := v[0]
+		val = autorest.Encode("query", val)
+		queryParameters[k] = val
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(uri.Path),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForList handles the response to the List request. The method always
+// closes the http.Response Body.
+func (c ReplicationPoliciesClient) responderForList(resp *http.Response) (result ListOperationResponse, err error) {
+	type page struct {
+		Values   []Policy `json:"value"`
+		NextLink *string  `json:"nextLink"`
+	}
+	var respObj page
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&respObj),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	result.Model = &respObj.Values
+	result.nextLink = respObj.NextLink
+	if respObj.NextLink != nil {
+		result.nextPageFunc = func(ctx context.Context, nextLink string) (result ListOperationResponse, err error) {
+			req, err := c.preparerForListWithNextLink(ctx, nextLink)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "replicationpolicies.ReplicationPoliciesClient", "List", nil, "Failure preparing request")
+				return
+			}
+
+			result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "replicationpolicies.ReplicationPoliciesClient", "List", result.HttpResponse, "Failure sending request")
+				return
+			}
+
+			result, err = c.responderForList(result.HttpResponse)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "replicationpolicies.ReplicationPoliciesClient", "List", result.HttpResponse, "Failure responding to request")
+				return
+			}
+
+			return
+		}
+	}
+	return
+}
+
+// ListComplete retrieves all of the results into a single object
+func (c ReplicationPoliciesClient) ListComplete(ctx context.Context, id VaultId) (ListCompleteResult, error) {
+	return c.ListCompleteMatchingPredicate(ctx, id, PolicyOperationPredicate{})
+}
+
+// ListCompleteMatchingPredicate retrieves all of the results and then applied the predicate
+func (c ReplicationPoliciesClient) ListCompleteMatchingPredicate(ctx context.Context, id VaultId, predicate PolicyOperationPredicate) (resp ListCompleteResult, err error) {
+	items := make([]Policy, 0)
+
+	page, err := c.List(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading the initial page: %+v", err)
+		return
+	}
+	if page.Model != nil {
+		for _, v := range *page.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	for page.HasMore() {
+		page, err = page.LoadMore(ctx)
+		if err != nil {
+			err = fmt.Errorf("loading the next page: %+v", err)
+			return
+		}
+
+		if page.Model != nil {
+			for _, v := range *page.Model {
+				if predicate.Matches(v) {
+					items = append(items, v)
+				}
+			}
+		}
+	}
+
+	out := ListCompleteResult{
+		Items: items,
+	}
+	return out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/method_update_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/method_update_autorest.go
@@ -1,0 +1,79 @@
+package replicationpolicies
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UpdateOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// Update ...
+func (c ReplicationPoliciesClient) Update(ctx context.Context, id ReplicationPolicyId, input UpdatePolicyInput) (result UpdateOperationResponse, err error) {
+	req, err := c.preparerForUpdate(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationpolicies.ReplicationPoliciesClient", "Update", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForUpdate(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationpolicies.ReplicationPoliciesClient", "Update", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// UpdateThenPoll performs Update then polls until it's completed
+func (c ReplicationPoliciesClient) UpdateThenPoll(ctx context.Context, id ReplicationPolicyId, input UpdatePolicyInput) error {
+	result, err := c.Update(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing Update: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after Update: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForUpdate prepares the Update request.
+func (c ReplicationPoliciesClient) preparerForUpdate(ctx context.Context, id ReplicationPolicyId, input UpdatePolicyInput) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPatch(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForUpdate sends the Update request. The method will close the
+// http.Response Body if it receives an error.
+func (c ReplicationPoliciesClient) senderForUpdate(ctx context.Context, req *http.Request) (future UpdateOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/model_a2acrossclustermigrationpolicycreationinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/model_a2acrossclustermigrationpolicycreationinput.go
@@ -1,0 +1,40 @@
+package replicationpolicies
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ PolicyProviderSpecificInput = A2ACrossClusterMigrationPolicyCreationInput{}
+
+type A2ACrossClusterMigrationPolicyCreationInput struct {
+
+	// Fields inherited from PolicyProviderSpecificInput
+}
+
+var _ json.Marshaler = A2ACrossClusterMigrationPolicyCreationInput{}
+
+func (s A2ACrossClusterMigrationPolicyCreationInput) MarshalJSON() ([]byte, error) {
+	type wrapper A2ACrossClusterMigrationPolicyCreationInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling A2ACrossClusterMigrationPolicyCreationInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling A2ACrossClusterMigrationPolicyCreationInput: %+v", err)
+	}
+	decoded["instanceType"] = "A2ACrossClusterMigration"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling A2ACrossClusterMigrationPolicyCreationInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/model_a2apolicycreationinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/model_a2apolicycreationinput.go
@@ -1,0 +1,44 @@
+package replicationpolicies
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ PolicyProviderSpecificInput = A2APolicyCreationInput{}
+
+type A2APolicyCreationInput struct {
+	AppConsistentFrequencyInMinutes   *int64               `json:"appConsistentFrequencyInMinutes,omitempty"`
+	CrashConsistentFrequencyInMinutes *int64               `json:"crashConsistentFrequencyInMinutes,omitempty"`
+	MultiVmSyncStatus                 SetMultiVmSyncStatus `json:"multiVmSyncStatus"`
+	RecoveryPointHistory              *int64               `json:"recoveryPointHistory,omitempty"`
+
+	// Fields inherited from PolicyProviderSpecificInput
+}
+
+var _ json.Marshaler = A2APolicyCreationInput{}
+
+func (s A2APolicyCreationInput) MarshalJSON() ([]byte, error) {
+	type wrapper A2APolicyCreationInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling A2APolicyCreationInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling A2APolicyCreationInput: %+v", err)
+	}
+	decoded["instanceType"] = "A2A"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling A2APolicyCreationInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/model_a2apolicydetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/model_a2apolicydetails.go
@@ -1,0 +1,45 @@
+package replicationpolicies
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ PolicyProviderSpecificDetails = A2APolicyDetails{}
+
+type A2APolicyDetails struct {
+	AppConsistentFrequencyInMinutes   *int64  `json:"appConsistentFrequencyInMinutes,omitempty"`
+	CrashConsistentFrequencyInMinutes *int64  `json:"crashConsistentFrequencyInMinutes,omitempty"`
+	MultiVmSyncStatus                 *string `json:"multiVmSyncStatus,omitempty"`
+	RecoveryPointHistory              *int64  `json:"recoveryPointHistory,omitempty"`
+	RecoveryPointThresholdInMinutes   *int64  `json:"recoveryPointThresholdInMinutes,omitempty"`
+
+	// Fields inherited from PolicyProviderSpecificDetails
+}
+
+var _ json.Marshaler = A2APolicyDetails{}
+
+func (s A2APolicyDetails) MarshalJSON() ([]byte, error) {
+	type wrapper A2APolicyDetails
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling A2APolicyDetails: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling A2APolicyDetails: %+v", err)
+	}
+	decoded["instanceType"] = "A2A"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling A2APolicyDetails: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/model_createpolicyinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/model_createpolicyinput.go
@@ -1,0 +1,8 @@
+package replicationpolicies
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CreatePolicyInput struct {
+	Properties *CreatePolicyInputProperties `json:"properties,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/model_createpolicyinputproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/model_createpolicyinputproperties.go
@@ -1,0 +1,32 @@
+package replicationpolicies
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CreatePolicyInputProperties struct {
+	ProviderSpecificInput PolicyProviderSpecificInput `json:"providerSpecificInput"`
+}
+
+var _ json.Unmarshaler = &CreatePolicyInputProperties{}
+
+func (s *CreatePolicyInputProperties) UnmarshalJSON(bytes []byte) error {
+
+	var temp map[string]json.RawMessage
+	if err := json.Unmarshal(bytes, &temp); err != nil {
+		return fmt.Errorf("unmarshaling CreatePolicyInputProperties into map[string]json.RawMessage: %+v", err)
+	}
+
+	if v, ok := temp["providerSpecificInput"]; ok {
+		impl, err := unmarshalPolicyProviderSpecificInputImplementation(v)
+		if err != nil {
+			return fmt.Errorf("unmarshaling field 'ProviderSpecificInput' for 'CreatePolicyInputProperties': %+v", err)
+		}
+		s.ProviderSpecificInput = impl
+	}
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/model_hypervreplicaazurepolicydetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/model_hypervreplicaazurepolicydetails.go
@@ -1,0 +1,46 @@
+package replicationpolicies
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ PolicyProviderSpecificDetails = HyperVReplicaAzurePolicyDetails{}
+
+type HyperVReplicaAzurePolicyDetails struct {
+	ActiveStorageAccountId                        *string `json:"activeStorageAccountId,omitempty"`
+	ApplicationConsistentSnapshotFrequencyInHours *int64  `json:"applicationConsistentSnapshotFrequencyInHours,omitempty"`
+	Encryption                                    *string `json:"encryption,omitempty"`
+	OnlineReplicationStartTime                    *string `json:"onlineReplicationStartTime,omitempty"`
+	RecoveryPointHistoryDurationInHours           *int64  `json:"recoveryPointHistoryDurationInHours,omitempty"`
+	ReplicationInterval                           *int64  `json:"replicationInterval,omitempty"`
+
+	// Fields inherited from PolicyProviderSpecificDetails
+}
+
+var _ json.Marshaler = HyperVReplicaAzurePolicyDetails{}
+
+func (s HyperVReplicaAzurePolicyDetails) MarshalJSON() ([]byte, error) {
+	type wrapper HyperVReplicaAzurePolicyDetails
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling HyperVReplicaAzurePolicyDetails: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling HyperVReplicaAzurePolicyDetails: %+v", err)
+	}
+	decoded["instanceType"] = "HyperVReplicaAzure"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling HyperVReplicaAzurePolicyDetails: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/model_hypervreplicaazurepolicyinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/model_hypervreplicaazurepolicyinput.go
@@ -1,0 +1,45 @@
+package replicationpolicies
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ PolicyProviderSpecificInput = HyperVReplicaAzurePolicyInput{}
+
+type HyperVReplicaAzurePolicyInput struct {
+	ApplicationConsistentSnapshotFrequencyInHours *int64    `json:"applicationConsistentSnapshotFrequencyInHours,omitempty"`
+	OnlineReplicationStartTime                    *string   `json:"onlineReplicationStartTime,omitempty"`
+	RecoveryPointHistoryDuration                  *int64    `json:"recoveryPointHistoryDuration,omitempty"`
+	ReplicationInterval                           *int64    `json:"replicationInterval,omitempty"`
+	StorageAccounts                               *[]string `json:"storageAccounts,omitempty"`
+
+	// Fields inherited from PolicyProviderSpecificInput
+}
+
+var _ json.Marshaler = HyperVReplicaAzurePolicyInput{}
+
+func (s HyperVReplicaAzurePolicyInput) MarshalJSON() ([]byte, error) {
+	type wrapper HyperVReplicaAzurePolicyInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling HyperVReplicaAzurePolicyInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling HyperVReplicaAzurePolicyInput: %+v", err)
+	}
+	decoded["instanceType"] = "HyperVReplicaAzure"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling HyperVReplicaAzurePolicyInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/model_hypervreplicabasepolicydetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/model_hypervreplicabasepolicydetails.go
@@ -1,0 +1,50 @@
+package replicationpolicies
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ PolicyProviderSpecificDetails = HyperVReplicaBasePolicyDetails{}
+
+type HyperVReplicaBasePolicyDetails struct {
+	AllowedAuthenticationType                     *int64  `json:"allowedAuthenticationType,omitempty"`
+	ApplicationConsistentSnapshotFrequencyInHours *int64  `json:"applicationConsistentSnapshotFrequencyInHours,omitempty"`
+	Compression                                   *string `json:"compression,omitempty"`
+	InitialReplicationMethod                      *string `json:"initialReplicationMethod,omitempty"`
+	OfflineReplicationExportPath                  *string `json:"offlineReplicationExportPath,omitempty"`
+	OfflineReplicationImportPath                  *string `json:"offlineReplicationImportPath,omitempty"`
+	OnlineReplicationStartTime                    *string `json:"onlineReplicationStartTime,omitempty"`
+	RecoveryPoints                                *int64  `json:"recoveryPoints,omitempty"`
+	ReplicaDeletionOption                         *string `json:"replicaDeletionOption,omitempty"`
+	ReplicationPort                               *int64  `json:"replicationPort,omitempty"`
+
+	// Fields inherited from PolicyProviderSpecificDetails
+}
+
+var _ json.Marshaler = HyperVReplicaBasePolicyDetails{}
+
+func (s HyperVReplicaBasePolicyDetails) MarshalJSON() ([]byte, error) {
+	type wrapper HyperVReplicaBasePolicyDetails
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling HyperVReplicaBasePolicyDetails: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling HyperVReplicaBasePolicyDetails: %+v", err)
+	}
+	decoded["instanceType"] = "HyperVReplicaBasePolicyDetails"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling HyperVReplicaBasePolicyDetails: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/model_hypervreplicabluepolicydetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/model_hypervreplicabluepolicydetails.go
@@ -1,0 +1,51 @@
+package replicationpolicies
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ PolicyProviderSpecificDetails = HyperVReplicaBluePolicyDetails{}
+
+type HyperVReplicaBluePolicyDetails struct {
+	AllowedAuthenticationType                     *int64  `json:"allowedAuthenticationType,omitempty"`
+	ApplicationConsistentSnapshotFrequencyInHours *int64  `json:"applicationConsistentSnapshotFrequencyInHours,omitempty"`
+	Compression                                   *string `json:"compression,omitempty"`
+	InitialReplicationMethod                      *string `json:"initialReplicationMethod,omitempty"`
+	OfflineReplicationExportPath                  *string `json:"offlineReplicationExportPath,omitempty"`
+	OfflineReplicationImportPath                  *string `json:"offlineReplicationImportPath,omitempty"`
+	OnlineReplicationStartTime                    *string `json:"onlineReplicationStartTime,omitempty"`
+	RecoveryPoints                                *int64  `json:"recoveryPoints,omitempty"`
+	ReplicaDeletionOption                         *string `json:"replicaDeletionOption,omitempty"`
+	ReplicationFrequencyInSeconds                 *int64  `json:"replicationFrequencyInSeconds,omitempty"`
+	ReplicationPort                               *int64  `json:"replicationPort,omitempty"`
+
+	// Fields inherited from PolicyProviderSpecificDetails
+}
+
+var _ json.Marshaler = HyperVReplicaBluePolicyDetails{}
+
+func (s HyperVReplicaBluePolicyDetails) MarshalJSON() ([]byte, error) {
+	type wrapper HyperVReplicaBluePolicyDetails
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling HyperVReplicaBluePolicyDetails: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling HyperVReplicaBluePolicyDetails: %+v", err)
+	}
+	decoded["instanceType"] = "HyperVReplica2012R2"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling HyperVReplicaBluePolicyDetails: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/model_hypervreplicabluepolicyinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/model_hypervreplicabluepolicyinput.go
@@ -1,0 +1,51 @@
+package replicationpolicies
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ PolicyProviderSpecificInput = HyperVReplicaBluePolicyInput{}
+
+type HyperVReplicaBluePolicyInput struct {
+	ReplicationFrequencyInSeconds *int64 `json:"replicationFrequencyInSeconds,omitempty"`
+
+	// Fields inherited from HyperVReplicaPolicyInput
+	AllowedAuthenticationType                     *int64  `json:"allowedAuthenticationType,omitempty"`
+	ApplicationConsistentSnapshotFrequencyInHours *int64  `json:"applicationConsistentSnapshotFrequencyInHours,omitempty"`
+	Compression                                   *string `json:"compression,omitempty"`
+	InitialReplicationMethod                      *string `json:"initialReplicationMethod,omitempty"`
+	OfflineReplicationExportPath                  *string `json:"offlineReplicationExportPath,omitempty"`
+	OfflineReplicationImportPath                  *string `json:"offlineReplicationImportPath,omitempty"`
+	OnlineReplicationStartTime                    *string `json:"onlineReplicationStartTime,omitempty"`
+	RecoveryPoints                                *int64  `json:"recoveryPoints,omitempty"`
+	ReplicaDeletion                               *string `json:"replicaDeletion,omitempty"`
+	ReplicationPort                               *int64  `json:"replicationPort,omitempty"`
+}
+
+var _ json.Marshaler = HyperVReplicaBluePolicyInput{}
+
+func (s HyperVReplicaBluePolicyInput) MarshalJSON() ([]byte, error) {
+	type wrapper HyperVReplicaBluePolicyInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling HyperVReplicaBluePolicyInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling HyperVReplicaBluePolicyInput: %+v", err)
+	}
+	decoded["instanceType"] = "HyperVReplica2012R2"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling HyperVReplicaBluePolicyInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/model_hypervreplicapolicydetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/model_hypervreplicapolicydetails.go
@@ -1,0 +1,50 @@
+package replicationpolicies
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ PolicyProviderSpecificDetails = HyperVReplicaPolicyDetails{}
+
+type HyperVReplicaPolicyDetails struct {
+	AllowedAuthenticationType                     *int64  `json:"allowedAuthenticationType,omitempty"`
+	ApplicationConsistentSnapshotFrequencyInHours *int64  `json:"applicationConsistentSnapshotFrequencyInHours,omitempty"`
+	Compression                                   *string `json:"compression,omitempty"`
+	InitialReplicationMethod                      *string `json:"initialReplicationMethod,omitempty"`
+	OfflineReplicationExportPath                  *string `json:"offlineReplicationExportPath,omitempty"`
+	OfflineReplicationImportPath                  *string `json:"offlineReplicationImportPath,omitempty"`
+	OnlineReplicationStartTime                    *string `json:"onlineReplicationStartTime,omitempty"`
+	RecoveryPoints                                *int64  `json:"recoveryPoints,omitempty"`
+	ReplicaDeletionOption                         *string `json:"replicaDeletionOption,omitempty"`
+	ReplicationPort                               *int64  `json:"replicationPort,omitempty"`
+
+	// Fields inherited from PolicyProviderSpecificDetails
+}
+
+var _ json.Marshaler = HyperVReplicaPolicyDetails{}
+
+func (s HyperVReplicaPolicyDetails) MarshalJSON() ([]byte, error) {
+	type wrapper HyperVReplicaPolicyDetails
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling HyperVReplicaPolicyDetails: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling HyperVReplicaPolicyDetails: %+v", err)
+	}
+	decoded["instanceType"] = "HyperVReplica2012"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling HyperVReplicaPolicyDetails: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/model_hypervreplicapolicyinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/model_hypervreplicapolicyinput.go
@@ -1,0 +1,50 @@
+package replicationpolicies
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ PolicyProviderSpecificInput = HyperVReplicaPolicyInput{}
+
+type HyperVReplicaPolicyInput struct {
+	AllowedAuthenticationType                     *int64  `json:"allowedAuthenticationType,omitempty"`
+	ApplicationConsistentSnapshotFrequencyInHours *int64  `json:"applicationConsistentSnapshotFrequencyInHours,omitempty"`
+	Compression                                   *string `json:"compression,omitempty"`
+	InitialReplicationMethod                      *string `json:"initialReplicationMethod,omitempty"`
+	OfflineReplicationExportPath                  *string `json:"offlineReplicationExportPath,omitempty"`
+	OfflineReplicationImportPath                  *string `json:"offlineReplicationImportPath,omitempty"`
+	OnlineReplicationStartTime                    *string `json:"onlineReplicationStartTime,omitempty"`
+	RecoveryPoints                                *int64  `json:"recoveryPoints,omitempty"`
+	ReplicaDeletion                               *string `json:"replicaDeletion,omitempty"`
+	ReplicationPort                               *int64  `json:"replicationPort,omitempty"`
+
+	// Fields inherited from PolicyProviderSpecificInput
+}
+
+var _ json.Marshaler = HyperVReplicaPolicyInput{}
+
+func (s HyperVReplicaPolicyInput) MarshalJSON() ([]byte, error) {
+	type wrapper HyperVReplicaPolicyInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling HyperVReplicaPolicyInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling HyperVReplicaPolicyInput: %+v", err)
+	}
+	decoded["instanceType"] = "HyperVReplica2012"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling HyperVReplicaPolicyInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/model_inmageazurev2policydetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/model_inmageazurev2policydetails.go
@@ -1,0 +1,45 @@
+package replicationpolicies
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ PolicyProviderSpecificDetails = InMageAzureV2PolicyDetails{}
+
+type InMageAzureV2PolicyDetails struct {
+	AppConsistentFrequencyInMinutes   *int64  `json:"appConsistentFrequencyInMinutes,omitempty"`
+	CrashConsistentFrequencyInMinutes *int64  `json:"crashConsistentFrequencyInMinutes,omitempty"`
+	MultiVmSyncStatus                 *string `json:"multiVmSyncStatus,omitempty"`
+	RecoveryPointHistory              *int64  `json:"recoveryPointHistory,omitempty"`
+	RecoveryPointThresholdInMinutes   *int64  `json:"recoveryPointThresholdInMinutes,omitempty"`
+
+	// Fields inherited from PolicyProviderSpecificDetails
+}
+
+var _ json.Marshaler = InMageAzureV2PolicyDetails{}
+
+func (s InMageAzureV2PolicyDetails) MarshalJSON() ([]byte, error) {
+	type wrapper InMageAzureV2PolicyDetails
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling InMageAzureV2PolicyDetails: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling InMageAzureV2PolicyDetails: %+v", err)
+	}
+	decoded["instanceType"] = "InMageAzureV2"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling InMageAzureV2PolicyDetails: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/model_inmageazurev2policyinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/model_inmageazurev2policyinput.go
@@ -1,0 +1,45 @@
+package replicationpolicies
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ PolicyProviderSpecificInput = InMageAzureV2PolicyInput{}
+
+type InMageAzureV2PolicyInput struct {
+	AppConsistentFrequencyInMinutes   *int64               `json:"appConsistentFrequencyInMinutes,omitempty"`
+	CrashConsistentFrequencyInMinutes *int64               `json:"crashConsistentFrequencyInMinutes,omitempty"`
+	MultiVmSyncStatus                 SetMultiVmSyncStatus `json:"multiVmSyncStatus"`
+	RecoveryPointHistory              *int64               `json:"recoveryPointHistory,omitempty"`
+	RecoveryPointThresholdInMinutes   *int64               `json:"recoveryPointThresholdInMinutes,omitempty"`
+
+	// Fields inherited from PolicyProviderSpecificInput
+}
+
+var _ json.Marshaler = InMageAzureV2PolicyInput{}
+
+func (s InMageAzureV2PolicyInput) MarshalJSON() ([]byte, error) {
+	type wrapper InMageAzureV2PolicyInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling InMageAzureV2PolicyInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling InMageAzureV2PolicyInput: %+v", err)
+	}
+	decoded["instanceType"] = "InMageAzureV2"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling InMageAzureV2PolicyInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/model_inmagebasepolicydetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/model_inmagebasepolicydetails.go
@@ -1,0 +1,44 @@
+package replicationpolicies
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ PolicyProviderSpecificDetails = InMageBasePolicyDetails{}
+
+type InMageBasePolicyDetails struct {
+	AppConsistentFrequencyInMinutes *int64  `json:"appConsistentFrequencyInMinutes,omitempty"`
+	MultiVmSyncStatus               *string `json:"multiVmSyncStatus,omitempty"`
+	RecoveryPointHistory            *int64  `json:"recoveryPointHistory,omitempty"`
+	RecoveryPointThresholdInMinutes *int64  `json:"recoveryPointThresholdInMinutes,omitempty"`
+
+	// Fields inherited from PolicyProviderSpecificDetails
+}
+
+var _ json.Marshaler = InMageBasePolicyDetails{}
+
+func (s InMageBasePolicyDetails) MarshalJSON() ([]byte, error) {
+	type wrapper InMageBasePolicyDetails
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling InMageBasePolicyDetails: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling InMageBasePolicyDetails: %+v", err)
+	}
+	decoded["instanceType"] = "InMageBasePolicyDetails"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling InMageBasePolicyDetails: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/model_inmagepolicydetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/model_inmagepolicydetails.go
@@ -1,0 +1,44 @@
+package replicationpolicies
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ PolicyProviderSpecificDetails = InMagePolicyDetails{}
+
+type InMagePolicyDetails struct {
+	AppConsistentFrequencyInMinutes *int64  `json:"appConsistentFrequencyInMinutes,omitempty"`
+	MultiVmSyncStatus               *string `json:"multiVmSyncStatus,omitempty"`
+	RecoveryPointHistory            *int64  `json:"recoveryPointHistory,omitempty"`
+	RecoveryPointThresholdInMinutes *int64  `json:"recoveryPointThresholdInMinutes,omitempty"`
+
+	// Fields inherited from PolicyProviderSpecificDetails
+}
+
+var _ json.Marshaler = InMagePolicyDetails{}
+
+func (s InMagePolicyDetails) MarshalJSON() ([]byte, error) {
+	type wrapper InMagePolicyDetails
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling InMagePolicyDetails: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling InMagePolicyDetails: %+v", err)
+	}
+	decoded["instanceType"] = "InMage"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling InMagePolicyDetails: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/model_inmagepolicyinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/model_inmagepolicyinput.go
@@ -1,0 +1,44 @@
+package replicationpolicies
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ PolicyProviderSpecificInput = InMagePolicyInput{}
+
+type InMagePolicyInput struct {
+	AppConsistentFrequencyInMinutes *int64               `json:"appConsistentFrequencyInMinutes,omitempty"`
+	MultiVmSyncStatus               SetMultiVmSyncStatus `json:"multiVmSyncStatus"`
+	RecoveryPointHistory            *int64               `json:"recoveryPointHistory,omitempty"`
+	RecoveryPointThresholdInMinutes *int64               `json:"recoveryPointThresholdInMinutes,omitempty"`
+
+	// Fields inherited from PolicyProviderSpecificInput
+}
+
+var _ json.Marshaler = InMagePolicyInput{}
+
+func (s InMagePolicyInput) MarshalJSON() ([]byte, error) {
+	type wrapper InMagePolicyInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling InMagePolicyInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling InMagePolicyInput: %+v", err)
+	}
+	decoded["instanceType"] = "InMage"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling InMagePolicyInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/model_inmagercmfailbackpolicycreationinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/model_inmagercmfailbackpolicycreationinput.go
@@ -1,0 +1,42 @@
+package replicationpolicies
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ PolicyProviderSpecificInput = InMageRcmFailbackPolicyCreationInput{}
+
+type InMageRcmFailbackPolicyCreationInput struct {
+	AppConsistentFrequencyInMinutes   *int64 `json:"appConsistentFrequencyInMinutes,omitempty"`
+	CrashConsistentFrequencyInMinutes *int64 `json:"crashConsistentFrequencyInMinutes,omitempty"`
+
+	// Fields inherited from PolicyProviderSpecificInput
+}
+
+var _ json.Marshaler = InMageRcmFailbackPolicyCreationInput{}
+
+func (s InMageRcmFailbackPolicyCreationInput) MarshalJSON() ([]byte, error) {
+	type wrapper InMageRcmFailbackPolicyCreationInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling InMageRcmFailbackPolicyCreationInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling InMageRcmFailbackPolicyCreationInput: %+v", err)
+	}
+	decoded["instanceType"] = "InMageRcmFailback"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling InMageRcmFailbackPolicyCreationInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/model_inmagercmfailbackpolicydetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/model_inmagercmfailbackpolicydetails.go
@@ -1,0 +1,42 @@
+package replicationpolicies
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ PolicyProviderSpecificDetails = InMageRcmFailbackPolicyDetails{}
+
+type InMageRcmFailbackPolicyDetails struct {
+	AppConsistentFrequencyInMinutes   *int64 `json:"appConsistentFrequencyInMinutes,omitempty"`
+	CrashConsistentFrequencyInMinutes *int64 `json:"crashConsistentFrequencyInMinutes,omitempty"`
+
+	// Fields inherited from PolicyProviderSpecificDetails
+}
+
+var _ json.Marshaler = InMageRcmFailbackPolicyDetails{}
+
+func (s InMageRcmFailbackPolicyDetails) MarshalJSON() ([]byte, error) {
+	type wrapper InMageRcmFailbackPolicyDetails
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling InMageRcmFailbackPolicyDetails: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling InMageRcmFailbackPolicyDetails: %+v", err)
+	}
+	decoded["instanceType"] = "InMageRcmFailback"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling InMageRcmFailbackPolicyDetails: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/model_inmagercmpolicycreationinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/model_inmagercmpolicycreationinput.go
@@ -1,0 +1,44 @@
+package replicationpolicies
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ PolicyProviderSpecificInput = InMageRcmPolicyCreationInput{}
+
+type InMageRcmPolicyCreationInput struct {
+	AppConsistentFrequencyInMinutes   *int64  `json:"appConsistentFrequencyInMinutes,omitempty"`
+	CrashConsistentFrequencyInMinutes *int64  `json:"crashConsistentFrequencyInMinutes,omitempty"`
+	EnableMultiVmSync                 *string `json:"enableMultiVmSync,omitempty"`
+	RecoveryPointHistoryInMinutes     *int64  `json:"recoveryPointHistoryInMinutes,omitempty"`
+
+	// Fields inherited from PolicyProviderSpecificInput
+}
+
+var _ json.Marshaler = InMageRcmPolicyCreationInput{}
+
+func (s InMageRcmPolicyCreationInput) MarshalJSON() ([]byte, error) {
+	type wrapper InMageRcmPolicyCreationInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling InMageRcmPolicyCreationInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling InMageRcmPolicyCreationInput: %+v", err)
+	}
+	decoded["instanceType"] = "InMageRcm"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling InMageRcmPolicyCreationInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/model_inmagercmpolicydetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/model_inmagercmpolicydetails.go
@@ -1,0 +1,44 @@
+package replicationpolicies
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ PolicyProviderSpecificDetails = InMageRcmPolicyDetails{}
+
+type InMageRcmPolicyDetails struct {
+	AppConsistentFrequencyInMinutes   *int64  `json:"appConsistentFrequencyInMinutes,omitempty"`
+	CrashConsistentFrequencyInMinutes *int64  `json:"crashConsistentFrequencyInMinutes,omitempty"`
+	EnableMultiVmSync                 *string `json:"enableMultiVmSync,omitempty"`
+	RecoveryPointHistoryInMinutes     *int64  `json:"recoveryPointHistoryInMinutes,omitempty"`
+
+	// Fields inherited from PolicyProviderSpecificDetails
+}
+
+var _ json.Marshaler = InMageRcmPolicyDetails{}
+
+func (s InMageRcmPolicyDetails) MarshalJSON() ([]byte, error) {
+	type wrapper InMageRcmPolicyDetails
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling InMageRcmPolicyDetails: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling InMageRcmPolicyDetails: %+v", err)
+	}
+	decoded["instanceType"] = "InMageRcm"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling InMageRcmPolicyDetails: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/model_policy.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/model_policy.go
@@ -1,0 +1,12 @@
+package replicationpolicies
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type Policy struct {
+	Id         *string           `json:"id,omitempty"`
+	Location   *string           `json:"location,omitempty"`
+	Name       *string           `json:"name,omitempty"`
+	Properties *PolicyProperties `json:"properties,omitempty"`
+	Type       *string           `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/model_policyproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/model_policyproperties.go
@@ -1,0 +1,40 @@
+package replicationpolicies
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PolicyProperties struct {
+	FriendlyName            *string                       `json:"friendlyName,omitempty"`
+	ProviderSpecificDetails PolicyProviderSpecificDetails `json:"providerSpecificDetails"`
+}
+
+var _ json.Unmarshaler = &PolicyProperties{}
+
+func (s *PolicyProperties) UnmarshalJSON(bytes []byte) error {
+	type alias PolicyProperties
+	var decoded alias
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling into PolicyProperties: %+v", err)
+	}
+
+	s.FriendlyName = decoded.FriendlyName
+
+	var temp map[string]json.RawMessage
+	if err := json.Unmarshal(bytes, &temp); err != nil {
+		return fmt.Errorf("unmarshaling PolicyProperties into map[string]json.RawMessage: %+v", err)
+	}
+
+	if v, ok := temp["providerSpecificDetails"]; ok {
+		impl, err := unmarshalPolicyProviderSpecificDetailsImplementation(v)
+		if err != nil {
+			return fmt.Errorf("unmarshaling field 'ProviderSpecificDetails' for 'PolicyProperties': %+v", err)
+		}
+		s.ProviderSpecificDetails = impl
+	}
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/model_policyproviderspecificdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/model_policyproviderspecificdetails.go
@@ -1,0 +1,128 @@
+package replicationpolicies
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PolicyProviderSpecificDetails interface {
+}
+
+func unmarshalPolicyProviderSpecificDetailsImplementation(input []byte) (PolicyProviderSpecificDetails, error) {
+	if input == nil {
+		return nil, nil
+	}
+
+	var temp map[string]interface{}
+	if err := json.Unmarshal(input, &temp); err != nil {
+		return nil, fmt.Errorf("unmarshaling PolicyProviderSpecificDetails into map[string]interface: %+v", err)
+	}
+
+	value, ok := temp["instanceType"].(string)
+	if !ok {
+		return nil, nil
+	}
+
+	if strings.EqualFold(value, "A2A") {
+		var out A2APolicyDetails
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into A2APolicyDetails: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "HyperVReplicaAzure") {
+		var out HyperVReplicaAzurePolicyDetails
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into HyperVReplicaAzurePolicyDetails: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "HyperVReplicaBasePolicyDetails") {
+		var out HyperVReplicaBasePolicyDetails
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into HyperVReplicaBasePolicyDetails: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "HyperVReplica2012R2") {
+		var out HyperVReplicaBluePolicyDetails
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into HyperVReplicaBluePolicyDetails: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "HyperVReplica2012") {
+		var out HyperVReplicaPolicyDetails
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into HyperVReplicaPolicyDetails: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "InMageAzureV2") {
+		var out InMageAzureV2PolicyDetails
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into InMageAzureV2PolicyDetails: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "InMageBasePolicyDetails") {
+		var out InMageBasePolicyDetails
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into InMageBasePolicyDetails: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "InMage") {
+		var out InMagePolicyDetails
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into InMagePolicyDetails: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "InMageRcmFailback") {
+		var out InMageRcmFailbackPolicyDetails
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into InMageRcmFailbackPolicyDetails: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "InMageRcm") {
+		var out InMageRcmPolicyDetails
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into InMageRcmPolicyDetails: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "VMwareCbt") {
+		var out VmwareCbtPolicyDetails
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into VmwareCbtPolicyDetails: %+v", err)
+		}
+		return out, nil
+	}
+
+	type RawPolicyProviderSpecificDetailsImpl struct {
+		Type   string                 `json:"-"`
+		Values map[string]interface{} `json:"-"`
+	}
+	out := RawPolicyProviderSpecificDetailsImpl{
+		Type:   value,
+		Values: temp,
+	}
+	return out, nil
+
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/model_policyproviderspecificinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/model_policyproviderspecificinput.go
@@ -1,0 +1,112 @@
+package replicationpolicies
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PolicyProviderSpecificInput interface {
+}
+
+func unmarshalPolicyProviderSpecificInputImplementation(input []byte) (PolicyProviderSpecificInput, error) {
+	if input == nil {
+		return nil, nil
+	}
+
+	var temp map[string]interface{}
+	if err := json.Unmarshal(input, &temp); err != nil {
+		return nil, fmt.Errorf("unmarshaling PolicyProviderSpecificInput into map[string]interface: %+v", err)
+	}
+
+	value, ok := temp["instanceType"].(string)
+	if !ok {
+		return nil, nil
+	}
+
+	if strings.EqualFold(value, "A2ACrossClusterMigration") {
+		var out A2ACrossClusterMigrationPolicyCreationInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into A2ACrossClusterMigrationPolicyCreationInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "A2A") {
+		var out A2APolicyCreationInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into A2APolicyCreationInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "HyperVReplicaAzure") {
+		var out HyperVReplicaAzurePolicyInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into HyperVReplicaAzurePolicyInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "HyperVReplica2012") {
+		var out HyperVReplicaPolicyInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into HyperVReplicaPolicyInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "InMageAzureV2") {
+		var out InMageAzureV2PolicyInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into InMageAzureV2PolicyInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "InMage") {
+		var out InMagePolicyInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into InMagePolicyInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "InMageRcmFailback") {
+		var out InMageRcmFailbackPolicyCreationInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into InMageRcmFailbackPolicyCreationInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "InMageRcm") {
+		var out InMageRcmPolicyCreationInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into InMageRcmPolicyCreationInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "VMwareCbt") {
+		var out VMwareCbtPolicyCreationInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into VMwareCbtPolicyCreationInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	type RawPolicyProviderSpecificInputImpl struct {
+		Type   string                 `json:"-"`
+		Values map[string]interface{} `json:"-"`
+	}
+	out := RawPolicyProviderSpecificInputImpl{
+		Type:   value,
+		Values: temp,
+	}
+	return out, nil
+
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/model_updatepolicyinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/model_updatepolicyinput.go
@@ -1,0 +1,8 @@
+package replicationpolicies
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UpdatePolicyInput struct {
+	Properties *UpdatePolicyInputProperties `json:"properties,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/model_updatepolicyinputproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/model_updatepolicyinputproperties.go
@@ -1,0 +1,32 @@
+package replicationpolicies
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UpdatePolicyInputProperties struct {
+	ReplicationProviderSettings PolicyProviderSpecificInput `json:"replicationProviderSettings"`
+}
+
+var _ json.Unmarshaler = &UpdatePolicyInputProperties{}
+
+func (s *UpdatePolicyInputProperties) UnmarshalJSON(bytes []byte) error {
+
+	var temp map[string]json.RawMessage
+	if err := json.Unmarshal(bytes, &temp); err != nil {
+		return fmt.Errorf("unmarshaling UpdatePolicyInputProperties into map[string]json.RawMessage: %+v", err)
+	}
+
+	if v, ok := temp["replicationProviderSettings"]; ok {
+		impl, err := unmarshalPolicyProviderSpecificInputImplementation(v)
+		if err != nil {
+			return fmt.Errorf("unmarshaling field 'ReplicationProviderSettings' for 'UpdatePolicyInputProperties': %+v", err)
+		}
+		s.ReplicationProviderSettings = impl
+	}
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/model_vmwarecbtpolicycreationinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/model_vmwarecbtpolicycreationinput.go
@@ -1,0 +1,43 @@
+package replicationpolicies
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ PolicyProviderSpecificInput = VMwareCbtPolicyCreationInput{}
+
+type VMwareCbtPolicyCreationInput struct {
+	AppConsistentFrequencyInMinutes   *int64 `json:"appConsistentFrequencyInMinutes,omitempty"`
+	CrashConsistentFrequencyInMinutes *int64 `json:"crashConsistentFrequencyInMinutes,omitempty"`
+	RecoveryPointHistoryInMinutes     *int64 `json:"recoveryPointHistoryInMinutes,omitempty"`
+
+	// Fields inherited from PolicyProviderSpecificInput
+}
+
+var _ json.Marshaler = VMwareCbtPolicyCreationInput{}
+
+func (s VMwareCbtPolicyCreationInput) MarshalJSON() ([]byte, error) {
+	type wrapper VMwareCbtPolicyCreationInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling VMwareCbtPolicyCreationInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling VMwareCbtPolicyCreationInput: %+v", err)
+	}
+	decoded["instanceType"] = "VMwareCbt"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling VMwareCbtPolicyCreationInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/model_vmwarecbtpolicydetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/model_vmwarecbtpolicydetails.go
@@ -1,0 +1,43 @@
+package replicationpolicies
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ PolicyProviderSpecificDetails = VmwareCbtPolicyDetails{}
+
+type VmwareCbtPolicyDetails struct {
+	AppConsistentFrequencyInMinutes   *int64 `json:"appConsistentFrequencyInMinutes,omitempty"`
+	CrashConsistentFrequencyInMinutes *int64 `json:"crashConsistentFrequencyInMinutes,omitempty"`
+	RecoveryPointHistoryInMinutes     *int64 `json:"recoveryPointHistoryInMinutes,omitempty"`
+
+	// Fields inherited from PolicyProviderSpecificDetails
+}
+
+var _ json.Marshaler = VmwareCbtPolicyDetails{}
+
+func (s VmwareCbtPolicyDetails) MarshalJSON() ([]byte, error) {
+	type wrapper VmwareCbtPolicyDetails
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling VmwareCbtPolicyDetails: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling VmwareCbtPolicyDetails: %+v", err)
+	}
+	decoded["instanceType"] = "VMwareCbt"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling VmwareCbtPolicyDetails: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/predicates.go
@@ -1,0 +1,29 @@
+package replicationpolicies
+
+type PolicyOperationPredicate struct {
+	Id       *string
+	Location *string
+	Name     *string
+	Type     *string
+}
+
+func (p PolicyOperationPredicate) Matches(input Policy) bool {
+
+	if p.Id != nil && (input.Id == nil && *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Location != nil && (input.Location == nil && *p.Location != *input.Location) {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil && *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil && *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/version.go
@@ -1,0 +1,12 @@
+package replicationpolicies
+
+import "fmt"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2022-10-01"
+
+func userAgent() string {
+	return fmt.Sprintf("hashicorp/go-azure-sdk/replicationpolicies/%s", defaultApiVersion)
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/README.md
@@ -1,0 +1,373 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems` Documentation
+
+The `replicationprotecteditems` SDK allows for interaction with the Azure Resource Manager Service `recoveryservicessiterecovery` (API Version `2022-10-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems"
+```
+
+
+### Client Initialization
+
+```go
+client := replicationprotecteditems.NewReplicationProtectedItemsClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `ReplicationProtectedItemsClient.AddDisks`
+
+```go
+ctx := context.TODO()
+id := replicationprotecteditems.NewReplicationProtectedItemID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue", "fabricValue", "protectionContainerValue", "replicatedProtectedItemValue")
+
+payload := replicationprotecteditems.AddDisksInput{
+	// ...
+}
+
+
+if err := client.AddDisksThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `ReplicationProtectedItemsClient.ApplyRecoveryPoint`
+
+```go
+ctx := context.TODO()
+id := replicationprotecteditems.NewReplicationProtectedItemID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue", "fabricValue", "protectionContainerValue", "replicatedProtectedItemValue")
+
+payload := replicationprotecteditems.ApplyRecoveryPointInput{
+	// ...
+}
+
+
+if err := client.ApplyRecoveryPointThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `ReplicationProtectedItemsClient.Create`
+
+```go
+ctx := context.TODO()
+id := replicationprotecteditems.NewReplicationProtectedItemID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue", "fabricValue", "protectionContainerValue", "replicatedProtectedItemValue")
+
+payload := replicationprotecteditems.EnableProtectionInput{
+	// ...
+}
+
+
+if err := client.CreateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `ReplicationProtectedItemsClient.Delete`
+
+```go
+ctx := context.TODO()
+id := replicationprotecteditems.NewReplicationProtectedItemID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue", "fabricValue", "protectionContainerValue", "replicatedProtectedItemValue")
+
+payload := replicationprotecteditems.DisableProtectionInput{
+	// ...
+}
+
+
+if err := client.DeleteThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `ReplicationProtectedItemsClient.FailoverCancel`
+
+```go
+ctx := context.TODO()
+id := replicationprotecteditems.NewReplicationProtectedItemID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue", "fabricValue", "protectionContainerValue", "replicatedProtectedItemValue")
+
+if err := client.FailoverCancelThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `ReplicationProtectedItemsClient.FailoverCommit`
+
+```go
+ctx := context.TODO()
+id := replicationprotecteditems.NewReplicationProtectedItemID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue", "fabricValue", "protectionContainerValue", "replicatedProtectedItemValue")
+
+if err := client.FailoverCommitThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `ReplicationProtectedItemsClient.Get`
+
+```go
+ctx := context.TODO()
+id := replicationprotecteditems.NewReplicationProtectedItemID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue", "fabricValue", "protectionContainerValue", "replicatedProtectedItemValue")
+
+read, err := client.Get(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `ReplicationProtectedItemsClient.List`
+
+```go
+ctx := context.TODO()
+id := replicationprotecteditems.NewVaultID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue")
+
+// alternatively `client.List(ctx, id, replicationprotecteditems.DefaultListOperationOptions())` can be used to do batched pagination
+items, err := client.ListComplete(ctx, id, replicationprotecteditems.DefaultListOperationOptions())
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `ReplicationProtectedItemsClient.ListByReplicationProtectionContainers`
+
+```go
+ctx := context.TODO()
+id := replicationprotecteditems.NewReplicationProtectionContainerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue", "fabricValue", "protectionContainerValue")
+
+// alternatively `client.ListByReplicationProtectionContainers(ctx, id)` can be used to do batched pagination
+items, err := client.ListByReplicationProtectionContainersComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `ReplicationProtectedItemsClient.PlannedFailover`
+
+```go
+ctx := context.TODO()
+id := replicationprotecteditems.NewReplicationProtectedItemID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue", "fabricValue", "protectionContainerValue", "replicatedProtectedItemValue")
+
+payload := replicationprotecteditems.PlannedFailoverInput{
+	// ...
+}
+
+
+if err := client.PlannedFailoverThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `ReplicationProtectedItemsClient.Purge`
+
+```go
+ctx := context.TODO()
+id := replicationprotecteditems.NewReplicationProtectedItemID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue", "fabricValue", "protectionContainerValue", "replicatedProtectedItemValue")
+
+if err := client.PurgeThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `ReplicationProtectedItemsClient.RemoveDisks`
+
+```go
+ctx := context.TODO()
+id := replicationprotecteditems.NewReplicationProtectedItemID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue", "fabricValue", "protectionContainerValue", "replicatedProtectedItemValue")
+
+payload := replicationprotecteditems.RemoveDisksInput{
+	// ...
+}
+
+
+if err := client.RemoveDisksThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `ReplicationProtectedItemsClient.RepairReplication`
+
+```go
+ctx := context.TODO()
+id := replicationprotecteditems.NewReplicationProtectedItemID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue", "fabricValue", "protectionContainerValue", "replicatedProtectedItemValue")
+
+if err := client.RepairReplicationThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `ReplicationProtectedItemsClient.Reprotect`
+
+```go
+ctx := context.TODO()
+id := replicationprotecteditems.NewReplicationProtectedItemID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue", "fabricValue", "protectionContainerValue", "replicatedProtectedItemValue")
+
+payload := replicationprotecteditems.ReverseReplicationInput{
+	// ...
+}
+
+
+if err := client.ReprotectThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `ReplicationProtectedItemsClient.ResolveHealthErrors`
+
+```go
+ctx := context.TODO()
+id := replicationprotecteditems.NewReplicationProtectedItemID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue", "fabricValue", "protectionContainerValue", "replicatedProtectedItemValue")
+
+payload := replicationprotecteditems.ResolveHealthInput{
+	// ...
+}
+
+
+if err := client.ResolveHealthErrorsThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `ReplicationProtectedItemsClient.SwitchProvider`
+
+```go
+ctx := context.TODO()
+id := replicationprotecteditems.NewReplicationProtectedItemID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue", "fabricValue", "protectionContainerValue", "replicatedProtectedItemValue")
+
+payload := replicationprotecteditems.SwitchProviderInput{
+	// ...
+}
+
+
+if err := client.SwitchProviderThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `ReplicationProtectedItemsClient.TestFailover`
+
+```go
+ctx := context.TODO()
+id := replicationprotecteditems.NewReplicationProtectedItemID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue", "fabricValue", "protectionContainerValue", "replicatedProtectedItemValue")
+
+payload := replicationprotecteditems.TestFailoverInput{
+	// ...
+}
+
+
+if err := client.TestFailoverThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `ReplicationProtectedItemsClient.TestFailoverCleanup`
+
+```go
+ctx := context.TODO()
+id := replicationprotecteditems.NewReplicationProtectedItemID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue", "fabricValue", "protectionContainerValue", "replicatedProtectedItemValue")
+
+payload := replicationprotecteditems.TestFailoverCleanupInput{
+	// ...
+}
+
+
+if err := client.TestFailoverCleanupThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `ReplicationProtectedItemsClient.UnplannedFailover`
+
+```go
+ctx := context.TODO()
+id := replicationprotecteditems.NewReplicationProtectedItemID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue", "fabricValue", "protectionContainerValue", "replicatedProtectedItemValue")
+
+payload := replicationprotecteditems.UnplannedFailoverInput{
+	// ...
+}
+
+
+if err := client.UnplannedFailoverThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `ReplicationProtectedItemsClient.Update`
+
+```go
+ctx := context.TODO()
+id := replicationprotecteditems.NewReplicationProtectedItemID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue", "fabricValue", "protectionContainerValue", "replicatedProtectedItemValue")
+
+payload := replicationprotecteditems.UpdateReplicationProtectedItemInput{
+	// ...
+}
+
+
+if err := client.UpdateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `ReplicationProtectedItemsClient.UpdateAppliance`
+
+```go
+ctx := context.TODO()
+id := replicationprotecteditems.NewReplicationProtectedItemID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue", "fabricValue", "protectionContainerValue", "replicatedProtectedItemValue")
+
+payload := replicationprotecteditems.UpdateApplianceForReplicationProtectedItemInput{
+	// ...
+}
+
+
+if err := client.UpdateApplianceThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `ReplicationProtectedItemsClient.UpdateMobilityService`
+
+```go
+ctx := context.TODO()
+id := replicationprotecteditems.NewReplicationProtectedItemID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue", "fabricValue", "protectionContainerValue", "replicatedProtectedItemValue")
+
+payload := replicationprotecteditems.UpdateMobilityServiceRequest{
+	// ...
+}
+
+
+if err := client.UpdateMobilityServiceThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/client.go
@@ -1,0 +1,18 @@
+package replicationprotecteditems
+
+import "github.com/Azure/go-autorest/autorest"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ReplicationProtectedItemsClient struct {
+	Client  autorest.Client
+	baseUri string
+}
+
+func NewReplicationProtectedItemsClientWithBaseURI(endpoint string) ReplicationProtectedItemsClient {
+	return ReplicationProtectedItemsClient{
+		Client:  autorest.NewClientWithUserAgent(userAgent()),
+		baseUri: endpoint,
+	}
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/constants.go
@@ -1,0 +1,566 @@
+package replicationprotecteditems
+
+import "strings"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AgentUpgradeBlockedReason string
+
+const (
+	AgentUpgradeBlockedReasonAgentNoHeartbeat              AgentUpgradeBlockedReason = "AgentNoHeartbeat"
+	AgentUpgradeBlockedReasonAlreadyOnLatestVersion        AgentUpgradeBlockedReason = "AlreadyOnLatestVersion"
+	AgentUpgradeBlockedReasonDistroIsNotReported           AgentUpgradeBlockedReason = "DistroIsNotReported"
+	AgentUpgradeBlockedReasonDistroNotSupportedForUpgrade  AgentUpgradeBlockedReason = "DistroNotSupportedForUpgrade"
+	AgentUpgradeBlockedReasonIncompatibleApplianceVersion  AgentUpgradeBlockedReason = "IncompatibleApplianceVersion"
+	AgentUpgradeBlockedReasonInvalidAgentVersion           AgentUpgradeBlockedReason = "InvalidAgentVersion"
+	AgentUpgradeBlockedReasonInvalidDriverVersion          AgentUpgradeBlockedReason = "InvalidDriverVersion"
+	AgentUpgradeBlockedReasonMissingUpgradePath            AgentUpgradeBlockedReason = "MissingUpgradePath"
+	AgentUpgradeBlockedReasonNotProtected                  AgentUpgradeBlockedReason = "NotProtected"
+	AgentUpgradeBlockedReasonProcessServerNoHeartbeat      AgentUpgradeBlockedReason = "ProcessServerNoHeartbeat"
+	AgentUpgradeBlockedReasonRcmProxyNoHeartbeat           AgentUpgradeBlockedReason = "RcmProxyNoHeartbeat"
+	AgentUpgradeBlockedReasonRebootRequired                AgentUpgradeBlockedReason = "RebootRequired"
+	AgentUpgradeBlockedReasonUnknown                       AgentUpgradeBlockedReason = "Unknown"
+	AgentUpgradeBlockedReasonUnsupportedProtectionScenario AgentUpgradeBlockedReason = "UnsupportedProtectionScenario"
+)
+
+func PossibleValuesForAgentUpgradeBlockedReason() []string {
+	return []string{
+		string(AgentUpgradeBlockedReasonAgentNoHeartbeat),
+		string(AgentUpgradeBlockedReasonAlreadyOnLatestVersion),
+		string(AgentUpgradeBlockedReasonDistroIsNotReported),
+		string(AgentUpgradeBlockedReasonDistroNotSupportedForUpgrade),
+		string(AgentUpgradeBlockedReasonIncompatibleApplianceVersion),
+		string(AgentUpgradeBlockedReasonInvalidAgentVersion),
+		string(AgentUpgradeBlockedReasonInvalidDriverVersion),
+		string(AgentUpgradeBlockedReasonMissingUpgradePath),
+		string(AgentUpgradeBlockedReasonNotProtected),
+		string(AgentUpgradeBlockedReasonProcessServerNoHeartbeat),
+		string(AgentUpgradeBlockedReasonRcmProxyNoHeartbeat),
+		string(AgentUpgradeBlockedReasonRebootRequired),
+		string(AgentUpgradeBlockedReasonUnknown),
+		string(AgentUpgradeBlockedReasonUnsupportedProtectionScenario),
+	}
+}
+
+func parseAgentUpgradeBlockedReason(input string) (*AgentUpgradeBlockedReason, error) {
+	vals := map[string]AgentUpgradeBlockedReason{
+		"agentnoheartbeat":              AgentUpgradeBlockedReasonAgentNoHeartbeat,
+		"alreadyonlatestversion":        AgentUpgradeBlockedReasonAlreadyOnLatestVersion,
+		"distroisnotreported":           AgentUpgradeBlockedReasonDistroIsNotReported,
+		"distronotsupportedforupgrade":  AgentUpgradeBlockedReasonDistroNotSupportedForUpgrade,
+		"incompatibleapplianceversion":  AgentUpgradeBlockedReasonIncompatibleApplianceVersion,
+		"invalidagentversion":           AgentUpgradeBlockedReasonInvalidAgentVersion,
+		"invaliddriverversion":          AgentUpgradeBlockedReasonInvalidDriverVersion,
+		"missingupgradepath":            AgentUpgradeBlockedReasonMissingUpgradePath,
+		"notprotected":                  AgentUpgradeBlockedReasonNotProtected,
+		"processservernoheartbeat":      AgentUpgradeBlockedReasonProcessServerNoHeartbeat,
+		"rcmproxynoheartbeat":           AgentUpgradeBlockedReasonRcmProxyNoHeartbeat,
+		"rebootrequired":                AgentUpgradeBlockedReasonRebootRequired,
+		"unknown":                       AgentUpgradeBlockedReasonUnknown,
+		"unsupportedprotectionscenario": AgentUpgradeBlockedReasonUnsupportedProtectionScenario,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := AgentUpgradeBlockedReason(input)
+	return &out, nil
+}
+
+type AutoProtectionOfDataDisk string
+
+const (
+	AutoProtectionOfDataDiskDisabled AutoProtectionOfDataDisk = "Disabled"
+	AutoProtectionOfDataDiskEnabled  AutoProtectionOfDataDisk = "Enabled"
+)
+
+func PossibleValuesForAutoProtectionOfDataDisk() []string {
+	return []string{
+		string(AutoProtectionOfDataDiskDisabled),
+		string(AutoProtectionOfDataDiskEnabled),
+	}
+}
+
+func parseAutoProtectionOfDataDisk(input string) (*AutoProtectionOfDataDisk, error) {
+	vals := map[string]AutoProtectionOfDataDisk{
+		"disabled": AutoProtectionOfDataDiskDisabled,
+		"enabled":  AutoProtectionOfDataDiskEnabled,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := AutoProtectionOfDataDisk(input)
+	return &out, nil
+}
+
+type DisableProtectionReason string
+
+const (
+	DisableProtectionReasonMigrationComplete DisableProtectionReason = "MigrationComplete"
+	DisableProtectionReasonNotSpecified      DisableProtectionReason = "NotSpecified"
+)
+
+func PossibleValuesForDisableProtectionReason() []string {
+	return []string{
+		string(DisableProtectionReasonMigrationComplete),
+		string(DisableProtectionReasonNotSpecified),
+	}
+}
+
+func parseDisableProtectionReason(input string) (*DisableProtectionReason, error) {
+	vals := map[string]DisableProtectionReason{
+		"migrationcomplete": DisableProtectionReasonMigrationComplete,
+		"notspecified":      DisableProtectionReasonNotSpecified,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := DisableProtectionReason(input)
+	return &out, nil
+}
+
+type DiskAccountType string
+
+const (
+	DiskAccountTypePremiumLRS     DiskAccountType = "Premium_LRS"
+	DiskAccountTypeStandardLRS    DiskAccountType = "Standard_LRS"
+	DiskAccountTypeStandardSSDLRS DiskAccountType = "StandardSSD_LRS"
+)
+
+func PossibleValuesForDiskAccountType() []string {
+	return []string{
+		string(DiskAccountTypePremiumLRS),
+		string(DiskAccountTypeStandardLRS),
+		string(DiskAccountTypeStandardSSDLRS),
+	}
+}
+
+func parseDiskAccountType(input string) (*DiskAccountType, error) {
+	vals := map[string]DiskAccountType{
+		"premium_lrs":     DiskAccountTypePremiumLRS,
+		"standard_lrs":    DiskAccountTypeStandardLRS,
+		"standardssd_lrs": DiskAccountTypeStandardSSDLRS,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := DiskAccountType(input)
+	return &out, nil
+}
+
+type DiskReplicationProgressHealth string
+
+const (
+	DiskReplicationProgressHealthInProgress   DiskReplicationProgressHealth = "InProgress"
+	DiskReplicationProgressHealthNoProgress   DiskReplicationProgressHealth = "NoProgress"
+	DiskReplicationProgressHealthNone         DiskReplicationProgressHealth = "None"
+	DiskReplicationProgressHealthQueued       DiskReplicationProgressHealth = "Queued"
+	DiskReplicationProgressHealthSlowProgress DiskReplicationProgressHealth = "SlowProgress"
+)
+
+func PossibleValuesForDiskReplicationProgressHealth() []string {
+	return []string{
+		string(DiskReplicationProgressHealthInProgress),
+		string(DiskReplicationProgressHealthNoProgress),
+		string(DiskReplicationProgressHealthNone),
+		string(DiskReplicationProgressHealthQueued),
+		string(DiskReplicationProgressHealthSlowProgress),
+	}
+}
+
+func parseDiskReplicationProgressHealth(input string) (*DiskReplicationProgressHealth, error) {
+	vals := map[string]DiskReplicationProgressHealth{
+		"inprogress":   DiskReplicationProgressHealthInProgress,
+		"noprogress":   DiskReplicationProgressHealthNoProgress,
+		"none":         DiskReplicationProgressHealthNone,
+		"queued":       DiskReplicationProgressHealthQueued,
+		"slowprogress": DiskReplicationProgressHealthSlowProgress,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := DiskReplicationProgressHealth(input)
+	return &out, nil
+}
+
+type EthernetAddressType string
+
+const (
+	EthernetAddressTypeDynamic EthernetAddressType = "Dynamic"
+	EthernetAddressTypeStatic  EthernetAddressType = "Static"
+)
+
+func PossibleValuesForEthernetAddressType() []string {
+	return []string{
+		string(EthernetAddressTypeDynamic),
+		string(EthernetAddressTypeStatic),
+	}
+}
+
+func parseEthernetAddressType(input string) (*EthernetAddressType, error) {
+	vals := map[string]EthernetAddressType{
+		"dynamic": EthernetAddressTypeDynamic,
+		"static":  EthernetAddressTypeStatic,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := EthernetAddressType(input)
+	return &out, nil
+}
+
+type HealthErrorCustomerResolvability string
+
+const (
+	HealthErrorCustomerResolvabilityAllowed    HealthErrorCustomerResolvability = "Allowed"
+	HealthErrorCustomerResolvabilityNotAllowed HealthErrorCustomerResolvability = "NotAllowed"
+)
+
+func PossibleValuesForHealthErrorCustomerResolvability() []string {
+	return []string{
+		string(HealthErrorCustomerResolvabilityAllowed),
+		string(HealthErrorCustomerResolvabilityNotAllowed),
+	}
+}
+
+func parseHealthErrorCustomerResolvability(input string) (*HealthErrorCustomerResolvability, error) {
+	vals := map[string]HealthErrorCustomerResolvability{
+		"allowed":    HealthErrorCustomerResolvabilityAllowed,
+		"notallowed": HealthErrorCustomerResolvabilityNotAllowed,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := HealthErrorCustomerResolvability(input)
+	return &out, nil
+}
+
+type InMageRcmFailbackRecoveryPointType string
+
+const (
+	InMageRcmFailbackRecoveryPointTypeApplicationConsistent InMageRcmFailbackRecoveryPointType = "ApplicationConsistent"
+	InMageRcmFailbackRecoveryPointTypeCrashConsistent       InMageRcmFailbackRecoveryPointType = "CrashConsistent"
+)
+
+func PossibleValuesForInMageRcmFailbackRecoveryPointType() []string {
+	return []string{
+		string(InMageRcmFailbackRecoveryPointTypeApplicationConsistent),
+		string(InMageRcmFailbackRecoveryPointTypeCrashConsistent),
+	}
+}
+
+func parseInMageRcmFailbackRecoveryPointType(input string) (*InMageRcmFailbackRecoveryPointType, error) {
+	vals := map[string]InMageRcmFailbackRecoveryPointType{
+		"applicationconsistent": InMageRcmFailbackRecoveryPointTypeApplicationConsistent,
+		"crashconsistent":       InMageRcmFailbackRecoveryPointTypeCrashConsistent,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := InMageRcmFailbackRecoveryPointType(input)
+	return &out, nil
+}
+
+type LicenseType string
+
+const (
+	LicenseTypeNoLicenseType LicenseType = "NoLicenseType"
+	LicenseTypeNotSpecified  LicenseType = "NotSpecified"
+	LicenseTypeWindowsServer LicenseType = "WindowsServer"
+)
+
+func PossibleValuesForLicenseType() []string {
+	return []string{
+		string(LicenseTypeNoLicenseType),
+		string(LicenseTypeNotSpecified),
+		string(LicenseTypeWindowsServer),
+	}
+}
+
+func parseLicenseType(input string) (*LicenseType, error) {
+	vals := map[string]LicenseType{
+		"nolicensetype": LicenseTypeNoLicenseType,
+		"notspecified":  LicenseTypeNotSpecified,
+		"windowsserver": LicenseTypeWindowsServer,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := LicenseType(input)
+	return &out, nil
+}
+
+type MobilityAgentUpgradeState string
+
+const (
+	MobilityAgentUpgradeStateCommit    MobilityAgentUpgradeState = "Commit"
+	MobilityAgentUpgradeStateCompleted MobilityAgentUpgradeState = "Completed"
+	MobilityAgentUpgradeStateNone      MobilityAgentUpgradeState = "None"
+	MobilityAgentUpgradeStateStarted   MobilityAgentUpgradeState = "Started"
+)
+
+func PossibleValuesForMobilityAgentUpgradeState() []string {
+	return []string{
+		string(MobilityAgentUpgradeStateCommit),
+		string(MobilityAgentUpgradeStateCompleted),
+		string(MobilityAgentUpgradeStateNone),
+		string(MobilityAgentUpgradeStateStarted),
+	}
+}
+
+func parseMobilityAgentUpgradeState(input string) (*MobilityAgentUpgradeState, error) {
+	vals := map[string]MobilityAgentUpgradeState{
+		"commit":    MobilityAgentUpgradeStateCommit,
+		"completed": MobilityAgentUpgradeStateCompleted,
+		"none":      MobilityAgentUpgradeStateNone,
+		"started":   MobilityAgentUpgradeStateStarted,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := MobilityAgentUpgradeState(input)
+	return &out, nil
+}
+
+type MultiVmGroupCreateOption string
+
+const (
+	MultiVmGroupCreateOptionAutoCreated   MultiVmGroupCreateOption = "AutoCreated"
+	MultiVmGroupCreateOptionUserSpecified MultiVmGroupCreateOption = "UserSpecified"
+)
+
+func PossibleValuesForMultiVmGroupCreateOption() []string {
+	return []string{
+		string(MultiVmGroupCreateOptionAutoCreated),
+		string(MultiVmGroupCreateOptionUserSpecified),
+	}
+}
+
+func parseMultiVmGroupCreateOption(input string) (*MultiVmGroupCreateOption, error) {
+	vals := map[string]MultiVmGroupCreateOption{
+		"autocreated":   MultiVmGroupCreateOptionAutoCreated,
+		"userspecified": MultiVmGroupCreateOptionUserSpecified,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := MultiVmGroupCreateOption(input)
+	return &out, nil
+}
+
+type PlannedFailoverStatus string
+
+const (
+	PlannedFailoverStatusCancelled PlannedFailoverStatus = "Cancelled"
+	PlannedFailoverStatusFailed    PlannedFailoverStatus = "Failed"
+	PlannedFailoverStatusSucceeded PlannedFailoverStatus = "Succeeded"
+	PlannedFailoverStatusUnknown   PlannedFailoverStatus = "Unknown"
+)
+
+func PossibleValuesForPlannedFailoverStatus() []string {
+	return []string{
+		string(PlannedFailoverStatusCancelled),
+		string(PlannedFailoverStatusFailed),
+		string(PlannedFailoverStatusSucceeded),
+		string(PlannedFailoverStatusUnknown),
+	}
+}
+
+func parsePlannedFailoverStatus(input string) (*PlannedFailoverStatus, error) {
+	vals := map[string]PlannedFailoverStatus{
+		"cancelled": PlannedFailoverStatusCancelled,
+		"failed":    PlannedFailoverStatusFailed,
+		"succeeded": PlannedFailoverStatusSucceeded,
+		"unknown":   PlannedFailoverStatusUnknown,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := PlannedFailoverStatus(input)
+	return &out, nil
+}
+
+type RecoveryPointType string
+
+const (
+	RecoveryPointTypeCustom     RecoveryPointType = "Custom"
+	RecoveryPointTypeLatestTag  RecoveryPointType = "LatestTag"
+	RecoveryPointTypeLatestTime RecoveryPointType = "LatestTime"
+)
+
+func PossibleValuesForRecoveryPointType() []string {
+	return []string{
+		string(RecoveryPointTypeCustom),
+		string(RecoveryPointTypeLatestTag),
+		string(RecoveryPointTypeLatestTime),
+	}
+}
+
+func parseRecoveryPointType(input string) (*RecoveryPointType, error) {
+	vals := map[string]RecoveryPointType{
+		"custom":     RecoveryPointTypeCustom,
+		"latesttag":  RecoveryPointTypeLatestTag,
+		"latesttime": RecoveryPointTypeLatestTime,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := RecoveryPointType(input)
+	return &out, nil
+}
+
+type ResyncState string
+
+const (
+	ResyncStateNone                         ResyncState = "None"
+	ResyncStatePreparedForResynchronization ResyncState = "PreparedForResynchronization"
+	ResyncStateStartedResynchronization     ResyncState = "StartedResynchronization"
+)
+
+func PossibleValuesForResyncState() []string {
+	return []string{
+		string(ResyncStateNone),
+		string(ResyncStatePreparedForResynchronization),
+		string(ResyncStateStartedResynchronization),
+	}
+}
+
+func parseResyncState(input string) (*ResyncState, error) {
+	vals := map[string]ResyncState{
+		"none":                         ResyncStateNone,
+		"preparedforresynchronization": ResyncStatePreparedForResynchronization,
+		"startedresynchronization":     ResyncStateStartedResynchronization,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ResyncState(input)
+	return &out, nil
+}
+
+type SqlServerLicenseType string
+
+const (
+	SqlServerLicenseTypeAHUB          SqlServerLicenseType = "AHUB"
+	SqlServerLicenseTypeNoLicenseType SqlServerLicenseType = "NoLicenseType"
+	SqlServerLicenseTypeNotSpecified  SqlServerLicenseType = "NotSpecified"
+	SqlServerLicenseTypePAYG          SqlServerLicenseType = "PAYG"
+)
+
+func PossibleValuesForSqlServerLicenseType() []string {
+	return []string{
+		string(SqlServerLicenseTypeAHUB),
+		string(SqlServerLicenseTypeNoLicenseType),
+		string(SqlServerLicenseTypeNotSpecified),
+		string(SqlServerLicenseTypePAYG),
+	}
+}
+
+func parseSqlServerLicenseType(input string) (*SqlServerLicenseType, error) {
+	vals := map[string]SqlServerLicenseType{
+		"ahub":          SqlServerLicenseTypeAHUB,
+		"nolicensetype": SqlServerLicenseTypeNoLicenseType,
+		"notspecified":  SqlServerLicenseTypeNotSpecified,
+		"payg":          SqlServerLicenseTypePAYG,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := SqlServerLicenseType(input)
+	return &out, nil
+}
+
+type VmEncryptionType string
+
+const (
+	VmEncryptionTypeNotEncrypted     VmEncryptionType = "NotEncrypted"
+	VmEncryptionTypeOnePassEncrypted VmEncryptionType = "OnePassEncrypted"
+	VmEncryptionTypeTwoPassEncrypted VmEncryptionType = "TwoPassEncrypted"
+)
+
+func PossibleValuesForVmEncryptionType() []string {
+	return []string{
+		string(VmEncryptionTypeNotEncrypted),
+		string(VmEncryptionTypeOnePassEncrypted),
+		string(VmEncryptionTypeTwoPassEncrypted),
+	}
+}
+
+func parseVmEncryptionType(input string) (*VmEncryptionType, error) {
+	vals := map[string]VmEncryptionType{
+		"notencrypted":     VmEncryptionTypeNotEncrypted,
+		"onepassencrypted": VmEncryptionTypeOnePassEncrypted,
+		"twopassencrypted": VmEncryptionTypeTwoPassEncrypted,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := VmEncryptionType(input)
+	return &out, nil
+}
+
+type VmReplicationProgressHealth string
+
+const (
+	VmReplicationProgressHealthInProgress   VmReplicationProgressHealth = "InProgress"
+	VmReplicationProgressHealthNoProgress   VmReplicationProgressHealth = "NoProgress"
+	VmReplicationProgressHealthNone         VmReplicationProgressHealth = "None"
+	VmReplicationProgressHealthSlowProgress VmReplicationProgressHealth = "SlowProgress"
+)
+
+func PossibleValuesForVmReplicationProgressHealth() []string {
+	return []string{
+		string(VmReplicationProgressHealthInProgress),
+		string(VmReplicationProgressHealthNoProgress),
+		string(VmReplicationProgressHealthNone),
+		string(VmReplicationProgressHealthSlowProgress),
+	}
+}
+
+func parseVmReplicationProgressHealth(input string) (*VmReplicationProgressHealth, error) {
+	vals := map[string]VmReplicationProgressHealth{
+		"inprogress":   VmReplicationProgressHealthInProgress,
+		"noprogress":   VmReplicationProgressHealthNoProgress,
+		"none":         VmReplicationProgressHealthNone,
+		"slowprogress": VmReplicationProgressHealthSlowProgress,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := VmReplicationProgressHealth(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/id_replicationprotecteditem.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/id_replicationprotecteditem.go
@@ -1,0 +1,163 @@
+package replicationprotecteditems
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = ReplicationProtectedItemId{}
+
+// ReplicationProtectedItemId is a struct representing the Resource ID for a Replication Protected Item
+type ReplicationProtectedItemId struct {
+	SubscriptionId              string
+	ResourceGroupName           string
+	ResourceName                string
+	FabricName                  string
+	ProtectionContainerName     string
+	ReplicatedProtectedItemName string
+}
+
+// NewReplicationProtectedItemID returns a new ReplicationProtectedItemId struct
+func NewReplicationProtectedItemID(subscriptionId string, resourceGroupName string, resourceName string, fabricName string, protectionContainerName string, replicatedProtectedItemName string) ReplicationProtectedItemId {
+	return ReplicationProtectedItemId{
+		SubscriptionId:              subscriptionId,
+		ResourceGroupName:           resourceGroupName,
+		ResourceName:                resourceName,
+		FabricName:                  fabricName,
+		ProtectionContainerName:     protectionContainerName,
+		ReplicatedProtectedItemName: replicatedProtectedItemName,
+	}
+}
+
+// ParseReplicationProtectedItemID parses 'input' into a ReplicationProtectedItemId
+func ParseReplicationProtectedItemID(input string) (*ReplicationProtectedItemId, error) {
+	parser := resourceids.NewParserFromResourceIdType(ReplicationProtectedItemId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := ReplicationProtectedItemId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceName, ok = parsed.Parsed["resourceName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceName' was not found in the resource id %q", input)
+	}
+
+	if id.FabricName, ok = parsed.Parsed["fabricName"]; !ok {
+		return nil, fmt.Errorf("the segment 'fabricName' was not found in the resource id %q", input)
+	}
+
+	if id.ProtectionContainerName, ok = parsed.Parsed["protectionContainerName"]; !ok {
+		return nil, fmt.Errorf("the segment 'protectionContainerName' was not found in the resource id %q", input)
+	}
+
+	if id.ReplicatedProtectedItemName, ok = parsed.Parsed["replicatedProtectedItemName"]; !ok {
+		return nil, fmt.Errorf("the segment 'replicatedProtectedItemName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ParseReplicationProtectedItemIDInsensitively parses 'input' case-insensitively into a ReplicationProtectedItemId
+// note: this method should only be used for API response data and not user input
+func ParseReplicationProtectedItemIDInsensitively(input string) (*ReplicationProtectedItemId, error) {
+	parser := resourceids.NewParserFromResourceIdType(ReplicationProtectedItemId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := ReplicationProtectedItemId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceName, ok = parsed.Parsed["resourceName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceName' was not found in the resource id %q", input)
+	}
+
+	if id.FabricName, ok = parsed.Parsed["fabricName"]; !ok {
+		return nil, fmt.Errorf("the segment 'fabricName' was not found in the resource id %q", input)
+	}
+
+	if id.ProtectionContainerName, ok = parsed.Parsed["protectionContainerName"]; !ok {
+		return nil, fmt.Errorf("the segment 'protectionContainerName' was not found in the resource id %q", input)
+	}
+
+	if id.ReplicatedProtectedItemName, ok = parsed.Parsed["replicatedProtectedItemName"]; !ok {
+		return nil, fmt.Errorf("the segment 'replicatedProtectedItemName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ValidateReplicationProtectedItemID checks that 'input' can be parsed as a Replication Protected Item ID
+func ValidateReplicationProtectedItemID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseReplicationProtectedItemID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Replication Protected Item ID
+func (id ReplicationProtectedItemId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.RecoveryServices/vaults/%s/replicationFabrics/%s/replicationProtectionContainers/%s/replicationProtectedItems/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.ResourceName, id.FabricName, id.ProtectionContainerName, id.ReplicatedProtectedItemName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Replication Protected Item ID
+func (id ReplicationProtectedItemId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftRecoveryServices", "Microsoft.RecoveryServices", "Microsoft.RecoveryServices"),
+		resourceids.StaticSegment("staticVaults", "vaults", "vaults"),
+		resourceids.UserSpecifiedSegment("resourceName", "resourceValue"),
+		resourceids.StaticSegment("staticReplicationFabrics", "replicationFabrics", "replicationFabrics"),
+		resourceids.UserSpecifiedSegment("fabricName", "fabricValue"),
+		resourceids.StaticSegment("staticReplicationProtectionContainers", "replicationProtectionContainers", "replicationProtectionContainers"),
+		resourceids.UserSpecifiedSegment("protectionContainerName", "protectionContainerValue"),
+		resourceids.StaticSegment("staticReplicationProtectedItems", "replicationProtectedItems", "replicationProtectedItems"),
+		resourceids.UserSpecifiedSegment("replicatedProtectedItemName", "replicatedProtectedItemValue"),
+	}
+}
+
+// String returns a human-readable description of this Replication Protected Item ID
+func (id ReplicationProtectedItemId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Resource Name: %q", id.ResourceName),
+		fmt.Sprintf("Fabric Name: %q", id.FabricName),
+		fmt.Sprintf("Protection Container Name: %q", id.ProtectionContainerName),
+		fmt.Sprintf("Replicated Protected Item Name: %q", id.ReplicatedProtectedItemName),
+	}
+	return fmt.Sprintf("Replication Protected Item (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/id_replicationprotectioncontainer.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/id_replicationprotectioncontainer.go
@@ -1,0 +1,150 @@
+package replicationprotecteditems
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = ReplicationProtectionContainerId{}
+
+// ReplicationProtectionContainerId is a struct representing the Resource ID for a Replication Protection Container
+type ReplicationProtectionContainerId struct {
+	SubscriptionId          string
+	ResourceGroupName       string
+	ResourceName            string
+	FabricName              string
+	ProtectionContainerName string
+}
+
+// NewReplicationProtectionContainerID returns a new ReplicationProtectionContainerId struct
+func NewReplicationProtectionContainerID(subscriptionId string, resourceGroupName string, resourceName string, fabricName string, protectionContainerName string) ReplicationProtectionContainerId {
+	return ReplicationProtectionContainerId{
+		SubscriptionId:          subscriptionId,
+		ResourceGroupName:       resourceGroupName,
+		ResourceName:            resourceName,
+		FabricName:              fabricName,
+		ProtectionContainerName: protectionContainerName,
+	}
+}
+
+// ParseReplicationProtectionContainerID parses 'input' into a ReplicationProtectionContainerId
+func ParseReplicationProtectionContainerID(input string) (*ReplicationProtectionContainerId, error) {
+	parser := resourceids.NewParserFromResourceIdType(ReplicationProtectionContainerId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := ReplicationProtectionContainerId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceName, ok = parsed.Parsed["resourceName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceName' was not found in the resource id %q", input)
+	}
+
+	if id.FabricName, ok = parsed.Parsed["fabricName"]; !ok {
+		return nil, fmt.Errorf("the segment 'fabricName' was not found in the resource id %q", input)
+	}
+
+	if id.ProtectionContainerName, ok = parsed.Parsed["protectionContainerName"]; !ok {
+		return nil, fmt.Errorf("the segment 'protectionContainerName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ParseReplicationProtectionContainerIDInsensitively parses 'input' case-insensitively into a ReplicationProtectionContainerId
+// note: this method should only be used for API response data and not user input
+func ParseReplicationProtectionContainerIDInsensitively(input string) (*ReplicationProtectionContainerId, error) {
+	parser := resourceids.NewParserFromResourceIdType(ReplicationProtectionContainerId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := ReplicationProtectionContainerId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceName, ok = parsed.Parsed["resourceName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceName' was not found in the resource id %q", input)
+	}
+
+	if id.FabricName, ok = parsed.Parsed["fabricName"]; !ok {
+		return nil, fmt.Errorf("the segment 'fabricName' was not found in the resource id %q", input)
+	}
+
+	if id.ProtectionContainerName, ok = parsed.Parsed["protectionContainerName"]; !ok {
+		return nil, fmt.Errorf("the segment 'protectionContainerName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ValidateReplicationProtectionContainerID checks that 'input' can be parsed as a Replication Protection Container ID
+func ValidateReplicationProtectionContainerID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseReplicationProtectionContainerID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Replication Protection Container ID
+func (id ReplicationProtectionContainerId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.RecoveryServices/vaults/%s/replicationFabrics/%s/replicationProtectionContainers/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.ResourceName, id.FabricName, id.ProtectionContainerName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Replication Protection Container ID
+func (id ReplicationProtectionContainerId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftRecoveryServices", "Microsoft.RecoveryServices", "Microsoft.RecoveryServices"),
+		resourceids.StaticSegment("staticVaults", "vaults", "vaults"),
+		resourceids.UserSpecifiedSegment("resourceName", "resourceValue"),
+		resourceids.StaticSegment("staticReplicationFabrics", "replicationFabrics", "replicationFabrics"),
+		resourceids.UserSpecifiedSegment("fabricName", "fabricValue"),
+		resourceids.StaticSegment("staticReplicationProtectionContainers", "replicationProtectionContainers", "replicationProtectionContainers"),
+		resourceids.UserSpecifiedSegment("protectionContainerName", "protectionContainerValue"),
+	}
+}
+
+// String returns a human-readable description of this Replication Protection Container ID
+func (id ReplicationProtectionContainerId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Resource Name: %q", id.ResourceName),
+		fmt.Sprintf("Fabric Name: %q", id.FabricName),
+		fmt.Sprintf("Protection Container Name: %q", id.ProtectionContainerName),
+	}
+	return fmt.Sprintf("Replication Protection Container (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/id_vault.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/id_vault.go
@@ -1,0 +1,124 @@
+package replicationprotecteditems
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = VaultId{}
+
+// VaultId is a struct representing the Resource ID for a Vault
+type VaultId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	ResourceName      string
+}
+
+// NewVaultID returns a new VaultId struct
+func NewVaultID(subscriptionId string, resourceGroupName string, resourceName string) VaultId {
+	return VaultId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		ResourceName:      resourceName,
+	}
+}
+
+// ParseVaultID parses 'input' into a VaultId
+func ParseVaultID(input string) (*VaultId, error) {
+	parser := resourceids.NewParserFromResourceIdType(VaultId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := VaultId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceName, ok = parsed.Parsed["resourceName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ParseVaultIDInsensitively parses 'input' case-insensitively into a VaultId
+// note: this method should only be used for API response data and not user input
+func ParseVaultIDInsensitively(input string) (*VaultId, error) {
+	parser := resourceids.NewParserFromResourceIdType(VaultId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := VaultId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceName, ok = parsed.Parsed["resourceName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ValidateVaultID checks that 'input' can be parsed as a Vault ID
+func ValidateVaultID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseVaultID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Vault ID
+func (id VaultId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.RecoveryServices/vaults/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.ResourceName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Vault ID
+func (id VaultId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftRecoveryServices", "Microsoft.RecoveryServices", "Microsoft.RecoveryServices"),
+		resourceids.StaticSegment("staticVaults", "vaults", "vaults"),
+		resourceids.UserSpecifiedSegment("resourceName", "resourceValue"),
+	}
+}
+
+// String returns a human-readable description of this Vault ID
+func (id VaultId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Resource Name: %q", id.ResourceName),
+	}
+	return fmt.Sprintf("Vault (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/method_adddisks_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/method_adddisks_autorest.go
@@ -1,0 +1,79 @@
+package replicationprotecteditems
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AddDisksOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// AddDisks ...
+func (c ReplicationProtectedItemsClient) AddDisks(ctx context.Context, id ReplicationProtectedItemId, input AddDisksInput) (result AddDisksOperationResponse, err error) {
+	req, err := c.preparerForAddDisks(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotecteditems.ReplicationProtectedItemsClient", "AddDisks", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForAddDisks(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotecteditems.ReplicationProtectedItemsClient", "AddDisks", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// AddDisksThenPoll performs AddDisks then polls until it's completed
+func (c ReplicationProtectedItemsClient) AddDisksThenPoll(ctx context.Context, id ReplicationProtectedItemId, input AddDisksInput) error {
+	result, err := c.AddDisks(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing AddDisks: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after AddDisks: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForAddDisks prepares the AddDisks request.
+func (c ReplicationProtectedItemsClient) preparerForAddDisks(ctx context.Context, id ReplicationProtectedItemId, input AddDisksInput) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/addDisks", id.ID())),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForAddDisks sends the AddDisks request. The method will close the
+// http.Response Body if it receives an error.
+func (c ReplicationProtectedItemsClient) senderForAddDisks(ctx context.Context, req *http.Request) (future AddDisksOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/method_applyrecoverypoint_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/method_applyrecoverypoint_autorest.go
@@ -1,0 +1,79 @@
+package replicationprotecteditems
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ApplyRecoveryPointOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// ApplyRecoveryPoint ...
+func (c ReplicationProtectedItemsClient) ApplyRecoveryPoint(ctx context.Context, id ReplicationProtectedItemId, input ApplyRecoveryPointInput) (result ApplyRecoveryPointOperationResponse, err error) {
+	req, err := c.preparerForApplyRecoveryPoint(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotecteditems.ReplicationProtectedItemsClient", "ApplyRecoveryPoint", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForApplyRecoveryPoint(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotecteditems.ReplicationProtectedItemsClient", "ApplyRecoveryPoint", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// ApplyRecoveryPointThenPoll performs ApplyRecoveryPoint then polls until it's completed
+func (c ReplicationProtectedItemsClient) ApplyRecoveryPointThenPoll(ctx context.Context, id ReplicationProtectedItemId, input ApplyRecoveryPointInput) error {
+	result, err := c.ApplyRecoveryPoint(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing ApplyRecoveryPoint: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after ApplyRecoveryPoint: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForApplyRecoveryPoint prepares the ApplyRecoveryPoint request.
+func (c ReplicationProtectedItemsClient) preparerForApplyRecoveryPoint(ctx context.Context, id ReplicationProtectedItemId, input ApplyRecoveryPointInput) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/applyRecoveryPoint", id.ID())),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForApplyRecoveryPoint sends the ApplyRecoveryPoint request. The method will close the
+// http.Response Body if it receives an error.
+func (c ReplicationProtectedItemsClient) senderForApplyRecoveryPoint(ctx context.Context, req *http.Request) (future ApplyRecoveryPointOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/method_create_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/method_create_autorest.go
@@ -1,0 +1,79 @@
+package replicationprotecteditems
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CreateOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// Create ...
+func (c ReplicationProtectedItemsClient) Create(ctx context.Context, id ReplicationProtectedItemId, input EnableProtectionInput) (result CreateOperationResponse, err error) {
+	req, err := c.preparerForCreate(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotecteditems.ReplicationProtectedItemsClient", "Create", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForCreate(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotecteditems.ReplicationProtectedItemsClient", "Create", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// CreateThenPoll performs Create then polls until it's completed
+func (c ReplicationProtectedItemsClient) CreateThenPoll(ctx context.Context, id ReplicationProtectedItemId, input EnableProtectionInput) error {
+	result, err := c.Create(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing Create: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after Create: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForCreate prepares the Create request.
+func (c ReplicationProtectedItemsClient) preparerForCreate(ctx context.Context, id ReplicationProtectedItemId, input EnableProtectionInput) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPut(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForCreate sends the Create request. The method will close the
+// http.Response Body if it receives an error.
+func (c ReplicationProtectedItemsClient) senderForCreate(ctx context.Context, req *http.Request) (future CreateOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/method_delete_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/method_delete_autorest.go
@@ -1,0 +1,79 @@
+package replicationprotecteditems
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DeleteOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// Delete ...
+func (c ReplicationProtectedItemsClient) Delete(ctx context.Context, id ReplicationProtectedItemId, input DisableProtectionInput) (result DeleteOperationResponse, err error) {
+	req, err := c.preparerForDelete(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotecteditems.ReplicationProtectedItemsClient", "Delete", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForDelete(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotecteditems.ReplicationProtectedItemsClient", "Delete", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// DeleteThenPoll performs Delete then polls until it's completed
+func (c ReplicationProtectedItemsClient) DeleteThenPoll(ctx context.Context, id ReplicationProtectedItemId, input DisableProtectionInput) error {
+	result, err := c.Delete(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing Delete: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after Delete: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForDelete prepares the Delete request.
+func (c ReplicationProtectedItemsClient) preparerForDelete(ctx context.Context, id ReplicationProtectedItemId, input DisableProtectionInput) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/remove", id.ID())),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForDelete sends the Delete request. The method will close the
+// http.Response Body if it receives an error.
+func (c ReplicationProtectedItemsClient) senderForDelete(ctx context.Context, req *http.Request) (future DeleteOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/method_failovercancel_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/method_failovercancel_autorest.go
@@ -1,0 +1,78 @@
+package replicationprotecteditems
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type FailoverCancelOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// FailoverCancel ...
+func (c ReplicationProtectedItemsClient) FailoverCancel(ctx context.Context, id ReplicationProtectedItemId) (result FailoverCancelOperationResponse, err error) {
+	req, err := c.preparerForFailoverCancel(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotecteditems.ReplicationProtectedItemsClient", "FailoverCancel", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForFailoverCancel(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotecteditems.ReplicationProtectedItemsClient", "FailoverCancel", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// FailoverCancelThenPoll performs FailoverCancel then polls until it's completed
+func (c ReplicationProtectedItemsClient) FailoverCancelThenPoll(ctx context.Context, id ReplicationProtectedItemId) error {
+	result, err := c.FailoverCancel(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing FailoverCancel: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after FailoverCancel: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForFailoverCancel prepares the FailoverCancel request.
+func (c ReplicationProtectedItemsClient) preparerForFailoverCancel(ctx context.Context, id ReplicationProtectedItemId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/failoverCancel", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForFailoverCancel sends the FailoverCancel request. The method will close the
+// http.Response Body if it receives an error.
+func (c ReplicationProtectedItemsClient) senderForFailoverCancel(ctx context.Context, req *http.Request) (future FailoverCancelOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/method_failovercommit_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/method_failovercommit_autorest.go
@@ -1,0 +1,78 @@
+package replicationprotecteditems
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type FailoverCommitOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// FailoverCommit ...
+func (c ReplicationProtectedItemsClient) FailoverCommit(ctx context.Context, id ReplicationProtectedItemId) (result FailoverCommitOperationResponse, err error) {
+	req, err := c.preparerForFailoverCommit(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotecteditems.ReplicationProtectedItemsClient", "FailoverCommit", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForFailoverCommit(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotecteditems.ReplicationProtectedItemsClient", "FailoverCommit", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// FailoverCommitThenPoll performs FailoverCommit then polls until it's completed
+func (c ReplicationProtectedItemsClient) FailoverCommitThenPoll(ctx context.Context, id ReplicationProtectedItemId) error {
+	result, err := c.FailoverCommit(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing FailoverCommit: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after FailoverCommit: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForFailoverCommit prepares the FailoverCommit request.
+func (c ReplicationProtectedItemsClient) preparerForFailoverCommit(ctx context.Context, id ReplicationProtectedItemId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/failoverCommit", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForFailoverCommit sends the FailoverCommit request. The method will close the
+// http.Response Body if it receives an error.
+func (c ReplicationProtectedItemsClient) senderForFailoverCommit(ctx context.Context, req *http.Request) (future FailoverCommitOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/method_get_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/method_get_autorest.go
@@ -1,0 +1,68 @@
+package replicationprotecteditems
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *ReplicationProtectedItem
+}
+
+// Get ...
+func (c ReplicationProtectedItemsClient) Get(ctx context.Context, id ReplicationProtectedItemId) (result GetOperationResponse, err error) {
+	req, err := c.preparerForGet(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotecteditems.ReplicationProtectedItemsClient", "Get", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotecteditems.ReplicationProtectedItemsClient", "Get", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForGet(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotecteditems.ReplicationProtectedItemsClient", "Get", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForGet prepares the Get request.
+func (c ReplicationProtectedItemsClient) preparerForGet(ctx context.Context, id ReplicationProtectedItemId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForGet handles the response to the Get request. The method always
+// closes the http.Response Body.
+func (c ReplicationProtectedItemsClient) responderForGet(resp *http.Response) (result GetOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/method_list_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/method_list_autorest.go
@@ -1,0 +1,220 @@
+package replicationprotecteditems
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *[]ReplicationProtectedItem
+
+	nextLink     *string
+	nextPageFunc func(ctx context.Context, nextLink string) (ListOperationResponse, error)
+}
+
+type ListCompleteResult struct {
+	Items []ReplicationProtectedItem
+}
+
+func (r ListOperationResponse) HasMore() bool {
+	return r.nextLink != nil
+}
+
+func (r ListOperationResponse) LoadMore(ctx context.Context) (resp ListOperationResponse, err error) {
+	if !r.HasMore() {
+		err = fmt.Errorf("no more pages returned")
+		return
+	}
+	return r.nextPageFunc(ctx, *r.nextLink)
+}
+
+type ListOperationOptions struct {
+	Filter    *string
+	SkipToken *string
+}
+
+func DefaultListOperationOptions() ListOperationOptions {
+	return ListOperationOptions{}
+}
+
+func (o ListOperationOptions) toHeaders() map[string]interface{} {
+	out := make(map[string]interface{})
+
+	return out
+}
+
+func (o ListOperationOptions) toQueryString() map[string]interface{} {
+	out := make(map[string]interface{})
+
+	if o.Filter != nil {
+		out["$filter"] = *o.Filter
+	}
+
+	if o.SkipToken != nil {
+		out["skipToken"] = *o.SkipToken
+	}
+
+	return out
+}
+
+// List ...
+func (c ReplicationProtectedItemsClient) List(ctx context.Context, id VaultId, options ListOperationOptions) (resp ListOperationResponse, err error) {
+	req, err := c.preparerForList(ctx, id, options)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotecteditems.ReplicationProtectedItemsClient", "List", nil, "Failure preparing request")
+		return
+	}
+
+	resp.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotecteditems.ReplicationProtectedItemsClient", "List", resp.HttpResponse, "Failure sending request")
+		return
+	}
+
+	resp, err = c.responderForList(resp.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotecteditems.ReplicationProtectedItemsClient", "List", resp.HttpResponse, "Failure responding to request")
+		return
+	}
+	return
+}
+
+// preparerForList prepares the List request.
+func (c ReplicationProtectedItemsClient) preparerForList(ctx context.Context, id VaultId, options ListOperationOptions) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	for k, v := range options.toQueryString() {
+		queryParameters[k] = autorest.Encode("query", v)
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithHeaders(options.toHeaders()),
+		autorest.WithPath(fmt.Sprintf("%s/replicationProtectedItems", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// preparerForListWithNextLink prepares the List request with the given nextLink token.
+func (c ReplicationProtectedItemsClient) preparerForListWithNextLink(ctx context.Context, nextLink string) (*http.Request, error) {
+	uri, err := url.Parse(nextLink)
+	if err != nil {
+		return nil, fmt.Errorf("parsing nextLink %q: %+v", nextLink, err)
+	}
+	queryParameters := map[string]interface{}{}
+	for k, v := range uri.Query() {
+		if len(v) == 0 {
+			continue
+		}
+		val := v[0]
+		val = autorest.Encode("query", val)
+		queryParameters[k] = val
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(uri.Path),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForList handles the response to the List request. The method always
+// closes the http.Response Body.
+func (c ReplicationProtectedItemsClient) responderForList(resp *http.Response) (result ListOperationResponse, err error) {
+	type page struct {
+		Values   []ReplicationProtectedItem `json:"value"`
+		NextLink *string                    `json:"nextLink"`
+	}
+	var respObj page
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&respObj),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	result.Model = &respObj.Values
+	result.nextLink = respObj.NextLink
+	if respObj.NextLink != nil {
+		result.nextPageFunc = func(ctx context.Context, nextLink string) (result ListOperationResponse, err error) {
+			req, err := c.preparerForListWithNextLink(ctx, nextLink)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "replicationprotecteditems.ReplicationProtectedItemsClient", "List", nil, "Failure preparing request")
+				return
+			}
+
+			result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "replicationprotecteditems.ReplicationProtectedItemsClient", "List", result.HttpResponse, "Failure sending request")
+				return
+			}
+
+			result, err = c.responderForList(result.HttpResponse)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "replicationprotecteditems.ReplicationProtectedItemsClient", "List", result.HttpResponse, "Failure responding to request")
+				return
+			}
+
+			return
+		}
+	}
+	return
+}
+
+// ListComplete retrieves all of the results into a single object
+func (c ReplicationProtectedItemsClient) ListComplete(ctx context.Context, id VaultId, options ListOperationOptions) (ListCompleteResult, error) {
+	return c.ListCompleteMatchingPredicate(ctx, id, options, ReplicationProtectedItemOperationPredicate{})
+}
+
+// ListCompleteMatchingPredicate retrieves all of the results and then applied the predicate
+func (c ReplicationProtectedItemsClient) ListCompleteMatchingPredicate(ctx context.Context, id VaultId, options ListOperationOptions, predicate ReplicationProtectedItemOperationPredicate) (resp ListCompleteResult, err error) {
+	items := make([]ReplicationProtectedItem, 0)
+
+	page, err := c.List(ctx, id, options)
+	if err != nil {
+		err = fmt.Errorf("loading the initial page: %+v", err)
+		return
+	}
+	if page.Model != nil {
+		for _, v := range *page.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	for page.HasMore() {
+		page, err = page.LoadMore(ctx)
+		if err != nil {
+			err = fmt.Errorf("loading the next page: %+v", err)
+			return
+		}
+
+		if page.Model != nil {
+			for _, v := range *page.Model {
+				if predicate.Matches(v) {
+					items = append(items, v)
+				}
+			}
+		}
+	}
+
+	out := ListCompleteResult{
+		Items: items,
+	}
+	return out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/method_listbyreplicationprotectioncontainers_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/method_listbyreplicationprotectioncontainers_autorest.go
@@ -1,0 +1,186 @@
+package replicationprotecteditems
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListByReplicationProtectionContainersOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *[]ReplicationProtectedItem
+
+	nextLink     *string
+	nextPageFunc func(ctx context.Context, nextLink string) (ListByReplicationProtectionContainersOperationResponse, error)
+}
+
+type ListByReplicationProtectionContainersCompleteResult struct {
+	Items []ReplicationProtectedItem
+}
+
+func (r ListByReplicationProtectionContainersOperationResponse) HasMore() bool {
+	return r.nextLink != nil
+}
+
+func (r ListByReplicationProtectionContainersOperationResponse) LoadMore(ctx context.Context) (resp ListByReplicationProtectionContainersOperationResponse, err error) {
+	if !r.HasMore() {
+		err = fmt.Errorf("no more pages returned")
+		return
+	}
+	return r.nextPageFunc(ctx, *r.nextLink)
+}
+
+// ListByReplicationProtectionContainers ...
+func (c ReplicationProtectedItemsClient) ListByReplicationProtectionContainers(ctx context.Context, id ReplicationProtectionContainerId) (resp ListByReplicationProtectionContainersOperationResponse, err error) {
+	req, err := c.preparerForListByReplicationProtectionContainers(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotecteditems.ReplicationProtectedItemsClient", "ListByReplicationProtectionContainers", nil, "Failure preparing request")
+		return
+	}
+
+	resp.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotecteditems.ReplicationProtectedItemsClient", "ListByReplicationProtectionContainers", resp.HttpResponse, "Failure sending request")
+		return
+	}
+
+	resp, err = c.responderForListByReplicationProtectionContainers(resp.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotecteditems.ReplicationProtectedItemsClient", "ListByReplicationProtectionContainers", resp.HttpResponse, "Failure responding to request")
+		return
+	}
+	return
+}
+
+// preparerForListByReplicationProtectionContainers prepares the ListByReplicationProtectionContainers request.
+func (c ReplicationProtectedItemsClient) preparerForListByReplicationProtectionContainers(ctx context.Context, id ReplicationProtectionContainerId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/replicationProtectedItems", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// preparerForListByReplicationProtectionContainersWithNextLink prepares the ListByReplicationProtectionContainers request with the given nextLink token.
+func (c ReplicationProtectedItemsClient) preparerForListByReplicationProtectionContainersWithNextLink(ctx context.Context, nextLink string) (*http.Request, error) {
+	uri, err := url.Parse(nextLink)
+	if err != nil {
+		return nil, fmt.Errorf("parsing nextLink %q: %+v", nextLink, err)
+	}
+	queryParameters := map[string]interface{}{}
+	for k, v := range uri.Query() {
+		if len(v) == 0 {
+			continue
+		}
+		val := v[0]
+		val = autorest.Encode("query", val)
+		queryParameters[k] = val
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(uri.Path),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForListByReplicationProtectionContainers handles the response to the ListByReplicationProtectionContainers request. The method always
+// closes the http.Response Body.
+func (c ReplicationProtectedItemsClient) responderForListByReplicationProtectionContainers(resp *http.Response) (result ListByReplicationProtectionContainersOperationResponse, err error) {
+	type page struct {
+		Values   []ReplicationProtectedItem `json:"value"`
+		NextLink *string                    `json:"nextLink"`
+	}
+	var respObj page
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&respObj),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	result.Model = &respObj.Values
+	result.nextLink = respObj.NextLink
+	if respObj.NextLink != nil {
+		result.nextPageFunc = func(ctx context.Context, nextLink string) (result ListByReplicationProtectionContainersOperationResponse, err error) {
+			req, err := c.preparerForListByReplicationProtectionContainersWithNextLink(ctx, nextLink)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "replicationprotecteditems.ReplicationProtectedItemsClient", "ListByReplicationProtectionContainers", nil, "Failure preparing request")
+				return
+			}
+
+			result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "replicationprotecteditems.ReplicationProtectedItemsClient", "ListByReplicationProtectionContainers", result.HttpResponse, "Failure sending request")
+				return
+			}
+
+			result, err = c.responderForListByReplicationProtectionContainers(result.HttpResponse)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "replicationprotecteditems.ReplicationProtectedItemsClient", "ListByReplicationProtectionContainers", result.HttpResponse, "Failure responding to request")
+				return
+			}
+
+			return
+		}
+	}
+	return
+}
+
+// ListByReplicationProtectionContainersComplete retrieves all of the results into a single object
+func (c ReplicationProtectedItemsClient) ListByReplicationProtectionContainersComplete(ctx context.Context, id ReplicationProtectionContainerId) (ListByReplicationProtectionContainersCompleteResult, error) {
+	return c.ListByReplicationProtectionContainersCompleteMatchingPredicate(ctx, id, ReplicationProtectedItemOperationPredicate{})
+}
+
+// ListByReplicationProtectionContainersCompleteMatchingPredicate retrieves all of the results and then applied the predicate
+func (c ReplicationProtectedItemsClient) ListByReplicationProtectionContainersCompleteMatchingPredicate(ctx context.Context, id ReplicationProtectionContainerId, predicate ReplicationProtectedItemOperationPredicate) (resp ListByReplicationProtectionContainersCompleteResult, err error) {
+	items := make([]ReplicationProtectedItem, 0)
+
+	page, err := c.ListByReplicationProtectionContainers(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading the initial page: %+v", err)
+		return
+	}
+	if page.Model != nil {
+		for _, v := range *page.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	for page.HasMore() {
+		page, err = page.LoadMore(ctx)
+		if err != nil {
+			err = fmt.Errorf("loading the next page: %+v", err)
+			return
+		}
+
+		if page.Model != nil {
+			for _, v := range *page.Model {
+				if predicate.Matches(v) {
+					items = append(items, v)
+				}
+			}
+		}
+	}
+
+	out := ListByReplicationProtectionContainersCompleteResult{
+		Items: items,
+	}
+	return out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/method_plannedfailover_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/method_plannedfailover_autorest.go
@@ -1,0 +1,79 @@
+package replicationprotecteditems
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PlannedFailoverOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// PlannedFailover ...
+func (c ReplicationProtectedItemsClient) PlannedFailover(ctx context.Context, id ReplicationProtectedItemId, input PlannedFailoverInput) (result PlannedFailoverOperationResponse, err error) {
+	req, err := c.preparerForPlannedFailover(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotecteditems.ReplicationProtectedItemsClient", "PlannedFailover", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForPlannedFailover(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotecteditems.ReplicationProtectedItemsClient", "PlannedFailover", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// PlannedFailoverThenPoll performs PlannedFailover then polls until it's completed
+func (c ReplicationProtectedItemsClient) PlannedFailoverThenPoll(ctx context.Context, id ReplicationProtectedItemId, input PlannedFailoverInput) error {
+	result, err := c.PlannedFailover(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing PlannedFailover: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after PlannedFailover: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForPlannedFailover prepares the PlannedFailover request.
+func (c ReplicationProtectedItemsClient) preparerForPlannedFailover(ctx context.Context, id ReplicationProtectedItemId, input PlannedFailoverInput) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/plannedFailover", id.ID())),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForPlannedFailover sends the PlannedFailover request. The method will close the
+// http.Response Body if it receives an error.
+func (c ReplicationProtectedItemsClient) senderForPlannedFailover(ctx context.Context, req *http.Request) (future PlannedFailoverOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/method_purge_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/method_purge_autorest.go
@@ -1,0 +1,78 @@
+package replicationprotecteditems
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PurgeOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// Purge ...
+func (c ReplicationProtectedItemsClient) Purge(ctx context.Context, id ReplicationProtectedItemId) (result PurgeOperationResponse, err error) {
+	req, err := c.preparerForPurge(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotecteditems.ReplicationProtectedItemsClient", "Purge", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForPurge(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotecteditems.ReplicationProtectedItemsClient", "Purge", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// PurgeThenPoll performs Purge then polls until it's completed
+func (c ReplicationProtectedItemsClient) PurgeThenPoll(ctx context.Context, id ReplicationProtectedItemId) error {
+	result, err := c.Purge(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing Purge: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after Purge: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForPurge prepares the Purge request.
+func (c ReplicationProtectedItemsClient) preparerForPurge(ctx context.Context, id ReplicationProtectedItemId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsDelete(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForPurge sends the Purge request. The method will close the
+// http.Response Body if it receives an error.
+func (c ReplicationProtectedItemsClient) senderForPurge(ctx context.Context, req *http.Request) (future PurgeOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/method_removedisks_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/method_removedisks_autorest.go
@@ -1,0 +1,79 @@
+package replicationprotecteditems
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RemoveDisksOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// RemoveDisks ...
+func (c ReplicationProtectedItemsClient) RemoveDisks(ctx context.Context, id ReplicationProtectedItemId, input RemoveDisksInput) (result RemoveDisksOperationResponse, err error) {
+	req, err := c.preparerForRemoveDisks(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotecteditems.ReplicationProtectedItemsClient", "RemoveDisks", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForRemoveDisks(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotecteditems.ReplicationProtectedItemsClient", "RemoveDisks", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// RemoveDisksThenPoll performs RemoveDisks then polls until it's completed
+func (c ReplicationProtectedItemsClient) RemoveDisksThenPoll(ctx context.Context, id ReplicationProtectedItemId, input RemoveDisksInput) error {
+	result, err := c.RemoveDisks(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing RemoveDisks: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after RemoveDisks: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForRemoveDisks prepares the RemoveDisks request.
+func (c ReplicationProtectedItemsClient) preparerForRemoveDisks(ctx context.Context, id ReplicationProtectedItemId, input RemoveDisksInput) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/removeDisks", id.ID())),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForRemoveDisks sends the RemoveDisks request. The method will close the
+// http.Response Body if it receives an error.
+func (c ReplicationProtectedItemsClient) senderForRemoveDisks(ctx context.Context, req *http.Request) (future RemoveDisksOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/method_repairreplication_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/method_repairreplication_autorest.go
@@ -1,0 +1,78 @@
+package replicationprotecteditems
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RepairReplicationOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// RepairReplication ...
+func (c ReplicationProtectedItemsClient) RepairReplication(ctx context.Context, id ReplicationProtectedItemId) (result RepairReplicationOperationResponse, err error) {
+	req, err := c.preparerForRepairReplication(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotecteditems.ReplicationProtectedItemsClient", "RepairReplication", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForRepairReplication(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotecteditems.ReplicationProtectedItemsClient", "RepairReplication", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// RepairReplicationThenPoll performs RepairReplication then polls until it's completed
+func (c ReplicationProtectedItemsClient) RepairReplicationThenPoll(ctx context.Context, id ReplicationProtectedItemId) error {
+	result, err := c.RepairReplication(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing RepairReplication: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after RepairReplication: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForRepairReplication prepares the RepairReplication request.
+func (c ReplicationProtectedItemsClient) preparerForRepairReplication(ctx context.Context, id ReplicationProtectedItemId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/repairReplication", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForRepairReplication sends the RepairReplication request. The method will close the
+// http.Response Body if it receives an error.
+func (c ReplicationProtectedItemsClient) senderForRepairReplication(ctx context.Context, req *http.Request) (future RepairReplicationOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/method_reprotect_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/method_reprotect_autorest.go
@@ -1,0 +1,79 @@
+package replicationprotecteditems
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ReprotectOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// Reprotect ...
+func (c ReplicationProtectedItemsClient) Reprotect(ctx context.Context, id ReplicationProtectedItemId, input ReverseReplicationInput) (result ReprotectOperationResponse, err error) {
+	req, err := c.preparerForReprotect(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotecteditems.ReplicationProtectedItemsClient", "Reprotect", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForReprotect(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotecteditems.ReplicationProtectedItemsClient", "Reprotect", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// ReprotectThenPoll performs Reprotect then polls until it's completed
+func (c ReplicationProtectedItemsClient) ReprotectThenPoll(ctx context.Context, id ReplicationProtectedItemId, input ReverseReplicationInput) error {
+	result, err := c.Reprotect(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing Reprotect: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after Reprotect: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForReprotect prepares the Reprotect request.
+func (c ReplicationProtectedItemsClient) preparerForReprotect(ctx context.Context, id ReplicationProtectedItemId, input ReverseReplicationInput) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/reProtect", id.ID())),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForReprotect sends the Reprotect request. The method will close the
+// http.Response Body if it receives an error.
+func (c ReplicationProtectedItemsClient) senderForReprotect(ctx context.Context, req *http.Request) (future ReprotectOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/method_resolvehealtherrors_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/method_resolvehealtherrors_autorest.go
@@ -1,0 +1,79 @@
+package replicationprotecteditems
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ResolveHealthErrorsOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// ResolveHealthErrors ...
+func (c ReplicationProtectedItemsClient) ResolveHealthErrors(ctx context.Context, id ReplicationProtectedItemId, input ResolveHealthInput) (result ResolveHealthErrorsOperationResponse, err error) {
+	req, err := c.preparerForResolveHealthErrors(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotecteditems.ReplicationProtectedItemsClient", "ResolveHealthErrors", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForResolveHealthErrors(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotecteditems.ReplicationProtectedItemsClient", "ResolveHealthErrors", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// ResolveHealthErrorsThenPoll performs ResolveHealthErrors then polls until it's completed
+func (c ReplicationProtectedItemsClient) ResolveHealthErrorsThenPoll(ctx context.Context, id ReplicationProtectedItemId, input ResolveHealthInput) error {
+	result, err := c.ResolveHealthErrors(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing ResolveHealthErrors: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after ResolveHealthErrors: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForResolveHealthErrors prepares the ResolveHealthErrors request.
+func (c ReplicationProtectedItemsClient) preparerForResolveHealthErrors(ctx context.Context, id ReplicationProtectedItemId, input ResolveHealthInput) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/resolveHealthErrors", id.ID())),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForResolveHealthErrors sends the ResolveHealthErrors request. The method will close the
+// http.Response Body if it receives an error.
+func (c ReplicationProtectedItemsClient) senderForResolveHealthErrors(ctx context.Context, req *http.Request) (future ResolveHealthErrorsOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/method_switchprovider_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/method_switchprovider_autorest.go
@@ -1,0 +1,79 @@
+package replicationprotecteditems
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SwitchProviderOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// SwitchProvider ...
+func (c ReplicationProtectedItemsClient) SwitchProvider(ctx context.Context, id ReplicationProtectedItemId, input SwitchProviderInput) (result SwitchProviderOperationResponse, err error) {
+	req, err := c.preparerForSwitchProvider(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotecteditems.ReplicationProtectedItemsClient", "SwitchProvider", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForSwitchProvider(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotecteditems.ReplicationProtectedItemsClient", "SwitchProvider", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// SwitchProviderThenPoll performs SwitchProvider then polls until it's completed
+func (c ReplicationProtectedItemsClient) SwitchProviderThenPoll(ctx context.Context, id ReplicationProtectedItemId, input SwitchProviderInput) error {
+	result, err := c.SwitchProvider(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing SwitchProvider: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after SwitchProvider: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForSwitchProvider prepares the SwitchProvider request.
+func (c ReplicationProtectedItemsClient) preparerForSwitchProvider(ctx context.Context, id ReplicationProtectedItemId, input SwitchProviderInput) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/switchProvider", id.ID())),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForSwitchProvider sends the SwitchProvider request. The method will close the
+// http.Response Body if it receives an error.
+func (c ReplicationProtectedItemsClient) senderForSwitchProvider(ctx context.Context, req *http.Request) (future SwitchProviderOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/method_testfailover_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/method_testfailover_autorest.go
@@ -1,0 +1,79 @@
+package replicationprotecteditems
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type TestFailoverOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// TestFailover ...
+func (c ReplicationProtectedItemsClient) TestFailover(ctx context.Context, id ReplicationProtectedItemId, input TestFailoverInput) (result TestFailoverOperationResponse, err error) {
+	req, err := c.preparerForTestFailover(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotecteditems.ReplicationProtectedItemsClient", "TestFailover", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForTestFailover(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotecteditems.ReplicationProtectedItemsClient", "TestFailover", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// TestFailoverThenPoll performs TestFailover then polls until it's completed
+func (c ReplicationProtectedItemsClient) TestFailoverThenPoll(ctx context.Context, id ReplicationProtectedItemId, input TestFailoverInput) error {
+	result, err := c.TestFailover(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing TestFailover: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after TestFailover: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForTestFailover prepares the TestFailover request.
+func (c ReplicationProtectedItemsClient) preparerForTestFailover(ctx context.Context, id ReplicationProtectedItemId, input TestFailoverInput) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/testFailover", id.ID())),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForTestFailover sends the TestFailover request. The method will close the
+// http.Response Body if it receives an error.
+func (c ReplicationProtectedItemsClient) senderForTestFailover(ctx context.Context, req *http.Request) (future TestFailoverOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/method_testfailovercleanup_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/method_testfailovercleanup_autorest.go
@@ -1,0 +1,79 @@
+package replicationprotecteditems
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type TestFailoverCleanupOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// TestFailoverCleanup ...
+func (c ReplicationProtectedItemsClient) TestFailoverCleanup(ctx context.Context, id ReplicationProtectedItemId, input TestFailoverCleanupInput) (result TestFailoverCleanupOperationResponse, err error) {
+	req, err := c.preparerForTestFailoverCleanup(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotecteditems.ReplicationProtectedItemsClient", "TestFailoverCleanup", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForTestFailoverCleanup(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotecteditems.ReplicationProtectedItemsClient", "TestFailoverCleanup", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// TestFailoverCleanupThenPoll performs TestFailoverCleanup then polls until it's completed
+func (c ReplicationProtectedItemsClient) TestFailoverCleanupThenPoll(ctx context.Context, id ReplicationProtectedItemId, input TestFailoverCleanupInput) error {
+	result, err := c.TestFailoverCleanup(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing TestFailoverCleanup: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after TestFailoverCleanup: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForTestFailoverCleanup prepares the TestFailoverCleanup request.
+func (c ReplicationProtectedItemsClient) preparerForTestFailoverCleanup(ctx context.Context, id ReplicationProtectedItemId, input TestFailoverCleanupInput) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/testFailoverCleanup", id.ID())),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForTestFailoverCleanup sends the TestFailoverCleanup request. The method will close the
+// http.Response Body if it receives an error.
+func (c ReplicationProtectedItemsClient) senderForTestFailoverCleanup(ctx context.Context, req *http.Request) (future TestFailoverCleanupOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/method_unplannedfailover_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/method_unplannedfailover_autorest.go
@@ -1,0 +1,79 @@
+package replicationprotecteditems
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UnplannedFailoverOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// UnplannedFailover ...
+func (c ReplicationProtectedItemsClient) UnplannedFailover(ctx context.Context, id ReplicationProtectedItemId, input UnplannedFailoverInput) (result UnplannedFailoverOperationResponse, err error) {
+	req, err := c.preparerForUnplannedFailover(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotecteditems.ReplicationProtectedItemsClient", "UnplannedFailover", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForUnplannedFailover(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotecteditems.ReplicationProtectedItemsClient", "UnplannedFailover", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// UnplannedFailoverThenPoll performs UnplannedFailover then polls until it's completed
+func (c ReplicationProtectedItemsClient) UnplannedFailoverThenPoll(ctx context.Context, id ReplicationProtectedItemId, input UnplannedFailoverInput) error {
+	result, err := c.UnplannedFailover(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing UnplannedFailover: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after UnplannedFailover: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForUnplannedFailover prepares the UnplannedFailover request.
+func (c ReplicationProtectedItemsClient) preparerForUnplannedFailover(ctx context.Context, id ReplicationProtectedItemId, input UnplannedFailoverInput) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/unplannedFailover", id.ID())),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForUnplannedFailover sends the UnplannedFailover request. The method will close the
+// http.Response Body if it receives an error.
+func (c ReplicationProtectedItemsClient) senderForUnplannedFailover(ctx context.Context, req *http.Request) (future UnplannedFailoverOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/method_update_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/method_update_autorest.go
@@ -1,0 +1,79 @@
+package replicationprotecteditems
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UpdateOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// Update ...
+func (c ReplicationProtectedItemsClient) Update(ctx context.Context, id ReplicationProtectedItemId, input UpdateReplicationProtectedItemInput) (result UpdateOperationResponse, err error) {
+	req, err := c.preparerForUpdate(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotecteditems.ReplicationProtectedItemsClient", "Update", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForUpdate(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotecteditems.ReplicationProtectedItemsClient", "Update", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// UpdateThenPoll performs Update then polls until it's completed
+func (c ReplicationProtectedItemsClient) UpdateThenPoll(ctx context.Context, id ReplicationProtectedItemId, input UpdateReplicationProtectedItemInput) error {
+	result, err := c.Update(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing Update: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after Update: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForUpdate prepares the Update request.
+func (c ReplicationProtectedItemsClient) preparerForUpdate(ctx context.Context, id ReplicationProtectedItemId, input UpdateReplicationProtectedItemInput) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPatch(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForUpdate sends the Update request. The method will close the
+// http.Response Body if it receives an error.
+func (c ReplicationProtectedItemsClient) senderForUpdate(ctx context.Context, req *http.Request) (future UpdateOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/method_updateappliance_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/method_updateappliance_autorest.go
@@ -1,0 +1,79 @@
+package replicationprotecteditems
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UpdateApplianceOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// UpdateAppliance ...
+func (c ReplicationProtectedItemsClient) UpdateAppliance(ctx context.Context, id ReplicationProtectedItemId, input UpdateApplianceForReplicationProtectedItemInput) (result UpdateApplianceOperationResponse, err error) {
+	req, err := c.preparerForUpdateAppliance(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotecteditems.ReplicationProtectedItemsClient", "UpdateAppliance", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForUpdateAppliance(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotecteditems.ReplicationProtectedItemsClient", "UpdateAppliance", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// UpdateApplianceThenPoll performs UpdateAppliance then polls until it's completed
+func (c ReplicationProtectedItemsClient) UpdateApplianceThenPoll(ctx context.Context, id ReplicationProtectedItemId, input UpdateApplianceForReplicationProtectedItemInput) error {
+	result, err := c.UpdateAppliance(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing UpdateAppliance: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after UpdateAppliance: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForUpdateAppliance prepares the UpdateAppliance request.
+func (c ReplicationProtectedItemsClient) preparerForUpdateAppliance(ctx context.Context, id ReplicationProtectedItemId, input UpdateApplianceForReplicationProtectedItemInput) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/updateAppliance", id.ID())),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForUpdateAppliance sends the UpdateAppliance request. The method will close the
+// http.Response Body if it receives an error.
+func (c ReplicationProtectedItemsClient) senderForUpdateAppliance(ctx context.Context, req *http.Request) (future UpdateApplianceOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/method_updatemobilityservice_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/method_updatemobilityservice_autorest.go
@@ -1,0 +1,79 @@
+package replicationprotecteditems
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UpdateMobilityServiceOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// UpdateMobilityService ...
+func (c ReplicationProtectedItemsClient) UpdateMobilityService(ctx context.Context, id ReplicationProtectedItemId, input UpdateMobilityServiceRequest) (result UpdateMobilityServiceOperationResponse, err error) {
+	req, err := c.preparerForUpdateMobilityService(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotecteditems.ReplicationProtectedItemsClient", "UpdateMobilityService", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForUpdateMobilityService(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotecteditems.ReplicationProtectedItemsClient", "UpdateMobilityService", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// UpdateMobilityServiceThenPoll performs UpdateMobilityService then polls until it's completed
+func (c ReplicationProtectedItemsClient) UpdateMobilityServiceThenPoll(ctx context.Context, id ReplicationProtectedItemId, input UpdateMobilityServiceRequest) error {
+	result, err := c.UpdateMobilityService(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing UpdateMobilityService: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after UpdateMobilityService: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForUpdateMobilityService prepares the UpdateMobilityService request.
+func (c ReplicationProtectedItemsClient) preparerForUpdateMobilityService(ctx context.Context, id ReplicationProtectedItemId, input UpdateMobilityServiceRequest) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/updateMobilityService", id.ID())),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForUpdateMobilityService sends the UpdateMobilityService request. The method will close the
+// http.Response Body if it receives an error.
+func (c ReplicationProtectedItemsClient) senderForUpdateMobilityService(ctx context.Context, req *http.Request) (future UpdateMobilityServiceOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_a2aadddisksinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_a2aadddisksinput.go
@@ -1,0 +1,42 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ AddDisksProviderSpecificInput = A2AAddDisksInput{}
+
+type A2AAddDisksInput struct {
+	VmDisks        *[]A2AVmDiskInputDetails        `json:"vmDisks,omitempty"`
+	VmManagedDisks *[]A2AVmManagedDiskInputDetails `json:"vmManagedDisks,omitempty"`
+
+	// Fields inherited from AddDisksProviderSpecificInput
+}
+
+var _ json.Marshaler = A2AAddDisksInput{}
+
+func (s A2AAddDisksInput) MarshalJSON() ([]byte, error) {
+	type wrapper A2AAddDisksInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling A2AAddDisksInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling A2AAddDisksInput: %+v", err)
+	}
+	decoded["instanceType"] = "A2A"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling A2AAddDisksInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_a2aapplyrecoverypointinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_a2aapplyrecoverypointinput.go
@@ -1,0 +1,40 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ApplyRecoveryPointProviderSpecificInput = A2AApplyRecoveryPointInput{}
+
+type A2AApplyRecoveryPointInput struct {
+
+	// Fields inherited from ApplyRecoveryPointProviderSpecificInput
+}
+
+var _ json.Marshaler = A2AApplyRecoveryPointInput{}
+
+func (s A2AApplyRecoveryPointInput) MarshalJSON() ([]byte, error) {
+	type wrapper A2AApplyRecoveryPointInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling A2AApplyRecoveryPointInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling A2AApplyRecoveryPointInput: %+v", err)
+	}
+	decoded["instanceType"] = "A2A"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling A2AApplyRecoveryPointInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_a2acrossclustermigrationapplyrecoverypointinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_a2acrossclustermigrationapplyrecoverypointinput.go
@@ -1,0 +1,40 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ApplyRecoveryPointProviderSpecificInput = A2ACrossClusterMigrationApplyRecoveryPointInput{}
+
+type A2ACrossClusterMigrationApplyRecoveryPointInput struct {
+
+	// Fields inherited from ApplyRecoveryPointProviderSpecificInput
+}
+
+var _ json.Marshaler = A2ACrossClusterMigrationApplyRecoveryPointInput{}
+
+func (s A2ACrossClusterMigrationApplyRecoveryPointInput) MarshalJSON() ([]byte, error) {
+	type wrapper A2ACrossClusterMigrationApplyRecoveryPointInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling A2ACrossClusterMigrationApplyRecoveryPointInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling A2ACrossClusterMigrationApplyRecoveryPointInput: %+v", err)
+	}
+	decoded["instanceType"] = "A2ACrossClusterMigration"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling A2ACrossClusterMigrationApplyRecoveryPointInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_a2acrossclustermigrationenableprotectioninput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_a2acrossclustermigrationenableprotectioninput.go
@@ -1,0 +1,42 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ EnableProtectionProviderSpecificInput = A2ACrossClusterMigrationEnableProtectionInput{}
+
+type A2ACrossClusterMigrationEnableProtectionInput struct {
+	FabricObjectId      *string `json:"fabricObjectId,omitempty"`
+	RecoveryContainerId *string `json:"recoveryContainerId,omitempty"`
+
+	// Fields inherited from EnableProtectionProviderSpecificInput
+}
+
+var _ json.Marshaler = A2ACrossClusterMigrationEnableProtectionInput{}
+
+func (s A2ACrossClusterMigrationEnableProtectionInput) MarshalJSON() ([]byte, error) {
+	type wrapper A2ACrossClusterMigrationEnableProtectionInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling A2ACrossClusterMigrationEnableProtectionInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling A2ACrossClusterMigrationEnableProtectionInput: %+v", err)
+	}
+	decoded["instanceType"] = "A2ACrossClusterMigration"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling A2ACrossClusterMigrationEnableProtectionInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_a2acrossclustermigrationreplicationdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_a2acrossclustermigrationreplicationdetails.go
@@ -1,0 +1,46 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ReplicationProviderSpecificSettings = A2ACrossClusterMigrationReplicationDetails{}
+
+type A2ACrossClusterMigrationReplicationDetails struct {
+	FabricObjectId               *string `json:"fabricObjectId,omitempty"`
+	LifecycleId                  *string `json:"lifecycleId,omitempty"`
+	OsType                       *string `json:"osType,omitempty"`
+	PrimaryFabricLocation        *string `json:"primaryFabricLocation,omitempty"`
+	VmProtectionState            *string `json:"vmProtectionState,omitempty"`
+	VmProtectionStateDescription *string `json:"vmProtectionStateDescription,omitempty"`
+
+	// Fields inherited from ReplicationProviderSpecificSettings
+}
+
+var _ json.Marshaler = A2ACrossClusterMigrationReplicationDetails{}
+
+func (s A2ACrossClusterMigrationReplicationDetails) MarshalJSON() ([]byte, error) {
+	type wrapper A2ACrossClusterMigrationReplicationDetails
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling A2ACrossClusterMigrationReplicationDetails: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling A2ACrossClusterMigrationReplicationDetails: %+v", err)
+	}
+	decoded["instanceType"] = "A2ACrossClusterMigration"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling A2ACrossClusterMigrationReplicationDetails: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_a2aenableprotectioninput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_a2aenableprotectioninput.go
@@ -1,0 +1,60 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/edgezones"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ EnableProtectionProviderSpecificInput = A2AEnableProtectionInput{}
+
+type A2AEnableProtectionInput struct {
+	DiskEncryptionInfo                 *DiskEncryptionInfo             `json:"diskEncryptionInfo,omitempty"`
+	FabricObjectId                     string                          `json:"fabricObjectId"`
+	MultiVmGroupId                     *string                         `json:"multiVmGroupId,omitempty"`
+	MultiVmGroupName                   *string                         `json:"multiVmGroupName,omitempty"`
+	RecoveryAvailabilitySetId          *string                         `json:"recoveryAvailabilitySetId,omitempty"`
+	RecoveryAvailabilityZone           *string                         `json:"recoveryAvailabilityZone,omitempty"`
+	RecoveryAzureNetworkId             *string                         `json:"recoveryAzureNetworkId,omitempty"`
+	RecoveryBootDiagStorageAccountId   *string                         `json:"recoveryBootDiagStorageAccountId,omitempty"`
+	RecoveryCapacityReservationGroupId *string                         `json:"recoveryCapacityReservationGroupId,omitempty"`
+	RecoveryCloudServiceId             *string                         `json:"recoveryCloudServiceId,omitempty"`
+	RecoveryContainerId                *string                         `json:"recoveryContainerId,omitempty"`
+	RecoveryExtendedLocation           *edgezones.Model                `json:"recoveryExtendedLocation,omitempty"`
+	RecoveryProximityPlacementGroupId  *string                         `json:"recoveryProximityPlacementGroupId,omitempty"`
+	RecoveryResourceGroupId            *string                         `json:"recoveryResourceGroupId,omitempty"`
+	RecoverySubnetName                 *string                         `json:"recoverySubnetName,omitempty"`
+	RecoveryVirtualMachineScaleSetId   *string                         `json:"recoveryVirtualMachineScaleSetId,omitempty"`
+	VmDisks                            *[]A2AVmDiskInputDetails        `json:"vmDisks,omitempty"`
+	VmManagedDisks                     *[]A2AVmManagedDiskInputDetails `json:"vmManagedDisks,omitempty"`
+
+	// Fields inherited from EnableProtectionProviderSpecificInput
+}
+
+var _ json.Marshaler = A2AEnableProtectionInput{}
+
+func (s A2AEnableProtectionInput) MarshalJSON() ([]byte, error) {
+	type wrapper A2AEnableProtectionInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling A2AEnableProtectionInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling A2AEnableProtectionInput: %+v", err)
+	}
+	decoded["instanceType"] = "A2A"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling A2AEnableProtectionInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_a2aprotecteddiskdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_a2aprotecteddiskdetails.go
@@ -1,0 +1,30 @@
+package replicationprotecteditems
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type A2AProtectedDiskDetails struct {
+	AllowedDiskLevelOperation              *[]string `json:"allowedDiskLevelOperation,omitempty"`
+	DataPendingAtSourceAgentInMB           *float64  `json:"dataPendingAtSourceAgentInMB,omitempty"`
+	DataPendingInStagingStorageAccountInMB *float64  `json:"dataPendingInStagingStorageAccountInMB,omitempty"`
+	DekKeyVaultArmId                       *string   `json:"dekKeyVaultArmId,omitempty"`
+	DiskCapacityInBytes                    *int64    `json:"diskCapacityInBytes,omitempty"`
+	DiskName                               *string   `json:"diskName,omitempty"`
+	DiskState                              *string   `json:"diskState,omitempty"`
+	DiskType                               *string   `json:"diskType,omitempty"`
+	DiskUri                                *string   `json:"diskUri,omitempty"`
+	FailoverDiskName                       *string   `json:"failoverDiskName,omitempty"`
+	IsDiskEncrypted                        *bool     `json:"isDiskEncrypted,omitempty"`
+	IsDiskKeyEncrypted                     *bool     `json:"isDiskKeyEncrypted,omitempty"`
+	KekKeyVaultArmId                       *string   `json:"kekKeyVaultArmId,omitempty"`
+	KeyIdentifier                          *string   `json:"keyIdentifier,omitempty"`
+	MonitoringJobType                      *string   `json:"monitoringJobType,omitempty"`
+	MonitoringPercentageCompletion         *int64    `json:"monitoringPercentageCompletion,omitempty"`
+	PrimaryDiskAzureStorageAccountId       *string   `json:"primaryDiskAzureStorageAccountId,omitempty"`
+	PrimaryStagingAzureStorageAccountId    *string   `json:"primaryStagingAzureStorageAccountId,omitempty"`
+	RecoveryAzureStorageAccountId          *string   `json:"recoveryAzureStorageAccountId,omitempty"`
+	RecoveryDiskUri                        *string   `json:"recoveryDiskUri,omitempty"`
+	ResyncRequired                         *bool     `json:"resyncRequired,omitempty"`
+	SecretIdentifier                       *string   `json:"secretIdentifier,omitempty"`
+	TfoDiskName                            *string   `json:"tfoDiskName,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_a2aprotectedmanageddiskdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_a2aprotectedmanageddiskdetails.go
@@ -1,0 +1,35 @@
+package replicationprotecteditems
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type A2AProtectedManagedDiskDetails struct {
+	AllowedDiskLevelOperation              *[]string `json:"allowedDiskLevelOperation,omitempty"`
+	DataPendingAtSourceAgentInMB           *float64  `json:"dataPendingAtSourceAgentInMB,omitempty"`
+	DataPendingInStagingStorageAccountInMB *float64  `json:"dataPendingInStagingStorageAccountInMB,omitempty"`
+	DekKeyVaultArmId                       *string   `json:"dekKeyVaultArmId,omitempty"`
+	DiskCapacityInBytes                    *int64    `json:"diskCapacityInBytes,omitempty"`
+	DiskId                                 *string   `json:"diskId,omitempty"`
+	DiskName                               *string   `json:"diskName,omitempty"`
+	DiskState                              *string   `json:"diskState,omitempty"`
+	DiskType                               *string   `json:"diskType,omitempty"`
+	FailoverDiskName                       *string   `json:"failoverDiskName,omitempty"`
+	IsDiskEncrypted                        *bool     `json:"isDiskEncrypted,omitempty"`
+	IsDiskKeyEncrypted                     *bool     `json:"isDiskKeyEncrypted,omitempty"`
+	KekKeyVaultArmId                       *string   `json:"kekKeyVaultArmId,omitempty"`
+	KeyIdentifier                          *string   `json:"keyIdentifier,omitempty"`
+	MonitoringJobType                      *string   `json:"monitoringJobType,omitempty"`
+	MonitoringPercentageCompletion         *int64    `json:"monitoringPercentageCompletion,omitempty"`
+	PrimaryDiskEncryptionSetId             *string   `json:"primaryDiskEncryptionSetId,omitempty"`
+	PrimaryStagingAzureStorageAccountId    *string   `json:"primaryStagingAzureStorageAccountId,omitempty"`
+	RecoveryDiskEncryptionSetId            *string   `json:"recoveryDiskEncryptionSetId,omitempty"`
+	RecoveryOrignalTargetDiskId            *string   `json:"recoveryOrignalTargetDiskId,omitempty"`
+	RecoveryReplicaDiskAccountType         *string   `json:"recoveryReplicaDiskAccountType,omitempty"`
+	RecoveryReplicaDiskId                  *string   `json:"recoveryReplicaDiskId,omitempty"`
+	RecoveryResourceGroupId                *string   `json:"recoveryResourceGroupId,omitempty"`
+	RecoveryTargetDiskAccountType          *string   `json:"recoveryTargetDiskAccountType,omitempty"`
+	RecoveryTargetDiskId                   *string   `json:"recoveryTargetDiskId,omitempty"`
+	ResyncRequired                         *bool     `json:"resyncRequired,omitempty"`
+	SecretIdentifier                       *string   `json:"secretIdentifier,omitempty"`
+	TfoDiskName                            *string   `json:"tfoDiskName,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_a2aremovedisksinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_a2aremovedisksinput.go
@@ -1,0 +1,42 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ RemoveDisksProviderSpecificInput = A2ARemoveDisksInput{}
+
+type A2ARemoveDisksInput struct {
+	VmDisksUris       *[]string `json:"vmDisksUris,omitempty"`
+	VmManagedDisksIds *[]string `json:"vmManagedDisksIds,omitempty"`
+
+	// Fields inherited from RemoveDisksProviderSpecificInput
+}
+
+var _ json.Marshaler = A2ARemoveDisksInput{}
+
+func (s A2ARemoveDisksInput) MarshalJSON() ([]byte, error) {
+	type wrapper A2ARemoveDisksInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling A2ARemoveDisksInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling A2ARemoveDisksInput: %+v", err)
+	}
+	decoded["instanceType"] = "A2A"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling A2ARemoveDisksInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_a2areplicationdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_a2areplicationdetails.go
@@ -1,0 +1,95 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/edgezones"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ReplicationProviderSpecificSettings = A2AReplicationDetails{}
+
+type A2AReplicationDetails struct {
+	AgentCertificateExpiryDate                  *string                            `json:"agentCertificateExpiryDate,omitempty"`
+	AgentExpiryDate                             *string                            `json:"agentExpiryDate,omitempty"`
+	AgentVersion                                *string                            `json:"agentVersion,omitempty"`
+	AutoProtectionOfDataDisk                    *AutoProtectionOfDataDisk          `json:"autoProtectionOfDataDisk,omitempty"`
+	FabricObjectId                              *string                            `json:"fabricObjectId,omitempty"`
+	InitialPrimaryExtendedLocation              *edgezones.Model                   `json:"initialPrimaryExtendedLocation,omitempty"`
+	InitialPrimaryFabricLocation                *string                            `json:"initialPrimaryFabricLocation,omitempty"`
+	InitialPrimaryZone                          *string                            `json:"initialPrimaryZone,omitempty"`
+	InitialRecoveryExtendedLocation             *edgezones.Model                   `json:"initialRecoveryExtendedLocation,omitempty"`
+	InitialRecoveryFabricLocation               *string                            `json:"initialRecoveryFabricLocation,omitempty"`
+	InitialRecoveryZone                         *string                            `json:"initialRecoveryZone,omitempty"`
+	IsReplicationAgentCertificateUpdateRequired *bool                              `json:"isReplicationAgentCertificateUpdateRequired,omitempty"`
+	IsReplicationAgentUpdateRequired            *bool                              `json:"isReplicationAgentUpdateRequired,omitempty"`
+	LastHeartbeat                               *string                            `json:"lastHeartbeat,omitempty"`
+	LastRpoCalculatedTime                       *string                            `json:"lastRpoCalculatedTime,omitempty"`
+	LifecycleId                                 *string                            `json:"lifecycleId,omitempty"`
+	ManagementId                                *string                            `json:"managementId,omitempty"`
+	MonitoringJobType                           *string                            `json:"monitoringJobType,omitempty"`
+	MonitoringPercentageCompletion              *int64                             `json:"monitoringPercentageCompletion,omitempty"`
+	MultiVmGroupCreateOption                    *MultiVmGroupCreateOption          `json:"multiVmGroupCreateOption,omitempty"`
+	MultiVmGroupId                              *string                            `json:"multiVmGroupId,omitempty"`
+	MultiVmGroupName                            *string                            `json:"multiVmGroupName,omitempty"`
+	OsType                                      *string                            `json:"osType,omitempty"`
+	PrimaryAvailabilityZone                     *string                            `json:"primaryAvailabilityZone,omitempty"`
+	PrimaryExtendedLocation                     *edgezones.Model                   `json:"primaryExtendedLocation,omitempty"`
+	PrimaryFabricLocation                       *string                            `json:"primaryFabricLocation,omitempty"`
+	ProtectedDisks                              *[]A2AProtectedDiskDetails         `json:"protectedDisks,omitempty"`
+	ProtectedManagedDisks                       *[]A2AProtectedManagedDiskDetails  `json:"protectedManagedDisks,omitempty"`
+	RecoveryAvailabilitySet                     *string                            `json:"recoveryAvailabilitySet,omitempty"`
+	RecoveryAvailabilityZone                    *string                            `json:"recoveryAvailabilityZone,omitempty"`
+	RecoveryAzureGeneration                     *string                            `json:"recoveryAzureGeneration,omitempty"`
+	RecoveryAzureResourceGroupId                *string                            `json:"recoveryAzureResourceGroupId,omitempty"`
+	RecoveryAzureVMName                         *string                            `json:"recoveryAzureVMName,omitempty"`
+	RecoveryAzureVMSize                         *string                            `json:"recoveryAzureVMSize,omitempty"`
+	RecoveryBootDiagStorageAccountId            *string                            `json:"recoveryBootDiagStorageAccountId,omitempty"`
+	RecoveryCapacityReservationGroupId          *string                            `json:"recoveryCapacityReservationGroupId,omitempty"`
+	RecoveryCloudService                        *string                            `json:"recoveryCloudService,omitempty"`
+	RecoveryExtendedLocation                    *edgezones.Model                   `json:"recoveryExtendedLocation,omitempty"`
+	RecoveryFabricLocation                      *string                            `json:"recoveryFabricLocation,omitempty"`
+	RecoveryFabricObjectId                      *string                            `json:"recoveryFabricObjectId,omitempty"`
+	RecoveryProximityPlacementGroupId           *string                            `json:"recoveryProximityPlacementGroupId,omitempty"`
+	RecoveryVirtualMachineScaleSetId            *string                            `json:"recoveryVirtualMachineScaleSetId,omitempty"`
+	RpoInSeconds                                *int64                             `json:"rpoInSeconds,omitempty"`
+	SelectedRecoveryAzureNetworkId              *string                            `json:"selectedRecoveryAzureNetworkId,omitempty"`
+	SelectedTfoAzureNetworkId                   *string                            `json:"selectedTfoAzureNetworkId,omitempty"`
+	TestFailoverRecoveryFabricObjectId          *string                            `json:"testFailoverRecoveryFabricObjectId,omitempty"`
+	TfoAzureVMName                              *string                            `json:"tfoAzureVMName,omitempty"`
+	UnprotectedDisks                            *[]A2AUnprotectedDiskDetails       `json:"unprotectedDisks,omitempty"`
+	VmEncryptionType                            *VmEncryptionType                  `json:"vmEncryptionType,omitempty"`
+	VmNics                                      *[]VMNicDetails                    `json:"vmNics,omitempty"`
+	VmProtectionState                           *string                            `json:"vmProtectionState,omitempty"`
+	VmProtectionStateDescription                *string                            `json:"vmProtectionStateDescription,omitempty"`
+	VmSyncedConfigDetails                       *AzureToAzureVmSyncedConfigDetails `json:"vmSyncedConfigDetails,omitempty"`
+
+	// Fields inherited from ReplicationProviderSpecificSettings
+}
+
+var _ json.Marshaler = A2AReplicationDetails{}
+
+func (s A2AReplicationDetails) MarshalJSON() ([]byte, error) {
+	type wrapper A2AReplicationDetails
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling A2AReplicationDetails: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling A2AReplicationDetails: %+v", err)
+	}
+	decoded["instanceType"] = "A2A"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling A2AReplicationDetails: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_a2areprotectinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_a2areprotectinput.go
@@ -1,0 +1,46 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ReverseReplicationProviderSpecificInput = A2AReprotectInput{}
+
+type A2AReprotectInput struct {
+	PolicyId                  *string                  `json:"policyId,omitempty"`
+	RecoveryAvailabilitySetId *string                  `json:"recoveryAvailabilitySetId,omitempty"`
+	RecoveryCloudServiceId    *string                  `json:"recoveryCloudServiceId,omitempty"`
+	RecoveryContainerId       *string                  `json:"recoveryContainerId,omitempty"`
+	RecoveryResourceGroupId   *string                  `json:"recoveryResourceGroupId,omitempty"`
+	VmDisks                   *[]A2AVmDiskInputDetails `json:"vmDisks,omitempty"`
+
+	// Fields inherited from ReverseReplicationProviderSpecificInput
+}
+
+var _ json.Marshaler = A2AReprotectInput{}
+
+func (s A2AReprotectInput) MarshalJSON() ([]byte, error) {
+	type wrapper A2AReprotectInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling A2AReprotectInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling A2AReprotectInput: %+v", err)
+	}
+	decoded["instanceType"] = "A2A"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling A2AReprotectInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_a2atestfailoverinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_a2atestfailoverinput.go
@@ -1,0 +1,42 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ TestFailoverProviderSpecificInput = A2ATestFailoverInput{}
+
+type A2ATestFailoverInput struct {
+	CloudServiceCreationOption *string `json:"cloudServiceCreationOption,omitempty"`
+	RecoveryPointId            *string `json:"recoveryPointId,omitempty"`
+
+	// Fields inherited from TestFailoverProviderSpecificInput
+}
+
+var _ json.Marshaler = A2ATestFailoverInput{}
+
+func (s A2ATestFailoverInput) MarshalJSON() ([]byte, error) {
+	type wrapper A2ATestFailoverInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling A2ATestFailoverInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling A2ATestFailoverInput: %+v", err)
+	}
+	decoded["instanceType"] = "A2A"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling A2ATestFailoverInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_a2aunplannedfailoverinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_a2aunplannedfailoverinput.go
@@ -1,0 +1,42 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ UnplannedFailoverProviderSpecificInput = A2AUnplannedFailoverInput{}
+
+type A2AUnplannedFailoverInput struct {
+	CloudServiceCreationOption *string `json:"cloudServiceCreationOption,omitempty"`
+	RecoveryPointId            *string `json:"recoveryPointId,omitempty"`
+
+	// Fields inherited from UnplannedFailoverProviderSpecificInput
+}
+
+var _ json.Marshaler = A2AUnplannedFailoverInput{}
+
+func (s A2AUnplannedFailoverInput) MarshalJSON() ([]byte, error) {
+	type wrapper A2AUnplannedFailoverInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling A2AUnplannedFailoverInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling A2AUnplannedFailoverInput: %+v", err)
+	}
+	decoded["instanceType"] = "A2A"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling A2AUnplannedFailoverInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_a2aunprotecteddiskdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_a2aunprotecteddiskdetails.go
@@ -1,0 +1,9 @@
+package replicationprotecteditems
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type A2AUnprotectedDiskDetails struct {
+	DiskAutoProtectionStatus *AutoProtectionOfDataDisk `json:"diskAutoProtectionStatus,omitempty"`
+	DiskLunId                *int64                    `json:"diskLunId,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_a2aupdatereplicationprotectediteminput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_a2aupdatereplicationprotectediteminput.go
@@ -1,0 +1,49 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ UpdateReplicationProtectedItemProviderInput = A2AUpdateReplicationProtectedItemInput{}
+
+type A2AUpdateReplicationProtectedItemInput struct {
+	DiskEncryptionInfo                 *DiskEncryptionInfo              `json:"diskEncryptionInfo,omitempty"`
+	ManagedDiskUpdateDetails           *[]A2AVmManagedDiskUpdateDetails `json:"managedDiskUpdateDetails,omitempty"`
+	RecoveryBootDiagStorageAccountId   *string                          `json:"recoveryBootDiagStorageAccountId,omitempty"`
+	RecoveryCapacityReservationGroupId *string                          `json:"recoveryCapacityReservationGroupId,omitempty"`
+	RecoveryCloudServiceId             *string                          `json:"recoveryCloudServiceId,omitempty"`
+	RecoveryProximityPlacementGroupId  *string                          `json:"recoveryProximityPlacementGroupId,omitempty"`
+	RecoveryResourceGroupId            *string                          `json:"recoveryResourceGroupId,omitempty"`
+	RecoveryVirtualMachineScaleSetId   *string                          `json:"recoveryVirtualMachineScaleSetId,omitempty"`
+	TfoAzureVMName                     *string                          `json:"tfoAzureVMName,omitempty"`
+
+	// Fields inherited from UpdateReplicationProtectedItemProviderInput
+}
+
+var _ json.Marshaler = A2AUpdateReplicationProtectedItemInput{}
+
+func (s A2AUpdateReplicationProtectedItemInput) MarshalJSON() ([]byte, error) {
+	type wrapper A2AUpdateReplicationProtectedItemInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling A2AUpdateReplicationProtectedItemInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling A2AUpdateReplicationProtectedItemInput: %+v", err)
+	}
+	decoded["instanceType"] = "A2A"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling A2AUpdateReplicationProtectedItemInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_a2avmdiskinputdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_a2avmdiskinputdetails.go
@@ -1,0 +1,10 @@
+package replicationprotecteditems
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type A2AVmDiskInputDetails struct {
+	DiskUri                             string `json:"diskUri"`
+	PrimaryStagingAzureStorageAccountId string `json:"primaryStagingAzureStorageAccountId"`
+	RecoveryAzureStorageAccountId       string `json:"recoveryAzureStorageAccountId"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_a2avmmanageddiskinputdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_a2avmmanageddiskinputdetails.go
@@ -1,0 +1,14 @@
+package replicationprotecteditems
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type A2AVmManagedDiskInputDetails struct {
+	DiskEncryptionInfo                  *DiskEncryptionInfo `json:"diskEncryptionInfo,omitempty"`
+	DiskId                              string              `json:"diskId"`
+	PrimaryStagingAzureStorageAccountId string              `json:"primaryStagingAzureStorageAccountId"`
+	RecoveryDiskEncryptionSetId         *string             `json:"recoveryDiskEncryptionSetId,omitempty"`
+	RecoveryReplicaDiskAccountType      *string             `json:"recoveryReplicaDiskAccountType,omitempty"`
+	RecoveryResourceGroupId             string              `json:"recoveryResourceGroupId"`
+	RecoveryTargetDiskAccountType       *string             `json:"recoveryTargetDiskAccountType,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_a2avmmanageddiskupdatedetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_a2avmmanageddiskupdatedetails.go
@@ -1,0 +1,13 @@
+package replicationprotecteditems
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type A2AVmManagedDiskUpdateDetails struct {
+	DiskEncryptionInfo             *DiskEncryptionInfo `json:"diskEncryptionInfo,omitempty"`
+	DiskId                         *string             `json:"diskId,omitempty"`
+	FailoverDiskName               *string             `json:"failoverDiskName,omitempty"`
+	RecoveryReplicaDiskAccountType *string             `json:"recoveryReplicaDiskAccountType,omitempty"`
+	RecoveryTargetDiskAccountType  *string             `json:"recoveryTargetDiskAccountType,omitempty"`
+	TfoDiskName                    *string             `json:"tfoDiskName,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_adddisksinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_adddisksinput.go
@@ -1,0 +1,8 @@
+package replicationprotecteditems
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AddDisksInput struct {
+	Properties *AddDisksInputProperties `json:"properties,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_adddisksinputproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_adddisksinputproperties.go
@@ -1,0 +1,32 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AddDisksInputProperties struct {
+	ProviderSpecificDetails AddDisksProviderSpecificInput `json:"providerSpecificDetails"`
+}
+
+var _ json.Unmarshaler = &AddDisksInputProperties{}
+
+func (s *AddDisksInputProperties) UnmarshalJSON(bytes []byte) error {
+
+	var temp map[string]json.RawMessage
+	if err := json.Unmarshal(bytes, &temp); err != nil {
+		return fmt.Errorf("unmarshaling AddDisksInputProperties into map[string]json.RawMessage: %+v", err)
+	}
+
+	if v, ok := temp["providerSpecificDetails"]; ok {
+		impl, err := unmarshalAddDisksProviderSpecificInputImplementation(v)
+		if err != nil {
+			return fmt.Errorf("unmarshaling field 'ProviderSpecificDetails' for 'AddDisksInputProperties': %+v", err)
+		}
+		s.ProviderSpecificDetails = impl
+	}
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_adddisksproviderspecificinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_adddisksproviderspecificinput.go
@@ -1,0 +1,48 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AddDisksProviderSpecificInput interface {
+}
+
+func unmarshalAddDisksProviderSpecificInputImplementation(input []byte) (AddDisksProviderSpecificInput, error) {
+	if input == nil {
+		return nil, nil
+	}
+
+	var temp map[string]interface{}
+	if err := json.Unmarshal(input, &temp); err != nil {
+		return nil, fmt.Errorf("unmarshaling AddDisksProviderSpecificInput into map[string]interface: %+v", err)
+	}
+
+	value, ok := temp["instanceType"].(string)
+	if !ok {
+		return nil, nil
+	}
+
+	if strings.EqualFold(value, "A2A") {
+		var out A2AAddDisksInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into A2AAddDisksInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	type RawAddDisksProviderSpecificInputImpl struct {
+		Type   string                 `json:"-"`
+		Values map[string]interface{} `json:"-"`
+	}
+	out := RawAddDisksProviderSpecificInputImpl{
+		Type:   value,
+		Values: temp,
+	}
+	return out, nil
+
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_applyrecoverypointinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_applyrecoverypointinput.go
@@ -1,0 +1,8 @@
+package replicationprotecteditems
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ApplyRecoveryPointInput struct {
+	Properties ApplyRecoveryPointInputProperties `json:"properties"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_applyrecoverypointinputproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_applyrecoverypointinputproperties.go
@@ -1,0 +1,40 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ApplyRecoveryPointInputProperties struct {
+	ProviderSpecificDetails ApplyRecoveryPointProviderSpecificInput `json:"providerSpecificDetails"`
+	RecoveryPointId         *string                                 `json:"recoveryPointId,omitempty"`
+}
+
+var _ json.Unmarshaler = &ApplyRecoveryPointInputProperties{}
+
+func (s *ApplyRecoveryPointInputProperties) UnmarshalJSON(bytes []byte) error {
+	type alias ApplyRecoveryPointInputProperties
+	var decoded alias
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling into ApplyRecoveryPointInputProperties: %+v", err)
+	}
+
+	s.RecoveryPointId = decoded.RecoveryPointId
+
+	var temp map[string]json.RawMessage
+	if err := json.Unmarshal(bytes, &temp); err != nil {
+		return fmt.Errorf("unmarshaling ApplyRecoveryPointInputProperties into map[string]json.RawMessage: %+v", err)
+	}
+
+	if v, ok := temp["providerSpecificDetails"]; ok {
+		impl, err := unmarshalApplyRecoveryPointProviderSpecificInputImplementation(v)
+		if err != nil {
+			return fmt.Errorf("unmarshaling field 'ProviderSpecificDetails' for 'ApplyRecoveryPointInputProperties': %+v", err)
+		}
+		s.ProviderSpecificDetails = impl
+	}
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_applyrecoverypointproviderspecificinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_applyrecoverypointproviderspecificinput.go
@@ -1,0 +1,80 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ApplyRecoveryPointProviderSpecificInput interface {
+}
+
+func unmarshalApplyRecoveryPointProviderSpecificInputImplementation(input []byte) (ApplyRecoveryPointProviderSpecificInput, error) {
+	if input == nil {
+		return nil, nil
+	}
+
+	var temp map[string]interface{}
+	if err := json.Unmarshal(input, &temp); err != nil {
+		return nil, fmt.Errorf("unmarshaling ApplyRecoveryPointProviderSpecificInput into map[string]interface: %+v", err)
+	}
+
+	value, ok := temp["instanceType"].(string)
+	if !ok {
+		return nil, nil
+	}
+
+	if strings.EqualFold(value, "A2A") {
+		var out A2AApplyRecoveryPointInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into A2AApplyRecoveryPointInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "A2ACrossClusterMigration") {
+		var out A2ACrossClusterMigrationApplyRecoveryPointInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into A2ACrossClusterMigrationApplyRecoveryPointInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "HyperVReplicaAzure") {
+		var out HyperVReplicaAzureApplyRecoveryPointInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into HyperVReplicaAzureApplyRecoveryPointInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "InMageAzureV2") {
+		var out InMageAzureV2ApplyRecoveryPointInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into InMageAzureV2ApplyRecoveryPointInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "InMageRcm") {
+		var out InMageRcmApplyRecoveryPointInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into InMageRcmApplyRecoveryPointInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	type RawApplyRecoveryPointProviderSpecificInputImpl struct {
+		Type   string                 `json:"-"`
+		Values map[string]interface{} `json:"-"`
+	}
+	out := RawApplyRecoveryPointProviderSpecificInputImpl{
+		Type:   value,
+		Values: temp,
+	}
+	return out, nil
+
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_azuretoazurevmsyncedconfigdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_azuretoazurevmsyncedconfigdetails.go
@@ -1,0 +1,9 @@
+package replicationprotecteditems
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AzureToAzureVmSyncedConfigDetails struct {
+	InputEndpoints *[]InputEndpoint   `json:"inputEndpoints,omitempty"`
+	Tags           *map[string]string `json:"tags,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_azurevmdiskdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_azurevmdiskdetails.go
@@ -1,0 +1,17 @@
+package replicationprotecteditems
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AzureVmDiskDetails struct {
+	CustomTargetDiskName *string `json:"customTargetDiskName,omitempty"`
+	DiskEncryptionSetId  *string `json:"diskEncryptionSetId,omitempty"`
+	DiskId               *string `json:"diskId,omitempty"`
+	LunId                *string `json:"lunId,omitempty"`
+	MaxSizeMB            *string `json:"maxSizeMB,omitempty"`
+	TargetDiskLocation   *string `json:"targetDiskLocation,omitempty"`
+	TargetDiskName       *string `json:"targetDiskName,omitempty"`
+	VhdId                *string `json:"vhdId,omitempty"`
+	VhdName              *string `json:"vhdName,omitempty"`
+	VhdType              *string `json:"vhdType,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_currentscenariodetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_currentscenariodetails.go
@@ -1,0 +1,28 @@
+package replicationprotecteditems
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CurrentScenarioDetails struct {
+	JobId        *string `json:"jobId,omitempty"`
+	ScenarioName *string `json:"scenarioName,omitempty"`
+	StartTime    *string `json:"startTime,omitempty"`
+}
+
+func (o *CurrentScenarioDetails) GetStartTimeAsTime() (*time.Time, error) {
+	if o.StartTime == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.StartTime, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *CurrentScenarioDetails) SetStartTimeAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.StartTime = &formatted
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_disableprotectioninput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_disableprotectioninput.go
@@ -1,0 +1,8 @@
+package replicationprotecteditems
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DisableProtectionInput struct {
+	Properties DisableProtectionInputProperties `json:"properties"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_disableprotectioninputproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_disableprotectioninputproperties.go
@@ -1,0 +1,40 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DisableProtectionInputProperties struct {
+	DisableProtectionReason  *DisableProtectionReason               `json:"disableProtectionReason,omitempty"`
+	ReplicationProviderInput DisableProtectionProviderSpecificInput `json:"replicationProviderInput"`
+}
+
+var _ json.Unmarshaler = &DisableProtectionInputProperties{}
+
+func (s *DisableProtectionInputProperties) UnmarshalJSON(bytes []byte) error {
+	type alias DisableProtectionInputProperties
+	var decoded alias
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling into DisableProtectionInputProperties: %+v", err)
+	}
+
+	s.DisableProtectionReason = decoded.DisableProtectionReason
+
+	var temp map[string]json.RawMessage
+	if err := json.Unmarshal(bytes, &temp); err != nil {
+		return fmt.Errorf("unmarshaling DisableProtectionInputProperties into map[string]json.RawMessage: %+v", err)
+	}
+
+	if v, ok := temp["replicationProviderInput"]; ok {
+		impl, err := unmarshalDisableProtectionProviderSpecificInputImplementation(v)
+		if err != nil {
+			return fmt.Errorf("unmarshaling field 'ReplicationProviderInput' for 'DisableProtectionInputProperties': %+v", err)
+		}
+		s.ReplicationProviderInput = impl
+	}
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_disableprotectionproviderspecificinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_disableprotectionproviderspecificinput.go
@@ -1,0 +1,48 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DisableProtectionProviderSpecificInput interface {
+}
+
+func unmarshalDisableProtectionProviderSpecificInputImplementation(input []byte) (DisableProtectionProviderSpecificInput, error) {
+	if input == nil {
+		return nil, nil
+	}
+
+	var temp map[string]interface{}
+	if err := json.Unmarshal(input, &temp); err != nil {
+		return nil, fmt.Errorf("unmarshaling DisableProtectionProviderSpecificInput into map[string]interface: %+v", err)
+	}
+
+	value, ok := temp["instanceType"].(string)
+	if !ok {
+		return nil, nil
+	}
+
+	if strings.EqualFold(value, "InMage") {
+		var out InMageDisableProtectionProviderSpecificInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into InMageDisableProtectionProviderSpecificInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	type RawDisableProtectionProviderSpecificInputImpl struct {
+		Type   string                 `json:"-"`
+		Values map[string]interface{} `json:"-"`
+	}
+	out := RawDisableProtectionProviderSpecificInputImpl{
+		Type:   value,
+		Values: temp,
+	}
+	return out, nil
+
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_diskdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_diskdetails.go
@@ -1,0 +1,11 @@
+package replicationprotecteditems
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DiskDetails struct {
+	MaxSizeMB *int64  `json:"maxSizeMB,omitempty"`
+	VhdId     *string `json:"vhdId,omitempty"`
+	VhdName   *string `json:"vhdName,omitempty"`
+	VhdType   *string `json:"vhdType,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_diskencryptioninfo.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_diskencryptioninfo.go
@@ -1,0 +1,9 @@
+package replicationprotecteditems
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DiskEncryptionInfo struct {
+	DiskEncryptionKeyInfo *DiskEncryptionKeyInfo `json:"diskEncryptionKeyInfo,omitempty"`
+	KeyEncryptionKeyInfo  *KeyEncryptionKeyInfo  `json:"keyEncryptionKeyInfo,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_diskencryptionkeyinfo.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_diskencryptionkeyinfo.go
@@ -1,0 +1,9 @@
+package replicationprotecteditems
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DiskEncryptionKeyInfo struct {
+	KeyVaultResourceArmId *string `json:"keyVaultResourceArmId,omitempty"`
+	SecretIdentifier      *string `json:"secretIdentifier,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_enableprotectioninput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_enableprotectioninput.go
@@ -1,0 +1,8 @@
+package replicationprotecteditems
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type EnableProtectionInput struct {
+	Properties *EnableProtectionInputProperties `json:"properties,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_enableprotectioninputproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_enableprotectioninputproperties.go
@@ -1,0 +1,42 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type EnableProtectionInputProperties struct {
+	PolicyId                *string                               `json:"policyId,omitempty"`
+	ProtectableItemId       *string                               `json:"protectableItemId,omitempty"`
+	ProviderSpecificDetails EnableProtectionProviderSpecificInput `json:"providerSpecificDetails"`
+}
+
+var _ json.Unmarshaler = &EnableProtectionInputProperties{}
+
+func (s *EnableProtectionInputProperties) UnmarshalJSON(bytes []byte) error {
+	type alias EnableProtectionInputProperties
+	var decoded alias
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling into EnableProtectionInputProperties: %+v", err)
+	}
+
+	s.PolicyId = decoded.PolicyId
+	s.ProtectableItemId = decoded.ProtectableItemId
+
+	var temp map[string]json.RawMessage
+	if err := json.Unmarshal(bytes, &temp); err != nil {
+		return fmt.Errorf("unmarshaling EnableProtectionInputProperties into map[string]json.RawMessage: %+v", err)
+	}
+
+	if v, ok := temp["providerSpecificDetails"]; ok {
+		impl, err := unmarshalEnableProtectionProviderSpecificInputImplementation(v)
+		if err != nil {
+			return fmt.Errorf("unmarshaling field 'ProviderSpecificDetails' for 'EnableProtectionInputProperties': %+v", err)
+		}
+		s.ProviderSpecificDetails = impl
+	}
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_enableprotectionproviderspecificinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_enableprotectionproviderspecificinput.go
@@ -1,0 +1,88 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type EnableProtectionProviderSpecificInput interface {
+}
+
+func unmarshalEnableProtectionProviderSpecificInputImplementation(input []byte) (EnableProtectionProviderSpecificInput, error) {
+	if input == nil {
+		return nil, nil
+	}
+
+	var temp map[string]interface{}
+	if err := json.Unmarshal(input, &temp); err != nil {
+		return nil, fmt.Errorf("unmarshaling EnableProtectionProviderSpecificInput into map[string]interface: %+v", err)
+	}
+
+	value, ok := temp["instanceType"].(string)
+	if !ok {
+		return nil, nil
+	}
+
+	if strings.EqualFold(value, "A2ACrossClusterMigration") {
+		var out A2ACrossClusterMigrationEnableProtectionInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into A2ACrossClusterMigrationEnableProtectionInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "A2A") {
+		var out A2AEnableProtectionInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into A2AEnableProtectionInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "HyperVReplicaAzure") {
+		var out HyperVReplicaAzureEnableProtectionInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into HyperVReplicaAzureEnableProtectionInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "InMageAzureV2") {
+		var out InMageAzureV2EnableProtectionInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into InMageAzureV2EnableProtectionInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "InMage") {
+		var out InMageEnableProtectionInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into InMageEnableProtectionInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "InMageRcm") {
+		var out InMageRcmEnableProtectionInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into InMageRcmEnableProtectionInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	type RawEnableProtectionProviderSpecificInputImpl struct {
+		Type   string                 `json:"-"`
+		Values map[string]interface{} `json:"-"`
+	}
+	out := RawEnableProtectionProviderSpecificInputImpl{
+		Type:   value,
+		Values: temp,
+	}
+	return out, nil
+
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_healtherror.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_healtherror.go
@@ -1,0 +1,40 @@
+package replicationprotecteditems
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type HealthError struct {
+	CreationTimeUtc              *string                           `json:"creationTimeUtc,omitempty"`
+	CustomerResolvability        *HealthErrorCustomerResolvability `json:"customerResolvability,omitempty"`
+	EntityId                     *string                           `json:"entityId,omitempty"`
+	ErrorCategory                *string                           `json:"errorCategory,omitempty"`
+	ErrorCode                    *string                           `json:"errorCode,omitempty"`
+	ErrorId                      *string                           `json:"errorId,omitempty"`
+	ErrorLevel                   *string                           `json:"errorLevel,omitempty"`
+	ErrorMessage                 *string                           `json:"errorMessage,omitempty"`
+	ErrorSource                  *string                           `json:"errorSource,omitempty"`
+	ErrorType                    *string                           `json:"errorType,omitempty"`
+	InnerHealthErrors            *[]InnerHealthError               `json:"innerHealthErrors,omitempty"`
+	PossibleCauses               *string                           `json:"possibleCauses,omitempty"`
+	RecommendedAction            *string                           `json:"recommendedAction,omitempty"`
+	RecoveryProviderErrorMessage *string                           `json:"recoveryProviderErrorMessage,omitempty"`
+	SummaryMessage               *string                           `json:"summaryMessage,omitempty"`
+}
+
+func (o *HealthError) GetCreationTimeUtcAsTime() (*time.Time, error) {
+	if o.CreationTimeUtc == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.CreationTimeUtc, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *HealthError) SetCreationTimeUtcAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.CreationTimeUtc = &formatted
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_hypervreplicaazureapplyrecoverypointinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_hypervreplicaazureapplyrecoverypointinput.go
@@ -1,0 +1,42 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ApplyRecoveryPointProviderSpecificInput = HyperVReplicaAzureApplyRecoveryPointInput{}
+
+type HyperVReplicaAzureApplyRecoveryPointInput struct {
+	PrimaryKekCertificatePfx   *string `json:"primaryKekCertificatePfx,omitempty"`
+	SecondaryKekCertificatePfx *string `json:"secondaryKekCertificatePfx,omitempty"`
+
+	// Fields inherited from ApplyRecoveryPointProviderSpecificInput
+}
+
+var _ json.Marshaler = HyperVReplicaAzureApplyRecoveryPointInput{}
+
+func (s HyperVReplicaAzureApplyRecoveryPointInput) MarshalJSON() ([]byte, error) {
+	type wrapper HyperVReplicaAzureApplyRecoveryPointInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling HyperVReplicaAzureApplyRecoveryPointInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling HyperVReplicaAzureApplyRecoveryPointInput: %+v", err)
+	}
+	decoded["instanceType"] = "HyperVReplicaAzure"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling HyperVReplicaAzureApplyRecoveryPointInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_hypervreplicaazurediskinputdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_hypervreplicaazurediskinputdetails.go
@@ -1,0 +1,11 @@
+package replicationprotecteditems
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type HyperVReplicaAzureDiskInputDetails struct {
+	DiskEncryptionSetId *string          `json:"diskEncryptionSetId,omitempty"`
+	DiskId              *string          `json:"diskId,omitempty"`
+	DiskType            *DiskAccountType `json:"diskType,omitempty"`
+	LogStorageAccountId *string          `json:"logStorageAccountId,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_hypervreplicaazureenableprotectioninput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_hypervreplicaazureenableprotectioninput.go
@@ -1,0 +1,68 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ EnableProtectionProviderSpecificInput = HyperVReplicaAzureEnableProtectionInput{}
+
+type HyperVReplicaAzureEnableProtectionInput struct {
+	DiskEncryptionSetId             *string                               `json:"diskEncryptionSetId,omitempty"`
+	DiskType                        *DiskAccountType                      `json:"diskType,omitempty"`
+	DisksToInclude                  *[]string                             `json:"disksToInclude,omitempty"`
+	DisksToIncludeForManagedDisks   *[]HyperVReplicaAzureDiskInputDetails `json:"disksToIncludeForManagedDisks,omitempty"`
+	EnableRdpOnTargetOption         *string                               `json:"enableRdpOnTargetOption,omitempty"`
+	HvHostVmId                      *string                               `json:"hvHostVmId,omitempty"`
+	LicenseType                     *LicenseType                          `json:"licenseType,omitempty"`
+	LogStorageAccountId             *string                               `json:"logStorageAccountId,omitempty"`
+	OsType                          *string                               `json:"osType,omitempty"`
+	SeedManagedDiskTags             *map[string]string                    `json:"seedManagedDiskTags,omitempty"`
+	SqlServerLicenseType            *SqlServerLicenseType                 `json:"sqlServerLicenseType,omitempty"`
+	TargetAvailabilitySetId         *string                               `json:"targetAvailabilitySetId,omitempty"`
+	TargetAvailabilityZone          *string                               `json:"targetAvailabilityZone,omitempty"`
+	TargetAzureNetworkId            *string                               `json:"targetAzureNetworkId,omitempty"`
+	TargetAzureSubnetId             *string                               `json:"targetAzureSubnetId,omitempty"`
+	TargetAzureV1ResourceGroupId    *string                               `json:"targetAzureV1ResourceGroupId,omitempty"`
+	TargetAzureV2ResourceGroupId    *string                               `json:"targetAzureV2ResourceGroupId,omitempty"`
+	TargetAzureVmName               *string                               `json:"targetAzureVmName,omitempty"`
+	TargetManagedDiskTags           *map[string]string                    `json:"targetManagedDiskTags,omitempty"`
+	TargetNicTags                   *map[string]string                    `json:"targetNicTags,omitempty"`
+	TargetProximityPlacementGroupId *string                               `json:"targetProximityPlacementGroupId,omitempty"`
+	TargetStorageAccountId          *string                               `json:"targetStorageAccountId,omitempty"`
+	TargetVmSize                    *string                               `json:"targetVmSize,omitempty"`
+	TargetVmTags                    *map[string]string                    `json:"targetVmTags,omitempty"`
+	UseManagedDisks                 *string                               `json:"useManagedDisks,omitempty"`
+	UseManagedDisksForReplication   *string                               `json:"useManagedDisksForReplication,omitempty"`
+	VhdId                           *string                               `json:"vhdId,omitempty"`
+	VirtualMachineName              *string                               `json:"vmName,omitempty"`
+
+	// Fields inherited from EnableProtectionProviderSpecificInput
+}
+
+var _ json.Marshaler = HyperVReplicaAzureEnableProtectionInput{}
+
+func (s HyperVReplicaAzureEnableProtectionInput) MarshalJSON() ([]byte, error) {
+	type wrapper HyperVReplicaAzureEnableProtectionInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling HyperVReplicaAzureEnableProtectionInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling HyperVReplicaAzureEnableProtectionInput: %+v", err)
+	}
+	decoded["instanceType"] = "HyperVReplicaAzure"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling HyperVReplicaAzureEnableProtectionInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_hypervreplicaazurefailbackproviderinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_hypervreplicaazurefailbackproviderinput.go
@@ -1,0 +1,43 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ PlannedFailoverProviderSpecificFailoverInput = HyperVReplicaAzureFailbackProviderInput{}
+
+type HyperVReplicaAzureFailbackProviderInput struct {
+	DataSyncOption                 *string `json:"dataSyncOption,omitempty"`
+	ProviderIdForAlternateRecovery *string `json:"providerIdForAlternateRecovery,omitempty"`
+	RecoveryVmCreationOption       *string `json:"recoveryVmCreationOption,omitempty"`
+
+	// Fields inherited from PlannedFailoverProviderSpecificFailoverInput
+}
+
+var _ json.Marshaler = HyperVReplicaAzureFailbackProviderInput{}
+
+func (s HyperVReplicaAzureFailbackProviderInput) MarshalJSON() ([]byte, error) {
+	type wrapper HyperVReplicaAzureFailbackProviderInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling HyperVReplicaAzureFailbackProviderInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling HyperVReplicaAzureFailbackProviderInput: %+v", err)
+	}
+	decoded["instanceType"] = "HyperVReplicaAzureFailback"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling HyperVReplicaAzureFailbackProviderInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_hypervreplicaazuremanageddiskdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_hypervreplicaazuremanageddiskdetails.go
@@ -1,0 +1,11 @@
+package replicationprotecteditems
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type HyperVReplicaAzureManagedDiskDetails struct {
+	DiskEncryptionSetId *string `json:"diskEncryptionSetId,omitempty"`
+	DiskId              *string `json:"diskId,omitempty"`
+	ReplicaDiskType     *string `json:"replicaDiskType,omitempty"`
+	SeedManagedDiskId   *string `json:"seedManagedDiskId,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_hypervreplicaazureplannedfailoverproviderinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_hypervreplicaazureplannedfailoverproviderinput.go
@@ -1,0 +1,43 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ PlannedFailoverProviderSpecificFailoverInput = HyperVReplicaAzurePlannedFailoverProviderInput{}
+
+type HyperVReplicaAzurePlannedFailoverProviderInput struct {
+	PrimaryKekCertificatePfx   *string `json:"primaryKekCertificatePfx,omitempty"`
+	RecoveryPointId            *string `json:"recoveryPointId,omitempty"`
+	SecondaryKekCertificatePfx *string `json:"secondaryKekCertificatePfx,omitempty"`
+
+	// Fields inherited from PlannedFailoverProviderSpecificFailoverInput
+}
+
+var _ json.Marshaler = HyperVReplicaAzurePlannedFailoverProviderInput{}
+
+func (s HyperVReplicaAzurePlannedFailoverProviderInput) MarshalJSON() ([]byte, error) {
+	type wrapper HyperVReplicaAzurePlannedFailoverProviderInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling HyperVReplicaAzurePlannedFailoverProviderInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling HyperVReplicaAzurePlannedFailoverProviderInput: %+v", err)
+	}
+	decoded["instanceType"] = "HyperVReplicaAzure"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling HyperVReplicaAzurePlannedFailoverProviderInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_hypervreplicaazurereplicationdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_hypervreplicaazurereplicationdetails.go
@@ -1,0 +1,73 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ReplicationProviderSpecificSettings = HyperVReplicaAzureReplicationDetails{}
+
+type HyperVReplicaAzureReplicationDetails struct {
+	AzureVmDiskDetails               *[]AzureVmDiskDetails                   `json:"azureVmDiskDetails,omitempty"`
+	EnableRdpOnTargetOption          *string                                 `json:"enableRdpOnTargetOption,omitempty"`
+	Encryption                       *string                                 `json:"encryption,omitempty"`
+	InitialReplicationDetails        *InitialReplicationDetails              `json:"initialReplicationDetails,omitempty"`
+	LastRecoveryPointReceived        *string                                 `json:"lastRecoveryPointReceived,omitempty"`
+	LastReplicatedTime               *string                                 `json:"lastReplicatedTime,omitempty"`
+	LastRpoCalculatedTime            *string                                 `json:"lastRpoCalculatedTime,omitempty"`
+	LicenseType                      *string                                 `json:"licenseType,omitempty"`
+	OSDetails                        *OSDetails                              `json:"oSDetails,omitempty"`
+	ProtectedManagedDisks            *[]HyperVReplicaAzureManagedDiskDetails `json:"protectedManagedDisks,omitempty"`
+	RecoveryAvailabilitySetId        *string                                 `json:"recoveryAvailabilitySetId,omitempty"`
+	RecoveryAzureLogStorageAccountId *string                                 `json:"recoveryAzureLogStorageAccountId,omitempty"`
+	RecoveryAzureResourceGroupId     *string                                 `json:"recoveryAzureResourceGroupId,omitempty"`
+	RecoveryAzureStorageAccount      *string                                 `json:"recoveryAzureStorageAccount,omitempty"`
+	RecoveryAzureVMSize              *string                                 `json:"recoveryAzureVMSize,omitempty"`
+	RecoveryAzureVmName              *string                                 `json:"recoveryAzureVmName,omitempty"`
+	RpoInSeconds                     *int64                                  `json:"rpoInSeconds,omitempty"`
+	SeedManagedDiskTags              *map[string]string                      `json:"seedManagedDiskTags,omitempty"`
+	SelectedRecoveryAzureNetworkId   *string                                 `json:"selectedRecoveryAzureNetworkId,omitempty"`
+	SelectedSourceNicId              *string                                 `json:"selectedSourceNicId,omitempty"`
+	SourceVmCpuCount                 *int64                                  `json:"sourceVmCpuCount,omitempty"`
+	SourceVmRamSizeInMB              *int64                                  `json:"sourceVmRamSizeInMB,omitempty"`
+	SqlServerLicenseType             *string                                 `json:"sqlServerLicenseType,omitempty"`
+	TargetAvailabilityZone           *string                                 `json:"targetAvailabilityZone,omitempty"`
+	TargetManagedDiskTags            *map[string]string                      `json:"targetManagedDiskTags,omitempty"`
+	TargetNicTags                    *map[string]string                      `json:"targetNicTags,omitempty"`
+	TargetProximityPlacementGroupId  *string                                 `json:"targetProximityPlacementGroupId,omitempty"`
+	TargetVmTags                     *map[string]string                      `json:"targetVmTags,omitempty"`
+	UseManagedDisks                  *string                                 `json:"useManagedDisks,omitempty"`
+	VmId                             *string                                 `json:"vmId,omitempty"`
+	VmNics                           *[]VMNicDetails                         `json:"vmNics,omitempty"`
+	VmProtectionState                *string                                 `json:"vmProtectionState,omitempty"`
+	VmProtectionStateDescription     *string                                 `json:"vmProtectionStateDescription,omitempty"`
+
+	// Fields inherited from ReplicationProviderSpecificSettings
+}
+
+var _ json.Marshaler = HyperVReplicaAzureReplicationDetails{}
+
+func (s HyperVReplicaAzureReplicationDetails) MarshalJSON() ([]byte, error) {
+	type wrapper HyperVReplicaAzureReplicationDetails
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling HyperVReplicaAzureReplicationDetails: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling HyperVReplicaAzureReplicationDetails: %+v", err)
+	}
+	decoded["instanceType"] = "HyperVReplicaAzure"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling HyperVReplicaAzureReplicationDetails: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_hypervreplicaazurereprotectinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_hypervreplicaazurereprotectinput.go
@@ -1,0 +1,46 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ReverseReplicationProviderSpecificInput = HyperVReplicaAzureReprotectInput{}
+
+type HyperVReplicaAzureReprotectInput struct {
+	HvHostVmId          *string `json:"hvHostVmId,omitempty"`
+	LogStorageAccountId *string `json:"logStorageAccountId,omitempty"`
+	OsType              *string `json:"osType,omitempty"`
+	StorageAccountId    *string `json:"storageAccountId,omitempty"`
+	VHDId               *string `json:"vHDId,omitempty"`
+	VirtualMachineName  *string `json:"vmName,omitempty"`
+
+	// Fields inherited from ReverseReplicationProviderSpecificInput
+}
+
+var _ json.Marshaler = HyperVReplicaAzureReprotectInput{}
+
+func (s HyperVReplicaAzureReprotectInput) MarshalJSON() ([]byte, error) {
+	type wrapper HyperVReplicaAzureReprotectInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling HyperVReplicaAzureReprotectInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling HyperVReplicaAzureReprotectInput: %+v", err)
+	}
+	decoded["instanceType"] = "HyperVReplicaAzure"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling HyperVReplicaAzureReprotectInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_hypervreplicaazuretestfailoverinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_hypervreplicaazuretestfailoverinput.go
@@ -1,0 +1,43 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ TestFailoverProviderSpecificInput = HyperVReplicaAzureTestFailoverInput{}
+
+type HyperVReplicaAzureTestFailoverInput struct {
+	PrimaryKekCertificatePfx   *string `json:"primaryKekCertificatePfx,omitempty"`
+	RecoveryPointId            *string `json:"recoveryPointId,omitempty"`
+	SecondaryKekCertificatePfx *string `json:"secondaryKekCertificatePfx,omitempty"`
+
+	// Fields inherited from TestFailoverProviderSpecificInput
+}
+
+var _ json.Marshaler = HyperVReplicaAzureTestFailoverInput{}
+
+func (s HyperVReplicaAzureTestFailoverInput) MarshalJSON() ([]byte, error) {
+	type wrapper HyperVReplicaAzureTestFailoverInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling HyperVReplicaAzureTestFailoverInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling HyperVReplicaAzureTestFailoverInput: %+v", err)
+	}
+	decoded["instanceType"] = "HyperVReplicaAzure"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling HyperVReplicaAzureTestFailoverInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_hypervreplicaazureunplannedfailoverinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_hypervreplicaazureunplannedfailoverinput.go
@@ -1,0 +1,43 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ UnplannedFailoverProviderSpecificInput = HyperVReplicaAzureUnplannedFailoverInput{}
+
+type HyperVReplicaAzureUnplannedFailoverInput struct {
+	PrimaryKekCertificatePfx   *string `json:"primaryKekCertificatePfx,omitempty"`
+	RecoveryPointId            *string `json:"recoveryPointId,omitempty"`
+	SecondaryKekCertificatePfx *string `json:"secondaryKekCertificatePfx,omitempty"`
+
+	// Fields inherited from UnplannedFailoverProviderSpecificInput
+}
+
+var _ json.Marshaler = HyperVReplicaAzureUnplannedFailoverInput{}
+
+func (s HyperVReplicaAzureUnplannedFailoverInput) MarshalJSON() ([]byte, error) {
+	type wrapper HyperVReplicaAzureUnplannedFailoverInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling HyperVReplicaAzureUnplannedFailoverInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling HyperVReplicaAzureUnplannedFailoverInput: %+v", err)
+	}
+	decoded["instanceType"] = "HyperVReplicaAzure"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling HyperVReplicaAzureUnplannedFailoverInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_hypervreplicaazureupdatereplicationprotectediteminput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_hypervreplicaazureupdatereplicationprotectediteminput.go
@@ -1,0 +1,51 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ UpdateReplicationProtectedItemProviderInput = HyperVReplicaAzureUpdateReplicationProtectedItemInput{}
+
+type HyperVReplicaAzureUpdateReplicationProtectedItemInput struct {
+	DiskIdToDiskEncryptionMap       *map[string]string    `json:"diskIdToDiskEncryptionMap,omitempty"`
+	RecoveryAzureV1ResourceGroupId  *string               `json:"recoveryAzureV1ResourceGroupId,omitempty"`
+	RecoveryAzureV2ResourceGroupId  *string               `json:"recoveryAzureV2ResourceGroupId,omitempty"`
+	SqlServerLicenseType            *SqlServerLicenseType `json:"sqlServerLicenseType,omitempty"`
+	TargetAvailabilityZone          *string               `json:"targetAvailabilityZone,omitempty"`
+	TargetManagedDiskTags           *map[string]string    `json:"targetManagedDiskTags,omitempty"`
+	TargetNicTags                   *map[string]string    `json:"targetNicTags,omitempty"`
+	TargetProximityPlacementGroupId *string               `json:"targetProximityPlacementGroupId,omitempty"`
+	TargetVmTags                    *map[string]string    `json:"targetVmTags,omitempty"`
+	UseManagedDisks                 *string               `json:"useManagedDisks,omitempty"`
+	VmDisks                         *[]UpdateDiskInput    `json:"vmDisks,omitempty"`
+
+	// Fields inherited from UpdateReplicationProtectedItemProviderInput
+}
+
+var _ json.Marshaler = HyperVReplicaAzureUpdateReplicationProtectedItemInput{}
+
+func (s HyperVReplicaAzureUpdateReplicationProtectedItemInput) MarshalJSON() ([]byte, error) {
+	type wrapper HyperVReplicaAzureUpdateReplicationProtectedItemInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling HyperVReplicaAzureUpdateReplicationProtectedItemInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling HyperVReplicaAzureUpdateReplicationProtectedItemInput: %+v", err)
+	}
+	decoded["instanceType"] = "HyperVReplicaAzure"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling HyperVReplicaAzureUpdateReplicationProtectedItemInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_hypervreplicabasereplicationdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_hypervreplicabasereplicationdetails.go
@@ -1,0 +1,47 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ReplicationProviderSpecificSettings = HyperVReplicaBaseReplicationDetails{}
+
+type HyperVReplicaBaseReplicationDetails struct {
+	InitialReplicationDetails    *InitialReplicationDetails `json:"initialReplicationDetails,omitempty"`
+	LastReplicatedTime           *string                    `json:"lastReplicatedTime,omitempty"`
+	VMDiskDetails                *[]DiskDetails             `json:"vMDiskDetails,omitempty"`
+	VmId                         *string                    `json:"vmId,omitempty"`
+	VmNics                       *[]VMNicDetails            `json:"vmNics,omitempty"`
+	VmProtectionState            *string                    `json:"vmProtectionState,omitempty"`
+	VmProtectionStateDescription *string                    `json:"vmProtectionStateDescription,omitempty"`
+
+	// Fields inherited from ReplicationProviderSpecificSettings
+}
+
+var _ json.Marshaler = HyperVReplicaBaseReplicationDetails{}
+
+func (s HyperVReplicaBaseReplicationDetails) MarshalJSON() ([]byte, error) {
+	type wrapper HyperVReplicaBaseReplicationDetails
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling HyperVReplicaBaseReplicationDetails: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling HyperVReplicaBaseReplicationDetails: %+v", err)
+	}
+	decoded["instanceType"] = "HyperVReplicaBaseReplicationDetails"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling HyperVReplicaBaseReplicationDetails: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_hypervreplicabluereplicationdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_hypervreplicabluereplicationdetails.go
@@ -1,0 +1,47 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ReplicationProviderSpecificSettings = HyperVReplicaBlueReplicationDetails{}
+
+type HyperVReplicaBlueReplicationDetails struct {
+	InitialReplicationDetails    *InitialReplicationDetails `json:"initialReplicationDetails,omitempty"`
+	LastReplicatedTime           *string                    `json:"lastReplicatedTime,omitempty"`
+	VMDiskDetails                *[]DiskDetails             `json:"vMDiskDetails,omitempty"`
+	VmId                         *string                    `json:"vmId,omitempty"`
+	VmNics                       *[]VMNicDetails            `json:"vmNics,omitempty"`
+	VmProtectionState            *string                    `json:"vmProtectionState,omitempty"`
+	VmProtectionStateDescription *string                    `json:"vmProtectionStateDescription,omitempty"`
+
+	// Fields inherited from ReplicationProviderSpecificSettings
+}
+
+var _ json.Marshaler = HyperVReplicaBlueReplicationDetails{}
+
+func (s HyperVReplicaBlueReplicationDetails) MarshalJSON() ([]byte, error) {
+	type wrapper HyperVReplicaBlueReplicationDetails
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling HyperVReplicaBlueReplicationDetails: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling HyperVReplicaBlueReplicationDetails: %+v", err)
+	}
+	decoded["instanceType"] = "HyperVReplica2012R2"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling HyperVReplicaBlueReplicationDetails: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_hypervreplicareplicationdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_hypervreplicareplicationdetails.go
@@ -1,0 +1,47 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ReplicationProviderSpecificSettings = HyperVReplicaReplicationDetails{}
+
+type HyperVReplicaReplicationDetails struct {
+	InitialReplicationDetails    *InitialReplicationDetails `json:"initialReplicationDetails,omitempty"`
+	LastReplicatedTime           *string                    `json:"lastReplicatedTime,omitempty"`
+	VMDiskDetails                *[]DiskDetails             `json:"vMDiskDetails,omitempty"`
+	VmId                         *string                    `json:"vmId,omitempty"`
+	VmNics                       *[]VMNicDetails            `json:"vmNics,omitempty"`
+	VmProtectionState            *string                    `json:"vmProtectionState,omitempty"`
+	VmProtectionStateDescription *string                    `json:"vmProtectionStateDescription,omitempty"`
+
+	// Fields inherited from ReplicationProviderSpecificSettings
+}
+
+var _ json.Marshaler = HyperVReplicaReplicationDetails{}
+
+func (s HyperVReplicaReplicationDetails) MarshalJSON() ([]byte, error) {
+	type wrapper HyperVReplicaReplicationDetails
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling HyperVReplicaReplicationDetails: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling HyperVReplicaReplicationDetails: %+v", err)
+	}
+	decoded["instanceType"] = "HyperVReplica2012"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling HyperVReplicaReplicationDetails: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_initialreplicationdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_initialreplicationdetails.go
@@ -1,0 +1,9 @@
+package replicationprotecteditems
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type InitialReplicationDetails struct {
+	InitialReplicationProgressPercentage *string `json:"initialReplicationProgressPercentage,omitempty"`
+	InitialReplicationType               *string `json:"initialReplicationType,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmageagentdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmageagentdetails.go
@@ -1,0 +1,29 @@
+package replicationprotecteditems
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type InMageAgentDetails struct {
+	AgentExpiryDate        *string `json:"agentExpiryDate,omitempty"`
+	AgentUpdateStatus      *string `json:"agentUpdateStatus,omitempty"`
+	AgentVersion           *string `json:"agentVersion,omitempty"`
+	PostUpdateRebootStatus *string `json:"postUpdateRebootStatus,omitempty"`
+}
+
+func (o *InMageAgentDetails) GetAgentExpiryDateAsTime() (*time.Time, error) {
+	if o.AgentExpiryDate == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.AgentExpiryDate, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *InMageAgentDetails) SetAgentExpiryDateAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.AgentExpiryDate = &formatted
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmageazurev2applyrecoverypointinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmageazurev2applyrecoverypointinput.go
@@ -1,0 +1,40 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ApplyRecoveryPointProviderSpecificInput = InMageAzureV2ApplyRecoveryPointInput{}
+
+type InMageAzureV2ApplyRecoveryPointInput struct {
+
+	// Fields inherited from ApplyRecoveryPointProviderSpecificInput
+}
+
+var _ json.Marshaler = InMageAzureV2ApplyRecoveryPointInput{}
+
+func (s InMageAzureV2ApplyRecoveryPointInput) MarshalJSON() ([]byte, error) {
+	type wrapper InMageAzureV2ApplyRecoveryPointInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling InMageAzureV2ApplyRecoveryPointInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling InMageAzureV2ApplyRecoveryPointInput: %+v", err)
+	}
+	decoded["instanceType"] = "InMageAzureV2"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling InMageAzureV2ApplyRecoveryPointInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmageazurev2diskinputdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmageazurev2diskinputdetails.go
@@ -1,0 +1,11 @@
+package replicationprotecteditems
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type InMageAzureV2DiskInputDetails struct {
+	DiskEncryptionSetId *string          `json:"diskEncryptionSetId,omitempty"`
+	DiskId              *string          `json:"diskId,omitempty"`
+	DiskType            *DiskAccountType `json:"diskType,omitempty"`
+	LogStorageAccountId *string          `json:"logStorageAccountId,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmageazurev2enableprotectioninput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmageazurev2enableprotectioninput.go
@@ -1,0 +1,66 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ EnableProtectionProviderSpecificInput = InMageAzureV2EnableProtectionInput{}
+
+type InMageAzureV2EnableProtectionInput struct {
+	DiskEncryptionSetId             *string                          `json:"diskEncryptionSetId,omitempty"`
+	DiskType                        *DiskAccountType                 `json:"diskType,omitempty"`
+	DisksToInclude                  *[]InMageAzureV2DiskInputDetails `json:"disksToInclude,omitempty"`
+	EnableRdpOnTargetOption         *string                          `json:"enableRdpOnTargetOption,omitempty"`
+	LicenseType                     *LicenseType                     `json:"licenseType,omitempty"`
+	LogStorageAccountId             *string                          `json:"logStorageAccountId,omitempty"`
+	MasterTargetId                  *string                          `json:"masterTargetId,omitempty"`
+	MultiVmGroupId                  *string                          `json:"multiVmGroupId,omitempty"`
+	MultiVmGroupName                *string                          `json:"multiVmGroupName,omitempty"`
+	ProcessServerId                 *string                          `json:"processServerId,omitempty"`
+	RunAsAccountId                  *string                          `json:"runAsAccountId,omitempty"`
+	SeedManagedDiskTags             *map[string]string               `json:"seedManagedDiskTags,omitempty"`
+	SqlServerLicenseType            *SqlServerLicenseType            `json:"sqlServerLicenseType,omitempty"`
+	StorageAccountId                *string                          `json:"storageAccountId,omitempty"`
+	TargetAvailabilitySetId         *string                          `json:"targetAvailabilitySetId,omitempty"`
+	TargetAvailabilityZone          *string                          `json:"targetAvailabilityZone,omitempty"`
+	TargetAzureNetworkId            *string                          `json:"targetAzureNetworkId,omitempty"`
+	TargetAzureSubnetId             *string                          `json:"targetAzureSubnetId,omitempty"`
+	TargetAzureV1ResourceGroupId    *string                          `json:"targetAzureV1ResourceGroupId,omitempty"`
+	TargetAzureV2ResourceGroupId    *string                          `json:"targetAzureV2ResourceGroupId,omitempty"`
+	TargetAzureVmName               *string                          `json:"targetAzureVmName,omitempty"`
+	TargetManagedDiskTags           *map[string]string               `json:"targetManagedDiskTags,omitempty"`
+	TargetNicTags                   *map[string]string               `json:"targetNicTags,omitempty"`
+	TargetProximityPlacementGroupId *string                          `json:"targetProximityPlacementGroupId,omitempty"`
+	TargetVmSize                    *string                          `json:"targetVmSize,omitempty"`
+	TargetVmTags                    *map[string]string               `json:"targetVmTags,omitempty"`
+
+	// Fields inherited from EnableProtectionProviderSpecificInput
+}
+
+var _ json.Marshaler = InMageAzureV2EnableProtectionInput{}
+
+func (s InMageAzureV2EnableProtectionInput) MarshalJSON() ([]byte, error) {
+	type wrapper InMageAzureV2EnableProtectionInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling InMageAzureV2EnableProtectionInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling InMageAzureV2EnableProtectionInput: %+v", err)
+	}
+	decoded["instanceType"] = "InMageAzureV2"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling InMageAzureV2EnableProtectionInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmageazurev2manageddiskdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmageazurev2manageddiskdetails.go
@@ -1,0 +1,12 @@
+package replicationprotecteditems
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type InMageAzureV2ManagedDiskDetails struct {
+	DiskEncryptionSetId *string `json:"diskEncryptionSetId,omitempty"`
+	DiskId              *string `json:"diskId,omitempty"`
+	ReplicaDiskType     *string `json:"replicaDiskType,omitempty"`
+	SeedManagedDiskId   *string `json:"seedManagedDiskId,omitempty"`
+	TargetDiskName      *string `json:"targetDiskName,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmageazurev2protecteddiskdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmageazurev2protecteddiskdetails.go
@@ -1,0 +1,72 @@
+package replicationprotecteditems
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type InMageAzureV2ProtectedDiskDetails struct {
+	DiskCapacityInBytes                 *int64   `json:"diskCapacityInBytes,omitempty"`
+	DiskId                              *string  `json:"diskId,omitempty"`
+	DiskName                            *string  `json:"diskName,omitempty"`
+	DiskResized                         *string  `json:"diskResized,omitempty"`
+	FileSystemCapacityInBytes           *int64   `json:"fileSystemCapacityInBytes,omitempty"`
+	HealthErrorCode                     *string  `json:"healthErrorCode,omitempty"`
+	LastRpoCalculatedTime               *string  `json:"lastRpoCalculatedTime,omitempty"`
+	ProgressHealth                      *string  `json:"progressHealth,omitempty"`
+	ProgressStatus                      *string  `json:"progressStatus,omitempty"`
+	ProtectionStage                     *string  `json:"protectionStage,omitempty"`
+	PsDataInMegaBytes                   *float64 `json:"psDataInMegaBytes,omitempty"`
+	ResyncDurationInSeconds             *int64   `json:"resyncDurationInSeconds,omitempty"`
+	ResyncLast15MinutesTransferredBytes *int64   `json:"resyncLast15MinutesTransferredBytes,omitempty"`
+	ResyncLastDataTransferTimeUTC       *string  `json:"resyncLastDataTransferTimeUTC,omitempty"`
+	ResyncProcessedBytes                *int64   `json:"resyncProcessedBytes,omitempty"`
+	ResyncProgressPercentage            *int64   `json:"resyncProgressPercentage,omitempty"`
+	ResyncRequired                      *string  `json:"resyncRequired,omitempty"`
+	ResyncStartTime                     *string  `json:"resyncStartTime,omitempty"`
+	ResyncTotalTransferredBytes         *int64   `json:"resyncTotalTransferredBytes,omitempty"`
+	RpoInSeconds                        *int64   `json:"rpoInSeconds,omitempty"`
+	SecondsToTakeSwitchProvider         *int64   `json:"secondsToTakeSwitchProvider,omitempty"`
+	SourceDataInMegaBytes               *float64 `json:"sourceDataInMegaBytes,omitempty"`
+	TargetDataInMegaBytes               *float64 `json:"targetDataInMegaBytes,omitempty"`
+}
+
+func (o *InMageAzureV2ProtectedDiskDetails) GetLastRpoCalculatedTimeAsTime() (*time.Time, error) {
+	if o.LastRpoCalculatedTime == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.LastRpoCalculatedTime, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *InMageAzureV2ProtectedDiskDetails) SetLastRpoCalculatedTimeAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.LastRpoCalculatedTime = &formatted
+}
+
+func (o *InMageAzureV2ProtectedDiskDetails) GetResyncLastDataTransferTimeUTCAsTime() (*time.Time, error) {
+	if o.ResyncLastDataTransferTimeUTC == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.ResyncLastDataTransferTimeUTC, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *InMageAzureV2ProtectedDiskDetails) SetResyncLastDataTransferTimeUTCAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.ResyncLastDataTransferTimeUTC = &formatted
+}
+
+func (o *InMageAzureV2ProtectedDiskDetails) GetResyncStartTimeAsTime() (*time.Time, error) {
+	if o.ResyncStartTime == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.ResyncStartTime, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *InMageAzureV2ProtectedDiskDetails) SetResyncStartTimeAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.ResyncStartTime = &formatted
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmageazurev2replicationdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmageazurev2replicationdetails.go
@@ -1,0 +1,107 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ReplicationProviderSpecificSettings = InMageAzureV2ReplicationDetails{}
+
+type InMageAzureV2ReplicationDetails struct {
+	AgentExpiryDate                    *string                                            `json:"agentExpiryDate,omitempty"`
+	AgentVersion                       *string                                            `json:"agentVersion,omitempty"`
+	AzureVMDiskDetails                 *[]AzureVmDiskDetails                              `json:"azureVMDiskDetails,omitempty"`
+	AzureVmGeneration                  *string                                            `json:"azureVmGeneration,omitempty"`
+	CompressedDataRateInMB             *float64                                           `json:"compressedDataRateInMB,omitempty"`
+	DataStores                         *[]string                                          `json:"datastores,omitempty"`
+	DiscoveryType                      *string                                            `json:"discoveryType,omitempty"`
+	DiskResized                        *string                                            `json:"diskResized,omitempty"`
+	EnableRdpOnTargetOption            *string                                            `json:"enableRdpOnTargetOption,omitempty"`
+	FirmwareType                       *string                                            `json:"firmwareType,omitempty"`
+	IPAddress                          *string                                            `json:"ipAddress,omitempty"`
+	InfrastructureVmId                 *string                                            `json:"infrastructureVmId,omitempty"`
+	IsAdditionalStatsAvailable         *bool                                              `json:"isAdditionalStatsAvailable,omitempty"`
+	IsAgentUpdateRequired              *string                                            `json:"isAgentUpdateRequired,omitempty"`
+	IsRebootAfterUpdateRequired        *string                                            `json:"isRebootAfterUpdateRequired,omitempty"`
+	LastHeartbeat                      *string                                            `json:"lastHeartbeat,omitempty"`
+	LastRecoveryPointReceived          *string                                            `json:"lastRecoveryPointReceived,omitempty"`
+	LastRpoCalculatedTime              *string                                            `json:"lastRpoCalculatedTime,omitempty"`
+	LastUpdateReceivedTime             *string                                            `json:"lastUpdateReceivedTime,omitempty"`
+	LicenseType                        *string                                            `json:"licenseType,omitempty"`
+	MasterTargetId                     *string                                            `json:"masterTargetId,omitempty"`
+	MultiVmGroupId                     *string                                            `json:"multiVmGroupId,omitempty"`
+	MultiVmGroupName                   *string                                            `json:"multiVmGroupName,omitempty"`
+	MultiVmSyncStatus                  *string                                            `json:"multiVmSyncStatus,omitempty"`
+	OsDiskId                           *string                                            `json:"osDiskId,omitempty"`
+	OsType                             *string                                            `json:"osType,omitempty"`
+	OsVersion                          *string                                            `json:"osVersion,omitempty"`
+	ProcessServerId                    *string                                            `json:"processServerId,omitempty"`
+	ProcessServerName                  *string                                            `json:"processServerName,omitempty"`
+	ProtectedDisks                     *[]InMageAzureV2ProtectedDiskDetails               `json:"protectedDisks,omitempty"`
+	ProtectedManagedDisks              *[]InMageAzureV2ManagedDiskDetails                 `json:"protectedManagedDisks,omitempty"`
+	ProtectionStage                    *string                                            `json:"protectionStage,omitempty"`
+	RecoveryAvailabilitySetId          *string                                            `json:"recoveryAvailabilitySetId,omitempty"`
+	RecoveryAzureLogStorageAccountId   *string                                            `json:"recoveryAzureLogStorageAccountId,omitempty"`
+	RecoveryAzureResourceGroupId       *string                                            `json:"recoveryAzureResourceGroupId,omitempty"`
+	RecoveryAzureStorageAccount        *string                                            `json:"recoveryAzureStorageAccount,omitempty"`
+	RecoveryAzureVMName                *string                                            `json:"recoveryAzureVMName,omitempty"`
+	RecoveryAzureVMSize                *string                                            `json:"recoveryAzureVMSize,omitempty"`
+	ReplicaId                          *string                                            `json:"replicaId,omitempty"`
+	ResyncProgressPercentage           *int64                                             `json:"resyncProgressPercentage,omitempty"`
+	RpoInSeconds                       *int64                                             `json:"rpoInSeconds,omitempty"`
+	SeedManagedDiskTags                *map[string]string                                 `json:"seedManagedDiskTags,omitempty"`
+	SelectedRecoveryAzureNetworkId     *string                                            `json:"selectedRecoveryAzureNetworkId,omitempty"`
+	SelectedSourceNicId                *string                                            `json:"selectedSourceNicId,omitempty"`
+	SelectedTfoAzureNetworkId          *string                                            `json:"selectedTfoAzureNetworkId,omitempty"`
+	SourceVmCpuCount                   *int64                                             `json:"sourceVmCpuCount,omitempty"`
+	SourceVmRamSizeInMB                *int64                                             `json:"sourceVmRamSizeInMB,omitempty"`
+	SqlServerLicenseType               *string                                            `json:"sqlServerLicenseType,omitempty"`
+	SwitchProviderBlockingErrorDetails *[]InMageAzureV2SwitchProviderBlockingErrorDetails `json:"switchProviderBlockingErrorDetails,omitempty"`
+	SwitchProviderDetails              *InMageAzureV2SwitchProviderDetails                `json:"switchProviderDetails,omitempty"`
+	TargetAvailabilityZone             *string                                            `json:"targetAvailabilityZone,omitempty"`
+	TargetManagedDiskTags              *map[string]string                                 `json:"targetManagedDiskTags,omitempty"`
+	TargetNicTags                      *map[string]string                                 `json:"targetNicTags,omitempty"`
+	TargetProximityPlacementGroupId    *string                                            `json:"targetProximityPlacementGroupId,omitempty"`
+	TargetVmId                         *string                                            `json:"targetVmId,omitempty"`
+	TargetVmTags                       *map[string]string                                 `json:"targetVmTags,omitempty"`
+	TotalDataTransferred               *int64                                             `json:"totalDataTransferred,omitempty"`
+	TotalProgressHealth                *string                                            `json:"totalProgressHealth,omitempty"`
+	UncompressedDataRateInMB           *float64                                           `json:"uncompressedDataRateInMB,omitempty"`
+	UseManagedDisks                    *string                                            `json:"useManagedDisks,omitempty"`
+	VCenterInfrastructureId            *string                                            `json:"vCenterInfrastructureId,omitempty"`
+	ValidationErrors                   *[]HealthError                                     `json:"validationErrors,omitempty"`
+	VhdName                            *string                                            `json:"vhdName,omitempty"`
+	VmId                               *string                                            `json:"vmId,omitempty"`
+	VmNics                             *[]VMNicDetails                                    `json:"vmNics,omitempty"`
+	VmProtectionState                  *string                                            `json:"vmProtectionState,omitempty"`
+	VmProtectionStateDescription       *string                                            `json:"vmProtectionStateDescription,omitempty"`
+
+	// Fields inherited from ReplicationProviderSpecificSettings
+}
+
+var _ json.Marshaler = InMageAzureV2ReplicationDetails{}
+
+func (s InMageAzureV2ReplicationDetails) MarshalJSON() ([]byte, error) {
+	type wrapper InMageAzureV2ReplicationDetails
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling InMageAzureV2ReplicationDetails: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling InMageAzureV2ReplicationDetails: %+v", err)
+	}
+	decoded["instanceType"] = "InMageAzureV2"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling InMageAzureV2ReplicationDetails: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmageazurev2reprotectinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmageazurev2reprotectinput.go
@@ -1,0 +1,47 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ReverseReplicationProviderSpecificInput = InMageAzureV2ReprotectInput{}
+
+type InMageAzureV2ReprotectInput struct {
+	DisksToInclude      *[]string `json:"disksToInclude,omitempty"`
+	LogStorageAccountId *string   `json:"logStorageAccountId,omitempty"`
+	MasterTargetId      *string   `json:"masterTargetId,omitempty"`
+	PolicyId            *string   `json:"policyId,omitempty"`
+	ProcessServerId     *string   `json:"processServerId,omitempty"`
+	RunAsAccountId      *string   `json:"runAsAccountId,omitempty"`
+	StorageAccountId    *string   `json:"storageAccountId,omitempty"`
+
+	// Fields inherited from ReverseReplicationProviderSpecificInput
+}
+
+var _ json.Marshaler = InMageAzureV2ReprotectInput{}
+
+func (s InMageAzureV2ReprotectInput) MarshalJSON() ([]byte, error) {
+	type wrapper InMageAzureV2ReprotectInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling InMageAzureV2ReprotectInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling InMageAzureV2ReprotectInput: %+v", err)
+	}
+	decoded["instanceType"] = "InMageAzureV2"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling InMageAzureV2ReprotectInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmageazurev2switchproviderblockingerrordetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmageazurev2switchproviderblockingerrordetails.go
@@ -1,0 +1,13 @@
+package replicationprotecteditems
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type InMageAzureV2SwitchProviderBlockingErrorDetails struct {
+	ErrorCode              *string            `json:"errorCode,omitempty"`
+	ErrorMessage           *string            `json:"errorMessage,omitempty"`
+	ErrorMessageParameters *map[string]string `json:"errorMessageParameters,omitempty"`
+	ErrorTags              *map[string]string `json:"errorTags,omitempty"`
+	PossibleCauses         *string            `json:"possibleCauses,omitempty"`
+	RecommendedAction      *string            `json:"recommendedAction,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmageazurev2switchproviderdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmageazurev2switchproviderdetails.go
@@ -1,0 +1,11 @@
+package replicationprotecteditems
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type InMageAzureV2SwitchProviderDetails struct {
+	TargetApplianceId *string `json:"targetApplianceId,omitempty"`
+	TargetFabricId    *string `json:"targetFabricId,omitempty"`
+	TargetResourceId  *string `json:"targetResourceId,omitempty"`
+	TargetVaultId     *string `json:"targetVaultId,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmageazurev2switchproviderproviderinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmageazurev2switchproviderproviderinput.go
@@ -1,0 +1,43 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ SwitchProviderProviderSpecificInput = InMageAzureV2SwitchProviderProviderInput{}
+
+type InMageAzureV2SwitchProviderProviderInput struct {
+	TargetApplianceID string `json:"targetApplianceID"`
+	TargetFabricID    string `json:"targetFabricID"`
+	TargetVaultID     string `json:"targetVaultID"`
+
+	// Fields inherited from SwitchProviderProviderSpecificInput
+}
+
+var _ json.Marshaler = InMageAzureV2SwitchProviderProviderInput{}
+
+func (s InMageAzureV2SwitchProviderProviderInput) MarshalJSON() ([]byte, error) {
+	type wrapper InMageAzureV2SwitchProviderProviderInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling InMageAzureV2SwitchProviderProviderInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling InMageAzureV2SwitchProviderProviderInput: %+v", err)
+	}
+	decoded["instanceType"] = "InMageAzureV2"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling InMageAzureV2SwitchProviderProviderInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmageazurev2testfailoverinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmageazurev2testfailoverinput.go
@@ -1,0 +1,41 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ TestFailoverProviderSpecificInput = InMageAzureV2TestFailoverInput{}
+
+type InMageAzureV2TestFailoverInput struct {
+	RecoveryPointId *string `json:"recoveryPointId,omitempty"`
+
+	// Fields inherited from TestFailoverProviderSpecificInput
+}
+
+var _ json.Marshaler = InMageAzureV2TestFailoverInput{}
+
+func (s InMageAzureV2TestFailoverInput) MarshalJSON() ([]byte, error) {
+	type wrapper InMageAzureV2TestFailoverInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling InMageAzureV2TestFailoverInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling InMageAzureV2TestFailoverInput: %+v", err)
+	}
+	decoded["instanceType"] = "InMageAzureV2"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling InMageAzureV2TestFailoverInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmageazurev2unplannedfailoverinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmageazurev2unplannedfailoverinput.go
@@ -1,0 +1,41 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ UnplannedFailoverProviderSpecificInput = InMageAzureV2UnplannedFailoverInput{}
+
+type InMageAzureV2UnplannedFailoverInput struct {
+	RecoveryPointId *string `json:"recoveryPointId,omitempty"`
+
+	// Fields inherited from UnplannedFailoverProviderSpecificInput
+}
+
+var _ json.Marshaler = InMageAzureV2UnplannedFailoverInput{}
+
+func (s InMageAzureV2UnplannedFailoverInput) MarshalJSON() ([]byte, error) {
+	type wrapper InMageAzureV2UnplannedFailoverInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling InMageAzureV2UnplannedFailoverInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling InMageAzureV2UnplannedFailoverInput: %+v", err)
+	}
+	decoded["instanceType"] = "InMageAzureV2"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling InMageAzureV2UnplannedFailoverInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmageazurev2updatereplicationprotectediteminput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmageazurev2updatereplicationprotectediteminput.go
@@ -1,0 +1,50 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ UpdateReplicationProtectedItemProviderInput = InMageAzureV2UpdateReplicationProtectedItemInput{}
+
+type InMageAzureV2UpdateReplicationProtectedItemInput struct {
+	RecoveryAzureV1ResourceGroupId  *string               `json:"recoveryAzureV1ResourceGroupId,omitempty"`
+	RecoveryAzureV2ResourceGroupId  *string               `json:"recoveryAzureV2ResourceGroupId,omitempty"`
+	SqlServerLicenseType            *SqlServerLicenseType `json:"sqlServerLicenseType,omitempty"`
+	TargetAvailabilityZone          *string               `json:"targetAvailabilityZone,omitempty"`
+	TargetManagedDiskTags           *map[string]string    `json:"targetManagedDiskTags,omitempty"`
+	TargetNicTags                   *map[string]string    `json:"targetNicTags,omitempty"`
+	TargetProximityPlacementGroupId *string               `json:"targetProximityPlacementGroupId,omitempty"`
+	TargetVmTags                    *map[string]string    `json:"targetVmTags,omitempty"`
+	UseManagedDisks                 *string               `json:"useManagedDisks,omitempty"`
+	VmDisks                         *[]UpdateDiskInput    `json:"vmDisks,omitempty"`
+
+	// Fields inherited from UpdateReplicationProtectedItemProviderInput
+}
+
+var _ json.Marshaler = InMageAzureV2UpdateReplicationProtectedItemInput{}
+
+func (s InMageAzureV2UpdateReplicationProtectedItemInput) MarshalJSON() ([]byte, error) {
+	type wrapper InMageAzureV2UpdateReplicationProtectedItemInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling InMageAzureV2UpdateReplicationProtectedItemInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling InMageAzureV2UpdateReplicationProtectedItemInput: %+v", err)
+	}
+	decoded["instanceType"] = "InMageAzureV2"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling InMageAzureV2UpdateReplicationProtectedItemInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmagedisableprotectionproviderspecificinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmagedisableprotectionproviderspecificinput.go
@@ -1,0 +1,41 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ DisableProtectionProviderSpecificInput = InMageDisableProtectionProviderSpecificInput{}
+
+type InMageDisableProtectionProviderSpecificInput struct {
+	ReplicaVmDeletionStatus *string `json:"replicaVmDeletionStatus,omitempty"`
+
+	// Fields inherited from DisableProtectionProviderSpecificInput
+}
+
+var _ json.Marshaler = InMageDisableProtectionProviderSpecificInput{}
+
+func (s InMageDisableProtectionProviderSpecificInput) MarshalJSON() ([]byte, error) {
+	type wrapper InMageDisableProtectionProviderSpecificInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling InMageDisableProtectionProviderSpecificInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling InMageDisableProtectionProviderSpecificInput: %+v", err)
+	}
+	decoded["instanceType"] = "InMage"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling InMageDisableProtectionProviderSpecificInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmagediskexclusioninput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmagediskexclusioninput.go
@@ -1,0 +1,9 @@
+package replicationprotecteditems
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type InMageDiskExclusionInput struct {
+	DiskSignatureOptions *[]InMageDiskSignatureExclusionOptions `json:"diskSignatureOptions,omitempty"`
+	VolumeOptions        *[]InMageVolumeExclusionOptions        `json:"volumeOptions,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmagedisksignatureexclusionoptions.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmagedisksignatureexclusionoptions.go
@@ -1,0 +1,8 @@
+package replicationprotecteditems
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type InMageDiskSignatureExclusionOptions struct {
+	DiskSignature *string `json:"diskSignature,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmageenableprotectioninput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmageenableprotectioninput.go
@@ -1,0 +1,50 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ EnableProtectionProviderSpecificInput = InMageEnableProtectionInput{}
+
+type InMageEnableProtectionInput struct {
+	DatastoreName      *string                   `json:"datastoreName,omitempty"`
+	DiskExclusionInput *InMageDiskExclusionInput `json:"diskExclusionInput,omitempty"`
+	DisksToInclude     *[]string                 `json:"disksToInclude,omitempty"`
+	MasterTargetId     string                    `json:"masterTargetId"`
+	MultiVmGroupId     string                    `json:"multiVmGroupId"`
+	MultiVmGroupName   string                    `json:"multiVmGroupName"`
+	ProcessServerId    string                    `json:"processServerId"`
+	RetentionDrive     string                    `json:"retentionDrive"`
+	RunAsAccountId     *string                   `json:"runAsAccountId,omitempty"`
+	VmFriendlyName     *string                   `json:"vmFriendlyName,omitempty"`
+
+	// Fields inherited from EnableProtectionProviderSpecificInput
+}
+
+var _ json.Marshaler = InMageEnableProtectionInput{}
+
+func (s InMageEnableProtectionInput) MarshalJSON() ([]byte, error) {
+	type wrapper InMageEnableProtectionInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling InMageEnableProtectionInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling InMageEnableProtectionInput: %+v", err)
+	}
+	decoded["instanceType"] = "InMage"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling InMageEnableProtectionInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmageprotecteddiskdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmageprotecteddiskdetails.go
@@ -1,0 +1,71 @@
+package replicationprotecteditems
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type InMageProtectedDiskDetails struct {
+	DiskCapacityInBytes                 *int64   `json:"diskCapacityInBytes,omitempty"`
+	DiskId                              *string  `json:"diskId,omitempty"`
+	DiskName                            *string  `json:"diskName,omitempty"`
+	DiskResized                         *string  `json:"diskResized,omitempty"`
+	FileSystemCapacityInBytes           *int64   `json:"fileSystemCapacityInBytes,omitempty"`
+	HealthErrorCode                     *string  `json:"healthErrorCode,omitempty"`
+	LastRpoCalculatedTime               *string  `json:"lastRpoCalculatedTime,omitempty"`
+	ProgressHealth                      *string  `json:"progressHealth,omitempty"`
+	ProgressStatus                      *string  `json:"progressStatus,omitempty"`
+	ProtectionStage                     *string  `json:"protectionStage,omitempty"`
+	PsDataInMB                          *float64 `json:"psDataInMB,omitempty"`
+	ResyncDurationInSeconds             *int64   `json:"resyncDurationInSeconds,omitempty"`
+	ResyncLast15MinutesTransferredBytes *int64   `json:"resyncLast15MinutesTransferredBytes,omitempty"`
+	ResyncLastDataTransferTimeUTC       *string  `json:"resyncLastDataTransferTimeUTC,omitempty"`
+	ResyncProcessedBytes                *int64   `json:"resyncProcessedBytes,omitempty"`
+	ResyncProgressPercentage            *int64   `json:"resyncProgressPercentage,omitempty"`
+	ResyncRequired                      *string  `json:"resyncRequired,omitempty"`
+	ResyncStartTime                     *string  `json:"resyncStartTime,omitempty"`
+	ResyncTotalTransferredBytes         *int64   `json:"resyncTotalTransferredBytes,omitempty"`
+	RpoInSeconds                        *int64   `json:"rpoInSeconds,omitempty"`
+	SourceDataInMB                      *float64 `json:"sourceDataInMB,omitempty"`
+	TargetDataInMB                      *float64 `json:"targetDataInMB,omitempty"`
+}
+
+func (o *InMageProtectedDiskDetails) GetLastRpoCalculatedTimeAsTime() (*time.Time, error) {
+	if o.LastRpoCalculatedTime == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.LastRpoCalculatedTime, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *InMageProtectedDiskDetails) SetLastRpoCalculatedTimeAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.LastRpoCalculatedTime = &formatted
+}
+
+func (o *InMageProtectedDiskDetails) GetResyncLastDataTransferTimeUTCAsTime() (*time.Time, error) {
+	if o.ResyncLastDataTransferTimeUTC == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.ResyncLastDataTransferTimeUTC, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *InMageProtectedDiskDetails) SetResyncLastDataTransferTimeUTCAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.ResyncLastDataTransferTimeUTC = &formatted
+}
+
+func (o *InMageProtectedDiskDetails) GetResyncStartTimeAsTime() (*time.Time, error) {
+	if o.ResyncStartTime == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.ResyncStartTime, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *InMageProtectedDiskDetails) SetResyncStartTimeAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.ResyncStartTime = &formatted
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmagercmagentupgradeblockingerrordetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmagercmagentupgradeblockingerrordetails.go
@@ -1,0 +1,13 @@
+package replicationprotecteditems
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type InMageRcmAgentUpgradeBlockingErrorDetails struct {
+	ErrorCode              *string            `json:"errorCode,omitempty"`
+	ErrorMessage           *string            `json:"errorMessage,omitempty"`
+	ErrorMessageParameters *map[string]string `json:"errorMessageParameters,omitempty"`
+	ErrorTags              *map[string]string `json:"errorTags,omitempty"`
+	PossibleCauses         *string            `json:"possibleCauses,omitempty"`
+	RecommendedAction      *string            `json:"recommendedAction,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmagercmapplyrecoverypointinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmagercmapplyrecoverypointinput.go
@@ -1,0 +1,41 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ApplyRecoveryPointProviderSpecificInput = InMageRcmApplyRecoveryPointInput{}
+
+type InMageRcmApplyRecoveryPointInput struct {
+	RecoveryPointId string `json:"recoveryPointId"`
+
+	// Fields inherited from ApplyRecoveryPointProviderSpecificInput
+}
+
+var _ json.Marshaler = InMageRcmApplyRecoveryPointInput{}
+
+func (s InMageRcmApplyRecoveryPointInput) MarshalJSON() ([]byte, error) {
+	type wrapper InMageRcmApplyRecoveryPointInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling InMageRcmApplyRecoveryPointInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling InMageRcmApplyRecoveryPointInput: %+v", err)
+	}
+	decoded["instanceType"] = "InMageRcm"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling InMageRcmApplyRecoveryPointInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmagercmdiscoveredprotectedvmdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmagercmdiscoveredprotectedvmdetails.go
@@ -1,0 +1,61 @@
+package replicationprotecteditems
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type InMageRcmDiscoveredProtectedVmDetails struct {
+	CreatedTimestamp       *string   `json:"createdTimestamp,omitempty"`
+	DataStores             *[]string `json:"datastores,omitempty"`
+	IPAddresses            *[]string `json:"ipAddresses,omitempty"`
+	IsDeleted              *bool     `json:"isDeleted,omitempty"`
+	LastDiscoveryTimeInUtc *string   `json:"lastDiscoveryTimeInUtc,omitempty"`
+	OsName                 *string   `json:"osName,omitempty"`
+	PowerStatus            *string   `json:"powerStatus,omitempty"`
+	UpdatedTimestamp       *string   `json:"updatedTimestamp,omitempty"`
+	VCenterFqdn            *string   `json:"vCenterFqdn,omitempty"`
+	VCenterId              *string   `json:"vCenterId,omitempty"`
+	VmFqdn                 *string   `json:"vmFqdn,omitempty"`
+	VmwareToolsStatus      *string   `json:"vmwareToolsStatus,omitempty"`
+}
+
+func (o *InMageRcmDiscoveredProtectedVmDetails) GetCreatedTimestampAsTime() (*time.Time, error) {
+	if o.CreatedTimestamp == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.CreatedTimestamp, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *InMageRcmDiscoveredProtectedVmDetails) SetCreatedTimestampAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.CreatedTimestamp = &formatted
+}
+
+func (o *InMageRcmDiscoveredProtectedVmDetails) GetLastDiscoveryTimeInUtcAsTime() (*time.Time, error) {
+	if o.LastDiscoveryTimeInUtc == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.LastDiscoveryTimeInUtc, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *InMageRcmDiscoveredProtectedVmDetails) SetLastDiscoveryTimeInUtcAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.LastDiscoveryTimeInUtc = &formatted
+}
+
+func (o *InMageRcmDiscoveredProtectedVmDetails) GetUpdatedTimestampAsTime() (*time.Time, error) {
+	if o.UpdatedTimestamp == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.UpdatedTimestamp, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *InMageRcmDiscoveredProtectedVmDetails) SetUpdatedTimestampAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.UpdatedTimestamp = &formatted
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmagercmdiskinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmagercmdiskinput.go
@@ -1,0 +1,11 @@
+package replicationprotecteditems
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type InMageRcmDiskInput struct {
+	DiskEncryptionSetId *string         `json:"diskEncryptionSetId,omitempty"`
+	DiskId              string          `json:"diskId"`
+	DiskType            DiskAccountType `json:"diskType"`
+	LogStorageAccountId string          `json:"logStorageAccountId"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmagercmdisksdefaultinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmagercmdisksdefaultinput.go
@@ -1,0 +1,10 @@
+package replicationprotecteditems
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type InMageRcmDisksDefaultInput struct {
+	DiskEncryptionSetId *string         `json:"diskEncryptionSetId,omitempty"`
+	DiskType            DiskAccountType `json:"diskType"`
+	LogStorageAccountId string          `json:"logStorageAccountId"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmagercmenableprotectioninput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmagercmenableprotectioninput.go
@@ -1,0 +1,58 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ EnableProtectionProviderSpecificInput = InMageRcmEnableProtectionInput{}
+
+type InMageRcmEnableProtectionInput struct {
+	DisksDefault                          *InMageRcmDisksDefaultInput `json:"disksDefault,omitempty"`
+	DisksToInclude                        *[]InMageRcmDiskInput       `json:"disksToInclude,omitempty"`
+	FabricDiscoveryMachineId              string                      `json:"fabricDiscoveryMachineId"`
+	LicenseType                           *LicenseType                `json:"licenseType,omitempty"`
+	MultiVmGroupName                      *string                     `json:"multiVmGroupName,omitempty"`
+	ProcessServerId                       string                      `json:"processServerId"`
+	RunAsAccountId                        *string                     `json:"runAsAccountId,omitempty"`
+	TargetAvailabilitySetId               *string                     `json:"targetAvailabilitySetId,omitempty"`
+	TargetAvailabilityZone                *string                     `json:"targetAvailabilityZone,omitempty"`
+	TargetBootDiagnosticsStorageAccountId *string                     `json:"targetBootDiagnosticsStorageAccountId,omitempty"`
+	TargetNetworkId                       *string                     `json:"targetNetworkId,omitempty"`
+	TargetProximityPlacementGroupId       *string                     `json:"targetProximityPlacementGroupId,omitempty"`
+	TargetResourceGroupId                 string                      `json:"targetResourceGroupId"`
+	TargetSubnetName                      *string                     `json:"targetSubnetName,omitempty"`
+	TargetVmName                          *string                     `json:"targetVmName,omitempty"`
+	TargetVmSize                          *string                     `json:"targetVmSize,omitempty"`
+	TestNetworkId                         *string                     `json:"testNetworkId,omitempty"`
+	TestSubnetName                        *string                     `json:"testSubnetName,omitempty"`
+
+	// Fields inherited from EnableProtectionProviderSpecificInput
+}
+
+var _ json.Marshaler = InMageRcmEnableProtectionInput{}
+
+func (s InMageRcmEnableProtectionInput) MarshalJSON() ([]byte, error) {
+	type wrapper InMageRcmEnableProtectionInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling InMageRcmEnableProtectionInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling InMageRcmEnableProtectionInput: %+v", err)
+	}
+	decoded["instanceType"] = "InMageRcm"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling InMageRcmEnableProtectionInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmagercmfailbackdiscoveredprotectedvmdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmagercmfailbackdiscoveredprotectedvmdetails.go
@@ -1,0 +1,61 @@
+package replicationprotecteditems
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type InMageRcmFailbackDiscoveredProtectedVmDetails struct {
+	CreatedTimestamp       *string   `json:"createdTimestamp,omitempty"`
+	DataStores             *[]string `json:"datastores,omitempty"`
+	IPAddresses            *[]string `json:"ipAddresses,omitempty"`
+	IsDeleted              *bool     `json:"isDeleted,omitempty"`
+	LastDiscoveryTimeInUtc *string   `json:"lastDiscoveryTimeInUtc,omitempty"`
+	OsName                 *string   `json:"osName,omitempty"`
+	PowerStatus            *string   `json:"powerStatus,omitempty"`
+	UpdatedTimestamp       *string   `json:"updatedTimestamp,omitempty"`
+	VCenterFqdn            *string   `json:"vCenterFqdn,omitempty"`
+	VCenterId              *string   `json:"vCenterId,omitempty"`
+	VmFqdn                 *string   `json:"vmFqdn,omitempty"`
+	VmwareToolsStatus      *string   `json:"vmwareToolsStatus,omitempty"`
+}
+
+func (o *InMageRcmFailbackDiscoveredProtectedVmDetails) GetCreatedTimestampAsTime() (*time.Time, error) {
+	if o.CreatedTimestamp == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.CreatedTimestamp, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *InMageRcmFailbackDiscoveredProtectedVmDetails) SetCreatedTimestampAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.CreatedTimestamp = &formatted
+}
+
+func (o *InMageRcmFailbackDiscoveredProtectedVmDetails) GetLastDiscoveryTimeInUtcAsTime() (*time.Time, error) {
+	if o.LastDiscoveryTimeInUtc == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.LastDiscoveryTimeInUtc, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *InMageRcmFailbackDiscoveredProtectedVmDetails) SetLastDiscoveryTimeInUtcAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.LastDiscoveryTimeInUtc = &formatted
+}
+
+func (o *InMageRcmFailbackDiscoveredProtectedVmDetails) GetUpdatedTimestampAsTime() (*time.Time, error) {
+	if o.UpdatedTimestamp == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.UpdatedTimestamp, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *InMageRcmFailbackDiscoveredProtectedVmDetails) SetUpdatedTimestampAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.UpdatedTimestamp = &formatted
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmagercmfailbackmobilityagentdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmagercmfailbackmobilityagentdetails.go
@@ -1,0 +1,58 @@
+package replicationprotecteditems
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type InMageRcmFailbackMobilityAgentDetails struct {
+	AgentVersionExpiryDate               *string                      `json:"agentVersionExpiryDate,omitempty"`
+	DriverVersion                        *string                      `json:"driverVersion,omitempty"`
+	DriverVersionExpiryDate              *string                      `json:"driverVersionExpiryDate,omitempty"`
+	IsUpgradeable                        *string                      `json:"isUpgradeable,omitempty"`
+	LastHeartbeatUtc                     *string                      `json:"lastHeartbeatUtc,omitempty"`
+	LatestUpgradableVersionWithoutReboot *string                      `json:"latestUpgradableVersionWithoutReboot,omitempty"`
+	LatestVersion                        *string                      `json:"latestVersion,omitempty"`
+	ReasonsBlockingUpgrade               *[]AgentUpgradeBlockedReason `json:"reasonsBlockingUpgrade,omitempty"`
+	Version                              *string                      `json:"version,omitempty"`
+}
+
+func (o *InMageRcmFailbackMobilityAgentDetails) GetAgentVersionExpiryDateAsTime() (*time.Time, error) {
+	if o.AgentVersionExpiryDate == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.AgentVersionExpiryDate, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *InMageRcmFailbackMobilityAgentDetails) SetAgentVersionExpiryDateAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.AgentVersionExpiryDate = &formatted
+}
+
+func (o *InMageRcmFailbackMobilityAgentDetails) GetDriverVersionExpiryDateAsTime() (*time.Time, error) {
+	if o.DriverVersionExpiryDate == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.DriverVersionExpiryDate, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *InMageRcmFailbackMobilityAgentDetails) SetDriverVersionExpiryDateAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.DriverVersionExpiryDate = &formatted
+}
+
+func (o *InMageRcmFailbackMobilityAgentDetails) GetLastHeartbeatUtcAsTime() (*time.Time, error) {
+	if o.LastHeartbeatUtc == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.LastHeartbeatUtc, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *InMageRcmFailbackMobilityAgentDetails) SetLastHeartbeatUtcAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.LastHeartbeatUtc = &formatted
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmagercmfailbacknicdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmagercmfailbacknicdetails.go
@@ -1,0 +1,11 @@
+package replicationprotecteditems
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type InMageRcmFailbackNicDetails struct {
+	AdapterType     *string `json:"adapterType,omitempty"`
+	MacAddress      *string `json:"macAddress,omitempty"`
+	NetworkName     *string `json:"networkName,omitempty"`
+	SourceIPAddress *string `json:"sourceIpAddress,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmagercmfailbackplannedfailoverproviderinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmagercmfailbackplannedfailoverproviderinput.go
@@ -1,0 +1,41 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ PlannedFailoverProviderSpecificFailoverInput = InMageRcmFailbackPlannedFailoverProviderInput{}
+
+type InMageRcmFailbackPlannedFailoverProviderInput struct {
+	RecoveryPointType InMageRcmFailbackRecoveryPointType `json:"recoveryPointType"`
+
+	// Fields inherited from PlannedFailoverProviderSpecificFailoverInput
+}
+
+var _ json.Marshaler = InMageRcmFailbackPlannedFailoverProviderInput{}
+
+func (s InMageRcmFailbackPlannedFailoverProviderInput) MarshalJSON() ([]byte, error) {
+	type wrapper InMageRcmFailbackPlannedFailoverProviderInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling InMageRcmFailbackPlannedFailoverProviderInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling InMageRcmFailbackPlannedFailoverProviderInput: %+v", err)
+	}
+	decoded["instanceType"] = "InMageRcmFailback"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling InMageRcmFailbackPlannedFailoverProviderInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmagercmfailbackprotecteddiskdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmagercmfailbackprotecteddiskdetails.go
@@ -1,0 +1,36 @@
+package replicationprotecteditems
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type InMageRcmFailbackProtectedDiskDetails struct {
+	CapacityInBytes               *int64                        `json:"capacityInBytes,omitempty"`
+	DataPendingAtSourceAgentInMB  *float64                      `json:"dataPendingAtSourceAgentInMB,omitempty"`
+	DataPendingInLogDataStoreInMB *float64                      `json:"dataPendingInLogDataStoreInMB,omitempty"`
+	DiskId                        *string                       `json:"diskId,omitempty"`
+	DiskName                      *string                       `json:"diskName,omitempty"`
+	DiskUuid                      *string                       `json:"diskUuid,omitempty"`
+	IrDetails                     *InMageRcmFailbackSyncDetails `json:"irDetails,omitempty"`
+	IsInitialReplicationComplete  *string                       `json:"isInitialReplicationComplete,omitempty"`
+	IsOSDisk                      *string                       `json:"isOSDisk,omitempty"`
+	LastSyncTime                  *string                       `json:"lastSyncTime,omitempty"`
+	ResyncDetails                 *InMageRcmFailbackSyncDetails `json:"resyncDetails,omitempty"`
+}
+
+func (o *InMageRcmFailbackProtectedDiskDetails) GetLastSyncTimeAsTime() (*time.Time, error) {
+	if o.LastSyncTime == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.LastSyncTime, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *InMageRcmFailbackProtectedDiskDetails) SetLastSyncTimeAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.LastSyncTime = &formatted
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmagercmfailbackreplicationdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmagercmfailbackreplicationdetails.go
@@ -1,0 +1,69 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ReplicationProviderSpecificSettings = InMageRcmFailbackReplicationDetails{}
+
+type InMageRcmFailbackReplicationDetails struct {
+	AzureVirtualMachineId                      *string                                        `json:"azureVirtualMachineId,omitempty"`
+	DiscoveredVmDetails                        *InMageRcmFailbackDiscoveredProtectedVmDetails `json:"discoveredVmDetails,omitempty"`
+	InitialReplicationProcessedBytes           *int64                                         `json:"initialReplicationProcessedBytes,omitempty"`
+	InitialReplicationProgressHealth           *VmReplicationProgressHealth                   `json:"initialReplicationProgressHealth,omitempty"`
+	InitialReplicationProgressPercentage       *int64                                         `json:"initialReplicationProgressPercentage,omitempty"`
+	InitialReplicationTransferredBytes         *int64                                         `json:"initialReplicationTransferredBytes,omitempty"`
+	InternalIdentifier                         *string                                        `json:"internalIdentifier,omitempty"`
+	IsAgentRegistrationSuccessfulAfterFailover *bool                                          `json:"isAgentRegistrationSuccessfulAfterFailover,omitempty"`
+	LastPlannedFailoverStartTime               *string                                        `json:"lastPlannedFailoverStartTime,omitempty"`
+	LastPlannedFailoverStatus                  *PlannedFailoverStatus                         `json:"lastPlannedFailoverStatus,omitempty"`
+	LastUsedPolicyFriendlyName                 *string                                        `json:"lastUsedPolicyFriendlyName,omitempty"`
+	LastUsedPolicyId                           *string                                        `json:"lastUsedPolicyId,omitempty"`
+	LogStorageAccountId                        *string                                        `json:"logStorageAccountId,omitempty"`
+	MobilityAgentDetails                       *InMageRcmFailbackMobilityAgentDetails         `json:"mobilityAgentDetails,omitempty"`
+	MultiVmGroupName                           *string                                        `json:"multiVmGroupName,omitempty"`
+	OsType                                     *string                                        `json:"osType,omitempty"`
+	ProtectedDisks                             *[]InMageRcmFailbackProtectedDiskDetails       `json:"protectedDisks,omitempty"`
+	ReprotectAgentId                           *string                                        `json:"reprotectAgentId,omitempty"`
+	ReprotectAgentName                         *string                                        `json:"reprotectAgentName,omitempty"`
+	ResyncProcessedBytes                       *int64                                         `json:"resyncProcessedBytes,omitempty"`
+	ResyncProgressHealth                       *VmReplicationProgressHealth                   `json:"resyncProgressHealth,omitempty"`
+	ResyncProgressPercentage                   *int64                                         `json:"resyncProgressPercentage,omitempty"`
+	ResyncRequired                             *string                                        `json:"resyncRequired,omitempty"`
+	ResyncState                                *ResyncState                                   `json:"resyncState,omitempty"`
+	ResyncTransferredBytes                     *int64                                         `json:"resyncTransferredBytes,omitempty"`
+	TargetDataStoreName                        *string                                        `json:"targetDataStoreName,omitempty"`
+	TargetVmName                               *string                                        `json:"targetVmName,omitempty"`
+	TargetvCenterId                            *string                                        `json:"targetvCenterId,omitempty"`
+	VmNics                                     *[]InMageRcmFailbackNicDetails                 `json:"vmNics,omitempty"`
+
+	// Fields inherited from ReplicationProviderSpecificSettings
+}
+
+var _ json.Marshaler = InMageRcmFailbackReplicationDetails{}
+
+func (s InMageRcmFailbackReplicationDetails) MarshalJSON() ([]byte, error) {
+	type wrapper InMageRcmFailbackReplicationDetails
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling InMageRcmFailbackReplicationDetails: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling InMageRcmFailbackReplicationDetails: %+v", err)
+	}
+	decoded["instanceType"] = "InMageRcmFailback"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling InMageRcmFailbackReplicationDetails: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmagercmfailbackreprotectinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmagercmfailbackreprotectinput.go
@@ -1,0 +1,43 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ReverseReplicationProviderSpecificInput = InMageRcmFailbackReprotectInput{}
+
+type InMageRcmFailbackReprotectInput struct {
+	PolicyId        string  `json:"policyId"`
+	ProcessServerId string  `json:"processServerId"`
+	RunAsAccountId  *string `json:"runAsAccountId,omitempty"`
+
+	// Fields inherited from ReverseReplicationProviderSpecificInput
+}
+
+var _ json.Marshaler = InMageRcmFailbackReprotectInput{}
+
+func (s InMageRcmFailbackReprotectInput) MarshalJSON() ([]byte, error) {
+	type wrapper InMageRcmFailbackReprotectInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling InMageRcmFailbackReprotectInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling InMageRcmFailbackReprotectInput: %+v", err)
+	}
+	decoded["instanceType"] = "InMageRcmFailback"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling InMageRcmFailbackReprotectInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmagercmfailbacksyncdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmagercmfailbacksyncdetails.go
@@ -1,0 +1,15 @@
+package replicationprotecteditems
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type InMageRcmFailbackSyncDetails struct {
+	Last15MinutesTransferredBytes *int64                         `json:"last15MinutesTransferredBytes,omitempty"`
+	LastDataTransferTimeUtc       *string                        `json:"lastDataTransferTimeUtc,omitempty"`
+	LastRefreshTime               *string                        `json:"lastRefreshTime,omitempty"`
+	ProcessedBytes                *int64                         `json:"processedBytes,omitempty"`
+	ProgressHealth                *DiskReplicationProgressHealth `json:"progressHealth,omitempty"`
+	ProgressPercentage            *int64                         `json:"progressPercentage,omitempty"`
+	StartTime                     *string                        `json:"startTime,omitempty"`
+	TransferredBytes              *int64                         `json:"transferredBytes,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmagercmlastagentupgradeerrordetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmagercmlastagentupgradeerrordetails.go
@@ -1,0 +1,13 @@
+package replicationprotecteditems
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type InMageRcmLastAgentUpgradeErrorDetails struct {
+	ErrorCode              *string            `json:"errorCode,omitempty"`
+	ErrorMessage           *string            `json:"errorMessage,omitempty"`
+	ErrorMessageParameters *map[string]string `json:"errorMessageParameters,omitempty"`
+	ErrorTags              *map[string]string `json:"errorTags,omitempty"`
+	PossibleCauses         *string            `json:"possibleCauses,omitempty"`
+	RecommendedAction      *string            `json:"recommendedAction,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmagercmmobilityagentdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmagercmmobilityagentdetails.go
@@ -1,0 +1,59 @@
+package replicationprotecteditems
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type InMageRcmMobilityAgentDetails struct {
+	AgentVersionExpiryDate               *string                      `json:"agentVersionExpiryDate,omitempty"`
+	DriverVersion                        *string                      `json:"driverVersion,omitempty"`
+	DriverVersionExpiryDate              *string                      `json:"driverVersionExpiryDate,omitempty"`
+	IsUpgradeable                        *string                      `json:"isUpgradeable,omitempty"`
+	LastHeartbeatUtc                     *string                      `json:"lastHeartbeatUtc,omitempty"`
+	LatestAgentReleaseDate               *string                      `json:"latestAgentReleaseDate,omitempty"`
+	LatestUpgradableVersionWithoutReboot *string                      `json:"latestUpgradableVersionWithoutReboot,omitempty"`
+	LatestVersion                        *string                      `json:"latestVersion,omitempty"`
+	ReasonsBlockingUpgrade               *[]AgentUpgradeBlockedReason `json:"reasonsBlockingUpgrade,omitempty"`
+	Version                              *string                      `json:"version,omitempty"`
+}
+
+func (o *InMageRcmMobilityAgentDetails) GetAgentVersionExpiryDateAsTime() (*time.Time, error) {
+	if o.AgentVersionExpiryDate == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.AgentVersionExpiryDate, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *InMageRcmMobilityAgentDetails) SetAgentVersionExpiryDateAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.AgentVersionExpiryDate = &formatted
+}
+
+func (o *InMageRcmMobilityAgentDetails) GetDriverVersionExpiryDateAsTime() (*time.Time, error) {
+	if o.DriverVersionExpiryDate == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.DriverVersionExpiryDate, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *InMageRcmMobilityAgentDetails) SetDriverVersionExpiryDateAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.DriverVersionExpiryDate = &formatted
+}
+
+func (o *InMageRcmMobilityAgentDetails) GetLastHeartbeatUtcAsTime() (*time.Time, error) {
+	if o.LastHeartbeatUtc == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.LastHeartbeatUtc, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *InMageRcmMobilityAgentDetails) SetLastHeartbeatUtcAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.LastHeartbeatUtc = &formatted
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmagercmnicdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmagercmnicdetails.go
@@ -1,0 +1,20 @@
+package replicationprotecteditems
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type InMageRcmNicDetails struct {
+	IsPrimaryNic          *string              `json:"isPrimaryNic,omitempty"`
+	IsSelectedForFailover *string              `json:"isSelectedForFailover,omitempty"`
+	NicId                 *string              `json:"nicId,omitempty"`
+	SourceIPAddress       *string              `json:"sourceIPAddress,omitempty"`
+	SourceIPAddressType   *EthernetAddressType `json:"sourceIPAddressType,omitempty"`
+	SourceNetworkId       *string              `json:"sourceNetworkId,omitempty"`
+	SourceSubnetName      *string              `json:"sourceSubnetName,omitempty"`
+	TargetIPAddress       *string              `json:"targetIPAddress,omitempty"`
+	TargetIPAddressType   *EthernetAddressType `json:"targetIPAddressType,omitempty"`
+	TargetSubnetName      *string              `json:"targetSubnetName,omitempty"`
+	TestIPAddress         *string              `json:"testIPAddress,omitempty"`
+	TestIPAddressType     *EthernetAddressType `json:"testIPAddressType,omitempty"`
+	TestSubnetName        *string              `json:"testSubnetName,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmagercmnicinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmagercmnicinput.go
@@ -1,0 +1,14 @@
+package replicationprotecteditems
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type InMageRcmNicInput struct {
+	IsPrimaryNic          string  `json:"isPrimaryNic"`
+	IsSelectedForFailover *string `json:"isSelectedForFailover,omitempty"`
+	NicId                 string  `json:"nicId"`
+	TargetStaticIPAddress *string `json:"targetStaticIPAddress,omitempty"`
+	TargetSubnetName      *string `json:"targetSubnetName,omitempty"`
+	TestStaticIPAddress   *string `json:"testStaticIPAddress,omitempty"`
+	TestSubnetName        *string `json:"testSubnetName,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmagercmprotecteddiskdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmagercmprotecteddiskdetails.go
@@ -1,0 +1,22 @@
+package replicationprotecteditems
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type InMageRcmProtectedDiskDetails struct {
+	CapacityInBytes               *int64                `json:"capacityInBytes,omitempty"`
+	DataPendingAtSourceAgentInMB  *float64              `json:"dataPendingAtSourceAgentInMB,omitempty"`
+	DataPendingInLogDataStoreInMB *float64              `json:"dataPendingInLogDataStoreInMB,omitempty"`
+	DiskEncryptionSetId           *string               `json:"diskEncryptionSetId,omitempty"`
+	DiskId                        *string               `json:"diskId,omitempty"`
+	DiskName                      *string               `json:"diskName,omitempty"`
+	DiskType                      *DiskAccountType      `json:"diskType,omitempty"`
+	IrDetails                     *InMageRcmSyncDetails `json:"irDetails,omitempty"`
+	IsInitialReplicationComplete  *string               `json:"isInitialReplicationComplete,omitempty"`
+	IsOSDisk                      *string               `json:"isOSDisk,omitempty"`
+	LogStorageAccountId           *string               `json:"logStorageAccountId,omitempty"`
+	ResyncDetails                 *InMageRcmSyncDetails `json:"resyncDetails,omitempty"`
+	SeedBlobUri                   *string               `json:"seedBlobUri,omitempty"`
+	SeedManagedDiskId             *string               `json:"seedManagedDiskId,omitempty"`
+	TargetManagedDiskId           *string               `json:"targetManagedDiskId,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmagercmreplicationdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmagercmreplicationdetails.go
@@ -1,0 +1,92 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ReplicationProviderSpecificSettings = InMageRcmReplicationDetails{}
+
+type InMageRcmReplicationDetails struct {
+	AgentUpgradeAttemptToVersion               *string                                      `json:"agentUpgradeAttemptToVersion,omitempty"`
+	AgentUpgradeBlockingErrorDetails           *[]InMageRcmAgentUpgradeBlockingErrorDetails `json:"agentUpgradeBlockingErrorDetails,omitempty"`
+	AgentUpgradeJobId                          *string                                      `json:"agentUpgradeJobId,omitempty"`
+	AgentUpgradeState                          *MobilityAgentUpgradeState                   `json:"agentUpgradeState,omitempty"`
+	AllocatedMemoryInMB                        *float64                                     `json:"allocatedMemoryInMB,omitempty"`
+	DiscoveredVmDetails                        *InMageRcmDiscoveredProtectedVmDetails       `json:"discoveredVmDetails,omitempty"`
+	DiscoveryType                              *string                                      `json:"discoveryType,omitempty"`
+	FabricDiscoveryMachineId                   *string                                      `json:"fabricDiscoveryMachineId,omitempty"`
+	FailoverRecoveryPointId                    *string                                      `json:"failoverRecoveryPointId,omitempty"`
+	FirmwareType                               *string                                      `json:"firmwareType,omitempty"`
+	InitialReplicationProcessedBytes           *int64                                       `json:"initialReplicationProcessedBytes,omitempty"`
+	InitialReplicationProgressHealth           *VmReplicationProgressHealth                 `json:"initialReplicationProgressHealth,omitempty"`
+	InitialReplicationProgressPercentage       *int64                                       `json:"initialReplicationProgressPercentage,omitempty"`
+	InitialReplicationTransferredBytes         *int64                                       `json:"initialReplicationTransferredBytes,omitempty"`
+	InternalIdentifier                         *string                                      `json:"internalIdentifier,omitempty"`
+	IsAgentRegistrationSuccessfulAfterFailover *bool                                        `json:"isAgentRegistrationSuccessfulAfterFailover,omitempty"`
+	IsLastUpgradeSuccessful                    *string                                      `json:"isLastUpgradeSuccessful,omitempty"`
+	LastAgentUpgradeErrorDetails               *[]InMageRcmLastAgentUpgradeErrorDetails     `json:"lastAgentUpgradeErrorDetails,omitempty"`
+	LastAgentUpgradeType                       *string                                      `json:"lastAgentUpgradeType,omitempty"`
+	LastRecoveryPointId                        *string                                      `json:"lastRecoveryPointId,omitempty"`
+	LastRecoveryPointReceived                  *string                                      `json:"lastRecoveryPointReceived,omitempty"`
+	LastRpoCalculatedTime                      *string                                      `json:"lastRpoCalculatedTime,omitempty"`
+	LastRpoInSeconds                           *int64                                       `json:"lastRpoInSeconds,omitempty"`
+	LicenseType                                *string                                      `json:"licenseType,omitempty"`
+	MobilityAgentDetails                       *InMageRcmMobilityAgentDetails               `json:"mobilityAgentDetails,omitempty"`
+	MultiVmGroupName                           *string                                      `json:"multiVmGroupName,omitempty"`
+	OsType                                     *string                                      `json:"osType,omitempty"`
+	PrimaryNicIPAddress                        *string                                      `json:"primaryNicIpAddress,omitempty"`
+	ProcessServerId                            *string                                      `json:"processServerId,omitempty"`
+	ProcessServerName                          *string                                      `json:"processServerName,omitempty"`
+	ProcessorCoreCount                         *int64                                       `json:"processorCoreCount,omitempty"`
+	ProtectedDisks                             *[]InMageRcmProtectedDiskDetails             `json:"protectedDisks,omitempty"`
+	ResyncProcessedBytes                       *int64                                       `json:"resyncProcessedBytes,omitempty"`
+	ResyncProgressHealth                       *VmReplicationProgressHealth                 `json:"resyncProgressHealth,omitempty"`
+	ResyncProgressPercentage                   *int64                                       `json:"resyncProgressPercentage,omitempty"`
+	ResyncRequired                             *string                                      `json:"resyncRequired,omitempty"`
+	ResyncState                                *ResyncState                                 `json:"resyncState,omitempty"`
+	ResyncTransferredBytes                     *int64                                       `json:"resyncTransferredBytes,omitempty"`
+	RunAsAccountId                             *string                                      `json:"runAsAccountId,omitempty"`
+	StorageAccountId                           *string                                      `json:"storageAccountId,omitempty"`
+	TargetAvailabilitySetId                    *string                                      `json:"targetAvailabilitySetId,omitempty"`
+	TargetAvailabilityZone                     *string                                      `json:"targetAvailabilityZone,omitempty"`
+	TargetBootDiagnosticsStorageAccountId      *string                                      `json:"targetBootDiagnosticsStorageAccountId,omitempty"`
+	TargetGeneration                           *string                                      `json:"targetGeneration,omitempty"`
+	TargetLocation                             *string                                      `json:"targetLocation,omitempty"`
+	TargetNetworkId                            *string                                      `json:"targetNetworkId,omitempty"`
+	TargetProximityPlacementGroupId            *string                                      `json:"targetProximityPlacementGroupId,omitempty"`
+	TargetResourceGroupId                      *string                                      `json:"targetResourceGroupId,omitempty"`
+	TargetVmName                               *string                                      `json:"targetVmName,omitempty"`
+	TargetVmSize                               *string                                      `json:"targetVmSize,omitempty"`
+	TestNetworkId                              *string                                      `json:"testNetworkId,omitempty"`
+	VmNics                                     *[]InMageRcmNicDetails                       `json:"vmNics,omitempty"`
+
+	// Fields inherited from ReplicationProviderSpecificSettings
+}
+
+var _ json.Marshaler = InMageRcmReplicationDetails{}
+
+func (s InMageRcmReplicationDetails) MarshalJSON() ([]byte, error) {
+	type wrapper InMageRcmReplicationDetails
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling InMageRcmReplicationDetails: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling InMageRcmReplicationDetails: %+v", err)
+	}
+	decoded["instanceType"] = "InMageRcm"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling InMageRcmReplicationDetails: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmagercmreprotectinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmagercmreprotectinput.go
@@ -1,0 +1,44 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ReverseReplicationProviderSpecificInput = InMageRcmReprotectInput{}
+
+type InMageRcmReprotectInput struct {
+	DatastoreName       string  `json:"datastoreName"`
+	LogStorageAccountId string  `json:"logStorageAccountId"`
+	PolicyId            *string `json:"policyId,omitempty"`
+	ReprotectAgentId    string  `json:"reprotectAgentId"`
+
+	// Fields inherited from ReverseReplicationProviderSpecificInput
+}
+
+var _ json.Marshaler = InMageRcmReprotectInput{}
+
+func (s InMageRcmReprotectInput) MarshalJSON() ([]byte, error) {
+	type wrapper InMageRcmReprotectInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling InMageRcmReprotectInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling InMageRcmReprotectInput: %+v", err)
+	}
+	decoded["instanceType"] = "InMageRcm"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling InMageRcmReprotectInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmagercmsyncdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmagercmsyncdetails.go
@@ -1,0 +1,15 @@
+package replicationprotecteditems
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type InMageRcmSyncDetails struct {
+	Last15MinutesTransferredBytes *int64                         `json:"last15MinutesTransferredBytes,omitempty"`
+	LastDataTransferTimeUtc       *string                        `json:"lastDataTransferTimeUtc,omitempty"`
+	LastRefreshTime               *string                        `json:"lastRefreshTime,omitempty"`
+	ProcessedBytes                *int64                         `json:"processedBytes,omitempty"`
+	ProgressHealth                *DiskReplicationProgressHealth `json:"progressHealth,omitempty"`
+	ProgressPercentage            *int64                         `json:"progressPercentage,omitempty"`
+	StartTime                     *string                        `json:"startTime,omitempty"`
+	TransferredBytes              *int64                         `json:"transferredBytes,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmagercmtestfailoverinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmagercmtestfailoverinput.go
@@ -1,0 +1,42 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ TestFailoverProviderSpecificInput = InMageRcmTestFailoverInput{}
+
+type InMageRcmTestFailoverInput struct {
+	NetworkId       *string `json:"networkId,omitempty"`
+	RecoveryPointId *string `json:"recoveryPointId,omitempty"`
+
+	// Fields inherited from TestFailoverProviderSpecificInput
+}
+
+var _ json.Marshaler = InMageRcmTestFailoverInput{}
+
+func (s InMageRcmTestFailoverInput) MarshalJSON() ([]byte, error) {
+	type wrapper InMageRcmTestFailoverInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling InMageRcmTestFailoverInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling InMageRcmTestFailoverInput: %+v", err)
+	}
+	decoded["instanceType"] = "InMageRcm"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling InMageRcmTestFailoverInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmagercmunplannedfailoverinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmagercmunplannedfailoverinput.go
@@ -1,0 +1,42 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ UnplannedFailoverProviderSpecificInput = InMageRcmUnplannedFailoverInput{}
+
+type InMageRcmUnplannedFailoverInput struct {
+	PerformShutdown string  `json:"performShutdown"`
+	RecoveryPointId *string `json:"recoveryPointId,omitempty"`
+
+	// Fields inherited from UnplannedFailoverProviderSpecificInput
+}
+
+var _ json.Marshaler = InMageRcmUnplannedFailoverInput{}
+
+func (s InMageRcmUnplannedFailoverInput) MarshalJSON() ([]byte, error) {
+	type wrapper InMageRcmUnplannedFailoverInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling InMageRcmUnplannedFailoverInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling InMageRcmUnplannedFailoverInput: %+v", err)
+	}
+	decoded["instanceType"] = "InMageRcm"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling InMageRcmUnplannedFailoverInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmagercmupdateapplianceforreplicationprotectediteminput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmagercmupdateapplianceforreplicationprotectediteminput.go
@@ -1,0 +1,41 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ UpdateApplianceForReplicationProtectedItemProviderSpecificInput = InMageRcmUpdateApplianceForReplicationProtectedItemInput{}
+
+type InMageRcmUpdateApplianceForReplicationProtectedItemInput struct {
+	RunAsAccountId *string `json:"runAsAccountId,omitempty"`
+
+	// Fields inherited from UpdateApplianceForReplicationProtectedItemProviderSpecificInput
+}
+
+var _ json.Marshaler = InMageRcmUpdateApplianceForReplicationProtectedItemInput{}
+
+func (s InMageRcmUpdateApplianceForReplicationProtectedItemInput) MarshalJSON() ([]byte, error) {
+	type wrapper InMageRcmUpdateApplianceForReplicationProtectedItemInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling InMageRcmUpdateApplianceForReplicationProtectedItemInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling InMageRcmUpdateApplianceForReplicationProtectedItemInput: %+v", err)
+	}
+	decoded["instanceType"] = "InMageRcm"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling InMageRcmUpdateApplianceForReplicationProtectedItemInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmagercmupdatereplicationprotectediteminput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmagercmupdatereplicationprotectediteminput.go
@@ -1,0 +1,51 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ UpdateReplicationProtectedItemProviderInput = InMageRcmUpdateReplicationProtectedItemInput{}
+
+type InMageRcmUpdateReplicationProtectedItemInput struct {
+	LicenseType                           *LicenseType         `json:"licenseType,omitempty"`
+	TargetAvailabilitySetId               *string              `json:"targetAvailabilitySetId,omitempty"`
+	TargetAvailabilityZone                *string              `json:"targetAvailabilityZone,omitempty"`
+	TargetBootDiagnosticsStorageAccountId *string              `json:"targetBootDiagnosticsStorageAccountId,omitempty"`
+	TargetNetworkId                       *string              `json:"targetNetworkId,omitempty"`
+	TargetProximityPlacementGroupId       *string              `json:"targetProximityPlacementGroupId,omitempty"`
+	TargetResourceGroupId                 *string              `json:"targetResourceGroupId,omitempty"`
+	TargetVmName                          *string              `json:"targetVmName,omitempty"`
+	TargetVmSize                          *string              `json:"targetVmSize,omitempty"`
+	TestNetworkId                         *string              `json:"testNetworkId,omitempty"`
+	VmNics                                *[]InMageRcmNicInput `json:"vmNics,omitempty"`
+
+	// Fields inherited from UpdateReplicationProtectedItemProviderInput
+}
+
+var _ json.Marshaler = InMageRcmUpdateReplicationProtectedItemInput{}
+
+func (s InMageRcmUpdateReplicationProtectedItemInput) MarshalJSON() ([]byte, error) {
+	type wrapper InMageRcmUpdateReplicationProtectedItemInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling InMageRcmUpdateReplicationProtectedItemInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling InMageRcmUpdateReplicationProtectedItemInput: %+v", err)
+	}
+	decoded["instanceType"] = "InMageRcm"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling InMageRcmUpdateReplicationProtectedItemInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmagereplicationdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmagereplicationdetails.go
@@ -1,0 +1,80 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ReplicationProviderSpecificSettings = InMageReplicationDetails{}
+
+type InMageReplicationDetails struct {
+	ActiveSiteType               *string                       `json:"activeSiteType,omitempty"`
+	AgentDetails                 *InMageAgentDetails           `json:"agentDetails,omitempty"`
+	AzureStorageAccountId        *string                       `json:"azureStorageAccountId,omitempty"`
+	CompressedDataRateInMB       *float64                      `json:"compressedDataRateInMB,omitempty"`
+	ConsistencyPoints            *map[string]string            `json:"consistencyPoints,omitempty"`
+	DataStores                   *[]string                     `json:"datastores,omitempty"`
+	DiscoveryType                *string                       `json:"discoveryType,omitempty"`
+	DiskResized                  *string                       `json:"diskResized,omitempty"`
+	IPAddress                    *string                       `json:"ipAddress,omitempty"`
+	InfrastructureVmId           *string                       `json:"infrastructureVmId,omitempty"`
+	IsAdditionalStatsAvailable   *bool                         `json:"isAdditionalStatsAvailable,omitempty"`
+	LastHeartbeat                *string                       `json:"lastHeartbeat,omitempty"`
+	LastRpoCalculatedTime        *string                       `json:"lastRpoCalculatedTime,omitempty"`
+	LastUpdateReceivedTime       *string                       `json:"lastUpdateReceivedTime,omitempty"`
+	MasterTargetId               *string                       `json:"masterTargetId,omitempty"`
+	MultiVmGroupId               *string                       `json:"multiVmGroupId,omitempty"`
+	MultiVmGroupName             *string                       `json:"multiVmGroupName,omitempty"`
+	MultiVmSyncStatus            *string                       `json:"multiVmSyncStatus,omitempty"`
+	OsDetails                    *OSDiskDetails                `json:"osDetails,omitempty"`
+	OsVersion                    *string                       `json:"osVersion,omitempty"`
+	ProcessServerId              *string                       `json:"processServerId,omitempty"`
+	ProtectedDisks               *[]InMageProtectedDiskDetails `json:"protectedDisks,omitempty"`
+	ProtectionStage              *string                       `json:"protectionStage,omitempty"`
+	RebootAfterUpdateStatus      *string                       `json:"rebootAfterUpdateStatus,omitempty"`
+	ReplicaId                    *string                       `json:"replicaId,omitempty"`
+	ResyncDetails                *InitialReplicationDetails    `json:"resyncDetails,omitempty"`
+	RetentionWindowEnd           *string                       `json:"retentionWindowEnd,omitempty"`
+	RetentionWindowStart         *string                       `json:"retentionWindowStart,omitempty"`
+	RpoInSeconds                 *int64                        `json:"rpoInSeconds,omitempty"`
+	SourceVmCpuCount             *int64                        `json:"sourceVmCpuCount,omitempty"`
+	SourceVmRamSizeInMB          *int64                        `json:"sourceVmRamSizeInMB,omitempty"`
+	TotalDataTransferred         *int64                        `json:"totalDataTransferred,omitempty"`
+	TotalProgressHealth          *string                       `json:"totalProgressHealth,omitempty"`
+	UncompressedDataRateInMB     *float64                      `json:"uncompressedDataRateInMB,omitempty"`
+	VCenterInfrastructureId      *string                       `json:"vCenterInfrastructureId,omitempty"`
+	ValidationErrors             *[]HealthError                `json:"validationErrors,omitempty"`
+	VmId                         *string                       `json:"vmId,omitempty"`
+	VmNics                       *[]VMNicDetails               `json:"vmNics,omitempty"`
+	VmProtectionState            *string                       `json:"vmProtectionState,omitempty"`
+	VmProtectionStateDescription *string                       `json:"vmProtectionStateDescription,omitempty"`
+
+	// Fields inherited from ReplicationProviderSpecificSettings
+}
+
+var _ json.Marshaler = InMageReplicationDetails{}
+
+func (s InMageReplicationDetails) MarshalJSON() ([]byte, error) {
+	type wrapper InMageReplicationDetails
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling InMageReplicationDetails: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling InMageReplicationDetails: %+v", err)
+	}
+	decoded["instanceType"] = "InMage"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling InMageReplicationDetails: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmagereprotectinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmagereprotectinput.go
@@ -1,0 +1,48 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ReverseReplicationProviderSpecificInput = InMageReprotectInput{}
+
+type InMageReprotectInput struct {
+	DatastoreName      *string                   `json:"datastoreName,omitempty"`
+	DiskExclusionInput *InMageDiskExclusionInput `json:"diskExclusionInput,omitempty"`
+	DisksToInclude     *[]string                 `json:"disksToInclude,omitempty"`
+	MasterTargetId     string                    `json:"masterTargetId"`
+	ProcessServerId    string                    `json:"processServerId"`
+	ProfileId          string                    `json:"profileId"`
+	RetentionDrive     string                    `json:"retentionDrive"`
+	RunAsAccountId     *string                   `json:"runAsAccountId,omitempty"`
+
+	// Fields inherited from ReverseReplicationProviderSpecificInput
+}
+
+var _ json.Marshaler = InMageReprotectInput{}
+
+func (s InMageReprotectInput) MarshalJSON() ([]byte, error) {
+	type wrapper InMageReprotectInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling InMageReprotectInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling InMageReprotectInput: %+v", err)
+	}
+	decoded["instanceType"] = "InMage"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling InMageReprotectInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmagetestfailoverinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmagetestfailoverinput.go
@@ -1,0 +1,42 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ TestFailoverProviderSpecificInput = InMageTestFailoverInput{}
+
+type InMageTestFailoverInput struct {
+	RecoveryPointId   *string            `json:"recoveryPointId,omitempty"`
+	RecoveryPointType *RecoveryPointType `json:"recoveryPointType,omitempty"`
+
+	// Fields inherited from TestFailoverProviderSpecificInput
+}
+
+var _ json.Marshaler = InMageTestFailoverInput{}
+
+func (s InMageTestFailoverInput) MarshalJSON() ([]byte, error) {
+	type wrapper InMageTestFailoverInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling InMageTestFailoverInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling InMageTestFailoverInput: %+v", err)
+	}
+	decoded["instanceType"] = "InMage"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling InMageTestFailoverInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmageunplannedfailoverinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmageunplannedfailoverinput.go
@@ -1,0 +1,42 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ UnplannedFailoverProviderSpecificInput = InMageUnplannedFailoverInput{}
+
+type InMageUnplannedFailoverInput struct {
+	RecoveryPointId   *string            `json:"recoveryPointId,omitempty"`
+	RecoveryPointType *RecoveryPointType `json:"recoveryPointType,omitempty"`
+
+	// Fields inherited from UnplannedFailoverProviderSpecificInput
+}
+
+var _ json.Marshaler = InMageUnplannedFailoverInput{}
+
+func (s InMageUnplannedFailoverInput) MarshalJSON() ([]byte, error) {
+	type wrapper InMageUnplannedFailoverInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling InMageUnplannedFailoverInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling InMageUnplannedFailoverInput: %+v", err)
+	}
+	decoded["instanceType"] = "InMage"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling InMageUnplannedFailoverInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmagevolumeexclusionoptions.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inmagevolumeexclusionoptions.go
@@ -1,0 +1,9 @@
+package replicationprotecteditems
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type InMageVolumeExclusionOptions struct {
+	OnlyExcludeIfSingleVolume *string `json:"onlyExcludeIfSingleVolume,omitempty"`
+	VolumeLabel               *string `json:"volumeLabel,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_innerhealtherror.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_innerhealtherror.go
@@ -1,0 +1,39 @@
+package replicationprotecteditems
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type InnerHealthError struct {
+	CreationTimeUtc              *string                           `json:"creationTimeUtc,omitempty"`
+	CustomerResolvability        *HealthErrorCustomerResolvability `json:"customerResolvability,omitempty"`
+	EntityId                     *string                           `json:"entityId,omitempty"`
+	ErrorCategory                *string                           `json:"errorCategory,omitempty"`
+	ErrorCode                    *string                           `json:"errorCode,omitempty"`
+	ErrorId                      *string                           `json:"errorId,omitempty"`
+	ErrorLevel                   *string                           `json:"errorLevel,omitempty"`
+	ErrorMessage                 *string                           `json:"errorMessage,omitempty"`
+	ErrorSource                  *string                           `json:"errorSource,omitempty"`
+	ErrorType                    *string                           `json:"errorType,omitempty"`
+	PossibleCauses               *string                           `json:"possibleCauses,omitempty"`
+	RecommendedAction            *string                           `json:"recommendedAction,omitempty"`
+	RecoveryProviderErrorMessage *string                           `json:"recoveryProviderErrorMessage,omitempty"`
+	SummaryMessage               *string                           `json:"summaryMessage,omitempty"`
+}
+
+func (o *InnerHealthError) GetCreationTimeUtcAsTime() (*time.Time, error) {
+	if o.CreationTimeUtc == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.CreationTimeUtc, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *InnerHealthError) SetCreationTimeUtcAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.CreationTimeUtc = &formatted
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inputendpoint.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_inputendpoint.go
@@ -1,0 +1,11 @@
+package replicationprotecteditems
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type InputEndpoint struct {
+	EndpointName *string `json:"endpointName,omitempty"`
+	PrivatePort  *int64  `json:"privatePort,omitempty"`
+	Protocol     *string `json:"protocol,omitempty"`
+	PublicPort   *int64  `json:"publicPort,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_ipconfigdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_ipconfigdetails.go
@@ -1,0 +1,22 @@
+package replicationprotecteditems
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type IPConfigDetails struct {
+	IPAddressType                   *string   `json:"ipAddressType,omitempty"`
+	IsPrimary                       *bool     `json:"isPrimary,omitempty"`
+	IsSeletedForFailover            *bool     `json:"isSeletedForFailover,omitempty"`
+	Name                            *string   `json:"name,omitempty"`
+	RecoveryIPAddressType           *string   `json:"recoveryIPAddressType,omitempty"`
+	RecoveryLBBackendAddressPoolIds *[]string `json:"recoveryLBBackendAddressPoolIds,omitempty"`
+	RecoveryPublicIPAddressId       *string   `json:"recoveryPublicIPAddressId,omitempty"`
+	RecoveryStaticIPAddress         *string   `json:"recoveryStaticIPAddress,omitempty"`
+	RecoverySubnetName              *string   `json:"recoverySubnetName,omitempty"`
+	StaticIPAddress                 *string   `json:"staticIPAddress,omitempty"`
+	SubnetName                      *string   `json:"subnetName,omitempty"`
+	TfoLBBackendAddressPoolIds      *[]string `json:"tfoLBBackendAddressPoolIds,omitempty"`
+	TfoPublicIPAddressId            *string   `json:"tfoPublicIPAddressId,omitempty"`
+	TfoStaticIPAddress              *string   `json:"tfoStaticIPAddress,omitempty"`
+	TfoSubnetName                   *string   `json:"tfoSubnetName,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_ipconfiginputdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_ipconfiginputdetails.go
@@ -1,0 +1,18 @@
+package replicationprotecteditems
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type IPConfigInputDetails struct {
+	IPConfigName                    *string   `json:"ipConfigName,omitempty"`
+	IsPrimary                       *bool     `json:"isPrimary,omitempty"`
+	IsSeletedForFailover            *bool     `json:"isSeletedForFailover,omitempty"`
+	RecoveryLBBackendAddressPoolIds *[]string `json:"recoveryLBBackendAddressPoolIds,omitempty"`
+	RecoveryPublicIPAddressId       *string   `json:"recoveryPublicIPAddressId,omitempty"`
+	RecoveryStaticIPAddress         *string   `json:"recoveryStaticIPAddress,omitempty"`
+	RecoverySubnetName              *string   `json:"recoverySubnetName,omitempty"`
+	TfoLBBackendAddressPoolIds      *[]string `json:"tfoLBBackendAddressPoolIds,omitempty"`
+	TfoPublicIPAddressId            *string   `json:"tfoPublicIPAddressId,omitempty"`
+	TfoStaticIPAddress              *string   `json:"tfoStaticIPAddress,omitempty"`
+	TfoSubnetName                   *string   `json:"tfoSubnetName,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_keyencryptionkeyinfo.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_keyencryptionkeyinfo.go
@@ -1,0 +1,9 @@
+package replicationprotecteditems
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type KeyEncryptionKeyInfo struct {
+	KeyIdentifier         *string `json:"keyIdentifier,omitempty"`
+	KeyVaultResourceArmId *string `json:"keyVaultResourceArmId,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_osdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_osdetails.go
@@ -1,0 +1,13 @@
+package replicationprotecteditems
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type OSDetails struct {
+	OSMajorVersion *string `json:"oSMajorVersion,omitempty"`
+	OSMinorVersion *string `json:"oSMinorVersion,omitempty"`
+	OSVersion      *string `json:"oSVersion,omitempty"`
+	OsEdition      *string `json:"osEdition,omitempty"`
+	OsType         *string `json:"osType,omitempty"`
+	ProductType    *string `json:"productType,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_osdiskdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_osdiskdetails.go
@@ -1,0 +1,10 @@
+package replicationprotecteditems
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type OSDiskDetails struct {
+	OsType  *string `json:"osType,omitempty"`
+	OsVhdId *string `json:"osVhdId,omitempty"`
+	VhdName *string `json:"vhdName,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_plannedfailoverinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_plannedfailoverinput.go
@@ -1,0 +1,8 @@
+package replicationprotecteditems
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PlannedFailoverInput struct {
+	Properties *PlannedFailoverInputProperties `json:"properties,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_plannedfailoverinputproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_plannedfailoverinputproperties.go
@@ -1,0 +1,40 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PlannedFailoverInputProperties struct {
+	FailoverDirection       *string                                      `json:"failoverDirection,omitempty"`
+	ProviderSpecificDetails PlannedFailoverProviderSpecificFailoverInput `json:"providerSpecificDetails"`
+}
+
+var _ json.Unmarshaler = &PlannedFailoverInputProperties{}
+
+func (s *PlannedFailoverInputProperties) UnmarshalJSON(bytes []byte) error {
+	type alias PlannedFailoverInputProperties
+	var decoded alias
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling into PlannedFailoverInputProperties: %+v", err)
+	}
+
+	s.FailoverDirection = decoded.FailoverDirection
+
+	var temp map[string]json.RawMessage
+	if err := json.Unmarshal(bytes, &temp); err != nil {
+		return fmt.Errorf("unmarshaling PlannedFailoverInputProperties into map[string]json.RawMessage: %+v", err)
+	}
+
+	if v, ok := temp["providerSpecificDetails"]; ok {
+		impl, err := unmarshalPlannedFailoverProviderSpecificFailoverInputImplementation(v)
+		if err != nil {
+			return fmt.Errorf("unmarshaling field 'ProviderSpecificDetails' for 'PlannedFailoverInputProperties': %+v", err)
+		}
+		s.ProviderSpecificDetails = impl
+	}
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_plannedfailoverproviderspecificfailoverinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_plannedfailoverproviderspecificfailoverinput.go
@@ -1,0 +1,64 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PlannedFailoverProviderSpecificFailoverInput interface {
+}
+
+func unmarshalPlannedFailoverProviderSpecificFailoverInputImplementation(input []byte) (PlannedFailoverProviderSpecificFailoverInput, error) {
+	if input == nil {
+		return nil, nil
+	}
+
+	var temp map[string]interface{}
+	if err := json.Unmarshal(input, &temp); err != nil {
+		return nil, fmt.Errorf("unmarshaling PlannedFailoverProviderSpecificFailoverInput into map[string]interface: %+v", err)
+	}
+
+	value, ok := temp["instanceType"].(string)
+	if !ok {
+		return nil, nil
+	}
+
+	if strings.EqualFold(value, "HyperVReplicaAzureFailback") {
+		var out HyperVReplicaAzureFailbackProviderInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into HyperVReplicaAzureFailbackProviderInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "HyperVReplicaAzure") {
+		var out HyperVReplicaAzurePlannedFailoverProviderInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into HyperVReplicaAzurePlannedFailoverProviderInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "InMageRcmFailback") {
+		var out InMageRcmFailbackPlannedFailoverProviderInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into InMageRcmFailbackPlannedFailoverProviderInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	type RawPlannedFailoverProviderSpecificFailoverInputImpl struct {
+		Type   string                 `json:"-"`
+		Values map[string]interface{} `json:"-"`
+	}
+	out := RawPlannedFailoverProviderSpecificFailoverInputImpl{
+		Type:   value,
+		Values: temp,
+	}
+	return out, nil
+
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_removedisksinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_removedisksinput.go
@@ -1,0 +1,8 @@
+package replicationprotecteditems
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RemoveDisksInput struct {
+	Properties *RemoveDisksInputProperties `json:"properties,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_removedisksinputproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_removedisksinputproperties.go
@@ -1,0 +1,32 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RemoveDisksInputProperties struct {
+	ProviderSpecificDetails RemoveDisksProviderSpecificInput `json:"providerSpecificDetails"`
+}
+
+var _ json.Unmarshaler = &RemoveDisksInputProperties{}
+
+func (s *RemoveDisksInputProperties) UnmarshalJSON(bytes []byte) error {
+
+	var temp map[string]json.RawMessage
+	if err := json.Unmarshal(bytes, &temp); err != nil {
+		return fmt.Errorf("unmarshaling RemoveDisksInputProperties into map[string]json.RawMessage: %+v", err)
+	}
+
+	if v, ok := temp["providerSpecificDetails"]; ok {
+		impl, err := unmarshalRemoveDisksProviderSpecificInputImplementation(v)
+		if err != nil {
+			return fmt.Errorf("unmarshaling field 'ProviderSpecificDetails' for 'RemoveDisksInputProperties': %+v", err)
+		}
+		s.ProviderSpecificDetails = impl
+	}
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_removedisksproviderspecificinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_removedisksproviderspecificinput.go
@@ -1,0 +1,48 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RemoveDisksProviderSpecificInput interface {
+}
+
+func unmarshalRemoveDisksProviderSpecificInputImplementation(input []byte) (RemoveDisksProviderSpecificInput, error) {
+	if input == nil {
+		return nil, nil
+	}
+
+	var temp map[string]interface{}
+	if err := json.Unmarshal(input, &temp); err != nil {
+		return nil, fmt.Errorf("unmarshaling RemoveDisksProviderSpecificInput into map[string]interface: %+v", err)
+	}
+
+	value, ok := temp["instanceType"].(string)
+	if !ok {
+		return nil, nil
+	}
+
+	if strings.EqualFold(value, "A2A") {
+		var out A2ARemoveDisksInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into A2ARemoveDisksInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	type RawRemoveDisksProviderSpecificInputImpl struct {
+		Type   string                 `json:"-"`
+		Values map[string]interface{} `json:"-"`
+	}
+	out := RawRemoveDisksProviderSpecificInputImpl{
+		Type:   value,
+		Values: temp,
+	}
+	return out, nil
+
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_replicationprotecteditem.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_replicationprotecteditem.go
@@ -1,0 +1,12 @@
+package replicationprotecteditems
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ReplicationProtectedItem struct {
+	Id         *string                             `json:"id,omitempty"`
+	Location   *string                             `json:"location,omitempty"`
+	Name       *string                             `json:"name,omitempty"`
+	Properties *ReplicationProtectedItemProperties `json:"properties,omitempty"`
+	Type       *string                             `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_replicationprotecteditemproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_replicationprotecteditemproperties.go
@@ -1,0 +1,123 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ReplicationProtectedItemProperties struct {
+	ActiveLocation                          *string                             `json:"activeLocation,omitempty"`
+	AllowedOperations                       *[]string                           `json:"allowedOperations,omitempty"`
+	CurrentScenario                         *CurrentScenarioDetails             `json:"currentScenario,omitempty"`
+	EventCorrelationId                      *string                             `json:"eventCorrelationId,omitempty"`
+	FailoverHealth                          *string                             `json:"failoverHealth,omitempty"`
+	FailoverRecoveryPointId                 *string                             `json:"failoverRecoveryPointId,omitempty"`
+	FriendlyName                            *string                             `json:"friendlyName,omitempty"`
+	HealthErrors                            *[]HealthError                      `json:"healthErrors,omitempty"`
+	LastSuccessfulFailoverTime              *string                             `json:"lastSuccessfulFailoverTime,omitempty"`
+	LastSuccessfulTestFailoverTime          *string                             `json:"lastSuccessfulTestFailoverTime,omitempty"`
+	PolicyFriendlyName                      *string                             `json:"policyFriendlyName,omitempty"`
+	PolicyId                                *string                             `json:"policyId,omitempty"`
+	PrimaryFabricFriendlyName               *string                             `json:"primaryFabricFriendlyName,omitempty"`
+	PrimaryFabricProvider                   *string                             `json:"primaryFabricProvider,omitempty"`
+	PrimaryProtectionContainerFriendlyName  *string                             `json:"primaryProtectionContainerFriendlyName,omitempty"`
+	ProtectableItemId                       *string                             `json:"protectableItemId,omitempty"`
+	ProtectedItemType                       *string                             `json:"protectedItemType,omitempty"`
+	ProtectionState                         *string                             `json:"protectionState,omitempty"`
+	ProtectionStateDescription              *string                             `json:"protectionStateDescription,omitempty"`
+	ProviderSpecificDetails                 ReplicationProviderSpecificSettings `json:"providerSpecificDetails"`
+	RecoveryContainerId                     *string                             `json:"recoveryContainerId,omitempty"`
+	RecoveryFabricFriendlyName              *string                             `json:"recoveryFabricFriendlyName,omitempty"`
+	RecoveryFabricId                        *string                             `json:"recoveryFabricId,omitempty"`
+	RecoveryProtectionContainerFriendlyName *string                             `json:"recoveryProtectionContainerFriendlyName,omitempty"`
+	RecoveryServicesProviderId              *string                             `json:"recoveryServicesProviderId,omitempty"`
+	ReplicationHealth                       *string                             `json:"replicationHealth,omitempty"`
+	SwitchProviderState                     *string                             `json:"switchProviderState,omitempty"`
+	SwitchProviderStateDescription          *string                             `json:"switchProviderStateDescription,omitempty"`
+	TestFailoverState                       *string                             `json:"testFailoverState,omitempty"`
+	TestFailoverStateDescription            *string                             `json:"testFailoverStateDescription,omitempty"`
+}
+
+func (o *ReplicationProtectedItemProperties) GetLastSuccessfulFailoverTimeAsTime() (*time.Time, error) {
+	if o.LastSuccessfulFailoverTime == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.LastSuccessfulFailoverTime, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *ReplicationProtectedItemProperties) SetLastSuccessfulFailoverTimeAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.LastSuccessfulFailoverTime = &formatted
+}
+
+func (o *ReplicationProtectedItemProperties) GetLastSuccessfulTestFailoverTimeAsTime() (*time.Time, error) {
+	if o.LastSuccessfulTestFailoverTime == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.LastSuccessfulTestFailoverTime, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *ReplicationProtectedItemProperties) SetLastSuccessfulTestFailoverTimeAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.LastSuccessfulTestFailoverTime = &formatted
+}
+
+var _ json.Unmarshaler = &ReplicationProtectedItemProperties{}
+
+func (s *ReplicationProtectedItemProperties) UnmarshalJSON(bytes []byte) error {
+	type alias ReplicationProtectedItemProperties
+	var decoded alias
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling into ReplicationProtectedItemProperties: %+v", err)
+	}
+
+	s.ActiveLocation = decoded.ActiveLocation
+	s.AllowedOperations = decoded.AllowedOperations
+	s.CurrentScenario = decoded.CurrentScenario
+	s.EventCorrelationId = decoded.EventCorrelationId
+	s.FailoverHealth = decoded.FailoverHealth
+	s.FailoverRecoveryPointId = decoded.FailoverRecoveryPointId
+	s.FriendlyName = decoded.FriendlyName
+	s.HealthErrors = decoded.HealthErrors
+	s.LastSuccessfulFailoverTime = decoded.LastSuccessfulFailoverTime
+	s.LastSuccessfulTestFailoverTime = decoded.LastSuccessfulTestFailoverTime
+	s.PolicyFriendlyName = decoded.PolicyFriendlyName
+	s.PolicyId = decoded.PolicyId
+	s.PrimaryFabricFriendlyName = decoded.PrimaryFabricFriendlyName
+	s.PrimaryFabricProvider = decoded.PrimaryFabricProvider
+	s.PrimaryProtectionContainerFriendlyName = decoded.PrimaryProtectionContainerFriendlyName
+	s.ProtectableItemId = decoded.ProtectableItemId
+	s.ProtectedItemType = decoded.ProtectedItemType
+	s.ProtectionState = decoded.ProtectionState
+	s.ProtectionStateDescription = decoded.ProtectionStateDescription
+	s.RecoveryContainerId = decoded.RecoveryContainerId
+	s.RecoveryFabricFriendlyName = decoded.RecoveryFabricFriendlyName
+	s.RecoveryFabricId = decoded.RecoveryFabricId
+	s.RecoveryProtectionContainerFriendlyName = decoded.RecoveryProtectionContainerFriendlyName
+	s.RecoveryServicesProviderId = decoded.RecoveryServicesProviderId
+	s.ReplicationHealth = decoded.ReplicationHealth
+	s.SwitchProviderState = decoded.SwitchProviderState
+	s.SwitchProviderStateDescription = decoded.SwitchProviderStateDescription
+	s.TestFailoverState = decoded.TestFailoverState
+	s.TestFailoverStateDescription = decoded.TestFailoverStateDescription
+
+	var temp map[string]json.RawMessage
+	if err := json.Unmarshal(bytes, &temp); err != nil {
+		return fmt.Errorf("unmarshaling ReplicationProtectedItemProperties into map[string]json.RawMessage: %+v", err)
+	}
+
+	if v, ok := temp["providerSpecificDetails"]; ok {
+		impl, err := unmarshalReplicationProviderSpecificSettingsImplementation(v)
+		if err != nil {
+			return fmt.Errorf("unmarshaling field 'ProviderSpecificDetails' for 'ReplicationProtectedItemProperties': %+v", err)
+		}
+		s.ProviderSpecificDetails = impl
+	}
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_replicationproviderspecificsettings.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_replicationproviderspecificsettings.go
@@ -1,0 +1,120 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ReplicationProviderSpecificSettings interface {
+}
+
+func unmarshalReplicationProviderSpecificSettingsImplementation(input []byte) (ReplicationProviderSpecificSettings, error) {
+	if input == nil {
+		return nil, nil
+	}
+
+	var temp map[string]interface{}
+	if err := json.Unmarshal(input, &temp); err != nil {
+		return nil, fmt.Errorf("unmarshaling ReplicationProviderSpecificSettings into map[string]interface: %+v", err)
+	}
+
+	value, ok := temp["instanceType"].(string)
+	if !ok {
+		return nil, nil
+	}
+
+	if strings.EqualFold(value, "A2ACrossClusterMigration") {
+		var out A2ACrossClusterMigrationReplicationDetails
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into A2ACrossClusterMigrationReplicationDetails: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "A2A") {
+		var out A2AReplicationDetails
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into A2AReplicationDetails: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "HyperVReplicaAzure") {
+		var out HyperVReplicaAzureReplicationDetails
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into HyperVReplicaAzureReplicationDetails: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "HyperVReplicaBaseReplicationDetails") {
+		var out HyperVReplicaBaseReplicationDetails
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into HyperVReplicaBaseReplicationDetails: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "HyperVReplica2012R2") {
+		var out HyperVReplicaBlueReplicationDetails
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into HyperVReplicaBlueReplicationDetails: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "HyperVReplica2012") {
+		var out HyperVReplicaReplicationDetails
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into HyperVReplicaReplicationDetails: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "InMageAzureV2") {
+		var out InMageAzureV2ReplicationDetails
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into InMageAzureV2ReplicationDetails: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "InMageRcmFailback") {
+		var out InMageRcmFailbackReplicationDetails
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into InMageRcmFailbackReplicationDetails: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "InMageRcm") {
+		var out InMageRcmReplicationDetails
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into InMageRcmReplicationDetails: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "InMage") {
+		var out InMageReplicationDetails
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into InMageReplicationDetails: %+v", err)
+		}
+		return out, nil
+	}
+
+	type RawReplicationProviderSpecificSettingsImpl struct {
+		Type   string                 `json:"-"`
+		Values map[string]interface{} `json:"-"`
+	}
+	out := RawReplicationProviderSpecificSettingsImpl{
+		Type:   value,
+		Values: temp,
+	}
+	return out, nil
+
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_resolvehealtherror.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_resolvehealtherror.go
@@ -1,0 +1,8 @@
+package replicationprotecteditems
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ResolveHealthError struct {
+	HealthErrorId *string `json:"healthErrorId,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_resolvehealthinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_resolvehealthinput.go
@@ -1,0 +1,8 @@
+package replicationprotecteditems
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ResolveHealthInput struct {
+	Properties *ResolveHealthInputProperties `json:"properties,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_resolvehealthinputproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_resolvehealthinputproperties.go
@@ -1,0 +1,8 @@
+package replicationprotecteditems
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ResolveHealthInputProperties struct {
+	HealthErrors *[]ResolveHealthError `json:"healthErrors,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_reversereplicationinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_reversereplicationinput.go
@@ -1,0 +1,8 @@
+package replicationprotecteditems
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ReverseReplicationInput struct {
+	Properties *ReverseReplicationInputProperties `json:"properties,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_reversereplicationinputproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_reversereplicationinputproperties.go
@@ -1,0 +1,40 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ReverseReplicationInputProperties struct {
+	FailoverDirection       *string                                 `json:"failoverDirection,omitempty"`
+	ProviderSpecificDetails ReverseReplicationProviderSpecificInput `json:"providerSpecificDetails"`
+}
+
+var _ json.Unmarshaler = &ReverseReplicationInputProperties{}
+
+func (s *ReverseReplicationInputProperties) UnmarshalJSON(bytes []byte) error {
+	type alias ReverseReplicationInputProperties
+	var decoded alias
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling into ReverseReplicationInputProperties: %+v", err)
+	}
+
+	s.FailoverDirection = decoded.FailoverDirection
+
+	var temp map[string]json.RawMessage
+	if err := json.Unmarshal(bytes, &temp); err != nil {
+		return fmt.Errorf("unmarshaling ReverseReplicationInputProperties into map[string]json.RawMessage: %+v", err)
+	}
+
+	if v, ok := temp["providerSpecificDetails"]; ok {
+		impl, err := unmarshalReverseReplicationProviderSpecificInputImplementation(v)
+		if err != nil {
+			return fmt.Errorf("unmarshaling field 'ProviderSpecificDetails' for 'ReverseReplicationInputProperties': %+v", err)
+		}
+		s.ProviderSpecificDetails = impl
+	}
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_reversereplicationproviderspecificinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_reversereplicationproviderspecificinput.go
@@ -1,0 +1,88 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ReverseReplicationProviderSpecificInput interface {
+}
+
+func unmarshalReverseReplicationProviderSpecificInputImplementation(input []byte) (ReverseReplicationProviderSpecificInput, error) {
+	if input == nil {
+		return nil, nil
+	}
+
+	var temp map[string]interface{}
+	if err := json.Unmarshal(input, &temp); err != nil {
+		return nil, fmt.Errorf("unmarshaling ReverseReplicationProviderSpecificInput into map[string]interface: %+v", err)
+	}
+
+	value, ok := temp["instanceType"].(string)
+	if !ok {
+		return nil, nil
+	}
+
+	if strings.EqualFold(value, "A2A") {
+		var out A2AReprotectInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into A2AReprotectInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "HyperVReplicaAzure") {
+		var out HyperVReplicaAzureReprotectInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into HyperVReplicaAzureReprotectInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "InMageAzureV2") {
+		var out InMageAzureV2ReprotectInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into InMageAzureV2ReprotectInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "InMageRcmFailback") {
+		var out InMageRcmFailbackReprotectInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into InMageRcmFailbackReprotectInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "InMageRcm") {
+		var out InMageRcmReprotectInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into InMageRcmReprotectInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "InMage") {
+		var out InMageReprotectInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into InMageReprotectInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	type RawReverseReplicationProviderSpecificInputImpl struct {
+		Type   string                 `json:"-"`
+		Values map[string]interface{} `json:"-"`
+	}
+	out := RawReverseReplicationProviderSpecificInputImpl{
+		Type:   value,
+		Values: temp,
+	}
+	return out, nil
+
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_switchproviderinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_switchproviderinput.go
@@ -1,0 +1,8 @@
+package replicationprotecteditems
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SwitchProviderInput struct {
+	Properties *SwitchProviderInputProperties `json:"properties,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_switchproviderinputproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_switchproviderinputproperties.go
@@ -1,0 +1,40 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SwitchProviderInputProperties struct {
+	ProviderSpecificDetails SwitchProviderProviderSpecificInput `json:"providerSpecificDetails"`
+	TargetInstanceType      *string                             `json:"targetInstanceType,omitempty"`
+}
+
+var _ json.Unmarshaler = &SwitchProviderInputProperties{}
+
+func (s *SwitchProviderInputProperties) UnmarshalJSON(bytes []byte) error {
+	type alias SwitchProviderInputProperties
+	var decoded alias
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling into SwitchProviderInputProperties: %+v", err)
+	}
+
+	s.TargetInstanceType = decoded.TargetInstanceType
+
+	var temp map[string]json.RawMessage
+	if err := json.Unmarshal(bytes, &temp); err != nil {
+		return fmt.Errorf("unmarshaling SwitchProviderInputProperties into map[string]json.RawMessage: %+v", err)
+	}
+
+	if v, ok := temp["providerSpecificDetails"]; ok {
+		impl, err := unmarshalSwitchProviderProviderSpecificInputImplementation(v)
+		if err != nil {
+			return fmt.Errorf("unmarshaling field 'ProviderSpecificDetails' for 'SwitchProviderInputProperties': %+v", err)
+		}
+		s.ProviderSpecificDetails = impl
+	}
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_switchproviderproviderspecificinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_switchproviderproviderspecificinput.go
@@ -1,0 +1,48 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SwitchProviderProviderSpecificInput interface {
+}
+
+func unmarshalSwitchProviderProviderSpecificInputImplementation(input []byte) (SwitchProviderProviderSpecificInput, error) {
+	if input == nil {
+		return nil, nil
+	}
+
+	var temp map[string]interface{}
+	if err := json.Unmarshal(input, &temp); err != nil {
+		return nil, fmt.Errorf("unmarshaling SwitchProviderProviderSpecificInput into map[string]interface: %+v", err)
+	}
+
+	value, ok := temp["instanceType"].(string)
+	if !ok {
+		return nil, nil
+	}
+
+	if strings.EqualFold(value, "InMageAzureV2") {
+		var out InMageAzureV2SwitchProviderProviderInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into InMageAzureV2SwitchProviderProviderInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	type RawSwitchProviderProviderSpecificInputImpl struct {
+		Type   string                 `json:"-"`
+		Values map[string]interface{} `json:"-"`
+	}
+	out := RawSwitchProviderProviderSpecificInputImpl{
+		Type:   value,
+		Values: temp,
+	}
+	return out, nil
+
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_testfailovercleanupinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_testfailovercleanupinput.go
@@ -1,0 +1,8 @@
+package replicationprotecteditems
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type TestFailoverCleanupInput struct {
+	Properties TestFailoverCleanupInputProperties `json:"properties"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_testfailovercleanupinputproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_testfailovercleanupinputproperties.go
@@ -1,0 +1,8 @@
+package replicationprotecteditems
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type TestFailoverCleanupInputProperties struct {
+	Comments *string `json:"comments,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_testfailoverinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_testfailoverinput.go
@@ -1,0 +1,8 @@
+package replicationprotecteditems
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type TestFailoverInput struct {
+	Properties TestFailoverInputProperties `json:"properties"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_testfailoverinputproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_testfailoverinputproperties.go
@@ -1,0 +1,44 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type TestFailoverInputProperties struct {
+	FailoverDirection       *string                           `json:"failoverDirection,omitempty"`
+	NetworkId               *string                           `json:"networkId,omitempty"`
+	NetworkType             *string                           `json:"networkType,omitempty"`
+	ProviderSpecificDetails TestFailoverProviderSpecificInput `json:"providerSpecificDetails"`
+}
+
+var _ json.Unmarshaler = &TestFailoverInputProperties{}
+
+func (s *TestFailoverInputProperties) UnmarshalJSON(bytes []byte) error {
+	type alias TestFailoverInputProperties
+	var decoded alias
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling into TestFailoverInputProperties: %+v", err)
+	}
+
+	s.FailoverDirection = decoded.FailoverDirection
+	s.NetworkId = decoded.NetworkId
+	s.NetworkType = decoded.NetworkType
+
+	var temp map[string]json.RawMessage
+	if err := json.Unmarshal(bytes, &temp); err != nil {
+		return fmt.Errorf("unmarshaling TestFailoverInputProperties into map[string]json.RawMessage: %+v", err)
+	}
+
+	if v, ok := temp["providerSpecificDetails"]; ok {
+		impl, err := unmarshalTestFailoverProviderSpecificInputImplementation(v)
+		if err != nil {
+			return fmt.Errorf("unmarshaling field 'ProviderSpecificDetails' for 'TestFailoverInputProperties': %+v", err)
+		}
+		s.ProviderSpecificDetails = impl
+	}
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_testfailoverproviderspecificinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_testfailoverproviderspecificinput.go
@@ -1,0 +1,80 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type TestFailoverProviderSpecificInput interface {
+}
+
+func unmarshalTestFailoverProviderSpecificInputImplementation(input []byte) (TestFailoverProviderSpecificInput, error) {
+	if input == nil {
+		return nil, nil
+	}
+
+	var temp map[string]interface{}
+	if err := json.Unmarshal(input, &temp); err != nil {
+		return nil, fmt.Errorf("unmarshaling TestFailoverProviderSpecificInput into map[string]interface: %+v", err)
+	}
+
+	value, ok := temp["instanceType"].(string)
+	if !ok {
+		return nil, nil
+	}
+
+	if strings.EqualFold(value, "A2A") {
+		var out A2ATestFailoverInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into A2ATestFailoverInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "HyperVReplicaAzure") {
+		var out HyperVReplicaAzureTestFailoverInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into HyperVReplicaAzureTestFailoverInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "InMageAzureV2") {
+		var out InMageAzureV2TestFailoverInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into InMageAzureV2TestFailoverInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "InMageRcm") {
+		var out InMageRcmTestFailoverInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into InMageRcmTestFailoverInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "InMage") {
+		var out InMageTestFailoverInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into InMageTestFailoverInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	type RawTestFailoverProviderSpecificInputImpl struct {
+		Type   string                 `json:"-"`
+		Values map[string]interface{} `json:"-"`
+	}
+	out := RawTestFailoverProviderSpecificInputImpl{
+		Type:   value,
+		Values: temp,
+	}
+	return out, nil
+
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_unplannedfailoverinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_unplannedfailoverinput.go
@@ -1,0 +1,8 @@
+package replicationprotecteditems
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UnplannedFailoverInput struct {
+	Properties UnplannedFailoverInputProperties `json:"properties"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_unplannedfailoverinputproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_unplannedfailoverinputproperties.go
@@ -1,0 +1,42 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UnplannedFailoverInputProperties struct {
+	FailoverDirection       *string                                `json:"failoverDirection,omitempty"`
+	ProviderSpecificDetails UnplannedFailoverProviderSpecificInput `json:"providerSpecificDetails"`
+	SourceSiteOperations    *string                                `json:"sourceSiteOperations,omitempty"`
+}
+
+var _ json.Unmarshaler = &UnplannedFailoverInputProperties{}
+
+func (s *UnplannedFailoverInputProperties) UnmarshalJSON(bytes []byte) error {
+	type alias UnplannedFailoverInputProperties
+	var decoded alias
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling into UnplannedFailoverInputProperties: %+v", err)
+	}
+
+	s.FailoverDirection = decoded.FailoverDirection
+	s.SourceSiteOperations = decoded.SourceSiteOperations
+
+	var temp map[string]json.RawMessage
+	if err := json.Unmarshal(bytes, &temp); err != nil {
+		return fmt.Errorf("unmarshaling UnplannedFailoverInputProperties into map[string]json.RawMessage: %+v", err)
+	}
+
+	if v, ok := temp["providerSpecificDetails"]; ok {
+		impl, err := unmarshalUnplannedFailoverProviderSpecificInputImplementation(v)
+		if err != nil {
+			return fmt.Errorf("unmarshaling field 'ProviderSpecificDetails' for 'UnplannedFailoverInputProperties': %+v", err)
+		}
+		s.ProviderSpecificDetails = impl
+	}
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_unplannedfailoverproviderspecificinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_unplannedfailoverproviderspecificinput.go
@@ -1,0 +1,80 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UnplannedFailoverProviderSpecificInput interface {
+}
+
+func unmarshalUnplannedFailoverProviderSpecificInputImplementation(input []byte) (UnplannedFailoverProviderSpecificInput, error) {
+	if input == nil {
+		return nil, nil
+	}
+
+	var temp map[string]interface{}
+	if err := json.Unmarshal(input, &temp); err != nil {
+		return nil, fmt.Errorf("unmarshaling UnplannedFailoverProviderSpecificInput into map[string]interface: %+v", err)
+	}
+
+	value, ok := temp["instanceType"].(string)
+	if !ok {
+		return nil, nil
+	}
+
+	if strings.EqualFold(value, "A2A") {
+		var out A2AUnplannedFailoverInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into A2AUnplannedFailoverInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "HyperVReplicaAzure") {
+		var out HyperVReplicaAzureUnplannedFailoverInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into HyperVReplicaAzureUnplannedFailoverInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "InMageAzureV2") {
+		var out InMageAzureV2UnplannedFailoverInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into InMageAzureV2UnplannedFailoverInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "InMageRcm") {
+		var out InMageRcmUnplannedFailoverInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into InMageRcmUnplannedFailoverInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "InMage") {
+		var out InMageUnplannedFailoverInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into InMageUnplannedFailoverInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	type RawUnplannedFailoverProviderSpecificInputImpl struct {
+		Type   string                 `json:"-"`
+		Values map[string]interface{} `json:"-"`
+	}
+	out := RawUnplannedFailoverProviderSpecificInputImpl{
+		Type:   value,
+		Values: temp,
+	}
+	return out, nil
+
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_updateapplianceforreplicationprotectediteminput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_updateapplianceforreplicationprotectediteminput.go
@@ -1,0 +1,8 @@
+package replicationprotecteditems
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UpdateApplianceForReplicationProtectedItemInput struct {
+	Properties UpdateApplianceForReplicationProtectedItemInputProperties `json:"properties"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_updateapplianceforreplicationprotectediteminputproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_updateapplianceforreplicationprotectediteminputproperties.go
@@ -1,0 +1,40 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UpdateApplianceForReplicationProtectedItemInputProperties struct {
+	ProviderSpecificDetails UpdateApplianceForReplicationProtectedItemProviderSpecificInput `json:"providerSpecificDetails"`
+	TargetApplianceId       string                                                          `json:"targetApplianceId"`
+}
+
+var _ json.Unmarshaler = &UpdateApplianceForReplicationProtectedItemInputProperties{}
+
+func (s *UpdateApplianceForReplicationProtectedItemInputProperties) UnmarshalJSON(bytes []byte) error {
+	type alias UpdateApplianceForReplicationProtectedItemInputProperties
+	var decoded alias
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling into UpdateApplianceForReplicationProtectedItemInputProperties: %+v", err)
+	}
+
+	s.TargetApplianceId = decoded.TargetApplianceId
+
+	var temp map[string]json.RawMessage
+	if err := json.Unmarshal(bytes, &temp); err != nil {
+		return fmt.Errorf("unmarshaling UpdateApplianceForReplicationProtectedItemInputProperties into map[string]json.RawMessage: %+v", err)
+	}
+
+	if v, ok := temp["providerSpecificDetails"]; ok {
+		impl, err := unmarshalUpdateApplianceForReplicationProtectedItemProviderSpecificInputImplementation(v)
+		if err != nil {
+			return fmt.Errorf("unmarshaling field 'ProviderSpecificDetails' for 'UpdateApplianceForReplicationProtectedItemInputProperties': %+v", err)
+		}
+		s.ProviderSpecificDetails = impl
+	}
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_updateapplianceforreplicationprotecteditemproviderspecificinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_updateapplianceforreplicationprotecteditemproviderspecificinput.go
@@ -1,0 +1,48 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UpdateApplianceForReplicationProtectedItemProviderSpecificInput interface {
+}
+
+func unmarshalUpdateApplianceForReplicationProtectedItemProviderSpecificInputImplementation(input []byte) (UpdateApplianceForReplicationProtectedItemProviderSpecificInput, error) {
+	if input == nil {
+		return nil, nil
+	}
+
+	var temp map[string]interface{}
+	if err := json.Unmarshal(input, &temp); err != nil {
+		return nil, fmt.Errorf("unmarshaling UpdateApplianceForReplicationProtectedItemProviderSpecificInput into map[string]interface: %+v", err)
+	}
+
+	value, ok := temp["instanceType"].(string)
+	if !ok {
+		return nil, nil
+	}
+
+	if strings.EqualFold(value, "InMageRcm") {
+		var out InMageRcmUpdateApplianceForReplicationProtectedItemInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into InMageRcmUpdateApplianceForReplicationProtectedItemInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	type RawUpdateApplianceForReplicationProtectedItemProviderSpecificInputImpl struct {
+		Type   string                 `json:"-"`
+		Values map[string]interface{} `json:"-"`
+	}
+	out := RawUpdateApplianceForReplicationProtectedItemProviderSpecificInputImpl{
+		Type:   value,
+		Values: temp,
+	}
+	return out, nil
+
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_updatediskinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_updatediskinput.go
@@ -1,0 +1,9 @@
+package replicationprotecteditems
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UpdateDiskInput struct {
+	DiskId         string  `json:"diskId"`
+	TargetDiskName *string `json:"targetDiskName,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_updatemobilityservicerequest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_updatemobilityservicerequest.go
@@ -1,0 +1,8 @@
+package replicationprotecteditems
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UpdateMobilityServiceRequest struct {
+	Properties *UpdateMobilityServiceRequestProperties `json:"properties,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_updatemobilityservicerequestproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_updatemobilityservicerequestproperties.go
@@ -1,0 +1,8 @@
+package replicationprotecteditems
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UpdateMobilityServiceRequestProperties struct {
+	RunAsAccountId *string `json:"runAsAccountId,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_updatereplicationprotectediteminput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_updatereplicationprotectediteminput.go
@@ -1,0 +1,8 @@
+package replicationprotecteditems
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UpdateReplicationProtectedItemInput struct {
+	Properties *UpdateReplicationProtectedItemInputProperties `json:"properties,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_updatereplicationprotectediteminputproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_updatereplicationprotectediteminputproperties.go
@@ -1,0 +1,56 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UpdateReplicationProtectedItemInputProperties struct {
+	EnableRdpOnTargetOption        *string                                     `json:"enableRdpOnTargetOption,omitempty"`
+	LicenseType                    *LicenseType                                `json:"licenseType,omitempty"`
+	ProviderSpecificDetails        UpdateReplicationProtectedItemProviderInput `json:"providerSpecificDetails"`
+	RecoveryAvailabilitySetId      *string                                     `json:"recoveryAvailabilitySetId,omitempty"`
+	RecoveryAzureVMName            *string                                     `json:"recoveryAzureVMName,omitempty"`
+	RecoveryAzureVMSize            *string                                     `json:"recoveryAzureVMSize,omitempty"`
+	SelectedRecoveryAzureNetworkId *string                                     `json:"selectedRecoveryAzureNetworkId,omitempty"`
+	SelectedSourceNicId            *string                                     `json:"selectedSourceNicId,omitempty"`
+	SelectedTfoAzureNetworkId      *string                                     `json:"selectedTfoAzureNetworkId,omitempty"`
+	VmNics                         *[]VMNicInputDetails                        `json:"vmNics,omitempty"`
+}
+
+var _ json.Unmarshaler = &UpdateReplicationProtectedItemInputProperties{}
+
+func (s *UpdateReplicationProtectedItemInputProperties) UnmarshalJSON(bytes []byte) error {
+	type alias UpdateReplicationProtectedItemInputProperties
+	var decoded alias
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling into UpdateReplicationProtectedItemInputProperties: %+v", err)
+	}
+
+	s.EnableRdpOnTargetOption = decoded.EnableRdpOnTargetOption
+	s.LicenseType = decoded.LicenseType
+	s.RecoveryAvailabilitySetId = decoded.RecoveryAvailabilitySetId
+	s.RecoveryAzureVMName = decoded.RecoveryAzureVMName
+	s.RecoveryAzureVMSize = decoded.RecoveryAzureVMSize
+	s.SelectedRecoveryAzureNetworkId = decoded.SelectedRecoveryAzureNetworkId
+	s.SelectedSourceNicId = decoded.SelectedSourceNicId
+	s.SelectedTfoAzureNetworkId = decoded.SelectedTfoAzureNetworkId
+	s.VmNics = decoded.VmNics
+
+	var temp map[string]json.RawMessage
+	if err := json.Unmarshal(bytes, &temp); err != nil {
+		return fmt.Errorf("unmarshaling UpdateReplicationProtectedItemInputProperties into map[string]json.RawMessage: %+v", err)
+	}
+
+	if v, ok := temp["providerSpecificDetails"]; ok {
+		impl, err := unmarshalUpdateReplicationProtectedItemProviderInputImplementation(v)
+		if err != nil {
+			return fmt.Errorf("unmarshaling field 'ProviderSpecificDetails' for 'UpdateReplicationProtectedItemInputProperties': %+v", err)
+		}
+		s.ProviderSpecificDetails = impl
+	}
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_updatereplicationprotecteditemproviderinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_updatereplicationprotecteditemproviderinput.go
@@ -1,0 +1,72 @@
+package replicationprotecteditems
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UpdateReplicationProtectedItemProviderInput interface {
+}
+
+func unmarshalUpdateReplicationProtectedItemProviderInputImplementation(input []byte) (UpdateReplicationProtectedItemProviderInput, error) {
+	if input == nil {
+		return nil, nil
+	}
+
+	var temp map[string]interface{}
+	if err := json.Unmarshal(input, &temp); err != nil {
+		return nil, fmt.Errorf("unmarshaling UpdateReplicationProtectedItemProviderInput into map[string]interface: %+v", err)
+	}
+
+	value, ok := temp["instanceType"].(string)
+	if !ok {
+		return nil, nil
+	}
+
+	if strings.EqualFold(value, "A2A") {
+		var out A2AUpdateReplicationProtectedItemInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into A2AUpdateReplicationProtectedItemInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "HyperVReplicaAzure") {
+		var out HyperVReplicaAzureUpdateReplicationProtectedItemInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into HyperVReplicaAzureUpdateReplicationProtectedItemInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "InMageAzureV2") {
+		var out InMageAzureV2UpdateReplicationProtectedItemInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into InMageAzureV2UpdateReplicationProtectedItemInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "InMageRcm") {
+		var out InMageRcmUpdateReplicationProtectedItemInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into InMageRcmUpdateReplicationProtectedItemInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	type RawUpdateReplicationProtectedItemProviderInputImpl struct {
+		Type   string                 `json:"-"`
+		Values map[string]interface{} `json:"-"`
+	}
+	out := RawUpdateReplicationProtectedItemProviderInputImpl{
+		Type:   value,
+		Values: temp,
+	}
+	return out, nil
+
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_vmnicdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_vmnicdetails.go
@@ -1,0 +1,26 @@
+package replicationprotecteditems
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VMNicDetails struct {
+	EnableAcceleratedNetworkingOnRecovery *bool              `json:"enableAcceleratedNetworkingOnRecovery,omitempty"`
+	EnableAcceleratedNetworkingOnTfo      *bool              `json:"enableAcceleratedNetworkingOnTfo,omitempty"`
+	IPConfigs                             *[]IPConfigDetails `json:"ipConfigs,omitempty"`
+	NicId                                 *string            `json:"nicId,omitempty"`
+	RecoveryNetworkSecurityGroupId        *string            `json:"recoveryNetworkSecurityGroupId,omitempty"`
+	RecoveryNicName                       *string            `json:"recoveryNicName,omitempty"`
+	RecoveryNicResourceGroupName          *string            `json:"recoveryNicResourceGroupName,omitempty"`
+	RecoveryVMNetworkId                   *string            `json:"recoveryVMNetworkId,omitempty"`
+	ReplicaNicId                          *string            `json:"replicaNicId,omitempty"`
+	ReuseExistingNic                      *bool              `json:"reuseExistingNic,omitempty"`
+	SelectionType                         *string            `json:"selectionType,omitempty"`
+	SourceNicArmId                        *string            `json:"sourceNicArmId,omitempty"`
+	TargetNicName                         *string            `json:"targetNicName,omitempty"`
+	TfoNetworkSecurityGroupId             *string            `json:"tfoNetworkSecurityGroupId,omitempty"`
+	TfoRecoveryNicName                    *string            `json:"tfoRecoveryNicName,omitempty"`
+	TfoRecoveryNicResourceGroupName       *string            `json:"tfoRecoveryNicResourceGroupName,omitempty"`
+	TfoReuseExistingNic                   *bool              `json:"tfoReuseExistingNic,omitempty"`
+	TfoVMNetworkId                        *string            `json:"tfoVMNetworkId,omitempty"`
+	VMNetworkName                         *string            `json:"vMNetworkName,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_vmnicinputdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_vmnicinputdetails.go
@@ -1,0 +1,21 @@
+package replicationprotecteditems
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VMNicInputDetails struct {
+	EnableAcceleratedNetworkingOnRecovery *bool                   `json:"enableAcceleratedNetworkingOnRecovery,omitempty"`
+	EnableAcceleratedNetworkingOnTfo      *bool                   `json:"enableAcceleratedNetworkingOnTfo,omitempty"`
+	IPConfigs                             *[]IPConfigInputDetails `json:"ipConfigs,omitempty"`
+	NicId                                 *string                 `json:"nicId,omitempty"`
+	RecoveryNetworkSecurityGroupId        *string                 `json:"recoveryNetworkSecurityGroupId,omitempty"`
+	RecoveryNicName                       *string                 `json:"recoveryNicName,omitempty"`
+	RecoveryNicResourceGroupName          *string                 `json:"recoveryNicResourceGroupName,omitempty"`
+	ReuseExistingNic                      *bool                   `json:"reuseExistingNic,omitempty"`
+	SelectionType                         *string                 `json:"selectionType,omitempty"`
+	TargetNicName                         *string                 `json:"targetNicName,omitempty"`
+	TfoNetworkSecurityGroupId             *string                 `json:"tfoNetworkSecurityGroupId,omitempty"`
+	TfoNicName                            *string                 `json:"tfoNicName,omitempty"`
+	TfoNicResourceGroupName               *string                 `json:"tfoNicResourceGroupName,omitempty"`
+	TfoReuseExistingNic                   *bool                   `json:"tfoReuseExistingNic,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/predicates.go
@@ -1,0 +1,29 @@
+package replicationprotecteditems
+
+type ReplicationProtectedItemOperationPredicate struct {
+	Id       *string
+	Location *string
+	Name     *string
+	Type     *string
+}
+
+func (p ReplicationProtectedItemOperationPredicate) Matches(input ReplicationProtectedItem) bool {
+
+	if p.Id != nil && (input.Id == nil && *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Location != nil && (input.Location == nil && *p.Location != *input.Location) {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil && *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil && *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/version.go
@@ -1,0 +1,12 @@
+package replicationprotecteditems
+
+import "fmt"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2022-10-01"
+
+func userAgent() string {
+	return fmt.Sprintf("hashicorp/go-azure-sdk/replicationprotecteditems/%s", defaultApiVersion)
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/README.md
@@ -1,0 +1,133 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings` Documentation
+
+The `replicationprotectioncontainermappings` SDK allows for interaction with the Azure Resource Manager Service `recoveryservicessiterecovery` (API Version `2022-10-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings"
+```
+
+
+### Client Initialization
+
+```go
+client := replicationprotectioncontainermappings.NewReplicationProtectionContainerMappingsClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `ReplicationProtectionContainerMappingsClient.Create`
+
+```go
+ctx := context.TODO()
+id := replicationprotectioncontainermappings.NewReplicationProtectionContainerMappingID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue", "fabricValue", "protectionContainerValue", "mappingValue")
+
+payload := replicationprotectioncontainermappings.CreateProtectionContainerMappingInput{
+	// ...
+}
+
+
+if err := client.CreateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `ReplicationProtectionContainerMappingsClient.Delete`
+
+```go
+ctx := context.TODO()
+id := replicationprotectioncontainermappings.NewReplicationProtectionContainerMappingID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue", "fabricValue", "protectionContainerValue", "mappingValue")
+
+payload := replicationprotectioncontainermappings.RemoveProtectionContainerMappingInput{
+	// ...
+}
+
+
+if err := client.DeleteThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `ReplicationProtectionContainerMappingsClient.Get`
+
+```go
+ctx := context.TODO()
+id := replicationprotectioncontainermappings.NewReplicationProtectionContainerMappingID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue", "fabricValue", "protectionContainerValue", "mappingValue")
+
+read, err := client.Get(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `ReplicationProtectionContainerMappingsClient.List`
+
+```go
+ctx := context.TODO()
+id := replicationprotectioncontainermappings.NewVaultID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue")
+
+// alternatively `client.List(ctx, id)` can be used to do batched pagination
+items, err := client.ListComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `ReplicationProtectionContainerMappingsClient.ListByReplicationProtectionContainers`
+
+```go
+ctx := context.TODO()
+id := replicationprotectioncontainermappings.NewReplicationProtectionContainerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue", "fabricValue", "protectionContainerValue")
+
+// alternatively `client.ListByReplicationProtectionContainers(ctx, id)` can be used to do batched pagination
+items, err := client.ListByReplicationProtectionContainersComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `ReplicationProtectionContainerMappingsClient.Purge`
+
+```go
+ctx := context.TODO()
+id := replicationprotectioncontainermappings.NewReplicationProtectionContainerMappingID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue", "fabricValue", "protectionContainerValue", "mappingValue")
+
+if err := client.PurgeThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `ReplicationProtectionContainerMappingsClient.Update`
+
+```go
+ctx := context.TODO()
+id := replicationprotectioncontainermappings.NewReplicationProtectionContainerMappingID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue", "fabricValue", "protectionContainerValue", "mappingValue")
+
+payload := replicationprotectioncontainermappings.UpdateProtectionContainerMappingInput{
+	// ...
+}
+
+
+if err := client.UpdateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/client.go
@@ -1,0 +1,18 @@
+package replicationprotectioncontainermappings
+
+import "github.com/Azure/go-autorest/autorest"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ReplicationProtectionContainerMappingsClient struct {
+	Client  autorest.Client
+	baseUri string
+}
+
+func NewReplicationProtectionContainerMappingsClientWithBaseURI(endpoint string) ReplicationProtectionContainerMappingsClient {
+	return ReplicationProtectionContainerMappingsClient{
+		Client:  autorest.NewClientWithUserAgent(userAgent()),
+		baseUri: endpoint,
+	}
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/constants.go
@@ -1,0 +1,90 @@
+package replicationprotectioncontainermappings
+
+import "strings"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AgentAutoUpdateStatus string
+
+const (
+	AgentAutoUpdateStatusDisabled AgentAutoUpdateStatus = "Disabled"
+	AgentAutoUpdateStatusEnabled  AgentAutoUpdateStatus = "Enabled"
+)
+
+func PossibleValuesForAgentAutoUpdateStatus() []string {
+	return []string{
+		string(AgentAutoUpdateStatusDisabled),
+		string(AgentAutoUpdateStatusEnabled),
+	}
+}
+
+func parseAgentAutoUpdateStatus(input string) (*AgentAutoUpdateStatus, error) {
+	vals := map[string]AgentAutoUpdateStatus{
+		"disabled": AgentAutoUpdateStatusDisabled,
+		"enabled":  AgentAutoUpdateStatusEnabled,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := AgentAutoUpdateStatus(input)
+	return &out, nil
+}
+
+type AutomationAccountAuthenticationType string
+
+const (
+	AutomationAccountAuthenticationTypeRunAsAccount           AutomationAccountAuthenticationType = "RunAsAccount"
+	AutomationAccountAuthenticationTypeSystemAssignedIdentity AutomationAccountAuthenticationType = "SystemAssignedIdentity"
+)
+
+func PossibleValuesForAutomationAccountAuthenticationType() []string {
+	return []string{
+		string(AutomationAccountAuthenticationTypeRunAsAccount),
+		string(AutomationAccountAuthenticationTypeSystemAssignedIdentity),
+	}
+}
+
+func parseAutomationAccountAuthenticationType(input string) (*AutomationAccountAuthenticationType, error) {
+	vals := map[string]AutomationAccountAuthenticationType{
+		"runasaccount":           AutomationAccountAuthenticationTypeRunAsAccount,
+		"systemassignedidentity": AutomationAccountAuthenticationTypeSystemAssignedIdentity,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := AutomationAccountAuthenticationType(input)
+	return &out, nil
+}
+
+type HealthErrorCustomerResolvability string
+
+const (
+	HealthErrorCustomerResolvabilityAllowed    HealthErrorCustomerResolvability = "Allowed"
+	HealthErrorCustomerResolvabilityNotAllowed HealthErrorCustomerResolvability = "NotAllowed"
+)
+
+func PossibleValuesForHealthErrorCustomerResolvability() []string {
+	return []string{
+		string(HealthErrorCustomerResolvabilityAllowed),
+		string(HealthErrorCustomerResolvabilityNotAllowed),
+	}
+}
+
+func parseHealthErrorCustomerResolvability(input string) (*HealthErrorCustomerResolvability, error) {
+	vals := map[string]HealthErrorCustomerResolvability{
+		"allowed":    HealthErrorCustomerResolvabilityAllowed,
+		"notallowed": HealthErrorCustomerResolvabilityNotAllowed,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := HealthErrorCustomerResolvability(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/id_replicationprotectioncontainer.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/id_replicationprotectioncontainer.go
@@ -1,0 +1,150 @@
+package replicationprotectioncontainermappings
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = ReplicationProtectionContainerId{}
+
+// ReplicationProtectionContainerId is a struct representing the Resource ID for a Replication Protection Container
+type ReplicationProtectionContainerId struct {
+	SubscriptionId          string
+	ResourceGroupName       string
+	ResourceName            string
+	FabricName              string
+	ProtectionContainerName string
+}
+
+// NewReplicationProtectionContainerID returns a new ReplicationProtectionContainerId struct
+func NewReplicationProtectionContainerID(subscriptionId string, resourceGroupName string, resourceName string, fabricName string, protectionContainerName string) ReplicationProtectionContainerId {
+	return ReplicationProtectionContainerId{
+		SubscriptionId:          subscriptionId,
+		ResourceGroupName:       resourceGroupName,
+		ResourceName:            resourceName,
+		FabricName:              fabricName,
+		ProtectionContainerName: protectionContainerName,
+	}
+}
+
+// ParseReplicationProtectionContainerID parses 'input' into a ReplicationProtectionContainerId
+func ParseReplicationProtectionContainerID(input string) (*ReplicationProtectionContainerId, error) {
+	parser := resourceids.NewParserFromResourceIdType(ReplicationProtectionContainerId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := ReplicationProtectionContainerId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceName, ok = parsed.Parsed["resourceName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceName' was not found in the resource id %q", input)
+	}
+
+	if id.FabricName, ok = parsed.Parsed["fabricName"]; !ok {
+		return nil, fmt.Errorf("the segment 'fabricName' was not found in the resource id %q", input)
+	}
+
+	if id.ProtectionContainerName, ok = parsed.Parsed["protectionContainerName"]; !ok {
+		return nil, fmt.Errorf("the segment 'protectionContainerName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ParseReplicationProtectionContainerIDInsensitively parses 'input' case-insensitively into a ReplicationProtectionContainerId
+// note: this method should only be used for API response data and not user input
+func ParseReplicationProtectionContainerIDInsensitively(input string) (*ReplicationProtectionContainerId, error) {
+	parser := resourceids.NewParserFromResourceIdType(ReplicationProtectionContainerId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := ReplicationProtectionContainerId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceName, ok = parsed.Parsed["resourceName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceName' was not found in the resource id %q", input)
+	}
+
+	if id.FabricName, ok = parsed.Parsed["fabricName"]; !ok {
+		return nil, fmt.Errorf("the segment 'fabricName' was not found in the resource id %q", input)
+	}
+
+	if id.ProtectionContainerName, ok = parsed.Parsed["protectionContainerName"]; !ok {
+		return nil, fmt.Errorf("the segment 'protectionContainerName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ValidateReplicationProtectionContainerID checks that 'input' can be parsed as a Replication Protection Container ID
+func ValidateReplicationProtectionContainerID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseReplicationProtectionContainerID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Replication Protection Container ID
+func (id ReplicationProtectionContainerId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.RecoveryServices/vaults/%s/replicationFabrics/%s/replicationProtectionContainers/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.ResourceName, id.FabricName, id.ProtectionContainerName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Replication Protection Container ID
+func (id ReplicationProtectionContainerId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftRecoveryServices", "Microsoft.RecoveryServices", "Microsoft.RecoveryServices"),
+		resourceids.StaticSegment("staticVaults", "vaults", "vaults"),
+		resourceids.UserSpecifiedSegment("resourceName", "resourceValue"),
+		resourceids.StaticSegment("staticReplicationFabrics", "replicationFabrics", "replicationFabrics"),
+		resourceids.UserSpecifiedSegment("fabricName", "fabricValue"),
+		resourceids.StaticSegment("staticReplicationProtectionContainers", "replicationProtectionContainers", "replicationProtectionContainers"),
+		resourceids.UserSpecifiedSegment("protectionContainerName", "protectionContainerValue"),
+	}
+}
+
+// String returns a human-readable description of this Replication Protection Container ID
+func (id ReplicationProtectionContainerId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Resource Name: %q", id.ResourceName),
+		fmt.Sprintf("Fabric Name: %q", id.FabricName),
+		fmt.Sprintf("Protection Container Name: %q", id.ProtectionContainerName),
+	}
+	return fmt.Sprintf("Replication Protection Container (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/id_replicationprotectioncontainermapping.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/id_replicationprotectioncontainermapping.go
@@ -1,0 +1,163 @@
+package replicationprotectioncontainermappings
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = ReplicationProtectionContainerMappingId{}
+
+// ReplicationProtectionContainerMappingId is a struct representing the Resource ID for a Replication Protection Container Mapping
+type ReplicationProtectionContainerMappingId struct {
+	SubscriptionId          string
+	ResourceGroupName       string
+	ResourceName            string
+	FabricName              string
+	ProtectionContainerName string
+	MappingName             string
+}
+
+// NewReplicationProtectionContainerMappingID returns a new ReplicationProtectionContainerMappingId struct
+func NewReplicationProtectionContainerMappingID(subscriptionId string, resourceGroupName string, resourceName string, fabricName string, protectionContainerName string, mappingName string) ReplicationProtectionContainerMappingId {
+	return ReplicationProtectionContainerMappingId{
+		SubscriptionId:          subscriptionId,
+		ResourceGroupName:       resourceGroupName,
+		ResourceName:            resourceName,
+		FabricName:              fabricName,
+		ProtectionContainerName: protectionContainerName,
+		MappingName:             mappingName,
+	}
+}
+
+// ParseReplicationProtectionContainerMappingID parses 'input' into a ReplicationProtectionContainerMappingId
+func ParseReplicationProtectionContainerMappingID(input string) (*ReplicationProtectionContainerMappingId, error) {
+	parser := resourceids.NewParserFromResourceIdType(ReplicationProtectionContainerMappingId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := ReplicationProtectionContainerMappingId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceName, ok = parsed.Parsed["resourceName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceName' was not found in the resource id %q", input)
+	}
+
+	if id.FabricName, ok = parsed.Parsed["fabricName"]; !ok {
+		return nil, fmt.Errorf("the segment 'fabricName' was not found in the resource id %q", input)
+	}
+
+	if id.ProtectionContainerName, ok = parsed.Parsed["protectionContainerName"]; !ok {
+		return nil, fmt.Errorf("the segment 'protectionContainerName' was not found in the resource id %q", input)
+	}
+
+	if id.MappingName, ok = parsed.Parsed["mappingName"]; !ok {
+		return nil, fmt.Errorf("the segment 'mappingName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ParseReplicationProtectionContainerMappingIDInsensitively parses 'input' case-insensitively into a ReplicationProtectionContainerMappingId
+// note: this method should only be used for API response data and not user input
+func ParseReplicationProtectionContainerMappingIDInsensitively(input string) (*ReplicationProtectionContainerMappingId, error) {
+	parser := resourceids.NewParserFromResourceIdType(ReplicationProtectionContainerMappingId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := ReplicationProtectionContainerMappingId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceName, ok = parsed.Parsed["resourceName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceName' was not found in the resource id %q", input)
+	}
+
+	if id.FabricName, ok = parsed.Parsed["fabricName"]; !ok {
+		return nil, fmt.Errorf("the segment 'fabricName' was not found in the resource id %q", input)
+	}
+
+	if id.ProtectionContainerName, ok = parsed.Parsed["protectionContainerName"]; !ok {
+		return nil, fmt.Errorf("the segment 'protectionContainerName' was not found in the resource id %q", input)
+	}
+
+	if id.MappingName, ok = parsed.Parsed["mappingName"]; !ok {
+		return nil, fmt.Errorf("the segment 'mappingName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ValidateReplicationProtectionContainerMappingID checks that 'input' can be parsed as a Replication Protection Container Mapping ID
+func ValidateReplicationProtectionContainerMappingID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseReplicationProtectionContainerMappingID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Replication Protection Container Mapping ID
+func (id ReplicationProtectionContainerMappingId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.RecoveryServices/vaults/%s/replicationFabrics/%s/replicationProtectionContainers/%s/replicationProtectionContainerMappings/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.ResourceName, id.FabricName, id.ProtectionContainerName, id.MappingName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Replication Protection Container Mapping ID
+func (id ReplicationProtectionContainerMappingId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftRecoveryServices", "Microsoft.RecoveryServices", "Microsoft.RecoveryServices"),
+		resourceids.StaticSegment("staticVaults", "vaults", "vaults"),
+		resourceids.UserSpecifiedSegment("resourceName", "resourceValue"),
+		resourceids.StaticSegment("staticReplicationFabrics", "replicationFabrics", "replicationFabrics"),
+		resourceids.UserSpecifiedSegment("fabricName", "fabricValue"),
+		resourceids.StaticSegment("staticReplicationProtectionContainers", "replicationProtectionContainers", "replicationProtectionContainers"),
+		resourceids.UserSpecifiedSegment("protectionContainerName", "protectionContainerValue"),
+		resourceids.StaticSegment("staticReplicationProtectionContainerMappings", "replicationProtectionContainerMappings", "replicationProtectionContainerMappings"),
+		resourceids.UserSpecifiedSegment("mappingName", "mappingValue"),
+	}
+}
+
+// String returns a human-readable description of this Replication Protection Container Mapping ID
+func (id ReplicationProtectionContainerMappingId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Resource Name: %q", id.ResourceName),
+		fmt.Sprintf("Fabric Name: %q", id.FabricName),
+		fmt.Sprintf("Protection Container Name: %q", id.ProtectionContainerName),
+		fmt.Sprintf("Mapping Name: %q", id.MappingName),
+	}
+	return fmt.Sprintf("Replication Protection Container Mapping (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/id_vault.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/id_vault.go
@@ -1,0 +1,124 @@
+package replicationprotectioncontainermappings
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = VaultId{}
+
+// VaultId is a struct representing the Resource ID for a Vault
+type VaultId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	ResourceName      string
+}
+
+// NewVaultID returns a new VaultId struct
+func NewVaultID(subscriptionId string, resourceGroupName string, resourceName string) VaultId {
+	return VaultId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		ResourceName:      resourceName,
+	}
+}
+
+// ParseVaultID parses 'input' into a VaultId
+func ParseVaultID(input string) (*VaultId, error) {
+	parser := resourceids.NewParserFromResourceIdType(VaultId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := VaultId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceName, ok = parsed.Parsed["resourceName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ParseVaultIDInsensitively parses 'input' case-insensitively into a VaultId
+// note: this method should only be used for API response data and not user input
+func ParseVaultIDInsensitively(input string) (*VaultId, error) {
+	parser := resourceids.NewParserFromResourceIdType(VaultId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := VaultId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceName, ok = parsed.Parsed["resourceName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ValidateVaultID checks that 'input' can be parsed as a Vault ID
+func ValidateVaultID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseVaultID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Vault ID
+func (id VaultId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.RecoveryServices/vaults/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.ResourceName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Vault ID
+func (id VaultId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftRecoveryServices", "Microsoft.RecoveryServices", "Microsoft.RecoveryServices"),
+		resourceids.StaticSegment("staticVaults", "vaults", "vaults"),
+		resourceids.UserSpecifiedSegment("resourceName", "resourceValue"),
+	}
+}
+
+// String returns a human-readable description of this Vault ID
+func (id VaultId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Resource Name: %q", id.ResourceName),
+	}
+	return fmt.Sprintf("Vault (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/method_create_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/method_create_autorest.go
@@ -1,0 +1,79 @@
+package replicationprotectioncontainermappings
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CreateOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// Create ...
+func (c ReplicationProtectionContainerMappingsClient) Create(ctx context.Context, id ReplicationProtectionContainerMappingId, input CreateProtectionContainerMappingInput) (result CreateOperationResponse, err error) {
+	req, err := c.preparerForCreate(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotectioncontainermappings.ReplicationProtectionContainerMappingsClient", "Create", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForCreate(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotectioncontainermappings.ReplicationProtectionContainerMappingsClient", "Create", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// CreateThenPoll performs Create then polls until it's completed
+func (c ReplicationProtectionContainerMappingsClient) CreateThenPoll(ctx context.Context, id ReplicationProtectionContainerMappingId, input CreateProtectionContainerMappingInput) error {
+	result, err := c.Create(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing Create: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after Create: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForCreate prepares the Create request.
+func (c ReplicationProtectionContainerMappingsClient) preparerForCreate(ctx context.Context, id ReplicationProtectionContainerMappingId, input CreateProtectionContainerMappingInput) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPut(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForCreate sends the Create request. The method will close the
+// http.Response Body if it receives an error.
+func (c ReplicationProtectionContainerMappingsClient) senderForCreate(ctx context.Context, req *http.Request) (future CreateOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/method_delete_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/method_delete_autorest.go
@@ -1,0 +1,79 @@
+package replicationprotectioncontainermappings
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DeleteOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// Delete ...
+func (c ReplicationProtectionContainerMappingsClient) Delete(ctx context.Context, id ReplicationProtectionContainerMappingId, input RemoveProtectionContainerMappingInput) (result DeleteOperationResponse, err error) {
+	req, err := c.preparerForDelete(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotectioncontainermappings.ReplicationProtectionContainerMappingsClient", "Delete", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForDelete(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotectioncontainermappings.ReplicationProtectionContainerMappingsClient", "Delete", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// DeleteThenPoll performs Delete then polls until it's completed
+func (c ReplicationProtectionContainerMappingsClient) DeleteThenPoll(ctx context.Context, id ReplicationProtectionContainerMappingId, input RemoveProtectionContainerMappingInput) error {
+	result, err := c.Delete(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing Delete: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after Delete: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForDelete prepares the Delete request.
+func (c ReplicationProtectionContainerMappingsClient) preparerForDelete(ctx context.Context, id ReplicationProtectionContainerMappingId, input RemoveProtectionContainerMappingInput) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/remove", id.ID())),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForDelete sends the Delete request. The method will close the
+// http.Response Body if it receives an error.
+func (c ReplicationProtectionContainerMappingsClient) senderForDelete(ctx context.Context, req *http.Request) (future DeleteOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/method_get_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/method_get_autorest.go
@@ -1,0 +1,68 @@
+package replicationprotectioncontainermappings
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *ProtectionContainerMapping
+}
+
+// Get ...
+func (c ReplicationProtectionContainerMappingsClient) Get(ctx context.Context, id ReplicationProtectionContainerMappingId) (result GetOperationResponse, err error) {
+	req, err := c.preparerForGet(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotectioncontainermappings.ReplicationProtectionContainerMappingsClient", "Get", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotectioncontainermappings.ReplicationProtectionContainerMappingsClient", "Get", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForGet(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotectioncontainermappings.ReplicationProtectionContainerMappingsClient", "Get", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForGet prepares the Get request.
+func (c ReplicationProtectionContainerMappingsClient) preparerForGet(ctx context.Context, id ReplicationProtectionContainerMappingId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForGet handles the response to the Get request. The method always
+// closes the http.Response Body.
+func (c ReplicationProtectionContainerMappingsClient) responderForGet(resp *http.Response) (result GetOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/method_list_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/method_list_autorest.go
@@ -1,0 +1,186 @@
+package replicationprotectioncontainermappings
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *[]ProtectionContainerMapping
+
+	nextLink     *string
+	nextPageFunc func(ctx context.Context, nextLink string) (ListOperationResponse, error)
+}
+
+type ListCompleteResult struct {
+	Items []ProtectionContainerMapping
+}
+
+func (r ListOperationResponse) HasMore() bool {
+	return r.nextLink != nil
+}
+
+func (r ListOperationResponse) LoadMore(ctx context.Context) (resp ListOperationResponse, err error) {
+	if !r.HasMore() {
+		err = fmt.Errorf("no more pages returned")
+		return
+	}
+	return r.nextPageFunc(ctx, *r.nextLink)
+}
+
+// List ...
+func (c ReplicationProtectionContainerMappingsClient) List(ctx context.Context, id VaultId) (resp ListOperationResponse, err error) {
+	req, err := c.preparerForList(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotectioncontainermappings.ReplicationProtectionContainerMappingsClient", "List", nil, "Failure preparing request")
+		return
+	}
+
+	resp.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotectioncontainermappings.ReplicationProtectionContainerMappingsClient", "List", resp.HttpResponse, "Failure sending request")
+		return
+	}
+
+	resp, err = c.responderForList(resp.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotectioncontainermappings.ReplicationProtectionContainerMappingsClient", "List", resp.HttpResponse, "Failure responding to request")
+		return
+	}
+	return
+}
+
+// preparerForList prepares the List request.
+func (c ReplicationProtectionContainerMappingsClient) preparerForList(ctx context.Context, id VaultId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/replicationProtectionContainerMappings", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// preparerForListWithNextLink prepares the List request with the given nextLink token.
+func (c ReplicationProtectionContainerMappingsClient) preparerForListWithNextLink(ctx context.Context, nextLink string) (*http.Request, error) {
+	uri, err := url.Parse(nextLink)
+	if err != nil {
+		return nil, fmt.Errorf("parsing nextLink %q: %+v", nextLink, err)
+	}
+	queryParameters := map[string]interface{}{}
+	for k, v := range uri.Query() {
+		if len(v) == 0 {
+			continue
+		}
+		val := v[0]
+		val = autorest.Encode("query", val)
+		queryParameters[k] = val
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(uri.Path),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForList handles the response to the List request. The method always
+// closes the http.Response Body.
+func (c ReplicationProtectionContainerMappingsClient) responderForList(resp *http.Response) (result ListOperationResponse, err error) {
+	type page struct {
+		Values   []ProtectionContainerMapping `json:"value"`
+		NextLink *string                      `json:"nextLink"`
+	}
+	var respObj page
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&respObj),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	result.Model = &respObj.Values
+	result.nextLink = respObj.NextLink
+	if respObj.NextLink != nil {
+		result.nextPageFunc = func(ctx context.Context, nextLink string) (result ListOperationResponse, err error) {
+			req, err := c.preparerForListWithNextLink(ctx, nextLink)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "replicationprotectioncontainermappings.ReplicationProtectionContainerMappingsClient", "List", nil, "Failure preparing request")
+				return
+			}
+
+			result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "replicationprotectioncontainermappings.ReplicationProtectionContainerMappingsClient", "List", result.HttpResponse, "Failure sending request")
+				return
+			}
+
+			result, err = c.responderForList(result.HttpResponse)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "replicationprotectioncontainermappings.ReplicationProtectionContainerMappingsClient", "List", result.HttpResponse, "Failure responding to request")
+				return
+			}
+
+			return
+		}
+	}
+	return
+}
+
+// ListComplete retrieves all of the results into a single object
+func (c ReplicationProtectionContainerMappingsClient) ListComplete(ctx context.Context, id VaultId) (ListCompleteResult, error) {
+	return c.ListCompleteMatchingPredicate(ctx, id, ProtectionContainerMappingOperationPredicate{})
+}
+
+// ListCompleteMatchingPredicate retrieves all of the results and then applied the predicate
+func (c ReplicationProtectionContainerMappingsClient) ListCompleteMatchingPredicate(ctx context.Context, id VaultId, predicate ProtectionContainerMappingOperationPredicate) (resp ListCompleteResult, err error) {
+	items := make([]ProtectionContainerMapping, 0)
+
+	page, err := c.List(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading the initial page: %+v", err)
+		return
+	}
+	if page.Model != nil {
+		for _, v := range *page.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	for page.HasMore() {
+		page, err = page.LoadMore(ctx)
+		if err != nil {
+			err = fmt.Errorf("loading the next page: %+v", err)
+			return
+		}
+
+		if page.Model != nil {
+			for _, v := range *page.Model {
+				if predicate.Matches(v) {
+					items = append(items, v)
+				}
+			}
+		}
+	}
+
+	out := ListCompleteResult{
+		Items: items,
+	}
+	return out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/method_listbyreplicationprotectioncontainers_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/method_listbyreplicationprotectioncontainers_autorest.go
@@ -1,0 +1,186 @@
+package replicationprotectioncontainermappings
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListByReplicationProtectionContainersOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *[]ProtectionContainerMapping
+
+	nextLink     *string
+	nextPageFunc func(ctx context.Context, nextLink string) (ListByReplicationProtectionContainersOperationResponse, error)
+}
+
+type ListByReplicationProtectionContainersCompleteResult struct {
+	Items []ProtectionContainerMapping
+}
+
+func (r ListByReplicationProtectionContainersOperationResponse) HasMore() bool {
+	return r.nextLink != nil
+}
+
+func (r ListByReplicationProtectionContainersOperationResponse) LoadMore(ctx context.Context) (resp ListByReplicationProtectionContainersOperationResponse, err error) {
+	if !r.HasMore() {
+		err = fmt.Errorf("no more pages returned")
+		return
+	}
+	return r.nextPageFunc(ctx, *r.nextLink)
+}
+
+// ListByReplicationProtectionContainers ...
+func (c ReplicationProtectionContainerMappingsClient) ListByReplicationProtectionContainers(ctx context.Context, id ReplicationProtectionContainerId) (resp ListByReplicationProtectionContainersOperationResponse, err error) {
+	req, err := c.preparerForListByReplicationProtectionContainers(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotectioncontainermappings.ReplicationProtectionContainerMappingsClient", "ListByReplicationProtectionContainers", nil, "Failure preparing request")
+		return
+	}
+
+	resp.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotectioncontainermappings.ReplicationProtectionContainerMappingsClient", "ListByReplicationProtectionContainers", resp.HttpResponse, "Failure sending request")
+		return
+	}
+
+	resp, err = c.responderForListByReplicationProtectionContainers(resp.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotectioncontainermappings.ReplicationProtectionContainerMappingsClient", "ListByReplicationProtectionContainers", resp.HttpResponse, "Failure responding to request")
+		return
+	}
+	return
+}
+
+// preparerForListByReplicationProtectionContainers prepares the ListByReplicationProtectionContainers request.
+func (c ReplicationProtectionContainerMappingsClient) preparerForListByReplicationProtectionContainers(ctx context.Context, id ReplicationProtectionContainerId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/replicationProtectionContainerMappings", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// preparerForListByReplicationProtectionContainersWithNextLink prepares the ListByReplicationProtectionContainers request with the given nextLink token.
+func (c ReplicationProtectionContainerMappingsClient) preparerForListByReplicationProtectionContainersWithNextLink(ctx context.Context, nextLink string) (*http.Request, error) {
+	uri, err := url.Parse(nextLink)
+	if err != nil {
+		return nil, fmt.Errorf("parsing nextLink %q: %+v", nextLink, err)
+	}
+	queryParameters := map[string]interface{}{}
+	for k, v := range uri.Query() {
+		if len(v) == 0 {
+			continue
+		}
+		val := v[0]
+		val = autorest.Encode("query", val)
+		queryParameters[k] = val
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(uri.Path),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForListByReplicationProtectionContainers handles the response to the ListByReplicationProtectionContainers request. The method always
+// closes the http.Response Body.
+func (c ReplicationProtectionContainerMappingsClient) responderForListByReplicationProtectionContainers(resp *http.Response) (result ListByReplicationProtectionContainersOperationResponse, err error) {
+	type page struct {
+		Values   []ProtectionContainerMapping `json:"value"`
+		NextLink *string                      `json:"nextLink"`
+	}
+	var respObj page
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&respObj),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	result.Model = &respObj.Values
+	result.nextLink = respObj.NextLink
+	if respObj.NextLink != nil {
+		result.nextPageFunc = func(ctx context.Context, nextLink string) (result ListByReplicationProtectionContainersOperationResponse, err error) {
+			req, err := c.preparerForListByReplicationProtectionContainersWithNextLink(ctx, nextLink)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "replicationprotectioncontainermappings.ReplicationProtectionContainerMappingsClient", "ListByReplicationProtectionContainers", nil, "Failure preparing request")
+				return
+			}
+
+			result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "replicationprotectioncontainermappings.ReplicationProtectionContainerMappingsClient", "ListByReplicationProtectionContainers", result.HttpResponse, "Failure sending request")
+				return
+			}
+
+			result, err = c.responderForListByReplicationProtectionContainers(result.HttpResponse)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "replicationprotectioncontainermappings.ReplicationProtectionContainerMappingsClient", "ListByReplicationProtectionContainers", result.HttpResponse, "Failure responding to request")
+				return
+			}
+
+			return
+		}
+	}
+	return
+}
+
+// ListByReplicationProtectionContainersComplete retrieves all of the results into a single object
+func (c ReplicationProtectionContainerMappingsClient) ListByReplicationProtectionContainersComplete(ctx context.Context, id ReplicationProtectionContainerId) (ListByReplicationProtectionContainersCompleteResult, error) {
+	return c.ListByReplicationProtectionContainersCompleteMatchingPredicate(ctx, id, ProtectionContainerMappingOperationPredicate{})
+}
+
+// ListByReplicationProtectionContainersCompleteMatchingPredicate retrieves all of the results and then applied the predicate
+func (c ReplicationProtectionContainerMappingsClient) ListByReplicationProtectionContainersCompleteMatchingPredicate(ctx context.Context, id ReplicationProtectionContainerId, predicate ProtectionContainerMappingOperationPredicate) (resp ListByReplicationProtectionContainersCompleteResult, err error) {
+	items := make([]ProtectionContainerMapping, 0)
+
+	page, err := c.ListByReplicationProtectionContainers(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading the initial page: %+v", err)
+		return
+	}
+	if page.Model != nil {
+		for _, v := range *page.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	for page.HasMore() {
+		page, err = page.LoadMore(ctx)
+		if err != nil {
+			err = fmt.Errorf("loading the next page: %+v", err)
+			return
+		}
+
+		if page.Model != nil {
+			for _, v := range *page.Model {
+				if predicate.Matches(v) {
+					items = append(items, v)
+				}
+			}
+		}
+	}
+
+	out := ListByReplicationProtectionContainersCompleteResult{
+		Items: items,
+	}
+	return out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/method_purge_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/method_purge_autorest.go
@@ -1,0 +1,78 @@
+package replicationprotectioncontainermappings
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PurgeOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// Purge ...
+func (c ReplicationProtectionContainerMappingsClient) Purge(ctx context.Context, id ReplicationProtectionContainerMappingId) (result PurgeOperationResponse, err error) {
+	req, err := c.preparerForPurge(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotectioncontainermappings.ReplicationProtectionContainerMappingsClient", "Purge", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForPurge(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotectioncontainermappings.ReplicationProtectionContainerMappingsClient", "Purge", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// PurgeThenPoll performs Purge then polls until it's completed
+func (c ReplicationProtectionContainerMappingsClient) PurgeThenPoll(ctx context.Context, id ReplicationProtectionContainerMappingId) error {
+	result, err := c.Purge(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing Purge: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after Purge: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForPurge prepares the Purge request.
+func (c ReplicationProtectionContainerMappingsClient) preparerForPurge(ctx context.Context, id ReplicationProtectionContainerMappingId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsDelete(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForPurge sends the Purge request. The method will close the
+// http.Response Body if it receives an error.
+func (c ReplicationProtectionContainerMappingsClient) senderForPurge(ctx context.Context, req *http.Request) (future PurgeOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/method_update_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/method_update_autorest.go
@@ -1,0 +1,79 @@
+package replicationprotectioncontainermappings
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UpdateOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// Update ...
+func (c ReplicationProtectionContainerMappingsClient) Update(ctx context.Context, id ReplicationProtectionContainerMappingId, input UpdateProtectionContainerMappingInput) (result UpdateOperationResponse, err error) {
+	req, err := c.preparerForUpdate(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotectioncontainermappings.ReplicationProtectionContainerMappingsClient", "Update", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForUpdate(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotectioncontainermappings.ReplicationProtectionContainerMappingsClient", "Update", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// UpdateThenPoll performs Update then polls until it's completed
+func (c ReplicationProtectionContainerMappingsClient) UpdateThenPoll(ctx context.Context, id ReplicationProtectionContainerMappingId, input UpdateProtectionContainerMappingInput) error {
+	result, err := c.Update(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing Update: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after Update: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForUpdate prepares the Update request.
+func (c ReplicationProtectionContainerMappingsClient) preparerForUpdate(ctx context.Context, id ReplicationProtectionContainerMappingId, input UpdateProtectionContainerMappingInput) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPatch(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForUpdate sends the Update request. The method will close the
+// http.Response Body if it receives an error.
+func (c ReplicationProtectionContainerMappingsClient) senderForUpdate(ctx context.Context, req *http.Request) (future UpdateOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/model_a2acontainermappinginput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/model_a2acontainermappinginput.go
@@ -1,0 +1,43 @@
+package replicationprotectioncontainermappings
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ReplicationProviderSpecificContainerMappingInput = A2AContainerMappingInput{}
+
+type A2AContainerMappingInput struct {
+	AgentAutoUpdateStatus               *AgentAutoUpdateStatus               `json:"agentAutoUpdateStatus,omitempty"`
+	AutomationAccountArmId              *string                              `json:"automationAccountArmId,omitempty"`
+	AutomationAccountAuthenticationType *AutomationAccountAuthenticationType `json:"automationAccountAuthenticationType,omitempty"`
+
+	// Fields inherited from ReplicationProviderSpecificContainerMappingInput
+}
+
+var _ json.Marshaler = A2AContainerMappingInput{}
+
+func (s A2AContainerMappingInput) MarshalJSON() ([]byte, error) {
+	type wrapper A2AContainerMappingInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling A2AContainerMappingInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling A2AContainerMappingInput: %+v", err)
+	}
+	decoded["instanceType"] = "A2A"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling A2AContainerMappingInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/model_a2aprotectioncontainermappingdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/model_a2aprotectioncontainermappingdetails.go
@@ -1,0 +1,45 @@
+package replicationprotectioncontainermappings
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ProtectionContainerMappingProviderSpecificDetails = A2AProtectionContainerMappingDetails{}
+
+type A2AProtectionContainerMappingDetails struct {
+	AgentAutoUpdateStatus               *AgentAutoUpdateStatus               `json:"agentAutoUpdateStatus,omitempty"`
+	AutomationAccountArmId              *string                              `json:"automationAccountArmId,omitempty"`
+	AutomationAccountAuthenticationType *AutomationAccountAuthenticationType `json:"automationAccountAuthenticationType,omitempty"`
+	JobScheduleName                     *string                              `json:"jobScheduleName,omitempty"`
+	ScheduleName                        *string                              `json:"scheduleName,omitempty"`
+
+	// Fields inherited from ProtectionContainerMappingProviderSpecificDetails
+}
+
+var _ json.Marshaler = A2AProtectionContainerMappingDetails{}
+
+func (s A2AProtectionContainerMappingDetails) MarshalJSON() ([]byte, error) {
+	type wrapper A2AProtectionContainerMappingDetails
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling A2AProtectionContainerMappingDetails: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling A2AProtectionContainerMappingDetails: %+v", err)
+	}
+	decoded["instanceType"] = "A2A"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling A2AProtectionContainerMappingDetails: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/model_a2aupdatecontainermappinginput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/model_a2aupdatecontainermappinginput.go
@@ -1,0 +1,43 @@
+package replicationprotectioncontainermappings
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ReplicationProviderSpecificUpdateContainerMappingInput = A2AUpdateContainerMappingInput{}
+
+type A2AUpdateContainerMappingInput struct {
+	AgentAutoUpdateStatus               *AgentAutoUpdateStatus               `json:"agentAutoUpdateStatus,omitempty"`
+	AutomationAccountArmId              *string                              `json:"automationAccountArmId,omitempty"`
+	AutomationAccountAuthenticationType *AutomationAccountAuthenticationType `json:"automationAccountAuthenticationType,omitempty"`
+
+	// Fields inherited from ReplicationProviderSpecificUpdateContainerMappingInput
+}
+
+var _ json.Marshaler = A2AUpdateContainerMappingInput{}
+
+func (s A2AUpdateContainerMappingInput) MarshalJSON() ([]byte, error) {
+	type wrapper A2AUpdateContainerMappingInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling A2AUpdateContainerMappingInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling A2AUpdateContainerMappingInput: %+v", err)
+	}
+	decoded["instanceType"] = "A2A"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling A2AUpdateContainerMappingInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/model_createprotectioncontainermappinginput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/model_createprotectioncontainermappinginput.go
@@ -1,0 +1,8 @@
+package replicationprotectioncontainermappings
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CreateProtectionContainerMappingInput struct {
+	Properties *CreateProtectionContainerMappingInputProperties `json:"properties,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/model_createprotectioncontainermappinginputproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/model_createprotectioncontainermappinginputproperties.go
@@ -1,0 +1,42 @@
+package replicationprotectioncontainermappings
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CreateProtectionContainerMappingInputProperties struct {
+	PolicyId                    *string                                          `json:"policyId,omitempty"`
+	ProviderSpecificInput       ReplicationProviderSpecificContainerMappingInput `json:"providerSpecificInput"`
+	TargetProtectionContainerId *string                                          `json:"targetProtectionContainerId,omitempty"`
+}
+
+var _ json.Unmarshaler = &CreateProtectionContainerMappingInputProperties{}
+
+func (s *CreateProtectionContainerMappingInputProperties) UnmarshalJSON(bytes []byte) error {
+	type alias CreateProtectionContainerMappingInputProperties
+	var decoded alias
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling into CreateProtectionContainerMappingInputProperties: %+v", err)
+	}
+
+	s.PolicyId = decoded.PolicyId
+	s.TargetProtectionContainerId = decoded.TargetProtectionContainerId
+
+	var temp map[string]json.RawMessage
+	if err := json.Unmarshal(bytes, &temp); err != nil {
+		return fmt.Errorf("unmarshaling CreateProtectionContainerMappingInputProperties into map[string]json.RawMessage: %+v", err)
+	}
+
+	if v, ok := temp["providerSpecificInput"]; ok {
+		impl, err := unmarshalReplicationProviderSpecificContainerMappingInputImplementation(v)
+		if err != nil {
+			return fmt.Errorf("unmarshaling field 'ProviderSpecificInput' for 'CreateProtectionContainerMappingInputProperties': %+v", err)
+		}
+		s.ProviderSpecificInput = impl
+	}
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/model_healtherror.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/model_healtherror.go
@@ -1,0 +1,40 @@
+package replicationprotectioncontainermappings
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type HealthError struct {
+	CreationTimeUtc              *string                           `json:"creationTimeUtc,omitempty"`
+	CustomerResolvability        *HealthErrorCustomerResolvability `json:"customerResolvability,omitempty"`
+	EntityId                     *string                           `json:"entityId,omitempty"`
+	ErrorCategory                *string                           `json:"errorCategory,omitempty"`
+	ErrorCode                    *string                           `json:"errorCode,omitempty"`
+	ErrorId                      *string                           `json:"errorId,omitempty"`
+	ErrorLevel                   *string                           `json:"errorLevel,omitempty"`
+	ErrorMessage                 *string                           `json:"errorMessage,omitempty"`
+	ErrorSource                  *string                           `json:"errorSource,omitempty"`
+	ErrorType                    *string                           `json:"errorType,omitempty"`
+	InnerHealthErrors            *[]InnerHealthError               `json:"innerHealthErrors,omitempty"`
+	PossibleCauses               *string                           `json:"possibleCauses,omitempty"`
+	RecommendedAction            *string                           `json:"recommendedAction,omitempty"`
+	RecoveryProviderErrorMessage *string                           `json:"recoveryProviderErrorMessage,omitempty"`
+	SummaryMessage               *string                           `json:"summaryMessage,omitempty"`
+}
+
+func (o *HealthError) GetCreationTimeUtcAsTime() (*time.Time, error) {
+	if o.CreationTimeUtc == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.CreationTimeUtc, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *HealthError) SetCreationTimeUtcAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.CreationTimeUtc = &formatted
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/model_inmagercmprotectioncontainermappingdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/model_inmagercmprotectioncontainermappingdetails.go
@@ -1,0 +1,41 @@
+package replicationprotectioncontainermappings
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ProtectionContainerMappingProviderSpecificDetails = InMageRcmProtectionContainerMappingDetails{}
+
+type InMageRcmProtectionContainerMappingDetails struct {
+	EnableAgentAutoUpgrade *string `json:"enableAgentAutoUpgrade,omitempty"`
+
+	// Fields inherited from ProtectionContainerMappingProviderSpecificDetails
+}
+
+var _ json.Marshaler = InMageRcmProtectionContainerMappingDetails{}
+
+func (s InMageRcmProtectionContainerMappingDetails) MarshalJSON() ([]byte, error) {
+	type wrapper InMageRcmProtectionContainerMappingDetails
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling InMageRcmProtectionContainerMappingDetails: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling InMageRcmProtectionContainerMappingDetails: %+v", err)
+	}
+	decoded["instanceType"] = "InMageRcm"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling InMageRcmProtectionContainerMappingDetails: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/model_inmagercmupdatecontainermappinginput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/model_inmagercmupdatecontainermappinginput.go
@@ -1,0 +1,41 @@
+package replicationprotectioncontainermappings
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ReplicationProviderSpecificUpdateContainerMappingInput = InMageRcmUpdateContainerMappingInput{}
+
+type InMageRcmUpdateContainerMappingInput struct {
+	EnableAgentAutoUpgrade string `json:"enableAgentAutoUpgrade"`
+
+	// Fields inherited from ReplicationProviderSpecificUpdateContainerMappingInput
+}
+
+var _ json.Marshaler = InMageRcmUpdateContainerMappingInput{}
+
+func (s InMageRcmUpdateContainerMappingInput) MarshalJSON() ([]byte, error) {
+	type wrapper InMageRcmUpdateContainerMappingInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling InMageRcmUpdateContainerMappingInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling InMageRcmUpdateContainerMappingInput: %+v", err)
+	}
+	decoded["instanceType"] = "InMageRcm"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling InMageRcmUpdateContainerMappingInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/model_innerhealtherror.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/model_innerhealtherror.go
@@ -1,0 +1,39 @@
+package replicationprotectioncontainermappings
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type InnerHealthError struct {
+	CreationTimeUtc              *string                           `json:"creationTimeUtc,omitempty"`
+	CustomerResolvability        *HealthErrorCustomerResolvability `json:"customerResolvability,omitempty"`
+	EntityId                     *string                           `json:"entityId,omitempty"`
+	ErrorCategory                *string                           `json:"errorCategory,omitempty"`
+	ErrorCode                    *string                           `json:"errorCode,omitempty"`
+	ErrorId                      *string                           `json:"errorId,omitempty"`
+	ErrorLevel                   *string                           `json:"errorLevel,omitempty"`
+	ErrorMessage                 *string                           `json:"errorMessage,omitempty"`
+	ErrorSource                  *string                           `json:"errorSource,omitempty"`
+	ErrorType                    *string                           `json:"errorType,omitempty"`
+	PossibleCauses               *string                           `json:"possibleCauses,omitempty"`
+	RecommendedAction            *string                           `json:"recommendedAction,omitempty"`
+	RecoveryProviderErrorMessage *string                           `json:"recoveryProviderErrorMessage,omitempty"`
+	SummaryMessage               *string                           `json:"summaryMessage,omitempty"`
+}
+
+func (o *InnerHealthError) GetCreationTimeUtcAsTime() (*time.Time, error) {
+	if o.CreationTimeUtc == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.CreationTimeUtc, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *InnerHealthError) SetCreationTimeUtcAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.CreationTimeUtc = &formatted
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/model_protectioncontainermapping.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/model_protectioncontainermapping.go
@@ -1,0 +1,12 @@
+package replicationprotectioncontainermappings
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ProtectionContainerMapping struct {
+	Id         *string                               `json:"id,omitempty"`
+	Location   *string                               `json:"location,omitempty"`
+	Name       *string                               `json:"name,omitempty"`
+	Properties *ProtectionContainerMappingProperties `json:"properties,omitempty"`
+	Type       *string                               `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/model_protectioncontainermappingproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/model_protectioncontainermappingproperties.go
@@ -1,0 +1,58 @@
+package replicationprotectioncontainermappings
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ProtectionContainerMappingProperties struct {
+	Health                                *string                                           `json:"health,omitempty"`
+	HealthErrorDetails                    *[]HealthError                                    `json:"healthErrorDetails,omitempty"`
+	PolicyFriendlyName                    *string                                           `json:"policyFriendlyName,omitempty"`
+	PolicyId                              *string                                           `json:"policyId,omitempty"`
+	ProviderSpecificDetails               ProtectionContainerMappingProviderSpecificDetails `json:"providerSpecificDetails"`
+	SourceFabricFriendlyName              *string                                           `json:"sourceFabricFriendlyName,omitempty"`
+	SourceProtectionContainerFriendlyName *string                                           `json:"sourceProtectionContainerFriendlyName,omitempty"`
+	State                                 *string                                           `json:"state,omitempty"`
+	TargetFabricFriendlyName              *string                                           `json:"targetFabricFriendlyName,omitempty"`
+	TargetProtectionContainerFriendlyName *string                                           `json:"targetProtectionContainerFriendlyName,omitempty"`
+	TargetProtectionContainerId           *string                                           `json:"targetProtectionContainerId,omitempty"`
+}
+
+var _ json.Unmarshaler = &ProtectionContainerMappingProperties{}
+
+func (s *ProtectionContainerMappingProperties) UnmarshalJSON(bytes []byte) error {
+	type alias ProtectionContainerMappingProperties
+	var decoded alias
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling into ProtectionContainerMappingProperties: %+v", err)
+	}
+
+	s.Health = decoded.Health
+	s.HealthErrorDetails = decoded.HealthErrorDetails
+	s.PolicyFriendlyName = decoded.PolicyFriendlyName
+	s.PolicyId = decoded.PolicyId
+	s.SourceFabricFriendlyName = decoded.SourceFabricFriendlyName
+	s.SourceProtectionContainerFriendlyName = decoded.SourceProtectionContainerFriendlyName
+	s.State = decoded.State
+	s.TargetFabricFriendlyName = decoded.TargetFabricFriendlyName
+	s.TargetProtectionContainerFriendlyName = decoded.TargetProtectionContainerFriendlyName
+	s.TargetProtectionContainerId = decoded.TargetProtectionContainerId
+
+	var temp map[string]json.RawMessage
+	if err := json.Unmarshal(bytes, &temp); err != nil {
+		return fmt.Errorf("unmarshaling ProtectionContainerMappingProperties into map[string]json.RawMessage: %+v", err)
+	}
+
+	if v, ok := temp["providerSpecificDetails"]; ok {
+		impl, err := unmarshalProtectionContainerMappingProviderSpecificDetailsImplementation(v)
+		if err != nil {
+			return fmt.Errorf("unmarshaling field 'ProviderSpecificDetails' for 'ProtectionContainerMappingProperties': %+v", err)
+		}
+		s.ProviderSpecificDetails = impl
+	}
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/model_protectioncontainermappingproviderspecificdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/model_protectioncontainermappingproviderspecificdetails.go
@@ -1,0 +1,64 @@
+package replicationprotectioncontainermappings
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ProtectionContainerMappingProviderSpecificDetails interface {
+}
+
+func unmarshalProtectionContainerMappingProviderSpecificDetailsImplementation(input []byte) (ProtectionContainerMappingProviderSpecificDetails, error) {
+	if input == nil {
+		return nil, nil
+	}
+
+	var temp map[string]interface{}
+	if err := json.Unmarshal(input, &temp); err != nil {
+		return nil, fmt.Errorf("unmarshaling ProtectionContainerMappingProviderSpecificDetails into map[string]interface: %+v", err)
+	}
+
+	value, ok := temp["instanceType"].(string)
+	if !ok {
+		return nil, nil
+	}
+
+	if strings.EqualFold(value, "A2A") {
+		var out A2AProtectionContainerMappingDetails
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into A2AProtectionContainerMappingDetails: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "InMageRcm") {
+		var out InMageRcmProtectionContainerMappingDetails
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into InMageRcmProtectionContainerMappingDetails: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "VMwareCbt") {
+		var out VMwareCbtProtectionContainerMappingDetails
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into VMwareCbtProtectionContainerMappingDetails: %+v", err)
+		}
+		return out, nil
+	}
+
+	type RawProtectionContainerMappingProviderSpecificDetailsImpl struct {
+		Type   string                 `json:"-"`
+		Values map[string]interface{} `json:"-"`
+	}
+	out := RawProtectionContainerMappingProviderSpecificDetailsImpl{
+		Type:   value,
+		Values: temp,
+	}
+	return out, nil
+
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/model_removeprotectioncontainermappinginput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/model_removeprotectioncontainermappinginput.go
@@ -1,0 +1,8 @@
+package replicationprotectioncontainermappings
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RemoveProtectionContainerMappingInput struct {
+	Properties *RemoveProtectionContainerMappingInputProperties `json:"properties,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/model_removeprotectioncontainermappinginputproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/model_removeprotectioncontainermappinginputproperties.go
@@ -1,0 +1,8 @@
+package replicationprotectioncontainermappings
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RemoveProtectionContainerMappingInputProperties struct {
+	ProviderSpecificInput *ReplicationProviderContainerUnmappingInput `json:"providerSpecificInput,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/model_replicationprovidercontainerunmappinginput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/model_replicationprovidercontainerunmappinginput.go
@@ -1,0 +1,8 @@
+package replicationprotectioncontainermappings
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ReplicationProviderContainerUnmappingInput struct {
+	InstanceType *string `json:"instanceType,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/model_replicationproviderspecificcontainermappinginput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/model_replicationproviderspecificcontainermappinginput.go
@@ -1,0 +1,56 @@
+package replicationprotectioncontainermappings
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ReplicationProviderSpecificContainerMappingInput interface {
+}
+
+func unmarshalReplicationProviderSpecificContainerMappingInputImplementation(input []byte) (ReplicationProviderSpecificContainerMappingInput, error) {
+	if input == nil {
+		return nil, nil
+	}
+
+	var temp map[string]interface{}
+	if err := json.Unmarshal(input, &temp); err != nil {
+		return nil, fmt.Errorf("unmarshaling ReplicationProviderSpecificContainerMappingInput into map[string]interface: %+v", err)
+	}
+
+	value, ok := temp["instanceType"].(string)
+	if !ok {
+		return nil, nil
+	}
+
+	if strings.EqualFold(value, "A2A") {
+		var out A2AContainerMappingInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into A2AContainerMappingInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "VMwareCbt") {
+		var out VMwareCbtContainerMappingInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into VMwareCbtContainerMappingInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	type RawReplicationProviderSpecificContainerMappingInputImpl struct {
+		Type   string                 `json:"-"`
+		Values map[string]interface{} `json:"-"`
+	}
+	out := RawReplicationProviderSpecificContainerMappingInputImpl{
+		Type:   value,
+		Values: temp,
+	}
+	return out, nil
+
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/model_replicationproviderspecificupdatecontainermappinginput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/model_replicationproviderspecificupdatecontainermappinginput.go
@@ -1,0 +1,56 @@
+package replicationprotectioncontainermappings
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ReplicationProviderSpecificUpdateContainerMappingInput interface {
+}
+
+func unmarshalReplicationProviderSpecificUpdateContainerMappingInputImplementation(input []byte) (ReplicationProviderSpecificUpdateContainerMappingInput, error) {
+	if input == nil {
+		return nil, nil
+	}
+
+	var temp map[string]interface{}
+	if err := json.Unmarshal(input, &temp); err != nil {
+		return nil, fmt.Errorf("unmarshaling ReplicationProviderSpecificUpdateContainerMappingInput into map[string]interface: %+v", err)
+	}
+
+	value, ok := temp["instanceType"].(string)
+	if !ok {
+		return nil, nil
+	}
+
+	if strings.EqualFold(value, "A2A") {
+		var out A2AUpdateContainerMappingInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into A2AUpdateContainerMappingInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "InMageRcm") {
+		var out InMageRcmUpdateContainerMappingInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into InMageRcmUpdateContainerMappingInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	type RawReplicationProviderSpecificUpdateContainerMappingInputImpl struct {
+		Type   string                 `json:"-"`
+		Values map[string]interface{} `json:"-"`
+	}
+	out := RawReplicationProviderSpecificUpdateContainerMappingInputImpl{
+		Type:   value,
+		Values: temp,
+	}
+	return out, nil
+
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/model_updateprotectioncontainermappinginput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/model_updateprotectioncontainermappinginput.go
@@ -1,0 +1,8 @@
+package replicationprotectioncontainermappings
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UpdateProtectionContainerMappingInput struct {
+	Properties *UpdateProtectionContainerMappingInputProperties `json:"properties,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/model_updateprotectioncontainermappinginputproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/model_updateprotectioncontainermappinginputproperties.go
@@ -1,0 +1,32 @@
+package replicationprotectioncontainermappings
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UpdateProtectionContainerMappingInputProperties struct {
+	ProviderSpecificInput ReplicationProviderSpecificUpdateContainerMappingInput `json:"providerSpecificInput"`
+}
+
+var _ json.Unmarshaler = &UpdateProtectionContainerMappingInputProperties{}
+
+func (s *UpdateProtectionContainerMappingInputProperties) UnmarshalJSON(bytes []byte) error {
+
+	var temp map[string]json.RawMessage
+	if err := json.Unmarshal(bytes, &temp); err != nil {
+		return fmt.Errorf("unmarshaling UpdateProtectionContainerMappingInputProperties into map[string]json.RawMessage: %+v", err)
+	}
+
+	if v, ok := temp["providerSpecificInput"]; ok {
+		impl, err := unmarshalReplicationProviderSpecificUpdateContainerMappingInputImplementation(v)
+		if err != nil {
+			return fmt.Errorf("unmarshaling field 'ProviderSpecificInput' for 'UpdateProtectionContainerMappingInputProperties': %+v", err)
+		}
+		s.ProviderSpecificInput = impl
+	}
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/model_vmwarecbtcontainermappinginput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/model_vmwarecbtcontainermappinginput.go
@@ -1,0 +1,46 @@
+package replicationprotectioncontainermappings
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ReplicationProviderSpecificContainerMappingInput = VMwareCbtContainerMappingInput{}
+
+type VMwareCbtContainerMappingInput struct {
+	KeyVaultId                           *string `json:"keyVaultId,omitempty"`
+	KeyVaultUri                          *string `json:"keyVaultUri,omitempty"`
+	ServiceBusConnectionStringSecretName *string `json:"serviceBusConnectionStringSecretName,omitempty"`
+	StorageAccountId                     string  `json:"storageAccountId"`
+	StorageAccountSasSecretName          *string `json:"storageAccountSasSecretName,omitempty"`
+	TargetLocation                       string  `json:"targetLocation"`
+
+	// Fields inherited from ReplicationProviderSpecificContainerMappingInput
+}
+
+var _ json.Marshaler = VMwareCbtContainerMappingInput{}
+
+func (s VMwareCbtContainerMappingInput) MarshalJSON() ([]byte, error) {
+	type wrapper VMwareCbtContainerMappingInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling VMwareCbtContainerMappingInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling VMwareCbtContainerMappingInput: %+v", err)
+	}
+	decoded["instanceType"] = "VMwareCbt"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling VMwareCbtContainerMappingInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/model_vmwarecbtprotectioncontainermappingdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/model_vmwarecbtprotectioncontainermappingdetails.go
@@ -1,0 +1,47 @@
+package replicationprotectioncontainermappings
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ProtectionContainerMappingProviderSpecificDetails = VMwareCbtProtectionContainerMappingDetails{}
+
+type VMwareCbtProtectionContainerMappingDetails struct {
+	KeyVaultId                           *string           `json:"keyVaultId,omitempty"`
+	KeyVaultUri                          *string           `json:"keyVaultUri,omitempty"`
+	RoleSizeToNicCountMap                *map[string]int64 `json:"roleSizeToNicCountMap,omitempty"`
+	ServiceBusConnectionStringSecretName *string           `json:"serviceBusConnectionStringSecretName,omitempty"`
+	StorageAccountId                     *string           `json:"storageAccountId,omitempty"`
+	StorageAccountSasSecretName          *string           `json:"storageAccountSasSecretName,omitempty"`
+	TargetLocation                       *string           `json:"targetLocation,omitempty"`
+
+	// Fields inherited from ProtectionContainerMappingProviderSpecificDetails
+}
+
+var _ json.Marshaler = VMwareCbtProtectionContainerMappingDetails{}
+
+func (s VMwareCbtProtectionContainerMappingDetails) MarshalJSON() ([]byte, error) {
+	type wrapper VMwareCbtProtectionContainerMappingDetails
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling VMwareCbtProtectionContainerMappingDetails: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling VMwareCbtProtectionContainerMappingDetails: %+v", err)
+	}
+	decoded["instanceType"] = "VMwareCbt"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling VMwareCbtProtectionContainerMappingDetails: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/predicates.go
@@ -1,0 +1,29 @@
+package replicationprotectioncontainermappings
+
+type ProtectionContainerMappingOperationPredicate struct {
+	Id       *string
+	Location *string
+	Name     *string
+	Type     *string
+}
+
+func (p ProtectionContainerMappingOperationPredicate) Matches(input ProtectionContainerMapping) bool {
+
+	if p.Id != nil && (input.Id == nil && *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Location != nil && (input.Location == nil && *p.Location != *input.Location) {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil && *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil && *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/version.go
@@ -1,0 +1,12 @@
+package replicationprotectioncontainermappings
+
+import "fmt"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2022-10-01"
+
+func userAgent() string {
+	return fmt.Sprintf("hashicorp/go-azure-sdk/replicationprotectioncontainermappings/%s", defaultApiVersion)
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/README.md
@@ -1,0 +1,133 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers` Documentation
+
+The `replicationprotectioncontainers` SDK allows for interaction with the Azure Resource Manager Service `recoveryservicessiterecovery` (API Version `2022-10-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers"
+```
+
+
+### Client Initialization
+
+```go
+client := replicationprotectioncontainers.NewReplicationProtectionContainersClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `ReplicationProtectionContainersClient.Create`
+
+```go
+ctx := context.TODO()
+id := replicationprotectioncontainers.NewReplicationProtectionContainerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue", "fabricValue", "protectionContainerValue")
+
+payload := replicationprotectioncontainers.CreateProtectionContainerInput{
+	// ...
+}
+
+
+if err := client.CreateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `ReplicationProtectionContainersClient.Delete`
+
+```go
+ctx := context.TODO()
+id := replicationprotectioncontainers.NewReplicationProtectionContainerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue", "fabricValue", "protectionContainerValue")
+
+if err := client.DeleteThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `ReplicationProtectionContainersClient.DiscoverProtectableItem`
+
+```go
+ctx := context.TODO()
+id := replicationprotectioncontainers.NewReplicationProtectionContainerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue", "fabricValue", "protectionContainerValue")
+
+payload := replicationprotectioncontainers.DiscoverProtectableItemRequest{
+	// ...
+}
+
+
+if err := client.DiscoverProtectableItemThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `ReplicationProtectionContainersClient.Get`
+
+```go
+ctx := context.TODO()
+id := replicationprotectioncontainers.NewReplicationProtectionContainerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue", "fabricValue", "protectionContainerValue")
+
+read, err := client.Get(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `ReplicationProtectionContainersClient.List`
+
+```go
+ctx := context.TODO()
+id := replicationprotectioncontainers.NewVaultID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue")
+
+// alternatively `client.List(ctx, id)` can be used to do batched pagination
+items, err := client.ListComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `ReplicationProtectionContainersClient.ListByReplicationFabrics`
+
+```go
+ctx := context.TODO()
+id := replicationprotectioncontainers.NewReplicationFabricID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue", "fabricValue")
+
+// alternatively `client.ListByReplicationFabrics(ctx, id)` can be used to do batched pagination
+items, err := client.ListByReplicationFabricsComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `ReplicationProtectionContainersClient.SwitchProtection`
+
+```go
+ctx := context.TODO()
+id := replicationprotectioncontainers.NewReplicationProtectionContainerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue", "fabricValue", "protectionContainerValue")
+
+payload := replicationprotectioncontainers.SwitchProtectionInput{
+	// ...
+}
+
+
+if err := client.SwitchProtectionThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/client.go
@@ -1,0 +1,18 @@
+package replicationprotectioncontainers
+
+import "github.com/Azure/go-autorest/autorest"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ReplicationProtectionContainersClient struct {
+	Client  autorest.Client
+	baseUri string
+}
+
+func NewReplicationProtectionContainersClientWithBaseURI(endpoint string) ReplicationProtectionContainersClient {
+	return ReplicationProtectionContainersClient{
+		Client:  autorest.NewClientWithUserAgent(userAgent()),
+		baseUri: endpoint,
+	}
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/id_replicationfabric.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/id_replicationfabric.go
@@ -1,0 +1,137 @@
+package replicationprotectioncontainers
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = ReplicationFabricId{}
+
+// ReplicationFabricId is a struct representing the Resource ID for a Replication Fabric
+type ReplicationFabricId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	ResourceName      string
+	FabricName        string
+}
+
+// NewReplicationFabricID returns a new ReplicationFabricId struct
+func NewReplicationFabricID(subscriptionId string, resourceGroupName string, resourceName string, fabricName string) ReplicationFabricId {
+	return ReplicationFabricId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		ResourceName:      resourceName,
+		FabricName:        fabricName,
+	}
+}
+
+// ParseReplicationFabricID parses 'input' into a ReplicationFabricId
+func ParseReplicationFabricID(input string) (*ReplicationFabricId, error) {
+	parser := resourceids.NewParserFromResourceIdType(ReplicationFabricId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := ReplicationFabricId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceName, ok = parsed.Parsed["resourceName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceName' was not found in the resource id %q", input)
+	}
+
+	if id.FabricName, ok = parsed.Parsed["fabricName"]; !ok {
+		return nil, fmt.Errorf("the segment 'fabricName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ParseReplicationFabricIDInsensitively parses 'input' case-insensitively into a ReplicationFabricId
+// note: this method should only be used for API response data and not user input
+func ParseReplicationFabricIDInsensitively(input string) (*ReplicationFabricId, error) {
+	parser := resourceids.NewParserFromResourceIdType(ReplicationFabricId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := ReplicationFabricId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceName, ok = parsed.Parsed["resourceName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceName' was not found in the resource id %q", input)
+	}
+
+	if id.FabricName, ok = parsed.Parsed["fabricName"]; !ok {
+		return nil, fmt.Errorf("the segment 'fabricName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ValidateReplicationFabricID checks that 'input' can be parsed as a Replication Fabric ID
+func ValidateReplicationFabricID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseReplicationFabricID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Replication Fabric ID
+func (id ReplicationFabricId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.RecoveryServices/vaults/%s/replicationFabrics/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.ResourceName, id.FabricName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Replication Fabric ID
+func (id ReplicationFabricId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftRecoveryServices", "Microsoft.RecoveryServices", "Microsoft.RecoveryServices"),
+		resourceids.StaticSegment("staticVaults", "vaults", "vaults"),
+		resourceids.UserSpecifiedSegment("resourceName", "resourceValue"),
+		resourceids.StaticSegment("staticReplicationFabrics", "replicationFabrics", "replicationFabrics"),
+		resourceids.UserSpecifiedSegment("fabricName", "fabricValue"),
+	}
+}
+
+// String returns a human-readable description of this Replication Fabric ID
+func (id ReplicationFabricId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Resource Name: %q", id.ResourceName),
+		fmt.Sprintf("Fabric Name: %q", id.FabricName),
+	}
+	return fmt.Sprintf("Replication Fabric (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/id_replicationprotectioncontainer.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/id_replicationprotectioncontainer.go
@@ -1,0 +1,150 @@
+package replicationprotectioncontainers
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = ReplicationProtectionContainerId{}
+
+// ReplicationProtectionContainerId is a struct representing the Resource ID for a Replication Protection Container
+type ReplicationProtectionContainerId struct {
+	SubscriptionId          string
+	ResourceGroupName       string
+	ResourceName            string
+	FabricName              string
+	ProtectionContainerName string
+}
+
+// NewReplicationProtectionContainerID returns a new ReplicationProtectionContainerId struct
+func NewReplicationProtectionContainerID(subscriptionId string, resourceGroupName string, resourceName string, fabricName string, protectionContainerName string) ReplicationProtectionContainerId {
+	return ReplicationProtectionContainerId{
+		SubscriptionId:          subscriptionId,
+		ResourceGroupName:       resourceGroupName,
+		ResourceName:            resourceName,
+		FabricName:              fabricName,
+		ProtectionContainerName: protectionContainerName,
+	}
+}
+
+// ParseReplicationProtectionContainerID parses 'input' into a ReplicationProtectionContainerId
+func ParseReplicationProtectionContainerID(input string) (*ReplicationProtectionContainerId, error) {
+	parser := resourceids.NewParserFromResourceIdType(ReplicationProtectionContainerId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := ReplicationProtectionContainerId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceName, ok = parsed.Parsed["resourceName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceName' was not found in the resource id %q", input)
+	}
+
+	if id.FabricName, ok = parsed.Parsed["fabricName"]; !ok {
+		return nil, fmt.Errorf("the segment 'fabricName' was not found in the resource id %q", input)
+	}
+
+	if id.ProtectionContainerName, ok = parsed.Parsed["protectionContainerName"]; !ok {
+		return nil, fmt.Errorf("the segment 'protectionContainerName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ParseReplicationProtectionContainerIDInsensitively parses 'input' case-insensitively into a ReplicationProtectionContainerId
+// note: this method should only be used for API response data and not user input
+func ParseReplicationProtectionContainerIDInsensitively(input string) (*ReplicationProtectionContainerId, error) {
+	parser := resourceids.NewParserFromResourceIdType(ReplicationProtectionContainerId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := ReplicationProtectionContainerId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceName, ok = parsed.Parsed["resourceName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceName' was not found in the resource id %q", input)
+	}
+
+	if id.FabricName, ok = parsed.Parsed["fabricName"]; !ok {
+		return nil, fmt.Errorf("the segment 'fabricName' was not found in the resource id %q", input)
+	}
+
+	if id.ProtectionContainerName, ok = parsed.Parsed["protectionContainerName"]; !ok {
+		return nil, fmt.Errorf("the segment 'protectionContainerName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ValidateReplicationProtectionContainerID checks that 'input' can be parsed as a Replication Protection Container ID
+func ValidateReplicationProtectionContainerID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseReplicationProtectionContainerID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Replication Protection Container ID
+func (id ReplicationProtectionContainerId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.RecoveryServices/vaults/%s/replicationFabrics/%s/replicationProtectionContainers/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.ResourceName, id.FabricName, id.ProtectionContainerName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Replication Protection Container ID
+func (id ReplicationProtectionContainerId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftRecoveryServices", "Microsoft.RecoveryServices", "Microsoft.RecoveryServices"),
+		resourceids.StaticSegment("staticVaults", "vaults", "vaults"),
+		resourceids.UserSpecifiedSegment("resourceName", "resourceValue"),
+		resourceids.StaticSegment("staticReplicationFabrics", "replicationFabrics", "replicationFabrics"),
+		resourceids.UserSpecifiedSegment("fabricName", "fabricValue"),
+		resourceids.StaticSegment("staticReplicationProtectionContainers", "replicationProtectionContainers", "replicationProtectionContainers"),
+		resourceids.UserSpecifiedSegment("protectionContainerName", "protectionContainerValue"),
+	}
+}
+
+// String returns a human-readable description of this Replication Protection Container ID
+func (id ReplicationProtectionContainerId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Resource Name: %q", id.ResourceName),
+		fmt.Sprintf("Fabric Name: %q", id.FabricName),
+		fmt.Sprintf("Protection Container Name: %q", id.ProtectionContainerName),
+	}
+	return fmt.Sprintf("Replication Protection Container (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/id_vault.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/id_vault.go
@@ -1,0 +1,124 @@
+package replicationprotectioncontainers
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = VaultId{}
+
+// VaultId is a struct representing the Resource ID for a Vault
+type VaultId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	ResourceName      string
+}
+
+// NewVaultID returns a new VaultId struct
+func NewVaultID(subscriptionId string, resourceGroupName string, resourceName string) VaultId {
+	return VaultId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		ResourceName:      resourceName,
+	}
+}
+
+// ParseVaultID parses 'input' into a VaultId
+func ParseVaultID(input string) (*VaultId, error) {
+	parser := resourceids.NewParserFromResourceIdType(VaultId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := VaultId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceName, ok = parsed.Parsed["resourceName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ParseVaultIDInsensitively parses 'input' case-insensitively into a VaultId
+// note: this method should only be used for API response data and not user input
+func ParseVaultIDInsensitively(input string) (*VaultId, error) {
+	parser := resourceids.NewParserFromResourceIdType(VaultId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := VaultId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceName, ok = parsed.Parsed["resourceName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ValidateVaultID checks that 'input' can be parsed as a Vault ID
+func ValidateVaultID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseVaultID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Vault ID
+func (id VaultId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.RecoveryServices/vaults/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.ResourceName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Vault ID
+func (id VaultId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftRecoveryServices", "Microsoft.RecoveryServices", "Microsoft.RecoveryServices"),
+		resourceids.StaticSegment("staticVaults", "vaults", "vaults"),
+		resourceids.UserSpecifiedSegment("resourceName", "resourceValue"),
+	}
+}
+
+// String returns a human-readable description of this Vault ID
+func (id VaultId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Resource Name: %q", id.ResourceName),
+	}
+	return fmt.Sprintf("Vault (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/method_create_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/method_create_autorest.go
@@ -1,0 +1,79 @@
+package replicationprotectioncontainers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CreateOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// Create ...
+func (c ReplicationProtectionContainersClient) Create(ctx context.Context, id ReplicationProtectionContainerId, input CreateProtectionContainerInput) (result CreateOperationResponse, err error) {
+	req, err := c.preparerForCreate(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotectioncontainers.ReplicationProtectionContainersClient", "Create", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForCreate(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotectioncontainers.ReplicationProtectionContainersClient", "Create", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// CreateThenPoll performs Create then polls until it's completed
+func (c ReplicationProtectionContainersClient) CreateThenPoll(ctx context.Context, id ReplicationProtectionContainerId, input CreateProtectionContainerInput) error {
+	result, err := c.Create(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing Create: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after Create: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForCreate prepares the Create request.
+func (c ReplicationProtectionContainersClient) preparerForCreate(ctx context.Context, id ReplicationProtectionContainerId, input CreateProtectionContainerInput) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPut(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForCreate sends the Create request. The method will close the
+// http.Response Body if it receives an error.
+func (c ReplicationProtectionContainersClient) senderForCreate(ctx context.Context, req *http.Request) (future CreateOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/method_delete_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/method_delete_autorest.go
@@ -1,0 +1,78 @@
+package replicationprotectioncontainers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DeleteOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// Delete ...
+func (c ReplicationProtectionContainersClient) Delete(ctx context.Context, id ReplicationProtectionContainerId) (result DeleteOperationResponse, err error) {
+	req, err := c.preparerForDelete(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotectioncontainers.ReplicationProtectionContainersClient", "Delete", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForDelete(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotectioncontainers.ReplicationProtectionContainersClient", "Delete", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// DeleteThenPoll performs Delete then polls until it's completed
+func (c ReplicationProtectionContainersClient) DeleteThenPoll(ctx context.Context, id ReplicationProtectionContainerId) error {
+	result, err := c.Delete(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing Delete: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after Delete: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForDelete prepares the Delete request.
+func (c ReplicationProtectionContainersClient) preparerForDelete(ctx context.Context, id ReplicationProtectionContainerId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/remove", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForDelete sends the Delete request. The method will close the
+// http.Response Body if it receives an error.
+func (c ReplicationProtectionContainersClient) senderForDelete(ctx context.Context, req *http.Request) (future DeleteOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/method_discoverprotectableitem_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/method_discoverprotectableitem_autorest.go
@@ -1,0 +1,79 @@
+package replicationprotectioncontainers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DiscoverProtectableItemOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// DiscoverProtectableItem ...
+func (c ReplicationProtectionContainersClient) DiscoverProtectableItem(ctx context.Context, id ReplicationProtectionContainerId, input DiscoverProtectableItemRequest) (result DiscoverProtectableItemOperationResponse, err error) {
+	req, err := c.preparerForDiscoverProtectableItem(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotectioncontainers.ReplicationProtectionContainersClient", "DiscoverProtectableItem", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForDiscoverProtectableItem(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotectioncontainers.ReplicationProtectionContainersClient", "DiscoverProtectableItem", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// DiscoverProtectableItemThenPoll performs DiscoverProtectableItem then polls until it's completed
+func (c ReplicationProtectionContainersClient) DiscoverProtectableItemThenPoll(ctx context.Context, id ReplicationProtectionContainerId, input DiscoverProtectableItemRequest) error {
+	result, err := c.DiscoverProtectableItem(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing DiscoverProtectableItem: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after DiscoverProtectableItem: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForDiscoverProtectableItem prepares the DiscoverProtectableItem request.
+func (c ReplicationProtectionContainersClient) preparerForDiscoverProtectableItem(ctx context.Context, id ReplicationProtectionContainerId, input DiscoverProtectableItemRequest) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/discoverProtectableItem", id.ID())),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForDiscoverProtectableItem sends the DiscoverProtectableItem request. The method will close the
+// http.Response Body if it receives an error.
+func (c ReplicationProtectionContainersClient) senderForDiscoverProtectableItem(ctx context.Context, req *http.Request) (future DiscoverProtectableItemOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/method_get_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/method_get_autorest.go
@@ -1,0 +1,68 @@
+package replicationprotectioncontainers
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *ProtectionContainer
+}
+
+// Get ...
+func (c ReplicationProtectionContainersClient) Get(ctx context.Context, id ReplicationProtectionContainerId) (result GetOperationResponse, err error) {
+	req, err := c.preparerForGet(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotectioncontainers.ReplicationProtectionContainersClient", "Get", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotectioncontainers.ReplicationProtectionContainersClient", "Get", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForGet(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotectioncontainers.ReplicationProtectionContainersClient", "Get", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForGet prepares the Get request.
+func (c ReplicationProtectionContainersClient) preparerForGet(ctx context.Context, id ReplicationProtectionContainerId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForGet handles the response to the Get request. The method always
+// closes the http.Response Body.
+func (c ReplicationProtectionContainersClient) responderForGet(resp *http.Response) (result GetOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/method_list_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/method_list_autorest.go
@@ -1,0 +1,186 @@
+package replicationprotectioncontainers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *[]ProtectionContainer
+
+	nextLink     *string
+	nextPageFunc func(ctx context.Context, nextLink string) (ListOperationResponse, error)
+}
+
+type ListCompleteResult struct {
+	Items []ProtectionContainer
+}
+
+func (r ListOperationResponse) HasMore() bool {
+	return r.nextLink != nil
+}
+
+func (r ListOperationResponse) LoadMore(ctx context.Context) (resp ListOperationResponse, err error) {
+	if !r.HasMore() {
+		err = fmt.Errorf("no more pages returned")
+		return
+	}
+	return r.nextPageFunc(ctx, *r.nextLink)
+}
+
+// List ...
+func (c ReplicationProtectionContainersClient) List(ctx context.Context, id VaultId) (resp ListOperationResponse, err error) {
+	req, err := c.preparerForList(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotectioncontainers.ReplicationProtectionContainersClient", "List", nil, "Failure preparing request")
+		return
+	}
+
+	resp.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotectioncontainers.ReplicationProtectionContainersClient", "List", resp.HttpResponse, "Failure sending request")
+		return
+	}
+
+	resp, err = c.responderForList(resp.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotectioncontainers.ReplicationProtectionContainersClient", "List", resp.HttpResponse, "Failure responding to request")
+		return
+	}
+	return
+}
+
+// preparerForList prepares the List request.
+func (c ReplicationProtectionContainersClient) preparerForList(ctx context.Context, id VaultId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/replicationProtectionContainers", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// preparerForListWithNextLink prepares the List request with the given nextLink token.
+func (c ReplicationProtectionContainersClient) preparerForListWithNextLink(ctx context.Context, nextLink string) (*http.Request, error) {
+	uri, err := url.Parse(nextLink)
+	if err != nil {
+		return nil, fmt.Errorf("parsing nextLink %q: %+v", nextLink, err)
+	}
+	queryParameters := map[string]interface{}{}
+	for k, v := range uri.Query() {
+		if len(v) == 0 {
+			continue
+		}
+		val := v[0]
+		val = autorest.Encode("query", val)
+		queryParameters[k] = val
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(uri.Path),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForList handles the response to the List request. The method always
+// closes the http.Response Body.
+func (c ReplicationProtectionContainersClient) responderForList(resp *http.Response) (result ListOperationResponse, err error) {
+	type page struct {
+		Values   []ProtectionContainer `json:"value"`
+		NextLink *string               `json:"nextLink"`
+	}
+	var respObj page
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&respObj),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	result.Model = &respObj.Values
+	result.nextLink = respObj.NextLink
+	if respObj.NextLink != nil {
+		result.nextPageFunc = func(ctx context.Context, nextLink string) (result ListOperationResponse, err error) {
+			req, err := c.preparerForListWithNextLink(ctx, nextLink)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "replicationprotectioncontainers.ReplicationProtectionContainersClient", "List", nil, "Failure preparing request")
+				return
+			}
+
+			result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "replicationprotectioncontainers.ReplicationProtectionContainersClient", "List", result.HttpResponse, "Failure sending request")
+				return
+			}
+
+			result, err = c.responderForList(result.HttpResponse)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "replicationprotectioncontainers.ReplicationProtectionContainersClient", "List", result.HttpResponse, "Failure responding to request")
+				return
+			}
+
+			return
+		}
+	}
+	return
+}
+
+// ListComplete retrieves all of the results into a single object
+func (c ReplicationProtectionContainersClient) ListComplete(ctx context.Context, id VaultId) (ListCompleteResult, error) {
+	return c.ListCompleteMatchingPredicate(ctx, id, ProtectionContainerOperationPredicate{})
+}
+
+// ListCompleteMatchingPredicate retrieves all of the results and then applied the predicate
+func (c ReplicationProtectionContainersClient) ListCompleteMatchingPredicate(ctx context.Context, id VaultId, predicate ProtectionContainerOperationPredicate) (resp ListCompleteResult, err error) {
+	items := make([]ProtectionContainer, 0)
+
+	page, err := c.List(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading the initial page: %+v", err)
+		return
+	}
+	if page.Model != nil {
+		for _, v := range *page.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	for page.HasMore() {
+		page, err = page.LoadMore(ctx)
+		if err != nil {
+			err = fmt.Errorf("loading the next page: %+v", err)
+			return
+		}
+
+		if page.Model != nil {
+			for _, v := range *page.Model {
+				if predicate.Matches(v) {
+					items = append(items, v)
+				}
+			}
+		}
+	}
+
+	out := ListCompleteResult{
+		Items: items,
+	}
+	return out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/method_listbyreplicationfabrics_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/method_listbyreplicationfabrics_autorest.go
@@ -1,0 +1,186 @@
+package replicationprotectioncontainers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListByReplicationFabricsOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *[]ProtectionContainer
+
+	nextLink     *string
+	nextPageFunc func(ctx context.Context, nextLink string) (ListByReplicationFabricsOperationResponse, error)
+}
+
+type ListByReplicationFabricsCompleteResult struct {
+	Items []ProtectionContainer
+}
+
+func (r ListByReplicationFabricsOperationResponse) HasMore() bool {
+	return r.nextLink != nil
+}
+
+func (r ListByReplicationFabricsOperationResponse) LoadMore(ctx context.Context) (resp ListByReplicationFabricsOperationResponse, err error) {
+	if !r.HasMore() {
+		err = fmt.Errorf("no more pages returned")
+		return
+	}
+	return r.nextPageFunc(ctx, *r.nextLink)
+}
+
+// ListByReplicationFabrics ...
+func (c ReplicationProtectionContainersClient) ListByReplicationFabrics(ctx context.Context, id ReplicationFabricId) (resp ListByReplicationFabricsOperationResponse, err error) {
+	req, err := c.preparerForListByReplicationFabrics(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotectioncontainers.ReplicationProtectionContainersClient", "ListByReplicationFabrics", nil, "Failure preparing request")
+		return
+	}
+
+	resp.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotectioncontainers.ReplicationProtectionContainersClient", "ListByReplicationFabrics", resp.HttpResponse, "Failure sending request")
+		return
+	}
+
+	resp, err = c.responderForListByReplicationFabrics(resp.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotectioncontainers.ReplicationProtectionContainersClient", "ListByReplicationFabrics", resp.HttpResponse, "Failure responding to request")
+		return
+	}
+	return
+}
+
+// preparerForListByReplicationFabrics prepares the ListByReplicationFabrics request.
+func (c ReplicationProtectionContainersClient) preparerForListByReplicationFabrics(ctx context.Context, id ReplicationFabricId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/replicationProtectionContainers", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// preparerForListByReplicationFabricsWithNextLink prepares the ListByReplicationFabrics request with the given nextLink token.
+func (c ReplicationProtectionContainersClient) preparerForListByReplicationFabricsWithNextLink(ctx context.Context, nextLink string) (*http.Request, error) {
+	uri, err := url.Parse(nextLink)
+	if err != nil {
+		return nil, fmt.Errorf("parsing nextLink %q: %+v", nextLink, err)
+	}
+	queryParameters := map[string]interface{}{}
+	for k, v := range uri.Query() {
+		if len(v) == 0 {
+			continue
+		}
+		val := v[0]
+		val = autorest.Encode("query", val)
+		queryParameters[k] = val
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(uri.Path),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForListByReplicationFabrics handles the response to the ListByReplicationFabrics request. The method always
+// closes the http.Response Body.
+func (c ReplicationProtectionContainersClient) responderForListByReplicationFabrics(resp *http.Response) (result ListByReplicationFabricsOperationResponse, err error) {
+	type page struct {
+		Values   []ProtectionContainer `json:"value"`
+		NextLink *string               `json:"nextLink"`
+	}
+	var respObj page
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&respObj),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	result.Model = &respObj.Values
+	result.nextLink = respObj.NextLink
+	if respObj.NextLink != nil {
+		result.nextPageFunc = func(ctx context.Context, nextLink string) (result ListByReplicationFabricsOperationResponse, err error) {
+			req, err := c.preparerForListByReplicationFabricsWithNextLink(ctx, nextLink)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "replicationprotectioncontainers.ReplicationProtectionContainersClient", "ListByReplicationFabrics", nil, "Failure preparing request")
+				return
+			}
+
+			result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "replicationprotectioncontainers.ReplicationProtectionContainersClient", "ListByReplicationFabrics", result.HttpResponse, "Failure sending request")
+				return
+			}
+
+			result, err = c.responderForListByReplicationFabrics(result.HttpResponse)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "replicationprotectioncontainers.ReplicationProtectionContainersClient", "ListByReplicationFabrics", result.HttpResponse, "Failure responding to request")
+				return
+			}
+
+			return
+		}
+	}
+	return
+}
+
+// ListByReplicationFabricsComplete retrieves all of the results into a single object
+func (c ReplicationProtectionContainersClient) ListByReplicationFabricsComplete(ctx context.Context, id ReplicationFabricId) (ListByReplicationFabricsCompleteResult, error) {
+	return c.ListByReplicationFabricsCompleteMatchingPredicate(ctx, id, ProtectionContainerOperationPredicate{})
+}
+
+// ListByReplicationFabricsCompleteMatchingPredicate retrieves all of the results and then applied the predicate
+func (c ReplicationProtectionContainersClient) ListByReplicationFabricsCompleteMatchingPredicate(ctx context.Context, id ReplicationFabricId, predicate ProtectionContainerOperationPredicate) (resp ListByReplicationFabricsCompleteResult, err error) {
+	items := make([]ProtectionContainer, 0)
+
+	page, err := c.ListByReplicationFabrics(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading the initial page: %+v", err)
+		return
+	}
+	if page.Model != nil {
+		for _, v := range *page.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	for page.HasMore() {
+		page, err = page.LoadMore(ctx)
+		if err != nil {
+			err = fmt.Errorf("loading the next page: %+v", err)
+			return
+		}
+
+		if page.Model != nil {
+			for _, v := range *page.Model {
+				if predicate.Matches(v) {
+					items = append(items, v)
+				}
+			}
+		}
+	}
+
+	out := ListByReplicationFabricsCompleteResult{
+		Items: items,
+	}
+	return out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/method_switchprotection_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/method_switchprotection_autorest.go
@@ -1,0 +1,79 @@
+package replicationprotectioncontainers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SwitchProtectionOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// SwitchProtection ...
+func (c ReplicationProtectionContainersClient) SwitchProtection(ctx context.Context, id ReplicationProtectionContainerId, input SwitchProtectionInput) (result SwitchProtectionOperationResponse, err error) {
+	req, err := c.preparerForSwitchProtection(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotectioncontainers.ReplicationProtectionContainersClient", "SwitchProtection", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForSwitchProtection(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationprotectioncontainers.ReplicationProtectionContainersClient", "SwitchProtection", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// SwitchProtectionThenPoll performs SwitchProtection then polls until it's completed
+func (c ReplicationProtectionContainersClient) SwitchProtectionThenPoll(ctx context.Context, id ReplicationProtectionContainerId, input SwitchProtectionInput) error {
+	result, err := c.SwitchProtection(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing SwitchProtection: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after SwitchProtection: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForSwitchProtection prepares the SwitchProtection request.
+func (c ReplicationProtectionContainersClient) preparerForSwitchProtection(ctx context.Context, id ReplicationProtectionContainerId, input SwitchProtectionInput) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/switchprotection", id.ID())),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForSwitchProtection sends the SwitchProtection request. The method will close the
+// http.Response Body if it receives an error.
+func (c ReplicationProtectionContainersClient) senderForSwitchProtection(ctx context.Context, req *http.Request) (future SwitchProtectionOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/model_a2acontainercreationinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/model_a2acontainercreationinput.go
@@ -1,0 +1,40 @@
+package replicationprotectioncontainers
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ReplicationProviderSpecificContainerCreationInput = A2AContainerCreationInput{}
+
+type A2AContainerCreationInput struct {
+
+	// Fields inherited from ReplicationProviderSpecificContainerCreationInput
+}
+
+var _ json.Marshaler = A2AContainerCreationInput{}
+
+func (s A2AContainerCreationInput) MarshalJSON() ([]byte, error) {
+	type wrapper A2AContainerCreationInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling A2AContainerCreationInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling A2AContainerCreationInput: %+v", err)
+	}
+	decoded["instanceType"] = "A2A"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling A2AContainerCreationInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/model_a2acrossclustermigrationcontainercreationinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/model_a2acrossclustermigrationcontainercreationinput.go
@@ -1,0 +1,40 @@
+package replicationprotectioncontainers
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ReplicationProviderSpecificContainerCreationInput = A2ACrossClusterMigrationContainerCreationInput{}
+
+type A2ACrossClusterMigrationContainerCreationInput struct {
+
+	// Fields inherited from ReplicationProviderSpecificContainerCreationInput
+}
+
+var _ json.Marshaler = A2ACrossClusterMigrationContainerCreationInput{}
+
+func (s A2ACrossClusterMigrationContainerCreationInput) MarshalJSON() ([]byte, error) {
+	type wrapper A2ACrossClusterMigrationContainerCreationInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling A2ACrossClusterMigrationContainerCreationInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling A2ACrossClusterMigrationContainerCreationInput: %+v", err)
+	}
+	decoded["instanceType"] = "A2ACrossClusterMigration"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling A2ACrossClusterMigrationContainerCreationInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/model_a2aswitchprotectioninput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/model_a2aswitchprotectioninput.go
@@ -1,0 +1,53 @@
+package replicationprotectioncontainers
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ SwitchProtectionProviderSpecificInput = A2ASwitchProtectionInput{}
+
+type A2ASwitchProtectionInput struct {
+	DiskEncryptionInfo                 *DiskEncryptionInfo             `json:"diskEncryptionInfo,omitempty"`
+	PolicyId                           *string                         `json:"policyId,omitempty"`
+	RecoveryAvailabilitySetId          *string                         `json:"recoveryAvailabilitySetId,omitempty"`
+	RecoveryAvailabilityZone           *string                         `json:"recoveryAvailabilityZone,omitempty"`
+	RecoveryBootDiagStorageAccountId   *string                         `json:"recoveryBootDiagStorageAccountId,omitempty"`
+	RecoveryCapacityReservationGroupId *string                         `json:"recoveryCapacityReservationGroupId,omitempty"`
+	RecoveryCloudServiceId             *string                         `json:"recoveryCloudServiceId,omitempty"`
+	RecoveryContainerId                *string                         `json:"recoveryContainerId,omitempty"`
+	RecoveryProximityPlacementGroupId  *string                         `json:"recoveryProximityPlacementGroupId,omitempty"`
+	RecoveryResourceGroupId            *string                         `json:"recoveryResourceGroupId,omitempty"`
+	RecoveryVirtualMachineScaleSetId   *string                         `json:"recoveryVirtualMachineScaleSetId,omitempty"`
+	VmDisks                            *[]A2AVmDiskInputDetails        `json:"vmDisks,omitempty"`
+	VmManagedDisks                     *[]A2AVmManagedDiskInputDetails `json:"vmManagedDisks,omitempty"`
+
+	// Fields inherited from SwitchProtectionProviderSpecificInput
+}
+
+var _ json.Marshaler = A2ASwitchProtectionInput{}
+
+func (s A2ASwitchProtectionInput) MarshalJSON() ([]byte, error) {
+	type wrapper A2ASwitchProtectionInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling A2ASwitchProtectionInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling A2ASwitchProtectionInput: %+v", err)
+	}
+	decoded["instanceType"] = "A2A"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling A2ASwitchProtectionInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/model_a2avmdiskinputdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/model_a2avmdiskinputdetails.go
@@ -1,0 +1,10 @@
+package replicationprotectioncontainers
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type A2AVmDiskInputDetails struct {
+	DiskUri                             string `json:"diskUri"`
+	PrimaryStagingAzureStorageAccountId string `json:"primaryStagingAzureStorageAccountId"`
+	RecoveryAzureStorageAccountId       string `json:"recoveryAzureStorageAccountId"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/model_a2avmmanageddiskinputdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/model_a2avmmanageddiskinputdetails.go
@@ -1,0 +1,14 @@
+package replicationprotectioncontainers
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type A2AVmManagedDiskInputDetails struct {
+	DiskEncryptionInfo                  *DiskEncryptionInfo `json:"diskEncryptionInfo,omitempty"`
+	DiskId                              string              `json:"diskId"`
+	PrimaryStagingAzureStorageAccountId string              `json:"primaryStagingAzureStorageAccountId"`
+	RecoveryDiskEncryptionSetId         *string             `json:"recoveryDiskEncryptionSetId,omitempty"`
+	RecoveryReplicaDiskAccountType      *string             `json:"recoveryReplicaDiskAccountType,omitempty"`
+	RecoveryResourceGroupId             string              `json:"recoveryResourceGroupId"`
+	RecoveryTargetDiskAccountType       *string             `json:"recoveryTargetDiskAccountType,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/model_createprotectioncontainerinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/model_createprotectioncontainerinput.go
@@ -1,0 +1,8 @@
+package replicationprotectioncontainers
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CreateProtectionContainerInput struct {
+	Properties *CreateProtectionContainerInputProperties `json:"properties,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/model_createprotectioncontainerinputproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/model_createprotectioncontainerinputproperties.go
@@ -1,0 +1,41 @@
+package replicationprotectioncontainers
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CreateProtectionContainerInputProperties struct {
+	ProviderSpecificInput *[]ReplicationProviderSpecificContainerCreationInput `json:"providerSpecificInput,omitempty"`
+}
+
+var _ json.Unmarshaler = &CreateProtectionContainerInputProperties{}
+
+func (s *CreateProtectionContainerInputProperties) UnmarshalJSON(bytes []byte) error {
+
+	var temp map[string]json.RawMessage
+	if err := json.Unmarshal(bytes, &temp); err != nil {
+		return fmt.Errorf("unmarshaling CreateProtectionContainerInputProperties into map[string]json.RawMessage: %+v", err)
+	}
+
+	if v, ok := temp["providerSpecificInput"]; ok {
+		var listTemp []json.RawMessage
+		if err := json.Unmarshal(v, &listTemp); err != nil {
+			return fmt.Errorf("unmarshaling ProviderSpecificInput into list []json.RawMessage: %+v", err)
+		}
+
+		output := make([]ReplicationProviderSpecificContainerCreationInput, 0)
+		for i, val := range listTemp {
+			impl, err := unmarshalReplicationProviderSpecificContainerCreationInputImplementation(val)
+			if err != nil {
+				return fmt.Errorf("unmarshaling index %d field 'ProviderSpecificInput' for 'CreateProtectionContainerInputProperties': %+v", i, err)
+			}
+			output = append(output, impl)
+		}
+		s.ProviderSpecificInput = &output
+	}
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/model_discoverprotectableitemrequest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/model_discoverprotectableitemrequest.go
@@ -1,0 +1,8 @@
+package replicationprotectioncontainers
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DiscoverProtectableItemRequest struct {
+	Properties *DiscoverProtectableItemRequestProperties `json:"properties,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/model_discoverprotectableitemrequestproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/model_discoverprotectableitemrequestproperties.go
@@ -1,0 +1,10 @@
+package replicationprotectioncontainers
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DiscoverProtectableItemRequestProperties struct {
+	FriendlyName *string `json:"friendlyName,omitempty"`
+	IPAddress    *string `json:"ipAddress,omitempty"`
+	OsType       *string `json:"osType,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/model_diskencryptioninfo.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/model_diskencryptioninfo.go
@@ -1,0 +1,9 @@
+package replicationprotectioncontainers
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DiskEncryptionInfo struct {
+	DiskEncryptionKeyInfo *DiskEncryptionKeyInfo `json:"diskEncryptionKeyInfo,omitempty"`
+	KeyEncryptionKeyInfo  *KeyEncryptionKeyInfo  `json:"keyEncryptionKeyInfo,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/model_diskencryptionkeyinfo.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/model_diskencryptionkeyinfo.go
@@ -1,0 +1,9 @@
+package replicationprotectioncontainers
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DiskEncryptionKeyInfo struct {
+	KeyVaultResourceArmId *string `json:"keyVaultResourceArmId,omitempty"`
+	SecretIdentifier      *string `json:"secretIdentifier,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/model_keyencryptionkeyinfo.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/model_keyencryptionkeyinfo.go
@@ -1,0 +1,9 @@
+package replicationprotectioncontainers
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type KeyEncryptionKeyInfo struct {
+	KeyIdentifier         *string `json:"keyIdentifier,omitempty"`
+	KeyVaultResourceArmId *string `json:"keyVaultResourceArmId,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/model_protectioncontainer.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/model_protectioncontainer.go
@@ -1,0 +1,12 @@
+package replicationprotectioncontainers
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ProtectionContainer struct {
+	Id         *string                        `json:"id,omitempty"`
+	Location   *string                        `json:"location,omitempty"`
+	Name       *string                        `json:"name,omitempty"`
+	Properties *ProtectionContainerProperties `json:"properties,omitempty"`
+	Type       *string                        `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/model_protectioncontainerfabricspecificdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/model_protectioncontainerfabricspecificdetails.go
@@ -1,0 +1,8 @@
+package replicationprotectioncontainers
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ProtectionContainerFabricSpecificDetails struct {
+	InstanceType *string `json:"instanceType,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/model_protectioncontainerproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/model_protectioncontainerproperties.go
@@ -1,0 +1,14 @@
+package replicationprotectioncontainers
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ProtectionContainerProperties struct {
+	FabricFriendlyName    *string                                   `json:"fabricFriendlyName,omitempty"`
+	FabricSpecificDetails *ProtectionContainerFabricSpecificDetails `json:"fabricSpecificDetails,omitempty"`
+	FabricType            *string                                   `json:"fabricType,omitempty"`
+	FriendlyName          *string                                   `json:"friendlyName,omitempty"`
+	PairingStatus         *string                                   `json:"pairingStatus,omitempty"`
+	ProtectedItemCount    *int64                                    `json:"protectedItemCount,omitempty"`
+	Role                  *string                                   `json:"role,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/model_replicationproviderspecificcontainercreationinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/model_replicationproviderspecificcontainercreationinput.go
@@ -1,0 +1,64 @@
+package replicationprotectioncontainers
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ReplicationProviderSpecificContainerCreationInput interface {
+}
+
+func unmarshalReplicationProviderSpecificContainerCreationInputImplementation(input []byte) (ReplicationProviderSpecificContainerCreationInput, error) {
+	if input == nil {
+		return nil, nil
+	}
+
+	var temp map[string]interface{}
+	if err := json.Unmarshal(input, &temp); err != nil {
+		return nil, fmt.Errorf("unmarshaling ReplicationProviderSpecificContainerCreationInput into map[string]interface: %+v", err)
+	}
+
+	value, ok := temp["instanceType"].(string)
+	if !ok {
+		return nil, nil
+	}
+
+	if strings.EqualFold(value, "A2A") {
+		var out A2AContainerCreationInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into A2AContainerCreationInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "A2ACrossClusterMigration") {
+		var out A2ACrossClusterMigrationContainerCreationInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into A2ACrossClusterMigrationContainerCreationInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "VMwareCbt") {
+		var out VMwareCbtContainerCreationInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into VMwareCbtContainerCreationInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	type RawReplicationProviderSpecificContainerCreationInputImpl struct {
+		Type   string                 `json:"-"`
+		Values map[string]interface{} `json:"-"`
+	}
+	out := RawReplicationProviderSpecificContainerCreationInputImpl{
+		Type:   value,
+		Values: temp,
+	}
+	return out, nil
+
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/model_switchprotectioninput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/model_switchprotectioninput.go
@@ -1,0 +1,8 @@
+package replicationprotectioncontainers
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SwitchProtectionInput struct {
+	Properties *SwitchProtectionInputProperties `json:"properties,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/model_switchprotectioninputproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/model_switchprotectioninputproperties.go
@@ -1,0 +1,40 @@
+package replicationprotectioncontainers
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SwitchProtectionInputProperties struct {
+	ProviderSpecificDetails      SwitchProtectionProviderSpecificInput `json:"providerSpecificDetails"`
+	ReplicationProtectedItemName *string                               `json:"replicationProtectedItemName,omitempty"`
+}
+
+var _ json.Unmarshaler = &SwitchProtectionInputProperties{}
+
+func (s *SwitchProtectionInputProperties) UnmarshalJSON(bytes []byte) error {
+	type alias SwitchProtectionInputProperties
+	var decoded alias
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling into SwitchProtectionInputProperties: %+v", err)
+	}
+
+	s.ReplicationProtectedItemName = decoded.ReplicationProtectedItemName
+
+	var temp map[string]json.RawMessage
+	if err := json.Unmarshal(bytes, &temp); err != nil {
+		return fmt.Errorf("unmarshaling SwitchProtectionInputProperties into map[string]json.RawMessage: %+v", err)
+	}
+
+	if v, ok := temp["providerSpecificDetails"]; ok {
+		impl, err := unmarshalSwitchProtectionProviderSpecificInputImplementation(v)
+		if err != nil {
+			return fmt.Errorf("unmarshaling field 'ProviderSpecificDetails' for 'SwitchProtectionInputProperties': %+v", err)
+		}
+		s.ProviderSpecificDetails = impl
+	}
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/model_switchprotectionproviderspecificinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/model_switchprotectionproviderspecificinput.go
@@ -1,0 +1,48 @@
+package replicationprotectioncontainers
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SwitchProtectionProviderSpecificInput interface {
+}
+
+func unmarshalSwitchProtectionProviderSpecificInputImplementation(input []byte) (SwitchProtectionProviderSpecificInput, error) {
+	if input == nil {
+		return nil, nil
+	}
+
+	var temp map[string]interface{}
+	if err := json.Unmarshal(input, &temp); err != nil {
+		return nil, fmt.Errorf("unmarshaling SwitchProtectionProviderSpecificInput into map[string]interface: %+v", err)
+	}
+
+	value, ok := temp["instanceType"].(string)
+	if !ok {
+		return nil, nil
+	}
+
+	if strings.EqualFold(value, "A2A") {
+		var out A2ASwitchProtectionInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into A2ASwitchProtectionInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	type RawSwitchProtectionProviderSpecificInputImpl struct {
+		Type   string                 `json:"-"`
+		Values map[string]interface{} `json:"-"`
+	}
+	out := RawSwitchProtectionProviderSpecificInputImpl{
+		Type:   value,
+		Values: temp,
+	}
+	return out, nil
+
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/model_vmwarecbtcontainercreationinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/model_vmwarecbtcontainercreationinput.go
@@ -1,0 +1,40 @@
+package replicationprotectioncontainers
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ReplicationProviderSpecificContainerCreationInput = VMwareCbtContainerCreationInput{}
+
+type VMwareCbtContainerCreationInput struct {
+
+	// Fields inherited from ReplicationProviderSpecificContainerCreationInput
+}
+
+var _ json.Marshaler = VMwareCbtContainerCreationInput{}
+
+func (s VMwareCbtContainerCreationInput) MarshalJSON() ([]byte, error) {
+	type wrapper VMwareCbtContainerCreationInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling VMwareCbtContainerCreationInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling VMwareCbtContainerCreationInput: %+v", err)
+	}
+	decoded["instanceType"] = "VMwareCbt"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling VMwareCbtContainerCreationInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/predicates.go
@@ -1,0 +1,29 @@
+package replicationprotectioncontainers
+
+type ProtectionContainerOperationPredicate struct {
+	Id       *string
+	Location *string
+	Name     *string
+	Type     *string
+}
+
+func (p ProtectionContainerOperationPredicate) Matches(input ProtectionContainer) bool {
+
+	if p.Id != nil && (input.Id == nil && *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Location != nil && (input.Location == nil && *p.Location != *input.Location) {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil && *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil && *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/version.go
@@ -1,0 +1,12 @@
+package replicationprotectioncontainers
+
+import "fmt"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2022-10-01"
+
+func userAgent() string {
+	return fmt.Sprintf("hashicorp/go-azure-sdk/replicationprotectioncontainers/%s", defaultApiVersion)
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/README.md
@@ -1,0 +1,203 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans` Documentation
+
+The `replicationrecoveryplans` SDK allows for interaction with the Azure Resource Manager Service `recoveryservicessiterecovery` (API Version `2022-10-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans"
+```
+
+
+### Client Initialization
+
+```go
+client := replicationrecoveryplans.NewReplicationRecoveryPlansClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `ReplicationRecoveryPlansClient.Create`
+
+```go
+ctx := context.TODO()
+id := replicationrecoveryplans.NewReplicationRecoveryPlanID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue", "recoveryPlanValue")
+
+payload := replicationrecoveryplans.CreateRecoveryPlanInput{
+	// ...
+}
+
+
+if err := client.CreateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `ReplicationRecoveryPlansClient.Delete`
+
+```go
+ctx := context.TODO()
+id := replicationrecoveryplans.NewReplicationRecoveryPlanID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue", "recoveryPlanValue")
+
+if err := client.DeleteThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `ReplicationRecoveryPlansClient.FailoverCancel`
+
+```go
+ctx := context.TODO()
+id := replicationrecoveryplans.NewReplicationRecoveryPlanID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue", "recoveryPlanValue")
+
+if err := client.FailoverCancelThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `ReplicationRecoveryPlansClient.FailoverCommit`
+
+```go
+ctx := context.TODO()
+id := replicationrecoveryplans.NewReplicationRecoveryPlanID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue", "recoveryPlanValue")
+
+if err := client.FailoverCommitThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `ReplicationRecoveryPlansClient.Get`
+
+```go
+ctx := context.TODO()
+id := replicationrecoveryplans.NewReplicationRecoveryPlanID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue", "recoveryPlanValue")
+
+read, err := client.Get(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `ReplicationRecoveryPlansClient.List`
+
+```go
+ctx := context.TODO()
+id := replicationrecoveryplans.NewVaultID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue")
+
+// alternatively `client.List(ctx, id)` can be used to do batched pagination
+items, err := client.ListComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `ReplicationRecoveryPlansClient.PlannedFailover`
+
+```go
+ctx := context.TODO()
+id := replicationrecoveryplans.NewReplicationRecoveryPlanID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue", "recoveryPlanValue")
+
+payload := replicationrecoveryplans.RecoveryPlanPlannedFailoverInput{
+	// ...
+}
+
+
+if err := client.PlannedFailoverThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `ReplicationRecoveryPlansClient.Reprotect`
+
+```go
+ctx := context.TODO()
+id := replicationrecoveryplans.NewReplicationRecoveryPlanID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue", "recoveryPlanValue")
+
+if err := client.ReprotectThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `ReplicationRecoveryPlansClient.TestFailover`
+
+```go
+ctx := context.TODO()
+id := replicationrecoveryplans.NewReplicationRecoveryPlanID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue", "recoveryPlanValue")
+
+payload := replicationrecoveryplans.RecoveryPlanTestFailoverInput{
+	// ...
+}
+
+
+if err := client.TestFailoverThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `ReplicationRecoveryPlansClient.TestFailoverCleanup`
+
+```go
+ctx := context.TODO()
+id := replicationrecoveryplans.NewReplicationRecoveryPlanID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue", "recoveryPlanValue")
+
+payload := replicationrecoveryplans.RecoveryPlanTestFailoverCleanupInput{
+	// ...
+}
+
+
+if err := client.TestFailoverCleanupThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `ReplicationRecoveryPlansClient.UnplannedFailover`
+
+```go
+ctx := context.TODO()
+id := replicationrecoveryplans.NewReplicationRecoveryPlanID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue", "recoveryPlanValue")
+
+payload := replicationrecoveryplans.RecoveryPlanUnplannedFailoverInput{
+	// ...
+}
+
+
+if err := client.UnplannedFailoverThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `ReplicationRecoveryPlansClient.Update`
+
+```go
+ctx := context.TODO()
+id := replicationrecoveryplans.NewReplicationRecoveryPlanID("12345678-1234-9876-4563-123456789012", "example-resource-group", "resourceValue", "recoveryPlanValue")
+
+payload := replicationrecoveryplans.UpdateRecoveryPlanInput{
+	// ...
+}
+
+
+if err := client.UpdateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/client.go
@@ -1,0 +1,18 @@
+package replicationrecoveryplans
+
+import "github.com/Azure/go-autorest/autorest"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ReplicationRecoveryPlansClient struct {
+	Client  autorest.Client
+	baseUri string
+}
+
+func NewReplicationRecoveryPlansClientWithBaseURI(endpoint string) ReplicationRecoveryPlansClient {
+	return ReplicationRecoveryPlansClient{
+		Client:  autorest.NewClientWithUserAgent(userAgent()),
+		baseUri: endpoint,
+	}
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/constants.go
@@ -1,0 +1,492 @@
+package replicationrecoveryplans
+
+import "strings"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type A2ARpRecoveryPointType string
+
+const (
+	A2ARpRecoveryPointTypeLatest                      A2ARpRecoveryPointType = "Latest"
+	A2ARpRecoveryPointTypeLatestApplicationConsistent A2ARpRecoveryPointType = "LatestApplicationConsistent"
+	A2ARpRecoveryPointTypeLatestCrashConsistent       A2ARpRecoveryPointType = "LatestCrashConsistent"
+	A2ARpRecoveryPointTypeLatestProcessed             A2ARpRecoveryPointType = "LatestProcessed"
+)
+
+func PossibleValuesForA2ARpRecoveryPointType() []string {
+	return []string{
+		string(A2ARpRecoveryPointTypeLatest),
+		string(A2ARpRecoveryPointTypeLatestApplicationConsistent),
+		string(A2ARpRecoveryPointTypeLatestCrashConsistent),
+		string(A2ARpRecoveryPointTypeLatestProcessed),
+	}
+}
+
+func parseA2ARpRecoveryPointType(input string) (*A2ARpRecoveryPointType, error) {
+	vals := map[string]A2ARpRecoveryPointType{
+		"latest":                      A2ARpRecoveryPointTypeLatest,
+		"latestapplicationconsistent": A2ARpRecoveryPointTypeLatestApplicationConsistent,
+		"latestcrashconsistent":       A2ARpRecoveryPointTypeLatestCrashConsistent,
+		"latestprocessed":             A2ARpRecoveryPointTypeLatestProcessed,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := A2ARpRecoveryPointType(input)
+	return &out, nil
+}
+
+type AlternateLocationRecoveryOption string
+
+const (
+	AlternateLocationRecoveryOptionCreateVmIfNotFound AlternateLocationRecoveryOption = "CreateVmIfNotFound"
+	AlternateLocationRecoveryOptionNoAction           AlternateLocationRecoveryOption = "NoAction"
+)
+
+func PossibleValuesForAlternateLocationRecoveryOption() []string {
+	return []string{
+		string(AlternateLocationRecoveryOptionCreateVmIfNotFound),
+		string(AlternateLocationRecoveryOptionNoAction),
+	}
+}
+
+func parseAlternateLocationRecoveryOption(input string) (*AlternateLocationRecoveryOption, error) {
+	vals := map[string]AlternateLocationRecoveryOption{
+		"createvmifnotfound": AlternateLocationRecoveryOptionCreateVmIfNotFound,
+		"noaction":           AlternateLocationRecoveryOptionNoAction,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := AlternateLocationRecoveryOption(input)
+	return &out, nil
+}
+
+type DataSyncStatus string
+
+const (
+	DataSyncStatusForDownTime        DataSyncStatus = "ForDownTime"
+	DataSyncStatusForSynchronization DataSyncStatus = "ForSynchronization"
+)
+
+func PossibleValuesForDataSyncStatus() []string {
+	return []string{
+		string(DataSyncStatusForDownTime),
+		string(DataSyncStatusForSynchronization),
+	}
+}
+
+func parseDataSyncStatus(input string) (*DataSyncStatus, error) {
+	vals := map[string]DataSyncStatus{
+		"fordowntime":        DataSyncStatusForDownTime,
+		"forsynchronization": DataSyncStatusForSynchronization,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := DataSyncStatus(input)
+	return &out, nil
+}
+
+type FailoverDeploymentModel string
+
+const (
+	FailoverDeploymentModelClassic         FailoverDeploymentModel = "Classic"
+	FailoverDeploymentModelNotApplicable   FailoverDeploymentModel = "NotApplicable"
+	FailoverDeploymentModelResourceManager FailoverDeploymentModel = "ResourceManager"
+)
+
+func PossibleValuesForFailoverDeploymentModel() []string {
+	return []string{
+		string(FailoverDeploymentModelClassic),
+		string(FailoverDeploymentModelNotApplicable),
+		string(FailoverDeploymentModelResourceManager),
+	}
+}
+
+func parseFailoverDeploymentModel(input string) (*FailoverDeploymentModel, error) {
+	vals := map[string]FailoverDeploymentModel{
+		"classic":         FailoverDeploymentModelClassic,
+		"notapplicable":   FailoverDeploymentModelNotApplicable,
+		"resourcemanager": FailoverDeploymentModelResourceManager,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := FailoverDeploymentModel(input)
+	return &out, nil
+}
+
+type HyperVReplicaAzureRpRecoveryPointType string
+
+const (
+	HyperVReplicaAzureRpRecoveryPointTypeLatest                      HyperVReplicaAzureRpRecoveryPointType = "Latest"
+	HyperVReplicaAzureRpRecoveryPointTypeLatestApplicationConsistent HyperVReplicaAzureRpRecoveryPointType = "LatestApplicationConsistent"
+	HyperVReplicaAzureRpRecoveryPointTypeLatestProcessed             HyperVReplicaAzureRpRecoveryPointType = "LatestProcessed"
+)
+
+func PossibleValuesForHyperVReplicaAzureRpRecoveryPointType() []string {
+	return []string{
+		string(HyperVReplicaAzureRpRecoveryPointTypeLatest),
+		string(HyperVReplicaAzureRpRecoveryPointTypeLatestApplicationConsistent),
+		string(HyperVReplicaAzureRpRecoveryPointTypeLatestProcessed),
+	}
+}
+
+func parseHyperVReplicaAzureRpRecoveryPointType(input string) (*HyperVReplicaAzureRpRecoveryPointType, error) {
+	vals := map[string]HyperVReplicaAzureRpRecoveryPointType{
+		"latest":                      HyperVReplicaAzureRpRecoveryPointTypeLatest,
+		"latestapplicationconsistent": HyperVReplicaAzureRpRecoveryPointTypeLatestApplicationConsistent,
+		"latestprocessed":             HyperVReplicaAzureRpRecoveryPointTypeLatestProcessed,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := HyperVReplicaAzureRpRecoveryPointType(input)
+	return &out, nil
+}
+
+type InMageRcmFailbackRecoveryPointType string
+
+const (
+	InMageRcmFailbackRecoveryPointTypeApplicationConsistent InMageRcmFailbackRecoveryPointType = "ApplicationConsistent"
+	InMageRcmFailbackRecoveryPointTypeCrashConsistent       InMageRcmFailbackRecoveryPointType = "CrashConsistent"
+)
+
+func PossibleValuesForInMageRcmFailbackRecoveryPointType() []string {
+	return []string{
+		string(InMageRcmFailbackRecoveryPointTypeApplicationConsistent),
+		string(InMageRcmFailbackRecoveryPointTypeCrashConsistent),
+	}
+}
+
+func parseInMageRcmFailbackRecoveryPointType(input string) (*InMageRcmFailbackRecoveryPointType, error) {
+	vals := map[string]InMageRcmFailbackRecoveryPointType{
+		"applicationconsistent": InMageRcmFailbackRecoveryPointTypeApplicationConsistent,
+		"crashconsistent":       InMageRcmFailbackRecoveryPointTypeCrashConsistent,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := InMageRcmFailbackRecoveryPointType(input)
+	return &out, nil
+}
+
+type InMageV2RpRecoveryPointType string
+
+const (
+	InMageV2RpRecoveryPointTypeLatest                      InMageV2RpRecoveryPointType = "Latest"
+	InMageV2RpRecoveryPointTypeLatestApplicationConsistent InMageV2RpRecoveryPointType = "LatestApplicationConsistent"
+	InMageV2RpRecoveryPointTypeLatestCrashConsistent       InMageV2RpRecoveryPointType = "LatestCrashConsistent"
+	InMageV2RpRecoveryPointTypeLatestProcessed             InMageV2RpRecoveryPointType = "LatestProcessed"
+)
+
+func PossibleValuesForInMageV2RpRecoveryPointType() []string {
+	return []string{
+		string(InMageV2RpRecoveryPointTypeLatest),
+		string(InMageV2RpRecoveryPointTypeLatestApplicationConsistent),
+		string(InMageV2RpRecoveryPointTypeLatestCrashConsistent),
+		string(InMageV2RpRecoveryPointTypeLatestProcessed),
+	}
+}
+
+func parseInMageV2RpRecoveryPointType(input string) (*InMageV2RpRecoveryPointType, error) {
+	vals := map[string]InMageV2RpRecoveryPointType{
+		"latest":                      InMageV2RpRecoveryPointTypeLatest,
+		"latestapplicationconsistent": InMageV2RpRecoveryPointTypeLatestApplicationConsistent,
+		"latestcrashconsistent":       InMageV2RpRecoveryPointTypeLatestCrashConsistent,
+		"latestprocessed":             InMageV2RpRecoveryPointTypeLatestProcessed,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := InMageV2RpRecoveryPointType(input)
+	return &out, nil
+}
+
+type MultiVmSyncPointOption string
+
+const (
+	MultiVmSyncPointOptionUseMultiVmSyncRecoveryPoint MultiVmSyncPointOption = "UseMultiVmSyncRecoveryPoint"
+	MultiVmSyncPointOptionUsePerVmRecoveryPoint       MultiVmSyncPointOption = "UsePerVmRecoveryPoint"
+)
+
+func PossibleValuesForMultiVmSyncPointOption() []string {
+	return []string{
+		string(MultiVmSyncPointOptionUseMultiVmSyncRecoveryPoint),
+		string(MultiVmSyncPointOptionUsePerVmRecoveryPoint),
+	}
+}
+
+func parseMultiVmSyncPointOption(input string) (*MultiVmSyncPointOption, error) {
+	vals := map[string]MultiVmSyncPointOption{
+		"usemultivmsyncrecoverypoint": MultiVmSyncPointOptionUseMultiVmSyncRecoveryPoint,
+		"usepervmrecoverypoint":       MultiVmSyncPointOptionUsePerVmRecoveryPoint,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := MultiVmSyncPointOption(input)
+	return &out, nil
+}
+
+type PossibleOperationsDirections string
+
+const (
+	PossibleOperationsDirectionsPrimaryToRecovery PossibleOperationsDirections = "PrimaryToRecovery"
+	PossibleOperationsDirectionsRecoveryToPrimary PossibleOperationsDirections = "RecoveryToPrimary"
+)
+
+func PossibleValuesForPossibleOperationsDirections() []string {
+	return []string{
+		string(PossibleOperationsDirectionsPrimaryToRecovery),
+		string(PossibleOperationsDirectionsRecoveryToPrimary),
+	}
+}
+
+func parsePossibleOperationsDirections(input string) (*PossibleOperationsDirections, error) {
+	vals := map[string]PossibleOperationsDirections{
+		"primarytorecovery": PossibleOperationsDirectionsPrimaryToRecovery,
+		"recoverytoprimary": PossibleOperationsDirectionsRecoveryToPrimary,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := PossibleOperationsDirections(input)
+	return &out, nil
+}
+
+type RecoveryPlanActionLocation string
+
+const (
+	RecoveryPlanActionLocationPrimary  RecoveryPlanActionLocation = "Primary"
+	RecoveryPlanActionLocationRecovery RecoveryPlanActionLocation = "Recovery"
+)
+
+func PossibleValuesForRecoveryPlanActionLocation() []string {
+	return []string{
+		string(RecoveryPlanActionLocationPrimary),
+		string(RecoveryPlanActionLocationRecovery),
+	}
+}
+
+func parseRecoveryPlanActionLocation(input string) (*RecoveryPlanActionLocation, error) {
+	vals := map[string]RecoveryPlanActionLocation{
+		"primary":  RecoveryPlanActionLocationPrimary,
+		"recovery": RecoveryPlanActionLocationRecovery,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := RecoveryPlanActionLocation(input)
+	return &out, nil
+}
+
+type RecoveryPlanGroupType string
+
+const (
+	RecoveryPlanGroupTypeBoot     RecoveryPlanGroupType = "Boot"
+	RecoveryPlanGroupTypeFailover RecoveryPlanGroupType = "Failover"
+	RecoveryPlanGroupTypeShutdown RecoveryPlanGroupType = "Shutdown"
+)
+
+func PossibleValuesForRecoveryPlanGroupType() []string {
+	return []string{
+		string(RecoveryPlanGroupTypeBoot),
+		string(RecoveryPlanGroupTypeFailover),
+		string(RecoveryPlanGroupTypeShutdown),
+	}
+}
+
+func parseRecoveryPlanGroupType(input string) (*RecoveryPlanGroupType, error) {
+	vals := map[string]RecoveryPlanGroupType{
+		"boot":     RecoveryPlanGroupTypeBoot,
+		"failover": RecoveryPlanGroupTypeFailover,
+		"shutdown": RecoveryPlanGroupTypeShutdown,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := RecoveryPlanGroupType(input)
+	return &out, nil
+}
+
+type RecoveryPlanPointType string
+
+const (
+	RecoveryPlanPointTypeLatest                      RecoveryPlanPointType = "Latest"
+	RecoveryPlanPointTypeLatestApplicationConsistent RecoveryPlanPointType = "LatestApplicationConsistent"
+	RecoveryPlanPointTypeLatestCrashConsistent       RecoveryPlanPointType = "LatestCrashConsistent"
+	RecoveryPlanPointTypeLatestProcessed             RecoveryPlanPointType = "LatestProcessed"
+)
+
+func PossibleValuesForRecoveryPlanPointType() []string {
+	return []string{
+		string(RecoveryPlanPointTypeLatest),
+		string(RecoveryPlanPointTypeLatestApplicationConsistent),
+		string(RecoveryPlanPointTypeLatestCrashConsistent),
+		string(RecoveryPlanPointTypeLatestProcessed),
+	}
+}
+
+func parseRecoveryPlanPointType(input string) (*RecoveryPlanPointType, error) {
+	vals := map[string]RecoveryPlanPointType{
+		"latest":                      RecoveryPlanPointTypeLatest,
+		"latestapplicationconsistent": RecoveryPlanPointTypeLatestApplicationConsistent,
+		"latestcrashconsistent":       RecoveryPlanPointTypeLatestCrashConsistent,
+		"latestprocessed":             RecoveryPlanPointTypeLatestProcessed,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := RecoveryPlanPointType(input)
+	return &out, nil
+}
+
+type ReplicationProtectedItemOperation string
+
+const (
+	ReplicationProtectedItemOperationCancelFailover      ReplicationProtectedItemOperation = "CancelFailover"
+	ReplicationProtectedItemOperationChangePit           ReplicationProtectedItemOperation = "ChangePit"
+	ReplicationProtectedItemOperationCommit              ReplicationProtectedItemOperation = "Commit"
+	ReplicationProtectedItemOperationCompleteMigration   ReplicationProtectedItemOperation = "CompleteMigration"
+	ReplicationProtectedItemOperationDisableProtection   ReplicationProtectedItemOperation = "DisableProtection"
+	ReplicationProtectedItemOperationFailback            ReplicationProtectedItemOperation = "Failback"
+	ReplicationProtectedItemOperationFinalizeFailback    ReplicationProtectedItemOperation = "FinalizeFailback"
+	ReplicationProtectedItemOperationPlannedFailover     ReplicationProtectedItemOperation = "PlannedFailover"
+	ReplicationProtectedItemOperationRepairReplication   ReplicationProtectedItemOperation = "RepairReplication"
+	ReplicationProtectedItemOperationReverseReplicate    ReplicationProtectedItemOperation = "ReverseReplicate"
+	ReplicationProtectedItemOperationSwitchProtection    ReplicationProtectedItemOperation = "SwitchProtection"
+	ReplicationProtectedItemOperationTestFailover        ReplicationProtectedItemOperation = "TestFailover"
+	ReplicationProtectedItemOperationTestFailoverCleanup ReplicationProtectedItemOperation = "TestFailoverCleanup"
+	ReplicationProtectedItemOperationUnplannedFailover   ReplicationProtectedItemOperation = "UnplannedFailover"
+)
+
+func PossibleValuesForReplicationProtectedItemOperation() []string {
+	return []string{
+		string(ReplicationProtectedItemOperationCancelFailover),
+		string(ReplicationProtectedItemOperationChangePit),
+		string(ReplicationProtectedItemOperationCommit),
+		string(ReplicationProtectedItemOperationCompleteMigration),
+		string(ReplicationProtectedItemOperationDisableProtection),
+		string(ReplicationProtectedItemOperationFailback),
+		string(ReplicationProtectedItemOperationFinalizeFailback),
+		string(ReplicationProtectedItemOperationPlannedFailover),
+		string(ReplicationProtectedItemOperationRepairReplication),
+		string(ReplicationProtectedItemOperationReverseReplicate),
+		string(ReplicationProtectedItemOperationSwitchProtection),
+		string(ReplicationProtectedItemOperationTestFailover),
+		string(ReplicationProtectedItemOperationTestFailoverCleanup),
+		string(ReplicationProtectedItemOperationUnplannedFailover),
+	}
+}
+
+func parseReplicationProtectedItemOperation(input string) (*ReplicationProtectedItemOperation, error) {
+	vals := map[string]ReplicationProtectedItemOperation{
+		"cancelfailover":      ReplicationProtectedItemOperationCancelFailover,
+		"changepit":           ReplicationProtectedItemOperationChangePit,
+		"commit":              ReplicationProtectedItemOperationCommit,
+		"completemigration":   ReplicationProtectedItemOperationCompleteMigration,
+		"disableprotection":   ReplicationProtectedItemOperationDisableProtection,
+		"failback":            ReplicationProtectedItemOperationFailback,
+		"finalizefailback":    ReplicationProtectedItemOperationFinalizeFailback,
+		"plannedfailover":     ReplicationProtectedItemOperationPlannedFailover,
+		"repairreplication":   ReplicationProtectedItemOperationRepairReplication,
+		"reversereplicate":    ReplicationProtectedItemOperationReverseReplicate,
+		"switchprotection":    ReplicationProtectedItemOperationSwitchProtection,
+		"testfailover":        ReplicationProtectedItemOperationTestFailover,
+		"testfailovercleanup": ReplicationProtectedItemOperationTestFailoverCleanup,
+		"unplannedfailover":   ReplicationProtectedItemOperationUnplannedFailover,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ReplicationProtectedItemOperation(input)
+	return &out, nil
+}
+
+type RpInMageRecoveryPointType string
+
+const (
+	RpInMageRecoveryPointTypeCustom     RpInMageRecoveryPointType = "Custom"
+	RpInMageRecoveryPointTypeLatestTag  RpInMageRecoveryPointType = "LatestTag"
+	RpInMageRecoveryPointTypeLatestTime RpInMageRecoveryPointType = "LatestTime"
+)
+
+func PossibleValuesForRpInMageRecoveryPointType() []string {
+	return []string{
+		string(RpInMageRecoveryPointTypeCustom),
+		string(RpInMageRecoveryPointTypeLatestTag),
+		string(RpInMageRecoveryPointTypeLatestTime),
+	}
+}
+
+func parseRpInMageRecoveryPointType(input string) (*RpInMageRecoveryPointType, error) {
+	vals := map[string]RpInMageRecoveryPointType{
+		"custom":     RpInMageRecoveryPointTypeCustom,
+		"latesttag":  RpInMageRecoveryPointTypeLatestTag,
+		"latesttime": RpInMageRecoveryPointTypeLatestTime,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := RpInMageRecoveryPointType(input)
+	return &out, nil
+}
+
+type SourceSiteOperations string
+
+const (
+	SourceSiteOperationsNotRequired SourceSiteOperations = "NotRequired"
+	SourceSiteOperationsRequired    SourceSiteOperations = "Required"
+)
+
+func PossibleValuesForSourceSiteOperations() []string {
+	return []string{
+		string(SourceSiteOperationsNotRequired),
+		string(SourceSiteOperationsRequired),
+	}
+}
+
+func parseSourceSiteOperations(input string) (*SourceSiteOperations, error) {
+	vals := map[string]SourceSiteOperations{
+		"notrequired": SourceSiteOperationsNotRequired,
+		"required":    SourceSiteOperationsRequired,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := SourceSiteOperations(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/id_replicationrecoveryplan.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/id_replicationrecoveryplan.go
@@ -1,0 +1,137 @@
+package replicationrecoveryplans
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = ReplicationRecoveryPlanId{}
+
+// ReplicationRecoveryPlanId is a struct representing the Resource ID for a Replication Recovery Plan
+type ReplicationRecoveryPlanId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	ResourceName      string
+	RecoveryPlanName  string
+}
+
+// NewReplicationRecoveryPlanID returns a new ReplicationRecoveryPlanId struct
+func NewReplicationRecoveryPlanID(subscriptionId string, resourceGroupName string, resourceName string, recoveryPlanName string) ReplicationRecoveryPlanId {
+	return ReplicationRecoveryPlanId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		ResourceName:      resourceName,
+		RecoveryPlanName:  recoveryPlanName,
+	}
+}
+
+// ParseReplicationRecoveryPlanID parses 'input' into a ReplicationRecoveryPlanId
+func ParseReplicationRecoveryPlanID(input string) (*ReplicationRecoveryPlanId, error) {
+	parser := resourceids.NewParserFromResourceIdType(ReplicationRecoveryPlanId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := ReplicationRecoveryPlanId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceName, ok = parsed.Parsed["resourceName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceName' was not found in the resource id %q", input)
+	}
+
+	if id.RecoveryPlanName, ok = parsed.Parsed["recoveryPlanName"]; !ok {
+		return nil, fmt.Errorf("the segment 'recoveryPlanName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ParseReplicationRecoveryPlanIDInsensitively parses 'input' case-insensitively into a ReplicationRecoveryPlanId
+// note: this method should only be used for API response data and not user input
+func ParseReplicationRecoveryPlanIDInsensitively(input string) (*ReplicationRecoveryPlanId, error) {
+	parser := resourceids.NewParserFromResourceIdType(ReplicationRecoveryPlanId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := ReplicationRecoveryPlanId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceName, ok = parsed.Parsed["resourceName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceName' was not found in the resource id %q", input)
+	}
+
+	if id.RecoveryPlanName, ok = parsed.Parsed["recoveryPlanName"]; !ok {
+		return nil, fmt.Errorf("the segment 'recoveryPlanName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ValidateReplicationRecoveryPlanID checks that 'input' can be parsed as a Replication Recovery Plan ID
+func ValidateReplicationRecoveryPlanID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseReplicationRecoveryPlanID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Replication Recovery Plan ID
+func (id ReplicationRecoveryPlanId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.RecoveryServices/vaults/%s/replicationRecoveryPlans/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.ResourceName, id.RecoveryPlanName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Replication Recovery Plan ID
+func (id ReplicationRecoveryPlanId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftRecoveryServices", "Microsoft.RecoveryServices", "Microsoft.RecoveryServices"),
+		resourceids.StaticSegment("staticVaults", "vaults", "vaults"),
+		resourceids.UserSpecifiedSegment("resourceName", "resourceValue"),
+		resourceids.StaticSegment("staticReplicationRecoveryPlans", "replicationRecoveryPlans", "replicationRecoveryPlans"),
+		resourceids.UserSpecifiedSegment("recoveryPlanName", "recoveryPlanValue"),
+	}
+}
+
+// String returns a human-readable description of this Replication Recovery Plan ID
+func (id ReplicationRecoveryPlanId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Resource Name: %q", id.ResourceName),
+		fmt.Sprintf("Recovery Plan Name: %q", id.RecoveryPlanName),
+	}
+	return fmt.Sprintf("Replication Recovery Plan (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/id_vault.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/id_vault.go
@@ -1,0 +1,124 @@
+package replicationrecoveryplans
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = VaultId{}
+
+// VaultId is a struct representing the Resource ID for a Vault
+type VaultId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	ResourceName      string
+}
+
+// NewVaultID returns a new VaultId struct
+func NewVaultID(subscriptionId string, resourceGroupName string, resourceName string) VaultId {
+	return VaultId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		ResourceName:      resourceName,
+	}
+}
+
+// ParseVaultID parses 'input' into a VaultId
+func ParseVaultID(input string) (*VaultId, error) {
+	parser := resourceids.NewParserFromResourceIdType(VaultId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := VaultId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceName, ok = parsed.Parsed["resourceName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ParseVaultIDInsensitively parses 'input' case-insensitively into a VaultId
+// note: this method should only be used for API response data and not user input
+func ParseVaultIDInsensitively(input string) (*VaultId, error) {
+	parser := resourceids.NewParserFromResourceIdType(VaultId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := VaultId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceName, ok = parsed.Parsed["resourceName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ValidateVaultID checks that 'input' can be parsed as a Vault ID
+func ValidateVaultID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseVaultID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Vault ID
+func (id VaultId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.RecoveryServices/vaults/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.ResourceName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Vault ID
+func (id VaultId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftRecoveryServices", "Microsoft.RecoveryServices", "Microsoft.RecoveryServices"),
+		resourceids.StaticSegment("staticVaults", "vaults", "vaults"),
+		resourceids.UserSpecifiedSegment("resourceName", "resourceValue"),
+	}
+}
+
+// String returns a human-readable description of this Vault ID
+func (id VaultId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Resource Name: %q", id.ResourceName),
+	}
+	return fmt.Sprintf("Vault (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/method_create_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/method_create_autorest.go
@@ -1,0 +1,79 @@
+package replicationrecoveryplans
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CreateOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// Create ...
+func (c ReplicationRecoveryPlansClient) Create(ctx context.Context, id ReplicationRecoveryPlanId, input CreateRecoveryPlanInput) (result CreateOperationResponse, err error) {
+	req, err := c.preparerForCreate(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationrecoveryplans.ReplicationRecoveryPlansClient", "Create", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForCreate(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationrecoveryplans.ReplicationRecoveryPlansClient", "Create", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// CreateThenPoll performs Create then polls until it's completed
+func (c ReplicationRecoveryPlansClient) CreateThenPoll(ctx context.Context, id ReplicationRecoveryPlanId, input CreateRecoveryPlanInput) error {
+	result, err := c.Create(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing Create: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after Create: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForCreate prepares the Create request.
+func (c ReplicationRecoveryPlansClient) preparerForCreate(ctx context.Context, id ReplicationRecoveryPlanId, input CreateRecoveryPlanInput) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPut(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForCreate sends the Create request. The method will close the
+// http.Response Body if it receives an error.
+func (c ReplicationRecoveryPlansClient) senderForCreate(ctx context.Context, req *http.Request) (future CreateOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/method_delete_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/method_delete_autorest.go
@@ -1,0 +1,78 @@
+package replicationrecoveryplans
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DeleteOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// Delete ...
+func (c ReplicationRecoveryPlansClient) Delete(ctx context.Context, id ReplicationRecoveryPlanId) (result DeleteOperationResponse, err error) {
+	req, err := c.preparerForDelete(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationrecoveryplans.ReplicationRecoveryPlansClient", "Delete", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForDelete(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationrecoveryplans.ReplicationRecoveryPlansClient", "Delete", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// DeleteThenPoll performs Delete then polls until it's completed
+func (c ReplicationRecoveryPlansClient) DeleteThenPoll(ctx context.Context, id ReplicationRecoveryPlanId) error {
+	result, err := c.Delete(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing Delete: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after Delete: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForDelete prepares the Delete request.
+func (c ReplicationRecoveryPlansClient) preparerForDelete(ctx context.Context, id ReplicationRecoveryPlanId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsDelete(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForDelete sends the Delete request. The method will close the
+// http.Response Body if it receives an error.
+func (c ReplicationRecoveryPlansClient) senderForDelete(ctx context.Context, req *http.Request) (future DeleteOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/method_failovercancel_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/method_failovercancel_autorest.go
@@ -1,0 +1,78 @@
+package replicationrecoveryplans
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type FailoverCancelOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// FailoverCancel ...
+func (c ReplicationRecoveryPlansClient) FailoverCancel(ctx context.Context, id ReplicationRecoveryPlanId) (result FailoverCancelOperationResponse, err error) {
+	req, err := c.preparerForFailoverCancel(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationrecoveryplans.ReplicationRecoveryPlansClient", "FailoverCancel", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForFailoverCancel(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationrecoveryplans.ReplicationRecoveryPlansClient", "FailoverCancel", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// FailoverCancelThenPoll performs FailoverCancel then polls until it's completed
+func (c ReplicationRecoveryPlansClient) FailoverCancelThenPoll(ctx context.Context, id ReplicationRecoveryPlanId) error {
+	result, err := c.FailoverCancel(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing FailoverCancel: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after FailoverCancel: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForFailoverCancel prepares the FailoverCancel request.
+func (c ReplicationRecoveryPlansClient) preparerForFailoverCancel(ctx context.Context, id ReplicationRecoveryPlanId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/failoverCancel", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForFailoverCancel sends the FailoverCancel request. The method will close the
+// http.Response Body if it receives an error.
+func (c ReplicationRecoveryPlansClient) senderForFailoverCancel(ctx context.Context, req *http.Request) (future FailoverCancelOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/method_failovercommit_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/method_failovercommit_autorest.go
@@ -1,0 +1,78 @@
+package replicationrecoveryplans
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type FailoverCommitOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// FailoverCommit ...
+func (c ReplicationRecoveryPlansClient) FailoverCommit(ctx context.Context, id ReplicationRecoveryPlanId) (result FailoverCommitOperationResponse, err error) {
+	req, err := c.preparerForFailoverCommit(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationrecoveryplans.ReplicationRecoveryPlansClient", "FailoverCommit", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForFailoverCommit(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationrecoveryplans.ReplicationRecoveryPlansClient", "FailoverCommit", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// FailoverCommitThenPoll performs FailoverCommit then polls until it's completed
+func (c ReplicationRecoveryPlansClient) FailoverCommitThenPoll(ctx context.Context, id ReplicationRecoveryPlanId) error {
+	result, err := c.FailoverCommit(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing FailoverCommit: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after FailoverCommit: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForFailoverCommit prepares the FailoverCommit request.
+func (c ReplicationRecoveryPlansClient) preparerForFailoverCommit(ctx context.Context, id ReplicationRecoveryPlanId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/failoverCommit", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForFailoverCommit sends the FailoverCommit request. The method will close the
+// http.Response Body if it receives an error.
+func (c ReplicationRecoveryPlansClient) senderForFailoverCommit(ctx context.Context, req *http.Request) (future FailoverCommitOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/method_get_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/method_get_autorest.go
@@ -1,0 +1,68 @@
+package replicationrecoveryplans
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *RecoveryPlan
+}
+
+// Get ...
+func (c ReplicationRecoveryPlansClient) Get(ctx context.Context, id ReplicationRecoveryPlanId) (result GetOperationResponse, err error) {
+	req, err := c.preparerForGet(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationrecoveryplans.ReplicationRecoveryPlansClient", "Get", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationrecoveryplans.ReplicationRecoveryPlansClient", "Get", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForGet(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationrecoveryplans.ReplicationRecoveryPlansClient", "Get", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForGet prepares the Get request.
+func (c ReplicationRecoveryPlansClient) preparerForGet(ctx context.Context, id ReplicationRecoveryPlanId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForGet handles the response to the Get request. The method always
+// closes the http.Response Body.
+func (c ReplicationRecoveryPlansClient) responderForGet(resp *http.Response) (result GetOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/method_list_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/method_list_autorest.go
@@ -1,0 +1,186 @@
+package replicationrecoveryplans
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *[]RecoveryPlan
+
+	nextLink     *string
+	nextPageFunc func(ctx context.Context, nextLink string) (ListOperationResponse, error)
+}
+
+type ListCompleteResult struct {
+	Items []RecoveryPlan
+}
+
+func (r ListOperationResponse) HasMore() bool {
+	return r.nextLink != nil
+}
+
+func (r ListOperationResponse) LoadMore(ctx context.Context) (resp ListOperationResponse, err error) {
+	if !r.HasMore() {
+		err = fmt.Errorf("no more pages returned")
+		return
+	}
+	return r.nextPageFunc(ctx, *r.nextLink)
+}
+
+// List ...
+func (c ReplicationRecoveryPlansClient) List(ctx context.Context, id VaultId) (resp ListOperationResponse, err error) {
+	req, err := c.preparerForList(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationrecoveryplans.ReplicationRecoveryPlansClient", "List", nil, "Failure preparing request")
+		return
+	}
+
+	resp.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationrecoveryplans.ReplicationRecoveryPlansClient", "List", resp.HttpResponse, "Failure sending request")
+		return
+	}
+
+	resp, err = c.responderForList(resp.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationrecoveryplans.ReplicationRecoveryPlansClient", "List", resp.HttpResponse, "Failure responding to request")
+		return
+	}
+	return
+}
+
+// preparerForList prepares the List request.
+func (c ReplicationRecoveryPlansClient) preparerForList(ctx context.Context, id VaultId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/replicationRecoveryPlans", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// preparerForListWithNextLink prepares the List request with the given nextLink token.
+func (c ReplicationRecoveryPlansClient) preparerForListWithNextLink(ctx context.Context, nextLink string) (*http.Request, error) {
+	uri, err := url.Parse(nextLink)
+	if err != nil {
+		return nil, fmt.Errorf("parsing nextLink %q: %+v", nextLink, err)
+	}
+	queryParameters := map[string]interface{}{}
+	for k, v := range uri.Query() {
+		if len(v) == 0 {
+			continue
+		}
+		val := v[0]
+		val = autorest.Encode("query", val)
+		queryParameters[k] = val
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(uri.Path),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForList handles the response to the List request. The method always
+// closes the http.Response Body.
+func (c ReplicationRecoveryPlansClient) responderForList(resp *http.Response) (result ListOperationResponse, err error) {
+	type page struct {
+		Values   []RecoveryPlan `json:"value"`
+		NextLink *string        `json:"nextLink"`
+	}
+	var respObj page
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&respObj),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	result.Model = &respObj.Values
+	result.nextLink = respObj.NextLink
+	if respObj.NextLink != nil {
+		result.nextPageFunc = func(ctx context.Context, nextLink string) (result ListOperationResponse, err error) {
+			req, err := c.preparerForListWithNextLink(ctx, nextLink)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "replicationrecoveryplans.ReplicationRecoveryPlansClient", "List", nil, "Failure preparing request")
+				return
+			}
+
+			result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "replicationrecoveryplans.ReplicationRecoveryPlansClient", "List", result.HttpResponse, "Failure sending request")
+				return
+			}
+
+			result, err = c.responderForList(result.HttpResponse)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "replicationrecoveryplans.ReplicationRecoveryPlansClient", "List", result.HttpResponse, "Failure responding to request")
+				return
+			}
+
+			return
+		}
+	}
+	return
+}
+
+// ListComplete retrieves all of the results into a single object
+func (c ReplicationRecoveryPlansClient) ListComplete(ctx context.Context, id VaultId) (ListCompleteResult, error) {
+	return c.ListCompleteMatchingPredicate(ctx, id, RecoveryPlanOperationPredicate{})
+}
+
+// ListCompleteMatchingPredicate retrieves all of the results and then applied the predicate
+func (c ReplicationRecoveryPlansClient) ListCompleteMatchingPredicate(ctx context.Context, id VaultId, predicate RecoveryPlanOperationPredicate) (resp ListCompleteResult, err error) {
+	items := make([]RecoveryPlan, 0)
+
+	page, err := c.List(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading the initial page: %+v", err)
+		return
+	}
+	if page.Model != nil {
+		for _, v := range *page.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	for page.HasMore() {
+		page, err = page.LoadMore(ctx)
+		if err != nil {
+			err = fmt.Errorf("loading the next page: %+v", err)
+			return
+		}
+
+		if page.Model != nil {
+			for _, v := range *page.Model {
+				if predicate.Matches(v) {
+					items = append(items, v)
+				}
+			}
+		}
+	}
+
+	out := ListCompleteResult{
+		Items: items,
+	}
+	return out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/method_plannedfailover_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/method_plannedfailover_autorest.go
@@ -1,0 +1,79 @@
+package replicationrecoveryplans
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PlannedFailoverOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// PlannedFailover ...
+func (c ReplicationRecoveryPlansClient) PlannedFailover(ctx context.Context, id ReplicationRecoveryPlanId, input RecoveryPlanPlannedFailoverInput) (result PlannedFailoverOperationResponse, err error) {
+	req, err := c.preparerForPlannedFailover(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationrecoveryplans.ReplicationRecoveryPlansClient", "PlannedFailover", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForPlannedFailover(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationrecoveryplans.ReplicationRecoveryPlansClient", "PlannedFailover", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// PlannedFailoverThenPoll performs PlannedFailover then polls until it's completed
+func (c ReplicationRecoveryPlansClient) PlannedFailoverThenPoll(ctx context.Context, id ReplicationRecoveryPlanId, input RecoveryPlanPlannedFailoverInput) error {
+	result, err := c.PlannedFailover(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing PlannedFailover: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after PlannedFailover: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForPlannedFailover prepares the PlannedFailover request.
+func (c ReplicationRecoveryPlansClient) preparerForPlannedFailover(ctx context.Context, id ReplicationRecoveryPlanId, input RecoveryPlanPlannedFailoverInput) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/plannedFailover", id.ID())),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForPlannedFailover sends the PlannedFailover request. The method will close the
+// http.Response Body if it receives an error.
+func (c ReplicationRecoveryPlansClient) senderForPlannedFailover(ctx context.Context, req *http.Request) (future PlannedFailoverOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/method_reprotect_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/method_reprotect_autorest.go
@@ -1,0 +1,78 @@
+package replicationrecoveryplans
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ReprotectOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// Reprotect ...
+func (c ReplicationRecoveryPlansClient) Reprotect(ctx context.Context, id ReplicationRecoveryPlanId) (result ReprotectOperationResponse, err error) {
+	req, err := c.preparerForReprotect(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationrecoveryplans.ReplicationRecoveryPlansClient", "Reprotect", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForReprotect(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationrecoveryplans.ReplicationRecoveryPlansClient", "Reprotect", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// ReprotectThenPoll performs Reprotect then polls until it's completed
+func (c ReplicationRecoveryPlansClient) ReprotectThenPoll(ctx context.Context, id ReplicationRecoveryPlanId) error {
+	result, err := c.Reprotect(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing Reprotect: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after Reprotect: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForReprotect prepares the Reprotect request.
+func (c ReplicationRecoveryPlansClient) preparerForReprotect(ctx context.Context, id ReplicationRecoveryPlanId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/reProtect", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForReprotect sends the Reprotect request. The method will close the
+// http.Response Body if it receives an error.
+func (c ReplicationRecoveryPlansClient) senderForReprotect(ctx context.Context, req *http.Request) (future ReprotectOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/method_testfailover_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/method_testfailover_autorest.go
@@ -1,0 +1,79 @@
+package replicationrecoveryplans
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type TestFailoverOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// TestFailover ...
+func (c ReplicationRecoveryPlansClient) TestFailover(ctx context.Context, id ReplicationRecoveryPlanId, input RecoveryPlanTestFailoverInput) (result TestFailoverOperationResponse, err error) {
+	req, err := c.preparerForTestFailover(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationrecoveryplans.ReplicationRecoveryPlansClient", "TestFailover", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForTestFailover(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationrecoveryplans.ReplicationRecoveryPlansClient", "TestFailover", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// TestFailoverThenPoll performs TestFailover then polls until it's completed
+func (c ReplicationRecoveryPlansClient) TestFailoverThenPoll(ctx context.Context, id ReplicationRecoveryPlanId, input RecoveryPlanTestFailoverInput) error {
+	result, err := c.TestFailover(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing TestFailover: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after TestFailover: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForTestFailover prepares the TestFailover request.
+func (c ReplicationRecoveryPlansClient) preparerForTestFailover(ctx context.Context, id ReplicationRecoveryPlanId, input RecoveryPlanTestFailoverInput) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/testFailover", id.ID())),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForTestFailover sends the TestFailover request. The method will close the
+// http.Response Body if it receives an error.
+func (c ReplicationRecoveryPlansClient) senderForTestFailover(ctx context.Context, req *http.Request) (future TestFailoverOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/method_testfailovercleanup_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/method_testfailovercleanup_autorest.go
@@ -1,0 +1,79 @@
+package replicationrecoveryplans
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type TestFailoverCleanupOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// TestFailoverCleanup ...
+func (c ReplicationRecoveryPlansClient) TestFailoverCleanup(ctx context.Context, id ReplicationRecoveryPlanId, input RecoveryPlanTestFailoverCleanupInput) (result TestFailoverCleanupOperationResponse, err error) {
+	req, err := c.preparerForTestFailoverCleanup(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationrecoveryplans.ReplicationRecoveryPlansClient", "TestFailoverCleanup", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForTestFailoverCleanup(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationrecoveryplans.ReplicationRecoveryPlansClient", "TestFailoverCleanup", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// TestFailoverCleanupThenPoll performs TestFailoverCleanup then polls until it's completed
+func (c ReplicationRecoveryPlansClient) TestFailoverCleanupThenPoll(ctx context.Context, id ReplicationRecoveryPlanId, input RecoveryPlanTestFailoverCleanupInput) error {
+	result, err := c.TestFailoverCleanup(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing TestFailoverCleanup: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after TestFailoverCleanup: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForTestFailoverCleanup prepares the TestFailoverCleanup request.
+func (c ReplicationRecoveryPlansClient) preparerForTestFailoverCleanup(ctx context.Context, id ReplicationRecoveryPlanId, input RecoveryPlanTestFailoverCleanupInput) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/testFailoverCleanup", id.ID())),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForTestFailoverCleanup sends the TestFailoverCleanup request. The method will close the
+// http.Response Body if it receives an error.
+func (c ReplicationRecoveryPlansClient) senderForTestFailoverCleanup(ctx context.Context, req *http.Request) (future TestFailoverCleanupOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/method_unplannedfailover_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/method_unplannedfailover_autorest.go
@@ -1,0 +1,79 @@
+package replicationrecoveryplans
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UnplannedFailoverOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// UnplannedFailover ...
+func (c ReplicationRecoveryPlansClient) UnplannedFailover(ctx context.Context, id ReplicationRecoveryPlanId, input RecoveryPlanUnplannedFailoverInput) (result UnplannedFailoverOperationResponse, err error) {
+	req, err := c.preparerForUnplannedFailover(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationrecoveryplans.ReplicationRecoveryPlansClient", "UnplannedFailover", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForUnplannedFailover(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationrecoveryplans.ReplicationRecoveryPlansClient", "UnplannedFailover", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// UnplannedFailoverThenPoll performs UnplannedFailover then polls until it's completed
+func (c ReplicationRecoveryPlansClient) UnplannedFailoverThenPoll(ctx context.Context, id ReplicationRecoveryPlanId, input RecoveryPlanUnplannedFailoverInput) error {
+	result, err := c.UnplannedFailover(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing UnplannedFailover: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after UnplannedFailover: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForUnplannedFailover prepares the UnplannedFailover request.
+func (c ReplicationRecoveryPlansClient) preparerForUnplannedFailover(ctx context.Context, id ReplicationRecoveryPlanId, input RecoveryPlanUnplannedFailoverInput) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/unplannedFailover", id.ID())),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForUnplannedFailover sends the UnplannedFailover request. The method will close the
+// http.Response Body if it receives an error.
+func (c ReplicationRecoveryPlansClient) senderForUnplannedFailover(ctx context.Context, req *http.Request) (future UnplannedFailoverOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/method_update_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/method_update_autorest.go
@@ -1,0 +1,79 @@
+package replicationrecoveryplans
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UpdateOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// Update ...
+func (c ReplicationRecoveryPlansClient) Update(ctx context.Context, id ReplicationRecoveryPlanId, input UpdateRecoveryPlanInput) (result UpdateOperationResponse, err error) {
+	req, err := c.preparerForUpdate(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationrecoveryplans.ReplicationRecoveryPlansClient", "Update", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForUpdate(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationrecoveryplans.ReplicationRecoveryPlansClient", "Update", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// UpdateThenPoll performs Update then polls until it's completed
+func (c ReplicationRecoveryPlansClient) UpdateThenPoll(ctx context.Context, id ReplicationRecoveryPlanId, input UpdateRecoveryPlanInput) error {
+	result, err := c.Update(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing Update: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after Update: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForUpdate prepares the Update request.
+func (c ReplicationRecoveryPlansClient) preparerForUpdate(ctx context.Context, id ReplicationRecoveryPlanId, input UpdateRecoveryPlanInput) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPatch(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForUpdate sends the Update request. The method will close the
+// http.Response Body if it receives an error.
+func (c ReplicationRecoveryPlansClient) senderForUpdate(ctx context.Context, req *http.Request) (future UpdateOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_createrecoveryplaninput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_createrecoveryplaninput.go
@@ -1,0 +1,8 @@
+package replicationrecoveryplans
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CreateRecoveryPlanInput struct {
+	Properties CreateRecoveryPlanInputProperties `json:"properties"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_createrecoveryplaninputproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_createrecoveryplaninputproperties.go
@@ -1,0 +1,55 @@
+package replicationrecoveryplans
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CreateRecoveryPlanInputProperties struct {
+	FailoverDeploymentModel *FailoverDeploymentModel             `json:"failoverDeploymentModel,omitempty"`
+	Groups                  []RecoveryPlanGroup                  `json:"groups"`
+	PrimaryFabricId         string                               `json:"primaryFabricId"`
+	ProviderSpecificInput   *[]RecoveryPlanProviderSpecificInput `json:"providerSpecificInput,omitempty"`
+	RecoveryFabricId        string                               `json:"recoveryFabricId"`
+}
+
+var _ json.Unmarshaler = &CreateRecoveryPlanInputProperties{}
+
+func (s *CreateRecoveryPlanInputProperties) UnmarshalJSON(bytes []byte) error {
+	type alias CreateRecoveryPlanInputProperties
+	var decoded alias
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling into CreateRecoveryPlanInputProperties: %+v", err)
+	}
+
+	s.FailoverDeploymentModel = decoded.FailoverDeploymentModel
+	s.Groups = decoded.Groups
+	s.PrimaryFabricId = decoded.PrimaryFabricId
+	s.RecoveryFabricId = decoded.RecoveryFabricId
+
+	var temp map[string]json.RawMessage
+	if err := json.Unmarshal(bytes, &temp); err != nil {
+		return fmt.Errorf("unmarshaling CreateRecoveryPlanInputProperties into map[string]json.RawMessage: %+v", err)
+	}
+
+	if v, ok := temp["providerSpecificInput"]; ok {
+		var listTemp []json.RawMessage
+		if err := json.Unmarshal(v, &listTemp); err != nil {
+			return fmt.Errorf("unmarshaling ProviderSpecificInput into list []json.RawMessage: %+v", err)
+		}
+
+		output := make([]RecoveryPlanProviderSpecificInput, 0)
+		for i, val := range listTemp {
+			impl, err := unmarshalRecoveryPlanProviderSpecificInputImplementation(val)
+			if err != nil {
+				return fmt.Errorf("unmarshaling index %d field 'ProviderSpecificInput' for 'CreateRecoveryPlanInputProperties': %+v", i, err)
+			}
+			output = append(output, impl)
+		}
+		s.ProviderSpecificInput = &output
+	}
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_currentscenariodetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_currentscenariodetails.go
@@ -1,0 +1,28 @@
+package replicationrecoveryplans
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CurrentScenarioDetails struct {
+	JobId        *string `json:"jobId,omitempty"`
+	ScenarioName *string `json:"scenarioName,omitempty"`
+	StartTime    *string `json:"startTime,omitempty"`
+}
+
+func (o *CurrentScenarioDetails) GetStartTimeAsTime() (*time.Time, error) {
+	if o.StartTime == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.StartTime, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *CurrentScenarioDetails) SetStartTimeAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.StartTime = &formatted
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_recoveryplan.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_recoveryplan.go
@@ -1,0 +1,12 @@
+package replicationrecoveryplans
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RecoveryPlan struct {
+	Id         *string                 `json:"id,omitempty"`
+	Location   *string                 `json:"location,omitempty"`
+	Name       *string                 `json:"name,omitempty"`
+	Properties *RecoveryPlanProperties `json:"properties,omitempty"`
+	Type       *string                 `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_recoveryplana2adetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_recoveryplana2adetails.go
@@ -1,0 +1,46 @@
+package replicationrecoveryplans
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/edgezones"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ RecoveryPlanProviderSpecificDetails = RecoveryPlanA2ADetails{}
+
+type RecoveryPlanA2ADetails struct {
+	PrimaryExtendedLocation  *edgezones.Model `json:"primaryExtendedLocation,omitempty"`
+	PrimaryZone              *string          `json:"primaryZone,omitempty"`
+	RecoveryExtendedLocation *edgezones.Model `json:"recoveryExtendedLocation,omitempty"`
+	RecoveryZone             *string          `json:"recoveryZone,omitempty"`
+
+	// Fields inherited from RecoveryPlanProviderSpecificDetails
+}
+
+var _ json.Marshaler = RecoveryPlanA2ADetails{}
+
+func (s RecoveryPlanA2ADetails) MarshalJSON() ([]byte, error) {
+	type wrapper RecoveryPlanA2ADetails
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling RecoveryPlanA2ADetails: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling RecoveryPlanA2ADetails: %+v", err)
+	}
+	decoded["instanceType"] = "A2A"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling RecoveryPlanA2ADetails: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_recoveryplana2afailoverinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_recoveryplana2afailoverinput.go
@@ -1,0 +1,43 @@
+package replicationrecoveryplans
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ RecoveryPlanProviderSpecificFailoverInput = RecoveryPlanA2AFailoverInput{}
+
+type RecoveryPlanA2AFailoverInput struct {
+	CloudServiceCreationOption *string                 `json:"cloudServiceCreationOption,omitempty"`
+	MultiVmSyncPointOption     *MultiVmSyncPointOption `json:"multiVmSyncPointOption,omitempty"`
+	RecoveryPointType          A2ARpRecoveryPointType  `json:"recoveryPointType"`
+
+	// Fields inherited from RecoveryPlanProviderSpecificFailoverInput
+}
+
+var _ json.Marshaler = RecoveryPlanA2AFailoverInput{}
+
+func (s RecoveryPlanA2AFailoverInput) MarshalJSON() ([]byte, error) {
+	type wrapper RecoveryPlanA2AFailoverInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling RecoveryPlanA2AFailoverInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling RecoveryPlanA2AFailoverInput: %+v", err)
+	}
+	decoded["instanceType"] = "A2A"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling RecoveryPlanA2AFailoverInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_recoveryplana2ainput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_recoveryplana2ainput.go
@@ -1,0 +1,46 @@
+package replicationrecoveryplans
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/edgezones"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ RecoveryPlanProviderSpecificInput = RecoveryPlanA2AInput{}
+
+type RecoveryPlanA2AInput struct {
+	PrimaryExtendedLocation  *edgezones.Model `json:"primaryExtendedLocation,omitempty"`
+	PrimaryZone              *string          `json:"primaryZone,omitempty"`
+	RecoveryExtendedLocation *edgezones.Model `json:"recoveryExtendedLocation,omitempty"`
+	RecoveryZone             *string          `json:"recoveryZone,omitempty"`
+
+	// Fields inherited from RecoveryPlanProviderSpecificInput
+}
+
+var _ json.Marshaler = RecoveryPlanA2AInput{}
+
+func (s RecoveryPlanA2AInput) MarshalJSON() ([]byte, error) {
+	type wrapper RecoveryPlanA2AInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling RecoveryPlanA2AInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling RecoveryPlanA2AInput: %+v", err)
+	}
+	decoded["instanceType"] = "A2A"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling RecoveryPlanA2AInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_recoveryplanaction.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_recoveryplanaction.go
@@ -1,0 +1,44 @@
+package replicationrecoveryplans
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RecoveryPlanAction struct {
+	ActionName         string                              `json:"actionName"`
+	CustomDetails      RecoveryPlanActionDetails           `json:"customDetails"`
+	FailoverDirections []PossibleOperationsDirections      `json:"failoverDirections"`
+	FailoverTypes      []ReplicationProtectedItemOperation `json:"failoverTypes"`
+}
+
+var _ json.Unmarshaler = &RecoveryPlanAction{}
+
+func (s *RecoveryPlanAction) UnmarshalJSON(bytes []byte) error {
+	type alias RecoveryPlanAction
+	var decoded alias
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling into RecoveryPlanAction: %+v", err)
+	}
+
+	s.ActionName = decoded.ActionName
+	s.FailoverDirections = decoded.FailoverDirections
+	s.FailoverTypes = decoded.FailoverTypes
+
+	var temp map[string]json.RawMessage
+	if err := json.Unmarshal(bytes, &temp); err != nil {
+		return fmt.Errorf("unmarshaling RecoveryPlanAction into map[string]json.RawMessage: %+v", err)
+	}
+
+	if v, ok := temp["customDetails"]; ok {
+		impl, err := unmarshalRecoveryPlanActionDetailsImplementation(v)
+		if err != nil {
+			return fmt.Errorf("unmarshaling field 'CustomDetails' for 'RecoveryPlanAction': %+v", err)
+		}
+		s.CustomDetails = impl
+	}
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_recoveryplanactiondetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_recoveryplanactiondetails.go
@@ -1,0 +1,64 @@
+package replicationrecoveryplans
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RecoveryPlanActionDetails interface {
+}
+
+func unmarshalRecoveryPlanActionDetailsImplementation(input []byte) (RecoveryPlanActionDetails, error) {
+	if input == nil {
+		return nil, nil
+	}
+
+	var temp map[string]interface{}
+	if err := json.Unmarshal(input, &temp); err != nil {
+		return nil, fmt.Errorf("unmarshaling RecoveryPlanActionDetails into map[string]interface: %+v", err)
+	}
+
+	value, ok := temp["instanceType"].(string)
+	if !ok {
+		return nil, nil
+	}
+
+	if strings.EqualFold(value, "AutomationRunbookActionDetails") {
+		var out RecoveryPlanAutomationRunbookActionDetails
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into RecoveryPlanAutomationRunbookActionDetails: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "ManualActionDetails") {
+		var out RecoveryPlanManualActionDetails
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into RecoveryPlanManualActionDetails: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "ScriptActionDetails") {
+		var out RecoveryPlanScriptActionDetails
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into RecoveryPlanScriptActionDetails: %+v", err)
+		}
+		return out, nil
+	}
+
+	type RawRecoveryPlanActionDetailsImpl struct {
+		Type   string                 `json:"-"`
+		Values map[string]interface{} `json:"-"`
+	}
+	out := RawRecoveryPlanActionDetailsImpl{
+		Type:   value,
+		Values: temp,
+	}
+	return out, nil
+
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_recoveryplanautomationrunbookactiondetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_recoveryplanautomationrunbookactiondetails.go
@@ -1,0 +1,43 @@
+package replicationrecoveryplans
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ RecoveryPlanActionDetails = RecoveryPlanAutomationRunbookActionDetails{}
+
+type RecoveryPlanAutomationRunbookActionDetails struct {
+	FabricLocation RecoveryPlanActionLocation `json:"fabricLocation"`
+	RunbookId      *string                    `json:"runbookId,omitempty"`
+	Timeout        *string                    `json:"timeout,omitempty"`
+
+	// Fields inherited from RecoveryPlanActionDetails
+}
+
+var _ json.Marshaler = RecoveryPlanAutomationRunbookActionDetails{}
+
+func (s RecoveryPlanAutomationRunbookActionDetails) MarshalJSON() ([]byte, error) {
+	type wrapper RecoveryPlanAutomationRunbookActionDetails
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling RecoveryPlanAutomationRunbookActionDetails: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling RecoveryPlanAutomationRunbookActionDetails: %+v", err)
+	}
+	decoded["instanceType"] = "AutomationRunbookActionDetails"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling RecoveryPlanAutomationRunbookActionDetails: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_recoveryplangroup.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_recoveryplangroup.go
@@ -1,0 +1,11 @@
+package replicationrecoveryplans
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RecoveryPlanGroup struct {
+	EndGroupActions           *[]RecoveryPlanAction        `json:"endGroupActions,omitempty"`
+	GroupType                 RecoveryPlanGroupType        `json:"groupType"`
+	ReplicationProtectedItems *[]RecoveryPlanProtectedItem `json:"replicationProtectedItems,omitempty"`
+	StartGroupActions         *[]RecoveryPlanAction        `json:"startGroupActions,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_recoveryplanhypervreplicaazurefailbackinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_recoveryplanhypervreplicaazurefailbackinput.go
@@ -1,0 +1,42 @@
+package replicationrecoveryplans
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ RecoveryPlanProviderSpecificFailoverInput = RecoveryPlanHyperVReplicaAzureFailbackInput{}
+
+type RecoveryPlanHyperVReplicaAzureFailbackInput struct {
+	DataSyncOption           DataSyncStatus                  `json:"dataSyncOption"`
+	RecoveryVmCreationOption AlternateLocationRecoveryOption `json:"recoveryVmCreationOption"`
+
+	// Fields inherited from RecoveryPlanProviderSpecificFailoverInput
+}
+
+var _ json.Marshaler = RecoveryPlanHyperVReplicaAzureFailbackInput{}
+
+func (s RecoveryPlanHyperVReplicaAzureFailbackInput) MarshalJSON() ([]byte, error) {
+	type wrapper RecoveryPlanHyperVReplicaAzureFailbackInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling RecoveryPlanHyperVReplicaAzureFailbackInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling RecoveryPlanHyperVReplicaAzureFailbackInput: %+v", err)
+	}
+	decoded["instanceType"] = "HyperVReplicaAzureFailback"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling RecoveryPlanHyperVReplicaAzureFailbackInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_recoveryplanhypervreplicaazurefailoverinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_recoveryplanhypervreplicaazurefailoverinput.go
@@ -1,0 +1,43 @@
+package replicationrecoveryplans
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ RecoveryPlanProviderSpecificFailoverInput = RecoveryPlanHyperVReplicaAzureFailoverInput{}
+
+type RecoveryPlanHyperVReplicaAzureFailoverInput struct {
+	PrimaryKekCertificatePfx   *string                                `json:"primaryKekCertificatePfx,omitempty"`
+	RecoveryPointType          *HyperVReplicaAzureRpRecoveryPointType `json:"recoveryPointType,omitempty"`
+	SecondaryKekCertificatePfx *string                                `json:"secondaryKekCertificatePfx,omitempty"`
+
+	// Fields inherited from RecoveryPlanProviderSpecificFailoverInput
+}
+
+var _ json.Marshaler = RecoveryPlanHyperVReplicaAzureFailoverInput{}
+
+func (s RecoveryPlanHyperVReplicaAzureFailoverInput) MarshalJSON() ([]byte, error) {
+	type wrapper RecoveryPlanHyperVReplicaAzureFailoverInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling RecoveryPlanHyperVReplicaAzureFailoverInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling RecoveryPlanHyperVReplicaAzureFailoverInput: %+v", err)
+	}
+	decoded["instanceType"] = "HyperVReplicaAzure"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling RecoveryPlanHyperVReplicaAzureFailoverInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_recoveryplaninmageazurev2failoverinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_recoveryplaninmageazurev2failoverinput.go
@@ -1,0 +1,42 @@
+package replicationrecoveryplans
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ RecoveryPlanProviderSpecificFailoverInput = RecoveryPlanInMageAzureV2FailoverInput{}
+
+type RecoveryPlanInMageAzureV2FailoverInput struct {
+	RecoveryPointType   InMageV2RpRecoveryPointType `json:"recoveryPointType"`
+	UseMultiVmSyncPoint *string                     `json:"useMultiVmSyncPoint,omitempty"`
+
+	// Fields inherited from RecoveryPlanProviderSpecificFailoverInput
+}
+
+var _ json.Marshaler = RecoveryPlanInMageAzureV2FailoverInput{}
+
+func (s RecoveryPlanInMageAzureV2FailoverInput) MarshalJSON() ([]byte, error) {
+	type wrapper RecoveryPlanInMageAzureV2FailoverInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling RecoveryPlanInMageAzureV2FailoverInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling RecoveryPlanInMageAzureV2FailoverInput: %+v", err)
+	}
+	decoded["instanceType"] = "InMageAzureV2"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling RecoveryPlanInMageAzureV2FailoverInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_recoveryplaninmagefailoverinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_recoveryplaninmagefailoverinput.go
@@ -1,0 +1,41 @@
+package replicationrecoveryplans
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ RecoveryPlanProviderSpecificFailoverInput = RecoveryPlanInMageFailoverInput{}
+
+type RecoveryPlanInMageFailoverInput struct {
+	RecoveryPointType RpInMageRecoveryPointType `json:"recoveryPointType"`
+
+	// Fields inherited from RecoveryPlanProviderSpecificFailoverInput
+}
+
+var _ json.Marshaler = RecoveryPlanInMageFailoverInput{}
+
+func (s RecoveryPlanInMageFailoverInput) MarshalJSON() ([]byte, error) {
+	type wrapper RecoveryPlanInMageFailoverInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling RecoveryPlanInMageFailoverInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling RecoveryPlanInMageFailoverInput: %+v", err)
+	}
+	decoded["instanceType"] = "InMage"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling RecoveryPlanInMageFailoverInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_recoveryplaninmagercmfailbackfailoverinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_recoveryplaninmagercmfailbackfailoverinput.go
@@ -1,0 +1,42 @@
+package replicationrecoveryplans
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ RecoveryPlanProviderSpecificFailoverInput = RecoveryPlanInMageRcmFailbackFailoverInput{}
+
+type RecoveryPlanInMageRcmFailbackFailoverInput struct {
+	RecoveryPointType   InMageRcmFailbackRecoveryPointType `json:"recoveryPointType"`
+	UseMultiVmSyncPoint *string                            `json:"useMultiVmSyncPoint,omitempty"`
+
+	// Fields inherited from RecoveryPlanProviderSpecificFailoverInput
+}
+
+var _ json.Marshaler = RecoveryPlanInMageRcmFailbackFailoverInput{}
+
+func (s RecoveryPlanInMageRcmFailbackFailoverInput) MarshalJSON() ([]byte, error) {
+	type wrapper RecoveryPlanInMageRcmFailbackFailoverInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling RecoveryPlanInMageRcmFailbackFailoverInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling RecoveryPlanInMageRcmFailbackFailoverInput: %+v", err)
+	}
+	decoded["instanceType"] = "InMageRcmFailback"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling RecoveryPlanInMageRcmFailbackFailoverInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_recoveryplaninmagercmfailoverinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_recoveryplaninmagercmfailoverinput.go
@@ -1,0 +1,42 @@
+package replicationrecoveryplans
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ RecoveryPlanProviderSpecificFailoverInput = RecoveryPlanInMageRcmFailoverInput{}
+
+type RecoveryPlanInMageRcmFailoverInput struct {
+	RecoveryPointType   RecoveryPlanPointType `json:"recoveryPointType"`
+	UseMultiVmSyncPoint *string               `json:"useMultiVmSyncPoint,omitempty"`
+
+	// Fields inherited from RecoveryPlanProviderSpecificFailoverInput
+}
+
+var _ json.Marshaler = RecoveryPlanInMageRcmFailoverInput{}
+
+func (s RecoveryPlanInMageRcmFailoverInput) MarshalJSON() ([]byte, error) {
+	type wrapper RecoveryPlanInMageRcmFailoverInput
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling RecoveryPlanInMageRcmFailoverInput: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling RecoveryPlanInMageRcmFailoverInput: %+v", err)
+	}
+	decoded["instanceType"] = "InMageRcm"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling RecoveryPlanInMageRcmFailoverInput: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_recoveryplanmanualactiondetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_recoveryplanmanualactiondetails.go
@@ -1,0 +1,41 @@
+package replicationrecoveryplans
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ RecoveryPlanActionDetails = RecoveryPlanManualActionDetails{}
+
+type RecoveryPlanManualActionDetails struct {
+	Description *string `json:"description,omitempty"`
+
+	// Fields inherited from RecoveryPlanActionDetails
+}
+
+var _ json.Marshaler = RecoveryPlanManualActionDetails{}
+
+func (s RecoveryPlanManualActionDetails) MarshalJSON() ([]byte, error) {
+	type wrapper RecoveryPlanManualActionDetails
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling RecoveryPlanManualActionDetails: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling RecoveryPlanManualActionDetails: %+v", err)
+	}
+	decoded["instanceType"] = "ManualActionDetails"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling RecoveryPlanManualActionDetails: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_recoveryplanplannedfailoverinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_recoveryplanplannedfailoverinput.go
@@ -1,0 +1,8 @@
+package replicationrecoveryplans
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RecoveryPlanPlannedFailoverInput struct {
+	Properties RecoveryPlanPlannedFailoverInputProperties `json:"properties"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_recoveryplanplannedfailoverinputproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_recoveryplanplannedfailoverinputproperties.go
@@ -1,0 +1,49 @@
+package replicationrecoveryplans
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RecoveryPlanPlannedFailoverInputProperties struct {
+	FailoverDirection       PossibleOperationsDirections                 `json:"failoverDirection"`
+	ProviderSpecificDetails *[]RecoveryPlanProviderSpecificFailoverInput `json:"providerSpecificDetails,omitempty"`
+}
+
+var _ json.Unmarshaler = &RecoveryPlanPlannedFailoverInputProperties{}
+
+func (s *RecoveryPlanPlannedFailoverInputProperties) UnmarshalJSON(bytes []byte) error {
+	type alias RecoveryPlanPlannedFailoverInputProperties
+	var decoded alias
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling into RecoveryPlanPlannedFailoverInputProperties: %+v", err)
+	}
+
+	s.FailoverDirection = decoded.FailoverDirection
+
+	var temp map[string]json.RawMessage
+	if err := json.Unmarshal(bytes, &temp); err != nil {
+		return fmt.Errorf("unmarshaling RecoveryPlanPlannedFailoverInputProperties into map[string]json.RawMessage: %+v", err)
+	}
+
+	if v, ok := temp["providerSpecificDetails"]; ok {
+		var listTemp []json.RawMessage
+		if err := json.Unmarshal(v, &listTemp); err != nil {
+			return fmt.Errorf("unmarshaling ProviderSpecificDetails into list []json.RawMessage: %+v", err)
+		}
+
+		output := make([]RecoveryPlanProviderSpecificFailoverInput, 0)
+		for i, val := range listTemp {
+			impl, err := unmarshalRecoveryPlanProviderSpecificFailoverInputImplementation(val)
+			if err != nil {
+				return fmt.Errorf("unmarshaling index %d field 'ProviderSpecificDetails' for 'RecoveryPlanPlannedFailoverInputProperties': %+v", i, err)
+			}
+			output = append(output, impl)
+		}
+		s.ProviderSpecificDetails = &output
+	}
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_recoveryplanproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_recoveryplanproperties.go
@@ -1,0 +1,116 @@
+package replicationrecoveryplans
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RecoveryPlanProperties struct {
+	AllowedOperations                *[]string                              `json:"allowedOperations,omitempty"`
+	CurrentScenario                  *CurrentScenarioDetails                `json:"currentScenario,omitempty"`
+	CurrentScenarioStatus            *string                                `json:"currentScenarioStatus,omitempty"`
+	CurrentScenarioStatusDescription *string                                `json:"currentScenarioStatusDescription,omitempty"`
+	FailoverDeploymentModel          *string                                `json:"failoverDeploymentModel,omitempty"`
+	FriendlyName                     *string                                `json:"friendlyName,omitempty"`
+	Groups                           *[]RecoveryPlanGroup                   `json:"groups,omitempty"`
+	LastPlannedFailoverTime          *string                                `json:"lastPlannedFailoverTime,omitempty"`
+	LastTestFailoverTime             *string                                `json:"lastTestFailoverTime,omitempty"`
+	LastUnplannedFailoverTime        *string                                `json:"lastUnplannedFailoverTime,omitempty"`
+	PrimaryFabricFriendlyName        *string                                `json:"primaryFabricFriendlyName,omitempty"`
+	PrimaryFabricId                  *string                                `json:"primaryFabricId,omitempty"`
+	ProviderSpecificDetails          *[]RecoveryPlanProviderSpecificDetails `json:"providerSpecificDetails,omitempty"`
+	RecoveryFabricFriendlyName       *string                                `json:"recoveryFabricFriendlyName,omitempty"`
+	RecoveryFabricId                 *string                                `json:"recoveryFabricId,omitempty"`
+	ReplicationProviders             *[]string                              `json:"replicationProviders,omitempty"`
+}
+
+func (o *RecoveryPlanProperties) GetLastPlannedFailoverTimeAsTime() (*time.Time, error) {
+	if o.LastPlannedFailoverTime == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.LastPlannedFailoverTime, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *RecoveryPlanProperties) SetLastPlannedFailoverTimeAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.LastPlannedFailoverTime = &formatted
+}
+
+func (o *RecoveryPlanProperties) GetLastTestFailoverTimeAsTime() (*time.Time, error) {
+	if o.LastTestFailoverTime == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.LastTestFailoverTime, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *RecoveryPlanProperties) SetLastTestFailoverTimeAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.LastTestFailoverTime = &formatted
+}
+
+func (o *RecoveryPlanProperties) GetLastUnplannedFailoverTimeAsTime() (*time.Time, error) {
+	if o.LastUnplannedFailoverTime == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.LastUnplannedFailoverTime, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *RecoveryPlanProperties) SetLastUnplannedFailoverTimeAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.LastUnplannedFailoverTime = &formatted
+}
+
+var _ json.Unmarshaler = &RecoveryPlanProperties{}
+
+func (s *RecoveryPlanProperties) UnmarshalJSON(bytes []byte) error {
+	type alias RecoveryPlanProperties
+	var decoded alias
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling into RecoveryPlanProperties: %+v", err)
+	}
+
+	s.AllowedOperations = decoded.AllowedOperations
+	s.CurrentScenario = decoded.CurrentScenario
+	s.CurrentScenarioStatus = decoded.CurrentScenarioStatus
+	s.CurrentScenarioStatusDescription = decoded.CurrentScenarioStatusDescription
+	s.FailoverDeploymentModel = decoded.FailoverDeploymentModel
+	s.FriendlyName = decoded.FriendlyName
+	s.Groups = decoded.Groups
+	s.LastPlannedFailoverTime = decoded.LastPlannedFailoverTime
+	s.LastTestFailoverTime = decoded.LastTestFailoverTime
+	s.LastUnplannedFailoverTime = decoded.LastUnplannedFailoverTime
+	s.PrimaryFabricFriendlyName = decoded.PrimaryFabricFriendlyName
+	s.PrimaryFabricId = decoded.PrimaryFabricId
+	s.RecoveryFabricFriendlyName = decoded.RecoveryFabricFriendlyName
+	s.RecoveryFabricId = decoded.RecoveryFabricId
+	s.ReplicationProviders = decoded.ReplicationProviders
+
+	var temp map[string]json.RawMessage
+	if err := json.Unmarshal(bytes, &temp); err != nil {
+		return fmt.Errorf("unmarshaling RecoveryPlanProperties into map[string]json.RawMessage: %+v", err)
+	}
+
+	if v, ok := temp["providerSpecificDetails"]; ok {
+		var listTemp []json.RawMessage
+		if err := json.Unmarshal(v, &listTemp); err != nil {
+			return fmt.Errorf("unmarshaling ProviderSpecificDetails into list []json.RawMessage: %+v", err)
+		}
+
+		output := make([]RecoveryPlanProviderSpecificDetails, 0)
+		for i, val := range listTemp {
+			impl, err := unmarshalRecoveryPlanProviderSpecificDetailsImplementation(val)
+			if err != nil {
+				return fmt.Errorf("unmarshaling index %d field 'ProviderSpecificDetails' for 'RecoveryPlanProperties': %+v", i, err)
+			}
+			output = append(output, impl)
+		}
+		s.ProviderSpecificDetails = &output
+	}
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_recoveryplanprotecteditem.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_recoveryplanprotecteditem.go
@@ -1,0 +1,9 @@
+package replicationrecoveryplans
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RecoveryPlanProtectedItem struct {
+	Id               *string `json:"id,omitempty"`
+	VirtualMachineId *string `json:"virtualMachineId,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_recoveryplanproviderspecificdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_recoveryplanproviderspecificdetails.go
@@ -1,0 +1,48 @@
+package replicationrecoveryplans
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RecoveryPlanProviderSpecificDetails interface {
+}
+
+func unmarshalRecoveryPlanProviderSpecificDetailsImplementation(input []byte) (RecoveryPlanProviderSpecificDetails, error) {
+	if input == nil {
+		return nil, nil
+	}
+
+	var temp map[string]interface{}
+	if err := json.Unmarshal(input, &temp); err != nil {
+		return nil, fmt.Errorf("unmarshaling RecoveryPlanProviderSpecificDetails into map[string]interface: %+v", err)
+	}
+
+	value, ok := temp["instanceType"].(string)
+	if !ok {
+		return nil, nil
+	}
+
+	if strings.EqualFold(value, "A2A") {
+		var out RecoveryPlanA2ADetails
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into RecoveryPlanA2ADetails: %+v", err)
+		}
+		return out, nil
+	}
+
+	type RawRecoveryPlanProviderSpecificDetailsImpl struct {
+		Type   string                 `json:"-"`
+		Values map[string]interface{} `json:"-"`
+	}
+	out := RawRecoveryPlanProviderSpecificDetailsImpl{
+		Type:   value,
+		Values: temp,
+	}
+	return out, nil
+
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_recoveryplanproviderspecificfailoverinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_recoveryplanproviderspecificfailoverinput.go
@@ -1,0 +1,96 @@
+package replicationrecoveryplans
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RecoveryPlanProviderSpecificFailoverInput interface {
+}
+
+func unmarshalRecoveryPlanProviderSpecificFailoverInputImplementation(input []byte) (RecoveryPlanProviderSpecificFailoverInput, error) {
+	if input == nil {
+		return nil, nil
+	}
+
+	var temp map[string]interface{}
+	if err := json.Unmarshal(input, &temp); err != nil {
+		return nil, fmt.Errorf("unmarshaling RecoveryPlanProviderSpecificFailoverInput into map[string]interface: %+v", err)
+	}
+
+	value, ok := temp["instanceType"].(string)
+	if !ok {
+		return nil, nil
+	}
+
+	if strings.EqualFold(value, "A2A") {
+		var out RecoveryPlanA2AFailoverInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into RecoveryPlanA2AFailoverInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "HyperVReplicaAzureFailback") {
+		var out RecoveryPlanHyperVReplicaAzureFailbackInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into RecoveryPlanHyperVReplicaAzureFailbackInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "HyperVReplicaAzure") {
+		var out RecoveryPlanHyperVReplicaAzureFailoverInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into RecoveryPlanHyperVReplicaAzureFailoverInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "InMageAzureV2") {
+		var out RecoveryPlanInMageAzureV2FailoverInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into RecoveryPlanInMageAzureV2FailoverInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "InMage") {
+		var out RecoveryPlanInMageFailoverInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into RecoveryPlanInMageFailoverInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "InMageRcmFailback") {
+		var out RecoveryPlanInMageRcmFailbackFailoverInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into RecoveryPlanInMageRcmFailbackFailoverInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "InMageRcm") {
+		var out RecoveryPlanInMageRcmFailoverInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into RecoveryPlanInMageRcmFailoverInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	type RawRecoveryPlanProviderSpecificFailoverInputImpl struct {
+		Type   string                 `json:"-"`
+		Values map[string]interface{} `json:"-"`
+	}
+	out := RawRecoveryPlanProviderSpecificFailoverInputImpl{
+		Type:   value,
+		Values: temp,
+	}
+	return out, nil
+
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_recoveryplanproviderspecificinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_recoveryplanproviderspecificinput.go
@@ -1,0 +1,48 @@
+package replicationrecoveryplans
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RecoveryPlanProviderSpecificInput interface {
+}
+
+func unmarshalRecoveryPlanProviderSpecificInputImplementation(input []byte) (RecoveryPlanProviderSpecificInput, error) {
+	if input == nil {
+		return nil, nil
+	}
+
+	var temp map[string]interface{}
+	if err := json.Unmarshal(input, &temp); err != nil {
+		return nil, fmt.Errorf("unmarshaling RecoveryPlanProviderSpecificInput into map[string]interface: %+v", err)
+	}
+
+	value, ok := temp["instanceType"].(string)
+	if !ok {
+		return nil, nil
+	}
+
+	if strings.EqualFold(value, "A2A") {
+		var out RecoveryPlanA2AInput
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into RecoveryPlanA2AInput: %+v", err)
+		}
+		return out, nil
+	}
+
+	type RawRecoveryPlanProviderSpecificInputImpl struct {
+		Type   string                 `json:"-"`
+		Values map[string]interface{} `json:"-"`
+	}
+	out := RawRecoveryPlanProviderSpecificInputImpl{
+		Type:   value,
+		Values: temp,
+	}
+	return out, nil
+
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_recoveryplanscriptactiondetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_recoveryplanscriptactiondetails.go
@@ -1,0 +1,43 @@
+package replicationrecoveryplans
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ RecoveryPlanActionDetails = RecoveryPlanScriptActionDetails{}
+
+type RecoveryPlanScriptActionDetails struct {
+	FabricLocation RecoveryPlanActionLocation `json:"fabricLocation"`
+	Path           string                     `json:"path"`
+	Timeout        *string                    `json:"timeout,omitempty"`
+
+	// Fields inherited from RecoveryPlanActionDetails
+}
+
+var _ json.Marshaler = RecoveryPlanScriptActionDetails{}
+
+func (s RecoveryPlanScriptActionDetails) MarshalJSON() ([]byte, error) {
+	type wrapper RecoveryPlanScriptActionDetails
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling RecoveryPlanScriptActionDetails: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling RecoveryPlanScriptActionDetails: %+v", err)
+	}
+	decoded["instanceType"] = "ScriptActionDetails"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling RecoveryPlanScriptActionDetails: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_recoveryplantestfailovercleanupinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_recoveryplantestfailovercleanupinput.go
@@ -1,0 +1,8 @@
+package replicationrecoveryplans
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RecoveryPlanTestFailoverCleanupInput struct {
+	Properties RecoveryPlanTestFailoverCleanupInputProperties `json:"properties"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_recoveryplantestfailovercleanupinputproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_recoveryplantestfailovercleanupinputproperties.go
@@ -1,0 +1,8 @@
+package replicationrecoveryplans
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RecoveryPlanTestFailoverCleanupInputProperties struct {
+	Comments *string `json:"comments,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_recoveryplantestfailoverinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_recoveryplantestfailoverinput.go
@@ -1,0 +1,8 @@
+package replicationrecoveryplans
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RecoveryPlanTestFailoverInput struct {
+	Properties RecoveryPlanTestFailoverInputProperties `json:"properties"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_recoveryplantestfailoverinputproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_recoveryplantestfailoverinputproperties.go
@@ -1,0 +1,53 @@
+package replicationrecoveryplans
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RecoveryPlanTestFailoverInputProperties struct {
+	FailoverDirection       PossibleOperationsDirections                 `json:"failoverDirection"`
+	NetworkId               *string                                      `json:"networkId,omitempty"`
+	NetworkType             string                                       `json:"networkType"`
+	ProviderSpecificDetails *[]RecoveryPlanProviderSpecificFailoverInput `json:"providerSpecificDetails,omitempty"`
+}
+
+var _ json.Unmarshaler = &RecoveryPlanTestFailoverInputProperties{}
+
+func (s *RecoveryPlanTestFailoverInputProperties) UnmarshalJSON(bytes []byte) error {
+	type alias RecoveryPlanTestFailoverInputProperties
+	var decoded alias
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling into RecoveryPlanTestFailoverInputProperties: %+v", err)
+	}
+
+	s.FailoverDirection = decoded.FailoverDirection
+	s.NetworkId = decoded.NetworkId
+	s.NetworkType = decoded.NetworkType
+
+	var temp map[string]json.RawMessage
+	if err := json.Unmarshal(bytes, &temp); err != nil {
+		return fmt.Errorf("unmarshaling RecoveryPlanTestFailoverInputProperties into map[string]json.RawMessage: %+v", err)
+	}
+
+	if v, ok := temp["providerSpecificDetails"]; ok {
+		var listTemp []json.RawMessage
+		if err := json.Unmarshal(v, &listTemp); err != nil {
+			return fmt.Errorf("unmarshaling ProviderSpecificDetails into list []json.RawMessage: %+v", err)
+		}
+
+		output := make([]RecoveryPlanProviderSpecificFailoverInput, 0)
+		for i, val := range listTemp {
+			impl, err := unmarshalRecoveryPlanProviderSpecificFailoverInputImplementation(val)
+			if err != nil {
+				return fmt.Errorf("unmarshaling index %d field 'ProviderSpecificDetails' for 'RecoveryPlanTestFailoverInputProperties': %+v", i, err)
+			}
+			output = append(output, impl)
+		}
+		s.ProviderSpecificDetails = &output
+	}
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_recoveryplanunplannedfailoverinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_recoveryplanunplannedfailoverinput.go
@@ -1,0 +1,8 @@
+package replicationrecoveryplans
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RecoveryPlanUnplannedFailoverInput struct {
+	Properties RecoveryPlanUnplannedFailoverInputProperties `json:"properties"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_recoveryplanunplannedfailoverinputproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_recoveryplanunplannedfailoverinputproperties.go
@@ -1,0 +1,51 @@
+package replicationrecoveryplans
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RecoveryPlanUnplannedFailoverInputProperties struct {
+	FailoverDirection       PossibleOperationsDirections                 `json:"failoverDirection"`
+	ProviderSpecificDetails *[]RecoveryPlanProviderSpecificFailoverInput `json:"providerSpecificDetails,omitempty"`
+	SourceSiteOperations    SourceSiteOperations                         `json:"sourceSiteOperations"`
+}
+
+var _ json.Unmarshaler = &RecoveryPlanUnplannedFailoverInputProperties{}
+
+func (s *RecoveryPlanUnplannedFailoverInputProperties) UnmarshalJSON(bytes []byte) error {
+	type alias RecoveryPlanUnplannedFailoverInputProperties
+	var decoded alias
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling into RecoveryPlanUnplannedFailoverInputProperties: %+v", err)
+	}
+
+	s.FailoverDirection = decoded.FailoverDirection
+	s.SourceSiteOperations = decoded.SourceSiteOperations
+
+	var temp map[string]json.RawMessage
+	if err := json.Unmarshal(bytes, &temp); err != nil {
+		return fmt.Errorf("unmarshaling RecoveryPlanUnplannedFailoverInputProperties into map[string]json.RawMessage: %+v", err)
+	}
+
+	if v, ok := temp["providerSpecificDetails"]; ok {
+		var listTemp []json.RawMessage
+		if err := json.Unmarshal(v, &listTemp); err != nil {
+			return fmt.Errorf("unmarshaling ProviderSpecificDetails into list []json.RawMessage: %+v", err)
+		}
+
+		output := make([]RecoveryPlanProviderSpecificFailoverInput, 0)
+		for i, val := range listTemp {
+			impl, err := unmarshalRecoveryPlanProviderSpecificFailoverInputImplementation(val)
+			if err != nil {
+				return fmt.Errorf("unmarshaling index %d field 'ProviderSpecificDetails' for 'RecoveryPlanUnplannedFailoverInputProperties': %+v", i, err)
+			}
+			output = append(output, impl)
+		}
+		s.ProviderSpecificDetails = &output
+	}
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_updaterecoveryplaninput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_updaterecoveryplaninput.go
@@ -1,0 +1,8 @@
+package replicationrecoveryplans
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UpdateRecoveryPlanInput struct {
+	Properties *UpdateRecoveryPlanInputProperties `json:"properties,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_updaterecoveryplaninputproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_updaterecoveryplaninputproperties.go
@@ -1,0 +1,8 @@
+package replicationrecoveryplans
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UpdateRecoveryPlanInputProperties struct {
+	Groups *[]RecoveryPlanGroup `json:"groups,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/predicates.go
@@ -1,0 +1,29 @@
+package replicationrecoveryplans
+
+type RecoveryPlanOperationPredicate struct {
+	Id       *string
+	Location *string
+	Name     *string
+	Type     *string
+}
+
+func (p RecoveryPlanOperationPredicate) Matches(input RecoveryPlan) bool {
+
+	if p.Id != nil && (input.Id == nil && *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Location != nil && (input.Location == nil && *p.Location != *input.Location) {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil && *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil && *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/version.go
@@ -1,0 +1,12 @@
+package replicationrecoveryplans
+
+import "fmt"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2022-10-01"
+
+func userAgent() string {
+	return fmt.Sprintf("hashicorp/go-azure-sdk/replicationrecoveryplans/%s", defaultApiVersion)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -364,6 +364,13 @@ github.com/hashicorp/go-azure-sdk/resource-manager/privatedns/2018-09-01/private
 github.com/hashicorp/go-azure-sdk/resource-manager/privatedns/2018-09-01/recordsets
 github.com/hashicorp/go-azure-sdk/resource-manager/privatedns/2018-09-01/virtualnetworklinks
 github.com/hashicorp/go-azure-sdk/resource-manager/purview/2021-07-01/account
+github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics
+github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings
+github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies
+github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems
+github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings
+github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers
+github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans
 github.com/hashicorp/go-azure-sdk/resource-manager/redisenterprise/2022-01-01/databases
 github.com/hashicorp/go-azure-sdk/resource-manager/redisenterprise/2022-01-01/redisenterprise
 github.com/hashicorp/go-azure-sdk/resource-manager/relay/2017-04-01/hybridconnections

--- a/website/docs/r/site_recovery_replicated_vm.html.markdown
+++ b/website/docs/r/site_recovery_replicated_vm.html.markdown
@@ -246,7 +246,19 @@ The following arguments are supported:
 
 * `managed_disk` - (Optional) One or more `managed_disk` block.
 
+* `unmanaged_disk` - (Optional) One or more `unmanaged_disk` block.
+
+* `target_proximity_placement_group_id` (Optional) Id of Proximity Placement Group the new VM should belong to when a failover is done.
+
+* `target_boot_diag_storage_account_id` - (Optional) Id of the storage account which the new VM should used for boot diagnostic when a failover is done.
+
+* `target_capacity_reservation_group_id` - (Optional) Id of the Capacity reservation group where the new VM should belong to when a failover is done.
+
+* `target_virtual_machine_scale_set_id` - (Optional) Id of the Virtual Machine Scale Set which the new Vm should belong to when a failover is done.
+
 * `target_network_id` - (Optional) Network to use when a failover is done (recommended to set if any network_interface is configured for failover).
+
+* `multi_vm_group_name` - (Optional) Name of group in which all machines will replicate together and have shared crash consistent and app-consistent recovery points when failed over.
 
 * `network_interface` - (Optional) One or more `network_interface` block.
 
@@ -266,7 +278,19 @@ A `managed_disk` block supports the following:
 
 * `target_disk_encryption_set_id` - (Optional)  The Disk Encryption Set that the Managed Disk will be associated with.
 
+-> **NOTE:** Creating replicated vm with `target_disk_encryption_set_id` wil take more time (up to 5 hours), please extend the `timeout` for `create`. 
+
 * `target_disk_encryption` - (Optional) A `target_disk_encryption` block as defined below.
+
+---
+
+A `unmanaged_disk` block supports the following:
+
+* `disk_uri` - (Required) Id of disk that should be replicated.
+
+* `staging_storage_account_id` - (Required) Storage account that should be used for caching.
+
+* `target_storage_account_id` - (Required) Storage account disk should belong to when a failover is done.
 
 ---
 
@@ -314,7 +338,7 @@ In addition to the arguments above, the following attributes are exported:
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `create` - (Defaults to 120 minutes) Used when creating the Site Recovery Replicated VM.
+* `create` - (Defaults to 180 minutes) Used when creating the Site Recovery Replicated VM.
 * `update` - (Defaults to 80 minutes) Used when updating the Site Recovery Replicated VM.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Site Recovery Replicated VM.
 * `delete` - (Defaults to 80 minutes) Used when deleting the Site Recovery Replicated VM.


### PR DESCRIPTION
depends on #19571, once it merged the diff will show only the feature codes.