### PR TITLE
New resource `azurerm_key_vault_certificate_contacts`

### DIFF
--- a/internal/services/keyvault/key_vault_certificate_contacts_resource.go
+++ b/internal/services/keyvault/key_vault_certificate_contacts_resource.go
@@ -1,0 +1,296 @@
+package keyvault
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/keyvault/v7.1/keyvault"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+type KeyVaultCertificateContactsResource struct{}
+
+var (
+	_ sdk.ResourceWithUpdate = KeyVaultCertificateContactsResource{}
+)
+
+type KeyVaultCertificateContactsResourceModel struct {
+	KeyVaultId string    `tfschema:"key_vault_id"`
+	Contact    []Contact `tfschema:"contact"`
+}
+
+type Contact struct {
+	Email string `tfschema:"email"`
+	Name  string `tfschema:"name"`
+	Phone string `tfschema:"phone"`
+}
+
+func (r KeyVaultCertificateContactsResource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"key_vault_id": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validate.VaultID,
+		},
+
+		"contact": {
+			Type:     pluginsdk.TypeSet,
+			Required: true,
+			MinItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"email": {
+						Type:         pluginsdk.TypeString,
+						Required:     true,
+						ValidateFunc: validation.StringIsNotEmpty,
+					},
+
+					"name": {
+						Type:         pluginsdk.TypeString,
+						Optional:     true,
+						ValidateFunc: validation.StringIsNotEmpty,
+					},
+
+					"phone": {
+						Type:         pluginsdk.TypeString,
+						Optional:     true,
+						ValidateFunc: validation.StringIsNotEmpty,
+					},
+				},
+			},
+		},
+	}
+}
+
+func (r KeyVaultCertificateContactsResource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{}
+}
+
+func (r KeyVaultCertificateContactsResource) ResourceType() string {
+	return "azurerm_key_vault_certificate_contacts"
+}
+
+func (r KeyVaultCertificateContactsResource) ModelObject() interface{} {
+	return &KeyVaultCertificateContactsResourceModel{}
+}
+
+func (r KeyVaultCertificateContactsResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+	return validate.CertificateContactsID
+}
+
+func (r KeyVaultCertificateContactsResource) Create() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			vaultClient := metadata.Client.KeyVault
+			client := metadata.Client.KeyVault.ManagementClient
+			var state KeyVaultCertificateContactsResourceModel
+			if err := metadata.Decode(&state); err != nil {
+				return err
+			}
+
+			keyVaultId, err := parse.VaultID(state.KeyVaultId)
+			if err != nil {
+				return fmt.Errorf("parsing `key_vault_id`, %+v", err)
+			}
+
+			keyVaultBaseUri, err := vaultClient.BaseUriForKeyVault(ctx, *keyVaultId)
+			if err != nil {
+				return fmt.Errorf("looking up Base URI for Key Vault Certificate Contacts from %s: %+v", *keyVaultId, err)
+			}
+
+			id, err := parse.NewCertificateContactsID(*keyVaultBaseUri)
+			if err != nil {
+				return err
+			}
+
+			locks.ByID(id.ID())
+			defer locks.UnlockByID(id.ID())
+
+			existing, err := client.GetCertificateContacts(ctx, *keyVaultBaseUri)
+			if err != nil {
+				if !utils.ResponseWasNotFound(existing.Response) {
+					return fmt.Errorf("checking for presence of existing Certificate Contacts (Key Vault %q): %s", *keyVaultBaseUri, err)
+				}
+			}
+
+			if existing.ContactList != nil && len(*existing.ContactList) != 0 {
+				return tf.ImportAsExistsError(r.ResourceType(), id.ID())
+			}
+
+			contacts := keyvault.Contacts{
+				ContactList: expandKeyVaultCertificateContactsContact(state.Contact),
+			}
+
+			if _, err := client.SetCertificateContacts(ctx, *keyVaultBaseUri, contacts); err != nil {
+				return fmt.Errorf("creating Key Vault Certificate Contacts %s: %+v", id, err)
+			}
+
+			metadata.SetID(id)
+			return nil
+		},
+		Timeout: 30 * time.Minute,
+	}
+}
+
+func (r KeyVaultCertificateContactsResource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			vaultClient := metadata.Client.KeyVault
+			client := metadata.Client.KeyVault.ManagementClient
+			resourcesClient := metadata.Client.Resource
+
+			id, err := parse.CertificateContactsID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			keyVaultIdRaw, err := vaultClient.KeyVaultIDFromBaseUrl(ctx, resourcesClient, id.KeyVaultBaseUrl)
+			if err != nil {
+				return fmt.Errorf("retrieving resource ID of the Key Vault at URL %s: %+v", id.KeyVaultBaseUrl, err)
+			}
+			if keyVaultIdRaw == nil {
+				metadata.Logger.Infof("Unable to determine the Resource ID for the Key Vault at URL %s - removing from state!", id.KeyVaultBaseUrl)
+				return metadata.MarkAsGone(id)
+			}
+			keyVaultId, err := parse.VaultID(*keyVaultIdRaw)
+			if err != nil {
+				return fmt.Errorf("parsing Key Vault ID: %+v", err)
+			}
+
+			existing, err := client.GetCertificateContacts(ctx, id.KeyVaultBaseUrl)
+			if err != nil {
+				if !utils.ResponseWasNotFound(existing.Response) {
+					return fmt.Errorf("checking for presence of existing Certificate Contacts (Key Vault %q): %s", id.KeyVaultBaseUrl, err)
+				}
+			}
+
+			state := KeyVaultCertificateContactsResourceModel{
+				KeyVaultId: keyVaultId.ID(),
+				Contact:    flattenKeyVaultCertificateContactsContact(existing.ContactList),
+			}
+
+			return metadata.Encode(&state)
+		},
+		Timeout: 5 * time.Minute,
+	}
+}
+
+func (r KeyVaultCertificateContactsResource) Update() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.KeyVault.ManagementClient
+
+			var state KeyVaultCertificateContactsResourceModel
+			if err := metadata.Decode(&state); err != nil {
+				return err
+			}
+
+			id, err := parse.CertificateContactsID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			locks.ByID(id.ID())
+			defer locks.UnlockByID(id.ID())
+
+			existing, err := client.GetCertificateContacts(ctx, id.KeyVaultBaseUrl)
+			if err != nil {
+				if !utils.ResponseWasNotFound(existing.Response) {
+					return fmt.Errorf("checking for presence of existing Certificate Contacts (Key Vault %q): %s", id.KeyVaultBaseUrl, err)
+				}
+			}
+
+			if metadata.ResourceData.HasChange("contact") {
+				existing.ContactList = expandKeyVaultCertificateContactsContact(state.Contact)
+			}
+
+			if _, err := client.SetCertificateContacts(ctx, id.KeyVaultBaseUrl, existing); err != nil {
+				return fmt.Errorf("updating Key Vault Certificate Contacts %s: %+v", id, err)
+			}
+
+			return nil
+		},
+		Timeout: 30 * time.Minute,
+	}
+}
+
+func (r KeyVaultCertificateContactsResource) Delete() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.KeyVault.ManagementClient
+
+			id, err := parse.CertificateContactsID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			locks.ByID(id.ID())
+			defer locks.UnlockByID(id.ID())
+
+			if _, err := client.DeleteCertificateContacts(ctx, id.KeyVaultBaseUrl); err != nil {
+				return fmt.Errorf("deleting %s: %+v", id, err)
+			}
+
+			return nil
+		},
+		Timeout: 30 * time.Minute,
+	}
+}
+
+func expandKeyVaultCertificateContactsContact(input []Contact) *[]keyvault.Contact {
+	results := make([]keyvault.Contact, 0)
+	if len(input) == 0 {
+		return &results
+	}
+
+	for _, item := range input {
+		results = append(results, keyvault.Contact{
+			EmailAddress: utils.String(item.Email),
+			Name:         utils.String(item.Name),
+			Phone:        utils.String(item.Phone),
+		})
+	}
+
+	return &results
+}
+
+func flattenKeyVaultCertificateContactsContact(input *[]keyvault.Contact) []Contact {
+	result := make([]Contact, 0)
+	if input == nil {
+		return result
+	}
+
+	for _, item := range *input {
+		emailAddress := ""
+		if item.EmailAddress != nil {
+			emailAddress = *item.EmailAddress
+		}
+
+		name := ""
+		if item.Name != nil {
+			name = *item.Name
+		}
+
+		phone := ""
+		if item.Phone != nil {
+			phone = *item.Phone
+		}
+
+		result = append(result, Contact{
+			Email: emailAddress,
+			Name:  name,
+			Phone: phone,
+		})
+	}
+
+	return result
+}

