### PR TITLE
dependencies: updating to `v0.20221207.1121859` of `github.com/hashicorp/go-azure-sdk`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.1.2
 	github.com/hashicorp/go-azure-helpers v0.47.0
-	github.com/hashicorp/go-azure-sdk v0.20221202.1180026
+	github.com/hashicorp/go-azure-sdk v0.20221207.1121859
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/go-version v1.6.0

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.1.2
 	github.com/hashicorp/go-azure-helpers v0.47.0
-	github.com/hashicorp/go-azure-sdk v0.20221130.1102501
+	github.com/hashicorp/go-azure-sdk v0.20221202.1180026
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/go-version v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -207,8 +207,8 @@ github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brv
 github.com/hashicorp/go-azure-helpers v0.12.0/go.mod h1:Zc3v4DNeX6PDdy7NljlYpnrdac1++qNW0I4U+ofGwpg=
 github.com/hashicorp/go-azure-helpers v0.47.0 h1:E90ZN2hqMtzI+tfGWCnNtyLZYG4csoKSs+hWZZ8ywSM=
 github.com/hashicorp/go-azure-helpers v0.47.0/go.mod h1:WiJNl0fD6PoM/MYuGTZ8yuzIaXQR3m2H2g6+EJ8nSwc=
-github.com/hashicorp/go-azure-sdk v0.20221130.1102501 h1:7SEIIXQC9gPK+v4ZyQl46dE6XC87ie4BYt92WGPJNGI=
-github.com/hashicorp/go-azure-sdk v0.20221130.1102501/go.mod h1:BEjoURzcFwd+K3MqkbOt9jArIIrsqpBQ2Gz6DdemFIs=
+github.com/hashicorp/go-azure-sdk v0.20221202.1180026 h1:zPNQQphXZy6ZSCqE0Wje1jQJm2cuyl8+3FfeLaeQLro=
+github.com/hashicorp/go-azure-sdk v0.20221202.1180026/go.mod h1:BEjoURzcFwd+K3MqkbOt9jArIIrsqpBQ2Gz6DdemFIs=
 github.com/hashicorp/go-checkpoint v0.5.0 h1:MFYpPZCnQqQTE18jFwSII6eUQrD/oxMFp3mlgcqk5mU=
 github.com/hashicorp/go-checkpoint v0.5.0/go.mod h1:7nfLNL10NsxqO4iWuW6tWW0HjZuDrwkBuEQsVcpCOgg=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=

--- a/go.sum
+++ b/go.sum
@@ -207,8 +207,8 @@ github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brv
 github.com/hashicorp/go-azure-helpers v0.12.0/go.mod h1:Zc3v4DNeX6PDdy7NljlYpnrdac1++qNW0I4U+ofGwpg=
 github.com/hashicorp/go-azure-helpers v0.47.0 h1:E90ZN2hqMtzI+tfGWCnNtyLZYG4csoKSs+hWZZ8ywSM=
 github.com/hashicorp/go-azure-helpers v0.47.0/go.mod h1:WiJNl0fD6PoM/MYuGTZ8yuzIaXQR3m2H2g6+EJ8nSwc=
-github.com/hashicorp/go-azure-sdk v0.20221202.1180026 h1:zPNQQphXZy6ZSCqE0Wje1jQJm2cuyl8+3FfeLaeQLro=
-github.com/hashicorp/go-azure-sdk v0.20221202.1180026/go.mod h1:BEjoURzcFwd+K3MqkbOt9jArIIrsqpBQ2Gz6DdemFIs=
+github.com/hashicorp/go-azure-sdk v0.20221207.1121859 h1:FVhKaMCtpeNfa+aoiuFt62rywpvY5pBEKtxgN35OnAo=
+github.com/hashicorp/go-azure-sdk v0.20221207.1121859/go.mod h1:BEjoURzcFwd+K3MqkbOt9jArIIrsqpBQ2Gz6DdemFIs=
 github.com/hashicorp/go-checkpoint v0.5.0 h1:MFYpPZCnQqQTE18jFwSII6eUQrD/oxMFp3mlgcqk5mU=
 github.com/hashicorp/go-checkpoint v0.5.0/go.mod h1:7nfLNL10NsxqO4iWuW6tWW0HjZuDrwkBuEQsVcpCOgg=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=

