### PR TITLE
`azurerm_virtual_network_gateway_connection`:  can now be created with a `azurerm_virtual_network_gateway` in another resource group

### DIFF
--- a/internal/services/network/virtual_network_gateway_connection_resource.go
+++ b/internal/services/network/virtual_network_gateway_connection_resource.go
@@ -374,7 +374,7 @@ func resourceVirtualNetworkGatewayConnectionCreateUpdate(d *pluginsdk.ResourceDa
 			return err
 		}
 
-		virtualNetworkGateway, err = vnetGatewayClient.Get(ctx, id.ResourceGroup, gwid.Name)
+		virtualNetworkGateway, err = vnetGatewayClient.Get(ctx, gwid.ResourceGroup, gwid.Name)
 		if err != nil {
 			return err
 		}

--- a/internal/services/network/virtual_network_gateway_connection_resource_test.go
+++ b/internal/services/network/virtual_network_gateway_connection_resource_test.go
@@ -271,6 +271,11 @@ resource "azurerm_resource_group" "test" {
   location = "%s"
 }
 
+resource "azurerm_resource_group" "test2" {
+  name     = "acctestRG2-${var.random}"
+  location = azurerm_resource_group.test.location
+}
+
 resource "azurerm_virtual_network" "test" {
   name                = "acctestvn-${var.random}"
   location            = azurerm_resource_group.test.location
@@ -311,8 +316,8 @@ resource "azurerm_virtual_network_gateway" "test" {
 
 resource "azurerm_local_network_gateway" "test" {
   name                = "acctest-${var.random}"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test2.location
+  resource_group_name = azurerm_resource_group.test2.name
 
   gateway_address = "168.62.225.23"
   address_space   = ["10.1.1.0/24"]
@@ -320,8 +325,8 @@ resource "azurerm_local_network_gateway" "test" {
 
 resource "azurerm_virtual_network_gateway_connection" "test" {
   name                = "acctest-${var.random}"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test2.location
+  resource_group_name = azurerm_resource_group.test2.name
 
   type                       = "IPsec"
   virtual_network_gateway_id = azurerm_virtual_network_gateway.test.id


### PR DESCRIPTION
Also extending tests to cover the use case where the connection is not in the same resource group as the gateway.

closes #19185 