### PR TITLE
`azurerm_kubernetes_cluster` - support for the `backend_pool_type` property

### DIFF
--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -588,6 +588,8 @@ Examples of how to use [AKS with Advanced Networking](https://docs.microsoft.com
 
 A `load_balancer_profile` block supports the following:
 
+* `backend_pool_type` - (Optional) Specifies the type of the managed inbound Load Balancer Backend Pool. Possible values are `NodeIP` and `NodeIPConfiguration`.
+
 ~> **Note:** The fields `managed_outbound_ip_count`, `outbound_ip_address_ids` and `outbound_ip_prefix_ids` are mutually exclusive. Note that when specifying `outbound_ip_address_ids` ([azurerm_public_ip](/docs/providers/azurerm/r/public_ip.html)) the SKU must be `standard`.
 
 * `idle_timeout_in_minutes` - (Optional) Desired outbound flow idle timeout in minutes for the cluster load balancer. Must be between `4` and `120` inclusive. Defaults to `30`.

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -590,6 +590,8 @@ A `load_balancer_profile` block supports the following:
 
 * `backend_pool_type` - (Optional) Specifies the type of the managed inbound Load Balancer Backend Pool. Possible values are `NodeIP` and `NodeIPConfiguration`.
 
+-> **Note** This requires that the Preview Feature `Microsoft.ContainerService/IPBasedLoadBalancerPreview` is enabled and the Resource Provider is re-registered.
+
 ~> **Note:** The fields `managed_outbound_ip_count`, `outbound_ip_address_ids` and `outbound_ip_prefix_ids` are mutually exclusive. Note that when specifying `outbound_ip_address_ids` ([azurerm_public_ip](/docs/providers/azurerm/r/public_ip.html)) the SKU must be `standard`.
 
 * `idle_timeout_in_minutes` - (Optional) Desired outbound flow idle timeout in minutes for the cluster load balancer. Must be between `4` and `120` inclusive. Defaults to `30`.


### PR DESCRIPTION
```
=== RUN   TestAccKubernetesCluster_backendPoolType
=== PAUSE TestAccKubernetesCluster_backendPoolType
=== CONT  TestAccKubernetesCluster_backendPoolType
--- PASS: TestAccKubernetesCluster_backendPoolType (1036.95s)
PASS
```