### PR TITLE
`azurerm_monitor_scheduled_query_rules_alert_v2` - Fix `criteria.operator` Enum

### DIFF
--- a/internal/services/monitor/monitor_scheduled_query_rules_alert_v2_resource.go
+++ b/internal/services/monitor/monitor_scheduled_query_rules_alert_v2_resource.go
@@ -114,7 +114,8 @@ func (r ScheduledQueryRulesAlertV2Resource) Arguments() map[string]*pluginsdk.Sc
 						Type:     pluginsdk.TypeString,
 						Required: true,
 						ValidateFunc: validation.StringInSlice([]string{
-							string(scheduledqueryrules.ConditionOperatorEquals),
+							// see https://github.com/Azure/azure-rest-api-specs/issues/21794
+							"Equal",
 							string(scheduledqueryrules.ConditionOperatorGreaterThan),
 							string(scheduledqueryrules.ConditionOperatorGreaterThanOrEqual),
 							string(scheduledqueryrules.ConditionOperatorLessThan),

--- a/internal/services/monitor/monitor_scheduled_query_rules_alert_v2_resource_test.go
+++ b/internal/services/monitor/monitor_scheduled_query_rules_alert_v2_resource_test.go
@@ -149,7 +149,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "test" {
 	  QUERY
     time_aggregation_method = "Count"
     threshold               = 5.0
-    operator                = "GreaterThan"
+    operator                = "Equal"
   }
 }
 `, template, data.RandomInteger, data.Locations.Primary)

--- a/website/docs/r/monitor_scheduled_query_rules_alert_v2.html.markdown
+++ b/website/docs/r/monitor_scheduled_query_rules_alert_v2.html.markdown
@@ -146,7 +146,7 @@ An `action` block supports the following:
 
 A `criteria` block supports the following:
 
-* `operator` - (Required) Specifies the criteria operator. Possible values are `Equals`, `GreaterThan`, `GreaterThanOrEqual`, `LessThan`,and `LessThanOrEqual`.
+* `operator` - (Required) Specifies the criteria operator. Possible values are `Equal`, `GreaterThan`, `GreaterThanOrEqual`, `LessThan`,and `LessThanOrEqual`.
 
 * `query` - (Required) The query to run on logs. The results returned by this query are used to populate the alert.
 


### PR DESCRIPTION
Resolves #19581
The swagger enum error is related to https://github.com/Azure/azure-rest-api-specs/issues/21794