### PR TITLE
Doc: replace all NBSP/NNBSP as whitspace and New requiredness correctness

### DIFF
--- a/website/docs/r/api_management.html.markdown
+++ b/website/docs/r/api_management.html.markdown
@@ -345,7 +345,7 @@ A `terms_of_service` block supports the following:
 
 * `enabled` - (Required) Should Terms of Service be displayed during sign up?.
 
-* `text` - (Required) The Terms of Service which users are required to agree to in order to sign up.
+* `text` - (Optional) The Terms of Service which users are required to agree to in order to sign up.
 
 ## Attributes Reference
 

--- a/website/docs/r/api_management_api.html.markdown
+++ b/website/docs/r/api_management_api.html.markdown
@@ -174,9 +174,9 @@ In addition to all arguments above, the following attributes are exported:
 
 * `is_online` - Is this API Revision online/accessible via the Gateway?
 
-* `version` - The Version number of this API, if this API is versioned.
+* `version` - (Optional) The Version number of this API, if this API is versioned.
 
-* `version_set_id` - The ID of the Version Set which this API is associated with.
+* `version_set_id` - (Optional) The ID of the Version Set which this API is associated with.
 
 ## Timeouts
 

--- a/website/docs/r/app_configuration_key.html.markdown
+++ b/website/docs/r/app_configuration_key.html.markdown
@@ -147,7 +147,7 @@ The following attributes are exported:
 
 * `id` - The App Configuration Key ID.
 
-* `etag` - The ETag of the key.
+* `etag` - (Optional) The ETag of the key.
 
 ## Timeouts
 

--- a/website/docs/r/app_service.html.markdown
+++ b/website/docs/r/app_service.html.markdown
@@ -273,7 +273,7 @@ Additional examples of how to run Containers via the `azurerm_app_service` resou
 
 A `cors` block supports the following:
 
-* `allowed_origins` - (Optional) A list of origins which should be able to make cross-origin calls. `*` can be used to allow all calls.
+* `allowed_origins` - (Required) A list of origins which should be able to make cross-origin calls. `*` can be used to allow all calls.
 
 * `support_credentials` - (Optional) Are credentials supported?
 
@@ -421,7 +421,7 @@ A `schedule` block supports the following:
 
 * `frequency_interval` - (Required) Sets how often the backup should be executed.
 
-* `frequency_unit` - (Optional) Sets the unit of time for how often the backup should be executed. Possible values are `Day` or `Hour`.
+* `frequency_unit` - (Required) Sets the unit of time for how often the backup should be executed. Possible values are `Day` or `Hour`.
 
 * `keep_at_least_one_backup` - (Optional) Should at least one backup always be kept in the Storage Account by the Retention Policy, regardless of how old it is?
 
@@ -491,8 +491,8 @@ A `site_credential` block exports the following:
 
 A `source_control` block exports the following:
 
-* `repo_url` - URL of the Git repository for this App Service.
-* `branch` - Branch name of the Git repository for this App Service.
+* `repo_url` - (Optional) URL of the Git repository for this App Service.
+* `branch` - (Optional) Branch name of the Git repository for this App Service.
 
 ## Timeouts
 

--- a/website/docs/r/app_service_certificate_order.html.markdown
+++ b/website/docs/r/app_service_certificate_order.html.markdown
@@ -76,7 +76,7 @@ The following attributes are exported:
 
 * `intermediate_thumbprint` - Certificate thumbprint intermediate certificate.
 
-* `tags` - A mapping of tags to assign to the resource.
+* `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ---
 

--- a/website/docs/r/app_service_slot.html.markdown
+++ b/website/docs/r/app_service_slot.html.markdown
@@ -293,7 +293,7 @@ Additional examples of how to run Containers via the `azurerm_app_service_slot` 
 
 A `cors` block supports the following:
 
-* `allowed_origins` - (Optional) A list of origins which should be able to make cross-origin calls. `*` can be used to allow all calls.
+* `allowed_origins` - (Required) A list of origins which should be able to make cross-origin calls. `*` can be used to allow all calls.
 
 * `support_credentials` - (Optional) Are credentials supported?
 
@@ -463,7 +463,7 @@ A `file_system` block supports the following:
 
 A `ip_restriction` block (attribute as block) support:
 
-* `ip_address` - (Required) The IP Address used for this IP Restriction.
+* `ip_address` - (Optional) The IP Address used for this IP Restriction.
 
 * `subnet_mask` - (Optional) The Subnet mask used for this IP Restriction. Defaults to `255.255.255.255`.
 

--- a/website/docs/r/app_service_slot.html.markdown
+++ b/website/docs/r/app_service_slot.html.markdown
@@ -461,7 +461,7 @@ A `file_system` block supports the following:
 
 ---
 
-Elements of `ip_restriction` [block](/docs/configuration/attr-as-blocks.html) support:
+A `ip_restriction` block (attribute as block) support:
 
 * `ip_address` - (Required) The IP Address used for this IP Restriction.
 

--- a/website/docs/r/app_service_source_control.html.markdown
+++ b/website/docs/r/app_service_source_control.html.markdown
@@ -78,7 +78,7 @@ A `code_configuration` block supports the following:
 
 * `runtime_stack` - (Required) The value to use for the Runtime Stack in the workflow file content for code base apps. Changing this forces a new resource to be created.
 
-* `runtime_version` - (Optional) The value to use for the Runtime Version in the workflow file content for code base apps. Changing this forces a new resource to be created.
+* `runtime_version` - (Required) The value to use for the Runtime Version in the workflow file content for code base apps. Changing this forces a new resource to be created.
 
 ---
 

--- a/website/docs/r/application_gateway.html.markdown
+++ b/website/docs/r/application_gateway.html.markdown
@@ -363,7 +363,7 @@ An `ip_configuration` block supports the following:
 
 A `match` block supports the following:
 
-* `body` - A snippet from the Response Body which must be present in the Response.
+* `body` - (Optional) A snippet from the Response Body which must be present in the Response.
 
 * `status_code` - (Required) A list of allowed status codes for this Health Probe.
 

--- a/website/docs/r/application_gateway.html.markdown
+++ b/website/docs/r/application_gateway.html.markdown
@@ -46,7 +46,7 @@ resource "azurerm_public_ip" "example" {
   allocation_method   = "Dynamic"
 }
 
-# since these variables are re-used - a locals block makes this more maintainable
+# since these variables are re-used - a locals block makes this more maintainable
 locals {
   backend_address_pool_name      = "${azurerm_virtual_network.example.name}-beap"
   frontend_port_name             = "${azurerm_virtual_network.example.name}-feport"
@@ -237,11 +237,11 @@ A `backend_http_settings` block supports the following:
 
 * `path` - (Optional) The Path which should be used as a prefix for all HTTP requests.
 
-* `port`- (Required) The port which should be used for this Backend HTTP Settings Collection.
+* `port` - (Required) The port which should be used for this Backend HTTP Settings Collection.
 
 * `probe_name` - (Optional) The name of an associated HTTP Probe.
 
-* `protocol`- (Required) The Protocol which should be used. Possible values are `Http` and `Https`.
+* `protocol` - (Required) The Protocol which should be used. Possible values are `Http` and `Https`.
 
 * `request_timeout` - (Optional) The request timeout in seconds, which must be between 1 and 86400 seconds. Defaults to `30`.
 
@@ -249,7 +249,7 @@ A `backend_http_settings` block supports the following:
 
 * `pick_host_name_from_backend_address` - (Optional) Whether host header should be picked from the host name of the backend server. Defaults to `false`.
 
-* `authentication_certificate` - (Optional) One or more `authentication_certificate` blocks.
+* `authentication_certificate` - (Optional) One or more `authentication_certificate` blocks as defined below.
 
 * `trusted_root_certificate_names` - (Optional) A list of `trusted_root_certificate` names.
 

--- a/website/docs/r/application_insights_workbook.html.markdown
+++ b/website/docs/r/application_insights_workbook.html.markdown
@@ -78,13 +78,13 @@ The following arguments are supported:
 
 An `identity` block exports the following:
 
-* `type` - The type of Managed Service Identity that is configured on this Workbook. Possible values are `UserAssigned`, `SystemAssigned` and `SystemAssigned, UserAssigned`. Changing this forces a new resource to be created.
+* `type` - (Required) The type of Managed Service Identity that is configured on this Workbook. Possible values are `UserAssigned`, `SystemAssigned` and `SystemAssigned, UserAssigned`. Changing this forces a new resource to be created.
 
 * `principal_id` - The Principal ID of the System Assigned Managed Service Identity that is configured on this Workbook.
 
 * `tenant_id` - The Tenant ID of the System Assigned Managed Service Identity that is configured on this Workbook.
 
-* `identity_ids` - The list of User Assigned Managed Identity IDs assigned to this Workbook. Changing this forces a new resource to be created.
+* `identity_ids` - (Optional) The list of User Assigned Managed Identity IDs assigned to this Workbook. Changing this forces a new resource to be created.
 
 ## Attributes Reference
 

--- a/website/docs/r/automation_job_schedule.html.markdown
+++ b/website/docs/r/automation_job_schedule.html.markdown
@@ -52,7 +52,7 @@ The following attributes are exported:
 
 * `id` - The ID of the Automation Job Schedule.
 
-* `job_schedule_id` - The UUID identifying the Automation Job Schedule.
+* `job_schedule_id` - (Optional) The UUID identifying the Automation Job Schedule.
 
 ## Timeouts
 

--- a/website/docs/r/automation_runbook.html.markdown
+++ b/website/docs/r/automation_runbook.html.markdown
@@ -116,7 +116,7 @@ The `publish_content_link` block supports the following:
 
 * `version` - (Optional) Specifies the version of the content
 
-* `hash` - (Optional) A `hash` block as defined blow.
+* `hash` - (Optional) A `hash` block as defined below.
 
 ---
 
@@ -132,9 +132,9 @@ The `draft` block supports:
 
 * `edit_mode_enabled` - (Optional) Whether the draft in edit mode.
 
-* `content_link` (Optioinal) The Draft Content Link defined as `publish_content_link` above.
+* `content_link` - (Optioinal) The Draft Content Link defined as `publish_content_link` above.
 
-* `output_types` (Optioinal) Specifies the output types of the runbook.
+* `output_types` - (Optioinal) Specifies the output types of the runbook.
 
 * `parameter` - (Optional) A list of `parameter` block as define below.
 

--- a/website/docs/r/automation_webhook.html.markdown
+++ b/website/docs/r/automation_webhook.html.markdown
@@ -82,7 +82,7 @@ The following attributes are exported:
 
 * `id` - The Automation Webhook ID.
 
-* `uri` - (Sensitive) Generated URI for this Webhook.
+* `uri` - (Optional) (Sensitive) Generated URI for this Webhook.
 
 ## Timeouts
 

--- a/website/docs/r/batch_account.html.markdown
+++ b/website/docs/r/batch_account.html.markdown
@@ -62,7 +62,7 @@ The following arguments are supported:
 
 ~> **NOTE:** When using `UserSubscription` mode, the `Microsoft Azure Batch` service principal has to have `Contributor` role on your subscription scope, as documented [here](https://docs.microsoft.com/azure/batch/batch-account-create-portal#additional-configuration-for-user-subscription-mode).
 
-* `key_vault_reference` - (Optional) A `key_vault_reference` block that describes the Azure KeyVault reference to use when deploying the Azure Batch account using the `UserSubscription` pool allocation mode.
+* `key_vault_reference` - (Optional) A `key_vault_reference` block, as defined below, that describes the Azure KeyVault reference to use when deploying the Azure Batch account using the `UserSubscription` pool allocation mode.
 
 * `storage_account_id` - (Optional) Specifies the storage account to use for the Batch account. If not specified, Azure Batch will manage the storage.
 

--- a/website/docs/r/batch_pool.html.markdown
+++ b/website/docs/r/batch_pool.html.markdown
@@ -126,11 +126,11 @@ The following arguments are supported:
 
 * `storage_image_reference` - (Required) A `storage_image_reference` for the virtual machines that will compose the Batch pool.
 
-* `data_disks` - (Optional) A `data_disks` block describes the data disk settings.
+* `data_disks` - (Optional) A `data_disks` block describes the data disk settings as defined below.
 
 * `display_name` - (Optional) Specifies the display name of the Batch pool. Changing this forces a new resource to be created.
 
-* `disk_encryption` - (Optional) A `disk_encryption` block describes the disk encryption configuration applied on compute nodes in the pool. Disk encryption configuration is not supported on Linux pool created with Virtual Machine Image or Shared Image Gallery Image.
+* `disk_encryption` - (Optional) A `disk_encryption` block, as defined below, describes the disk encryption configuration applied on compute nodes in the pool. Disk encryption configuration is not supported on Linux pool created with Virtual Machine Image or Shared Image Gallery Image.
 
 * `extensions` - (Optional) An `extensions` block as defined below.
 
@@ -142,13 +142,13 @@ The following arguments are supported:
 
 * `max_tasks_per_node` - (Optional) Specifies the maximum number of tasks that can run concurrently on a single compute node in the pool. Defaults to `1`. Changing this forces a new resource to be created.
 
-* `fixed_scale` - (Optional) A `fixed_scale` block that describes the scale settings when using fixed scale.
+* `fixed_scale` - (Optional) A `fixed_scale` block that describes the scale settings when using fixed scale as defined below.
 
-* `auto_scale` - (Optional) A `auto_scale` block that describes the scale settings when using auto scale.
+* `auto_scale` - (Optional) A `auto_scale` block that describes the scale settings when using auto scale as defined below.
 
-* `start_task` - (Optional) A `start_task` block that describes the start task settings for the Batch pool.
+* `start_task` - (Optional) A `start_task` block that describes the start task settings for the Batch pool as defined below.
 
-* `certificate` - (Optional) One or more `certificate` blocks that describe the certificates to be installed on each compute node in the pool.
+* `certificate` - (Optional) One or more `certificate` blocks that describe the certificates to be installed on each compute node in the pool as defined below.
 
 * `container_configuration` - (Optional) The container configuration used in the pool's VMs.
 
@@ -156,17 +156,17 @@ The following arguments are supported:
 
 * `mount` - (Optional) A `mount` block defined as below.
 
-* `network_configuration` - (Optional) A `network_configuration` block that describes the network configurations for the Batch pool.
+* `network_configuration` - (Optional) A `network_configuration` block that describes the network configurations for the Batch pool as defined below.
 
-* `node_placement` - (Optional) A `node_placement` block that describes the placement policy for allocating nodes in the pool.
+* `node_placement` - (Optional) A `node_placement` block that describes the placement policy for allocating nodes in the pool as defined below.
 
 * `os_disk_placement` - (Optional) Specifies the ephemeral disk placement for operating system disk for all VMs in the pool. This property can be used by user in the request to choose which location the operating system should be in. e.g., cache disk space for Ephemeral OS disk provisioning. For more information on Ephemeral OS disk size requirements, please refer to Ephemeral OS disk size requirements for Windows VMs at <https://docs.microsoft.com/en-us/azure/virtual-machines/windows/ephemeral-os-disks#size-requirements> and Linux VMs at <https://docs.microsoft.com/en-us/azure/virtual-machines/linux/ephemeral-os-disks#size-requirements>. The only possible value is `CacheDisk`.
 
-* `task_scheduling_policy` - (Optional) A `task_scheduling_policy` block that describes how tasks are distributed across compute nodes in a pool. If not specified, the default is spread.
+* `task_scheduling_policy` - (Optional) A `task_scheduling_policy` block that describes how tasks are distributed across compute nodes in a pool. If not specified, the default is spread as defined below.
 
-* `user_accounts` - (Optional) A `user_accounts` block that describes the list of user accounts to be created on each node in the pool.
+* `user_accounts` - (Optional) A `user_accounts` block that describes the list of user accounts to be created on each node in the pool as defined below.
 
-* `windows` - (Optional) A `windows` block that describes the Windows configuration in the pool.
+* `windows` - A `windows` block that describes the Windows configuration in the pool as defined below.
 
 -> **NOTE:** For Windows compute nodes, the Batch service installs the certificates to the specified certificate store and location. For Linux compute nodes, the certificates are stored in a directory inside the task working directory and an environment variable `AZ_BATCH_CERTIFICATES_DIR` is supplied to the task to query for this location. For certificates with visibility of `remoteUser`, a `certs` directory is created in the user's home directory (e.g., `/home/{user-name}/certs`) and certificates are placed in that directory.
 
@@ -285,9 +285,9 @@ A `start_task` block supports the following:
 
 * `common_environment_properties` - (Optional) A map of strings (key,value) that represents the environment variables to set in the start task.
 
-* `user_identity` - (Required) A `user_identity` block that describes the user identity under which the start task runs.
+* `user_identity` - (Required) A `user_identity` block that describes the user identity under which the start task runs as defined below.
 
-* `resource_file` - (Optional) One or more `resource_file` blocks that describe the files to be downloaded to a compute node.
+* `resource_file` - (Optional) One or more `resource_file` blocks that describe the files to be downloaded to a compute node as defined below.
 
 ---
 
@@ -307,7 +307,7 @@ A `user_identity` block supports the following:
 
 * `user_name` - (Optional) The username to be used by the Batch pool start task.
 
-* `auto_user` - (Optional) A `auto_user` block that describes the user identity under which the start task runs.
+* `auto_user` - (Optional) A `auto_user` block that describes the user identity under which the start task runs as defined below.
 
 ~> **Please Note:** `user_name` and `auto_user` blocks cannot be used both at the same time, but you need to define one or the other.
 

--- a/website/docs/r/batch_pool.html.markdown
+++ b/website/docs/r/batch_pool.html.markdown
@@ -166,7 +166,7 @@ The following arguments are supported:
 
 * `user_accounts` - (Optional) A `user_accounts` block that describes the list of user accounts to be created on each node in the pool as defined below.
 
-* `windows` - A `windows` block that describes the Windows configuration in the pool as defined below.
+* `windows` - (Optional) A `windows` block that describes the Windows configuration in the pool as defined below.
 
 -> **NOTE:** For Windows compute nodes, the Batch service installs the certificates to the specified certificate store and location. For Linux compute nodes, the certificates are stored in a directory inside the task working directory and an environment variable `AZ_BATCH_CERTIFICATES_DIR` is supplied to the task to query for this location. For certificates with visibility of `remoteUser`, a `certs` directory is created in the user's home directory (e.g., `/home/{user-name}/certs`) and certificates are placed in that directory.
 
@@ -463,13 +463,13 @@ A `network_configuration` block supports the following:
 
 A `endpoint_configuration` block supports the following:
 
-* `name` - The name of the endpoint. The name must be unique within a Batch pool, can contain letters, numbers, underscores, periods, and hyphens. Names must start with a letter or number, must end with a letter, number, or underscore, and cannot exceed 77 characters. Changing this forces a new resource to be created.
+* `name` - (Required) The name of the endpoint. The name must be unique within a Batch pool, can contain letters, numbers, underscores, periods, and hyphens. Names must start with a letter or number, must end with a letter, number, or underscore, and cannot exceed 77 characters. Changing this forces a new resource to be created.
 
-* `backend_port` - The port number on the compute node. Acceptable values are between `1` and `65535` except for `29876`, `29877` as these are reserved. Changing this forces a new resource to be created.
+* `backend_port` - (Required) The port number on the compute node. Acceptable values are between `1` and `65535` except for `29876`, `29877` as these are reserved. Changing this forces a new resource to be created.
 
-* `protocol` - The protocol of the endpoint. Acceptable values are `TCP` and `UDP`. Changing this forces a new resource to be created.
+* `protocol` - (Required) The protocol of the endpoint. Acceptable values are `TCP` and `UDP`. Changing this forces a new resource to be created.
 
-* `frontend_port_range` - The range of external ports that will be used to provide inbound access to the backendPort on individual compute nodes in the format of `1000-1100`. Acceptable values range between `1` and `65534` except ports from `50000` to `55000` which are reserved by the Batch service. All ranges within a pool must be distinct and cannot overlap. Values must be a range of at least `100` nodes. Changing this forces a new resource to be created.
+* `frontend_port_range` - (Required) The range of external ports that will be used to provide inbound access to the backendPort on individual compute nodes in the format of `1000-1100`. Acceptable values range between `1` and `65534` except ports from `50000` to `55000` which are reserved by the Batch service. All ranges within a pool must be distinct and cannot overlap. Values must be a range of at least `100` nodes. Changing this forces a new resource to be created.
 
 * `network_security_group_rules` - (Optional) A list of network security group rules that will be applied to the endpoint. The maximum number of rules that can be specified across all the endpoints on a Batch pool is `25`. If no network security group rules are specified, a default rule will be created to allow inbound access to the specified backendPort. Set as documented in the network_security_group_rules block below. Changing this forces a new resource to be created.
 
@@ -519,7 +519,7 @@ A `linux_user_configuration` block supports the following:
 
 A `windows_user_configuration` block supports the following:
 
-* `login_mode` - (Optional) Specifies login mode for the user. The default value for VirtualMachineConfiguration pools is interactive mode and for CloudServiceConfiguration pools is batch mode. Values supported are "Batch" and "Interactive".
+* `login_mode` - (Required) Specifies login mode for the user. The default value for VirtualMachineConfiguration pools is interactive mode and for CloudServiceConfiguration pools is batch mode. Values supported are "Batch" and "Interactive".
 
 ---
 

--- a/website/docs/r/cdn_frontdoor_rule.html.markdown
+++ b/website/docs/r/cdn_frontdoor_rule.html.markdown
@@ -321,7 +321,7 @@ A `host_name_condition` block supports the following:
 
 * `operator` - (Required) A Conditional operator. Possible values include `Any`, `Equal`, `Contains`, `BeginsWith`, `EndsWith`, `LessThan`, `LessThanOrEqual`, `GreaterThan`, `GreaterThanOrEqual` or `RegEx`. Details can be found in the `Condition Operator List` below.
 
-* `match_values` - (Required) A list of one or more string values representing the value of the request hostname to match. If multiple values are specified, they're evaluated using `OR` logic.
+* `match_values` - (Optional) A list of one or more string values representing the value of the request hostname to match. If multiple values are specified, they're evaluated using `OR` logic.
 
 * `transforms` - (Optional) A Conditional operator. Possible values include `Lowercase`, `RemoveNulls`, `Trim`, `Uppercase`, `UrlDecode` or `UrlEncode`. Defaults to `Lowercase`. Details can be found in the `Condition Transform List` below.
 
@@ -373,7 +373,7 @@ A `remote_address_condition` block supports the following:
 
 ->Remote Address represents the original client IP that is either from the network connection or typically the `X-Forwarded-For` request header if the user is behind a proxy.
 
-* `operator` - (Required) The type of the remote address to match. Possible values include `Any`, `GeoMatch` or `IPMatch`. Use the `negate_condition` to specify Not `GeoMatch` or Not `IPMatch`.
+* `operator` - (Optional) The type of the remote address to match. Possible values include `Any`, `GeoMatch` or `IPMatch`. Use the `negate_condition` to specify Not `GeoMatch` or Not `IPMatch`.
 
 * `negate_condition` - (Optional) If `true` operator becomes the opposite of its value. Possible values `true` or `false`. Defaults to `false`. Details can be found in the `Condition Operator List` below.
 

--- a/website/docs/r/cdn_frontdoor_rule.html.markdown
+++ b/website/docs/r/cdn_frontdoor_rule.html.markdown
@@ -217,7 +217,7 @@ A `route_configuration_override_action` block supports the following:
 
 ->**NOTE:** Content won't be compressed on AzureFrontDoor when requested content is smaller than `1 byte` or larger than `1 MB`.
 
-* `cache_behavior` - (Optional) `HonorOrigin` the Front Door will always honor origin response header directive. If the origin directive is missing, Front Door will cache contents anywhere from `1` to `3` days. `OverrideAlways` the TTL value returned from your Front Door Origin is overwritten with the value specified in the action. This behavior will only be applied if the response is cacheable. `OverrideIfOriginMissing` if no TTL value gets returned from your Front Door Origin, the rule sets the TTL to the value specified in the action. This behavior will only be applied if the response is cacheable. `Disabled` the Front Door will not cache the response contents, irrespective of Front Door Origin response directives. Possible values include `HonorOrigin`, `OverrideAlways`, `OverrideIfOriginMissing` or `Disabled`. Defaults to `HonorOrigin`.
+* `cache_behavior` - (Optional) `HonorOrigin` the Front Door will always honor origin response header directive. If the origin directive is missing, Front Door will cache contents anywhere from `1` to `3` days. `OverrideAlways` the TTL value returned from your Front Door Origin is overwritten with the value specified in the action. This behavior will only be applied if the response is cacheable. `OverrideIfOriginMissing` if no TTL value gets returned from your Front Door Origin, the rule sets the TTL to the value specified in the action. This behavior will only be applied if the response is cacheable. `Disabled` the Front Door will not cache the response contents, irrespective of Front Door Origin response directives. Possible values include `HonorOrigin`, `OverrideAlways`, `OverrideIfOriginMissing` or `Disabled`. Defaults to `HonorOrigin`.
 
 ---
 
@@ -353,7 +353,7 @@ A `client_port_condition` block supports the following:
 
 A `socket_address_condition` block supports the following:
 
-->The `socket_address_condition` identifies requests based on the IP address of the direct connection to the Front Door Profiles edge. If the client used an HTTP proxy or a load balancer to send the request, the value of Socket address is the IP address of the proxy or load balancer.
+->The `socket_address_condition` identifies requests based on the IP address of the direct connection to the Front Door Profiles edge. If the client used an HTTP proxy or a load balancer to send the request, the value of Socket address is the IP address of the proxy or load balancer.
 
 ->Remote Address represents the original client IP that is either from the network connection or typically the `X-Forwarded-For` request header if the user is behind a proxy.
 

--- a/website/docs/r/consumption_budget_management_group.html.markdown
+++ b/website/docs/r/consumption_budget_management_group.html.markdown
@@ -160,7 +160,7 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `id` - The ID of the Management Group Consumption Budget.
 
-* `etag` - The ETag of the Management Group Consumption Budget.
+* `etag` - (Optional) The ETag of the Management Group Consumption Budget.
 
 ## Timeouts
 

--- a/website/docs/r/consumption_budget_resource_group.html.markdown
+++ b/website/docs/r/consumption_budget_resource_group.html.markdown
@@ -176,7 +176,7 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `id` - The ID of the Resource Group Consumption Budget.
 
-* `etag` - The ETag of the Resource Group Consumption Budget
+* `etag` - (Optional) The ETag of the Resource Group Consumption Budget
 
 ## Timeouts
 

--- a/website/docs/r/consumption_budget_subscription.html.markdown
+++ b/website/docs/r/consumption_budget_subscription.html.markdown
@@ -180,7 +180,7 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `id` - The ID of the Subscription Consumption Budget.
 
-* `etag` - The ETag of the Subscription Consumption Budget.
+* `etag` - (Optional) The ETag of the Subscription Consumption Budget.
 
 ## Timeouts
 

--- a/website/docs/r/container_group.html.markdown
+++ b/website/docs/r/container_group.html.markdown
@@ -177,9 +177,9 @@ A `container` block supports:
 
 An `exposed_port` block supports:
 
-* `port` - (Required) The port number the container will expose. Changing this forces a new resource to be created.
+* `port` - (Optional) The port number the container will expose. Changing this forces a new resource to be created.
 
-* `protocol` - (Required) The network protocol associated with port. Possible values are `TCP` & `UDP`. Changing this forces a new resource to be created.
+* `protocol` - (Optional) The network protocol associated with port. Possible values are `TCP` & `UDP`. Changing this forces a new resource to be created.
 
 ~> **Note:** Removing all `exposed_port` blocks requires setting `exposed_port = []`.
 
@@ -217,9 +217,9 @@ A `log_analytics` block supports:
 
 A `ports` block supports:
 
-* `port` - (Required) The port number the container will expose. Changing this forces a new resource to be created.
+* `port` - (Optional) The port number the container will expose. Changing this forces a new resource to be created.
 
-* `protocol` - (Required) The network protocol associated with port. Possible values are `TCP` & `UDP`. Changing this forces a new resource to be created.
+* `protocol` - (Optional) The network protocol associated with port. Possible values are `TCP` & `UDP`. Changing this forces a new resource to be created.
 
 ~> **Note:** Omitting these blocks will default the exposed ports on the group to all ports on all containers defined in the `container` blocks of this group.
 
@@ -227,9 +227,9 @@ A `ports` block supports:
 
 A `gpu` block supports:
 
-* `count` - (Required) The number of GPUs which should be assigned to this container. Allowed values are `1`, `2`, or `4`. Changing this forces a new resource to be created.
+* `count` - (Optional) The number of GPUs which should be assigned to this container. Allowed values are `1`, `2`, or `4`. Changing this forces a new resource to be created.
 
-* `sku` - (Required) The SKU which should be used for the GPU. Possible values are `K80`, `P100`, or `V100`. Changing this forces a new resource to be created.
+* `sku` - (Optional) The SKU which should be used for the GPU. Possible values are `K80`, `P100`, or `V100`. Changing this forces a new resource to be created.
 
 ---
 

--- a/website/docs/r/cosmosdb_account.html.markdown
+++ b/website/docs/r/cosmosdb_account.html.markdown
@@ -168,7 +168,7 @@ The `geo_location` block Configures the geographic locations the data is replica
 
 * `name` - (Required) The capability to enable - Possible values are `AllowSelfServeUpgradeToMongo36`, `DisableRateLimitingResponses`, `EnableAggregationPipeline`, `EnableCassandra`, `EnableGremlin`, `EnableMongo`, `EnableMongo16MBDocumentSupport`, `EnableTable`, `EnableServerless`, `MongoDBv3.4` and `mongoEnableDocLevelTTL`. Changing this forces a new resource to be created.
 
-**NOTE:**  Setting `MongoDBv3.4` also requires setting `EnableMongo`.
+~> **NOTE:**  Setting `MongoDBv3.4` also requires setting `EnableMongo`.
 
 ---
 
@@ -229,7 +229,7 @@ A `restore` block supports the following:
 
 * `source_cosmosdb_account_id` - (Required) The resource ID of the restorable database account from which the restore has to be initiated. The example is `/subscriptions/{subscriptionId}/providers/Microsoft.DocumentDB/locations/{location}/restorableDatabaseAccounts/{restorableDatabaseAccountName}`. Changing this forces a new resource to be created.
 
-**NOTE:** Any database account with `Continuous` type (live account or accounts deleted in last 30 days) are the restorable database accounts and there cannot be Create/Update/Delete operations on the restorable database accounts. They can only be read and be retrieved by `azurerm_cosmosdb_restorable_database_accounts`.
+~> **NOTE:** Any database account with `Continuous` type (live account or accounts deleted in last 30 days) are the restorable database accounts and there cannot be Create/Update/Delete operations on the restorable database accounts. They can only be read and be retrieved by `azurerm_cosmosdb_restorable_database_accounts`.
 
 * `restore_timestamp_in_utc` - (Required) The creation time of the database or the collection (Datetime Format `RFC 3339`). Changing this forces a new resource to be created.
 

--- a/website/docs/r/cosmosdb_gremlin_graph.html.markdown
+++ b/website/docs/r/cosmosdb_gremlin_graph.html.markdown
@@ -136,9 +136,9 @@ A `composite_index` block supports the following:
 
 An `index` block supports the following:
 
-* `path` - Path for which the indexing behaviour applies to.
+* `path` - (Required) Path for which the indexing behaviour applies to.
 
-* `order` - Order of the index. Possible values are `Ascending` or `Descending`.
+* `order` - (Required) Order of the index. Possible values are `Ascending` or `Descending`.
 
 ## Attributes Reference
 

--- a/website/docs/r/cosmosdb_sql_container.html.markdown
+++ b/website/docs/r/cosmosdb_sql_container.html.markdown
@@ -121,13 +121,13 @@ A `spatial_index` block supports the following:
 
 An `included_path` block supports the following:
 
-* `path` - Path for which the indexing behaviour applies to.
+* `path` - (Required) Path for which the indexing behaviour applies to.
 
 ---
 
 An `excluded_path` block supports the following:
 
-* `path` - Path that is excluded from indexing.
+* `path` - (Required) Path that is excluded from indexing.
 
 ---
 
@@ -139,9 +139,9 @@ A `composite_index` block supports the following:
 
 An `index` block supports the following:
 
-* `path` - Path for which the indexing behaviour applies to.
+* `path` - (Required) Path for which the indexing behaviour applies to.
 
-* `order` - Order of the index. Possible values are `Ascending` or `Descending`.
+* `order` - (Required) Order of the index. Possible values are `Ascending` or `Descending`.
 
 ---
 

--- a/website/docs/r/data_factory_tumbling_window.html.markdown
+++ b/website/docs/r/data_factory_tumbling_window.html.markdown
@@ -92,7 +92,7 @@ The following arguments are supported:
 
 * `description` - (Optional) The description for the Data Factory Tumbling Window Trigger.
 
-* `end_time` - (Required) Specifies the end time of Tumbling Window, formatted as an RFC3339 string.
+* `end_time` - (Optional) Specifies the end time of Tumbling Window, formatted as an RFC3339 string.
 
 * `max_concurrency` - (Optional) The max number for simultaneous trigger run fired by Tumbling Window. Possible values are between `1` and `50`. Defaults to `50`.
 

--- a/website/docs/r/databox_edge_order.html.markdown
+++ b/website/docs/r/databox_edge_order.html.markdown
@@ -57,7 +57,7 @@ The following arguments are supported:
 
 * `contact` - (Required)  A `contact` block as defined below.
 
-* `shipment_address` - (Required)  A `shipment_address block as defined below.
+* `shipment_address` - (Required)  A `shipment_address` block as defined below.
 
 ---
 