--- a/internal/services/keyvault/key_vault_certificate_contacts_resource_test.go
+++ b/internal/services/keyvault/key_vault_certificate_contacts_resource_test.go
@@ -1,0 +1,254 @@
+package keyvault_test
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+type KeyVaultCertificateContactsResource struct{}
+
+func TestAccKeyVaultCertificateContacts_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_key_vault_certificate_contacts", "test")
+	r := KeyVaultCertificateContactsResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccKeyVaultCertificateContacts_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_key_vault_certificate_contacts", "test")
+	r := KeyVaultCertificateContactsResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		{
+			Config:      r.requiresImport(data),
+			ExpectError: acceptance.RequiresImportError("azurerm_key_vault_certificate_contacts"),
+		},
+	})
+}
+
+func TestAccKeyVaultCertificateContacts_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_key_vault_certificate_contacts", "test")
+	r := KeyVaultCertificateContactsResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccKeyVaultCertificateContacts_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_key_vault_certificate_contacts", "test")
+	r := KeyVaultCertificateContactsResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccKeyVaultCertificateContacts_nonExistentVault(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_key_vault_certificate_contacts", "test")
+	r := KeyVaultCertificateContactsResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config:             r.nonExistentVault(data),
+			ExpectNonEmptyPlan: true,
+			ExpectError:        regexp.MustCompile(`not found`),
+		},
+	})
+}
+
+func (r KeyVaultCertificateContactsResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := parse.CertificateContactsID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := clients.KeyVault.ManagementClient.GetCertificateContacts(ctx, id.KeyVaultBaseUrl)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.Bool(resp.ContactList != nil && len(*resp.ContactList) != 0), nil
+}
+
+func (r KeyVaultCertificateContactsResource) basic(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_key_vault_certificate_contacts" "test" {
+  key_vault_id = azurerm_key_vault.test.id
+
+  contact {
+    email = "example@example.com"
+  }
+
+  depends_on = [
+    azurerm_key_vault_access_policy.test
+  ]
+}
+`, template)
+}
+
+func (r KeyVaultCertificateContactsResource) requiresImport(data acceptance.TestData) string {
+	template := r.basic(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_key_vault_certificate_contacts" "import" {
+  key_vault_id = azurerm_key_vault_certificate_contacts.test.key_vault_id
+
+  contact {
+    email = "example@example.com"
+  }
+
+  depends_on = [
+    azurerm_key_vault_access_policy.test
+  ]
+}
+`, template)
+}
+
+func (r KeyVaultCertificateContactsResource) complete(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_key_vault_certificate_contacts" "test" {
+  key_vault_id = azurerm_key_vault.test.id
+
+  contact {
+    email = "example@example.com"
+    name  = "example"
+    phone = "01234567890"
+  }
+
+  contact {
+    email = "example2@example.com"
+    name  = "example2"
+  }
+
+  depends_on = [
+    azurerm_key_vault_access_policy.test
+  ]
+}
+`, template)
+}
+
+func (r KeyVaultCertificateContactsResource) nonExistentVault(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_key_vault_certificate_contacts" "test" {
+  # Must appear to be URL, but not actually exist - appending a string works
+  key_vault_id = "${azurerm_key_vault.test.id}NOPE"
+
+  contact {
+    email = "example@example.com"
+  }
+
+  depends_on = [
+    azurerm_key_vault_access_policy.test
+  ]
+}
+`, template)
+}
+
+func (KeyVaultCertificateContactsResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {
+    key_vault {
+      recover_soft_deleted_key_vaults    = false
+      purge_soft_delete_on_destroy       = false
+      purge_soft_deleted_keys_on_destroy = false
+    }
+  }
+}
+
+data "azurerm_client_config" "current" {
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[2]d"
+  location = "%[1]s"
+}
+
+resource "azurerm_key_vault" "test" {
+  name                       = "acctestkv-%[3]s"
+  location                   = azurerm_resource_group.test.location
+  resource_group_name        = azurerm_resource_group.test.name
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "standard"
+  soft_delete_retention_days = 7
+
+  lifecycle {
+    ignore_changes = [
+      contact
+    ]
+  }
+}
+
+resource "azurerm_key_vault_access_policy" "test" {
+  key_vault_id = azurerm_key_vault.test.id
+
+  tenant_id = data.azurerm_client_config.current.tenant_id
+  object_id = data.azurerm_client_config.current.object_id
+
+  certificate_permissions = [
+    "ManageContacts",
+  ]
+
+  key_permissions = [
+    "Create",
+  ]
+
+  secret_permissions = [
+    "Set",
+  ]
+}
+`, data.Locations.Primary, data.RandomInteger, data.RandomString)
+}

--- a/internal/services/keyvault/parse/certificate_contacts.go
+++ b/internal/services/keyvault/parse/certificate_contacts.go
@@ -1,0 +1,64 @@
+package parse
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+type CertificateContactsId struct {
+	KeyVaultBaseUrl string
+}
+
+func NewCertificateContactsID(keyVaultBaseUrl string) (*CertificateContactsId, error) {
+	// example: https://example-keyvault.vault.azure.net/certificates/contacts
+	keyVaultUrl, err := url.Parse(keyVaultBaseUrl)
+	if err != nil || keyVaultBaseUrl == "" {
+		return nil, fmt.Errorf("parsing %q: %+v", keyVaultBaseUrl, err)
+	}
+
+	if hostParts := strings.Split(keyVaultUrl.Host, ":"); len(hostParts) > 1 {
+		keyVaultUrl.Host = hostParts[0]
+	}
+
+	return &CertificateContactsId{
+		KeyVaultBaseUrl: keyVaultUrl.String(),
+	}, nil
+}
+
+func (id CertificateContactsId) String() string {
+	components := []string{
+		fmt.Sprintf("Base Url %q", id.KeyVaultBaseUrl),
+	}
+	return fmt.Sprintf("Key Vault Certificate Contacts: (%s)", strings.Join(components, " / "))
+}
+
+func (id CertificateContactsId) ID() string {
+	// example: https://example-keyvault.vault.azure.net/certificates/contacts
+	segments := []string{
+		strings.TrimSuffix(id.KeyVaultBaseUrl, "/"),
+		"certificates",
+		"contacts",
+	}
+	return strings.TrimSuffix(strings.Join(segments, "/"), "/")
+}
+
+func CertificateContactsID(input string) (*CertificateContactsId, error) {
+	idURL, err := url.ParseRequestURI(input)
+	if err != nil {
+		return nil, fmt.Errorf("cannot parse Azure Key Vault Certificate Contacts Id: %s", err)
+	}
+
+	path := idURL.Path
+	path = strings.TrimSuffix(path, "/")
+
+	if path != "/certificates/contacts" {
+		return nil, fmt.Errorf("keyVault Certificate Contacts ID path must be '/certificates/contacts', got %q", path)
+	}
+
+	id := CertificateContactsId{
+		KeyVaultBaseUrl: fmt.Sprintf("%s://%s/", idURL.Scheme, idURL.Host),
+	}
+
+	return &id, nil
+}

--- a/internal/services/keyvault/parse/certificate_contacts_test.go
+++ b/internal/services/keyvault/parse/certificate_contacts_test.go
@@ -1,0 +1,76 @@
+package parse
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.Id = CertificateContactsId{}
+
+func TestCertificateContactsIDFormatter(t *testing.T) {
+	actual, err := NewCertificateContactsID("https://example-keyvault.vault.azure.net")
+	if err != nil {
+		t.Fatalf("Error occurred when creating ID: %+v", err)
+	}
+	expected := "https://example-keyvault.vault.azure.net/certificates/contacts"
+	if actual.ID() != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestCertificateContactsID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *CertificateContactsId
+	}{
+		{
+			// valid
+			Input: "https://example-keyvault.vault.azure.net/certificates/contacts",
+			Expected: &CertificateContactsId{
+				KeyVaultBaseUrl: "https://example-keyvault.vault.azure.net/",
+			},
+		},
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+		{
+			// missing suffix
+			Input: "https://my-keyvault.vault.azure.net",
+			Error: true,
+		},
+		{
+			// wrong suffix
+			Input: "https://my-keyvault.vault.azure.net/certificates/contact",
+			Error: true,
+		},
+		{
+			// additional item in path
+			Input: "https://my-keyvault.vault.azure.net/x/certificates/contact",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := CertificateContactsID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.KeyVaultBaseUrl != v.Expected.KeyVaultBaseUrl {
+			t.Fatalf("Expected %q but got %q for KeyVaultBaseUrl", v.Expected.KeyVaultBaseUrl, actual.KeyVaultBaseUrl)
+		}
+	}
+}

--- a/internal/services/keyvault/registration.go
+++ b/internal/services/keyvault/registration.go
@@ -63,5 +63,7 @@ func (r Registration) DataSources() []sdk.DataSource {
 }
 
 func (r Registration) Resources() []sdk.Resource {
-	return []sdk.Resource{}
+	return []sdk.Resource{
+		KeyVaultCertificateContactsResource{},
+	}
 }

--- a/internal/services/keyvault/validate/certificate_contacts_id.go
+++ b/internal/services/keyvault/validate/certificate_contacts_id.go
@@ -1,0 +1,21 @@
+package validate
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/parse"
+)
+
+func CertificateContactsID(input interface{}, k string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", k))
+		return
+	}
+
+	if _, err := parse.CertificateContactsID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}

--- a/internal/services/keyvault/validate/certificate_contacts_id_test.go
+++ b/internal/services/keyvault/validate/certificate_contacts_id_test.go
@@ -1,0 +1,52 @@
+package validate
+
+import "testing"
+
+func TestCertificateContactsID(t *testing.T) {
+	cases := []struct {
+		Input       string
+		ExpectError bool
+	}{
+		{
+			Input:       "https://my-keyvault.vault.azure.net/certificates/contacts",
+			ExpectError: false,
+		},
+		{
+			// empty
+			Input:       "",
+			ExpectError: true,
+		},
+		{
+			// missing suffix
+			Input:       "https://my-keyvault.vault.azure.net",
+			ExpectError: true,
+		},
+		{
+			// wrong suffix
+			Input:       "https://my-keyvault.vault.azure.net/certificates/contact",
+			ExpectError: true,
+		},
+		{
+			// additional item in path
+			Input:       "https://my-keyvault.vault.azure.net/x/certificates/contact",
+			ExpectError: true,
+		},
+	}
+
+	for _, tc := range cases {
+		warnings, err := CertificateContactsID(tc.Input, "example")
+		if err != nil {
+			if !tc.ExpectError {
+				t.Fatalf("Got error for input %q: %+v", tc.Input, err)
+			}
+
+			return
+		}
+
+		if tc.ExpectError && len(warnings) == 0 {
+			t.Fatalf("Got no errors for input %q but expected some", tc.Input)
+		} else if !tc.ExpectError && len(warnings) > 0 {
+			t.Fatalf("Got %d errors for input %q when didn't expect any", len(warnings), tc.Input)
+		}
+	}
+}

--- a/website/docs/r/key_vault.html.markdown
+++ b/website/docs/r/key_vault.html.markdown
@@ -14,6 +14,8 @@ Manages a Key Vault.
 
 ~> **Note:** It's possible to define Key Vault Access Policies both within [the `azurerm_key_vault` resource](key_vault.html) via the `access_policy` block and by using [the `azurerm_key_vault_access_policy` resource](key_vault_access_policy.html). However it's not possible to use both methods to manage Access Policies within a KeyVault, since there'll be conflicts.
 
+~> **Note:** It's possible to define Key Vault Certificate Contacts both within [the `azurerm_key_vault` resource](key_vault.html) via the `contact` block and by using [the `azurerm_key_vault_certificate_contacts` resource](key_vault_certificate_contacts.html). However it's not possible to use both methods to manage Certificate Contacts within a KeyVault, since there'll be conflicts.
+
 ~> **Note:** Terraform will automatically recover a soft-deleted Key Vault during Creation if one is found - you can opt out of this using the `features` block within the Provider block.
 
 ## Example Usage

--- a/website/docs/r/key_vault_certificate_contacts.html.markdown
+++ b/website/docs/r/key_vault_certificate_contacts.html.markdown
@@ -1,0 +1,112 @@
+---
+subcategory: "Key Vault"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_key_vault_certificate_contacts"
+description: |-
+  Manages Key Vault Certificate Contacts.
+---
+
+# azurerm_key_vault_certificate_contacts
+
+Manages Key Vault Certificate Contacts.
+
+## Disclaimers
+
+~> **Note:** It's possible to define Key Vault Certificate Contacts both within [the `azurerm_key_vault` resource](key_vault.html) via the `contact` block and by using [the `azurerm_key_vault_certificate_contacts` resource](key_vault_certificate_contacts.html). However it's not possible to use both methods to manage Certificate Contacts within a KeyVault, since there'll be conflicts.
+
+## Example Usage
+
+```hcl
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_key_vault" "example" {
+  name                = "examplekeyvault"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  tenant_id           = data.azurerm_client_config.current.tenant_id
+  sku_name            = "premium"
+}
+
+resource "azurerm_key_vault_access_policy" "example" {
+  key_vault_id = azurerm_key_vault.example.id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = data.azurerm_client_config.current.object_id
+
+  certificate_permissions = [
+    "ManageContacts",
+  ]
+
+  key_permissions = [
+    "Create",
+  ]
+
+  secret_permissions = [
+    "Set",
+  ]
+}
+
+resource "azurerm_key_vault_certificate_contacts" "example" {
+  key_vault_id = azurerm_key_vault.test.id
+
+  contact {
+    email = "example@example.com"
+    name  = "example"
+    phone = "01234567890"
+  }
+
+  contact {
+    email = "example2@example.com"
+  }
+
+  depends_on = [
+    azurerm_key_vault_access_policy.example
+  ]
+}
+
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `key_vault_id` - (Required) The ID of the Key Vault. Changing this forces a new resource to be created.
+
+* `contact` - (Required) One or more `contact` blocks as defined below.
+
+---
+
+A `contact` block supports the following:
+
+* `email` - (Required) E-mail address of the contact.
+
+* `name` - (Optional) Name of the contact.
+
+* `phone` - (Optional) Phone number of the contact.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported: 
+
+* `id` - The ID of the Key Vault Certificate Contacts.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Key Vault Certificate Contacts.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Key Vault Certificate Contacts.
+* `update` - (Defaults to 30 minutes) Used when updating the Key Vault Certificate Contacts.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Key Vault Certificate Contacts.
+
+## Import
+
+Key Vault Certificate Contacts can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_key_vault_certificate_contacts.example https://example-keyvault.vault.azure.net/certificates/contacts
+```


### PR DESCRIPTION
Close #10256
Close #16642

ID is `https://<kv_url>/certificates/contacts`, and there is no suitable ID for a single contact as it uses `email` as identifier and `email` could contain special characters like `/`, so using `_contacts` instead of single `_contact`.