### PR TITLE
Fix missing attribute in key vault secret data doc

### DIFF
--- a/website/docs/d/key_vault_secret.html.markdown
+++ b/website/docs/d/key_vault_secret.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "Key Vault"
 layout: "azurerm"
-page_title: "Azure Resource Manager: azurerm_key_vault_secret"
+page_title: "Azure Resource Manager: Data Source: azurerm_key_vault_secret"
 description: |-
   Gets information about an existing Key Vault Secret.
 ---
@@ -27,27 +27,35 @@ output "secret_value" {
 }
 ```
 
-## Argument Reference
+## Arguments Reference
 
 The following arguments are supported:
 
-* `name` - Specifies the name of the Key Vault Secret.
+* `key_vault_id` - (Required) The ID of the TODO.
 
-* `key_vault_id` - Specifies the ID of the Key Vault instance where the Secret resides, available on the `azurerm_key_vault` Data Source / Resource.
+* `name` - (Required) Specifies the ID of the Key Vault instance where the Secret resides, available on the `azurerm_key_vault` Data Source / Resource.
 
 **NOTE:** The vault must be in the same subscription as the provider. If the vault is in another subscription, you must create an aliased provider for that subscription.
 
 ## Attributes Reference
 
-The following attributes are exported:
+In addition to the Arguments listed above - the following Attributes are exported:
 
 * `id` - The Key Vault Secret ID.
-* `resource_id` - The (Versioned) ID for this Key Vault Secret. This property points to a specific version of a Key Vault Secret, as such using this won't auto-rotate values if used in other Azure Services.
-* `resource_versionless_id` - The Versionless ID of the Key Vault Secret. This property allows other Azure Services (that support it) to auto-rotate their value when the Key Vault Secret is updated.
-* `value` - The value of the Key Vault Secret.
-* `version` - The current version of the Key Vault Secret.
+
 * `content_type` - The content type for the Key Vault Secret.
+
+* `resource_id` - The (Versioned) ID for this Key Vault Secret. This property points to a specific version of a Key Vault Secret, as such using this won't auto-rotate values if used in other Azure Services.
+
+* `resource_versionless_id` - The Versionless ID of the Key Vault Secret. This property allows other Azure Services (that support it) to auto-rotate their value when the Key Vault Secret is updated.
+
 * `tags` - Any tags assigned to this resource.
+
+* `value` - The value of the Key Vault Secret.
+
+* `version` - The current version of the Key Vault Secret.
+
+* `versionless_id` - The Versionless ID of the Key Vault Secret. This can be used to always get latest secret value, and enable fetching automatically rotating secrets.
 
 ## Timeouts
 

--- a/website/docs/d/key_vault_secrets.html.markdown
+++ b/website/docs/d/key_vault_secrets.html.markdown
@@ -1,7 +1,7 @@
 ---
 subcategory: "Key Vault"
 layout: "azurerm"
-page_title: "Azure Resource Manager: azurerm_key_vault_secrets"
+page_title: "Azure Resource Manager: Data Source: azurerm_key_vault_secrets"
 description: |-
   Gets a list of secret names from an existing Key Vault Secret.
 ---
@@ -29,16 +29,15 @@ data "azurerm_key_vault_secret" "example" {
 
 The following arguments are supported:
 
-* `key_vault_id` - Specifies the ID of the Key Vault instance to fetch secret names from, available on the `azurerm_key_vault` Data Source / Resource.
+* `key_vault_id` - (Required) Specifies the ID of the Key Vault instance to fetch secret names from, available on the `azurerm_key_vault` Data Source / Resource.
 
 **NOTE:** The vault must be in the same subscription as the provider. If the vault is in another subscription, you must create an aliased provider for that subscription.
 
 ## Attributes Reference
 
-The following attributes are exported:
+In addition to the Argument listed above - the following Attributes are exported:
 
 * `names` - List containing names of secrets that exist in this Key Vault.
-* `key_vault_id` - The Key Vault ID.
 
 ## Timeouts
 


### PR DESCRIPTION
Fixed the missing `versionless_id` attribute in key vault secrets data documentations by rescaffolding the documentation.