### PR TITLE
`azurerm_log_analytics_workspace` - prevent ForceNew when `sku` is `LACluster`

### DIFF
--- a/internal/services/loganalytics/log_analytics_linked_service_resource_test.go
+++ b/internal/services/loganalytics/log_analytics_linked_service_resource_test.go
@@ -164,7 +164,6 @@ resource "azurerm_log_analytics_workspace" "test" {
   sku                 = "PerGB2018"
   retention_in_days   = 30
 }
-
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }
 

--- a/internal/services/loganalytics/log_analytics_linked_service_resource_test.go
+++ b/internal/services/loganalytics/log_analytics_linked_service_resource_test.go
@@ -163,12 +163,6 @@ resource "azurerm_log_analytics_workspace" "test" {
   resource_group_name = azurerm_resource_group.test.name
   sku                 = "PerGB2018"
   retention_in_days   = 30
-
-  lifecycle {
-    ignore_changes = [
-      sku
-    ]
-  }
 }
 
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)

--- a/internal/services/loganalytics/log_analytics_linked_service_resource_test.go
+++ b/internal/services/loganalytics/log_analytics_linked_service_resource_test.go
@@ -170,6 +170,7 @@ resource "azurerm_log_analytics_workspace" "test" {
     ]
   }
 }
+
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }
 