--- a/website/docs/r/databricks_access_connector.html.markdown
+++ b/website/docs/r/databricks_access_connector.html.markdown
@@ -64,7 +64,7 @@ The following attributes are exported:
 ---
 
 An `identity` block exports the following:
-* `type` - The type of identity.
+* `type` - (Required) The type of identity.
 * `principal_id` - The Principal Id associated with this system-assigned managed identity.
 * `tenant_id` - The Tenant Id associated with this system-assigned managed identity.
 

--- a/website/docs/r/databricks_access_connector.html.markdown
+++ b/website/docs/r/databricks_access_connector.html.markdown
@@ -47,6 +47,8 @@ The following arguments are supported:
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
+---
+
 An `identity` block supports the following:
 * `type` - (Required) The type of identity to use for this Access Connector. `SystemAssigned` is the only possible value.
 * `principal_id` - (Optional) The object id of an existing principal. If not specified, a new system-assigned managed identity is created.
@@ -58,6 +60,8 @@ The following attributes are exported:
 
 * `id` - The ID of the Databricks Access Connector in the Azure management plane.
 * `identity`  - A list of `identity` blocks containing the system-assigned managed identities as defined below.
+
+---
 
 An `identity` block exports the following:
 * `type` - The type of identity.

--- a/website/docs/r/databricks_workspace.html.markdown
+++ b/website/docs/r/databricks_workspace.html.markdown
@@ -58,7 +58,7 @@ The following arguments are supported:
 
 * `customer_managed_key_enabled` - (Optional) Is the workspace enabled for customer managed key encryption? If `true` this enables the Managed Identity for the managed storage account. Possible values are `true` or `false`. Defaults to `false`. This field is only valid if the Databricks Workspace `sku` is set to `premium`. Changing this forces a new resource to be created.
 
-* `infrastructure_encryption_enabled`- (Optional) Is the Databricks File System root file system enabled with a secondary layer of encryption with platform managed keys? Possible values are `true` or `false`. Defaults to `false`. This field is only valid if the Databricks Workspace `sku` is set to `premium`. Changing this forces a new resource to be created.
+* `infrastructure_encryption_enabled` - (Optional) Is the Databricks File System root file system enabled with a secondary layer of encryption with platform managed keys? Possible values are `true` or `false`. Defaults to `false`. This field is only valid if the Databricks Workspace `sku` is set to `premium`. Changing this forces a new resource to be created.
 
 * `public_network_access_enabled` - (Optional) Allow public access for accessing workspace. Set value to `false` to access workspace only via private link endpoint. Possible values include `true` or `false`. Defaults to `true`. Changing this forces a new resource to be created.
 

--- a/website/docs/r/eventgrid_event_subscription.html.markdown
+++ b/website/docs/r/eventgrid_event_subscription.html.markdown
@@ -147,25 +147,25 @@ A `subject_filter` block supports the following:
 
 A `advanced_filter` supports the following nested blocks:
 
-* `bool_equals` - Compares a value of an event using a single boolean value.
-* `number_greater_than` - Compares a value of an event using a single floating point number.
-* `number_greater_than_or_equals` - Compares a value of an event using a single floating point number.
-* `number_less_than` - Compares a value of an event using a single floating point number.
-* `number_less_than_or_equals` - Compares a value of an event using a single floating point number.
-* `number_in` - Compares a value of an event using multiple floating point numbers.
-* `number_not_in` - Compares a value of an event using multiple floating point numbers.
-* `number_in_range` - Compares a value of an event using multiple floating point number ranges.
-* `number_not_in_range` - Compares a value of an event using multiple floating point number ranges.
-* `string_begins_with` - Compares a value of an event using multiple string values.
-* `string_not_begins_with` - Compares a value of an event using multiple string values.
-* `string_ends_with` - Compares a value of an event using multiple string values.
-* `string_not_ends_with` - Compares a value of an event using multiple string values.
-* `string_contains` - Compares a value of an event using multiple string values.
-* `string_not_contains` - Compares a value of an event using multiple string values.
-* `string_in` - Compares a value of an event using multiple string values.
-* `string_not_in` - Compares a value of an event using multiple string values.
-* `is_not_null` - Evaluates if a value of an event isn't NULL or undefined.
-* `is_null_or_undefined` - Evaluates if a value of an event is NULL or undefined.
+* `bool_equals` - (Optional) Compares a value of an event using a single boolean value.
+* `number_greater_than` - (Optional) Compares a value of an event using a single floating point number.
+* `number_greater_than_or_equals` - (Optional) Compares a value of an event using a single floating point number.
+* `number_less_than` - (Optional) Compares a value of an event using a single floating point number.
+* `number_less_than_or_equals` - (Optional) Compares a value of an event using a single floating point number.
+* `number_in` - (Optional) Compares a value of an event using multiple floating point numbers.
+* `number_not_in` - (Optional) Compares a value of an event using multiple floating point numbers.
+* `number_in_range` - (Optional) Compares a value of an event using multiple floating point number ranges.
+* `number_not_in_range` - (Optional) Compares a value of an event using multiple floating point number ranges.
+* `string_begins_with` - (Optional) Compares a value of an event using multiple string values.
+* `string_not_begins_with` - (Optional) Compares a value of an event using multiple string values.
+* `string_ends_with` - (Optional) Compares a value of an event using multiple string values.
+* `string_not_ends_with` - (Optional) Compares a value of an event using multiple string values.
+* `string_contains` - (Optional) Compares a value of an event using multiple string values.
+* `string_not_contains` - (Optional) Compares a value of an event using multiple string values.
+* `string_in` - (Optional) Compares a value of an event using multiple string values.
+* `string_not_in` - (Optional) Compares a value of an event using multiple string values.
+* `is_not_null` - (Optional) Evaluates if a value of an event isn't NULL or undefined.
+* `is_null_or_undefined` - (Optional) Evaluates if a value of an event is NULL or undefined.
 
 Each nested block consists of a key and a value(s) element.
 

--- a/website/docs/r/eventgrid_system_topic_event_subscription.html.markdown
+++ b/website/docs/r/eventgrid_system_topic_event_subscription.html.markdown
@@ -157,25 +157,25 @@ A `subject_filter` block supports the following:
 
 A `advanced_filter` supports the following nested blocks:
 
-* `bool_equals` - Compares a value of an event using a single boolean value.
-* `number_greater_than` - Compares a value of an event using a single floating point number.
-* `number_greater_than_or_equals` - Compares a value of an event using a single floating point number.
-* `number_less_than` - Compares a value of an event using a single floating point number.
-* `number_less_than_or_equals` - Compares a value of an event using a single floating point number.
-* `number_in` - Compares a value of an event using multiple floating point numbers.
-* `number_not_in` - Compares a value of an event using multiple floating point numbers.
-* `number_in_range` - Compares a value of an event using multiple floating point number ranges.
-* `number_not_in_range` - Compares a value of an event using multiple floating point number ranges.
-* `string_begins_with` - Compares a value of an event using multiple string values.
-* `string_not_begins_with` - Compares a value of an event using multiple string values.
-* `string_ends_with` - Compares a value of an event using multiple string values.
-* `string_not_ends_with` - Compares a value of an event using multiple string values.
-* `string_contains` - Compares a value of an event using multiple string values.
-* `string_not_contains` - Compares a value of an event using multiple string values.
-* `string_in` - Compares a value of an event using multiple string values.
-* `string_not_in` - Compares a value of an event using multiple string values.
-* `is_not_null` - Evaluates if a value of an event isn't NULL or undefined.
-* `is_null_or_undefined` - Evaluates if a value of an event is NULL or undefined.
+* `bool_equals` - (Optional) Compares a value of an event using a single boolean value.
+* `number_greater_than` - (Optional) Compares a value of an event using a single floating point number.
+* `number_greater_than_or_equals` - (Optional) Compares a value of an event using a single floating point number.
+* `number_less_than` - (Optional) Compares a value of an event using a single floating point number.
+* `number_less_than_or_equals` - (Optional) Compares a value of an event using a single floating point number.
+* `number_in` - (Optional) Compares a value of an event using multiple floating point numbers.
+* `number_not_in` - (Optional) Compares a value of an event using multiple floating point numbers.
+* `number_in_range` - (Optional) Compares a value of an event using multiple floating point number ranges.
+* `number_not_in_range` - (Optional) Compares a value of an event using multiple floating point number ranges.
+* `string_begins_with` - (Optional) Compares a value of an event using multiple string values.
+* `string_not_begins_with` - (Optional) Compares a value of an event using multiple string values.
+* `string_ends_with` - (Optional) Compares a value of an event using multiple string values.
+* `string_not_ends_with` - (Optional) Compares a value of an event using multiple string values.
+* `string_contains` - (Optional) Compares a value of an event using multiple string values.
+* `string_not_contains` - (Optional) Compares a value of an event using multiple string values.
+* `string_in` - (Optional) Compares a value of an event using multiple string values.
+* `string_not_in` - (Optional) Compares a value of an event using multiple string values.
+* `is_not_null` - (Optional) Evaluates if a value of an event isn't NULL or undefined.
+* `is_null_or_undefined` - (Optional) Evaluates if a value of an event is NULL or undefined.
 
 Each nested block consists of a key and a value(s) element.
 

