### PR TITLE
`azurerm_stream_analytics_output_servicebus_topic`: shared access policy name and key parameters made optional to support MSI authentication

### DIFF
--- a/internal/services/streamanalytics/stream_analytics_output_servicebus_topic_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_output_servicebus_topic_resource.go
@@ -146,11 +146,11 @@ func resourceStreamAnalyticsOutputServiceBusTopicCreateUpdate(d *pluginsdk.Resou
 
 	systemPropertyColumns := d.Get("system_property_columns").(map[string]interface{})
 	dataSourceProperties := &outputs.ServiceBusTopicOutputDataSourceProperties{
-		TopicName:              utils.String(d.Get("topic_name").(string)),
-		ServiceBusNamespace:    utils.String(d.Get("servicebus_namespace").(string)),
-		PropertyColumns:        utils.ExpandStringSlice(d.Get("property_columns").([]interface{})),
-		SystemPropertyColumns:  expandSystemPropertyColumns(systemPropertyColumns),
-		AuthenticationMode: utils.ToPtr(outputs.AuthenticationMode(d.Get("authentication_mode").(string))),
+		TopicName:             utils.String(d.Get("topic_name").(string)),
+		ServiceBusNamespace:   utils.String(d.Get("servicebus_namespace").(string)),
+		PropertyColumns:       utils.ExpandStringSlice(d.Get("property_columns").([]interface{})),
+		SystemPropertyColumns: expandSystemPropertyColumns(systemPropertyColumns),
+		AuthenticationMode:    utils.ToPtr(outputs.AuthenticationMode(d.Get("authentication_mode").(string))),
 	}
 
 	// Add shared access policy key/name only if required by authentication mode

--- a/internal/services/streamanalytics/stream_analytics_output_servicebus_topic_resource_test.go
+++ b/internal/services/streamanalytics/stream_analytics_output_servicebus_topic_resource_test.go
@@ -114,13 +114,13 @@ func TestAccStreamAnalyticsOutputServiceBusTopic_requiresImport(t *testing.T) {
 	})
 }
 
