### PR TITLE
`azurerm_vpn_gateway_connection` - support for the `inbound_route_map_id` and `outbound_route_map_id` properties

### DIFF
--- a/internal/services/network/vpn_gateway_connection_resource_test.go
+++ b/internal/services/network/vpn_gateway_connection_resource_test.go
@@ -235,6 +235,22 @@ func TestAccVpnGatewayConnection_customBgpAddress(t *testing.T) {
 	})
 }
 
+func TestAccVpnGatewayConnection_routeMap(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_vpn_gateway_connection", "test")
+	r := VPNGatewayConnectionResource{}
+	nameSuffix := randString()
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.routeMap(data, nameSuffix),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (t VPNGatewayConnectionResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := parse.VpnConnectionID(state.ID)
 	if err != nil {
@@ -646,6 +662,104 @@ resource "azurerm_vpn_gateway_connection" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary)
+}
+
+func (r VPNGatewayConnectionResource) routeMap(data acceptance.TestData, nameSuffix string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_route_map" "test" {
+  name           = "acctestrm-%[2]s"
+  virtual_hub_id = azurerm_virtual_hub.test.id
+
+  rule {
+    name                 = "rule1"
+    next_step_if_matched = "Continue"
+
+    action {
+      type = "Add"
+
+      parameter {
+        as_path = ["22334"]
+      }
+    }
+
+    match_criterion {
+      match_condition = "Contains"
+      route_prefix    = ["10.0.0.0/8"]
+    }
+  }
+}
+
+resource "azurerm_route_map" "test2" {
+  name           = "acctestrmn-%[2]s"
+  virtual_hub_id = azurerm_virtual_hub.test.id
+
+  rule {
+    name                 = "rule1"
+    next_step_if_matched = "Continue"
+
+    action {
+      type = "Add"
+
+      parameter {
+        as_path = ["22334"]
+      }
+    }
+
+    match_criterion {
+      match_condition = "Contains"
+      route_prefix    = ["10.0.0.0/8"]
+    }
+  }
+}
+
+resource "azurerm_vpn_gateway_connection" "test" {
+  name               = "acctest-VpnGwConn-%[3]d"
+  vpn_gateway_id     = azurerm_vpn_gateway.test.id
+  remote_vpn_site_id = azurerm_vpn_site.test.id
+
+  routing {
+    associated_route_table = azurerm_virtual_hub.test.default_route_table_id
+    inbound_route_map_id   = azurerm_route_map.test.id
+    outbound_route_map_id  = azurerm_route_map.test2.id
+
+    propagated_route_table {
+      route_table_ids = [azurerm_virtual_hub.test.default_route_table_id]
+      labels          = ["label1"]
+    }
+  }
+
+  vpn_link {
+    name             = "link1"
+    vpn_site_link_id = azurerm_vpn_site.test.link[0].id
+
+    ipsec_policy {
+      sa_lifetime_sec          = 300
+      sa_data_size_kb          = 1024
+      encryption_algorithm     = "AES256"
+      integrity_algorithm      = "SHA256"
+      ike_encryption_algorithm = "AES128"
+      ike_integrity_algorithm  = "SHA256"
+      dh_group                 = "DHGroup14"
+      pfs_group                = "PFS14"
+    }
+
+    bandwidth_mbps                        = 30
+    protocol                              = "IKEv2"
+    ratelimit_enabled                     = true
+    route_weight                          = 2
+    shared_key                            = "secret"
+    local_azure_ip_address_enabled        = true
+    policy_based_traffic_selector_enabled = true
+  }
+
+  vpn_link {
+    name             = "link3"
+    vpn_site_link_id = azurerm_vpn_site.test.link[1].id
+  }
+}
+`, r.template(data), nameSuffix, data.RandomInteger)
 }
 
 func (VPNGatewayConnectionResource) template(data acceptance.TestData) string {

--- a/website/docs/r/vpn_gateway_connection.html.markdown
+++ b/website/docs/r/vpn_gateway_connection.html.markdown
@@ -151,6 +151,10 @@ A `routing` block supports the following:
 
 * `propagated_route_table` - (Required) A `propagated_route_table` block as defined below.
 
+* `inbound_route_map_id` - (Optional) The resource ID of the Route Map associated with this Routing Configuration for inbound learned routes.
+
+* `outbound_route_map_id` - (Optional) The resource ID of the Route Map associated with this Routing Configuration for outbound advertised routes.
+
 ---
 
 A `traffic_selector_policy` block supports the following:


### PR DESCRIPTION
This PR is to support new properties `inbound_route_map_id` and `outbound_route_map_id` for `azurerm_vpn_gateway_connection`.

--- PASS: TestAccVpnGatewayConnection_basic (5181.77s)
--- PASS: TestAccVpnGatewayConnection_customBgpAddress (5720.46s)
--- PASS: TestAccVpnGatewayConnection_routeMap (5948.91s)
--- PASS: TestAccVpnGatewayConnection_update (6331.25s)
--- PASS: TestAccVpnGatewayConnection_complete (6367.57s)
--- PASS: TestAccVpnGatewayConnection_updateTrafficSelectorPolicy (6395.80s)
--- PASS: TestAccVpnGatewayConnection_requiresImport (6712.33s)
--- PASS: TestAccVpnGatewayConnection_customRouteTable (6716.35s)
--- PASS: TestAccVpnGatewayConnection_natRuleIds (6777.86s)
--- PASS: TestAccVpnGatewayConnection_updateConnectionMode (6798.36s)