--- a/website/docs/r/eventhub.html.markdown
+++ b/website/docs/r/eventhub.html.markdown
@@ -87,7 +87,7 @@ A `destination` block supports the following:
 
 -> At this time it's only possible to Capture EventHub messages to Blob Storage. There's [a Feature Request for the Azure SDK to add support for Capturing messages to Azure Data Lake here](https://github.com/Azure/azure-rest-api-specs/issues/2255).
 
-* `archive_name_format` - The Blob naming convention for archiving. e.g. `{Namespace}/{EventHub}/{PartitionId}/{Year}/{Month}/{Day}/{Hour}/{Minute}/{Second}`. Here all the parameters (Namespace,EventHub .. etc) are mandatory irrespective of order
+* `archive_name_format` - (Required) The Blob naming convention for archiving. e.g. `{Namespace}/{EventHub}/{PartitionId}/{Year}/{Month}/{Day}/{Hour}/{Minute}/{Second}`. Here all the parameters (Namespace,EventHub .. etc) are mandatory irrespective of order
 
 * `blob_container_name` - (Required) The name of the Container within the Blob Storage Account where messages should be archived.
 

--- a/website/docs/r/express_route_circuit_peering.html.markdown
+++ b/website/docs/r/express_route_circuit_peering.html.markdown
@@ -170,7 +170,7 @@ A `ipv6` block contains:
 
 A `microsoft_peering` block contains:
 
-* `advertised_public_prefixes` - (Required) A list of Advertised Public Prefixes.
+* `advertised_public_prefixes` - (Optional) A list of Advertised Public Prefixes.
 
 * `customer_asn` - (Optional) The CustomerASN of the peering.
 

--- a/website/docs/r/firewall_policy_rule_collection_group.html.markdown
+++ b/website/docs/r/firewall_policy_rule_collection_group.html.markdown
@@ -183,7 +183,7 @@ A `rule` (NAT rule) block supports the following:
 
 * `name` - (Required) The name which should be used for this rule.
 
-* `protocols` - (Required) Specifies a list of network protocols this rule applies to. Possible values are `TCP`, `UDP`.
+* `protocols` - (Optional) Specifies a list of network protocols this rule applies to. Possible values are `TCP`, `UDP`.
 
 * `source_addresses` - (Optional) Specifies a list of source IP addresses (including CIDR and `*`).
 
@@ -191,7 +191,7 @@ A `rule` (NAT rule) block supports the following:
 
 * `destination_address` - (Optional) The destination IP address (including CIDR).
 
-* `destination_ports` - (Optional) Specifies a list of destination ports. Only one destination port is supported in a NAT rule.
+* `destination_ports` - (Required) Specifies a list of destination ports. Only one destination port is supported in a NAT rule.
 
 * `translated_address` - (Optional) Specifies the translated address.
 

--- a/website/docs/r/firewall_policy_rule_collection_group.html.markdown
+++ b/website/docs/r/firewall_policy_rule_collection_group.html.markdown
@@ -105,7 +105,7 @@ A `application_rule_collection` block supports the following:
 
 * `priority` - (Required) The priority of the application rule collection. The range is `100` - `65000`.
 
-* `rule` - (Required) One or more `rule` (application rule) blocks as defined below.
+* `rule` - (Required) One or more `application_rule` (application rule) blocks as defined below.
 
 ---
 
@@ -117,7 +117,7 @@ A `network_rule_collection` block supports the following:
 
 * `priority` - (Required) The priority of the network rule collection. The range is `100` - `65000`.
 
-* `rule` - (Required) One or more `rule` (network rule) blocks as defined above.
+* `rule` - (Required) One or more `network_rule` (network rule) blocks as defined below.
 
 ---
 
@@ -129,11 +129,11 @@ A `nat_rule_collection` block supports the following:
 
 * `priority` - (Required) The priority of the NAT rule collection. The range is `100` - `65000`.
 
-* `rule` - (Required) A `rule` (NAT rule) block as defined above.
+* `rule` - (Required) A `nat_rule` (NAT rule) block as defined below.
 
 ---
 
-A `rule` (application rule) block supports the following:
+A `application_rule` (application rule) block supports the following:
 
 * `name` - (Required) The name which should be used for this rule.
 
@@ -159,7 +159,7 @@ A `rule` (application rule) block supports the following:
 
 ---
 
-A `rule` (network rule) block supports the following:
+A `network_rule` (network rule) block supports the following:
 
 * `name` - (Required) The name which should be used for this rule.
 
@@ -179,11 +179,11 @@ A `rule` (network rule) block supports the following:
 
 ---
 
-A `rule` (NAT rule) block supports the following:
+A `nat_rule` (NAT rule) block supports the following:
 
 * `name` - (Required) The name which should be used for this rule.
 
-* `protocols` - (Optional) Specifies a list of network protocols this rule applies to. Possible values are `TCP`, `UDP`.
+* `protocols` - (Required) Specifies a list of network protocols this rule applies to. Possible values are `TCP`, `UDP`.
 
 * `source_addresses` - (Optional) Specifies a list of source IP addresses (including CIDR and `*`).
 
@@ -191,7 +191,7 @@ A `rule` (NAT rule) block supports the following:
 
 * `destination_address` - (Optional) The destination IP address (including CIDR).
 
-* `destination_ports` - (Required) Specifies a list of destination ports. Only one destination port is supported in a NAT rule.
+* `destination_ports` - (Optional) Specifies a list of destination ports. Only one destination port is supported in a NAT rule.
 
 * `translated_address` - (Optional) Specifies the translated address.
 

--- a/website/docs/r/frontdoor.html.markdown
+++ b/website/docs/r/frontdoor.html.markdown
@@ -195,9 +195,9 @@ The `routing_rule` block supports the following:
 
 * `frontend_endpoints` - (Required) The names of the `frontend_endpoint` blocks within this resource to associate with this `routing_rule`.
 
-* `accepted_protocols` - (Optional) Protocol schemes to match for the Backend Routing Rule. Possible values are `Http` and `Https`. Defaults to `Http`.
+* `accepted_protocols` - (Required) Protocol schemes to match for the Backend Routing Rule. Possible values are `Http` and `Https`. Defaults to `Http`.
 
-* `patterns_to_match` - (Optional) The route patterns for the Backend Routing Rule. Defaults to `/*`.
+* `patterns_to_match` - (Required) The route patterns for the Backend Routing Rule. Defaults to `/*`.
 
 * `enabled` - (Optional) `Enable` or `Disable` use of this Backend Routing Rule. Permitted values are `true` or `false`. Defaults to `true`.
 
@@ -231,7 +231,7 @@ The `redirect_configuration` block supports the following:
 
 * `custom_host` - (Optional)  Set this to change the URL for the redirection.
 
-* `redirect_protocol` - (Optional) Protocol to use when redirecting. Valid options are `HttpOnly`, `HttpsOnly`, or `MatchRequest`. Defaults to `MatchRequest`
+* `redirect_protocol` - (Required) Protocol to use when redirecting. Valid options are `HttpOnly`, `HttpsOnly`, or `MatchRequest`. Defaults to `MatchRequest`
 
 * `redirect_type` - (Required) Status code for the redirect. Valida options are `Moved`, `Found`, `TemporaryRedirect`, `PermanentRedirect`.
 

--- a/website/docs/r/frontdoor_custom_https_configuration.html.markdown
+++ b/website/docs/r/frontdoor_custom_https_configuration.html.markdown
@@ -113,9 +113,9 @@ The `custom_https_configuration` block supports the following:
 
 The following attributes are only valid if `certificate_source` is set to `AzureKeyVault`:
 
-* `azure_key_vault_certificate_vault_id` - (Required) The ID of the Key Vault containing the SSL certificate.
+* `azure_key_vault_certificate_vault_id` - (Optional) The ID of the Key Vault containing the SSL certificate.
 
-* `azure_key_vault_certificate_secret_name` - (Required) The name of the Key Vault secret representing the full certificate PFX.
+* `azure_key_vault_certificate_secret_name` - (Optional) The name of the Key Vault secret representing the full certificate PFX.
 
 * `azure_key_vault_certificate_secret_version` - (Optional) The version of the Key Vault secret representing the full certificate PFX. Defaults to `Latest`.
 

--- a/website/docs/r/frontdoor_firewall_policy.html.markdown
+++ b/website/docs/r/frontdoor_firewall_policy.html.markdown
@@ -157,7 +157,7 @@ The `custom_rule` block supports the following:
 
 * `enabled` - (Optional) Is the rule is enabled or disabled? Defaults to `true`.
 
-* `priority` - (Required) The priority of the rule. Rules with a lower value will be evaluated before rules with a higher value. Defaults to `1`.
+* `priority` - (Optional) The priority of the rule. Rules with a lower value will be evaluated before rules with a higher value. Defaults to `1`.
 
 * `type` - (Required) The type of rule. Possible values are `MatchRule` or `RateLimitRule`.
 

--- a/website/docs/r/frontdoor_rules_engine.html.markdown
+++ b/website/docs/r/frontdoor_rules_engine.html.markdown
@@ -141,37 +141,37 @@ The `action` block supports the following:
 
 The `request_header` block supports the following:
 
-* `header_action_type` - can be set to `Overwrite`, `Append` or `Delete`.
+* `header_action_type` - (Optional) can be set to `Overwrite`, `Append` or `Delete`.
 
-* `header_name` - header name (string).
+* `header_name` - (Optional) header name (string).
 
-* `value` - value name (string).
+* `value` - (Optional) value name (string).
 
 ---
 
 The `response_header` block supports the following:
 
-* `header_action_type` - can be set to `Overwrite`, `Append` or `Delete`.
+* `header_action_type` - (Optional) can be set to `Overwrite`, `Append` or `Delete`.
 
-* `header_name` - header name (string).
+* `header_name` - (Optional) header name (string).
 
-* `value` - value name (string).
+* `value` - (Optional) value name (string).
 
 ---
 
 The `match_condition` block supports the following:
 
-* `variable` - can be set to `IsMobile`, `RemoteAddr`, `RequestMethod`, `QueryString`, `PostArgs`, `RequestURI`, `RequestPath`, `RequestFilename`, `RequestFilenameExtension`,`RequestHeader`,`RequestBody` or `RequestScheme`.
+* `variable` - (Optional) can be set to `IsMobile`, `RemoteAddr`, `RequestMethod`, `QueryString`, `PostArgs`, `RequestURI`, `RequestPath`, `RequestFilename`, `RequestFilenameExtension`,`RequestHeader`,`RequestBody` or `RequestScheme`.
 
-* `selector` - match against a specific key when `variable` is set to `PostArgs` or `RequestHeader`. It cannot be used with `QueryString` and `RequestMethod`. Defaults to `null`.
+* `selector` - (Optional) match against a specific key when `variable` is set to `PostArgs` or `RequestHeader`. It cannot be used with `QueryString` and `RequestMethod`. Defaults to `null`.
 
-* `operator` - can be set to `Any`, `IPMatch`, `GeoMatch`, `Equal`, `Contains`, `LessThan`, `GreaterThan`, `LessThanOrEqual`, `GreaterThanOrEqual`, `BeginsWith` or `EndsWith`
+* `operator` - (Required) can be set to `Any`, `IPMatch`, `GeoMatch`, `Equal`, `Contains`, `LessThan`, `GreaterThan`, `LessThanOrEqual`, `GreaterThanOrEqual`, `BeginsWith` or `EndsWith`
 
-* `transform` - can be set to one or more values out of `Lowercase`, `RemoveNulls`, `Trim`, `Uppercase`, `UrlDecode` and `UrlEncode`
+* `transform` - (Optional) can be set to one or more values out of `Lowercase`, `RemoveNulls`, `Trim`, `Uppercase`, `UrlDecode` and `UrlEncode`
 
-* `negate_condition` - can be set to `true` or `false` to negate the given condition. Defaults to `true`.
+* `negate_condition` - (Optional) can be set to `true` or `false` to negate the given condition. Defaults to `true`.
 
-* `value` - (array) can contain one or more strings.
+* `value` - (Optional) (array) can contain one or more strings.
 
 ## Import
 

--- a/website/docs/r/frontdoor_rules_engine.html.markdown
+++ b/website/docs/r/frontdoor_rules_engine.html.markdown
@@ -141,37 +141,37 @@ The `action` block supports the following:
 
 The `request_header` block supports the following:
 
-* `header_action_type` can be set to `Overwrite`, `Append` or `Delete`.
+* `header_action_type` - can be set to `Overwrite`, `Append` or `Delete`.
 
-* `header_name` header name (string).
+* `header_name` - header name (string).
 
-* `value` value name (string).
+* `value` - value name (string).
 
 ---
 
 The `response_header` block supports the following:
 
-* `header_action_type` can be set to `Overwrite`, `Append` or `Delete`.
+* `header_action_type` - can be set to `Overwrite`, `Append` or `Delete`.
 
-* `header_name` header name (string).
+* `header_name` - header name (string).
 
-* `value` value name (string).
+* `value` - value name (string).
 
 ---
 
 The `match_condition` block supports the following:
 
-* `variable` can be set to `IsMobile`, `RemoteAddr`, `RequestMethod`, `QueryString`, `PostArgs`, `RequestURI`, `RequestPath`, `RequestFilename`, `RequestFilenameExtension`,`RequestHeader`,`RequestBody` or `RequestScheme`.
+* `variable` - can be set to `IsMobile`, `RemoteAddr`, `RequestMethod`, `QueryString`, `PostArgs`, `RequestURI`, `RequestPath`, `RequestFilename`, `RequestFilenameExtension`,`RequestHeader`,`RequestBody` or `RequestScheme`.
 
-* `selector` match against a specific key when `variable` is set to `PostArgs` or `RequestHeader`. It cannot be used with `QueryString` and `RequestMethod`. Defaults to `null`.
+* `selector` - match against a specific key when `variable` is set to `PostArgs` or `RequestHeader`. It cannot be used with `QueryString` and `RequestMethod`. Defaults to `null`.
 
-* `operator` can be set to `Any`, `IPMatch`, `GeoMatch`, `Equal`, `Contains`, `LessThan`, `GreaterThan`, `LessThanOrEqual`, `GreaterThanOrEqual`, `BeginsWith` or `EndsWith`
+* `operator` - can be set to `Any`, `IPMatch`, `GeoMatch`, `Equal`, `Contains`, `LessThan`, `GreaterThan`, `LessThanOrEqual`, `GreaterThanOrEqual`, `BeginsWith` or `EndsWith`
 
-* `transform` can be set to one or more values out of `Lowercase`, `RemoveNulls`, `Trim`, `Uppercase`, `UrlDecode` and `UrlEncode`
+* `transform` - can be set to one or more values out of `Lowercase`, `RemoveNulls`, `Trim`, `Uppercase`, `UrlDecode` and `UrlEncode`
 
-* `negate_condition` can be set to `true` or `false` to negate the given condition. Defaults to `true`.
+* `negate_condition` - can be set to `true` or `false` to negate the given condition. Defaults to `true`.
 
-* `value` (array) can contain one or more strings.
+* `value` - (array) can contain one or more strings.
 
 ## Import
 

--- a/website/docs/r/function_app.html.markdown
+++ b/website/docs/r/function_app.html.markdown
@@ -315,7 +315,7 @@ The `site_config` block supports the following:
 
 A `cors` block supports the following:
 
-* `allowed_origins` - (Optional) A list of origins which should be able to make cross-origin calls. `*` can be used to allow all calls.
+* `allowed_origins` - (Required) A list of origins which should be able to make cross-origin calls. `*` can be used to allow all calls.
 
 * `support_credentials` - (Optional) Are credentials supported?
 
@@ -407,9 +407,9 @@ A `microsoft` block supports the following:
 
 A `twitter` block supports the following:
 
-* `consumer_key` - The OAuth 1.0a consumer key of the Twitter application used for sign-in.
+* `consumer_key` - (Required) The OAuth 1.0a consumer key of the Twitter application used for sign-in.
 
-* `consumer_secret` - The OAuth 1.0a consumer secret of the Twitter application used for sign-in.
+* `consumer_secret` - (Required) The OAuth 1.0a consumer secret of the Twitter application used for sign-in.
 
 ---
 

--- a/website/docs/r/function_app_slot.html.markdown
+++ b/website/docs/r/function_app_slot.html.markdown
@@ -158,7 +158,7 @@ The `site_config` block supports the following:
 
 A `cors` block supports the following:
 
-* `allowed_origins` - (Optional) A list of origins which should be able to make cross-origin calls. `*` can be used to allow all calls.
+* `allowed_origins` - (Required) A list of origins which should be able to make cross-origin calls. `*` can be used to allow all calls.
 
 * `support_credentials` - (Optional) Are credentials supported?
 
@@ -252,7 +252,7 @@ A `twitter` block supports the following:
 
 * `consumer_key` - (Required) The OAuth 1.0a consumer key of the Twitter application used for sign-in.
 
-* `consumer_secret` - (Optional) The OAuth 1.0a consumer secret of the Twitter application used for sign-in.
+* `consumer_secret` - (Required) The OAuth 1.0a consumer secret of the Twitter application used for sign-in.
 
 ---
 

--- a/website/docs/r/hdinsight_hadoop_cluster.html.markdown
+++ b/website/docs/r/hdinsight_hadoop_cluster.html.markdown
@@ -249,7 +249,7 @@ A `worker_node` block supports the following:
 
 * `subnet_id` - (Optional) The ID of the Subnet within the Virtual Network where the Worker Nodes should be provisioned within. Changing this forces a new resource to be created.
 
-* `target_instance_count` - (Optional) The number of instances which should be run for the Worker Nodes.
+* `target_instance_count` - (Required) The number of instances which should be run for the Worker Nodes.
 
 * `virtual_network_id` - (Optional) The ID of the Virtual Network where the Worker Nodes should be provisioned within. Changing this forces a new resource to be created.
 

--- a/website/docs/r/hdinsight_hbase_cluster.html.markdown
+++ b/website/docs/r/hdinsight_hbase_cluster.html.markdown
@@ -247,7 +247,7 @@ A `worker_node` block supports the following:
 
 * `subnet_id` - (Optional) The ID of the Subnet within the Virtual Network where the Worker Nodes should be provisioned within. Changing this forces a new resource to be created.
 
-* `target_instance_count` - (Optional) The number of instances which should be run for the Worker Nodes.
+* `target_instance_count` - (Required) The number of instances which should be run for the Worker Nodes.
 
 * `virtual_network_id` - (Optional) The ID of the Virtual Network where the Worker Nodes should be provisioned within. Changing this forces a new resource to be created.
 

--- a/website/docs/r/hdinsight_interactive_query_cluster.html.markdown
+++ b/website/docs/r/hdinsight_interactive_query_cluster.html.markdown
@@ -253,7 +253,7 @@ A `worker_node` block supports the following:
 
 * `subnet_id` - (Optional) The ID of the Subnet within the Virtual Network where the Worker Nodes should be provisioned within. Changing this forces a new resource to be created.
 
-* `target_instance_count` - (Optional) The number of instances which should be run for the Worker Nodes.
+* `target_instance_count` - (Required) The number of instances which should be run for the Worker Nodes.
 
 * `virtual_network_id` - (Optional) The ID of the Virtual Network where the Worker Nodes should be provisioned within. Changing this forces a new resource to be created.
 

--- a/website/docs/r/hdinsight_kafka_cluster.html.markdown
+++ b/website/docs/r/hdinsight_kafka_cluster.html.markdown
@@ -242,7 +242,7 @@ A `worker_node` block supports the following:
 
 * `subnet_id` - (Optional) The ID of the Subnet within the Virtual Network where the Worker Nodes should be provisioned within. Changing this forces a new resource to be created.
 
-* `target_instance_count` - (Optional) The number of instances which should be run for the Worker Nodes.
+* `target_instance_count` - (Required) The number of instances which should be run for the Worker Nodes.
 
 * `virtual_network_id` - (Optional) The ID of the Virtual Network where the Worker Nodes should be provisioned within. Changing this forces a new resource to be created.
 

--- a/website/docs/r/hdinsight_spark_cluster.html.markdown
+++ b/website/docs/r/hdinsight_spark_cluster.html.markdown
@@ -249,7 +249,7 @@ A `worker_node` block supports the following:
 
 * `subnet_id` - (Optional) The ID of the Subnet within the Virtual Network where the Worker Nodes should be provisioned within. Changing this forces a new resource to be created.
 
-* `target_instance_count` - (Optional) The number of instances which should be run for the Worker Nodes.
+* `target_instance_count` - (Required) The number of instances which should be run for the Worker Nodes.
 
 * `virtual_network_id` - (Optional) The ID of the Virtual Network where the Worker Nodes should be provisioned within. Changing this forces a new resource to be created.
 

--- a/website/docs/r/healthcare_medtech_service.html.markdown
+++ b/website/docs/r/healthcare_medtech_service.html.markdown
@@ -88,7 +88,7 @@ The following arguments are supported:
 ---
 An `identity` block exports the following:
 
-* `type` - The type of identity used for the Healthcare Med Tech service.
+* `type` - (Required) The type of identity used for the Healthcare Med Tech service.
 
 * `principal_id` - The Principal ID associated with this System Assigned Managed Service Identity.
 

--- a/website/docs/r/image.html.markdown
+++ b/website/docs/r/image.html.markdown
@@ -119,8 +119,8 @@ The following arguments are supported:
 
 The `os_disk` block supports the following:
 
-* `os_type` - (Required) Specifies the type of operating system contained in the virtual machine image. Possible values are: Windows or Linux.
-* `os_state` - (Required) Specifies the state of the operating system contained in the blob. Currently, the only value is Generalized.
+* `os_type` - (Optional) Specifies the type of operating system contained in the virtual machine image. Possible values are: Windows or Linux.
+* `os_state` - (Optional) Specifies the state of the operating system contained in the blob. Currently, the only value is Generalized. Possible values are `Generalized` and `Specialized`.
 * `managed_disk_id` - (Optional) Specifies the ID of the managed disk resource that you want to use to create the image.
 * `blob_uri` - (Optional) Specifies the URI in Azure storage of the blob that you want to use to create the image.
 * `caching` - (Optional) Specifies the caching mode as `ReadWrite`, `ReadOnly`, or `None`. The default is `None`.
@@ -130,7 +130,7 @@ The `os_disk` block supports the following:
 
 The `data_disk` block supports the following:
 
-* `lun` - (Required) Specifies the logical unit number of the data disk.
+* `lun` - (Optional) Specifies the logical unit number of the data disk.
 * `managed_disk_id` - (Optional) Specifies the ID of the managed disk resource that you want to use to create the image.
 * `blob_uri` - (Optional) Specifies the URI in Azure storage of the blob that you want to use to create the image.
 * `caching` - (Optional) Specifies the caching mode as `ReadWrite`, `ReadOnly`, or `None`. The default is `None`.

--- a/website/docs/r/iot_time_series_insights_gen2_environment.html.markdown
+++ b/website/docs/r/iot_time_series_insights_gen2_environment.html.markdown
@@ -50,7 +50,7 @@ The following arguments are supported:
 
 * `sku_name` - (Required) Specifies the SKU Name for this IoT Time Series Insights Gen2 Environment. Currently it supports only `L1`. For gen2, capacity cannot be specified. Changing this forces a new resource to be created.
 
-* `warm_store_data_retention_time` - (Required) Specifies the ISO8601 timespan specifying the minimum number of days the environment's events will be available for query. 
+* `warm_store_data_retention_time` - (Optional) Specifies the ISO8601 timespan specifying the minimum number of days the environment's events will be available for query. 
 
 * `storage` - (Required) A `storage` block as defined below.
 

--- a/website/docs/r/iot_time_series_insights_reference_data_set.html.markdown
+++ b/website/docs/r/iot_time_series_insights_reference_data_set.html.markdown
@@ -56,7 +56,7 @@ The following arguments are supported:
 
 A `key_property` block supports the following:
 
-* `name`- (Required) The name of the key property. Changing this forces a new resource to be created.
+* `name` - (Required) The name of the key property. Changing this forces a new resource to be created.
 
 * `type` - (Required) The data type of the key property. Valid values include `Bool`, `DateTime`, `Double`, `String`. Changing this forces a new resource to be created.
 

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -219,7 +219,7 @@ resource "azurerm_kubernetes_cluster" "example" {
 
 ```
 
-`public_network_access_enabled` - (Optional) Whether public network access is allowed for this Kubernetes Cluster. Defaults to `true`. Changing this forces a new resource to be created.
+* `public_network_access_enabled` - (Optional) Whether public network access is allowed for this Kubernetes Cluster. Defaults to `true`. Changing this forces a new resource to be created.
 
 -> **Note:** When `public_network_access_enabled` is set to `true`, `0.0.0.0/32` must be added to `api_server_authorized_ip_ranges`.
 
@@ -476,11 +476,11 @@ A `kubelet_config` block supports the following:
 
 The `kubelet_identity` block supports the following:
 
-* `client_id` - (Required) The Client ID of the user-defined Managed Identity to be assigned to the Kubelets. If not specified a Managed Identity is created automatically.
+* `client_id` - (Optional) The Client ID of the user-defined Managed Identity to be assigned to the Kubelets. If not specified a Managed Identity is created automatically.
 
-* `object_id` - (Required) The Object ID of the user-defined Managed Identity assigned to the Kubelets.If not specified a Managed Identity is created automatically.
+* `object_id` - (Optional) The Object ID of the user-defined Managed Identity assigned to the Kubelets.If not specified a Managed Identity is created automatically.
 
-* `user_assigned_identity_id` - (Required) The ID of the User Assigned Identity assigned to the Kubelets. If not specified a Managed Identity is created automatically.
+* `user_assigned_identity_id` - (Optional) The ID of the User Assigned Identity assigned to the Kubelets. If not specified a Managed Identity is created automatically.
 
 -> **NOTE:** When `kubelet_identity` is enabled - The `type` field in the `identity` block must be set to `UserAssigned` and `identity_ids` must be set.
 
@@ -826,7 +826,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `oidc_issuer_url` - The OIDC issuer URL that is associated with the cluster.
 
-* `node_resource_group` - The auto-generated Resource Group which contains the resources for this Managed Kubernetes Cluster.
+* `node_resource_group` - (Optional) The auto-generated Resource Group which contains the resources for this Managed Kubernetes Cluster.
 
 ---
 

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -592,9 +592,9 @@ Examples of how to use [AKS with Advanced Networking](https://docs.microsoft.com
 
 * `load_balancer_sku` - (Optional) Specifies the SKU of the Load Balancer used for this Kubernetes Cluster. Possible values are `basic` and `standard`. Defaults to `standard`. Changing this forces a new resource to be created.
 
-* `load_balancer_profile` - (Optional) A `load_balancer_profile` block. This can only be specified when `load_balancer_sku` is set to `standard`.
+* `load_balancer_profile` - (Optional) A `load_balancer_profile` block as defined below. This can only be specified when `load_balancer_sku` is set to `standard`.
 
-* `nat_gateway_profile` - (Optional) A `nat_gateway_profile` block. This can only be specified when `load_balancer_sku` is set to `standard` and `outbound_type` is set to `managedNATGateway` or `userAssignedNATGateway`.
+* `nat_gateway_profile` - (Optional) A `nat_gateway_profile` block as defined below. This can only be specified when `load_balancer_sku` is set to `standard` and `outbound_type` is set to `managedNATGateway` or `userAssignedNATGateway`.
 
 ---
 
@@ -758,7 +758,7 @@ A `windows_profile` block supports the following:
 
 * `license` - (Optional) Specifies the type of on-premise license which should be used for Node Pool Windows Virtual Machine. At this time the only possible value is `Windows_Server`.
 
-* `gmsa`- (Optional) A `gmsa` block as defined below.
+* `gmsa` - (Optional) A `gmsa` block as defined below.
 
 ---
 

--- a/website/docs/r/kusto_cluster.html.markdown
+++ b/website/docs/r/kusto_cluster.html.markdown
@@ -68,7 +68,7 @@ The following arguments are supported:
 
 * `purge_enabled` - (Optional) Specifies if the purge operations are enabled.
 
-* `virtual_network_configuration`- (Optional) A `virtual_network_configuration` block as defined below. Changing this forces a new resource to be created.
+* `virtual_network_configuration` - (Optional) A `virtual_network_configuration` block as defined below. Changing this forces a new resource to be created.
 
 * `language_extensions` - (Optional) An list of `language_extensions` to enable. Valid values are: `PYTHON` and `R`.
 

--- a/website/docs/r/lb.html.markdown
+++ b/website/docs/r/lb.html.markdown
@@ -74,7 +74,7 @@ The `frontend_ip_configuration` block supports the following:
 * `gateway_load_balancer_frontend_ip_configuration_id` - (Optional) The Frontend IP Configuration ID of a Gateway SKU Load Balancer.
 * `private_ip_address` - (Optional) Private IP Address to assign to the Load Balancer. The last one and first four IPs in any range are reserved and cannot be manually assigned.
 * `private_ip_address_allocation` - (Optional) The allocation method for the Private IP Address used by this Load Balancer. Possible values as `Dynamic` and `Static`.
-* `private_ip_address_version` - The version of IP that the Private IP Address is. Possible values are `IPv4` or `IPv6`.
+* `private_ip_address_version` - (Optional) The version of IP that the Private IP Address is. Possible values are `IPv4` or `IPv6`.
 * `public_ip_address_id` - (Optional) The ID of a Public IP Address which should be associated with the Load Balancer.
 * `public_ip_prefix_id` - (Optional) The ID of a Public IP Prefix which should be associated with the Load Balancer. Public IP Prefix can only be used with outbound rules.
 
@@ -91,16 +91,16 @@ The following attributes are exported:
 
 A `frontend_ip_configuration` block exports the following:
 
-* `gateway_load_balancer_frontend_ip_configuration_id` - The id of the Frontend IP Configuration of a Gateway Load Balancer that this Load Balancer points to.
+* `gateway_load_balancer_frontend_ip_configuration_id` - (Optional) The id of the Frontend IP Configuration of a Gateway Load Balancer that this Load Balancer points to.
 * `id` - The id of the Frontend IP Configuration.
 * `inbound_nat_rules` - The list of IDs of inbound rules that use this frontend IP.
 * `load_balancer_rules` - The list of IDs of load balancing rules that use this frontend IP.
 * `outbound_rules` - The list of IDs outbound rules that use this frontend IP.
-* `private_ip_address` - Private IP Address to assign to the Load Balancer.
-* `private_ip_address_allocation` - The allocation method for the Private IP Address used by this Load Balancer.
-* `public_ip_address_id` - The ID of a  Public IP Address which is associated with this Load Balancer.
-* `public_ip_prefix_id` - The ID of a Public IP Prefix which is associated with the Load Balancer.
-* `subnet_id` - The ID of the Subnet which is associated with the IP Configuration.
+* `private_ip_address` - (Optional) Private IP Address to assign to the Load Balancer.
+* `private_ip_address_allocation` - (Optional) The allocation method for the Private IP Address used by this Load Balancer. Possible values are `Dynamic` and `Static`.
+* `public_ip_address_id` - (Optional) The ID of a  Public IP Address which is associated with this Load Balancer.
+* `public_ip_prefix_id` - (Optional) The ID of a Public IP Prefix which is associated with the Load Balancer.
+* `subnet_id` - (Optional) The ID of the Subnet which is associated with the IP Configuration.
 
 ## Timeouts
 

--- a/website/docs/r/linux_function_app.html.markdown
+++ b/website/docs/r/linux_function_app.html.markdown
@@ -166,7 +166,7 @@ A `application_stack` block supports the following:
 
 An `app_service_logs` block supports the following:
 
-* `disk_quota_mb` - (Required) The amount of disk space to use for logs. Valid values are between `25` and `100`.
+* `disk_quota_mb` - (Optional) The amount of disk space to use for logs. Valid values are between `25` and `100`.
 
 * `retention_period_days` - (Optional) The retention period for logs in days. Valid values are between `0` and `99999`. Defaults to `0` (never delete).
 

--- a/website/docs/r/linux_virtual_machine.html.markdown
+++ b/website/docs/r/linux_virtual_machine.html.markdown
@@ -174,7 +174,7 @@ The following arguments are supported:
 
 * `platform_fault_domain` - (Optional) Specifies the Platform Fault Domain in which this Linux Virtual Machine should be created. Defaults to `-1`, which means this will be automatically assigned to a fault domain that best maintains balance across the available fault domains. Changing this forces a new Linux Virtual Machine to be created.
 
-* `priority`- (Optional) Specifies the priority of this Virtual Machine. Possible values are `Regular` and `Spot`. Defaults to `Regular`. Changing this forces a new resource to be created.
+* `priority` - (Optional) Specifies the priority of this Virtual Machine. Possible values are `Regular` and `Spot`. Defaults to `Regular`. Changing this forces a new resource to be created.
 
 * `provision_vm_agent` - (Optional) Should the Azure VM Agent be provisioned on this Virtual Machine? Defaults to `true`. Changing this forces a new resource to be created.
 

--- a/website/docs/r/linux_virtual_machine.html.markdown
+++ b/website/docs/r/linux_virtual_machine.html.markdown
@@ -328,13 +328,13 @@ A `secret` block supports the following:
 
 The `source_image_reference` block supports the following:
 
-* `publisher` - (Optional) Specifies the publisher of the image used to create the virtual machines.
+* `publisher` - (Required) Specifies the publisher of the image used to create the virtual machines.
 
-* `offer` - (Optional) Specifies the offer of the image used to create the virtual machines.
+* `offer` - (Required) Specifies the offer of the image used to create the virtual machines.
 
-* `sku` - (Optional) Specifies the SKU of the image used to create the virtual machines.
+* `sku` - (Required) Specifies the SKU of the image used to create the virtual machines.
 
-* `version` - (Optional) Specifies the version of the image used to create the virtual machines.
+* `version` - (Required) Specifies the version of the image used to create the virtual machines.
 
 ---
 

--- a/website/docs/r/linux_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/linux_virtual_machine_scale_set.html.markdown
@@ -420,9 +420,9 @@ An `ip_configuration` block supports the following:
 
 An `ip_tag` block supports the following:
 
-* `tag` - The IP Tag associated with the Public IP, such as `SQL` or `Storage`.
+* `tag` - (Required) The IP Tag associated with the Public IP, such as `SQL` or `Storage`.
 
-* `type` - The Type of IP Tag, such as `FirstPartyUsage`.
+* `type` - (Required) The Type of IP Tag, such as `FirstPartyUsage`.
 
 ---
 

--- a/website/docs/r/linux_web_app.html.markdown
+++ b/website/docs/r/linux_web_app.html.markdown
@@ -215,7 +215,7 @@ An `azure_blob_storage` block supports the following:
 
 * `level` - (Required) The level at which to log. Possible values include `Error`, `Warning`, `Information`, `Verbose` and `Off`. **NOTE:** this field is not available for `http_logs`
 
-* `retention_in_days` - (Required) The time in days after which to remove blobs. A value of `0` means no retention.
+* `retention_in_days` - (Optional) The time in days after which to remove blobs. A value of `0` means no retention.
 
 * `sas_url` - (Required) SAS url to an Azure blob container with read/write/list/delete permissions.
 

--- a/website/docs/r/linux_web_app_slot.html.markdown
+++ b/website/docs/r/linux_web_app_slot.html.markdown
@@ -216,7 +216,7 @@ An `azure_blob_storage` block supports the following:
 
 * `level` - (Required) The level at which to log. Possible values include `Error`, `Warning`, `Information`, `Verbose` and `Off`. **NOTE:** this field is not available for `http_logs`
 
-* `retention_in_days` - (Required) The time in days after which to remove blobs. A value of `0` means no retention.
+* `retention_in_days` - (Optional) The time in days after which to remove blobs. A value of `0` means no retention.
 
 * `sas_url` - (Required) SAS URL to an Azure blob container with read/write/list/delete permissions.
 

--- a/website/docs/r/log_analytics_cluster.html.markdown
+++ b/website/docs/r/log_analytics_cluster.html.markdown
@@ -81,7 +81,7 @@ An `identity` block exports the following:
 
 * `tenant_id` - The Tenant ID associated with this Managed Service Identity.
 
-* `type` - The identity type of this Managed Service Identity.
+* `type` - (Required) The identity type of this Managed Service Identity.
 
 -> You can access the Principal ID via `azurerm_log_analytics_cluster.example.identity.0.principal_id` and the Tenant ID via `azurerm_log_analytics_cluster.example.identity.0.tenant_id`
 

--- a/website/docs/r/logic_app_standard.html.markdown
+++ b/website/docs/r/logic_app_standard.html.markdown
@@ -203,7 +203,7 @@ The `site_config` block supports the following:
 
 * `scm_min_tls_version` - (Optional) Configures the minimum version of TLS required for SSL requests to the SCM site.
 
-* `scm_type` - The type of Source Control used by the Logic App in use by the Windows Function App. Defaults to `None`. Possible values are: `BitbucketGit`, `BitbucketHg`, `CodePlexGit`, `CodePlexHg`, `Dropbox`, `ExternalGit`, `ExternalHg`, `GitHub`, `LocalGit`, `None`, `OneDrive`, `Tfs`, `VSO`, and `VSTSRM`
+* `scm_type` - (Optional) The type of Source Control used by the Logic App in use by the Windows Function App. Defaults to `None`. Possible values are: `BitbucketGit`, `BitbucketHg`, `CodePlexGit`, `CodePlexHg`, `Dropbox`, `ExternalGit`, `ExternalHg`, `GitHub`, `LocalGit`, `None`, `OneDrive`, `Tfs`, `VSO`, and `VSTSRM`
 
 * `linux_fx_version` - (Optional) Linux App Framework and version for the AppService, e.g. `DOCKER|(golang:latest)`. Setting this value will also set the `kind` of application deployed to `functionapp,linux,container,workflowapp`
 
@@ -225,7 +225,7 @@ The `site_config` block supports the following:
 
 A `cors` block supports the following:
 
-* `allowed_origins` - (Optional) A list of origins which should be able to make cross-origin calls. `*` can be used to allow all calls.
+* `allowed_origins` - (Required) A list of origins which should be able to make cross-origin calls. `*` can be used to allow all calls.
 
 * `support_credentials` - (Optional) Are credentials supported?
 

--- a/website/docs/r/managed_disk.html.markdown
+++ b/website/docs/r/managed_disk.html.markdown
@@ -108,7 +108,7 @@ The following arguments are supported:
 
 * `upload_size_bytes` - (Optional) Specifies the size of the managed disk to create in bytes. Required when `create_option` is `Upload`. The value must be equal to the source disk to be copied in bytes. Source disk size could be calculated with `ls -l` or `wc -c`. More information can be found at [Copy a managed disk](https://learn.microsoft.com/en-us/azure/virtual-machines/linux/disks-upload-vhd-to-managed-disk-cli#copy-a-managed-disk). Changing this forces a new resource to be created.
 
-* `disk_size_gb` - (Optional, Required for a new managed disk) Specifies the size of the managed disk to create in gigabytes. If `create_option` is `Copy` or `FromImage`, then the value must be equal to or greater than the source's size. The size can only be increased.
+* `disk_size_gb` - (Optional) (Optional, Required for a new managed disk) Specifies the size of the managed disk to create in gigabytes. If `create_option` is `Copy` or `FromImage`, then the value must be equal to or greater than the source's size. The size can only be increased.
 
 -> **NOTE:** In certain conditions the Data Disk size can be updated without shutting down the Virtual Machine, however only a subset of Virtual Machine SKUs/Disk combinations support this. More information can be found [for Linux Virtual Machines](https://learn.microsoft.com/en-us/azure/virtual-machines/linux/expand-disks?tabs=azure-cli%2Cubuntu#expand-without-downtime) and [Windows Virtual Machines](https://learn.microsoft.com/azure/virtual-machines/windows/expand-os-disk#expand-without-downtime) respectively.
 

--- a/website/docs/r/monitor_autoscale_setting.html.markdown
+++ b/website/docs/r/monitor_autoscale_setting.html.markdown
@@ -528,7 +528,7 @@ A `fixed_date` block supports the following:
 
 A `recurrence` block supports the following:
 
-* `timezone` - (Required) The Time Zone used for the `hours` field. A list of [possible values can be found here](https://msdn.microsoft.com/en-us/library/azure/dn931928.aspx). Defaults to `UTC`.
+* `timezone` - (Optional) The Time Zone used for the `hours` field. A list of [possible values can be found here](https://msdn.microsoft.com/en-us/library/azure/dn931928.aspx). Defaults to `UTC`.
 
 * `days` - (Required) A list of days that this profile takes effect on. Possible values include `Monday`, `Tuesday`, `Wednesday`, `Thursday`, `Friday`, `Saturday` and `Sunday`.
 

--- a/website/docs/r/monitor_scheduled_query_rules_log.html.markdown
+++ b/website/docs/r/monitor_scheduled_query_rules_log.html.markdown
@@ -107,7 +107,7 @@ The `criteria` block supports the following:
 The `dimension` block supports the following:
 
 * `name` - (Required) Name of the dimension. Changing this forces a new resource to be created.
-* `operator` - (Required) Operator for dimension values, - 'Include'.
+* `operator` - (Optional) Operator for dimension values, - 'Include'.
 * `values` - (Required) List of dimension values.
 
 ## Attributes Reference

--- a/website/docs/r/mssql_database.html.markdown
+++ b/website/docs/r/mssql_database.html.markdown
@@ -172,7 +172,7 @@ A `short_term_retention_policy` block supports the following:
 The following attributes are exported:
 
 * `id` - The ID of the MS SQL Database.
-* `name` - The Name of the MS SQL Database.
+* `name` - (Required) The Name of the MS SQL Database.
 
 ## Timeouts
 

--- a/website/docs/r/mssql_virtual_machine.html.markdown
+++ b/website/docs/r/mssql_virtual_machine.html.markdown
@@ -101,7 +101,7 @@ The `manual_schedule` block supports the following:
 
 * `days_of_week` - (Optional) A list of days on which backup can take place. Possible values are `Monday`, `Tuesday`, `Wednesday`, `Thursday`, `Friday`, `Saturday` and `Sunday`
 
-* ~> **NOTE:** `days_of_week` can only be specified when `manual_schedule` is set to `Weekly`
+~> **NOTE:** `days_of_week` - can only be specified when `manual_schedule` is set to `Weekly`
 
 ---
 

--- a/website/docs/r/mssql_virtual_machine.html.markdown
+++ b/website/docs/r/mssql_virtual_machine.html.markdown
@@ -101,7 +101,7 @@ The `manual_schedule` block supports the following:
 
 * `days_of_week` - (Optional) A list of days on which backup can take place. Possible values are `Monday`, `Tuesday`, `Wednesday`, `Thursday`, `Friday`, `Saturday` and `Sunday`
 
-~> **NOTE:** `days_of_week` - can only be specified when `manual_schedule` is set to `Weekly`
+~> **NOTE:** `days_of_week` can only be specified when `manual_schedule` is set to `Weekly`
 
 ---
 
@@ -207,9 +207,9 @@ The `schedule` block supports the following:
 
 ~> **NOTE:** Either one of `weekly_interval` or `monthly_occurrence` must be specified.
 
-* `day_of_week` - (Optional) What day of the week the assessment will be run. Default value is `Monday`. Possible values are `Friday`, `Monday`, `Saturday`, `Sunday`, `Thursday`, `Tuesday` and `Wednesday`.
+* `day_of_week` - (Required) What day of the week the assessment will be run. Default value is `Monday`. Possible values are `Friday`, `Monday`, `Saturday`, `Sunday`, `Thursday`, `Tuesday` and `Wednesday`.
 
-* `start_time` - (Optional) What time the assessment will be run. Must be in the format `HH:mm`.
+* `start_time` - (Required) What time the assessment will be run. Must be in the format `HH:mm`.
 
 ## Attributes Reference
 

--- a/website/docs/r/netapp_snapshot_policy.html.markdown
+++ b/website/docs/r/netapp_snapshot_policy.html.markdown
@@ -140,11 +140,11 @@ The following attributes are exported:
 
 * `enabled` - (Required) Defines that the NetApp Snapshot Policy is enabled or not.
 
-* `hourly_schedule` - Hourly snapshot schedule.
+* `hourly_schedule` - (Optional) Hourly snapshot schedule.
 
-* `daily_schedule` - Daily snapshot schedule.
+* `daily_schedule` - (Optional) Daily snapshot schedule.
   
-* `weekly_schedule` - Weekly snapshot schedule.
+* `weekly_schedule` - (Optional) Weekly snapshot schedule.
 
 * `monthly_schedule` - (Optional) Monthly snapshot schedule.
 

--- a/website/docs/r/netapp_snapshot_policy.html.markdown
+++ b/website/docs/r/netapp_snapshot_policy.html.markdown
@@ -130,15 +130,15 @@ The following attributes are exported:
 
 * `id` - The ID of the NetApp Snapshot.
   
-* `name` - The name of the NetApp Snapshot Policy.
+* `name` - (Required) The name of the NetApp Snapshot Policy.
 
-* `resource_group_name` - The name of the resource group where the NetApp Snapshot Policy should be created.
+* `resource_group_name` - (Required) The name of the resource group where the NetApp Snapshot Policy should be created.
   
-* `location` - Specifies the supported Azure location where the resource exists.
+* `location` - (Required) Specifies the supported Azure location where the resource exists.
 
-* `account_name` - The name of the NetApp Account in which the NetApp Snapshot Policy was created.
+* `account_name` - (Required) The name of the NetApp Account in which the NetApp Snapshot Policy was created.
 
-* `enabled` - Defines that the NetApp Snapshot Policy is enabled or not.
+* `enabled` - (Required) Defines that the NetApp Snapshot Policy is enabled or not.
 
 * `hourly_schedule` - Hourly snapshot schedule.
 
@@ -146,7 +146,7 @@ The following attributes are exported:
   
 * `weekly_schedule` - Weekly snapshot schedule.
 
-* `monthly_schedule` - Monthly snapshot schedule.
+* `monthly_schedule` - (Optional) Monthly snapshot schedule.
 
 ## Timeouts
 

--- a/website/docs/r/network_interface.html.markdown
+++ b/website/docs/r/network_interface.html.markdown
@@ -106,7 +106,7 @@ When `private_ip_address_allocation` is set to `Static` the following fields can
 
 When `private_ip_address_version` is set to `IPv4` the following fields can be configured:
 
-* `subnet_id` - (Required) The ID of the Subnet where this Network Interface should be located in.
+* `subnet_id` - (Optional) The ID of the Subnet where this Network Interface should be located in.
 
 ## Attributes Reference
 

--- a/website/docs/r/network_security_group.html.markdown
+++ b/website/docs/r/network_security_group.html.markdown
@@ -62,7 +62,9 @@ The following arguments are supported:
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
-Elements of `security_rule` support:
+---
+
+A `security_rule` block support:
 
 * `name` - (Required) The name of the security rule. Changing this forces a new resource to be created.
 

--- a/website/docs/r/orbital_contact_profile.html.markdown
+++ b/website/docs/r/orbital_contact_profile.html.markdown
@@ -128,7 +128,7 @@ A `channels` block supports the following:
 
 An `end_point` block supports the following:
 
-* `end_point_name` -(Required) Name of an end point.
+* `end_point_name` - (Required) Name of an end point.
 
 * `ip_address` - (Required) IP address of an end point.
 

--- a/website/docs/r/orchestrated_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/orchestrated_virtual_machine_scale_set.html.markdown
@@ -339,9 +339,9 @@ An `ip_configuration` block supports the following:
 
 An `ip_tag` block supports the following:
 
-* `tag` - The IP Tag associated with the Public IP, such as `SQL` or `Storage`.
+* `tag` - (Required) The IP Tag associated with the Public IP, such as `SQL` or `Storage`.
 
-* `type` - The Type of IP Tag, such as `FirstPartyUsage`.
+* `type` - (Required) The Type of IP Tag, such as `FirstPartyUsage`.
 
 ---
 
@@ -435,9 +435,9 @@ A `termination_notification` block supports the following:
 
 A `source_image_reference` block supports the following:
 
-* `publisher` - (Optional) Specifies the publisher of the image used to create the virtual machines. Changing this forces a new resource to be created.
+* `publisher` - (Required) Specifies the publisher of the image used to create the virtual machines. Changing this forces a new resource to be created.
 
-* `offer` - (Optional) Specifies the offer of the image used to create the virtual machines. Changing this forces a new resource to be created.
+* `offer` - (Required) Specifies the offer of the image used to create the virtual machines. Changing this forces a new resource to be created.
 
 * `sku` - (Required) Specifies the SKU of the image used to create the virtual machines.
 

--- a/website/docs/r/orchestrated_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/orchestrated_virtual_machine_scale_set.html.markdown
@@ -47,19 +47,19 @@ resource "azurerm_orchestrated_virtual_machine_scale_set" "example" {
 
 -> **NOTE:** The number of Fault Domains varies depending on which Azure Region you're using - a list can be found [here](https://github.com/MicrosoftDocs/azure-docs/blob/master/includes/managed-disks-common-fault-domain-region-list.md).
 
-* `sku_name` - (Optional) The `name` of the SKU to be used by this Orcestrated Virtual Machine Scale Set. Valid values include: any of the [General purpose](https://docs.microsoft.com/azure/virtual-machines/sizes-general), [Compute optimized](https://docs.microsoft.com/azure/virtual-machines/sizes-compute), [Memory optimized](https://docs.microsoft.com/azure/virtual-machines/sizes-memory), [Storage optimized](https://docs.microsoft.com/azure/virtual-machines/sizes-storage), [GPU optimized](https://docs.microsoft.com/azure/virtual-machines/sizes-gpu), [FPGA optimized](https://docs.microsoft.com/azure/virtual-machines/sizes-field-programmable-gate-arrays), [High performance](https://docs.microsoft.com/azure/virtual-machines/sizes-hpc), or [Previous generation](https://docs.microsoft.com/azure/virtual-machines/sizes-previous-gen) virtual machine SKUs.
+* `sku_name` - (Optional) The `name` of the SKU to be used by this Orcestrated Virtual Machine Scale Set. Valid values include: any of the [General purpose](https://docs.microsoft.com/azure/virtual-machines/sizes-general), [Compute optimized](https://docs.microsoft.com/azure/virtual-machines/sizes-compute), [Memory optimized](https://docs.microsoft.com/azure/virtual-machines/sizes-memory), [Storage optimized](https://docs.microsoft.com/azure/virtual-machines/sizes-storage), [GPU optimized](https://docs.microsoft.com/azure/virtual-machines/sizes-gpu), [FPGA optimized](https://docs.microsoft.com/azure/virtual-machines/sizes-field-programmable-gate-arrays), [High performance](https://docs.microsoft.com/azure/virtual-machines/sizes-hpc), or [Previous generation](https://docs.microsoft.com/azure/virtual-machines/sizes-previous-gen) virtual machine SKUs.
 
 * `additional_capabilities` - (Optional) An `additional_capabilities` block as defined below.
 
-* `instances`- (Optional) The number of Virtual Machines in the Orcestrated Virtual Machine Scale Set.
+* `instances` - (Optional) The number of Virtual Machines in the Orcestrated Virtual Machine Scale Set.
 
-* `network_interface` - (Optional) One or more `network_interface` blocks as defined below.
+* `network_interface` - (Optional) One or more `network_interface` blocks as defined below.
 
-* `os_profile` - (Optional) An `os_profile` block as defined below.
+* `os_profile` - (Optional) An `os_profile` block as defined below.
 
-* `os_disk` - (Optional) An `os_disk` block as defined below.
+* `os_disk` - (Optional) An `os_disk` block as defined below.
 
-* `boot_diagnostics` - (Optional) A `boot_diagnostics` block as defined below.
+* `boot_diagnostics` - (Optional) A `boot_diagnostics` block as defined below.
 
 * `capacity_reservation_group_id` - (Optional) Specifies the ID of the Capacity Reservation Group which the Virtual Machine Scale Set should be allocated to. Changing this forces a new resource to be created.
 
@@ -67,9 +67,9 @@ resource "azurerm_orchestrated_virtual_machine_scale_set" "example" {
 
 -> **NOTE:** If `capacity_reservation_group_id` is specified the `single_placement_group` must be set to `false`.
 
-* `data_disk` - (Optional) One or more `data_disk` blocks as defined below.
+* `data_disk` - (Optional) One or more `data_disk` blocks as defined below.
 
-* `extension` - (Optional) One or more `extension` blocks as defined below
+* `extension` - (Optional) One or more `extension` blocks as defined below
 
 * `extension_operations_enabled` - (Optional) Should extension operations be allowed on the Virtual Machine Scale Set? Possible values are `true` or `false`. Defaults to `true`. Changing this forces a new Orchestrated Virtual Machine Scale Set to be created.
 
@@ -77,27 +77,27 @@ resource "azurerm_orchestrated_virtual_machine_scale_set" "example" {
 
 * `extensions_time_budget` - (Optional) Specifies the time alloted for all extensions to start. The time duration should be between 15 minutes and 120 minutes (inclusive) and should be specified in ISO 8601 format. The default value is 90 minutes (PT1H30M).
 
-* `eviction_policy` - (Optional) The Policy which should be used Virtual Machines are Evicted from the Scale Set. Changing this forces a new resource to be created.
+* `eviction_policy` - (Optional) The Policy which should be used Virtual Machines are Evicted from the Scale Set. Changing this forces a new resource to be created.
 
-* `identity` - (Optional) An `identity` block as defined below.
+* `identity` - (Optional) An `identity` block as defined below.
 
-* `license_type` - (Optional) Specifies the type of on-premise license (also known as Azure Hybrid Use Benefit) which should be used for this Orchestrated Virtual Machine Scale Set. Possible values are `None`, `Windows_Client` and `Windows_Server`. 
+* `license_type` - (Optional) Specifies the type of on-premise license (also known as Azure Hybrid Use Benefit) which should be used for this Orchestrated Virtual Machine Scale Set. Possible values are `None`, `Windows_Client` and `Windows_Server`. 
 
-* `max_bid_price` - (Optional) The maximum price you're willing to pay for each Orchestrated Virtual Machine in this Scale Set, in US Dollars; which must be greater than the current spot price. If this bid price falls below the current spot price the Virtual Machines in the Scale Set will be evicted using the eviction_policy. Defaults to `-1`, which means that each Virtual Machine in the Orchestrated Scale Set should not be evicted for price reasons.
+* `max_bid_price` - (Optional) The maximum price you're willing to pay for each Orchestrated Virtual Machine in this Scale Set, in US Dollars; which must be greater than the current spot price. If this bid price falls below the current spot price the Virtual Machines in the Scale Set will be evicted using the eviction_policy. Defaults to `-1`, which means that each Virtual Machine in the Orchestrated Scale Set should not be evicted for price reasons.
 
-* `plan` - (Optional) A `plan` block as documented below.
+* `plan` - (Optional) A `plan` block as documented below.
 
-* `priority` - (Optional) The Priority of this Orchestrated Virtual Machine Scale Set. Possible values are `Regular` and `Spot`. Defaults to `Regular`. Changing this value forces a new resource.
+* `priority` - (Optional) The Priority of this Orchestrated Virtual Machine Scale Set. Possible values are `Regular` and `Spot`. Defaults to `Regular`. Changing this value forces a new resource.
 
 * `single_placement_group` - (Optional) Should this Virtual Machine Scale Set be limited to a Single Placement Group, which means the number of instances will be capped at 100 Virtual Machines. Possible values are `true` or `false`.
 
 -> **NOTE:** `single_placement_group` behaves differently for Orchestrated Virtual Machine Scale Sets than it does for other Virtual Machine Scale Sets. If you do not define the `single_placement_group` field in your configuration file the service will determin what this value should be based off of the value contained within the `sku_name` field of your configuration file. You may set the `single_placement_group` field to `true`, however once you set it to `false` you will not be able to revert it back to `true`. If you wish to use Specialty Sku virtual machines (e.g. [M-Seiries](https://docs.microsoft.com/azure/virtual-machines/m-series) virtual machines) you will need to contact you Microsoft support professional and request to be added to the include list since this feature is currently in private preview until the end of September 2022. Once you have been added to the private preview include list you will need to run the following command to register your subscription with the feature: `az feature register --namespace Microsoft.Compute --name SpecialSkusForVmssFlex`. If you are not on the include list this command will error out with the following error message `(featureRegistrationUnsupported) The feature 'SpecialSkusForVmssFlex' does not support registration`.
 
-* `source_image_id` - (Optional) The ID of an Image which each Virtual Machine in this Scale Set should be based on. Possible Image ID types include `Image ID`s, `Shared Image ID`s, `Shared Image Version ID`s, `Community Gallery Image ID`s, `Community Gallery Image Version ID`s, `Shared Gallery Image ID`s and `Shared Gallery Image Version ID`s.
+* `source_image_id` - (Optional) The ID of an Image which each Virtual Machine in this Scale Set should be based on. Possible Image ID types include `Image ID`s, `Shared Image ID`s, `Shared Image Version ID`s, `Community Gallery Image ID`s, `Community Gallery Image Version ID`s, `Shared Gallery Image ID`s and `Shared Gallery Image Version ID`s.
 
 * `source_image_reference` - (Optional) A `source_image_reference` block as defined below.
 
-* `termination_notification` - (Optional) A `termination_notification` block as defined below.
+* `termination_notification` - (Optional) A `termination_notification` block as defined below.
 
 * `user_data_base64` - (Optional) The Base64-Encoded User Data which should be used for this Virtual Machine Scale Set.
 
@@ -117,31 +117,31 @@ An `additional_capabilities` block supports the following:
 
 ---
 
-An `os_profile` block supports the following:
+An `os_profile` block supports the following:
 
-* `custom_data` - (Optional) The Base64-Encoded Custom Data which should be used for this Orchestrated Virtual Machine Scale Set.
+* `custom_data` - (Optional) The Base64-Encoded Custom Data which should be used for this Orchestrated Virtual Machine Scale Set.
 
 -> **NOTE:** When Custom Data has been configured, it's not possible to remove it without tainting the Orchestrated Virtual Machine Scale Set, due to a limitation of the Azure API.
 
-* `windows_configuration` - (Optional) A `windows_configuration` block as documented below.
+* `windows_configuration` - (Optional) A `windows_configuration` block as documented below.
 
-* `linux_configuration` - (Optional) A `linux_configuration` block as documented below.
+* `linux_configuration` - (Optional) A `linux_configuration` block as documented below.
 
 ---
 
 A `windows_configuration` block supports the following:
 
-* `admin_username` - (Required) The username of the local administrator on each Orchestrated Virtual Machine Scale Set instance. Changing this forces a new resource to be created.
+* `admin_username` - (Required) The username of the local administrator on each Orchestrated Virtual Machine Scale Set instance. Changing this forces a new resource to be created.
 
-* `admin_password` - (Required) The Password which should be used for the local-administrator on this Virtual Machine. Changing this forces a new resource to be created.
+* `admin_password` - (Required) The Password which should be used for the local-administrator on this Virtual Machine. Changing this forces a new resource to be created.
 
 * `automatic_instance_repair` - (Optional) An `automatic_instance_repair` block as defined below.
 
 -> **NOTE:** To enable the `automatic_instance_repair`, the Orchestrated Virtual Machine Scale Set must have a valid `health_probe_id` or an [Application Health Extension](https://docs.microsoft.com/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-health-extension).
 
-* `computer_name_prefix` - (Optional) The prefix which should be used for the name of the Virtual Machines in this Scale Set. If unspecified this defaults to the value for the `name` field. If the value of the `name` field is not a valid `computer_name_prefix`, then you must specify `computer_name_prefix`.
+* `computer_name_prefix` - (Optional) The prefix which should be used for the name of the Virtual Machines in this Scale Set. If unspecified this defaults to the value for the `name` field. If the value of the `name` field is not a valid `computer_name_prefix`, then you must specify `computer_name_prefix`.
 
-* `enable_automatic_updates` - (Optional) Are automatic updates enabled for this Virtual Machine? Defaults to `true`.
+* `enable_automatic_updates` - (Optional) Are automatic updates enabled for this Virtual Machine? Defaults to `true`.
 
 * `hotpatching_enabled` - (Optional) Should the VM be patched without requiring a reboot? Possible values are `true` or `false`. Defaults to `false`. For more information about hot patching please see the [product documentation](https://docs.microsoft.com/azure/automanage/automanage-hotpatch).
 
@@ -155,25 +155,25 @@ A `windows_configuration` block supports the following:
 
 -> **NOTE:** If `patch_mode` is set to `AutomaticByPlatform` the `provision_vm_agent` must be set to `true` and the `extension` must contain at least one application health extension.
 
-* `provision_vm_agent` - (Optional) Should the Azure VM Agent be provisioned on each Virtual Machine in the Scale Set? Defaults to `true`. Changing this value forces a new resource to be created.
+* `provision_vm_agent` - (Optional) Should the Azure VM Agent be provisioned on each Virtual Machine in the Scale Set? Defaults to `true`. Changing this value forces a new resource to be created.
 
-* `secret` - (Optional) One or more `secret` blocks as defined below.
+* `secret` - (Optional) One or more `secret` blocks as defined below.
 
-* `timezone` - (Optional) Specifies the time zone of the virtual machine, the possible values are defined [here](https://jackstromberg.com/2017/01/list-of-time-zones-consumed-by-azure/).
+* `timezone` - (Optional) Specifies the time zone of the virtual machine, the possible values are defined [here](https://jackstromberg.com/2017/01/list-of-time-zones-consumed-by-azure/).
 
-* `winrm_listener` - (Optional) One or more `winrm_listener` blocks as defined below.
+* `winrm_listener` - (Optional) One or more `winrm_listener` blocks as defined below.
 
 ---
 
-A `linux_configuration` block supports the following:
+A `linux_configuration` block supports the following:
 
-* `admin_username` - (Required) The username of the local administrator on each Orchestrated Virtual Machine Scale Set instance. Changing this forces a new resource to be created.
+* `admin_username` - (Required) The username of the local administrator on each Orchestrated Virtual Machine Scale Set instance. Changing this forces a new resource to be created.
 
-* `admin_password` - (Optional) The Password which should be used for the local-administrator on this Virtual Machine. Changing this forces a new resource to be created.
+* `admin_password` - (Optional) The Password which should be used for the local-administrator on this Virtual Machine. Changing this forces a new resource to be created.
 
-* `admin_ssh_key` - (Optional) A `admin_ssh_key` block as documented below.
+* `admin_ssh_key` - (Optional) A `admin_ssh_key` block as documented below.
 
-* `computer_name_prefix` - (Optional) The prefix which should be used for the name of the Virtual Machines in this Scale Set. If unspecified this defaults to the value for the name field. If the value of the name field is not a valid `computer_name_prefix`, then you must specify `computer_name_prefix`.
+* `computer_name_prefix` - (Optional) The prefix which should be used for the name of the Virtual Machines in this Scale Set. If unspecified this defaults to the value for the name field. If the value of the name field is not a valid `computer_name_prefix`, then you must specify `computer_name_prefix`.
 
 * `disable_password_authentication` - (Optional) When an `admin_password` is specified `disable_password_authentication` must be set to `false`. Defaults to `true`.
 
@@ -187,31 +187,31 @@ A `linux_configuration` block supports the following:
 
 -> **NOTE:** If `patch_mode` is set to `AutomaticByPlatform` the `provision_vm_agent` must be set to `true` and the `extension` must contain at least one application health extension.  An example of how to correctly configure a Orchestrated Virtual Machine Scale Set to provision a Linux Virtual Machine with Automatic VM Guest Patching enabled can be found in the [`./examples/orchestrated-vm-scale-set/automatic-vm-guest-patching`](https://github.com/hashicorp/terraform-provider-azurerm/tree/main/examples/orchestrated-vm-scale-set/automatic-vm-guest-patching) directory within the GitHub Repository.
 
-* `provision_vm_agent` - (Optional) Should the Azure VM Agent be provisioned on each Virtual Machine in the Scale Set? Defaults to `true`. Changing this value forces a new resource to be created.
+* `provision_vm_agent` - (Optional) Should the Azure VM Agent be provisioned on each Virtual Machine in the Scale Set? Defaults to `true`. Changing this value forces a new resource to be created.
 
-* `secret` - (Optional) One or more `secret` blocks as defined below.
+* `secret` - (Optional) One or more `secret` blocks as defined below.
 
 ---
 
-A `secret` block supports the following:
+A `secret` block supports the following:
 
-* `key_vault_id` - (Required) The ID of the Key Vault from which all Secrets should be sourced.
+* `key_vault_id` - (Required) The ID of the Key Vault from which all Secrets should be sourced.
 
-* `certificate` - (Required) One or more `certificate` blocks as defined below.
+* `certificate` - (Required) One or more `certificate` blocks as defined below.
 
 -> **NOTE:** The schema of the `certificate` block is slightly different depending on if you are provisioning a `windows_configuration` or a `linux_configuration`.
 
 ---
 
-A (Windows) `certificate` block supports the following:
+A (Windows) `certificate` block supports the following:
 
-* `store` - (Required) The certificate store on the Virtual Machine where the certificate should be added.
+* `store` - (Required) The certificate store on the Virtual Machine where the certificate should be added.
 
-* `url` - (Required) The Secret URL of a Key Vault Certificate.
+* `url` - (Required) The Secret URL of a Key Vault Certificate.
 
 ---
 
-A (Linux) `certificate` block supports the following:
+A (Linux) `certificate` block supports the following:
 
 * `url` - (Required) The Secret URL of a Key Vault Certificate.
 
@@ -227,35 +227,35 @@ An `admin_ssh_key` block supports the following:
 
 ---
 
-A `winrm_listener` block supports the following:
+A `winrm_listener` block supports the following:
 
-* `certificate_url` - (Optional) The Secret URL of a Key Vault Certificate, which must be specified when protocol is set to `Https`.
+* `certificate_url` - (Optional) The Secret URL of a Key Vault Certificate, which must be specified when protocol is set to `Https`.
 
--> **NOTE:** This can be sourced from the `secret_id` field within the `azurerm_key_vault_certificate` Resource.
-
----
-
-An `automatic_instance_repair` block supports the following:
-
-* `enabled` - (Required) Should the automatic instance repair be enabled on this Orchestrated Virtual Machine Scale Set? Possible values are `true` and `false`. Defaults to `false`.
-
-* `grace_period` - (Optional) Amount of time for which automatic repairs will be delayed. The grace period starts right after the VM is found unhealthy. Possible values are between `30` and `90` minutes. Defaults to `30` minutes. The time duration should be specified in `ISO 8601` format (e.g. `PT30M` to `PT90M`).
+-> **NOTE:** This can be sourced from the `secret_id` field within the `azurerm_key_vault_certificate` Resource.
 
 ---
 
-A `boot_diagnostics` block supports the following:
+An `automatic_instance_repair` block supports the following:
 
-* `storage_account_uri` - (Optional) The Primary/Secondary Endpoint for the Azure Storage Account which should be used to store Boot Diagnostics, including Console Output and Screenshots from the Hypervisor. By including a `boot_diagnostics` block without passing the `storage_account_uri` field will cause the API to utilize a Managed Storage Account to store the Boot Diagnostics output.
+* `enabled` - (Required) Should the automatic instance repair be enabled on this Orchestrated Virtual Machine Scale Set? Possible values are `true` and `false`. Defaults to `false`.
+
+* `grace_period` - (Optional) Amount of time for which automatic repairs will be delayed. The grace period starts right after the VM is found unhealthy. Possible values are between `30` and `90` minutes. Defaults to `30` minutes. The time duration should be specified in `ISO 8601` format (e.g. `PT30M` to `PT90M`).
 
 ---
 
-A `certificate` block supports the following:
+A `boot_diagnostics` block supports the following:
 
-* `store` - (Required) The certificate store on the Virtual Machine where the certificate should be added.
+* `storage_account_uri` - (Optional) The Primary/Secondary Endpoint for the Azure Storage Account which should be used to store Boot Diagnostics, including Console Output and Screenshots from the Hypervisor. By including a `boot_diagnostics` block without passing the `storage_account_uri` field will cause the API to utilize a Managed Storage Account to store the Boot Diagnostics output.
 
-* `url` - (Required) The Secret URL of a Key Vault Certificate.
+---
 
--> **NOTE:** This can be sourced from the `secret_id` field within the `azurerm_key_vault_certificate` Resource.
+A `certificate` block supports the following:
+
+* `store` - (Required) The certificate store on the Virtual Machine where the certificate should be added.
+
+* `url` - (Required) The Secret URL of a Key Vault Certificate.
+
+-> **NOTE:** This can be sourced from the `secret_id` field within the `azurerm_key_vault_certificate` Resource.
 
 ---
 
@@ -267,39 +267,39 @@ A `diff_disk_settings` block supports the following:
 
 ---
 
-A `data_disk` block supports the following:
+A `data_disk` block supports the following:
 
-* `caching` - (Required) The type of Caching which should be used for this Data Disk. Possible values are None, ReadOnly and ReadWrite.
+* `caching` - (Required) The type of Caching which should be used for this Data Disk. Possible values are None, ReadOnly and ReadWrite.
 
-* `create_option` - (Optional) The create option which should be used for this Data Disk. Possible values are Empty and FromImage. Defaults to Empty. (FromImage should only be used if the source image includes data disks).
+* `create_option` - (Optional) The create option which should be used for this Data Disk. Possible values are Empty and FromImage. Defaults to Empty. (FromImage should only be used if the source image includes data disks).
 
-* `disk_size_gb` - (Required) The size of the Data Disk which should be created.
+* `disk_size_gb` - (Required) The size of the Data Disk which should be created.
 
-* `lun` - (Required) The Logical Unit Number of the Data Disk, which must be unique within the Virtual Machine.
+* `lun` - (Required) The Logical Unit Number of the Data Disk, which must be unique within the Virtual Machine.
 
-* `storage_account_type` - (Required) The Type of Storage Account which should back this Data Disk. Possible values include `Standard_LRS`, `StandardSSD_LRS`, `StandardSSD_ZRS`, `Premium_LRS`, `PremiumV2_LRS`, `Premium_ZRS` and `UltraSSD_LRS`.
+* `storage_account_type` - (Required) The Type of Storage Account which should back this Data Disk. Possible values include `Standard_LRS`, `StandardSSD_LRS`, `StandardSSD_ZRS`, `Premium_LRS`, `PremiumV2_LRS`, `Premium_ZRS` and `UltraSSD_LRS`.
 
 ---
 
-An `extension` block supports the following:
+An `extension` block supports the following:
 
-* `name` - (Required) The name for the Virtual Machine Scale Set Extension.
+* `name` - (Required) The name for the Virtual Machine Scale Set Extension.
 
-* `publisher` - (Required) Specifies the Publisher of the Extension.
+* `publisher` - (Required) Specifies the Publisher of the Extension.
 
-* `type` - (Required) Specifies the Type of the Extension.
+* `type` - (Required) Specifies the Type of the Extension.
 
-* `type_handler_version` - (Required) Specifies the version of the extension to use, available versions can be found using the Azure CLI.
+* `type_handler_version` - (Required) Specifies the version of the extension to use, available versions can be found using the Azure CLI.
 
-* `auto_upgrade_minor_version_enabled` - (Optional) Should the latest version of the Extension be used at Deployment Time, if one is available? This won't auto-update the extension on existing installation. Defaults to true.
+* `auto_upgrade_minor_version_enabled` - (Optional) Should the latest version of the Extension be used at Deployment Time, if one is available? This won't auto-update the extension on existing installation. Defaults to true.
 
 * `extensions_to_provision_after_vm_creation` - (Optional) An ordered list of Extension names which Orchestrated Virtual Machine Scale Set should provision after VM creation.
 
-* `force_extension_execution_on_change` - (Optional) A value which, when different to the previous value can be used to force-run the Extension even if the Extension Configuration hasn't changed.
+* `force_extension_execution_on_change` - (Optional) A value which, when different to the previous value can be used to force-run the Extension even if the Extension Configuration hasn't changed.
 
-* `protected_settings` - (Optional) A JSON String which specifies Sensitive Settings (such as Passwords) for the Extension.
+* `protected_settings` - (Optional) A JSON String which specifies Sensitive Settings (such as Passwords) for the Extension.
 
--> **NOTE:** Keys within the `protected_settings` block are notoriously case-sensitive, where the casing required (e.g. `TitleCase` vs `snakeCase`) depends on the Extension being used. Please refer to the documentation for the specific Orchestrated Virtual Machine Extension you're looking to use for more information.
+-> **NOTE:** Keys within the `protected_settings` block are notoriously case-sensitive, where the casing required (e.g. `TitleCase` vs `snakeCase`) depends on the Extension being used. Please refer to the documentation for the specific Orchestrated Virtual Machine Extension you're looking to use for more information.
 
 * `protected_settings_from_key_vault` - (Optional) A `protected_settings_from_key_vault` block as defined below.
 
@@ -311,83 +311,83 @@ An `extension` block supports the following:
 
 ---
 
-An `ip_configuration` block supports the following:
+An `ip_configuration` block supports the following:
 
-* `name` - (Required) The Name which should be used for this IP Configuration.
+* `name` - (Required) The Name which should be used for this IP Configuration.
 
-* `application_gateway_backend_address_pool_ids` - (Optional) A list of Backend Address Pools IDs from a Application Gateway which this Orchestrated Virtual Machine Scale Set should be connected to.
+* `application_gateway_backend_address_pool_ids` - (Optional) A list of Backend Address Pools IDs from a Application Gateway which this Orchestrated Virtual Machine Scale Set should be connected to.
 
-* `application_security_group_ids` - (Optional) A list of Application Security Group IDs which this Orchestrated Virtual Machine Scale Set should be connected to.
+* `application_security_group_ids` - (Optional) A list of Application Security Group IDs which this Orchestrated Virtual Machine Scale Set should be connected to.
 
-* `load_balancer_backend_address_pool_ids` - (Optional) A list of Backend Address Pools IDs from a Load Balancer which this Orchestrated Virtual Machine Scale Set should be connected to.
+* `load_balancer_backend_address_pool_ids` - (Optional) A list of Backend Address Pools IDs from a Load Balancer which this Orchestrated Virtual Machine Scale Set should be connected to.
 
--> **NOTE:** When using this field you'll also need to configure a Rule for the Load Balancer, and use a depends_on between this resource and the Load Balancer Rule.
+-> **NOTE:** When using this field you'll also need to configure a Rule for the Load Balancer, and use a depends_on between this resource and the Load Balancer Rule.
 
-* `primary` - (Optional) Is this the Primary IP Configuration for this Network Interface? Possible values are `true` and `false`. Defaults to `false`.
+* `primary` - (Optional) Is this the Primary IP Configuration for this Network Interface? Possible values are `true` and `false`. Defaults to `false`.
 
--> **NOTE:** One `ip_configuration` block must be marked as Primary for each Network Interface.
+-> **NOTE:** One `ip_configuration` block must be marked as Primary for each Network Interface.
 
-* `public_ip_address` - (Optional) A `public_ip_address` block as defined below.
+* `public_ip_address` - (Optional) A `public_ip_address` block as defined below.
 
-* `subnet_id` - (Optional) The ID of the Subnet which this IP Configuration should be connected to.
+* `subnet_id` - (Optional) The ID of the Subnet which this IP Configuration should be connected to.
 
--> **NOTE:** `subnet_id` is required if version is set to `IPv4`.
+-> **NOTE:** `subnet_id` is required if version is set to `IPv4`.
 
-* `version` - (Optional) The Internet Protocol Version which should be used for this IP Configuration. Possible values are `IPv4` and `IPv6`. Defaults to `IPv4`.
-
----
-
-An `ip_tag` block supports the following:
-
-* `tag` - The IP Tag associated with the Public IP, such as `SQL` or `Storage`.
-
-* `type` - The Type of IP Tag, such as `FirstPartyUsage`.
+* `version` - (Optional) The Internet Protocol Version which should be used for this IP Configuration. Possible values are `IPv4` and `IPv6`. Defaults to `IPv4`.
 
 ---
 
-A `network_interface` block supports the following:
+An `ip_tag` block supports the following:
 
-* `name` - (Required) The Name which should be used for this Network Interface. Changing this forces a new resource to be created.
+* `tag` - The IP Tag associated with the Public IP, such as `SQL` or `Storage`.
 
-* `ip_configuration` - (Required) One or more `ip_configuration` blocks as defined above.
-
-* `dns_servers` - (Optional) A list of IP Addresses of DNS Servers which should be assigned to the Network Interface.
-
-* `enable_accelerated_networking` - (Optional) Does this Network Interface support Accelerated Networking? Possible values are `true` and `false`. Defaults to `false`.
-
-* `enable_ip_forwarding` - (Optional) Does this Network Interface support IP Forwarding? Possible values are `true` and `false`. Defaults to `false`.
-
-* `network_security_group_id` - (Optional) The ID of a Network Security Group which should be assigned to this Network Interface.
-
-* `primary` - (Optional) Is this the Primary IP Configuration? Possible values are `true` and `false`. Defaults to `false`.
-
--> **NOTE:** If multiple `network_interface` blocks are specified, one must be set to `primary`.
+* `type` - The Type of IP Tag, such as `FirstPartyUsage`.
 
 ---
 
-An `os_disk` block supports the following:
+A `network_interface` block supports the following:
 
-* `caching` - (Required) The Type of Caching which should be used for the Internal OS Disk. Possible values are `None`, `ReadOnly` and `ReadWrite`.
+* `name` - (Required) The Name which should be used for this Network Interface. Changing this forces a new resource to be created.
 
-* `storage_account_type` - (Required) The Type of Storage Account which should back this the Internal OS Disk. Possible values include `Standard_LRS`, `StandardSSD_LRS`, `StandardSSD_ZRS`, `Premium_LRS` and `Premium_ZRS`. Changing this forces a new resource to be created.
+* `ip_configuration` - (Required) One or more `ip_configuration` blocks as defined above.
 
-* `diff_disk_settings` - (Optional) A `diff_disk_settings` block as defined above.
+* `dns_servers` - (Optional) A list of IP Addresses of DNS Servers which should be assigned to the Network Interface.
 
-* `disk_encryption_set_id` - (Optional) The ID of the Disk Encryption Set which should be used to encrypt this OS Disk. Changing this forces a new resource to be created.
+* `enable_accelerated_networking` - (Optional) Does this Network Interface support Accelerated Networking? Possible values are `true` and `false`. Defaults to `false`.
+
+* `enable_ip_forwarding` - (Optional) Does this Network Interface support IP Forwarding? Possible values are `true` and `false`. Defaults to `false`.
+
+* `network_security_group_id` - (Optional) The ID of a Network Security Group which should be assigned to this Network Interface.
+
+* `primary` - (Optional) Is this the Primary IP Configuration? Possible values are `true` and `false`. Defaults to `false`.
+
+-> **NOTE:** If multiple `network_interface` blocks are specified, one must be set to `primary`.
+
+---
+
+An `os_disk` block supports the following:
+
+* `caching` - (Required) The Type of Caching which should be used for the Internal OS Disk. Possible values are `None`, `ReadOnly` and `ReadWrite`.
+
+* `storage_account_type` - (Required) The Type of Storage Account which should back this the Internal OS Disk. Possible values include `Standard_LRS`, `StandardSSD_LRS`, `StandardSSD_ZRS`, `Premium_LRS` and `Premium_ZRS`. Changing this forces a new resource to be created.
+
+* `diff_disk_settings` - (Optional) A `diff_disk_settings` block as defined above.
+
+* `disk_encryption_set_id` - (Optional) The ID of the Disk Encryption Set which should be used to encrypt this OS Disk. Changing this forces a new resource to be created.
 
 -> **NOTE:** Disk Encryption Sets are in Public Preview in a limited set of regions
 
-* `disk_size_gb` - (Optional) The Size of the Internal OS Disk in GB, if you wish to vary from the size used in the image this Virtual Machine Scale Set is sourced from.
+* `disk_size_gb` - (Optional) The Size of the Internal OS Disk in GB, if you wish to vary from the size used in the image this Virtual Machine Scale Set is sourced from.
 
 ---
 
-A `plan` block supports the following:
+A `plan` block supports the following:
 
-* `name` - (Required) Specifies the name of the image from the marketplace. Changing this forces a new resource to be created.
+* `name` - (Required) Specifies the name of the image from the marketplace. Changing this forces a new resource to be created.
 
-* `publisher` - (Required) Specifies the publisher of the image. Changing this forces a new resource to be created.
+* `publisher` - (Required) Specifies the publisher of the image. Changing this forces a new resource to be created.
 
-* `product` - (Required) Specifies the product of the image from the marketplace. Changing this forces a new resource to be created.
+* `product` - (Required) Specifies the product of the image from the marketplace. Changing this forces a new resource to be created.
 
 ---
 
@@ -399,25 +399,25 @@ A `protected_settings_from_key_vault` block supports the following:
 
 ---
 
-An `identity` block supports the following:
+An `identity` block supports the following:
 
-* `type` - (Required) The type of Managed Identity that should be configured on this Orchestrated Windows Virtual Machine Scale Set. Only possible value is `UserAssigned`.
+* `type` - (Required) The type of Managed Identity that should be configured on this Orchestrated Windows Virtual Machine Scale Set. Only possible value is `UserAssigned`.
 
-* `identity_ids` - (Required) Specifies a list of User Managed Identity IDs to be assigned to this Orchestrated Windows Virtual Machine Scale Set.
+* `identity_ids` - (Required) Specifies a list of User Managed Identity IDs to be assigned to this Orchestrated Windows Virtual Machine Scale Set.
 
 ---
 
-A `public_ip_address` block supports the following:
+A `public_ip_address` block supports the following:
 
-* `name` - (Required) The Name of the Public IP Address Configuration.
+* `name` - (Required) The Name of the Public IP Address Configuration.
 
-* `domain_name_label` - (Optional) The Prefix which should be used for the Domain Name Label for each Virtual Machine Instance. Azure concatenates the Domain Name Label and Virtual Machine Index to create a unique Domain Name Label for each Virtual Machine. Valid values must be between `1` and `26` characters long, start with a lower case letter, end with a lower case letter or number and contains only `a-z`, `0-9` and `hyphens`.
+* `domain_name_label` - (Optional) The Prefix which should be used for the Domain Name Label for each Virtual Machine Instance. Azure concatenates the Domain Name Label and Virtual Machine Index to create a unique Domain Name Label for each Virtual Machine. Valid values must be between `1` and `26` characters long, start with a lower case letter, end with a lower case letter or number and contains only `a-z`, `0-9` and `hyphens`.
 
-* `idle_timeout_in_minutes` - (Optional) The Idle Timeout in Minutes for the Public IP Address. Possible values are in the range `4` to `32`.
+* `idle_timeout_in_minutes` - (Optional) The Idle Timeout in Minutes for the Public IP Address. Possible values are in the range `4` to `32`.
 
-* `ip_tag` - (Optional) One or more `ip_tag` blocks as defined above.
+* `ip_tag` - (Optional) One or more `ip_tag` blocks as defined above.
 
-* `public_ip_prefix_id` - (Optional) The ID of the Public IP Address Prefix from where Public IP Addresses should be allocated. Changing this forces a new resource to be created.
+* `public_ip_prefix_id` - (Optional) The ID of the Public IP Address Prefix from where Public IP Addresses should be allocated. Changing this forces a new resource to be created.
 
 * `sku_name` - (Optional) Specifies what Public IP Address SKU the Public IP Address should be provisioned as. Possible vaules include `Basic_Regional`, `Basic_Global`, `Standard_Regional` or `Standard_Global`. Defaults to `Basic_Regional`. For more information about Public IP Address SKU's and their capabilities, please see the [product documentation](https://docs.microsoft.com/azure/virtual-network/ip-services/public-ip-addresses#sku). Changing this forces a new resource to be created.
 
@@ -425,23 +425,23 @@ A `public_ip_address` block supports the following:
 
 ---
 
-A `termination_notification` block supports the following:
+A `termination_notification` block supports the following:
 
-* `enabled` - (Required) Should the termination notification be enabled on this Virtual Machine Scale Set? Possible values `true` or `false` Defaults to `false`.
+* `enabled` - (Required) Should the termination notification be enabled on this Virtual Machine Scale Set? Possible values `true` or `false` Defaults to `false`.
 
-* `timeout` - (Optional) Length of time (in minutes, between `5` and `15`) a notification to be sent to the VM on the instance metadata server till the VM gets deleted. The time duration should be specified in `ISO 8601` format. Defaults to `PT5M`.
+* `timeout` - (Optional) Length of time (in minutes, between `5` and `15`) a notification to be sent to the VM on the instance metadata server till the VM gets deleted. The time duration should be specified in `ISO 8601` format. Defaults to `PT5M`.
 
 ---
 
-A `source_image_reference` block supports the following:
+A `source_image_reference` block supports the following:
 
-* `publisher` - (Optional) Specifies the publisher of the image used to create the virtual machines. Changing this forces a new resource to be created.
+* `publisher` - (Optional) Specifies the publisher of the image used to create the virtual machines. Changing this forces a new resource to be created.
 
-* `offer` - (Optional) Specifies the offer of the image used to create the virtual machines. Changing this forces a new resource to be created.
+* `offer` - (Optional) Specifies the offer of the image used to create the virtual machines. Changing this forces a new resource to be created.
 
-* `sku` - (Required) Specifies the SKU of the image used to create the virtual machines.
+* `sku` - (Required) Specifies the SKU of the image used to create the virtual machines.
 
-* `version` - (Required) Specifies the version of the image used to create the virtual machines.
+* `version` - (Required) Specifies the version of the image used to create the virtual machines.
 
 ---
 

--- a/website/docs/r/policy_virtual_machine_configuration_assignment.html.markdown
+++ b/website/docs/r/policy_virtual_machine_configuration_assignment.html.markdown
@@ -140,7 +140,7 @@ A `configuration` block supports the following:
 
 ~> **NOTE:** When deploying a Custom Guest Configuration package the `content_hash` and `content_uri` fields must be defined. For Built-in Guest Configuration packages, such as the `AzureWindowsBaseline` package, the `content_hash` and `content_uri` should not be defined, rather these fields will be returned after the Built-in Guest Configuration package has been provisioned. For more information on guest configuration assignments please see the [product documentation](https://docs.microsoft.com/azure/governance/policy/concepts/guest-configuration-assignments).
 
-* `parameter` - (Optional) One or more `parameter` blocks which define what configuration parameters and values against.
+* `parameter` - (Optional) One or more `parameter` blocks as defined below which define what configuration parameters and values against.
 
 * `version` - (Optional) The version of the Guest Configuration that will be assigned in this Guest Configuration Assignment.
 

--- a/website/docs/r/private_endpoint.html.markdown
+++ b/website/docs/r/private_endpoint.html.markdown
@@ -261,11 +261,11 @@ A `private_service_connection` block exports:
 
 An `ip_configuration` block exports:
 
-* `name` - The Name of the IP Configuration.
+* `name` - (Required) The Name of the IP Configuration.
 
-* `private_ip_address` - The static IP address set by this configuration. It is recommended to use the private IP address exported in the `private_service_connection` block to obtain the address associated with the private endpoint.
+* `private_ip_address` - (Required) The static IP address set by this configuration. It is recommended to use the private IP address exported in the `private_service_connection` block to obtain the address associated with the private endpoint.
 
-* `subresource_name` - The subresource this IP address applies to, which corresponds to the `group_id`.
+* `subresource_name` - (Required) The subresource this IP address applies to, which corresponds to the `group_id`.
 
 ---
 

--- a/website/docs/r/redis_enterprise_database.html.markdown
+++ b/website/docs/r/redis_enterprise_database.html.markdown
@@ -59,7 +59,7 @@ The following arguments are supported:
 
 * `name` - (Optional) The name which should be used for this Redis Enterprise Database. Currently the acceptable value for this argument is `default`. Defaults to `default`. Changing this forces a new Redis Enterprise Database to be created.
 
-* `resource_group_name` - (Required) The name of the Resource Group where the Redis Enterprise Database should exist. Changing this forces a new Redis Enterprise Database to be created.
+* `resource_group_name` - (Optional) The name of the Resource Group where the Redis Enterprise Database should exist. Changing this forces a new Redis Enterprise Database to be created.
 
 * `cluster_id` - (Required) The resource id of the Redis Enterprise Cluster to deploy this Redis Enterprise Database. Changing this forces a new Redis Enterprise Database to be created.
 

--- a/website/docs/r/resource_group_cost_management_export.html.markdown
+++ b/website/docs/r/resource_group_cost_management_export.html.markdown
@@ -79,7 +79,7 @@ A `export_data_storage_location` block supports the following:
 
 * `root_folder_path` - (Required) The path of the directory where exports will be uploaded. Changing this forces a new resource to be created.
 
-**Note:** The Resource Manager ID of a Storage Container is exposed via the `resource_manager_id` attribute of the `azurerm_storage_container` resource.
+~> **Note:** The Resource Manager ID of a Storage Container is exposed via the `resource_manager_id` attribute of the `azurerm_storage_container` resource.
 
 ---
 

--- a/website/docs/r/role_definition.html.markdown
+++ b/website/docs/r/role_definition.html.markdown
@@ -69,7 +69,7 @@ The following attributes are exported:
 
 * `id` - This ID is specific to Terraform - and is of the format `{roleDefinitionId}|{scope}`.
 
-* `role_definition_id` - The Role Definition ID.
+* `role_definition_id` - (Optional) The Role Definition ID.
 
 * `role_definition_resource_id` - The Azure Resource Manager ID for the resource.
 

--- a/website/docs/r/route_table.html.markdown
+++ b/website/docs/r/route_table.html.markdown
@@ -59,7 +59,9 @@ The following arguments are supported:
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
-Elements of `route` support:
+---
+
+A `route` block support:
 
 * `name` - (Required) The name of the route. Changing this forces a new resource to be created.
 

--- a/website/docs/r/security_center_automation.html.markdown
+++ b/website/docs/r/security_center_automation.html.markdown
@@ -105,9 +105,9 @@ A `action` block defines where the data will be exported and sent to, it support
 
 * `resource_id` - (Required) The resource id of the target Logic App, Event Hub namespace or Log Analytics workspace.
 
-* `connection_string` - (Optional, but required when `type` is `EventHub`) A connection string to send data to the target Event Hub namespace, this should include a key with send permissions.
+* `connection_string` - (Optional) (Optional, but required when `type` is `EventHub`) A connection string to send data to the target Event Hub namespace, this should include a key with send permissions.
 
-* `trigger_url` - (Optional, but required when `type` is `LogicApp`) The callback URL to trigger the Logic App that will receive and process data sent by this automation. This can be found in the Azure Portal under "See trigger history"
+* `trigger_url` - (Optional) (Optional, but required when `type` is `LogicApp`) The callback URL to trigger the Logic App that will receive and process data sent by this automation. This can be found in the Azure Portal under "See trigger history"
 
 ---
 

--- a/website/docs/r/sentinel_alert_rule_fusion.html.markdown
+++ b/website/docs/r/sentinel_alert_rule_fusion.html.markdown
@@ -77,7 +77,7 @@ A `sub_type` block supports the following:
 
 * `enabled` - (Optional) Whether this source subtype under source signal is enabled or disabled in Fusion detection. Defaults to `true`.
 
-* `severities_allowed` - (Optional) A list of severities that are enabled for this source subtype consumed in Fusion detection. Possible values for each element are `High`, `Medium`, `Low`, `Informational`.
+* `severities_allowed` - (Required) A list of severities that are enabled for this source subtype consumed in Fusion detection. Possible values for each element are `High`, `Medium`, `Low`, `Informational`.
 
 ## Attributes Reference
 

--- a/website/docs/r/signalr_service.html.markdown
+++ b/website/docs/r/signalr_service.html.markdown
@@ -59,13 +59,13 @@ The following arguments are supported:
 
 * `cors` - (Optional) A `cors` block as documented below.
 
-* `connectivity_logs_enabled`- (Optional) Specifies if Connectivity Logs are enabled or not. Defaults to `false`.
+* `connectivity_logs_enabled` - (Optional) Specifies if Connectivity Logs are enabled or not. Defaults to `false`.
 
-* `messaging_logs_enabled`- (Optional) Specifies if Messaging Logs are enabled or not. Defaults to `false`.
+* `messaging_logs_enabled` - (Optional) Specifies if Messaging Logs are enabled or not. Defaults to `false`.
 
-* `live_trace_enabled`- (Optional) Specifies if Live Trace is enabled or not. Defaults to `false`.
+* `live_trace_enabled` - (Optional) Specifies if Live Trace is enabled or not. Defaults to `false`.
 
-* `service_mode`- (Optional) Specifies the service mode. Possible values are `Classic`, `Default` and `Serverless`. Defaults to `Default`.
+* `service_mode` - (Optional) Specifies the service mode. Possible values are `Classic`, `Default` and `Serverless`. Defaults to `Default`.
 
 * `upstream_endpoint` - (Optional) An `upstream_endpoint` block as documented below. Using this block requires the SignalR service to be Serverless. When creating multiple blocks they will be processed in the order they are defined in.
 

--- a/website/docs/r/signalr_service_network_acl.html.markdown
+++ b/website/docs/r/signalr_service_network_acl.html.markdown
@@ -92,13 +92,13 @@ A `public_network` block supports the following:
 
 * `allowed_request_types` - (Optional) The allowed request types for the public network. Possible values are `ClientConnection`, `ServerConnection`, `RESTAPI` and `Trace`.
 
-**Note:** When `default_action` is `Allow`, `allowed_request_types`cannot be set.
+~> **Note:** When `default_action` is `Allow`, `allowed_request_types`cannot be set.
 
 * `denied_request_types` - (Optional) The denied request types for the public network. Possible values are `ClientConnection`, `ServerConnection`, `RESTAPI` and `Trace`.
 
-**Note:** When `default_action` is `Deny`, `denied_request_types`cannot be set.
+~> **Note:** When `default_action` is `Deny`, `denied_request_types`cannot be set.
 
-**Note:** `allowed_request_types` - (Optional) and `denied_request_types` cannot be set together.
+~> **Note:** `allowed_request_types` - (Optional) and `denied_request_types` cannot be set together.
 
 ---
 
@@ -108,13 +108,13 @@ A `private_endpoint` block supports the following:
 
 * `allowed_request_types` - (Optional) The allowed request types for the Private Endpoint Connection. Possible values are `ClientConnection`, `ServerConnection`, `RESTAPI` and `Trace`.
 
-**Note:** When `default_action` is `Allow`, `allowed_request_types`cannot be set.
+~> **Note:** When `default_action` is `Allow`, `allowed_request_types`cannot be set.
 
 * `denied_request_types` - (Optional) The denied request types for the Private Endpoint Connection. Possible values are `ClientConnection`, `ServerConnection`, `RESTAPI` and `Trace`.
 
-**Note:** When `default_action` is `Deny`, `denied_request_types`cannot be set.
+~> **Note:** When `default_action` is `Deny`, `denied_request_types`cannot be set.
 
-**Note:** `allowed_request_types` - (Optional) and `denied_request_types` cannot be set together.
+~> **Note:** `allowed_request_types` - (Optional) and `denied_request_types` cannot be set together.
 
 ## Attributes Reference
 

--- a/website/docs/r/site_recovery_replicated_vm.html.markdown
+++ b/website/docs/r/site_recovery_replicated_vm.html.markdown
@@ -272,7 +272,7 @@ A `managed_disk` block supports the following:
 
 A `network_interface` block supports the following:
 
-* `source_network_interface_id` - (Required if the network_interface block is specified) Id source network interface.
+* `source_network_interface_id` - (Optional) (Required if the network_interface block is specified) Id source network interface.
 
 * `target_static_ip` - (Optional) Static IP to assign when a failover is done.
 

--- a/website/docs/r/site_recovery_replicated_vm.html.markdown
+++ b/website/docs/r/site_recovery_replicated_vm.html.markdown
@@ -244,11 +244,11 @@ The following arguments are supported:
 
 * `target_zone` - (Optional) Specifies the Availability Zone where the Failover VM should exist. Changing this forces a new resource to be created.
 
-* `managed_disk` - (Optional) One or more `managed_disk` block.
+* `managed_disk` - (Optional) One or more `managed_disk` block as defined below.
 
 * `target_network_id` - (Optional) Network to use when a failover is done (recommended to set if any network_interface is configured for failover).
 
-* `network_interface` - (Optional) One or more `network_interface` block.
+* `network_interface` - (Optional) One or more `network_interface` block as defined below.
 
 ---
 

--- a/website/docs/r/snapshot.html.markdown
+++ b/website/docs/r/snapshot.html.markdown
@@ -95,7 +95,7 @@ The following attributes are exported:
 
 * `id` - The Snapshot ID.
 
-* `disk_size_gb` - The Size of the Snapshotted Disk in GB.
+* `disk_size_gb` - (Optional) The Size of the Snapshotted Disk in GB.
 
 * `trusted_launch_enabled` - Whether Trusted Launch is enabled for the Snapshot.
 

--- a/website/docs/r/spring_cloud_service.html.markdown
+++ b/website/docs/r/spring_cloud_service.html.markdown
@@ -154,7 +154,7 @@ The `ssh_auth` block supports the following:
 
 The `trace` block supports the following:
 
-* `connection_string` - (Required) The connection string used for Application Insights.
+* `connection_string` - (Optional) The connection string used for Application Insights.
 
 * `sample_rate` - (Optional) The sampling rate of Application Insights Agent. Must be between `0.0` and `100.0`. Defaults to `10.0`.
 

--- a/website/docs/r/sql_database.html.markdown
+++ b/website/docs/r/sql_database.html.markdown
@@ -124,7 +124,7 @@ The `import` block supports the following:
 
 The `threat_detection_policy` block supports the following:
 
-* `state` - (Required) The State of the Policy. Possible values are `Enabled`, `Disabled` or `New`.
+* `state` - (Optional) The State of the Policy. Possible values are `Enabled`, `Disabled` or `New`.
 * `disabled_alerts` - (Optional) Specifies a list of alerts which should be disabled. Possible values include `Access_Anomaly`, `Sql_Injection` and `Sql_Injection_Vulnerability`.
 * `email_account_admins` - (Optional) Should the account administrators be emailed when this alert is triggered?
 * `email_addresses` - (Optional) A list of email addresses which alerts should be sent to.

--- a/website/docs/r/sql_failover_group.html.markdown
+++ b/website/docs/r/sql_failover_group.html.markdown
@@ -112,7 +112,7 @@ The following attributes are exported:
 * `server_name` - (Required) the name of the primary SQL Database Server.
 * `role` - local replication role of the failover group instance.
 * `databases` - (Optional) list of databases in the failover group.
-* `partner_servers` - list of partner server information for the failover group.
+* `partner_servers` - (Required) list of partner server information for the failover group.
 
 ## Timeouts
 

--- a/website/docs/r/sql_failover_group.html.markdown
+++ b/website/docs/r/sql_failover_group.html.markdown
@@ -95,13 +95,13 @@ The `read_write_endpoint_failover_policy` block supports the following:
 
 * `mode` - (Required) the failover mode. Possible values are `Manual`, `Automatic`
 
-* `grace_minutes` - Applies only if `mode` is `Automatic`. The grace period in minutes before failover with data loss is attempted
+* `grace_minutes` - (Optional) Applies only if `mode` is `Automatic`. The grace period in minutes before failover with data loss is attempted
 
 ---
 
 The `readonly_endpoint_failover_policy` block supports the following:
 
-* `mode` - Failover policy for the read-only endpoint. Possible values are `Enabled`, and `Disabled`
+* `mode` - (Required) Failover policy for the read-only endpoint. Possible values are `Enabled`, and `Disabled`
 
 ## Attributes Reference
 
@@ -109,9 +109,9 @@ The following attributes are exported:
 
 * `id` - The failover group ID.
 * `location` - the location of the failover group.
-* `server_name` - the name of the primary SQL Database Server.
+* `server_name` - (Required) the name of the primary SQL Database Server.
 * `role` - local replication role of the failover group instance.
-* `databases` - list of databases in the failover group.
+* `databases` - (Optional) list of databases in the failover group.
 * `partner_servers` - list of partner server information for the failover group.
 
 ## Timeouts

--- a/website/docs/r/sql_managed_instance_failover_group.html.markdown
+++ b/website/docs/r/sql_managed_instance_failover_group.html.markdown
@@ -88,7 +88,7 @@ The following arguments are supported:
 
 * `managed_instance_name` - (Required) The name of the SQL Managed Instance which will be replicated using a SQL Instance Failover Group. Changing this forces a new SQL Instance Failover Group to be created.
 
-* `location` - The Azure Region where the SQL Instance Failover Group exists. Changing this forces a new resource to be created.
+* `location` - (Required) The Azure Region where the SQL Instance Failover Group exists. Changing this forces a new resource to be created.
 
 * `partner_managed_instance_id` - (Required) ID of the SQL Managed Instance which will be replicated to. Changing this forces a new resource to be created.
 

--- a/website/docs/r/sql_server.html.markdown
+++ b/website/docs/r/sql_server.html.markdown
@@ -81,7 +81,7 @@ An `identity` block supports the following:
 
 The `threat_detection_policy` block supports the following:
 
-* `state` - (Required) The State of the Policy. Possible values are `Enabled` or `Disabled`.
+* `state` - (Optional) The State of the Policy. Possible values are `Disabled`, `Enabled` and `New`.
 * `disabled_alerts` - (Optional) Specifies a list of alerts which should be disabled. Possible values include `Access_Anomaly`, `Data_Exfiltration`, `Sql_Injection`, `Sql_Injection_Vulnerability` and `Unsafe_Action"`,.
 * `email_account_admins` - (Optional) Should the account administrators be emailed when this alert is triggered?
 * `email_addresses` - (Optional) A list of email addresses which alerts should be sent to.

--- a/website/docs/r/static_site.html.markdown
+++ b/website/docs/r/static_site.html.markdown
@@ -64,7 +64,7 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 An `identity` block exports the following:
 
-* `type` - The Type of Managed Identity assigned to this resource. Possible values are `SystemAssigned`, `UserAssigned` and `SystemAssigned, UserAssigned`.
+* `type` - (Required) The Type of Managed Identity assigned to this resource. Possible values are `SystemAssigned`, `UserAssigned` and `SystemAssigned, UserAssigned`.
 
 * `principal_id` - (Optional) The Principal ID associated with this Managed Service Identity.
 

--- a/website/docs/r/storage_management_policy.html.markdown
+++ b/website/docs/r/storage_management_policy.html.markdown
@@ -121,23 +121,23 @@ The `actions` block supports the following:
 
 The `base_blob` block supports the following:
 
-* `tier_to_cool_after_days_since_modification_greater_than` - The age in days after last modification to tier blobs to cool storage. Supports blob currently at Hot tier. Must be between 0 and 99999.
-* `tier_to_cool_after_days_since_last_access_time_greater_than` - The age in days after last access time to tier blobs to cool storage. Supports blob currently at Hot tier. Must be between `0` and `99999`.
-* `tier_to_cool_after_days_since_creation_greater_than` - The age in days after creation to cool storage. Supports blob currently at Hot tier. Must be between `0` and `99999`.
+* `tier_to_cool_after_days_since_modification_greater_than` - (Optional) The age in days after last modification to tier blobs to cool storage. Supports blob currently at Hot tier. Must be between 0 and 99999.
+* `tier_to_cool_after_days_since_last_access_time_greater_than` - (Optional) The age in days after last access time to tier blobs to cool storage. Supports blob currently at Hot tier. Must be between `0` and `99999`.
+* `tier_to_cool_after_days_since_creation_greater_than` - (Optional) The age in days after creation to cool storage. Supports blob currently at Hot tier. Must be between `0` and `99999`.
 
 ~> **Note:** The `tier_to_cool_after_days_since_modification_greater_than`, `tier_to_cool_after_days_since_last_access_time_greater_than` and `tier_to_cool_after_days_since_creation_greater_than` can not be set at the same time.
 
-* `tier_to_archive_after_days_since_modification_greater_than` - The age in days after last modification to tier blobs to archive storage. Supports blob currently at Hot or Cool tier. Must be between 0 and 99999.
-* `tier_to_archive_after_days_since_last_access_time_greater_than` - The age in days after last access time to tier blobs to archive storage. Supports blob currently at Hot or Cool tier. Must be between `0` and`99999`.
-* `tier_to_archive_after_days_since_creation_greater_than` - The age in days after creation to archive storage. Supports blob currently at Hot or Cool tier. Must be between `0` and`99999`.
+* `tier_to_archive_after_days_since_modification_greater_than` - (Optional) The age in days after last modification to tier blobs to archive storage. Supports blob currently at Hot or Cool tier. Must be between 0 and 99999.
+* `tier_to_archive_after_days_since_last_access_time_greater_than` - (Optional) The age in days after last access time to tier blobs to archive storage. Supports blob currently at Hot or Cool tier. Must be between `0` and`99999`.
+* `tier_to_archive_after_days_since_creation_greater_than` - (Optional) The age in days after creation to archive storage. Supports blob currently at Hot or Cool tier. Must be between `0` and`99999`.
 
 ~> **Note:** The `tier_to_archive_after_days_since_modification_greater_than`, `tier_to_archive_after_days_since_last_access_time_greater_than` and `tier_to_archive_after_days_since_creation_greater_than` can not be set at the same time.
 
-* `tier_to_archive_after_days_since_last_tier_change_greater_than` - The age in days after last tier change to the blobs to skip to be archved. Must be between 0 and 99999.
+* `tier_to_archive_after_days_since_last_tier_change_greater_than` - (Optional) The age in days after last tier change to the blobs to skip to be archved. Must be between 0 and 99999.
 
-* `delete_after_days_since_modification_greater_than` - The age in days after last modification to delete the blob. Must be between 0 and 99999.
-* `delete_after_days_since_last_access_time_greater_than` - The age in days after last access time to delete the blob. Must be between `0` and `99999`.
-* `delete_after_days_since_creation_greater_than` - The age in days after creation to delete the blob. Must be between `0` and `99999`.
+* `delete_after_days_since_modification_greater_than` - (Optional) The age in days after last modification to delete the blob. Must be between 0 and 99999.
+* `delete_after_days_since_last_access_time_greater_than` - (Optional) The age in days after last access time to delete the blob. Must be between `0` and `99999`.
+* `delete_after_days_since_creation_greater_than` - (Optional) The age in days after creation to delete the blob. Must be between `0` and `99999`.
 
 ~> **Note:** The `delete_after_days_since_modification_greater_than`, `delete_after_days_since_last_access_time_greater_than` and `delete_after_days_since_creation_greater_than` can not be set at the same time.
 
@@ -147,27 +147,27 @@ The `base_blob` block supports the following:
 
 The `snapshot` block supports the following:
 
-* `change_tier_to_archive_after_days_since_creation` - The age in days after creation to tier blob snapshot to archive storage. Must be between 0 and 99999.
-* `tier_to_archive_after_days_since_last_tier_change_greater_than` - The age in days after last tier change to the blobs to skip to be archved. Must be between 0 and 99999.
-* `change_tier_to_cool_after_days_since_creation` - The age in days after creation to tier blob snapshot to cool storage. Must be between 0 and 99999.
-* `delete_after_days_since_creation_greater_than` - The age in days after creation to delete the blob snapshot. Must be between 0 and 99999.
+* `change_tier_to_archive_after_days_since_creation` - (Optional) The age in days after creation to tier blob snapshot to archive storage. Must be between 0 and 99999.
+* `tier_to_archive_after_days_since_last_tier_change_greater_than` - (Optional) The age in days after last tier change to the blobs to skip to be archved. Must be between 0 and 99999.
+* `change_tier_to_cool_after_days_since_creation` - (Optional) The age in days after creation to tier blob snapshot to cool storage. Must be between 0 and 99999.
+* `delete_after_days_since_creation_greater_than` - (Optional) The age in days after creation to delete the blob snapshot. Must be between 0 and 99999.
 
 ---
 
 The `version` block supports the following:
 
-* `change_tier_to_archive_after_days_since_creation` - The age in days after creation to tier blob version to archive storage. Must be between 0 and 99999.
-* `tier_to_archive_after_days_since_last_tier_change_greater_than` - The age in days after last tier change to the blobs to skip to be archved. Must be between 0 and 99999.
-* `change_tier_to_cool_after_days_since_creation` - The age in days creation create to  tier blob version to cool storage. Must be between 0 and 99999.
-* `delete_after_days_since_creation` - The age in days after creation to delete the blob version. Must be between 0 and 99999.
+* `change_tier_to_archive_after_days_since_creation` - (Optional) The age in days after creation to tier blob version to archive storage. Must be between 0 and 99999.
+* `tier_to_archive_after_days_since_last_tier_change_greater_than` - (Optional) The age in days after last tier change to the blobs to skip to be archved. Must be between 0 and 99999.
+* `change_tier_to_cool_after_days_since_creation` - (Optional) The age in days creation create to  tier blob version to cool storage. Must be between 0 and 99999.
+* `delete_after_days_since_creation` - (Optional) The age in days after creation to delete the blob version. Must be between 0 and 99999.
 
 ---
 
 The `match_blob_index_tag` block supports the following:
 
-* `name` - The filter tag name used for tag based filtering for blob objects.
-* `operation` - The comparison operator which is used for object comparison and filtering. Possible value is `==`. Defaults to `==`.
-* `value` -  The filter tag value used for tag based filtering for blob objects.
+* `name` - (Required) The filter tag name used for tag based filtering for blob objects.
+* `operation` - (Optional) The comparison operator which is used for object comparison and filtering. Possible value is `==`. Defaults to `==`.
+* `value` - (Required)  The filter tag value used for tag based filtering for blob objects.
 
 ## Attributes Reference
 

--- a/website/docs/r/subnet.html.markdown
+++ b/website/docs/r/subnet.html.markdown
@@ -102,11 +102,11 @@ A `service_delegation` block supports the following:
 The following attributes are exported:
 
 * `id` - The subnet ID.
-* `name` - The name of the subnet.
-* `resource_group_name` - The name of the resource group in which the subnet is created in.
-* `virtual_network_name` - The name of the virtual network in which the subnet is created in
+* `name` - (Required) The name of the subnet.
+* `resource_group_name` - (Required) The name of the resource group in which the subnet is created in.
+* `virtual_network_name` - (Required) The name of the virtual network in which the subnet is created in
 * `address_prefix` - (Deprecated) The address prefix for the subnet
-* `address_prefixes` - The address prefixes for the subnet
+* `address_prefixes` - (Required) The address prefixes for the subnet
 
 ## Timeouts
 

--- a/website/docs/r/subscription_cost_management_export.html.markdown
+++ b/website/docs/r/subscription_cost_management_export.html.markdown
@@ -81,7 +81,7 @@ A `export_data_storage_location` block supports the following:
 
 * `root_folder_path` - (Required) The path of the directory where exports will be uploaded. Changing this forces a new resource to be created.
 
-**Note:** The Resource Manager ID of a Storage Container is exposed via the `resource_manager_id` attribute of the `azurerm_storage_container` resource.
+~> **Note:** The Resource Manager ID of a Storage Container is exposed via the `resource_manager_id` attribute of the `azurerm_storage_container` resource.
 
 ---
 

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -135,7 +135,7 @@ The following arguments are supported:
 
 * `os_profile` - (Optional) An `os_profile` block as defined below. Required when `create_option` in the `storage_os_disk` block is set to `FromImage`.
 
-* `os_profile_secrets` - (Optional) One or more `os_profile_secrets` blocks.
+* `os_profile_secrets` - (Optional) One or more `os_profile_secrets` blocks as defined below.
 
 * `plan` - (Optional) A `plan` block as defined below.
 
@@ -143,7 +143,7 @@ The following arguments are supported:
 
 * `proximity_placement_group_id` - (Optional) The ID of the Proximity Placement Group to which this Virtual Machine should be assigned. Changing this forces a new resource to be created
 
-* `storage_data_disk` - (Optional) One or more `storage_data_disk` blocks.
+* `storage_data_disk` - (Optional) One or more `storage_data_disk` blocks as defined below.
 
 ~> **Please Note:** Data Disks can also be attached either using this block or [the `azurerm_virtual_machine_data_disk_attachment` resource](virtual_machine_data_disk_attachment.html) - but not both.
 
@@ -230,7 +230,7 @@ A `os_profile_linux_config` block supports the following:
 
 * `disable_password_authentication` - (Required) Specifies whether password authentication should be disabled. If set to `false`, an `admin_password` must be specified.
 
-* `ssh_keys` - (Optional) One or more `ssh_keys` blocks. This field is required if `disable_password_authentication` is set to `true`.
+* `ssh_keys` - (Optional) One or more `ssh_keys` blocks as defined below. This field is required if `disable_password_authentication` is set to `true`.
 
 ---
 
@@ -238,7 +238,7 @@ A `os_profile_secrets` block supports the following:
 
 * `source_vault_id` - (Required) Specifies the ID of the Key Vault to use.
 
-* `vault_certificates` - (Optional) One or more `vault_certificates` blocks.
+* `vault_certificates` - (Required) One or more `vault_certificates` blocks as defined below.
 
 ---
 

--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -169,7 +169,7 @@ An `additional_unattend_config` block supports the following:
 
 * `setting_name` - (Required) Specifies the name of the setting to which the content applies. Possible values are: `FirstLogonCommands` and `AutoLogon`.
 
-* `content` - (Optional) Specifies the base-64 encoded XML formatted content that is added to the unattend.xml file for the specified path and component.
+* `content` - (Required) Specifies the base-64 encoded XML formatted content that is added to the unattend.xml file for the specified path and component.
 
 ---
 
@@ -211,7 +211,7 @@ A `os_profile` block supports the following:
 
 * `admin_username` - (Required) Specifies the name of the local administrator account.
 
-* `admin_password` - (Optional for Windows, Optional for Linux) The password associated with the local administrator account.
+* `admin_password` - (Optional) (Optional for Windows, Optional for Linux) The password associated with the local administrator account.
 
 -> **NOTE:** If using Linux, it may be preferable to use SSH Key authentication (available in the `os_profile_linux_config` block) instead of password authentication.
 
@@ -378,7 +378,7 @@ A `vault_certificates` block supports the following:
 
 -> **NOTE:** If your certificate is stored in Azure Key Vault - this can be sourced from the `secret_id` property on the `azurerm_key_vault_certificate` resource.
 
-* `certificate_store` - (Required, on windows machines) Specifies the certificate store on the Virtual Machine where the certificate should be added to, such as `My`.
+* `certificate_store` - (Optional) (Required, on windows machines) Specifies the certificate store on the Virtual Machine where the certificate should be added to, such as `My`.
 
 ---
 

--- a/website/docs/r/virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/virtual_machine_scale_set.html.markdown
@@ -299,7 +299,7 @@ The following arguments are supported:
 
 * `health_probe_id` - (Optional) Specifies the identifier for the load balancer health probe. Required when using `Rolling` as your `upgrade_policy_mode`.
 
-* `license_type` - (Optional, when a Windows machine) Specifies the Windows OS license type. If supplied, the only allowed values are `Windows_Client` and `Windows_Server`.
+* `license_type` - (Optional) (Optional, when a Windows machine) Specifies the Windows OS license type. If supplied, the only allowed values are `Windows_Client` and `Windows_Server`.
 
 * `os_profile_secrets` - (Optional) A collection of Secret blocks as documented below.
 
@@ -385,7 +385,7 @@ The `os_profile` block supports the following:
 
 * `computer_name_prefix` - (Required) Specifies the computer name prefix for all of the virtual machines in the scale set. Computer name prefixes must be 1 to 9 characters long for windows images and 1 - 58 for Linux. Changing this forces a new resource to be created.
 * `admin_username` - (Required) Specifies the administrator account name to use for all the instances of virtual machines in the scale set.
-* `admin_password` - (Required) Specifies the administrator password to use for all the instances of virtual machines in a scale set.
+* `admin_password` - (Optional) Specifies the administrator password to use for all the instances of virtual machines in a scale set.
 * `custom_data` - (Optional) Specifies custom data to supply to the machine. On Linux-based systems, this can be used as a cloud-init script. On other systems, this will be copied as a file on disk. Internally, Terraform will base64 encode this value before sending it to the API. The maximum length of the binary array is 65535 bytes.
 
 ---
@@ -393,7 +393,7 @@ The `os_profile` block supports the following:
 The `os_profile_secrets` block supports the following:
 
 * `source_vault_id` - (Required) Specifies the key vault to use.
-* `vault_certificates` - (Required, on windows machines) A collection of Vault Certificates as documented below
+* `vault_certificates` - (Optional) (Required, on windows machines) A collection of Vault Certificates as documented below
 
 `vault_certificates` support the following:
 
@@ -423,7 +423,7 @@ The `additional_unattend_config` block supports the following:
 * `pass` - (Required) Specifies the name of the pass that the content applies to. The only allowable value is `oobeSystem`.
 * `component` - (Required) Specifies the name of the component to configure with the added content. The only allowable value is `Microsoft-Windows-Shell-Setup`.
 * `setting_name` - (Required) Specifies the name of the setting to which the content applies. Possible values are: `FirstLogonCommands` and `AutoLogon`.
-* `content` - (Optional) Specifies the base-64 encoded XML formatted content that is added to the unattend.xml file for the specified path and component.
+* `content` - (Required) Specifies the base-64 encoded XML formatted content that is added to the unattend.xml file for the specified path and component.
 
 ---
 
@@ -498,7 +498,7 @@ The `storage_profile_os_disk` block supports the following:
 The `storage_profile_data_disk` block supports the following:
 
 * `lun` - (Required) Specifies the Logical Unit Number of the disk in each virtual machine in the scale set.
-* `create_option` - (Optional) Specifies how the data disk should be created. The only possible options are `FromImage` and `Empty`.
+* `create_option` - (Required) Specifies how the data disk should be created. The only possible options are `FromImage` and `Empty`.
 * `caching` - (Optional) Specifies the caching requirements. Possible values include: `None` (default), `ReadOnly`, `ReadWrite`.
 * `disk_size_gb` - (Optional) Specifies the size of the disk in GB. This element is required when creating an empty disk.
 * `managed_disk_type` - (Optional) Specifies the type of managed disk to create. Value must be either `Standard_LRS`, `StandardSSD_LRS` or `Premium_LRS`.
@@ -518,7 +518,8 @@ machine scale set, as in the [example below](#example-of-storage_profile_image_r
 
 The `boot_diagnostics` block supports the following:
 
-* `enabled` - (Required) Whether to enable boot diagnostics for the virtual machine.
+* `enabled` - (Optional) Whether to enable boot diagnostics for the virtual machine.
+
 * `storage_uri` - (Required) Blob endpoint for the storage account to hold the virtual machine's diagnostic files. This must be the root of a storage account, and not a storage container.
 
 ---
@@ -531,7 +532,7 @@ The `extension` block supports the following:
 * `type_handler_version` - (Required) Specifies the version of the extension to use, available versions can be found using the Azure CLI.
 * `auto_upgrade_minor_version` - (Optional) Specifies whether or not to use the latest minor version available.
 * `provision_after_extensions` - (Optional) Specifies a dependency array of extensions required to be executed before, the array stores the name of each extension.
-* `settings` - (Required) The settings passed to the extension, these are specified as a JSON object in a string.
+* `settings` - (Optional) The settings passed to the extension, these are specified as a JSON object in a string.
 * `protected_settings` - (Optional) The protected_settings passed to the extension, like settings, these are specified as a JSON object in a string.
 
 ---

--- a/website/docs/r/virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/virtual_machine_scale_set.html.markdown
@@ -518,8 +518,8 @@ machine scale set, as in the [example below](#example-of-storage_profile_image_r
 
 The `boot_diagnostics` block supports the following:
 
-* `enabled`: - (Required) Whether to enable boot diagnostics for the virtual machine.
-* `storage_uri`: - (Required) Blob endpoint for the storage account to hold the virtual machine's diagnostic files. This must be the root of a storage account, and not a storage container.
+* `enabled` - (Required) Whether to enable boot diagnostics for the virtual machine.
+* `storage_uri` - (Required) Blob endpoint for the storage account to hold the virtual machine's diagnostic files. This must be the root of a storage account, and not a storage container.
 
 ---
 

--- a/website/docs/r/virtual_network.html.markdown
+++ b/website/docs/r/virtual_network.html.markdown
@@ -123,7 +123,7 @@ The following attributes are exported:
 
 * `guid` - The GUID of the virtual network.
 
-* `subnet`- One or more `subnet` blocks as defined below.
+* `subnet` - One or more `subnet` blocks as defined below.
 
 ---
 

--- a/website/docs/r/virtual_network.html.markdown
+++ b/website/docs/r/virtual_network.html.markdown
@@ -123,7 +123,7 @@ The following attributes are exported:
 
 * `guid` - The GUID of the virtual network.
 
-* `subnet` - One or more `subnet` blocks as defined below.
+* `subnet` - (Optional) One or more `subnet` blocks as defined below.
 
 ---
 

--- a/website/docs/r/virtual_network.html.markdown
+++ b/website/docs/r/virtual_network.html.markdown
@@ -113,13 +113,13 @@ The following attributes are exported:
 
 * `id` - The virtual NetworkConfiguration ID.
 
-* `name` - The name of the virtual network.
+* `name` - (Required) The name of the virtual network.
 
-* `resource_group_name` - The name of the resource group in which to create the virtual network.
+* `resource_group_name` - (Required) The name of the resource group in which to create the virtual network.
 
-* `location` - The location/region where the virtual network is created.
+* `location` - (Required) The location/region where the virtual network is created.
 
-* `address_space` - The list of address spaces used by the virtual network.
+* `address_space` - (Required) The list of address spaces used by the virtual network.
 
 * `guid` - The GUID of the virtual network.
 

--- a/website/docs/r/virtual_network_gateway.html.markdown
+++ b/website/docs/r/virtual_network_gateway.html.markdown
@@ -265,7 +265,7 @@ The following attributes are exported:
 
 * `id` - The ID of the Virtual Network Gateway.
 
-* `bgp_settings` - A block of `bgp_settings`.
+* `bgp_settings` - (Optional) A block of `bgp_settings`.
 
 ---
 

--- a/website/docs/r/virtual_network_gateway.html.markdown
+++ b/website/docs/r/virtual_network_gateway.html.markdown
@@ -157,9 +157,7 @@ The following arguments are supported:
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
-* `vpn_client_configuration` - (Optional) A `vpn_client_configuration` block which
-  is documented below. In this block the Virtual Network Gateway can be configured
-  to accept IPSec point-to-site connections.
+* `vpn_client_configuration` - (Optional) A `vpn_client_configuration` block which is documented below. In this block the Virtual Network Gateway can be configured to accept IPSec point-to-site connections.
 
 * `vpn_type` - (Optional) The routing type of the Virtual Network Gateway. Valid options are `RouteBased` or `PolicyBased`. Defaults to `RouteBased`. Changing this forces a new resource to be created.
 
@@ -196,12 +194,9 @@ The `vpn_client_configuration` block supports:
 
 * `aad_issuer` - (Optional) The STS url for your tenant
 
-* `root_certificate` - (Optional) One or more `root_certificate` blocks which are
-    defined below. These root certificates are used to sign the client certificate
-    used by the VPN clients to connect to the gateway.
+* `root_certificate` - (Optional) One or more `root_certificate` blocks which are defined below. These root certificates are used to sign the client certificate used by the VPN clients to connect to the gateway.
 
-* `revoked_certificate` - (Optional) One or more `revoked_certificate` blocks which
-    are defined below.
+* `revoked_certificate` - (Optional) One or more `revoked_certificate` blocks which are defined below.
 
 * `radius_server_address` - (Optional) The address of the Radius server.
 
@@ -232,7 +227,7 @@ The `bgp_settings` block supports:
 
 A `custom_route` block supports the following:
 
-* `address_prefixes` - (Optional) A list of address blocks reserved for this virtual network in CIDR notation.
+* `address_prefixes` - (Optional) A list of address blocks reserved for this virtual network in CIDR notation as defined below.
 
 ---
 

--- a/website/docs/r/virtual_network_gateway_connection.html.markdown
+++ b/website/docs/r/virtual_network_gateway_connection.html.markdown
@@ -307,9 +307,9 @@ The `ipsec_policy` block supports:
 
 The `traffic_selector_policy` block supports:
 
-* `local_address_cidrs` - List of local CIDRs.
+* `local_address_cidrs` - (Required) List of local CIDRs.
 
-* `remote_address_cidrs` - List of remote CIDRs.
+* `remote_address_cidrs` - (Required) List of remote CIDRs.
 
 ## Attributes Reference
 

--- a/website/docs/r/vpn_gateway.html.markdown
+++ b/website/docs/r/vpn_gateway.html.markdown
@@ -103,9 +103,9 @@ A `bgp_settings` block exports the following:
 
 * `bgp_peering_address` - The Address which should be used for the BGP Peering.
 
-* `instance_0_bgp_peering_address` - an `instance_bgp_peering_address` block as defined below.
+* `instance_0_bgp_peering_address` - (Optional) an `instance_bgp_peering_address` block as defined below.
 
-* `instance_1_bgp_peering_address` - an `instance_bgp_peering_address` block as defined below.
+* `instance_1_bgp_peering_address` - (Optional) an `instance_bgp_peering_address` block as defined below.
 
 ---
 

--- a/website/docs/r/web_application_firewall_policy.html.markdown
+++ b/website/docs/r/web_application_firewall_policy.html.markdown
@@ -134,7 +134,7 @@ The following arguments are supported:
 
 The `custom_rules` block supports the following:
 
-* `name` - (Required) Gets name of the resource that is unique within a policy. This name can be used to access the resource.
+* `name` - (Optional) Gets name of the resource that is unique within a policy. This name can be used to access the resource.
 
 * `priority` - (Required) Describes priority of the rule. Rules with a lower value will be evaluated before rules with a higher value.
 
@@ -194,7 +194,7 @@ The `exclusion` block supports the following:
 
 * `match_variable` - (Required) The name of the Match Variable. Possible values: `RequestArgKeys`, `RequestArgNames`, `RequestArgValues`, `RequestCookieKeys`, `RequestCookieNames`, `RequestCookieValues`, `RequestHeaderKeys`, `RequestHeaderNames`, `RequestHeaderValues`.
 
-* `selector` - (Optional) Describes field of the matchVariable collection.
+* `selector` - (Required) Describes field of the matchVariable collection.
 
 * `selector_match_operator` - (Required) Describes operator to be matched. Possible values: `Contains`, `EndsWith`, `Equals`, `EqualsAny`, `StartsWith`.
 

--- a/website/docs/r/web_pubsub_hub.html.markdown
+++ b/website/docs/r/web_pubsub_hub.html.markdown
@@ -102,7 +102,7 @@ The following attributes are exported:
 
 * `id` - The ID of the Web Pubsub Hub resource.
 
-* `name` - The name of the Web Pubsub Hub resource
+* `name` - (Required) The name of the Web Pubsub Hub resource
 
 ## Timeouts
 

--- a/website/docs/r/windows_function_app.html.markdown
+++ b/website/docs/r/windows_function_app.html.markdown
@@ -162,7 +162,7 @@ A `application_stack` block supports the following:
 
 An `app_service_logs` block supports the following:
 
-* `disk_quota_mb` - (Required) The amount of disk space to use for logs. Valid values are between `25` and `100`.
+* `disk_quota_mb` - (Optional) The amount of disk space to use for logs. Valid values are between `25` and `100`.
 
 * `retention_period_days` - (Optional) The retention period for logs in days. Valid values are between `0` and `99999`. Defaults to `0` (never delete).
 

--- a/website/docs/r/windows_virtual_machine.html.markdown
+++ b/website/docs/r/windows_virtual_machine.html.markdown
@@ -329,13 +329,13 @@ A `secret` block supports the following:
 
 The `source_image_reference` block supports the following:
 
-* `publisher` - (Optional) Specifies the publisher of the image used to create the virtual machines.
+* `publisher` - (Required) Specifies the publisher of the image used to create the virtual machines.
 
-* `offer` - (Optional) Specifies the offer of the image used to create the virtual machines.
+* `offer` - (Required) Specifies the offer of the image used to create the virtual machines.
 
-* `sku` - (Optional) Specifies the SKU of the image used to create the virtual machines.
+* `sku` - (Required) Specifies the SKU of the image used to create the virtual machines.
 
-* `version` - (Optional) Specifies the version of the image used to create the virtual machines.
+* `version` - (Required) Specifies the version of the image used to create the virtual machines.
 
 ---
 

--- a/website/docs/r/windows_virtual_machine.html.markdown
+++ b/website/docs/r/windows_virtual_machine.html.markdown
@@ -169,7 +169,7 @@ The following arguments are supported:
 
 * `platform_fault_domain` - (Optional) Specifies the Platform Fault Domain in which this Windows Virtual Machine should be created. Defaults to `-1`, which means this will be automatically assigned to a fault domain that best maintains balance across the available fault domains. Changing this forces a new Windows Virtual Machine to be created.
 
-* `priority`- (Optional) Specifies the priority of this Virtual Machine. Possible values are `Regular` and `Spot`. Defaults to `Regular`. Changing this forces a new resource to be created.
+* `priority` - (Optional) Specifies the priority of this Virtual Machine. Possible values are `Regular` and `Spot`. Defaults to `Regular`. Changing this forces a new resource to be created.
 
 * `provision_vm_agent` - (Optional) Should the Azure VM Agent be provisioned on this Virtual Machine? Defaults to `true`. Changing this forces a new resource to be created.
 

--- a/website/docs/r/windows_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/windows_virtual_machine_scale_set.html.markdown
@@ -408,9 +408,9 @@ An `ip_configuration` block supports the following:
 
 An `ip_tag` block supports the following:
 
-* `tag` - The IP Tag associated with the Public IP, such as `SQL` or `Storage`.
+* `tag` - (Required) The IP Tag associated with the Public IP, such as `SQL` or `Storage`.
 
-* `type` - The Type of IP Tag, such as `FirstPartyUsage`.
+* `type` - (Required) The Type of IP Tag, such as `FirstPartyUsage`.
 
 ---
 

--- a/website/docs/r/windows_web_app.html.markdown
+++ b/website/docs/r/windows_web_app.html.markdown
@@ -216,7 +216,7 @@ A `azure_blob_storage` block supports the following:
 
 * `level` - (Required) The level at which to log. Possible values include `Error`, `Warning`, `Information`, `Verbose` and `Off`. **NOTE:** this field is not available for `http_logs`
 
-* `retention_in_days` - (Required) The time in days after which to remove blobs. A value of `0` means no retention.
+* `retention_in_days` - (Optional) The time in days after which to remove blobs. A value of `0` means no retention.
 
 * `sas_url` - (Required) SAS url to an Azure blob container with read/write/list/delete permissions.
 

--- a/website/docs/r/windows_web_app_slot.html.markdown
+++ b/website/docs/r/windows_web_app_slot.html.markdown
@@ -220,7 +220,7 @@ A `azure_blob_storage` block supports the following:
 
 * `level` - (Required) The level at which to log. Possible values include `Error`, `Warning`, `Information`, `Verbose` and `Off`. **NOTE:** this field is not available for `http_logs`
 
-* `retention_in_days` - (Required) The time in days after which to remove blobs. A value of `0` means no retention.
+* `retention_in_days` - (Optional) The time in days after which to remove blobs. A value of `0` means no retention.
 
 * `sas_url` - (Required) SAS url to an Azure blob container with read/write/list/delete permissions.
 


### PR DESCRIPTION
1. property doc should be like ` - ` with whitespace
2. replace nbsp/nnbsp as common whitespace
3. block property line should have a `as defined below` description.
4. optional/required check auto correct in tool v2