-func TestAccStreamAnalyticsOutputServiceBusTopic_authenticationMode(t *testing.T) {
+func TestAccStreamAnalyticsOutputServiceBusTopic_authenticationModeMsi(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_stream_analytics_output_servicebus_topic", "test")
 	r := StreamAnalyticsOutputServiceBusTopicResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.json(data),
+			Config: r.authenticationModeMsi(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -238,6 +238,28 @@ resource "azurerm_stream_analytics_output_servicebus_topic" "test" {
   servicebus_namespace      = azurerm_servicebus_namespace.test.name
   shared_access_policy_key  = azurerm_servicebus_namespace.test.default_primary_key
   shared_access_policy_name = "RootManageSharedAccessKey"
+
+  serialization {
+    type     = "Json"
+    encoding = "UTF8"
+    format   = "LineSeparated"
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func (r StreamAnalyticsOutputServiceBusTopicResource) authenticationModeMsi(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_stream_analytics_output_servicebus_topic" "test" {
+  name                      = "acctestinput-%d"
+  stream_analytics_job_name = azurerm_stream_analytics_job.test.name
+  resource_group_name       = azurerm_stream_analytics_job.test.resource_group_name
+  topic_name                = azurerm_servicebus_topic.test.name
+  servicebus_namespace      = azurerm_servicebus_namespace.test.name
+  authentication_mode 		= "Msi"
 
   serialization {
     type     = "Json"

--- a/website/docs/r/stream_analytics_output_servicebus_topic.html.markdown
+++ b/website/docs/r/stream_analytics_output_servicebus_topic.html.markdown
@@ -37,7 +37,7 @@ resource "azurerm_servicebus_topic" "example" {
 }
 
 resource "azurerm_stream_analytics_output_servicebus_topic" "example" {
-  name                      = "blob-storage-output"
+  name                      = "service-bus-topic-output"
   stream_analytics_job_name = data.azurerm_stream_analytics_job.example.name
   resource_group_name       = data.azurerm_stream_analytics_job.example.resource_group_name
   topic_name                = azurerm_servicebus_topic.example.name
@@ -67,9 +67,9 @@ The following arguments are supported:
 
 * `servicebus_namespace` - (Required) The namespace that is associated with the desired Event Hub, Service Bus Topic, Service Bus Topic, etc.
 
-* `shared_access_policy_key` - (Required) The shared access policy key for the specified shared access policy.
+* `shared_access_policy_key` - (Optional) The shared access policy key for the specified shared access policy. Required if `authentication_mode` is `ConnectionString`.
 
-* `shared_access_policy_name` - (Required) The shared access policy name for the Event Hub, Service Bus Queue, Service Bus Topic, etc.
+* `shared_access_policy_name` - (Optional) The shared access policy name for the Event Hub, Service Bus Queue, Service Bus Topic, etc. Required if `authentication_mode` is `ConnectionString`.
 
 * `serialization` - (Required) A `serialization` block as defined below.
 


### PR DESCRIPTION
`shared_access_policy_name` and `shared_access_policy_key` parameters made optional as these are not required when authenticationMode is MSI (Managed Service Identity). See analog PR for service bus queues #19712 

This requires the go sdk for stream analytics to be upgraded to version "2021-10-01-preview". ~This has been initiated in [this PR](https://github.com/hashicorp/pandora/pull/1946).~ This has been prepared in PR #20145.

Acceptance tests were adapted and run successfully:
```
TF_ACC=1 go test -v ./internal/services/streamanalytics -run=TestAccStreamAnalyticsOutputServiceBusTopic -timeout 20m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccStreamAnalyticsOutputServiceBusTopic_avro
=== PAUSE TestAccStreamAnalyticsOutputServiceBusTopic_avro
=== RUN   TestAccStreamAnalyticsOutputServiceBusTopic_csv
=== PAUSE TestAccStreamAnalyticsOutputServiceBusTopic_csv
=== RUN   TestAccStreamAnalyticsOutputServiceBusTopic_json
=== PAUSE TestAccStreamAnalyticsOutputServiceBusTopic_json
=== RUN   TestAccStreamAnalyticsOutputServiceBusTopic_propertyColumns
=== PAUSE TestAccStreamAnalyticsOutputServiceBusTopic_propertyColumns
=== RUN   TestAccStreamAnalyticsOutputServiceBusTopic_update
=== PAUSE TestAccStreamAnalyticsOutputServiceBusTopic_update
=== RUN   TestAccStreamAnalyticsOutputServiceBusTopic_requiresImport
=== PAUSE TestAccStreamAnalyticsOutputServiceBusTopic_requiresImport
=== RUN   TestAccStreamAnalyticsOutputServiceBusTopic_authenticationModeMsi
=== PAUSE TestAccStreamAnalyticsOutputServiceBusTopic_authenticationModeMsi
=== RUN   TestAccStreamAnalyticsOutputServiceBusTopic_systemPropertyColumns
=== PAUSE TestAccStreamAnalyticsOutputServiceBusTopic_systemPropertyColumns
=== CONT  TestAccStreamAnalyticsOutputServiceBusTopic_avro
=== CONT  TestAccStreamAnalyticsOutputServiceBusTopic_update
=== CONT  TestAccStreamAnalyticsOutputServiceBusTopic_json
=== CONT  TestAccStreamAnalyticsOutputServiceBusTopic_authenticationModeMsi
=== CONT  TestAccStreamAnalyticsOutputServiceBusTopic_csv
=== CONT  TestAccStreamAnalyticsOutputServiceBusTopic_propertyColumns
=== CONT  TestAccStreamAnalyticsOutputServiceBusTopic_requiresImport
=== CONT  TestAccStreamAnalyticsOutputServiceBusTopic_systemPropertyColumns
--- PASS: TestAccStreamAnalyticsOutputServiceBusTopic_csv (300.18s)
--- PASS: TestAccStreamAnalyticsOutputServiceBusTopic_json (302.18s)
--- PASS: TestAccStreamAnalyticsOutputServiceBusTopic_propertyColumns (302.30s)
--- PASS: TestAccStreamAnalyticsOutputServiceBusTopic_requiresImport (322.28s)
--- PASS: TestAccStreamAnalyticsOutputServiceBusTopic_avro (361.49s)
--- PASS: TestAccStreamAnalyticsOutputServiceBusTopic_authenticationModeMsi (361.87s)
--- PASS: TestAccStreamAnalyticsOutputServiceBusTopic_update (433.09s)
--- PASS: TestAccStreamAnalyticsOutputServiceBusTopic_systemPropertyColumns (515.33s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/streamanalytics       517.063s
```