### PR TITLE
Doc: format resource document to use the same marks

### DIFF
--- a/website/docs/r/app_service.html.markdown
+++ b/website/docs/r/app_service.html.markdown
@@ -319,7 +319,7 @@ A `active_directory` block supports the following:
 
 * `client_secret` - (Optional) The Client Secret of this relying party application. If no secret is provided, implicit flow will be used.
 
-* `allowed_audiences` (Optional) Allowed audience values to consider when validating JWTs issued by Azure Active Directory.
+* `allowed_audiences` - (Optional) Allowed audience values to consider when validating JWTs issued by Azure Active Directory.
 
 ---
 
@@ -329,7 +329,7 @@ A `facebook` block supports the following:
 
 * `app_secret` - (Required) The App Secret of the Facebook app used for Facebook login.
 
-* `oauth_scopes` (Optional) The OAuth 2.0 scopes that will be requested as part of Facebook login authentication. <https://developers.facebook.com/docs/facebook-login>
+* `oauth_scopes` - (Optional) The OAuth 2.0 scopes that will be requested as part of Facebook login authentication. <https://developers.facebook.com/docs/facebook-login>
 
 ---
 
@@ -339,7 +339,7 @@ A `google` block supports the following:
 
 * `client_secret` - (Required) The client secret associated with the Google web application.
 
-* `oauth_scopes` (Optional) The OAuth 2.0 scopes that will be requested as part of Google Sign-In authentication. <https://developers.google.com/identity/sign-in/web/>
+* `oauth_scopes` - (Optional) The OAuth 2.0 scopes that will be requested as part of Google Sign-In authentication. <https://developers.google.com/identity/sign-in/web/>
 
 ---
 
@@ -401,17 +401,17 @@ A `microsoft` block supports the following:
 
 * `client_secret` - (Required) The OAuth 2.0 client secret that was created for the app used for authentication.
 
-* `oauth_scopes` (Optional) The OAuth 2.0 scopes that will be requested as part of Microsoft Account authentication. <https://msdn.microsoft.com/en-us/library/dn631845.aspx>
+* `oauth_scopes` - (Optional) The OAuth 2.0 scopes that will be requested as part of Microsoft Account authentication. <https://msdn.microsoft.com/en-us/library/dn631845.aspx>
 
 ---
 
 A `backup` block supports the following:
 
-* `name` (Required) Specifies the name for this Backup.
+* `name` - (Required) Specifies the name for this Backup.
 
 * `enabled` - (Optional) Is this Backup enabled?
 
-* `storage_account_url` (Required) The SAS URL to a Storage Container where Backups should be saved.
+* `storage_account_url` - (Required) The SAS URL to a Storage Container where Backups should be saved.
 
 * `schedule` - (Optional) A `schedule` block as defined below.
 

--- a/website/docs/r/app_service_certificate_order.html.markdown
+++ b/website/docs/r/app_service_certificate_order.html.markdown
@@ -80,7 +80,7 @@ The following attributes are exported:
 
 ---
 
-`certificates` supports the following:
+The `certificates` block supports the following:
 
 * `certificate_name` - The name of the App Service Certificate.
 

--- a/website/docs/r/app_service_plan.html.markdown
+++ b/website/docs/r/app_service_plan.html.markdown
@@ -129,7 +129,9 @@ The following arguments are supported:
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
-`sku` supports the following:
+---
+
+The `sku` block supports the following:
 
 * `tier` - (Required) Specifies the plan's pricing tier.
 

--- a/website/docs/r/app_service_slot.html.markdown
+++ b/website/docs/r/app_service_slot.html.markdown
@@ -339,7 +339,7 @@ A `active_directory` block supports the following:
 
 * `client_secret` - (Optional) The Client Secret of this relying party application. If no secret is provided, implicit flow will be used.
 
-* `allowed_audiences` (Optional) Allowed audience values to consider when validating JWTs issued by Azure Active Directory.
+* `allowed_audiences` - (Optional) Allowed audience values to consider when validating JWTs issued by Azure Active Directory.
 
 ---
 
@@ -349,7 +349,7 @@ A `facebook` block supports the following:
 
 * `app_secret` - (Required) The App Secret of the Facebook app used for Facebook login.
 
-* `oauth_scopes` (Optional) The OAuth 2.0 scopes that will be requested as part of Facebook login authentication. <https://developers.facebook.com/docs/facebook-login>
+* `oauth_scopes` - (Optional) The OAuth 2.0 scopes that will be requested as part of Facebook login authentication. <https://developers.facebook.com/docs/facebook-login>
 
 ---
 
@@ -359,7 +359,7 @@ A `google` block supports the following:
 
 * `client_secret` - (Required) The client secret associated with the Google web application.
 
-* `oauth_scopes` (Optional) The OAuth 2.0 scopes that will be requested as part of Google Sign-In authentication. <https://developers.google.com/identity/sign-in/web/>
+* `oauth_scopes` - (Optional) The OAuth 2.0 scopes that will be requested as part of Google Sign-In authentication. <https://developers.google.com/identity/sign-in/web/>
 
 ---
 
@@ -401,7 +401,7 @@ A `microsoft` block supports the following:
 
 * `client_secret` - (Required) The OAuth 2.0 client secret that was created for the app used for authentication.
 
-* `oauth_scopes` (Optional) The OAuth 2.0 scopes that will be requested as part of Microsoft Account authentication. <https://msdn.microsoft.com/en-us/library/dn631845.aspx>
+* `oauth_scopes` - (Optional) The OAuth 2.0 scopes that will be requested as part of Microsoft Account authentication. <https://msdn.microsoft.com/en-us/library/dn631845.aspx>
 
 ---
 

--- a/website/docs/r/app_service_slot.html.markdown
+++ b/website/docs/r/app_service_slot.html.markdown
@@ -197,7 +197,7 @@ A `storage_account` block supports the following:
 
 ---
 
-`connection_string` supports the following:
+The `connection_string` block supports the following:
 
 * `name` - (Required) The name of the Connection String. Changing this forces a new resource to be created.
 * `type` - (Required) The type of the Connection String. Possible values are `APIHub`, `Custom`, `DocDb`, `EventHub`, `MySQL`, `NotificationHub`, `PostgreSQL`, `RedisCache`, `ServiceBus`, `SQLAzure`, and  `SQLServer`.

