### PR TITLE
corrects VNET resource varibale name used in example

### DIFF
--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -40,7 +40,7 @@ resource "azurerm_virtual_network" "main" {
 resource "azurerm_subnet" "internal" {
   name                 = "internal"
   resource_group_name  = azurerm_resource_group.example.name
-  virtual_network_name = azurerm_virtual_network.example.name
+  virtual_network_name = azurerm_virtual_network.main.name
   address_prefixes     = ["10.0.2.0/24"]
 }
 


### PR DESCRIPTION
Fixes #19591

Changes resource variable name  from example to main as declared in the resource declaration. 

I ran the updated sample code through fmt and validate to confirm accuracy.