### PR TITLE
`azurerm_key_vault_managed_hardware_security_module`: support for `public_network_access_enabled` and `network_acls` properties

### DIFF
--- a/internal/services/keyvault/key_vault_managed_hardware_security_module_resource.go
+++ b/internal/services/keyvault/key_vault_managed_hardware_security_module_resource.go
@@ -96,6 +96,41 @@ func resourceKeyVaultManagedHardwareSecurityModule() *pluginsdk.Resource {
 				Computed: true,
 			},
 
+			"public_network_access_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+				//Computed: true,
+				Default:  true,
+				ForceNew: true,
+			},
+
+			"network_acls": {
+				Type:     pluginsdk.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"default_action": {
+							Type:     pluginsdk.TypeString,
+							Required: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								string(keyvault.NetworkRuleActionAllow),
+								string(keyvault.NetworkRuleActionDeny),
+							}, false),
+						},
+						"bypass": {
+							Type:     pluginsdk.TypeString,
+							Required: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								string(keyvault.NetworkRuleBypassOptionsNone),
+								string(keyvault.NetworkRuleBypassOptionsAzureServices),
+							}, false),
+						},
+					},
+				},
+			},
+
 			// https://github.com/Azure/azure-rest-api-specs/issues/13365
 			"tags": tags.ForceNewSchema(),
 		},
@@ -132,12 +167,18 @@ func resourceArmKeyVaultManagedHardwareSecurityModuleCreate(d *pluginsdk.Resourc
 			EnableSoftDelete:          utils.Bool(true),
 			SoftDeleteRetentionInDays: utils.Int32(int32(d.Get("soft_delete_retention_days").(int))),
 			EnablePurgeProtection:     utils.Bool(d.Get("purge_protection_enabled").(bool)),
+			PublicNetworkAccess:       keyvault.PublicNetworkAccessEnabled, // default enabled
+			NetworkAcls:               expandMHSMNetworkAcls(d.Get("network_acls").([]interface{})),
 		},
 		Sku: &keyvault.ManagedHsmSku{
 			Family: utils.String("B"),
 			Name:   keyvault.ManagedHsmSkuName(d.Get("sku_name").(string)),
 		},
 		Tags: tags.Expand(d.Get("tags").(map[string]interface{})),
+	}
+
+	if !d.Get("public_network_access_enabled").(bool) {
+		hsm.Properties.PublicNetworkAccess = keyvault.PublicNetworkAccessDisabled
 	}
 
 	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.Name, hsm)
@@ -194,6 +235,14 @@ func resourceArmKeyVaultManagedHardwareSecurityModuleRead(d *pluginsdk.ResourceD
 		d.Set("hsm_uri", props.HsmURI)
 		d.Set("soft_delete_retention_days", props.SoftDeleteRetentionInDays)
 		d.Set("purge_protection_enabled", props.EnablePurgeProtection)
+
+		var publicAccess = true
+		if props.PublicNetworkAccess == keyvault.PublicNetworkAccessDisabled {
+			publicAccess = false
+		}
+		d.Set("public_network_access_enabled", publicAccess)
+
+		d.Set("network_acls", flattenMHSMNetworkAcls(props.NetworkAcls))
 	}
 
 	return tags.FlattenAndSet(d, resp.Tags)
@@ -252,4 +301,30 @@ func resourceArmKeyVaultManagedHardwareSecurityModuleDelete(d *pluginsdk.Resourc
 	}
 
 	return nil
+}
+
+func expandMHSMNetworkAcls(input []interface{}) *keyvault.MHSMNetworkRuleSet {
+	if len(input) == 0 {
+		return nil
+	}
+	v := input[0].(map[string]interface{})
+	res := &keyvault.MHSMNetworkRuleSet{
+		Bypass:        keyvault.NetworkRuleBypassOptions(v["bypass"].(string)),
+		DefaultAction: keyvault.NetworkRuleAction(v["default_action"].(string)),
+	}
+
+	return res
+}
+
+func flattenMHSMNetworkAcls(acl *keyvault.MHSMNetworkRuleSet) []interface{} {
+	res := map[string]interface{}{
+		"bypass":         string(keyvault.NetworkRuleBypassOptionsAzureServices),
+		"default_action": string(keyvault.NetworkRuleActionAllow),
+	}
+
+	if acl != nil {
+		res["bypass"] = string(acl.Bypass)
+		res["default_action"] = string(acl.DefaultAction)
+	}
+	return []interface{}{res}
 }

