### PR TITLE
`azurerm_virtual_desktop_application_group` - Fix `azurerm_virtual_desktop_application_group` force new on `host_pool_id` change

### DIFF
--- a/internal/services/desktopvirtualization/virtual_desktop_application_group_resource.go
+++ b/internal/services/desktopvirtualization/virtual_desktop_application_group_resource.go
@@ -81,6 +81,7 @@ func resourceVirtualDesktopApplicationGroup() *pluginsdk.Resource {
 			"host_pool_id": {
 				Type:         pluginsdk.TypeString,
 				Required:     true,
+				ForceNew:     true,
 				ValidateFunc: hostpool.ValidateHostPoolID,
 			},
 

--- a/website/docs/r/virtual_desktop_application_group.html.markdown
+++ b/website/docs/r/virtual_desktop_application_group.html.markdown
@@ -76,8 +76,7 @@ The following arguments are supported:
 
 * `type` - (Required) Type of Virtual Desktop Application Group. Valid options are `RemoteApp` or `Desktop` application groups. Changing this forces a new resource to be created.
 
-* `host_pool_id` - (Required) Resource ID for a Virtual Desktop Host Pool to associate with the
-    Virtual Desktop Application Group.
+* `host_pool_id` - (Required) Resource ID for a Virtual Desktop Host Pool to associate with the Virtual Desktop Application Group. Changing the name forces a new resource to be created.
 
 * `friendly_name` - (Optional) Option to set a friendly name for the Virtual Desktop Application Group.
 


### PR DESCRIPTION
Property  `host_pool_id` could not be updated after checking API. So `azurerm_virtual_desktop_application_group` should  force new on `host_pool_id` change .

Fix #19687 .