### PR TITLE
`azurerm_stream_analytics_output_servicebus_queue`: Shared access policy name/key optional for MSI authentication

### DIFF
--- a/internal/services/streamanalytics/stream_analytics_output_servicebus_queue_resource_test.go
+++ b/internal/services/streamanalytics/stream_analytics_output_servicebus_queue_resource_test.go
@@ -61,14 +61,14 @@ func TestAccStreamAnalyticsOutputServiceBusQueue_json(t *testing.T) {
 	})
 }
 
-func TestAccStreamAnalyticsOutputServiceBusQueue_authenticationMode(t *testing.T) {
+func TestAccStreamAnalyticsOutputServiceBusQueue_authenticationModeMsi(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_stream_analytics_output_servicebus_queue", "test")
 	r := StreamAnalyticsOutputServiceBusQueueResource{}
 	identity := "identity { type = \"SystemAssigned\" }"
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.authenticationMode(data, identity),
+			Config: r.authenticationModeMsi(data, identity),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -434,7 +434,7 @@ resource "azurerm_stream_analytics_output_servicebus_queue" "import" {
 `, template)
 }
 
-func (r StreamAnalyticsOutputServiceBusQueueResource) authenticationMode(data acceptance.TestData, identity string) string {
+func (r StreamAnalyticsOutputServiceBusQueueResource) authenticationModeMsi(data acceptance.TestData, identity string) string {
 	template := r.template(data, identity)
 	return fmt.Sprintf(`
 %s
@@ -445,8 +445,7 @@ resource "azurerm_stream_analytics_output_servicebus_queue" "test" {
   resource_group_name       = azurerm_stream_analytics_job.test.resource_group_name
   queue_name                = azurerm_servicebus_queue.test.name
   servicebus_namespace      = azurerm_servicebus_namespace.test.name
-  shared_access_policy_key  = azurerm_servicebus_namespace.test.default_primary_key
-  shared_access_policy_name = "RootManageSharedAccessKey"
+  authentication_mode 		= "Msi"
 
   serialization {
     type     = "Json"

--- a/website/docs/r/stream_analytics_output_servicebus_queue.html.markdown
+++ b/website/docs/r/stream_analytics_output_servicebus_queue.html.markdown
@@ -66,9 +66,9 @@ The following arguments are supported:
 
 * `servicebus_namespace` - (Required) The namespace that is associated with the desired Event Hub, Service Bus Queue, Service Bus Topic, etc.
 
-* `shared_access_policy_key` - (Required) The shared access policy key for the specified shared access policy.
+* `shared_access_policy_key` - (Optional) The shared access policy key for the specified shared access policy. Required if `authentication_mode` is `ConnectionString`.
 
-* `shared_access_policy_name` - (Required) The shared access policy name for the Event Hub, Service Bus Queue, Service Bus Topic, etc.
+* `shared_access_policy_name` - (Optional) The shared access policy name for the Event Hub, Service Bus Queue, Service Bus Topic, etc. Required if `authentication_mode` is `ConnectionString`.
 
 * `serialization` - (Required) A `serialization` block as defined below.
 


### PR DESCRIPTION
`shared_access_policy_name` and `shared_access_policy_key` parameters made optional as these are not required when authenticationMode is MSI (Managed Service Identity). See analog PR for service bus topics: #19708 

This requires the go sdk for stream analytics to be upgraded to version "2021-10-01-preview". ~This has been initiated in [this PR](https://github.com/hashicorp/pandora/pull/1946).~ This has been prepared in PR #20145.

Acceptance tests were adapted and run successfully:
```
TF_ACC=1 go test -v ./internal/services/streamanalytics -run=TestAccStreamAnalyticsOutputServiceBusQueue -timeout 20m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccStreamAnalyticsOutputServiceBusQueue_avro
=== PAUSE TestAccStreamAnalyticsOutputServiceBusQueue_avro
=== RUN   TestAccStreamAnalyticsOutputServiceBusQueue_csv
=== PAUSE TestAccStreamAnalyticsOutputServiceBusQueue_csv
=== RUN   TestAccStreamAnalyticsOutputServiceBusQueue_json
=== PAUSE TestAccStreamAnalyticsOutputServiceBusQueue_json
=== RUN   TestAccStreamAnalyticsOutputServiceBusQueue_authenticationModeMsi
=== PAUSE TestAccStreamAnalyticsOutputServiceBusQueue_authenticationModeMsi
=== RUN   TestAccStreamAnalyticsOutputServiceBusQueue_update
=== PAUSE TestAccStreamAnalyticsOutputServiceBusQueue_update
=== RUN   TestAccStreamAnalyticsOutputServiceBusQueue_requiresImport
=== PAUSE TestAccStreamAnalyticsOutputServiceBusQueue_requiresImport
=== RUN   TestAccStreamAnalyticsOutputServiceBusQueue_propertyColumns
=== PAUSE TestAccStreamAnalyticsOutputServiceBusQueue_propertyColumns
=== RUN   TestAccStreamAnalyticsOutputServiceBusQueue_systemPropertyColumns
=== PAUSE TestAccStreamAnalyticsOutputServiceBusQueue_systemPropertyColumns
=== CONT  TestAccStreamAnalyticsOutputServiceBusQueue_avro
=== CONT  TestAccStreamAnalyticsOutputServiceBusQueue_update
=== CONT  TestAccStreamAnalyticsOutputServiceBusQueue_csv
=== CONT  TestAccStreamAnalyticsOutputServiceBusQueue_json
=== CONT  TestAccStreamAnalyticsOutputServiceBusQueue_authenticationModeMsi
=== CONT  TestAccStreamAnalyticsOutputServiceBusQueue_propertyColumns
=== CONT  TestAccStreamAnalyticsOutputServiceBusQueue_systemPropertyColumns
=== CONT  TestAccStreamAnalyticsOutputServiceBusQueue_requiresImport
--- PASS: TestAccStreamAnalyticsOutputServiceBusQueue_json (442.69s)
--- PASS: TestAccStreamAnalyticsOutputServiceBusQueue_avro (446.55s)
--- PASS: TestAccStreamAnalyticsOutputServiceBusQueue_csv (448.20s)
--- PASS: TestAccStreamAnalyticsOutputServiceBusQueue_authenticationModeMsi (448.84s)
--- PASS: TestAccStreamAnalyticsOutputServiceBusQueue_requiresImport (464.29s)
--- PASS: TestAccStreamAnalyticsOutputServiceBusQueue_systemPropertyColumns (692.07s)
--- PASS: TestAccStreamAnalyticsOutputServiceBusQueue_propertyColumns (698.98s)
--- PASS: TestAccStreamAnalyticsOutputServiceBusQueue_update (743.26s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/streamanalytics       744.912s
```