### PR TITLE
`azurerm_storage_account_network_rules` - Do not check `bypass` during "existance" check

### DIFF
--- a/internal/services/storage/storage_account_network_rules_resource.go
+++ b/internal/services/storage/storage_account_network_rules_resource.go
@@ -287,9 +287,10 @@ func checkForNonDefaultStorageAccountNetworkRule(rule *storage.NetworkRuleSet) b
 		return false
 	}
 
+	// THe default action "Allow" is set in the creation of the storage account resource as default value.
 	if (rule.IPRules != nil && len(*rule.IPRules) != 0) ||
 		(rule.VirtualNetworkRules != nil && len(*rule.VirtualNetworkRules) != 0) ||
-		rule.Bypass != "AzureServices" || rule.DefaultAction != "Allow" {
+		rule.DefaultAction != "Allow" {
 		return true
 	}
 


### PR DESCRIPTION
Fix #19718

This PR is to make the existance check of `azurerm_storage_account_network_rules` to be consistent with the default parameters set for the `networkRuleSet` in the creation of `azurerm_storage_account` when it is created with no `network_rules` specified: https://github.com/hashicorp/terraform-provider-azurerm/blob/a4bea1c7bc6f57c061a438dc51a35a9b05af5aba/internal/services/storage/storage_account_resource.go#L2502

Where it only specified the `defaultAction` to be `Allow`, but not specified the `bypass`. Whilst, in the existance check of `azurerm_storage_account_network_rules`, it checks both: https://github.com/hashicorp/terraform-provider-azurerm/blob/8f1fde661d2afacd59fd87b19d260bf55c9a42d7/internal/services/storage/storage_account_network_rules_resource.go#L292

So this depends on the service to always return the `AzureServices` for `bypass` when it is not set. As is reported by #19718, the service behavior is apparently not consistent, which I'll report to the service team in other channels. While for the provider code, I think we shall still make the code consistent and rely on the service behavior as far as possible. So we shall either change the default setting in the storage account creation, or reduce the check in the storage account network rules as is done by this PR. I chose the latter as its impact seems to be smaller.