--- a/internal/services/loganalytics/log_analytics_linked_service_resource_test.go
+++ b/internal/services/loganalytics/log_analytics_linked_service_resource_test.go
@@ -163,6 +163,12 @@ resource "azurerm_log_analytics_workspace" "test" {
   resource_group_name = azurerm_resource_group.test.name
   sku                 = "PerGB2018"
   retention_in_days   = 30
+
+  lifecycle {
+    ignore_changes = [
+      sku
+    ]
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }

--- a/internal/services/loganalytics/log_analytics_workspace_resource.go
+++ b/internal/services/loganalytics/log_analytics_workspace_resource.go
@@ -144,14 +144,13 @@ func resourceLogAnalyticsWorkspaceCustomDiff(ctx context.Context, d *pluginsdk.R
 	// custom diff here because when you link the workspace to a cluster the
 	// cluster changes the sku to LACluster, so we need to ignore the change
 	// if it is LACluster else invoke the ForceNew as before...
-	//
-	// NOTE: Since LACluster is not in our enum the value is returned as ""
+
 	if d.HasChange("sku") {
 		old, new := d.GetChange("sku")
 		log.Printf("[INFO] Log Analytics Workspace SKU: OLD: %q, NEW: %q", old, new)
 		// If the old value is not LACluster(e.g. "") return ForceNew because they are
 		// really changing the sku...
-		if !strings.EqualFold(old.(string), "") {
+		if !strings.EqualFold(old.(string), string(workspaces.WorkspaceSkuNameEnumLACluster)) {
 			d.ForceNew("sku")
 		}
 	}
@@ -198,7 +197,7 @@ func resourceLogAnalyticsWorkspaceCreateUpdate(d *pluginsdk.ResourceData, meta i
 		if err == nil {
 			if resp.Model != nil && resp.Model.Properties != nil {
 				if azSku := resp.Model.Properties.Sku; azSku != nil {
-					if strings.EqualFold(string(azSku.Name), "lacluster") {
+					if strings.EqualFold(string(azSku.Name), string(workspaces.WorkspaceSkuNameEnumLACluster)) {
 						isLACluster = true
 						log.Printf("[INFO] Log Analytics Workspace %q (Resource Group %q): SKU is linked to Log Analytics cluster", name, resourceGroup)
 					}
@@ -221,7 +220,7 @@ func resourceLogAnalyticsWorkspaceCreateUpdate(d *pluginsdk.ResourceData, meta i
 	t := d.Get("tags").(map[string]interface{})
 
 	if isLACluster {
-		sku.Name = "lacluster"
+		sku.Name = workspaces.WorkspaceSkuNameEnumLACluster
 	} else if skuName == "" {
 		// Default value if sku is not defined
 		sku.Name = workspaces.WorkspaceSkuNameEnumPerGBTwoZeroOneEight

--- a/internal/services/loganalytics/log_analytics_workspace_resource.go
+++ b/internal/services/loganalytics/log_analytics_workspace_resource.go
@@ -150,7 +150,7 @@ func resourceLogAnalyticsWorkspaceCustomDiff(ctx context.Context, d *pluginsdk.R
 		log.Printf("[INFO] Log Analytics Workspace SKU: OLD: %q, NEW: %q", old, new)
 		// If the old value is not LACluster(e.g. "") return ForceNew because they are
 		// really changing the sku...
-		if !strings.EqualFold(old.(string), string(workspaces.WorkspaceSkuNameEnumLACluster)) {
+		if !strings.EqualFold(old.(string), string(workspaces.WorkspaceSkuNameEnumLACluster)) && !strings.EqualFold(old.(string), "") {
 			d.ForceNew("sku")
 		}
 	}


### PR DESCRIPTION
Since we have updated to `go-azure-sdk`,  this workaround needs an update.
workaround was invovled in #17069

Test
---
LogAnalyticsWorkspace
```
TF_ACC=1 go test -v ./internal/services/loganalytics -run=TestAccLogAnalyticsWorkspace -timeout=600m
=== RUN   TestAccLogAnalyticsWorkspace_basic
=== PAUSE TestAccLogAnalyticsWorkspace_basic
=== RUN   TestAccLogAnalyticsWorkspace_requiresImport
=== PAUSE TestAccLogAnalyticsWorkspace_requiresImport
=== RUN   TestAccLogAnalyticsWorkspace_complete
=== PAUSE TestAccLogAnalyticsWorkspace_complete
=== RUN   TestAccLogAnalyticsWorkspace_freeTier
    log_analytics_workspace_resource_test.go:92: `TestAccLogAnalyticsWorkspace_freeTier` due to subscription pricing tier configuration (e.g. Pricing tier doesn't match the subscription's billing model.)
--- SKIP: TestAccLogAnalyticsWorkspace_freeTier (0.00s)
=== RUN   TestAccLogAnalyticsWorkspace_withDefaultSku
=== PAUSE TestAccLogAnalyticsWorkspace_withDefaultSku
=== RUN   TestAccLogAnalyticsWorkspace_withVolumeCap
=== PAUSE TestAccLogAnalyticsWorkspace_withVolumeCap
=== RUN   TestAccLogAnalyticsWorkspace_removeVolumeCap
=== PAUSE TestAccLogAnalyticsWorkspace_removeVolumeCap
=== RUN   TestAccLogAnalyticsWorkspace_withInternetIngestionEnabled
=== PAUSE TestAccLogAnalyticsWorkspace_withInternetIngestionEnabled
=== RUN   TestAccLogAnalyticsWorkspace_withInternetQueryEnabled
=== PAUSE TestAccLogAnalyticsWorkspace_withInternetQueryEnabled
=== RUN   TestAccLogAnalyticsWorkspace_withCapacityReservation
=== PAUSE TestAccLogAnalyticsWorkspace_withCapacityReservation
=== RUN   TestAccLogAnalyticsWorkspace_negativeOne
=== PAUSE TestAccLogAnalyticsWorkspace_negativeOne
=== RUN   TestAccLogAnalyticsWorkspace_cmkForQueryForced
=== PAUSE TestAccLogAnalyticsWorkspace_cmkForQueryForced
=== CONT  TestAccLogAnalyticsWorkspace_basic
=== CONT  TestAccLogAnalyticsWorkspace_withInternetIngestionEnabled
=== CONT  TestAccLogAnalyticsWorkspace_negativeOne
=== CONT  TestAccLogAnalyticsWorkspace_withDefaultSku
=== CONT  TestAccLogAnalyticsWorkspace_requiresImport
=== CONT  TestAccLogAnalyticsWorkspace_cmkForQueryForced
=== CONT  TestAccLogAnalyticsWorkspace_removeVolumeCap
=== CONT  TestAccLogAnalyticsWorkspace_withVolumeCap
--- PASS: TestAccLogAnalyticsWorkspace_basic (190.72s)
=== CONT  TestAccLogAnalyticsWorkspace_withCapacityReservation
--- PASS: TestAccLogAnalyticsWorkspace_negativeOne (191.73s)
=== CONT  TestAccLogAnalyticsWorkspace_withInternetQueryEnabled
--- PASS: TestAccLogAnalyticsWorkspace_withVolumeCap (251.00s)
=== CONT  TestAccLogAnalyticsWorkspace_complete
--- PASS: TestAccLogAnalyticsWorkspace_withDefaultSku (256.03s)
--- PASS: TestAccLogAnalyticsWorkspace_requiresImport (294.43s)
--- PASS: TestAccLogAnalyticsWorkspace_withInternetIngestionEnabled (365.87s)
--- PASS: TestAccLogAnalyticsWorkspace_removeVolumeCap (367.59s)
--- PASS: TestAccLogAnalyticsWorkspace_cmkForQueryForced (371.00s)
--- PASS: TestAccLogAnalyticsWorkspace_withCapacityReservation (329.00s)
--- PASS: TestAccLogAnalyticsWorkspace_withInternetQueryEnabled (341.60s)
--- PASS: TestAccLogAnalyticsWorkspace_complete (293.67s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/loganalytics	545.855s
```

test with a cluster which will set `sku` to `LACluster`
```
TF_ACC=1 go test -v ./internal/services/loganalytics -run=TestAccLogAnalyticsLinkedService_withWriteAccessResourceId -timeout=600m
=== RUN   TestAccLogAnalyticsLinkedService_withWriteAccessResourceId
=== PAUSE TestAccLogAnalyticsLinkedService_withWriteAccessResourceId
=== CONT  TestAccLogAnalyticsLinkedService_withWriteAccessResourceId
--- PASS: TestAccLogAnalyticsLinkedService_withWriteAccessResourceId (1460.34s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/loganalytics  1461.482s

```