### PR TITLE
`azurerm_mssql_database` - `threat_detection_policy.0.storage_*` can now be correctly set as empty

### DIFF
--- a/internal/services/mssql/mssql_database_resource.go
+++ b/internal/services/mssql/mssql_database_resource.go
@@ -742,10 +742,10 @@ func expandMsSqlServerSecurityAlertPolicy(d *pluginsdk.ResourceData) sql.Databas
 		if v, ok := securityAlert["retention_days"]; ok {
 			properties.RetentionDays = utils.Int32(int32(v.(int)))
 		}
-		if v, ok := securityAlert["storage_account_access_key"]; ok {
+		if v, ok := securityAlert["storage_account_access_key"]; ok && v.(string) != "" {
 			properties.StorageAccountAccessKey = utils.String(v.(string))
 		}
-		if v, ok := securityAlert["storage_endpoint"]; ok {
+		if v, ok := securityAlert["storage_endpoint"]; ok && v.(string) != "" {
 			properties.StorageEndpoint = utils.String(v.(string))
 		}
 

--- a/internal/services/mssql/mssql_database_resource_test.go
+++ b/internal/services/mssql/mssql_database_resource_test.go
@@ -510,13 +510,29 @@ func TestAccMsSqlDatabase_threatDetectionPolicyNoStorage(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("threat_detection_policy.#").HasValue("1"),
-				check.That(data.ResourceName).Key("threat_detection_policy.0.state").HasValue("Enabled"),
-				check.That(data.ResourceName).Key("threat_detection_policy.0.retention_days").HasValue("15"),
-				check.That(data.ResourceName).Key("threat_detection_policy.0.disabled_alerts.#").HasValue("1"),
-				check.That(data.ResourceName).Key("threat_detection_policy.0.email_account_admins").HasValue("Enabled"),
+				check.That(data.ResourceName).Key("threat_detection_policy.0.storage_account_access_key").IsEmpty(),
+				check.That(data.ResourceName).Key("threat_detection_policy.0.storage_endpoint").IsEmpty(),
 			),
 		},
 		data.ImportStep("sample_name", "threat_detection_policy.0.storage_account_access_key"),
+		{
+			Config: r.threatDetectionPolicy(data, "Enabled"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("threat_detection_policy.#").HasValue("1"),
+				check.That(data.ResourceName).Key("threat_detection_policy.0.storage_account_access_key").IsSet(),
+				check.That(data.ResourceName).Key("threat_detection_policy.0.storage_endpoint").IsSet(),
+			),
+		},
+		{
+			Config: r.threatDetectionPolicyNoStorage(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("threat_detection_policy.#").HasValue("1"),
+				check.That(data.ResourceName).Key("threat_detection_policy.0.storage_account_access_key").IsEmpty(),
+				check.That(data.ResourceName).Key("threat_detection_policy.0.storage_endpoint").IsEmpty(),
+			),
+		},
 	})
 }
 

--- a/internal/services/mssql/mssql_database_resource_test.go
+++ b/internal/services/mssql/mssql_database_resource_test.go
@@ -471,7 +471,7 @@ func TestAccMsSqlDatabase_storageAccountType(t *testing.T) {
 	})
 }
 
-func TestAccMsSqlDatabase_threatDetectionPolicy1(t *testing.T) {
+func TestAccMsSqlDatabase_threatDetectionPolicy(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_mssql_database", "test")
 	r := MsSqlDatabaseResource{}
 


### PR DESCRIPTION
<img width="691" alt="image" src="https://user-images.githubusercontent.com/6515518/207475559-75654d1b-7c87-4bea-b096-000f8075deb7.png">