--- a/internal/services/keyvault/key_vault_managed_hardware_security_module_resource_test.go
+++ b/internal/services/keyvault/key_vault_managed_hardware_security_module_resource_test.go
@@ -135,8 +135,23 @@ provider "azurerm" {
 
 %s
 
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvirtnet%[2]d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test_a" {
+  name                 = "acctestsubneta%[2]d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.2.0/24"]
+  service_endpoints    = ["Microsoft.KeyVault"]
+}
+
 resource "azurerm_key_vault_managed_hardware_security_module" "test" {
-  name                       = "kvHsm%d"
+  name                       = "kvHsm%[2]d"
   resource_group_name        = azurerm_resource_group.test.name
   location                   = azurerm_resource_group.test.location
   sku_name                   = "Standard_B1"
@@ -144,6 +159,13 @@ resource "azurerm_key_vault_managed_hardware_security_module" "test" {
   purge_protection_enabled   = false
   tenant_id                  = data.azurerm_client_config.current.tenant_id
   admin_object_ids           = [data.azurerm_client_config.current.object_id]
+
+  network_acls {
+    default_action = "Deny"
+    bypass         = "None"
+  }
+
+  public_network_access_enabled = true
 
   tags = {
     Env = "Test"

--- a/website/docs/r/key_vault_managed_hardware_security_module.html.markdown
+++ b/website/docs/r/key_vault_managed_hardware_security_module.html.markdown
@@ -78,7 +78,7 @@ A `network_acls` block supports the following:
 
 * `bypass` - (Required) Specifies which traffic can bypass the network rules. Possible values are `AzureServices` and `None`.
 
-* `default_action` - (Required) The Default Action to use when no rules match from `ip_rules` / `virtual_network_subnet_ids`. Possible values are `Allow` and `Deny`.
+* `default_action` - (Required) The Default Action to use. Possible values are `Allow` and `Deny`.
 
 ## Attributes Reference
 

--- a/website/docs/r/key_vault_managed_hardware_security_module.html.markdown
+++ b/website/docs/r/key_vault_managed_hardware_security_module.html.markdown
@@ -66,7 +66,19 @@ The following arguments are supported:
 
 * `soft_delete_retention_days` - (Optional) The number of days that items should be retained for once soft-deleted. This value can be between `7` and `90` days. Defaults to `90`. Changing this forces a new resource to be created.
 
+* `public_network_access_enabled` - (Optional) Whether traffic from public networks is permitted. Defaults to `True`. Changing this forces a new resource to be created.
+
+* `network_acls` - (Optional) A `network_acls` block as defined below.
+
 * `tags` - (Optional) A mapping of tags to assign to the resource. Changing this forces a new resource to be created.
+
+---
+
+A `network_acls` block supports the following:
+
+* `bypass` - (Required) Specifies which traffic can bypass the network rules. Possible values are `AzureServices` and `None`.
+
+* `default_action` - (Required) The Default Action to use when no rules match from `ip_rules` / `virtual_network_subnet_ids`. Possible values are `Allow` and `Deny`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
```
=== RUN   TestAccKeyVaultManagedHardwareSecurityModule
--- PASS: TestAccKeyVaultManagedHardwareSecurityModule (5817.81s)
=== RUN   TestAccKeyVaultManagedHardwareSecurityModule/data_source
    --- PASS: TestAccKeyVaultManagedHardwareSecurityModule/data_source (1450.50s)
=== RUN   TestAccKeyVaultManagedHardwareSecurityModule/data_source/basic
        --- PASS: TestAccKeyVaultManagedHardwareSecurityModule/data_source/basic (1450.50s)
=== RUN   TestAccKeyVaultManagedHardwareSecurityModule/resource
    --- PASS: TestAccKeyVaultManagedHardwareSecurityModule/resource (4367.30s)
=== RUN   TestAccKeyVaultManagedHardwareSecurityModule/resource/basic
        --- PASS: TestAccKeyVaultManagedHardwareSecurityModule/resource/basic (1514.99s)
=== RUN   TestAccKeyVaultManagedHardwareSecurityModule/resource/update
        --- PASS: TestAccKeyVaultManagedHardwareSecurityModule/resource/update (1453.90s)
=== RUN   TestAccKeyVaultManagedHardwareSecurityModule/resource/complete
        --- PASS: TestAccKeyVaultManagedHardwareSecurityModule/resource/complete (1398.41s)
PASS
```


![image](https://user-images.githubusercontent.com/2633022/206953525-07807418-0f58-4da4-aced-e82487cccb0f.png)
