### PR TITLE
`azurerm_data_factory_linked_service_azure_databricks` - increase worker range to databricks limit

### DIFF
--- a/internal/services/datafactory/data_factory_linked_service_azure_databricks_resource.go
+++ b/internal/services/datafactory/data_factory_linked_service_azure_databricks_resource.go
@@ -135,12 +135,12 @@ func resourceDataFactoryLinkedServiceAzureDatabricks() *pluginsdk.Resource {
 							Type:         pluginsdk.TypeInt,
 							Optional:     true,
 							Default:      "1",
-							ValidateFunc: validation.IntBetween(1, 10),
+							ValidateFunc: validation.IntBetween(1, 25000),
 						},
 						"max_number_of_workers": {
 							Type:         pluginsdk.TypeInt,
 							Optional:     true,
-							ValidateFunc: validation.IntBetween(1, 10),
+							ValidateFunc: validation.IntBetween(1, 25000),
 						},
 						"cluster_version": {
 							Type:         pluginsdk.TypeString,
@@ -196,12 +196,12 @@ func resourceDataFactoryLinkedServiceAzureDatabricks() *pluginsdk.Resource {
 							Type:         pluginsdk.TypeInt,
 							Optional:     true,
 							Default:      1,
-							ValidateFunc: validation.IntBetween(1, 10),
+							ValidateFunc: validation.IntBetween(1, 25000),
 						},
 						"max_number_of_workers": {
 							Type:         pluginsdk.TypeInt,
 							Optional:     true,
-							ValidateFunc: validation.IntBetween(1, 10),
+							ValidateFunc: validation.IntBetween(1, 25000),
 						},
 						"instance_pool_id": {
 							Type:         pluginsdk.TypeString,


### PR DESCRIPTION
fixes #19700

[Databricks limitations](https://learn.microsoft.com/en-us/azure/databricks/resources/limits)