### PR TITLE
`azurerm_stream_analytics_output_mssql`: Username and password parameters optional if MSI authentication

### DIFF
--- a/internal/services/streamanalytics/stream_analytics_output_mssql_resource_test.go
+++ b/internal/services/streamanalytics/stream_analytics_output_mssql_resource_test.go
@@ -52,13 +52,13 @@ func TestAccStreamAnalyticsOutputSql_update(t *testing.T) {
 	})
 }
 
-func TestAccStreamAnalyticsOutputSql_authenticationMode(t *testing.T) {
+func TestAccStreamAnalyticsOutputSql_authenticationModeMsi(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_stream_analytics_output_mssql", "test")
 	r := StreamAnalyticsOutputSqlResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.authenticationMode(data),
+			Config: r.authenticationModeMsi(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -213,7 +213,7 @@ resource "azurerm_stream_analytics_output_mssql" "test" {
 `, template, data.RandomInteger, maxBatchCount, maxWriterCount)
 }
 
-func (r StreamAnalyticsOutputSqlResource) authenticationMode(data acceptance.TestData) string {
+func (r StreamAnalyticsOutputSqlResource) authenticationModeMsi(data acceptance.TestData) string {
 	template := r.template(data)
 	return fmt.Sprintf(`
 %s
@@ -225,8 +225,6 @@ resource "azurerm_stream_analytics_output_mssql" "test" {
   authentication_mode       = "Msi"
 
   server   = azurerm_sql_server.test.fully_qualified_domain_name
-  user     = azurerm_sql_server.test.administrator_login
-  password = azurerm_sql_server.test.administrator_login_password
   database = azurerm_sql_database.test.name
   table    = "AccTestTable"
 }

--- a/website/docs/r/stream_analytics_output_mssql.html.markdown
+++ b/website/docs/r/stream_analytics_output_mssql.html.markdown
@@ -68,11 +68,11 @@ The following arguments are supported:
 
 * `server` - (Required) The SQL server url. Changing this forces a new resource to be created.
 
-* `user` - (Required) Username used to login to the Microsoft SQL Server. Changing this forces a new resource to be created.
+* `user` - (Optional) Username used to login to the Microsoft SQL Server. Changing this forces a new resource to be created. Required if `authentication_mode` is `ConnectionString`. 
 
 * `database` - (Required) The MS SQL database name where the reference table exists. Changing this forces a new resource to be created.
 
-* `password` - (Required) Password used together with username, to login to the Microsoft SQL Server. 
+* `password` - (Optional) Password used together with username, to login to the Microsoft SQL Server. Required if `authentication_mode` is `ConnectionString`.
 
 * `table` - (Required) Table in the database that the output points to. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
`username` and `password` parameters are optional when `authenticationMode` is MSI (Managed Service Identity).

Acceptance tests were adapted and run successfully:
```
TF_ACC=1 go test -v ./internal/services/streamanalytics -run=TestAccStreamAnalyticsOutputSql -timeout 20m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccStreamAnalyticsOutputSql_basic
=== PAUSE TestAccStreamAnalyticsOutputSql_basic
=== RUN   TestAccStreamAnalyticsOutputSql_update
=== PAUSE TestAccStreamAnalyticsOutputSql_update
=== RUN   TestAccStreamAnalyticsOutputSql_authenticationModeMsi
=== PAUSE TestAccStreamAnalyticsOutputSql_authenticationModeMsi
=== RUN   TestAccStreamAnalyticsOutputSql_requiresImport
=== PAUSE TestAccStreamAnalyticsOutputSql_requiresImport
=== RUN   TestAccStreamAnalyticsOutputSql_maxBatchCountAndMaxWriterCount
=== PAUSE TestAccStreamAnalyticsOutputSql_maxBatchCountAndMaxWriterCount
=== CONT  TestAccStreamAnalyticsOutputSql_basic
=== CONT  TestAccStreamAnalyticsOutputSql_requiresImport
=== CONT  TestAccStreamAnalyticsOutputSql_maxBatchCountAndMaxWriterCount
=== CONT  TestAccStreamAnalyticsOutputSql_authenticationModeMsi
=== CONT  TestAccStreamAnalyticsOutputSql_update
--- PASS: TestAccStreamAnalyticsOutputSql_basic (281.75s)
--- PASS: TestAccStreamAnalyticsOutputSql_authenticationModeMsi (322.58s)
--- PASS: TestAccStreamAnalyticsOutputSql_requiresImport (348.95s)
--- PASS: TestAccStreamAnalyticsOutputSql_update (367.62s)
--- PASS: TestAccStreamAnalyticsOutputSql_maxBatchCountAndMaxWriterCount (534.90s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/streamanalytics       537.343s
```