### PR TITLE
`azurerm_stream_analytics_output_blob` - fix type conversion for `batch_min_rows`

### DIFF
--- a/internal/services/streamanalytics/stream_analytics_output_blob_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_output_blob_resource.go
@@ -181,7 +181,7 @@ func resourceStreamAnalyticsOutputBlobCreateUpdate(d *pluginsdk.ResourceData, me
 	}
 
 	if batchMinRows, ok := d.GetOk("batch_min_rows"); ok {
-		props.Properties.SizeWindow = utils.Int64(batchMinRows.(int64))
+		props.Properties.SizeWindow = utils.Int64(int64(batchMinRows.(int)))
 	}
 
 	// timeWindow and sizeWindow must be set for Parquet serialization


### PR DESCRIPTION
fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/19725

There is a bug on type conversion for `batch_min_rows`. So submitted this PR to fix it.

![image](https://user-images.githubusercontent.com/19754191/208568878-71514e96-2d7a-4c0f-bdf6-fa7825fc566a.png)
