### PR TITLE
Doc Fix - `azurerm_application_gateway` - `ssl_profile_id` description update

### DIFF
--- a/website/docs/r/application_gateway.html.markdown
+++ b/website/docs/r/application_gateway.html.markdown
@@ -765,7 +765,7 @@ A `http_listener` block exports the following:
 
 * `ssl_certificate_id` - The ID of the associated SSL Certificate.
 
-* `ssl_profile_id` - The ID of the associated SSL Certificate.
+* `ssl_profile_id` - The ID of the associated SSL Profile.
 
 ---
 


### PR DESCRIPTION
Minor doc correction - `ssl_profile_id` was referring to "SSL Certificate" rather than SSL Profile.