### PR TITLE
`azurerm_key_vault` - fix mismatch document of `access_policy`

### DIFF
--- a/website/docs/r/key_vault.html.markdown
+++ b/website/docs/r/key_vault.html.markdown
@@ -81,7 +81,7 @@ The following arguments are supported:
 
 ---
 
-* `access_policy` - (Optional) [A list](/docs/configuration/attr-as-blocks.html) of up to 16 objects describing access policies, as described below.
+* `access_policy` - (Optional) [A list](/docs/configuration/attr-as-blocks.html) of up to 1024 objects describing access policies, as described below.
 
 -> **NOTE** Since `access_policy` can be configured both inline and via the separate `azurerm_key_vault_access_policy` resource, we have to explicitly set it to empty slice (`[]`) to remove it.
 


### PR DESCRIPTION
Limit is 1024, correcting the document
https://github.com/hashicorp/terraform-provider-azurerm/blob/5c310f03a5f4dc7fc2a48c3248e227d02e45d528/internal/services/keyvault/key_vault_resource.go#L94-L99


The document of `azurerm_key_vault` was not updated correctly in #2866 when updating the limit from 16 to 1024, it only updated the document for `azurerm_key_vault_access_policy`.