--- a/website/docs/r/app_service_virtual_network_swift_connection.html.markdown
+++ b/website/docs/r/app_service_virtual_network_swift_connection.html.markdown
@@ -156,24 +156,24 @@ resource "azurerm_app_service_virtual_network_swift_connection" "example" {
 
 The following arguments are supported:
 
-- `app_service_id` - (Required) The ID of the App Service or Function App to associate to the VNet. Changing this forces a new resource to be created.
+* `app_service_id` - (Required) The ID of the App Service or Function App to associate to the VNet. Changing this forces a new resource to be created.
 
-- `subnet_id` - (Required) The ID of the subnet the app service will be associated to (the subnet must have a `service_delegation` configured for `Microsoft.Web/serverFarms`).
+* `subnet_id` - (Required) The ID of the subnet the app service will be associated to (the subnet must have a `service_delegation` configured for `Microsoft.Web/serverFarms`).
 
 ## Attributes Reference
 
 The following attributes are exported:
 
-- `id` - The ID of the App Service Virtual Network Association
+* `id` - The ID of the App Service Virtual Network Association
 
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-- `create` - (Defaults to 30 minutes) Used when creating the App Service Virtual Network Association.
-- `update` - (Defaults to 30 minutes) Used when updating the App Service Virtual Network Association.
-- `read` - (Defaults to 5 minutes) Used when retrieving the App Service Virtual Network Association.
-- `delete` - (Defaults to 30 minutes) Used when deleting the App Service Virtual Network Association.
+* `create` - (Defaults to 30 minutes) Used when creating the App Service Virtual Network Association.
+* `update` - (Defaults to 30 minutes) Used when updating the App Service Virtual Network Association.
+* `read` - (Defaults to 5 minutes) Used when retrieving the App Service Virtual Network Association.
+* `delete` - (Defaults to 30 minutes) Used when deleting the App Service Virtual Network Association.
 
 ## Import
 

--- a/website/docs/r/automation_account.html.markdown
+++ b/website/docs/r/automation_account.html.markdown
@@ -64,7 +64,7 @@ An `identity` block supports the following:
 
 -> **Note:** `identity_ids` is required when `type` is set to `UserAssigned` or `SystemAssigned, UserAssigned`.
 
---
+---
 
 An `encryption` block supports the following:
 

--- a/website/docs/r/automation_module.html.markdown
+++ b/website/docs/r/automation_module.html.markdown
@@ -48,7 +48,9 @@ The following arguments are supported:
 
 * `module_link` - (Required) The published Module link.
 
-`module_link` supports the following:
+---
+
+The `module_link` block supports the following:
 
 * `uri` - (Required) The URI of the module content (zip or nupkg).
 

--- a/website/docs/r/automation_runbook.html.markdown
+++ b/website/docs/r/automation_runbook.html.markdown
@@ -138,7 +138,7 @@ The `draft` block supports:
 
 * `parameter` (Optional) A list of `parameter` block as define below.
 
---
+---
 
 The `parameter` block supports:
 

--- a/website/docs/r/automation_runbook.html.markdown
+++ b/website/docs/r/automation_runbook.html.markdown
@@ -110,7 +110,7 @@ The following arguments are supported:
 
 ---
 
-The `publish_content_link` supports the following:
+The `publish_content_link` block supports the following:
 
 * `uri` - (Required) The URI of the runbook content.
 

--- a/website/docs/r/automation_runbook.html.markdown
+++ b/website/docs/r/automation_runbook.html.markdown
@@ -136,21 +136,21 @@ The `draft` block supports:
 
 * `output_types` (Optioinal) Specifies the output types of the runbook.
 
-* `parameter` (Optional) A list of `parameter` block as define below.
+* `parameter` - (Optional) A list of `parameter` block as define below.
 
 ---
 
 The `parameter` block supports:
 
-* `key` (Required) The name of the parameter.
+* `key` - (Required) The name of the parameter.
 
-* `type` (Optional) Specifies the type of this parameter.
+* `type` - (Optional) Specifies the type of this parameter.
 
-* `mandatory` (Optional) Whether this parameter is mandatory.
+* `mandatory` - (Optional) Whether this parameter is mandatory.
 
-* `positioin` (Optional) Specifies the position of the parameter.
+* `positioin` - (Optional) Specifies the position of the parameter.
 
-* `default_value` (Optional) Specifies the default value of the parameter.
+* `default_value` - (Optional) Specifies the default value of the parameter.
 
 ## Attributes Reference
 

--- a/website/docs/r/automation_software_update_configuration.html.markdown
+++ b/website/docs/r/automation_software_update_configuration.html.markdown
@@ -51,7 +51,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name which should be used for this Automation. Changing this forces a new Automation to be created.
 
-* `automation_account_id` (Required) The ID of Automation Account to manage this Source Control. Changing this forces a new Automation Source Control to be created.
+* `automation_account_id` - (Required) The ID of Automation Account to manage this Source Control. Changing this forces a new Automation Source Control to be created.
 
 * `operating_system` - (Required) The Operating system of target machines. Possible values are `Windows` and `Linux`.
 

--- a/website/docs/r/automation_source_control.html.markdown
+++ b/website/docs/r/automation_source_control.html.markdown
@@ -34,7 +34,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name which should be used for this Automation Source Control. Changing this forces a new Automation Source Control to be created.
 
-* `automation_account_id` (Required) The ID of Automation Account to manage this Source Control. Changing this forces a new Automation Source Control to be created.
+* `automation_account_id` - (Required) The ID of Automation Account to manage this Source Control. Changing this forces a new Automation Source Control to be created.
 
 * `folder_path` - (Required) The folder path of the source control. This Path must be relative.
 

--- a/website/docs/r/bastion_host.html.markdown
+++ b/website/docs/r/bastion_host.html.markdown
@@ -104,7 +104,7 @@ A `ip_configuration` block supports the following:
 
 ~> **Note:** The Subnet used for the Bastion Host must have the name `AzureBastionSubnet` and the subnet mask must be at least a `/26`.
 
-* `public_ip_address_id` (Required)  Reference to a Public IP Address to associate with this Bastion Host. Changing this forces a new resource to be created.
+* `public_ip_address_id` - (Required)  Reference to a Public IP Address to associate with this Bastion Host. Changing this forces a new resource to be created.
 
 ## Attributes Reference
 

--- a/website/docs/r/batch_pool.html.markdown
+++ b/website/docs/r/batch_pool.html.markdown
@@ -192,6 +192,8 @@ A `data_disks` block supports the following:
 
 * `storage_account_type` - (Optional) The storage account type to be used for the data disk. If omitted, the default is "Standard_LRS". Values are: "Standard_LRS" - The data disk should use standard locally redundant storage. "Premium_LRS" - The data disk should use premium locally redundant storage.
 
+---
+
 A `disk_encryption` block supports the following:
 
 The disk encryption configuration applied on compute nodes in the pool. Disk encryption configuration is not supported on Linux pool created with Virtual Machine Image or Shared Image Gallery Image.

--- a/website/docs/r/bot_channel_directline.html.markdown
+++ b/website/docs/r/bot_channel_directline.html.markdown
@@ -44,52 +44,54 @@ resource "azurerm_bot_channel_directline" "example" {
 
 The following arguments are supported:
 
-- `resource_group_name` - (Required) The name of the resource group in which to create the Bot Channel. Changing this forces a new resource to be created.
+* `resource_group_name` - (Required) The name of the resource group in which to create the Bot Channel. Changing this forces a new resource to be created.
 
-- `location` - (Required) The supported Azure location where the resource exists. Changing this forces a new resource to be created.
+* `location` - (Required) The supported Azure location where the resource exists. Changing this forces a new resource to be created.
 
-- `bot_name` - (Required) The name of the Bot Resource this channel will be associated with. Changing this forces a new resource to be created.
+* `bot_name` - (Required) The name of the Bot Resource this channel will be associated with. Changing this forces a new resource to be created.
 
-- `site` - (Required) A site represents a client application that you want to connect to your bot. Multiple `site` blocks may be defined as below
+* `site` - (Required) A site represents a client application that you want to connect to your bot. Multiple `site` blocks may be defined as below
+
+---
 
 A `site` block has the following properties:
 
-- `name` - (Required) The name of the site
+* `name` - (Required) The name of the site
 
-- `enabled` - (Optional) Enables/Disables this site. Enabled by default
+* `enabled` - (Optional) Enables/Disables this site. Enabled by default
 
-- `v1_allowed` - (Optional) Enables v1 of the Directline protocol for this site. Enabled by default
+* `v1_allowed` - (Optional) Enables v1 of the Directline protocol for this site. Enabled by default
 
-- `v3_allowed` - (Optional) Enables v3 of the Directline protocol for this site. Enabled by default
+* `v3_allowed` - (Optional) Enables v3 of the Directline protocol for this site. Enabled by default
 
-- `enhanced_authentication_enabled` - (Optional) Enables additional security measures for this site, see [Enhanced Directline Authentication Features](https://blog.botframework.com/2018/09/25/enhanced-direct-line-authentication-features). Disabled by default.
+* `enhanced_authentication_enabled` - (Optional) Enables additional security measures for this site, see [Enhanced Directline Authentication Features](https://blog.botframework.com/2018/09/25/enhanced-direct-line-authentication-features). Disabled by default.
 
-- `trusted_origins` - (Optional) This field is required when `is_secure_site_enabled` is enabled. Determines which origins can establish a Directline conversation for this site.
+* `trusted_origins` - (Optional) This field is required when `is_secure_site_enabled` is enabled. Determines which origins can establish a Directline conversation for this site.
 
 ## Attributes Reference
 
 The following attributes are exported:
 
-- `id` - The Bot Channel ID.
+* `id` - The Bot Channel ID.
 
 ---
 
 A `site` block exports the following:
 
-- `key` - Primary key for accessing this site
+* `key` - Primary key for accessing this site
 
-- `key2` - Secondary key for accessing this site
+* `key2` - Secondary key for accessing this site
 
-- `id` - Id for the site
+* `id` - Id for the site
 
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-- `create` - (Defaults to 30 minutes) Used when creating the Directline Channel.
-- `update` - (Defaults to 30 minutes) Used when updating the Directline Channel.
-- `read` - (Defaults to 5 minutes) Used when retrieving the Directline Channel.
-- `delete` - (Defaults to 30 minutes) Used when deleting the Directline Channel.
+* `create` - (Defaults to 30 minutes) Used when creating the Directline Channel.
+* `update` - (Defaults to 30 minutes) Used when updating the Directline Channel.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Directline Channel.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Directline Channel.
 
 ## Import
 

--- a/website/docs/r/cdn_endpoint.html.markdown
+++ b/website/docs/r/cdn_endpoint.html.markdown
@@ -82,6 +82,8 @@ The following arguments are supported:
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
+---
+
 The `origin` block supports:
 
 * `name` - (Required) The name of the origin. This is an arbitrary value. However, this value needs to be unique under the endpoint. Changing this forces a new resource to be created.
@@ -91,6 +93,8 @@ The `origin` block supports:
 * `http_port` - (Optional) The HTTP port of the origin. Defaults to `80`. Changing this forces a new resource to be created.
 
 * `https_port` - (Optional) The HTTPS port of the origin. Defaults to `443`. Changing this forces a new resource to be created.
+
+---
 
 The `geo_filter` block supports:
 

--- a/website/docs/r/cdn_endpoint_custom_domain.html.markdown
+++ b/website/docs/r/cdn_endpoint_custom_domain.html.markdown
@@ -75,9 +75,9 @@ The following arguments are supported:
 
 * `host_name` - (Required) The host name of the custom domain. Changing this forces a new CDN Endpoint Custom Domain to be created.
 
-* `cdn_managed_https` (Optional) - A `cdn_managed_https` block as defined below.
+* `cdn_managed_https` - (Optional) A `cdn_managed_https` block as defined below.
 
-* `user_managed_https` (Optional) - A `user_managed_https` block as defined below.
+* `user_managed_https` - (Optional) A `user_managed_https` block as defined below.
 
 ~> **NOTE** Only one of `cdn_managed_https` and `user_managed_https` can be specified.
 

--- a/website/docs/r/cdn_frontdoor_rule.html.markdown
+++ b/website/docs/r/cdn_frontdoor_rule.html.markdown
@@ -245,7 +245,7 @@ A `request_header_action` block supports the following:
 
 ---
 
-* A `response_header_action` block supports the following:
+A `response_header_action` block supports the following:
 
 * `header_action` - (Required) The action to be taken on the specified `header_name`. Possible values include `Append`, `Overwrite` or `Delete`.
 

--- a/website/docs/r/cognitive_account.html.markdown
+++ b/website/docs/r/cognitive_account.html.markdown
@@ -102,6 +102,8 @@ A `network_acls` block supports the following:
 
 * `virtual_network_rules` - (Optional) A `virtual_network_rules` block as defined below.
 
+---
+
 A `virtual_network_rules` block supports the following:
 
 * `subnet_id` - (Required) The ID of the subnet which should be able to access this Cognitive Account.

--- a/website/docs/r/cognitive_account.html.markdown
+++ b/website/docs/r/cognitive_account.html.markdown
@@ -56,7 +56,7 @@ The following arguments are supported:
 
 * `dynamic_throttling_enabled` - (Optional) Whether to enable the dynamic throttling for this Cognitive Service Account. Defaults to `false`.
 
-* `customer_managed_key` (Optional) A `customer_managed_key` block as documented below.
+* `customer_managed_key` - (Optional) A `customer_managed_key` block as documented below.
 
 * `fqdns` - (Optional) List of FQDNs allowed for the Cognitive Account.
 

--- a/website/docs/r/container_group.html.markdown
+++ b/website/docs/r/container_group.html.markdown
@@ -223,7 +223,7 @@ A `ports` block supports:
 
 ~> **Note:** Omitting these blocks will default the exposed ports on the group to all ports on all containers defined in the `container` blocks of this group.
 
---
+---
 
 A `gpu` block supports:
 

--- a/website/docs/r/container_registry.html.markdown
+++ b/website/docs/r/container_registry.html.markdown
@@ -183,7 +183,7 @@ The following arguments are supported:
 
 ---
 
-`georeplications` supports the following:
+The `georeplications` block supports the following:
 
 * `location` - (Required) A location where the container registry should be geo-replicated. Changing this forces a new resource to be created.
 
@@ -197,7 +197,7 @@ The following arguments are supported:
 
 ---
 
-`network_rule_set` supports the following:
+The `network_rule_set` block supports the following:
 
 * `default_action` - (Optional) The behaviour for requests matching no rules. Either `Allow` or `Deny`. Defaults to `Allow`
 
@@ -211,7 +211,7 @@ The following arguments are supported:
 
 ---
 
-`ip_rule` supports the following:
+The `ip_rule` block supports the following:
 
 * `action` - (Required) The behaviour for requests matching this rule. At this time the only supported value is `Allow`
 
@@ -219,7 +219,7 @@ The following arguments are supported:
 
 ---
 
-`virtual_network` supports the following:
+The `virtual_network` block supports the following:
 
 * `action` - (Required) The behaviour for requests matching this rule. At this time the only supported value is `Allow`
 
@@ -227,13 +227,13 @@ The following arguments are supported:
 
 ---
 
-`trust_policy` supports the following:
+The `trust_policy` block supports the following:
 
 * `enabled` - (Optional) Boolean value that indicates whether the policy is enabled.
 
 ---
 
-`retention_policy` supports the following:
+The `retention_policy` block supports the following:
 
 * `days` - (Optional) The number of days to retain an untagged manifest after which it gets purged. Default is `7`.
 
@@ -251,7 +251,7 @@ An `identity` block supports the following:
 
 ---
 
-`encryption` supports the following:
+The `encryption` block supports the following:
 
 * `enabled` - (Optional) Boolean value that indicates whether encryption is enabled.
 

--- a/website/docs/r/cosmosdb_account.html.markdown
+++ b/website/docs/r/cosmosdb_account.html.markdown
@@ -146,7 +146,7 @@ The following arguments are supported:
 
 ---
 
-`consistency_policy` Configures the database consistency and supports the following:
+The `consistency_policy` block Configures the database consistency and supports the following:
 
 * `consistency_level` - (Required) The Consistency Level to use for this CosmosDB Account - can be either `BoundedStaleness`, `Eventual`, `Session`, `Strong` or `ConsistentPrefix`.
 * `max_interval_in_seconds` - (Optional) When used with the Bounded Staleness consistency level, this value represents the time amount of staleness (in seconds) tolerated. Accepted range for this value is `5` - `86400` (1 day). Defaults to `5`. Required when `consistency_level` is set to `BoundedStaleness`.
@@ -156,7 +156,7 @@ The following arguments are supported:
 
 ---
 
-`geo_location` Configures the geographic locations the data is replicated to and supports the following:
+The `geo_location` block Configures the geographic locations the data is replicated to and supports the following:
 
 * `location` - (Required) The name of the Azure region to host replicated data. Changing this forces a new resource to be created.
 * `failover_priority` - (Required) The failover priority of the region. A failover priority of `0` indicates a write region. The maximum value for a failover priority = (total number of regions - 1). Failover priority values must be unique for each of the regions in which the database account exists. Changing this causes the location to be re-provisioned and cannot be changed for the location with failover priority `0`.
@@ -172,7 +172,7 @@ The following arguments are supported:
 
 ---
 
-`virtual_network_rule` Configures the virtual network subnets allowed to access this Cosmos DB account and supports the following:
+The `virtual_network_rule` block Configures the virtual network subnets allowed to access this Cosmos DB account and supports the following:
 
 * `id` - (Required) The ID of the virtual network subnet.
 * `ignore_missing_vnet_service_endpoint` - (Optional) If set to true, the specified subnet will be added as a virtual network rule even if its CosmosDB service endpoint is not active. Defaults to `false`.

--- a/website/docs/r/cosmosdb_gremlin_graph.html.markdown
+++ b/website/docs/r/cosmosdb_gremlin_graph.html.markdown
@@ -80,7 +80,7 @@ The following arguments are supported:
 
 * `conflict_resolution_policy` - (Optional)  A `conflict_resolution_policy` blocks as defined below.
 
-* `unique_key` (Optional) One or more `unique_key` blocks as defined below. Changing this forces a new resource to be created.
+* `unique_key` - (Optional) One or more `unique_key` blocks as defined below. Changing this forces a new resource to be created.
 
 ---
 

--- a/website/docs/r/data_factory_linked_custom_service.html.markdown
+++ b/website/docs/r/data_factory_linked_custom_service.html.markdown
@@ -82,7 +82,7 @@ JSON
 
 ---
 
-An `integration_runtime` supports the following:
+An `integration_runtime` block supports the following:
 
 * `name` - (Required) The integration runtime reference to associate with the Data Factory Linked Service.
 

--- a/website/docs/r/dedicated_hardware_security_module.html.markdown
+++ b/website/docs/r/dedicated_hardware_security_module.html.markdown
@@ -143,6 +143,8 @@ An `network_profile` block exports the following:
 
 * `subnet_id` - (Required) The ID of the subnet. Changing this forces a new Dedicated Hardware Security Module to be created.
 
+---
+
 A `management_network_profile` block exports the following:
 
 * `network_interface_private_ip_addresses` - (Required) The private IPv4 address of the network interface. Changing this forces a new Dedicated Hardware Security Module to be created.

--- a/website/docs/r/eventgrid_domain.html.markdown
+++ b/website/docs/r/eventgrid_domain.html.markdown
@@ -74,7 +74,7 @@ A `identity` block supports the following:
 
 ---
 
-A `input_mapping_fields` supports the following:
+A `input_mapping_fields` block supports the following:
 
 * `id` - (Optional) Specifies the id of the EventGrid Event to associate with the domain. Changing this forces a new resource to be created.
 
@@ -90,7 +90,7 @@ A `input_mapping_fields` supports the following:
 
 ---
 
-A `input_mapping_default_values` supports the following:
+A `input_mapping_default_values` block supports the following:
 
 * `event_type` - (Optional) Specifies the default event type of the EventGrid Event to associate with the domain. Changing this forces a new resource to be created.
 

--- a/website/docs/r/eventgrid_event_subscription.html.markdown
+++ b/website/docs/r/eventgrid_event_subscription.html.markdown
@@ -99,7 +99,7 @@ The following arguments are supported:
 
 ---
 
-A `storage_queue_endpoint` supports the following:
+A `storage_queue_endpoint` block supports the following:
 
 * `storage_account_id` - (Required) Specifies the id of the storage account id where the storage queue is located.
 
@@ -109,7 +109,7 @@ A `storage_queue_endpoint` supports the following:
 
 ---
 
-An `azure_function_endpoint` supports the following:
+An `azure_function_endpoint` block supports the following:
 
 * `function_id` - (Required) Specifies the ID of the Function where the Event Subscription will receive events. This must be the functions ID in format {function_app.id}/functions/{name}.
 
@@ -119,7 +119,7 @@ An `azure_function_endpoint` supports the following:
 
 ---
 
-A `webhook_endpoint` supports the following:
+A `webhook_endpoint` block supports the following:
 
 * `url` - (Required) Specifies the url of the webhook where the Event Subscription will receive events.
 
@@ -135,7 +135,7 @@ A `webhook_endpoint` supports the following:
 
 ---
 
-A `subject_filter` supports the following:
+A `subject_filter` block supports the following:
 
 * `subject_begins_with` - (Optional) A string to filter events for an event subscription based on a resource path prefix.
 
@@ -181,7 +181,7 @@ OR
 
 ---
 
-A `delivery_identity` supports the following:
+A `delivery_identity` block supports the following:
 
 * `type` - (Required) Specifies the type of Managed Service Identity that is used for event delivery. Allowed value is `SystemAssigned`, `UserAssigned`.
 
@@ -189,7 +189,7 @@ A `delivery_identity` supports the following:
 
 ---
 
-A `delivery_property` supports the following:
+A `delivery_property` block supports the following:
 
 * `header_name` - (Required) The name of the header to send on to the destination
 
@@ -203,7 +203,7 @@ A `delivery_property` supports the following:
 
 ---
 
-A `dead_letter_identity` supports the following:
+A `dead_letter_identity` block supports the following:
 
 * `type` - (Required) Specifies the type of Managed Service Identity that is used for dead lettering. Allowed value is `SystemAssigned`, `UserAssigned`.
 
@@ -211,7 +211,7 @@ A `dead_letter_identity` supports the following:
 
 ---
 
-A `storage_blob_dead_letter_destination` supports the following:
+A `storage_blob_dead_letter_destination` block supports the following:
 
 * `storage_account_id` - (Required) Specifies the id of the storage account id where the storage blob is located.
 
@@ -219,7 +219,7 @@ A `storage_blob_dead_letter_destination` supports the following:
 
 ---
 
-A `retry_policy` supports the following:
+A `retry_policy` block supports the following:
 
 * `max_delivery_attempts` - (Required) Specifies the maximum number of delivery retry attempts for events.
 

--- a/website/docs/r/eventgrid_system_topic_event_subscription.html.markdown
+++ b/website/docs/r/eventgrid_system_topic_event_subscription.html.markdown
@@ -109,7 +109,7 @@ The following arguments are supported:
 
 ---
 
-A `storage_queue_endpoint` supports the following:
+A `storage_queue_endpoint` block supports the following:
 
 * `storage_account_id` - (Required) Specifies the id of the storage account id where the storage queue is located.
 
@@ -119,7 +119,7 @@ A `storage_queue_endpoint` supports the following:
 
 ---
 
-An `azure_function_endpoint` supports the following:
+An `azure_function_endpoint` block supports the following:
 
 * `function_id` - (Required) Specifies the ID of the Function where the Event Subscription will receive events. This must be the functions ID in format {function_app.id}/functions/{name}.
 
@@ -129,7 +129,7 @@ An `azure_function_endpoint` supports the following:
 
 ---
 
-A `webhook_endpoint` supports the following:
+A `webhook_endpoint` block supports the following:
 
 * `url` - (Required) Specifies the url of the webhook where the Event Subscription will receive events.
 
@@ -145,7 +145,7 @@ A `webhook_endpoint` supports the following:
 
 ---
 
-A `subject_filter` supports the following:
+A `subject_filter` block supports the following:
 
 * `subject_begins_with` - (Optional) A string to filter events for an event subscription based on a resource path prefix.
 
@@ -191,7 +191,7 @@ OR
 
 ---
 
-A `delivery_identity` supports the following:
+A `delivery_identity` block supports the following:
 
 * `type` - (Required) Specifies the type of Managed Service Identity that is used for event delivery. Allowed value is `SystemAssigned`, `UserAssigned`.
 
@@ -199,7 +199,7 @@ A `delivery_identity` supports the following:
 
 ---
 
-A `delivery_property` supports the following:
+A `delivery_property` block supports the following:
 
 ~> **NOTE:** `delivery_property` blocks are only effective when using an `azure_function_endpoint`, `eventhub_endpoint_id`, `hybrid_connection_endpoint_id`, `service_bus_topic_endpoint_id`, or `webhook_endpoint` endpoint specification.
 
@@ -215,7 +215,7 @@ A `delivery_property` supports the following:
 
 ---
 
-A `dead_letter_identity` supports the following:
+A `dead_letter_identity` block supports the following:
 
 * `type` - (Required) Specifies the type of Managed Service Identity that is used for dead lettering. Allowed value is `SystemAssigned`, `UserAssigned`.
 
@@ -223,7 +223,7 @@ A `dead_letter_identity` supports the following:
 
 ---
 
-A `storage_blob_dead_letter_destination` supports the following:
+A `storage_blob_dead_letter_destination` block supports the following:
 
 * `storage_account_id` - (Required) Specifies the id of the storage account id where the storage blob is located.
 
@@ -231,7 +231,7 @@ A `storage_blob_dead_letter_destination` supports the following:
 
 ---
 
-A `retry_policy` supports the following:
+A `retry_policy` block supports the following:
 
 * `max_delivery_attempts` - (Required) Specifies the maximum number of delivery retry attempts for events.
 

--- a/website/docs/r/eventgrid_topic.html.markdown
+++ b/website/docs/r/eventgrid_topic.html.markdown
@@ -72,7 +72,7 @@ A `identity` block supports the following:
 
 ---
 
-A `input_mapping_fields` supports the following:
+A `input_mapping_fields` block supports the following:
 
 * `id` - (Optional) Specifies the id of the EventGrid Event to associate with the domain. Changing this forces a new resource to be created.
 
@@ -88,7 +88,7 @@ A `input_mapping_fields` supports the following:
 
 ---
 
-A `input_mapping_default_values` supports the following:
+A `input_mapping_default_values` block supports the following:
 
 * `event_type` - (Optional) Specifies the default event type of the EventGrid Event to associate with the domain. Changing this forces a new resource to be created.
 

--- a/website/docs/r/eventhub.html.markdown
+++ b/website/docs/r/eventhub.html.markdown
@@ -79,6 +79,8 @@ A `capture_description` block supports the following:
 
 * `destination` - (Required) A `destination` block as defined below.
 
+---
+
 A `destination` block supports the following:
 
 * `name` - (Required) The Name of the Destination where the capture should take place. At this time the only supported value is `EventHubArchive.AzureBlockBlob`.

--- a/website/docs/r/express_route_circuit.html.markdown
+++ b/website/docs/r/express_route_circuit.html.markdown
@@ -71,7 +71,7 @@ The following arguments are supported:
 
 ---
 
-`sku` supports the following:
+The `sku` block supports the following:
 
 * `tier` - (Required) The service tier. Possible values are `Basic`, `Local`, `Standard` or `Premium`.
 

--- a/website/docs/r/firewall_policy.html.markdown
+++ b/website/docs/r/firewall_policy.html.markdown
@@ -161,17 +161,17 @@ A `traffic_bypass` block supports the following:
 
 A `explicit_proxy` block supports the following:
 
-* `enabled` (Optional) Whether the explicit proxy is enabled for this Firewall Policy.
+* `enabled` - (Optional) Whether the explicit proxy is enabled for this Firewall Policy.
 
-* `http_port` (Optional) The port number for explicit http protocol.
+* `http_port` - (Optional) The port number for explicit http protocol.
 
-* `https_port` (Optional) The port number for explicit proxy https protocol.
+* `https_port` - (Optional) The port number for explicit proxy https protocol.
 
-* `enable_pac_file` (Optional) Whether the pac file port and url need to be provided.
+* `enable_pac_file` - (Optional) Whether the pac file port and url need to be provided.
 
-* `pac_file_port` (Optional) Specifies a port number for firewall to serve PAC file.
+* `pac_file_port` - (Optional) Specifies a port number for firewall to serve PAC file.
 
-* `pac_file` (Optional) Specifies a SAS URL for PAC file.
+* `pac_file` - (Optional) Specifies a SAS URL for PAC file.
 
 ## Attributes Reference
 

--- a/website/docs/r/frontdoor_custom_https_configuration.html.markdown
+++ b/website/docs/r/frontdoor_custom_https_configuration.html.markdown
@@ -127,6 +127,8 @@ The following attributes are only valid if `certificate_source` is set to `Azure
 
 * `custom_https_configuration` - A `custom_https_configuration` block as defined below.
 
+---
+
 The `custom_https_configuration` block exports the following:
 
 * `minimum_tls_version` - Minimum client TLS version supported.

--- a/website/docs/r/function_app.html.markdown
+++ b/website/docs/r/function_app.html.markdown
@@ -247,7 +247,7 @@ The following arguments are supported:
 
 ---
 
-`connection_string` supports the following:
+The `connection_string` block supports the following:
 
 * `name` - (Required) The name of the Connection String. Changing this forces a new resource to be created.
 
@@ -257,7 +257,7 @@ The following arguments are supported:
 
 ---
 
-`site_config` supports the following:
+The `site_config` block supports the following:
 
 * `always_on` - (Optional) Should the Function App be loaded at all times? Defaults to `false`.
 

--- a/website/docs/r/function_app.html.markdown
+++ b/website/docs/r/function_app.html.markdown
@@ -371,7 +371,7 @@ An `active_directory` block supports the following:
 
 * `client_secret` - (Optional) The Client Secret of this relying party application. If no secret is provided, implicit flow will be used.
 
-* `allowed_audiences` (Optional) Allowed audience values to consider when validating JWTs issued by Azure Active Directory.
+* `allowed_audiences` - (Optional) Allowed audience values to consider when validating JWTs issued by Azure Active Directory.
 
 ---
 
@@ -381,7 +381,7 @@ A `facebook` block supports the following:
 
 * `app_secret` - (Required) The App Secret of the Facebook app used for Facebook login.
 
-* `oauth_scopes` (Optional) The OAuth 2.0 scopes that will be requested as part of Facebook login authentication. <https://developers.facebook.com/docs/facebook-login>
+* `oauth_scopes` - (Optional) The OAuth 2.0 scopes that will be requested as part of Facebook login authentication. <https://developers.facebook.com/docs/facebook-login>
 
 ---
 
@@ -391,7 +391,7 @@ A `google` block supports the following:
 
 * `client_secret` - (Required) The client secret associated with the Google web application.
 
-* `oauth_scopes` (Optional) The OAuth 2.0 scopes that will be requested as part of Google Sign-In authentication. <https://developers.google.com/identity/sign-in/web/>
+* `oauth_scopes` - (Optional) The OAuth 2.0 scopes that will be requested as part of Google Sign-In authentication. <https://developers.google.com/identity/sign-in/web/>
 
 ---
 
@@ -401,7 +401,7 @@ A `microsoft` block supports the following:
 
 * `client_secret` - (Required) The OAuth 2.0 client secret that was created for the app used for authentication.
 
-* `oauth_scopes` (Optional) The OAuth 2.0 scopes that will be requested as part of Microsoft Account authentication. <https://msdn.microsoft.com/en-us/library/dn631845.aspx>
+* `oauth_scopes` - (Optional) The OAuth 2.0 scopes that will be requested as part of Microsoft Account authentication. <https://msdn.microsoft.com/en-us/library/dn631845.aspx>
 
 ---
 

--- a/website/docs/r/function_app_slot.html.markdown
+++ b/website/docs/r/function_app_slot.html.markdown
@@ -312,6 +312,8 @@ The `identity` block exports the following:
 
 * `tenant_id` - The Tenant ID for the Service Principal associated with the Managed Service Identity of this App Service.
 
+---
+
 The `site_credential` block exports the following:
 
 * `username` - The username which can be used to publish to this App Service

--- a/website/docs/r/function_app_slot.html.markdown
+++ b/website/docs/r/function_app_slot.html.markdown
@@ -112,7 +112,7 @@ The following arguments are supported:
 
 ---
 
-`connection_string` supports the following:
+The `connection_string` block supports the following:
 
 * `name` - (Required) The name of the Connection String. Changing this forces a new resource to be created.
 * `type` - (Required) The type of the Connection String. Possible values are `APIHub`, `Custom`, `DocDb`, `EventHub`, `MySQL`, `NotificationHub`, `PostgreSQL`, `RedisCache`, `ServiceBus`, `SQLAzure` and  `SQLServer`.
@@ -120,7 +120,7 @@ The following arguments are supported:
 
 ---
 
-`site_config` supports the following:
+The `site_config` block supports the following:
 
 * `always_on` - (Optional) Should the Function App be loaded at all times? Defaults to `false`.
 

--- a/website/docs/r/function_app_slot.html.markdown
+++ b/website/docs/r/function_app_slot.html.markdown
@@ -214,7 +214,7 @@ An `active_directory` block supports the following:
 
 * `client_secret` - (Optional) The Client Secret of this relying party application. If no secret is provided, implicit flow will be used.
 
-* `allowed_audiences` (Optional) Allowed audience values to consider when validating JWTs issued by Azure Active Directory.
+* `allowed_audiences` - (Optional) Allowed audience values to consider when validating JWTs issued by Azure Active Directory.
 
 ---
 
@@ -224,7 +224,7 @@ A `facebook` block supports the following:
 
 * `app_secret` - (Required) The App Secret of the Facebook app used for Facebook login.
 
-* `oauth_scopes` (Optional) The OAuth 2.0 scopes that will be requested as part of Facebook login authentication. <https://developers.facebook.com/docs/facebook-login>
+* `oauth_scopes` - (Optional) The OAuth 2.0 scopes that will be requested as part of Facebook login authentication. <https://developers.facebook.com/docs/facebook-login>
 
 ---
 
@@ -234,7 +234,7 @@ A `google` block supports the following:
 
 * `client_secret` - (Required) The client secret associated with the Google web application.
 
-* `oauth_scopes` (Optional) The OAuth 2.0 scopes that will be requested as part of Google Sign-In authentication. <https://developers.google.com/identity/sign-in/web/>
+* `oauth_scopes` - (Optional) The OAuth 2.0 scopes that will be requested as part of Google Sign-In authentication. <https://developers.google.com/identity/sign-in/web/>
 
 ---
 
@@ -244,7 +244,7 @@ A `microsoft` block supports the following:
 
 * `client_secret` - (Required) The OAuth 2.0 client secret that was created for the app used for authentication.
 
-* `oauth_scopes` (Optional) The OAuth 2.0 scopes that will be requested as part of Microsoft Account authentication. <https://msdn.microsoft.com/en-us/library/dn631845.aspx>
+* `oauth_scopes` - (Optional) The OAuth 2.0 scopes that will be requested as part of Microsoft Account authentication. <https://msdn.microsoft.com/en-us/library/dn631845.aspx>
 
 ---
 

--- a/website/docs/r/healthcare_dicom.html.markdown
+++ b/website/docs/r/healthcare_dicom.html.markdown
@@ -67,7 +67,7 @@ The following attributes are exported:
 * `service_url` - The url of the Healthcare DICOM Services.
 
 ---
-An `authentication` supports the following:
+An `authentication` block supports the following:
 
 * `authority` - The Azure Active Directory (tenant) that serves as the authentication authority to access the service. The default authority is the Directory defined in the authentication scheme in use when running Terraform.
   Authority must be registered to Azure AD and in the following format: <https://{Azure-AD-endpoint}/{tenant-id>}.

--- a/website/docs/r/healthcare_fhir_service.html.markdown
+++ b/website/docs/r/healthcare_fhir_service.html.markdown
@@ -102,7 +102,7 @@ A `cors` block supports the following:
 * `credentials_allowed` - (Optional) If credentials are allowed via CORS.
 
 ---
-An `authentication` supports the following:
+An `authentication` block supports the following:
 
 * `authority` - (Required) The Azure Active Directory (tenant) that serves as the authentication authority to access the service. The default authority is the Directory defined in the authentication scheme in use when running Terraform.
   Authority must be registered to Azure AD and in the following format: <https://{Azure-AD-endpoint}/{tenant-id>}.

--- a/website/docs/r/healthcare_service.html.markdown
+++ b/website/docs/r/healthcare_service.html.markdown
@@ -69,7 +69,7 @@ The following arguments are supported:
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ---
-An `authentication_configuration` supports the following:
+An `authentication_configuration` block supports the following:
 
 * `authority` - (Optional) The Azure Active Directory (tenant) that serves as the authentication authority to access the service. The default authority is the Directory defined in the authentication scheme in use when running Terraform.
 Authority must be registered to Azure AD and in the following format: <https://{Azure-AD-endpoint}/{tenant-id>}.

--- a/website/docs/r/image.html.markdown
+++ b/website/docs/r/image.html.markdown
@@ -115,7 +115,9 @@ The following arguments are supported:
 
 ~> **Note:** `zone_resilient` can only be set to `true` if the image is stored in a region that supports availability zones.
 
-`os_disk` supports the following:
+---
+
+The `os_disk` block supports the following:
 
 * `os_type` - (Required) Specifies the type of operating system contained in the virtual machine image. Possible values are: Windows or Linux.
 * `os_state` - (Required) Specifies the state of the operating system contained in the blob. Currently, the only value is Generalized.
@@ -124,7 +126,9 @@ The following arguments are supported:
 * `caching` - (Optional) Specifies the caching mode as `ReadWrite`, `ReadOnly`, or `None`. The default is `None`.
 * `size_gb` - (Optional) Specifies the size of the image to be created. The target size can't be smaller than the source size.
 
-`data_disk` supports the following:
+---
+
+The `data_disk` block supports the following:
 
 * `lun` - (Required) Specifies the logical unit number of the data disk.
 * `managed_disk_id` - (Optional) Specifies the ID of the managed disk resource that you want to use to create the image.

--- a/website/docs/r/key_vault_certificate.html.markdown
+++ b/website/docs/r/key_vault_certificate.html.markdown
@@ -246,12 +246,14 @@ The following arguments are supported:
 
 ---
 
-`certificate` supports the following:
+The `certificate` block supports the following:
 
 * `contents` - (Required) The base64-encoded certificate contents.
 * `password` - (Optional) The password associated with the certificate.
 
-`certificate_policy` supports the following:
+---
+
+The `certificate_policy` block supports the following:
 
 * `issuer_parameters` - (Required) A `issuer_parameters` block as defined below.
 * `key_properties` - (Required) A `key_properties` block as defined below.
@@ -259,11 +261,15 @@ The following arguments are supported:
 * `secret_properties` - (Required) A `secret_properties` block as defined below.
 * `x509_certificate_properties` - (Optional) A `x509_certificate_properties` block as defined below. Required when `certificate` block is not specified.
 
-`issuer_parameters` supports the following:
+---
+
+The `issuer_parameters` block supports the following:
 
 * `name` - (Required) The name of the Certificate Issuer. Possible values include `Self` (for self-signed certificate), or `Unknown` (for a certificate issuing authority like `Let's Encrypt` and Azure direct supported ones). Changing this forces a new resource to be created.
 
-`key_properties` supports the following:
+---
+
+The `key_properties` block supports the following:
 
 * `curve` - (Optional) Specifies the curve to use when creating an `EC` key. Possible values are `P-256`, `P-256K`, `P-384`, and `P-521`. This field will be required in a future release if `key_type` is `EC` or `EC-HSM`. Changing this forces a new resource to be created.
 * `exportable` - (Required) Is this certificate exportable? Changing this forces a new resource to be created.
@@ -271,25 +277,35 @@ The following arguments are supported:
 * `key_type` - (Required) Specifies the type of key, such as `RSA` or `EC`. Changing this forces a new resource to be created.
 * `reuse_key` - (Required) Is the key reusable? Changing this forces a new resource to be created.
 
-`lifetime_action` supports the following:
+---
+
+The `lifetime_action` block supports the following:
 
 * `action` - (Required) A `action` block as defined below.
 * `trigger` - (Required) A `trigger` block as defined below.
 
-`action` supports the following:
+---
+
+The `action` block supports the following:
 
 * `action_type` - (Required) The Type of action to be performed when the lifetime trigger is triggerec. Possible values include `AutoRenew` and `EmailContacts`. Changing this forces a new resource to be created.
 
-`trigger` supports the following:
+---
+
+The `trigger` block supports the following:
 
 * `days_before_expiry` - (Optional) The number of days before the Certificate expires that the action associated with this Trigger should run. Changing this forces a new resource to be created. Conflicts with `lifetime_percentage`.
 * `lifetime_percentage` - (Optional) The percentage at which during the Certificates Lifetime the action associated with this Trigger should run. Changing this forces a new resource to be created. Conflicts with `days_before_expiry`.
 
-`secret_properties` supports the following:
+---
+
+The `secret_properties` block supports the following:
 
 * `content_type` - (Required) The Content-Type of the Certificate, such as `application/x-pkcs12` for a PFX or `application/x-pem-file` for a PEM. Changing this forces a new resource to be created.
 
-`x509_certificate_properties` supports the following:
+---
+
+The `x509_certificate_properties` block supports the following:
 
 * `extended_key_usage` - (Optional) A list of Extended/Enhanced Key Usages. Changing this forces a new resource to be created.
 * `key_usage` - (Required) A list of uses associated with this Key. Possible values include `cRLSign`, `dataEncipherment`, `decipherOnly`, `digitalSignature`, `encipherOnly`, `keyAgreement`, `keyCertSign`, `keyEncipherment` and `nonRepudiation` and are case-sensitive. Changing this forces a new resource to be created.
@@ -297,7 +313,9 @@ The following arguments are supported:
 * `subject_alternative_names` - (Optional) A `subject_alternative_names` block as defined below.
 * `validity_in_months` - (Required) The Certificates Validity Period in Months. Changing this forces a new resource to be created.
 
-`subject_alternative_names` supports the following:
+---
+
+The `subject_alternative_names` block supports the following:
 
 * `dns_names` - (Optional) A list of alternative DNS names (FQDNs) identified by the Certificate. Changing this forces a new resource to be created.
 * `emails` - (Optional) A list of email addresses identified by this Certificate. Changing this forces a new resource to be created.

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -95,7 +95,7 @@ In addition, one of either `identity` or `service_principal` blocks must be spec
 
 * `auto_scaler_profile` - (Optional) A `auto_scaler_profile` block as defined below.
 
-* `azure_active_directory_role_based_access_control` - - (Optional) A `azure_active_directory_role_based_access_control` block as defined below.
+* `azure_active_directory_role_based_access_control` - (Optional) A `azure_active_directory_role_based_access_control` block as defined below.
 
 * `azure_policy_enabled` - (Optional) Should the Azure Policy Add-On be enabled? For more details please visit [Understand Azure Policy for Azure Kubernetes Service](https://docs.microsoft.com/en-ie/azure/governance/policy/concepts/rego-for-aks)
 
@@ -127,7 +127,7 @@ In addition, one of either `identity` or `service_principal` blocks must be spec
 
 * `linux_profile` - (Optional) A `linux_profile` block as defined below.
 
-* `local_account_disabled` - - (Optional) If `true` local accounts will be disabled. Defaults to `false`. See [the documentation](https://docs.microsoft.com/azure/aks/managed-aad#disable-local-accounts) for more information.
+* `local_account_disabled` - (Optional) If `true` local accounts will be disabled. Defaults to `false`. See [the documentation](https://docs.microsoft.com/azure/aks/managed-aad#disable-local-accounts) for more information.
 
 -> **Note:** If `local_account_disabled` is set to `true`, it is required to enable Kubernetes RBAC and AKS-managed Azure AD integration. See [the documentation](https://docs.microsoft.com/azure/aks/managed-aad#azure-ad-authentication-overview) for more information.
 
@@ -711,8 +711,6 @@ A `sysctl_config` block supports the following:
 A `web_app_routing` block supports the following:
 
 * `dns_zone_id` - (Required) Specifies the ID of the DNS Zone in which DNS entries are created for applications deployed to the cluster when Web App Routing is enabled.
-
- ---
 
 ---
 

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -95,7 +95,7 @@ In addition, one of either `identity` or `service_principal` blocks must be spec
 
 * `auto_scaler_profile` - (Optional) A `auto_scaler_profile` block as defined below.
 
-* `azure_active_directory_role_based_access_control` - (Optional) - A `azure_active_directory_role_based_access_control` block as defined below.
+* `azure_active_directory_role_based_access_control` - - (Optional) A `azure_active_directory_role_based_access_control` block as defined below.
 
 * `azure_policy_enabled` - (Optional) Should the Azure Policy Add-On be enabled? For more details please visit [Understand Azure Policy for Azure Kubernetes Service](https://docs.microsoft.com/en-ie/azure/governance/policy/concepts/rego-for-aks)
 
@@ -127,7 +127,7 @@ In addition, one of either `identity` or `service_principal` blocks must be spec
 
 * `linux_profile` - (Optional) A `linux_profile` block as defined below.
 
-* `local_account_disabled` - (Optional) - If `true` local accounts will be disabled. Defaults to `false`. See [the documentation](https://docs.microsoft.com/azure/aks/managed-aad#disable-local-accounts) for more information.
+* `local_account_disabled` - - (Optional) If `true` local accounts will be disabled. Defaults to `false`. See [the documentation](https://docs.microsoft.com/azure/aks/managed-aad#disable-local-accounts) for more information.
 
 -> **Note:** If `local_account_disabled` is set to `true`, it is required to enable Kubernetes RBAC and AKS-managed Azure AD integration. See [the documentation](https://docs.microsoft.com/azure/aks/managed-aad#azure-ad-authentication-overview) for more information.
 
@@ -213,7 +213,7 @@ resource "azurerm_kubernetes_cluster" "example" {
 
 -> **Note:** When `public_network_access_enabled` is set to `true`, `0.0.0.0/32` must be added to `api_server_authorized_ip_ranges`.
 
-* `role_based_access_control_enabled` (Optional) - Whether Role Based Access Control for the Kubernetes Cluster should be enabled. Defaults to `true`. Changing this forces a new resource to be created.
+* `role_based_access_control_enabled` - (Optional) Whether Role Based Access Control for the Kubernetes Cluster should be enabled. Defaults to `true`. Changing this forces a new resource to be created.
 
 * `run_command_enabled` - (Optional) Whether to enable run command for the cluster or not. Defaults to `true`.
 
@@ -713,6 +713,8 @@ A `web_app_routing` block supports the following:
 * `dns_zone_id` - (Required) Specifies the ID of the DNS Zone in which DNS entries are created for applications deployed to the cluster when Web App Routing is enabled.
 
  ---
+
+---
 
 A `windows_profile` block supports the following:
 

--- a/website/docs/r/lb.html.markdown
+++ b/website/docs/r/lb.html.markdown
@@ -60,7 +60,9 @@ The following arguments are supported:
 * `sku_tier` - (Optional) `sku_tier` - (Optional) The SKU tier of this Load Balancer. Possible values are `Global` and `Regional`. Defaults to `Regional`. Changing this forces a new resource to be created.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
-`frontend_ip_configuration` supports the following:
+---
+
+The `frontend_ip_configuration` block supports the following:
 
 * `name` - (Required) Specifies the name of the frontend IP configuration. Changing this forces a new resource to be created.
 

--- a/website/docs/r/linux_virtual_machine.html.markdown
+++ b/website/docs/r/linux_virtual_machine.html.markdown
@@ -326,7 +326,7 @@ A `secret` block supports the following:
 
 ---
 
-`source_image_reference` supports the following:
+The `source_image_reference` block supports the following:
 
 * `publisher` - (Optional) Specifies the publisher of the image used to create the virtual machines.
 

--- a/website/docs/r/linux_virtual_machine.html.markdown
+++ b/website/docs/r/linux_virtual_machine.html.markdown
@@ -278,7 +278,7 @@ A `os_disk` block supports the following:
 
 * `storage_account_type` - (Required) The Type of Storage Account which should back this the Internal OS Disk. Possible values are `Standard_LRS`, `StandardSSD_LRS`, `Premium_LRS`, `StandardSSD_ZRS` and `Premium_ZRS`. Changing this forces a new resource to be created.
 
-* `diff_disk_settings` (Optional) A `diff_disk_settings` block as defined above. Changing this forces a new resource to be created.
+* `diff_disk_settings` - (Optional) A `diff_disk_settings` block as defined above. Changing this forces a new resource to be created.
 
 -> **NOTE:** `diff_disk_settings` can only be set when `caching` is set to `ReadOnly`. More information can be found [here](https://docs.microsoft.com/azure/virtual-machines/ephemeral-os-disks-deploy#vm-template-deployment)
 

--- a/website/docs/r/local_network_gateway.html.markdown
+++ b/website/docs/r/local_network_gateway.html.markdown
@@ -53,7 +53,7 @@ The following arguments are supported:
 
 ---
 
-`bgp_settings` supports the following:
+The `bgp_settings` block supports the following:
 
 * `asn` - (Required) The BGP speaker's ASN.
 

--- a/website/docs/r/logic_app_standard.html.markdown
+++ b/website/docs/r/logic_app_standard.html.markdown
@@ -163,7 +163,7 @@ The following arguments are supported:
 
 ---
 
-`connection_string` supports the following:
+The `connection_string` block supports the following:
 
 * `name` - (Required) The name of the Connection String. Changing this forces a new resource to be created.
 
@@ -173,7 +173,7 @@ The following arguments are supported:
 
 ---
 
-`site_config` supports the following:
+The `site_config` block supports the following:
 
 * `always_on` - (Optional) Should the Logic App be loaded at all times? Defaults to `false`.
 

--- a/website/docs/r/managed_disk.html.markdown
+++ b/website/docs/r/managed_disk.html.markdown
@@ -146,7 +146,7 @@ The following arguments are supported:
 
 -> **Note:** Premium SSD maxShares limit: `P15` and `P20` disks: 2. `P30`,`P40`,`P50` disks: 5. `P60`,`P70`,`P80` disks: 10. For ultra disks the `max_shares` minimum value is 1 and the maximum is 5.
 
-* `trusted_launch_enabled` (Optional) Specifies if Trusted Launch is enabled for the Managed Disk. Defaults to `false`. Changing this forces a new resource to be created.
+* `trusted_launch_enabled` - (Optional) Specifies if Trusted Launch is enabled for the Managed Disk. Defaults to `false`. Changing this forces a new resource to be created.
 
 -> **Note:** Trusted Launch can only be enabled when `create_option` is `FromImage` or `Import`.
 
@@ -160,7 +160,7 @@ The following arguments are supported:
 
 ~> **NOTE:** `secure_vm_disk_encryption_set_id` can only be specified when `security_type` is set to `ConfidentialVM_DiskEncryptedWithCustomerKey`.
 
-* `on_demand_bursting_enabled` (Optional) Specifies if On-Demand Bursting is enabled for the Managed Disk. Defaults to `false`.
+* `on_demand_bursting_enabled` - (Optional) Specifies if On-Demand Bursting is enabled for the Managed Disk. Defaults to `false`.
 
 -> **Note:** Credit-Based Bursting is enabled by default on all eligible disks. More information on [Credit-Based and On-Demand Bursting can be found in the documentation](https://docs.microsoft.com/azure/virtual-machines/disk-bursting#disk-level-bursting).
 

--- a/website/docs/r/monitor_action_group.html.markdown
+++ b/website/docs/r/monitor_action_group.html.markdown
@@ -139,7 +139,7 @@ The following arguments are supported:
 
 ---
 
-`arm_role_receiver` supports the following:
+The `arm_role_receiver` block supports the following:
 
 * `name` - (Required) The name of the ARM role receiver. Changing this forces a new resource to be created.
 * `role_id` - (Required) The arm role id.
@@ -147,7 +147,7 @@ The following arguments are supported:
 
 ---
 
-`automation_runbook_receiver` supports the following:
+The `automation_runbook_receiver` block supports the following:
 
 * `name` - (Required) The name of the automation runbook receiver. Changing this forces a new resource to be created.
 * `automation_account_id` - (Required) The automation account ID which holds this runbook and authenticates to Azure resources.
@@ -159,14 +159,14 @@ The following arguments are supported:
 
 ---
 
-`azure_app_push_receiver` supports the following:
+The `azure_app_push_receiver` block supports the following:
 
 * `name` - (Required) The name of the Azure app push receiver. Changing this forces a new resource to be created.
 * `email_address` - (Required) The email address of the user signed into the mobile app who will receive push notifications from this receiver.
 
 ---
 
-`azure_function_receiver` supports the following:
+The `azure_function_receiver` block supports the following:
 
 * `name` - (Required) The name of the Azure Function receiver. Changing this forces a new resource to be created.
 * `function_app_resource_id` - (Required) The Azure resource ID of the function app.
@@ -176,7 +176,7 @@ The following arguments are supported:
 
 ---
 
-`email_receiver` supports the following:
+The `email_receiver` block supports the following:
 
 * `name` - (Required) The name of the email receiver. Names must be unique (case-insensitive) across all receivers within an action group. Changing this forces a new resource to be created.
 * `email_address` - (Required) The email address of this receiver.
@@ -184,7 +184,7 @@ The following arguments are supported:
 
 ---
 
-`event_hub_receiver` supports the following:
+The `event_hub_receiver` block supports the following:
 
 * `name` - (Required) The name of the EventHub Receiver, must be unique within action group. Changing this forces a new resource to be created.
 * `event_hub_id` - (Optional) The resource ID of the respective Event Hub.
@@ -199,7 +199,7 @@ The following arguments are supported:
 
 ---
 
-`itsm_receiver` supports the following:
+The `itsm_receiver` block supports the following:
 
 * `name` - (Required) The name of the ITSM receiver. Changing this forces a new resource to be created.
 * `workspace_id` - (Required) The Azure Log Analytics workspace ID where this connection is defined. Format is `<subscription id>|<workspace id>`, for example `00000000-0000-0000-0000-000000000000|00000000-0000-0000-0000-000000000000`.
@@ -211,7 +211,7 @@ The following arguments are supported:
 
 ---
 
-`logic_app_receiver` supports the following:
+The `logic_app_receiver` block supports the following:
 
 * `name` - (Required) The name of the logic app receiver. Changing this forces a new resource to be created.
 * `resource_id` - (Required) The Azure resource ID of the logic app.
@@ -220,7 +220,7 @@ The following arguments are supported:
 
 ---
 
-`sms_receiver` supports the following:
+The `sms_receiver` block supports the following:
 
 * `name` - (Required) The name of the SMS receiver. Names must be unique (case-insensitive) across all receivers within an action group. Changing this forces a new resource to be created.
 * `country_code` - (Required) The country code of the SMS receiver.
@@ -228,7 +228,7 @@ The following arguments are supported:
 
 ---
 
-`voice_receiver` supports the following:
+The `voice_receiver` block supports the following:
 
 * `name` - (Required) The name of the voice receiver. Changing this forces a new resource to be created.
 * `country_code` - (Required) The country code of the voice receiver.
@@ -236,7 +236,7 @@ The following arguments are supported:
 
 ---
 
-`webhook_receiver` supports the following:
+The `webhook_receiver` block supports the following:
 
 * `name` - (Required) The name of the webhook receiver. Names must be unique (case-insensitive) across all receivers within an action group. Changing this forces a new resource to be created.
 * `service_uri` - (Required) The URI where webhooks should be sent.
@@ -245,7 +245,9 @@ The following arguments are supported:
 
 ~> **NOTE:** Before adding a secure webhook receiver by setting `aad_auth`, please read [the configuration instruction of the AAD application](https://docs.microsoft.com/azure/azure-monitor/platform/action-groups#secure-webhook).
 
-`aad_auth` supports the following:.
+---
+
+The `aad_auth` block supports the following:.
 
 * `object_id` - (Required) The webhook application object Id for AAD auth.
 * `identifier_uri` - (Optional) The identifier URI for AAD auth.

--- a/website/docs/r/monitor_activity_log_alert.html.markdown
+++ b/website/docs/r/monitor_activity_log_alert.html.markdown
@@ -103,17 +103,17 @@ A `criteria` block supports the following:
 
 A `resource_health` block supports the following:
 
-* `current` (Optional) The current resource health statuses that will log an alert. Possible values are `Available`, `Degraded`, `Unavailable` and `Unknown`.
-* `previous` (Optional) The previous resource health statuses that will log an alert. Possible values are `Available`, `Degraded`, `Unavailable` and `Unknown`.
-* `reason` (Optional)  The reason that will log an alert. Possible values are `PlatformInitiated` (such as a problem with the resource in an affected region of an Azure incident), `UserInitiated` (such as a shutdown request of a VM) and `Unknown`.
+* `current` - (Optional) The current resource health statuses that will log an alert. Possible values are `Available`, `Degraded`, `Unavailable` and `Unknown`.
+* `previous` - (Optional) The previous resource health statuses that will log an alert. Possible values are `Available`, `Degraded`, `Unavailable` and `Unknown`.
+* `reason` - (Optional)  The reason that will log an alert. Possible values are `PlatformInitiated` (such as a problem with the resource in an affected region of an Azure incident), `UserInitiated` (such as a shutdown request of a VM) and `Unknown`.
 
 ---
 
 A `service_health` block supports the following:
 
-* `events` (Optional) Events this alert will monitor Possible values are `Incident`, `Maintenance`, `Informational`, `ActionRequired` and `Security`.
-* `locations` (Optional) Locations this alert will monitor. For example, `West Europe`. Defaults to `Global`.
-* `services` (Optional) Services this alert will monitor. For example, `Activity Logs & Alerts`, `Action Groups`. Defaults to all Services.
+* `events` - (Optional) Events this alert will monitor Possible values are `Incident`, `Maintenance`, `Informational`, `ActionRequired` and `Security`.
+* `locations` - (Optional) Locations this alert will monitor. For example, `West Europe`. Defaults to `Global`.
+* `services` - (Optional) Services this alert will monitor. For example, `Activity Logs & Alerts`, `Action Groups`. Defaults to all Services.
 
 ## Attributes Reference
 

--- a/website/docs/r/monitor_autoscale_setting.html.markdown
+++ b/website/docs/r/monitor_autoscale_setting.html.markdown
@@ -522,7 +522,7 @@ A `fixed_date` block supports the following:
 
 * `start` - (Required) Specifies the start date for the profile, formatted as an RFC3339 date string.
 
-* `timezone` (Optional) The Time Zone of the `start` and `end` times. A list of [possible values can be found here](https://msdn.microsoft.com/en-us/library/azure/dn931928.aspx). Defaults to `UTC`.
+* `timezone` - (Optional) The Time Zone of the `start` and `end` times. A list of [possible values can be found here](https://msdn.microsoft.com/en-us/library/azure/dn931928.aspx). Defaults to `UTC`.
 
 ---
 

--- a/website/docs/r/monitor_scheduled_query_rules_alert.html.markdown
+++ b/website/docs/r/monitor_scheduled_query_rules_alert.html.markdown
@@ -125,7 +125,7 @@ The following arguments are supported:
 
 ---
 
-`action` supports the following:
+The `action` block supports the following:
 
 * `action_group` - (Required) List of action group reference resource IDs.
 * `custom_webhook_payload` - (Optional) Custom payload to be sent for all webhook payloads in alerting action.
@@ -133,7 +133,7 @@ The following arguments are supported:
 
 ---
 
-`metric_trigger` supports the following:
+The `metric_trigger` block supports the following:
 
 * `metric_column` - (Required) Evaluation of metric on a particular column.
 * `metric_trigger_type` - (Required) Metric Trigger Type - 'Consecutive' or 'Total'.
@@ -142,7 +142,7 @@ The following arguments are supported:
 
 ---
 
-`trigger` supports the following:
+The `trigger` block supports the following:
 
 * `metric_trigger` - (Optional) A `metric_trigger` block as defined above. Trigger condition for metric query rule.
 * `operator` - (Required) Evaluation operation for rule - 'GreaterThan', GreaterThanOrEqual', 'LessThan', or 'LessThanOrEqual'.

--- a/website/docs/r/monitor_scheduled_query_rules_log.html.markdown
+++ b/website/docs/r/monitor_scheduled_query_rules_log.html.markdown
@@ -97,14 +97,14 @@ The following arguments are supported:
 
 ---
 
-`criteria` supports the following:
+The `criteria` block supports the following:
 
 * `dimension` - (Required) A `dimension` block as defined below.
 * `metric_name` - (Required) Name of the metric.  Supported metrics are listed in the Azure Monitor [Microsoft.OperationalInsights/workspaces](https://docs.microsoft.com/azure/azure-monitor/platform/metrics-supported#microsoftoperationalinsightsworkspaces) metrics namespace.
 
 ---
 
-`dimension` supports the following:
+The `dimension` block supports the following:
 
 * `name` - (Required) Name of the dimension. Changing this forces a new resource to be created.
 * `operator` - (Required) Operator for dimension values, - 'Include'.

--- a/website/docs/r/mssql_elasticpool.html.markdown
+++ b/website/docs/r/mssql_elasticpool.html.markdown
@@ -83,7 +83,7 @@ The following arguments are supported:
 
 ---
 
-`sku` supports the following:
+The `sku` block supports the following:
 
 * `name` - (Required) Specifies the SKU Name for this Elasticpool. The name of the SKU, will be either `vCore` based `tier` + `family` pattern (e.g. GP_Gen4, BC_Gen5) or the `DTU` based `BasicPool`, `StandardPool`, or `PremiumPool` pattern. Changing this forces a new resource to be created.
 
@@ -95,7 +95,7 @@ The following arguments are supported:
 
 ---
 
-`per_database_settings` supports the following:
+The `per_database_settings` block supports the following:
 
 * `min_capacity` - (Required) The minimum capacity all databases are guaranteed.
 

--- a/website/docs/r/mssql_managed_instance_vulnerability_assessment.html.markdown
+++ b/website/docs/r/mssql_managed_instance_vulnerability_assessment.html.markdown
@@ -108,7 +108,7 @@ The following arguments are supported:
 
 ---
 
-`recurring_scans` supports the following:
+The `recurring_scans` block supports the following:
 
 * `enabled` - (Optional) Boolean flag which specifies if recurring scans is enabled or disabled. Defaults to `false`.
 * `email_subscription_admins` - (Optional) Boolean flag which specifies if the schedule scan notification will be sent to the subscription administrators. Defaults to `true`.

--- a/website/docs/r/mssql_server_vulnerability_assessment.html.markdown
+++ b/website/docs/r/mssql_server_vulnerability_assessment.html.markdown
@@ -86,7 +86,7 @@ The following arguments are supported:
 
 ---
 
-`recurring_scans` supports the following:
+The `recurring_scans` block supports the following:
 
 * `enabled` - (Optional) Boolean flag which specifies if recurring scans is enabled or disabled. Defaults to `false`.
 * `email_subscription_admins` - (Optional) Boolean flag which specifies if the schedule scan notification will be sent to the subscription administrators. Defaults to `false`.

--- a/website/docs/r/mssql_virtual_machine.html.markdown
+++ b/website/docs/r/mssql_virtual_machine.html.markdown
@@ -45,7 +45,7 @@ The following arguments are supported:
 
 * `sql_license_type` - (Required) The SQL Server license type. Possible values are `AHUB` (Azure Hybrid Benefit), `DR` (Disaster Recovery), and `PAYG` (Pay-As-You-Go). Changing this forces a new resource to be created.
 
-* `auto_backup` (Optional) An `auto_backup` block as defined below. This block can be added to an existing resource, but removing this block forces a new resource to be created.
+* `auto_backup` - (Optional) An `auto_backup` block as defined below. This block can be added to an existing resource, but removing this block forces a new resource to be created.
 
 * `auto_patching` - (Optional) An `auto_patching` block as defined below.
 

--- a/website/docs/r/network_packet_capture.html.markdown
+++ b/website/docs/r/network_packet_capture.html.markdown
@@ -150,6 +150,8 @@ A `storage_location` block contains:
 
 ~> **NOTE:** At least one of `file_path` or `storage_account_id` must be specified.
 
+---
+
 A `filter` block contains:
 
 * `local_ip_address` - (Optional) The local IP Address to be filtered on. Notation: "127.0.0.1" for single address entry. "127.0.0.1-127.0.0.255" for range. "127.0.0.1;127.0.0.5" for multiple entries. Multiple ranges not currently supported. Mixing ranges with multiple entries not currently supported. Changing this forces a new resource to be created.

--- a/website/docs/r/network_watcher_flow_log.html.markdown
+++ b/website/docs/r/network_watcher_flow_log.html.markdown
@@ -103,14 +103,14 @@ The following arguments are supported:
 
 ---
 
-* `retention_policy` supports the following:
+The `retention_policy` block supports the following:
 
 * `enabled` - (Required) Boolean flag to enable/disable retention.
 * `days` - (Required) The number of days to retain flow log records.
 
 ---
 
-* `traffic_analytics` supports the following:
+The `traffic_analytics` block supports the following:
 
 * `enabled` - (Required) Boolean flag to enable/disable traffic analytics.
 * `workspace_id` - (Required) The resource GUID of the attached workspace.

--- a/website/docs/r/private_endpoint.html.markdown
+++ b/website/docs/r/private_endpoint.html.markdown
@@ -152,7 +152,7 @@ The following arguments are supported:
 
 ---
 
-A `private_dns_zone_group` supports the following:
+A `private_dns_zone_group` block supports the following:
 
 * `name` - (Required) Specifies the Name of the Private DNS Zone Group. Changing this forces a new `private_dns_zone_group` resource to be created.
 
@@ -160,7 +160,7 @@ A `private_dns_zone_group` supports the following:
 
 ---
 
-A `private_service_connection` supports the following:
+A `private_service_connection` block supports the following:
 
 * `name` - (Required) Specifies the Name of the Private Service Connection. Changing this forces a new resource to be created.
 
@@ -195,7 +195,7 @@ Some resource types (such as Storage Account) only support 1 subresource per pri
 
 ---
 
-An `ip_configuration` supports the following:
+An `ip_configuration` block supports the following:
 
 * `name` - (Required) Specifies the Name of the IP Configuration. Changing this forces a new resource to be created. 
 

--- a/website/docs/r/sentinel_alert_rule_fusion.html.markdown
+++ b/website/docs/r/sentinel_alert_rule_fusion.html.markdown
@@ -57,7 +57,7 @@ The following arguments are supported:
 
 * `enabled` - (Optional) Should this Sentinel Fusion Alert Rule be enabled? Defaults to `true`.
 
-* `source` (Optional) One or more `source` blocks as defined below.
+* `source` - (Optional) One or more `source` blocks as defined below.
 
 ---
 

--- a/website/docs/r/servicebus_namespace.html.markdown
+++ b/website/docs/r/servicebus_namespace.html.markdown
@@ -78,6 +78,8 @@ An `identity` block supports the following:
 
 -> **Note:** Once customer-managed key encryption has been enabled, it cannot be disabled.
 
+---
+
 A `customer_managed_key` block supports the following:
 
 * `key_vault_key_id` - (Required) The ID of the Key Vault Key which should be used to Encrypt the data in this ServiceBus Namespace.

--- a/website/docs/r/servicebus_subscription_rule.html.markdown
+++ b/website/docs/r/servicebus_subscription_rule.html.markdown
@@ -113,7 +113,9 @@ The following arguments are supported:
 
 * `action` - (Optional) Represents set of actions written in SQL language-based syntax that is performed against a BrokeredMessage.
 
-`correlation_filter` supports the following:
+---
+
+The `correlation_filter` block supports the following:
 
 * `content_type` - (Optional) Content type of the message.
 

--- a/website/docs/r/spring_cloud_service.html.markdown
+++ b/website/docs/r/spring_cloud_service.html.markdown
@@ -172,7 +172,7 @@ The following attributes are exported:
 
 ---
 
-The `required_network_traffic_rules` supports the following:
+The `required_network_traffic_rules` block supports the following:
 
 * `direction` - The direction of required traffic. Possible values are `Inbound`, `Outbound`.
 

--- a/website/docs/r/sql_database.html.markdown
+++ b/website/docs/r/sql_database.html.markdown
@@ -108,7 +108,9 @@ The following arguments are supported:
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
-`import` supports the following:
+---
+
+The `import` block supports the following:
 
 * `storage_uri` - (Required) Specifies the blob URI of the .bacpac file.
 * `storage_key` - (Required) Specifies the access key for the storage account.
@@ -120,7 +122,7 @@ The following arguments are supported:
 
 ---
 
-`threat_detection_policy` supports the following:
+The `threat_detection_policy` block supports the following:
 
 * `state` - (Required) The State of the Policy. Possible values are `Enabled`, `Disabled` or `New`.
 * `disabled_alerts` - (Optional) Specifies a list of alerts which should be disabled. Possible values include `Access_Anomaly`, `Sql_Injection` and `Sql_Injection_Vulnerability`.

--- a/website/docs/r/sql_failover_group.html.markdown
+++ b/website/docs/r/sql_failover_group.html.markdown
@@ -83,17 +83,23 @@ The following arguments are supported:
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
-`partner_servers` supports the following:
+---
+
+The `partner_servers` block supports the following:
 
 * `id` - (Required) the SQL server ID
 
-`read_write_endpoint_failover_policy` supports the following:
+---
+
+The `read_write_endpoint_failover_policy` block supports the following:
 
 * `mode` - (Required) the failover mode. Possible values are `Manual`, `Automatic`
 
 * `grace_minutes` - Applies only if `mode` is `Automatic`. The grace period in minutes before failover with data loss is attempted
 
-`readonly_endpoint_failover_policy` supports the following:
+---
+
+The `readonly_endpoint_failover_policy` block supports the following:
 
 * `mode` - Failover policy for the read-only endpoint. Possible values are `Enabled`, and `Disabled`
 

--- a/website/docs/r/sql_server.html.markdown
+++ b/website/docs/r/sql_server.html.markdown
@@ -77,7 +77,9 @@ An `identity` block supports the following:
 
 ~> **NOTE:** The assigned `principal_id` and `tenant_id` can be retrieved after the identity `type` has been set to `SystemAssigned` and the Microsoft SQL Server has been created. More details are available below.
 
-`threat_detection_policy` supports the following:
+---
+
+The `threat_detection_policy` block supports the following:
 
 * `state` - (Required) The State of the Policy. Possible values are `Enabled` or `Disabled`.
 * `disabled_alerts` - (Optional) Specifies a list of alerts which should be disabled. Possible values include `Access_Anomaly`, `Data_Exfiltration`, `Sql_Injection`, `Sql_Injection_Vulnerability` and `Unsafe_Action"`,.

--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -129,7 +129,7 @@ The following arguments are supported:
 
 * `custom_domain` - (Optional) A `custom_domain` block as documented below.
 
-* `customer_managed_key` (Optional) A `customer_managed_key` block as documented below.
+* `customer_managed_key` - (Optional) A `customer_managed_key` block as documented below.
 
 * `identity` - (Optional) An `identity` block as defined below.
 

--- a/website/docs/r/storage_management_policy.html.markdown
+++ b/website/docs/r/storage_management_policy.html.markdown
@@ -92,7 +92,7 @@ The following arguments are supported:
 
 ---
 
-* `rule` supports the following:
+The `rule` block supports the following:
 
 * `name` - (Required) The name of the rule. Rule name is case-sensitive. It must be unique within a policy.
 * `enabled` - (Required)  Boolean to specify whether the rule is enabled.
@@ -101,7 +101,7 @@ The following arguments are supported:
 
 ---
 
-`filters` supports the following:
+The `filters` block supports the following:
 
 * `blob_types` - (Required) An array of predefined values. Valid options are `blockBlob` and `appendBlob`.
 * `prefix_match` - (Optional) An array of strings for prefixes to be matched.
@@ -111,7 +111,7 @@ The following arguments are supported:
 
 ---
 
-`actions` supports the following:
+The `actions` block supports the following:
 
 * `base_blob` - A `base_blob` block as documented below.
 * `snapshot` - A `snapshot` block as documented below.
@@ -119,7 +119,7 @@ The following arguments are supported:
 
 ---
 
-`base_blob` supports the following:
+The `base_blob` block supports the following:
 
 * `tier_to_cool_after_days_since_modification_greater_than` - The age in days after last modification to tier blobs to cool storage. Supports blob currently at Hot tier. Must be between 0 and 99999.
 * `tier_to_cool_after_days_since_last_access_time_greater_than` - The age in days after last access time to tier blobs to cool storage. Supports blob currently at Hot tier. Must be between `0` and `99999`.
@@ -145,7 +145,7 @@ The following arguments are supported:
 
 ---
 
-`snapshot` supports the following:
+The `snapshot` block supports the following:
 
 * `change_tier_to_archive_after_days_since_creation` - The age in days after creation to tier blob snapshot to archive storage. Must be between 0 and 99999.
 * `tier_to_archive_after_days_since_last_tier_change_greater_than` - The age in days after last tier change to the blobs to skip to be archved. Must be between 0 and 99999.
@@ -154,7 +154,7 @@ The following arguments are supported:
 
 ---
 
-`version` supports the following:
+The `version` block supports the following:
 
 * `change_tier_to_archive_after_days_since_creation` - The age in days after creation to tier blob version to archive storage. Must be between 0 and 99999.
 * `tier_to_archive_after_days_since_last_tier_change_greater_than` - The age in days after last tier change to the blobs to skip to be archved. Must be between 0 and 99999.
@@ -163,7 +163,7 @@ The following arguments are supported:
 
 ---
 
-`match_blob_index_tag` supports the following:
+The `match_blob_index_tag` block supports the following:
 
 * `name` - The filter tag name used for tag based filtering for blob objects.
 * `operation` - The comparison operator which is used for object comparison and filtering. Possible value is `==`. Defaults to `==`.

--- a/website/docs/r/subnet.html.markdown
+++ b/website/docs/r/subnet.html.markdown
@@ -81,9 +81,9 @@ The following arguments are supported:
 
 A `delegation` block supports the following:
 
-* `name` (Required) A name for this delegation.
+* `name` - (Required) A name for this delegation.
 
-* `service_delegation` (Required) A `service_delegation` block as defined below.
+* `service_delegation` - (Required) A `service_delegation` block as defined below.
 
 ---
 

--- a/website/docs/r/synapse_sql_pool_vulnerability_assessment.html.markdown
+++ b/website/docs/r/synapse_sql_pool_vulnerability_assessment.html.markdown
@@ -121,7 +121,7 @@ The following arguments are supported:
 
 ---
 
-`recurring_scans` supports the following:
+The `recurring_scans` block supports the following:
 
 * `enabled` - (Optional) Boolean flag which specifies if recurring scans is enabled or disabled. Defaults to `false`.
 * `email_subscription_admins_enabled` - (Optional) Boolean flag which specifies if the schedule scan notification will be sent to the subscription administrators. Defaults to `false`.

--- a/website/docs/r/synapse_workspace_vulnerability_assessment.html.markdown
+++ b/website/docs/r/synapse_workspace_vulnerability_assessment.html.markdown
@@ -114,7 +114,7 @@ The following arguments are supported:
 
 ---
 
-`recurring_scans` supports the following:
+The `recurring_scans` block supports the following:
 
 * `enabled` - (Optional) Boolean flag which specifies if recurring scans is enabled or disabled. Defaults to `false`.
 * `email_subscription_admins_enabled` - (Optional) Boolean flag which specifies if the schedule scan notification will be sent to the subscription administrators. Defaults to `false`.

--- a/website/docs/r/traffic_manager_profile.html.markdown
+++ b/website/docs/r/traffic_manager_profile.html.markdown
@@ -82,11 +82,15 @@ The following arguments are supported:
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
+---
+
 The `dns_config` block supports:
 
 * `relative_name` - (Required) The relative domain name, this is combined with the domain name used by Traffic Manager to form the FQDN which is exported as documented below. Changing this forces a new resource to be created.
 
 * `ttl` - (Required) The TTL value of the Profile used by Local DNS resolvers and clients.
+
+---
 
 The `monitor_config` block supports:
 
@@ -105,6 +109,8 @@ The `monitor_config` block supports:
 * `timeout_in_seconds` - (Optional) The amount of time the Traffic Manager probing agent should wait before considering that check a failure when a health check probe is sent to the endpoint. If `interval_in_seconds` is set to `30`, then `timeout_in_seconds` can be between `5` and `10`. The default value is `10`. If `interval_in_seconds` is set to `10`, then valid values are between `5` and `9` and `timeout_in_seconds` is required.
 
 * `tolerated_number_of_failures` - (Optional) The number of failures a Traffic Manager probing agent tolerates before marking that endpoint as unhealthy. Valid values are between `0` and `9`. The default value is `3`
+
+---
 
 A `custom_header` block supports the following:
 

--- a/website/docs/r/virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/virtual_machine_scale_set.html.markdown
@@ -325,20 +325,24 @@ The following arguments are supported:
 
 ---
 
-`sku` supports the following:
+The `sku` block supports the following:
 
 * `name` - (Required) Specifies the size of virtual machines in a scale set. Changing this forces a new resource to be created.
 * `tier` - (Optional) Specifies the tier of virtual machines in a scale set. Possible values, `standard` or `basic`.
 * `capacity` - (Required) Specifies the number of virtual machines in the scale set.
 
-`rolling_upgrade_policy` supports the following:
+---
+
+The `rolling_upgrade_policy` block supports the following:
 
 * `max_batch_instance_percent` - (Optional) The maximum percent of total virtual machine instances that will be upgraded simultaneously by the rolling upgrade in one batch. As this is a maximum, unhealthy instances in previous or future batches can cause the percentage of instances in a batch to decrease to ensure higher reliability. Defaults to `20`.
 * `max_unhealthy_instance_percent` - (Optional) The maximum percentage of the total virtual machine instances in the scale set that can be simultaneously unhealthy, either as a result of being upgraded, or by being found in an unhealthy state by the virtual machine health checks before the rolling upgrade aborts. This constraint will be checked prior to starting any batch. Defaults to `20`.
 * `max_unhealthy_upgraded_instance_percent` - (Optional) The maximum percentage of upgraded virtual machine instances that can be found to be in an unhealthy state. This check will happen after each batch is upgraded. If this percentage is ever exceeded, the rolling update aborts. Defaults to `20`.
 * `pause_time_between_batches` - (Optional) The wait time between completing the update for all virtual machines in one batch and starting the next batch. The time duration should be specified in ISO 8601 format for duration (<https://en.wikipedia.org/wiki/ISO_8601#Durations>). Defaults to `0` seconds represented as `PT0S`.
 
-`identity` supports the following:
+---
+
+The `identity` block supports the following:
 
 * `type` - (Required) Specifies the identity type to be assigned to the scale set. Allowable values are `SystemAssigned` and `UserAssigned`. For the `SystemAssigned` identity the scale set's Service Principal ID (SPN) can be retrieved after the scale set has been created. See [documentation](https://docs.microsoft.com/azure/active-directory/managed-service-identity/overview) for more information.
 
@@ -375,14 +379,18 @@ output "principal_id" {
 }
 ```
 
-`os_profile` supports the following:
+---
+
+The `os_profile` block supports the following:
 
 * `computer_name_prefix` - (Required) Specifies the computer name prefix for all of the virtual machines in the scale set. Computer name prefixes must be 1 to 9 characters long for windows images and 1 - 58 for Linux. Changing this forces a new resource to be created.
 * `admin_username` - (Required) Specifies the administrator account name to use for all the instances of virtual machines in the scale set.
 * `admin_password` - (Required) Specifies the administrator password to use for all the instances of virtual machines in a scale set.
 * `custom_data` - (Optional) Specifies custom data to supply to the machine. On Linux-based systems, this can be used as a cloud-init script. On other systems, this will be copied as a file on disk. Internally, Terraform will base64 encode this value before sending it to the API. The maximum length of the binary array is 65535 bytes.
 
-`os_profile_secrets` supports the following:
+---
+
+The `os_profile_secrets` block supports the following:
 
 * `source_vault_id` - (Required) Specifies the key vault to use.
 * `vault_certificates` - (Required, on windows machines) A collection of Vault Certificates as documented below
@@ -392,33 +400,43 @@ output "principal_id" {
 * `certificate_url` - (Required) It is the Base64 encoding of a JSON Object that which is encoded in UTF-8 of which the contents need to be `data`, `dataType` and `password`.
 * `certificate_store` - (Required, on windows machines) Specifies the certificate store on the Virtual Machine where the certificate should be added to.
 
-`os_profile_windows_config` supports the following:
+---
+
+The `os_profile_windows_config` block supports the following:
 
 * `provision_vm_agent` - (Optional) Indicates whether virtual machine agent should be provisioned on the virtual machines in the scale set.
 * `enable_automatic_upgrades` - (Optional) Indicates whether virtual machines in the scale set are enabled for automatic updates.
 * `winrm` - (Optional) A collection of WinRM configuration blocks as documented below.
 * `additional_unattend_config` - (Optional) An Additional Unattended Config block as documented below.
 
-`winrm` supports the following:
+---
+
+The `winrm` block supports the following:
 
 * `protocol` - (Required) Specifies the protocol of listener
 * `certificate_url` - (Optional) Specifies URL of the certificate with which new Virtual Machines is provisioned.
 
-`additional_unattend_config` supports the following:
+---
+
+The `additional_unattend_config` block supports the following:
 
 * `pass` - (Required) Specifies the name of the pass that the content applies to. The only allowable value is `oobeSystem`.
 * `component` - (Required) Specifies the name of the component to configure with the added content. The only allowable value is `Microsoft-Windows-Shell-Setup`.
 * `setting_name` - (Required) Specifies the name of the setting to which the content applies. Possible values are: `FirstLogonCommands` and `AutoLogon`.
 * `content` - (Optional) Specifies the base-64 encoded XML formatted content that is added to the unattend.xml file for the specified path and component.
 
-`os_profile_linux_config` supports the following:
+---
+
+The `os_profile_linux_config` block supports the following:
 
 * `disable_password_authentication` - (Optional) Specifies whether password authentication should be disabled. Defaults to `false`. Changing this forces a new resource to be created.
 * `ssh_keys` - (Optional) Specifies a collection of `path` and `key_data` to be placed on the virtual machine.
 
 ~> _**Note:** Please note that the only allowed `path` is `/home/<username>/.ssh/authorized_keys` due to a limitation of Azure_
 
-`network_profile` supports the following:
+---
+
+The `network_profile` block supports the following:
 
 * `name` - (Required) Specifies the name of the network interface configuration. Changing this forces a new resource to be created.
 * `primary` - (Required) Indicates whether network interfaces created from the network interface configuration will be the primary NIC of the VM.
@@ -428,11 +446,15 @@ output "principal_id" {
 * `ip_forwarding` - (Optional) Whether IP forwarding is enabled on this NIC. Defaults to `false`.
 * `network_security_group_id` - (Optional) Specifies the identifier for the network security group.
 
-`dns_settings` supports the following:
+---
+
+The `dns_settings` block supports the following:
 
 * `dns_servers` - (Required) Specifies an array of DNS servers.
 
-`ip_configuration` supports the following:
+---
+
+The `ip_configuration` block supports the following:
 
 * `name` - (Required) Specifies name of the IP configuration. Changing this forces a new resource to be created.
 * `subnet_id` - (Required) Specifies the identifier of the subnet.
@@ -449,13 +471,17 @@ output "principal_id" {
 * `application_security_group_ids` - (Optional) Specifies up to `20` application security group IDs.
 * `public_ip_address_configuration` - (Optional) Describes a virtual machines scale set IP Configuration's PublicIPAddress configuration. The public_ip_address_configuration is documented below.
 
-`public_ip_address_configuration` supports the following:
+---
+
+The `public_ip_address_configuration` block supports the following:
 
 * `name` - (Required) The name of the public IP address configuration Changing this forces a new resource to be created.
 * `idle_timeout` - (Required) The idle timeout in minutes. This value must be between 4 and 30.
 * `domain_name_label` - (Required) The domain name label for the DNS settings.
 
-`storage_profile_os_disk` supports the following:
+---
+
+The `storage_profile_os_disk` block supports the following:
 
 * `name` - (Optional) Specifies the disk name. Must be specified when using unmanaged disk ('managed_disk_type' property not set). Changing this forces a new resource to be created.
 * `vhd_containers` - (Optional) Specifies the VHD URI. Cannot be used when `image` or `managed_disk_type` is specified.
@@ -467,7 +493,9 @@ output "principal_id" {
                        When setting this field `os_type` needs to be specified. Cannot be used when `vhd_containers`, `managed_disk_type` or `storage_profile_image_reference` are specified.
 * `os_type` - (Optional) Specifies the operating system Type, valid values are windows, Linux.
 
-`storage_profile_data_disk` supports the following:
+---
+
+The `storage_profile_data_disk` block supports the following:
 
 * `lun` - (Required) Specifies the Logical Unit Number of the disk in each virtual machine in the scale set.
 * `create_option` - (Optional) Specifies how the data disk should be created. The only possible options are `FromImage` and `Empty`.
@@ -475,7 +503,9 @@ output "principal_id" {
 * `disk_size_gb` - (Optional) Specifies the size of the disk in GB. This element is required when creating an empty disk.
 * `managed_disk_type` - (Optional) Specifies the type of managed disk to create. Value must be either `Standard_LRS`, `StandardSSD_LRS` or `Premium_LRS`.
 
-`storage_profile_image_reference` supports the following:
+---
+
+The `storage_profile_image_reference` block supports the following:
 
 * `id` - (Optional) Specifies the ID of the (custom) image to use to create the virtual
 machine scale set, as in the [example below](#example-of-storage_profile_image_reference-with-id).
@@ -484,12 +514,16 @@ machine scale set, as in the [example below](#example-of-storage_profile_image_r
 * `sku` - (Optional) Specifies the SKU of the image used to create the virtual machines.
 * `version` - (Optional) Specifies the version of the image used to create the virtual machines.
 
-`boot_diagnostics` supports the following:
+---
+
+The `boot_diagnostics` block supports the following:
 
 * `enabled`: (Required) Whether to enable boot diagnostics for the virtual machine.
 * `storage_uri`: (Required) Blob endpoint for the storage account to hold the virtual machine's diagnostic files. This must be the root of a storage account, and not a storage container.
 
-`extension` supports the following:
+---
+
+The `extension` block supports the following:
 
 * `name` - (Required) Specifies the name of the extension. Changing this forces a new resource to be created.
 * `publisher` - (Required) The publisher of the extension, available publishers can be found by using the Azure CLI.
@@ -500,7 +534,9 @@ machine scale set, as in the [example below](#example-of-storage_profile_image_r
 * `settings` - (Required) The settings passed to the extension, these are specified as a JSON object in a string.
 * `protected_settings` - (Optional) The protected_settings passed to the extension, like settings, these are specified as a JSON object in a string.
 
-`plan` supports the following:
+---
+
+The `plan` block supports the following:
 
 * `name` - (Required) Specifies the name of the image from the marketplace. Changing this forces a new resource to be created.
 * `publisher` - (Required) Specifies the publisher of the image.

--- a/website/docs/r/virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/virtual_machine_scale_set.html.markdown
@@ -518,8 +518,8 @@ machine scale set, as in the [example below](#example-of-storage_profile_image_r
 
 The `boot_diagnostics` block supports the following:
 
-* `enabled`: (Required) Whether to enable boot diagnostics for the virtual machine.
-* `storage_uri`: (Required) Blob endpoint for the storage account to hold the virtual machine's diagnostic files. This must be the root of a storage account, and not a storage container.
+* `enabled`: - (Required) Whether to enable boot diagnostics for the virtual machine.
+* `storage_uri`: - (Required) Blob endpoint for the storage account to hold the virtual machine's diagnostic files. This must be the root of a storage account, and not a storage container.
 
 ---
 

--- a/website/docs/r/virtual_network_gateway.html.markdown
+++ b/website/docs/r/virtual_network_gateway.html.markdown
@@ -104,7 +104,7 @@ EOF
 
 The following arguments are supported:
 
-* `ip_configuration` (Required) One, two or three `ip_configuration` blocks documented below.
+* `ip_configuration` - (Required) One, two or three `ip_configuration` blocks documented below.
   An active-standby gateway requires exactly one `ip_configuration` block,
   an active-active gateway requires exactly two `ip_configuration` blocks whereas
   an active-active zone redundant gateway with P2S configuration requires exactly three `ip_configuration` blocks.
@@ -157,7 +157,7 @@ The following arguments are supported:
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
-* `vpn_client_configuration` (Optional) A `vpn_client_configuration` block which
+* `vpn_client_configuration` - (Optional) A `vpn_client_configuration` block which
   is documented below. In this block the Virtual Network Gateway can be configured
   to accept IPSec point-to-site connections.
 

--- a/website/docs/r/virtual_network_gateway.html.markdown
+++ b/website/docs/r/virtual_network_gateway.html.markdown
@@ -280,7 +280,7 @@ The `bgp_settings` block supports:
 
 ---
 
-The `peering_addresses` supports:
+The `peering_addresses` block supports:
 
 * `default_addresses` - A list of peering address assigned to the BGP peer of the Virtual Network Gateway.
 

--- a/website/docs/r/virtual_network_gateway.html.markdown
+++ b/website/docs/r/virtual_network_gateway.html.markdown
@@ -236,7 +236,7 @@ A `custom_route` block supports the following:
 
 ---
 
-A `peering_addresses` supports the following:
+A `peering_addresses` block supports the following:
 
 * `ip_configuration_name` - (Optional) The name of the IP configuration of this Virtual Network Gateway. In case there are multiple `ip_configuration` blocks defined, this property is **required** to specify.
 

--- a/website/docs/r/virtual_network_gateway_connection.html.markdown
+++ b/website/docs/r/virtual_network_gateway_connection.html.markdown
@@ -266,10 +266,14 @@ The following arguments are supported:
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
+---
+
 The `custom_bgp_addresses` block supports:
 
 * `primary` (Required) single IP address that is part of the `azurerm_virtual_network_gateway` ip_configuration (first one)
 * `secondary` (Required) single IP address that is part of the `azurerm_virtual_network_gateway` ip_configuration (second one)
+
+---
 
 The `ipsec_policy` block supports:
 
@@ -298,6 +302,8 @@ The `ipsec_policy` block supports:
 
 * `sa_lifetime` - (Optional) The IPSec SA lifetime in seconds. Must be at least
     `300` seconds. Defaults to `27000` seconds.
+
+---
 
 The `traffic_selector_policy` block supports:
 

--- a/website/docs/r/virtual_network_gateway_connection.html.markdown
+++ b/website/docs/r/virtual_network_gateway_connection.html.markdown
@@ -256,11 +256,11 @@ The following arguments are supported:
     selectors are enabled for this connection. Enabling policy-based traffic
     selectors requires an `ipsec_policy` block. Defaults to `false`.
 
-* `ipsec_policy` (Optional) A `ipsec_policy` block which is documented below.
+* `ipsec_policy` - (Optional) A `ipsec_policy` block which is documented below.
     Only a single policy can be defined for a connection. For details on
     custom policies refer to [the relevant section in the Azure documentation](https://docs.microsoft.com/azure/vpn-gateway/vpn-gateway-ipsecikepolicy-rm-powershell).
 
-* `traffic_selector_policy` (Optional) One or more `traffic_selector_policy` blocks which are documented below.
+* `traffic_selector_policy` - (Optional) One or more `traffic_selector_policy` blocks which are documented below.
     A `traffic_selector_policy` allows to specify a traffic selector policy proposal to be used in a virtual network gateway connection.
     For details about traffic selectors refer to [the relevant section in the Azure documentation](https://docs.microsoft.com/azure/vpn-gateway/vpn-gateway-connect-multiple-policybased-rm-ps).
 
@@ -270,8 +270,8 @@ The following arguments are supported:
 
 The `custom_bgp_addresses` block supports:
 
-* `primary` (Required) single IP address that is part of the `azurerm_virtual_network_gateway` ip_configuration (first one)
-* `secondary` (Required) single IP address that is part of the `azurerm_virtual_network_gateway` ip_configuration (second one)
+* `primary` - (Required) single IP address that is part of the `azurerm_virtual_network_gateway` ip_configuration (first one)
+* `secondary` - (Required) single IP address that is part of the `azurerm_virtual_network_gateway` ip_configuration (second one)
 
 ---
 

--- a/website/docs/r/windows_virtual_machine.html.markdown
+++ b/website/docs/r/windows_virtual_machine.html.markdown
@@ -277,7 +277,7 @@ A `os_disk` block supports the following:
 
 * `storage_account_type` - (Required) The Type of Storage Account which should back this the Internal OS Disk. Possible values are `Standard_LRS`, `StandardSSD_LRS`, `Premium_LRS`, `StandardSSD_ZRS` and `Premium_ZRS`. Changing this forces a new resource to be created.
 
-* `diff_disk_settings` (Optional) A `diff_disk_settings` block as defined above. Changing this forces a new resource to be created.
+* `diff_disk_settings` - (Optional) A `diff_disk_settings` block as defined above. Changing this forces a new resource to be created.
 
 -> **NOTE:** `diff_disk_settings` can only be set when `caching` is set to `ReadOnly`. More information can be found [here](https://docs.microsoft.com/azure/virtual-machines/ephemeral-os-disks-deploy#vm-template-deployment)
 

--- a/website/docs/r/windows_virtual_machine.html.markdown
+++ b/website/docs/r/windows_virtual_machine.html.markdown
@@ -327,7 +327,7 @@ A `secret` block supports the following:
 
 ---
 
-`source_image_reference` supports the following:
+The `source_image_reference` block supports the following:
 
 * `publisher` - (Optional) Specifies the publisher of the image used to create the virtual machines.
 


### PR DESCRIPTION
i have written a tool to fix the listed issues in the resource document

1. use `*` for the property list mark. (some documents use `-` as a list mark)
2. use a `---` as a separator mark before a block document. (some block has no separator, and some other use `--`)
3. remove redundant `*` before a block document
4. property format should be ``* `name` - (Optional)``, not ``* `name` (Optional) -``
5. A block document must be ``(A|An|The) `xxxx` block supports the following:``
6. must be a `-` after property name, means invalid of ``* `xxx` (Optional)``, must be ``* `xxx` - (Optional)``

The Good:
1. make it easier to analyze our document using program.