### PR TITLE
`azurerm_resource_policy_exemption/azurerm_resource_group_policy_exemption/azurerm_subscription_policy_exemption` - Mark `policy_assignment_id` as ForceNew

### DIFF
--- a/internal/services/policy/exemption_resource.go
+++ b/internal/services/policy/exemption_resource.go
@@ -67,6 +67,7 @@ func resourceArmResourcePolicyExemption() *pluginsdk.Resource {
 			"policy_assignment_id": {
 				Type:         schema.TypeString,
 				Required:     true,
+				ForceNew:     true,
 				ValidateFunc: validate.PolicyAssignmentID,
 			},
 

--- a/internal/services/policy/exemption_resource_group.go
+++ b/internal/services/policy/exemption_resource_group.go
@@ -68,6 +68,7 @@ func resourceArmResourceGroupPolicyExemption() *pluginsdk.Resource {
 			"policy_assignment_id": {
 				Type:         schema.TypeString,
 				Required:     true,
+				ForceNew:     true,
 				ValidateFunc: validate.PolicyAssignmentID,
 			},
 

--- a/internal/services/policy/exemption_subscription.go
+++ b/internal/services/policy/exemption_subscription.go
@@ -67,6 +67,7 @@ func resourceArmSubscriptionPolicyExemption() *pluginsdk.Resource {
 			"policy_assignment_id": {
 				Type:         schema.TypeString,
 				Required:     true,
+				ForceNew:     true,
 				ValidateFunc: validate.PolicyAssignmentID,
 			},
 

--- a/website/docs/r/resource_group_policy_exemption.html.markdown
+++ b/website/docs/r/resource_group_policy_exemption.html.markdown
@@ -51,7 +51,7 @@ The following arguments are supported:
 
 * `exemption_category` - (Required) The category of this policy exemption. Possible values are `Waiver` and `Mitigated`.
 
-* `policy_assignment_id` - (Required) The ID of the Policy Assignment to be exempted at the specified Scope.
+* `policy_assignment_id` - (Required) The ID of the Policy Assignment to be exempted at the specified Scope. Changing this forces a new resource to be created.
 
 * `description` - (Optional) A description to use for this Policy Exemption.
 

--- a/website/docs/r/resource_policy_exemption.html.markdown
+++ b/website/docs/r/resource_policy_exemption.html.markdown
@@ -58,7 +58,7 @@ The following arguments are supported:
 
 * `exemption_category` - (Required) The category of this policy exemption. Possible values are `Waiver` and `Mitigated`.
 
-* `policy_assignment_id` - (Required) The ID of the Policy Assignment to be exempted at the specified Scope.
+* `policy_assignment_id` - (Required) The ID of the Policy Assignment to be exempted at the specified Scope. Changing this forces a new resource to be created.
 
 * `description` - (Optional) A description to use for this Policy Exemption.
 

--- a/website/docs/r/subscription_policy_exemption.html.markdown
+++ b/website/docs/r/subscription_policy_exemption.html.markdown
@@ -48,7 +48,7 @@ The following arguments are supported:
 
 * `exemption_category` - (Required) The category of this policy exemption. Possible values are `Waiver` and `Mitigated`.
 
-* `policy_assignment_id` - (Required) The ID of the Policy Assignment to be exempted at the specified Scope.
+* `policy_assignment_id` - (Required) The ID of the Policy Assignment to be exempted at the specified Scope. Changing this forces a new resource to be created.
 
 * `description` - (Optional) A description to use for this Policy Exemption.
 


### PR DESCRIPTION
fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/19667

Per the error message mentioned in the original thread, it indicates API doesn't support to update policy_assignment_id. So the policy_assignment_id of azurerm_resource_policy_exemption, azurerm_resource_group_policy_exemption, azurerm_subscription_policy_exemption has to be added "ForceNew" attribute.

--- PASS: TestAccAzureRMResourceGroupPolicyExemption_basic (446.65s)
--- PASS: TestAccAzureRMResourceGroupPolicyExemption_complete (448.80s)
--- PASS: TestAccAzureRMResourceGroupPolicyExemption_update (685.40s)
--- PASS: TestAccAzureRMSubscriptionPolicyExemption_basic (363.55s)
--- PASS: TestAccAzureRMSubscriptionPolicyExemption_complete (368.06s)
--- PASS: TestAccAzureRMSubscriptionPolicyExemption_update (586.30s)
--- PASS: TestAccAzureRMResourcePolicyExemption_basic (496.47s)
--- PASS: TestAccAzureRMResourcePolicyExemption_complete (497.52s)
--- PASS: TestAccAzureRMResourcePolicyExemption_update (738.02s)