--- a/internal/services/streamanalytics/stream_analytics_output_blob_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_output_blob_resource.go
@@ -106,9 +106,9 @@ func resourceStreamAnalyticsOutputBlob() *pluginsdk.Resource {
 				ValidateFunc: validate.BatchMaxWaitTime,
 			},
 			"batch_min_rows": {
-				Type:         pluginsdk.TypeFloat,
+				Type:         pluginsdk.TypeInt,
 				Optional:     true,
-				ValidateFunc: validation.FloatBetween(0, 10000),
+				ValidateFunc: validation.IntBetween(0, 10000),
 			},
 
 			"storage_account_key": {
@@ -181,7 +181,7 @@ func resourceStreamAnalyticsOutputBlobCreateUpdate(d *pluginsdk.ResourceData, me
 	}
 
 	if batchMinRows, ok := d.GetOk("batch_min_rows"); ok {
-		props.Properties.SizeWindow = utils.Float(batchMinRows.(float64))
+		props.Properties.SizeWindow = utils.Int64(batchMinRows.(int64))
 	}
 
 	// timeWindow and sizeWindow must be set for Parquet serialization

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/outputs/model_outputproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/outputs/model_outputproperties.go
@@ -13,7 +13,7 @@ type OutputProperties struct {
 	Diagnostics   *Diagnostics     `json:"diagnostics,omitempty"`
 	Etag          *string          `json:"etag,omitempty"`
 	Serialization Serialization    `json:"serialization"`
-	SizeWindow    *float64         `json:"sizeWindow,omitempty"`
+	SizeWindow    *int64           `json:"sizeWindow,omitempty"`
 	TimeWindow    *string          `json:"timeWindow,omitempty"`
 }
 

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/streamingjobs/model_outputproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/streamingjobs/model_outputproperties.go
@@ -13,7 +13,7 @@ type OutputProperties struct {
 	Diagnostics   *Diagnostics     `json:"diagnostics,omitempty"`
 	Etag          *string          `json:"etag,omitempty"`
 	Serialization Serialization    `json:"serialization"`
-	SizeWindow    *float64         `json:"sizeWindow,omitempty"`
+	SizeWindow    *int64           `json:"sizeWindow,omitempty"`
 	TimeWindow    *string          `json:"timeWindow,omitempty"`
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -176,7 +176,7 @@ github.com/hashicorp/go-azure-helpers/resourcemanager/zones
 github.com/hashicorp/go-azure-helpers/resourceproviders
 github.com/hashicorp/go-azure-helpers/sender
 github.com/hashicorp/go-azure-helpers/storage
-# github.com/hashicorp/go-azure-sdk v0.20221202.1180026
+# github.com/hashicorp/go-azure-sdk v0.20221207.1121859
 ## explicit; go 1.18
 github.com/hashicorp/go-azure-sdk/resource-manager/aad/2021-05-01/domainservices
 github.com/hashicorp/go-azure-sdk/resource-manager/aadb2c/2021-04-01-preview

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -176,7 +176,7 @@ github.com/hashicorp/go-azure-helpers/resourcemanager/zones
 github.com/hashicorp/go-azure-helpers/resourceproviders
 github.com/hashicorp/go-azure-helpers/sender
 github.com/hashicorp/go-azure-helpers/storage
-# github.com/hashicorp/go-azure-sdk v0.20221130.1102501
+# github.com/hashicorp/go-azure-sdk v0.20221202.1180026
 ## explicit; go 1.18
 github.com/hashicorp/go-azure-sdk/resource-manager/aad/2021-05-01/domainservices
 github.com/hashicorp/go-azure-sdk/resource-manager/aadb2c/2021-04-01-preview


### PR DESCRIPTION
This PR also includes a breaking change to `azurerm_stream_analytics_output_blob` where the field `batch_min_rows` is now an integer rather than a float - since this has been updated in the Swagger (and at least in the tests/examples we have, this is used as an integer).