### PR TITLE
`azurerm_app_configuration_key` - id parse bugfix

### DIFF
--- a/internal/services/appconfiguration/app_configuration_key_resource.go
+++ b/internal/services/appconfiguration/app_configuration_key_resource.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/appconfiguration/migration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/appconfiguration/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/appconfiguration/sdk/1.0/appconfiguration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/appconfiguration/validate"
@@ -23,6 +24,8 @@ import (
 type KeyResource struct{}
 
 var _ sdk.ResourceWithCustomizeDiff = KeyResource{}
+
+var _ sdk.ResourceWithStateMigration = KeyResource{}
 
 const (
 	KeyTypeVault        = "vault"
@@ -393,4 +396,13 @@ func (k KeyResource) CustomizeDiff() sdk.ResourceFunc {
 
 func (k KeyResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
 	return validate.AppConfigurationKeyID
+}
+
+func (k KeyResource) StateUpgraders() sdk.StateUpgradeData {
+	return sdk.StateUpgradeData{
+		SchemaVersion: 1,
+		Upgraders: map[int]pluginsdk.StateUpgrade{
+			0: migration.KeyResourceV0ToV1{},
+		},
+	}
 }

--- a/internal/services/appconfiguration/migration/key_resource.go
+++ b/internal/services/appconfiguration/migration/key_resource.go
@@ -1,0 +1,99 @@
+package migration
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/appconfiguration/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+var _ pluginsdk.StateUpgrade = KeyResourceV0ToV1{}
+
+type KeyResourceV0ToV1 struct{}
+
+func (KeyResourceV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		// old:
+		// 	/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/resourceGroup1/providers/Microsoft.AppConfiguration/configurationStores/appConf1/AppConfigurationKey/key%3Aname%2Ftest/Label/test%3Alabel%2Fname
+		// new:
+		// 	/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/resourceGroup1/providers/Microsoft.AppConfiguration/configurationStores/appConf1/AppConfigurationKey/key:name/test/Label/test:label/name
+		oldId := rawState["id"].(string)
+		oldKeyNames := regexp.MustCompile(`AppConfigurationKey\/(.+)\/Label`).FindStringSubmatch(oldId)
+		if len(oldKeyNames) == 2 {
+			decodedName, err := url.QueryUnescape(oldKeyNames[1])
+			if err != nil {
+				return rawState, err
+			}
+			oldId = strings.Replace(oldId, oldKeyNames[1], decodedName, 1)
+		}
+		oldLabelNames := regexp.MustCompile(`AppConfigurationKey\/.+\/Label\/(.+)`).FindStringSubmatch(oldId)
+		if len(oldLabelNames) == 2 {
+			decodedName, err := url.QueryUnescape(oldLabelNames[1])
+			if err != nil {
+				return rawState, err
+			}
+			oldId = strings.Replace(oldId, oldLabelNames[1], decodedName, 1)
+		}
+		parsedNewId, err := parse.KeyId(oldId)
+		if err != nil {
+			return rawState, fmt.Errorf("parsing existing Key Resource %q: %+v", oldId, err)
+		}
+		rawState["id"] = parsedNewId.ID()
+
+		return rawState, nil
+	}
+}
+
+func (KeyResourceV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	return KeyResourceSchemaForV0AndV1()
+}
+
+func KeyResourceSchemaForV0AndV1() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"configuration_store_id": {
+			Required: true,
+			Type:     pluginsdk.TypeString,
+		},
+		"content_type": {
+			Optional: true,
+			Type:     pluginsdk.TypeString,
+		},
+		"etag": {
+			Optional: true,
+			Type:     pluginsdk.TypeString,
+		},
+		"key": {
+			Required: true,
+			Type:     pluginsdk.TypeString,
+		},
+		"label": {
+			Optional: true,
+			Type:     pluginsdk.TypeString,
+		},
+		"locked": {
+			Optional: true,
+			Type:     pluginsdk.TypeBool,
+		},
+		"tags": {
+			Elem:     &pluginsdk.Schema{Type: pluginsdk.TypeString},
+			Optional: true,
+			Type:     pluginsdk.TypeMap,
+		},
+		"type": {
+			Optional: true,
+			Type:     pluginsdk.TypeString,
+		},
+		"value": {
+			Optional: true,
+			Type:     pluginsdk.TypeString,
+		},
+		"vault_key_reference": {
+			Optional: true,
+			Type:     pluginsdk.TypeString,
+		},
+	}
+}

--- a/internal/services/appconfiguration/migration/key_resource_test.go
+++ b/internal/services/appconfiguration/migration/key_resource_test.go
@@ -1,0 +1,56 @@
+package migration
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+func TestKeyResourceV0ToV1(t *testing.T) {
+	testData := []struct {
+		name     string
+		input    map[string]interface{}
+		expected *string
+	}{
+		{
+			name: "old id (normal)",
+			input: map[string]interface{}{
+				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourcegroups/resourceGroup1/providers/Microsoft.AppConfiguration/configurationStores/appConf1/AppConfigurationKey/keyName/Label/labelName",
+			},
+			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourcegroups/resourceGroup1/providers/Microsoft.AppConfiguration/configurationStores/appConf1/AppConfigurationKey/keyName/Label/labelName"),
+		},
+		{
+			name: "old id (encoded)",
+			input: map[string]interface{}{
+				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourcegroups/resourceGroup1/providers/Microsoft.AppConfiguration/configurationStores/appConf1/AppConfigurationKey/key%3Aname%2Ftest/Label/test%3Alabel%2Fname",
+			},
+			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourcegroups/resourceGroup1/providers/Microsoft.AppConfiguration/configurationStores/appConf1/AppConfigurationKey/key:name/test/Label/test:label/name"),
+		},
+		{
+			name: "new id",
+			input: map[string]interface{}{
+				"id": "/subscriptions/12345678-1234-5678-1234-123456789012/resourcegroups/resourceGroup1/providers/Microsoft.AppConfiguration/configurationStores/appConf1/AppConfigurationKey/key:name/test/Label/test:label/name",
+			},
+			expected: utils.String("/subscriptions/12345678-1234-5678-1234-123456789012/resourcegroups/resourceGroup1/providers/Microsoft.AppConfiguration/configurationStores/appConf1/AppConfigurationKey/key:name/test/Label/test:label/name"),
+		},
+	}
+	for _, test := range testData {
+		t.Logf("Testing %q...", test.name)
+		result, err := KeyResourceV0ToV1{}.UpgradeFunc()(context.TODO(), test.input, nil)
+		if err != nil && test.expected == nil {
+			continue
+		} else {
+			if err == nil && test.expected == nil {
+				t.Fatalf("Expected an error but didn't get one")
+			} else if err != nil && test.expected != nil {
+				t.Fatalf("Expected no error but got: %+v", err)
+			}
+		}
+
+		actualId := result["id"].(string)
+		if *test.expected != actualId {
+			t.Fatalf("expected %q but got %q!", *test.expected, actualId)
+		}
+	}
+}


### PR DESCRIPTION
fix #19711

`azurerm_app_configuration_key` used to save id encoded in state file, changed parse function (#19470) needs to migrate the state file or the encoded id will be encoded again...
<img width="630" alt="Screenshot 2022-12-19 at 14 55 35" src="https://user-images.githubusercontent.com/51212351/208365753-4923a749-a8af-46b0-820b-e95e541a9ae2.png">

