### PR TITLE
Docs: fix outdated timeout values, or add missed timeouts lines of all resources

### DIFF
--- a/website/docs/r/active_directory_domain_service.html.markdown
+++ b/website/docs/r/active_directory_domain_service.html.markdown
@@ -268,10 +268,10 @@ An `initial_replica_set` block exports the following:
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `create` - (Defaults to 2 hours) Used when creating the Domain Service.
+* `create` - (Defaults to 3 hours) Used when creating the Domain Service.
 * `update` - (Defaults to 2 hours) Used when updating the Domain Service.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Domain Service.
-* `delete` - (Defaults to 30 minutes) Used when deleting the Domain Service.
+* `delete` - (Defaults to 60 minutes) Used when deleting the Domain Service.
 
 ## Import
 

--- a/website/docs/r/active_directory_domain_service_replica_set.html.markdown
+++ b/website/docs/r/active_directory_domain_service_replica_set.html.markdown
@@ -302,10 +302,10 @@ In addition to all arguments above, the following attributes are exported:
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `create` - (Defaults to 2 hours) Used when creating the Domain Service.
+* `create` - (Defaults to 3 hours) Used when creating the Domain Service.
 * `update` - (Defaults to 2 hours) Used when updating the Domain Service.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Domain Service.
-* `delete` - (Defaults to 30 minutes) Used when deleting the Domain Service.
+* `delete` - (Defaults to 60 minutes) Used when deleting the Domain Service.
 
 ## Import
 

--- a/website/docs/r/api_management_custom_domain.html.markdown
+++ b/website/docs/r/api_management_custom_domain.html.markdown
@@ -168,10 +168,10 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the API Management Custom Domain.
+* `create` - (Defaults to 45 minutes) Used when creating the API Management Custom Domain.
 * `read` - (Defaults to 5 minutes) Used when retrieving the API Management Custom Domain.
-* `update` - (Defaults to 30 minutes) Used when updating the API Management Custom Domain.
-* `delete` - (Defaults to 30 minutes) Used when deleting the API Management Custom Domain.
+* `update` - (Defaults to 45 minutes) Used when updating the API Management Custom Domain.
+* `delete` - (Defaults to 45 minutes) Used when deleting the API Management Custom Domain.
 
 ## Import
 

--- a/website/docs/r/app_service_certificate_binding.html.markdown
+++ b/website/docs/r/app_service_certificate_binding.html.markdown
@@ -105,6 +105,14 @@ In addition to the arguments listed above - the following attributes are exporte
 
 * `thumbprint` - The certificate thumbprint.
 
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the App Service Certificate Binding.
+* `create` - (Defaults to 30 minutes) Used when creating the App Service Certificate Binding.
+* `delete` - (Defaults to 30 minutes) Used when deleting the App Service Certificate Binding.
+
 ## Import
 
 App Service Certificate Bindings can be imported using the `hostname_binding_id` and the `app_service_certificate_id` , e.g.

--- a/website/docs/r/app_service_environment.html.markdown
+++ b/website/docs/r/app_service_environment.html.markdown
@@ -105,10 +105,10 @@ A `cluster_setting` block supports the following:
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `create` - (Defaults to 4 hours) Used when creating the App Service Environment.
-* `update` - (Defaults to 4 hours) Used when updating the App Service Environment.
+* `create` - (Defaults to 6 hours) Used when creating the App Service Environment.
+* `update` - (Defaults to 6 hours) Used when updating the App Service Environment.
 * `read` - (Defaults to 5 minutes) Used when retrieving the App Service Environment.
-* `delete` - (Defaults to 4 hours) Used when deleting the App Service Environment.
+* `delete` - (Defaults to 6 hours) Used when deleting the App Service Environment.
 
 ## Import
 

--- a/website/docs/r/app_service_hybrid_connection.html.markdown
+++ b/website/docs/r/app_service_hybrid_connection.html.markdown
@@ -97,6 +97,15 @@ The following attributes are exported:
 
 * `service_bus_suffix` - The suffix for the service bus endpoint.
 
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the App Service Hybrid Connection.
+* `create` - (Defaults to 30 minutes) Used when creating the App Service Hybrid Connection.
+* `update` - (Defaults to 30 minutes) Used when updating the App Service Hybrid Connection.
+* `delete` - (Defaults to 30 minutes) Used when deleting the App Service Hybrid Connection.
+
 ## Import
 
 App Service Hybrid Connections can be imported using the `resource id`, e.g.

--- a/website/docs/r/application_insights.html.markdown
+++ b/website/docs/r/application_insights.html.markdown
@@ -118,7 +118,7 @@ The following attributes are exported:
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the Application Insights Component.
+* `create` - (Defaults to 60 minutes) Used when creating the Application Insights Component.
 * `update` - (Defaults to 30 minutes) Used when updating the Application Insights Component.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Application Insights Component.
 * `delete` - (Defaults to 30 minutes) Used when deleting the Application Insights Component.

--- a/website/docs/r/cdn_frontdoor_route_disable_link_to_default_domain.html.markdown
+++ b/website/docs/r/cdn_frontdoor_route_disable_link_to_default_domain.html.markdown
@@ -44,6 +44,7 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 * `create` - (Defaults to 30 minutes) Used when creating the Front Door Route Disable Link To Default Domain.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Front Door Route Disable Link To Default Domain.
 * `delete` - (Defaults to 30 minutes) Used when deleting the Front Door Route Disable Link To Default Domain.
+* `update` - (Defaults to 30 minutes) Used when updating the Cdn Frontdoor Route Disable Link To Default Domain.
 
 ## Import
 

--- a/website/docs/r/cdn_frontdoor_rule_set.html.markdown
+++ b/website/docs/r/cdn_frontdoor_rule_set.html.markdown
@@ -51,6 +51,7 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 * `create` - (Defaults to 30 minutes) Used when creating the Front Door Rule Set.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Front Door Rule Set.
 * `delete` - (Defaults to 30 minutes) Used when deleting the Front Door Rule Set.
+* `update` - (Defaults to 30 minutes) Used when updating the Cdn Frontdoor Rule Set.
 
 ## Import
 

--- a/website/docs/r/data_factory_integration_runtime_azure.html.markdown
+++ b/website/docs/r/data_factory_integration_runtime_azure.html.markdown
@@ -55,6 +55,15 @@ The following arguments are supported:
 
 ---
 
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the Data Factory Integration Runtime Azure.
+* `create` - (Defaults to 30 minutes) Used when creating the Data Factory Integration Runtime Azure.
+* `update` - (Defaults to 30 minutes) Used when updating the Data Factory Integration Runtime Azure.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Data Factory Integration Runtime Azure.
+
 ## Import
 
 Data Factory Azure Integration Runtimes can be imported using the `resource id`, e.g.

--- a/website/docs/r/databricks_access_connector.html.markdown
+++ b/website/docs/r/databricks_access_connector.html.markdown
@@ -75,7 +75,7 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 * `create` - (Defaults to 5 minutes) Used when creating the Databricks Access Connector.
 * `update` - (Defaults to 5 minutes) Used when updating the Databricks Access Connector.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Databricks Access Connector.
-* `delete` - (Defaults to 5 minutes) Used when deleting the Databricks Access Connector.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Databricks Access Connector.
 
 ## Import
 

--- a/website/docs/r/dev_test_global_vm_shutdown_schedule.html.markdown
+++ b/website/docs/r/dev_test_global_vm_shutdown_schedule.html.markdown
@@ -121,6 +121,15 @@ The following additional attributes are exported:
 
 * `id` - The Dev Test Global Schedule ID.
 
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the Dev Test Global Vm Shutdown Schedule.
+* `create` - (Defaults to 30 minutes) Used when creating the Dev Test Global Vm Shutdown Schedule.
+* `update` - (Defaults to 30 minutes) Used when updating the Dev Test Global Vm Shutdown Schedule.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Dev Test Global Vm Shutdown Schedule.
+
 ## Import
 
 An existing Dev Test Global Shutdown Schedule can be imported using the `resource id`, e.g.

--- a/website/docs/r/disk_pool_iscsi_target.html.markdown
+++ b/website/docs/r/disk_pool_iscsi_target.html.markdown
@@ -120,10 +120,10 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the iSCSI Target.
+* `create` - (Defaults to 60 minutes) Used when creating the iSCSI Target.
 * `read` - (Defaults to 5 minutes) Used when retrieving the iSCSI Target.
 * `update` - (Defaults to 30 minutes) Used when updating the iSCSI Target.
-* `delete` - (Defaults to 30 minutes) Used when deleting the iSCSI Target.
+* `delete` - (Defaults to 60 minutes) Used when deleting the iSCSI Target.
 
 ## Import
 

--- a/website/docs/r/disk_pool_iscsi_target_lun.html.markdown
+++ b/website/docs/r/disk_pool_iscsi_target_lun.html.markdown
@@ -120,9 +120,9 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the iSCSI Target LUN.
+* `create` - (Defaults to 60 minutes) Used when creating the iSCSI Target LUN.
 * `read` - (Defaults to 5 minutes) Used when retrieving the iSCSI Target LUN.
-* `delete` - (Defaults to 30 minutes) Used when deleting the iSCSI Target LUN.
+* `delete` - (Defaults to 60 minutes) Used when deleting the iSCSI Target LUN.
 
 ## Import
 

--- a/website/docs/r/disk_pool_managed_disk_attachment.html.markdown
+++ b/website/docs/r/disk_pool_managed_disk_attachment.html.markdown
@@ -110,9 +110,9 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the Disks Pool Managed Disk Attachment.
+* `create` - (Defaults to 60 minutes) Used when creating the Disks Pool Managed Disk Attachment.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Disks Pool Managed Disk Attachment.
-* `delete` - (Defaults to 30 minutes) Used when deleting the Disks Pool Managed Disk Attachment.
+* `delete` - (Defaults to 60 minutes) Used when deleting the Disks Pool Managed Disk Attachment.
 
 ## Import
 

--- a/website/docs/r/elastic_cloud_elasticsearch.html.markdown
+++ b/website/docs/r/elastic_cloud_elasticsearch.html.markdown
@@ -93,10 +93,10 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the Elasticsearch.
+* `create` - (Defaults to 60 minutes) Used when creating the Elasticsearch.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Elasticsearch.
-* `update` - (Defaults to 30 minutes) Used when updating the Elasticsearch.
-* `delete` - (Defaults to 30 minutes) Used when deleting the Elasticsearch.
+* `update` - (Defaults to 60 minutes) Used when updating the Elasticsearch.
+* `delete` - (Defaults to 60 minutes) Used when deleting the Elasticsearch.
 
 ## Import
 

--- a/website/docs/r/express_route_gateway.html.markdown
+++ b/website/docs/r/express_route_gateway.html.markdown
@@ -71,13 +71,13 @@ The following attributes are exported:
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `create` - (Defaults to 60 minutes) Used when creating the ExpressRoute Gateway.
+* `create` - (Defaults to 90 minutes) Used when creating the ExpressRoute Gateway.
 
-* `update` - (Defaults to 60 minutes) Used when updating the ExpressRoute Gateway.
+* `update` - (Defaults to 90 minutes) Used when updating the ExpressRoute Gateway.
 
 * `read` - (Defaults to 5 minutes) Used when retrieving the ExpressRoute Gateway.
 
-* `delete` - (Defaults to 60 minutes) Used when deleting the ExpressRoute Gateway.
+* `delete` - (Defaults to 90 minutes) Used when deleting the ExpressRoute Gateway.
 
 ## Import
 

--- a/website/docs/r/frontdoor_rules_engine.html.markdown
+++ b/website/docs/r/frontdoor_rules_engine.html.markdown
@@ -173,6 +173,15 @@ The `match_condition` block supports the following:
 
 * `value` - (Optional) (array) can contain one or more strings.
 
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the Frontdoor Rules Engine.
+* `create` - (Defaults to 6 hours) Used when creating the Frontdoor Rules Engine.
+* `update` - (Defaults to 6 hours) Used when updating the Frontdoor Rules Engine.
+* `delete` - (Defaults to 6 hours) Used when deleting the Frontdoor Rules Engine.
+
 ## Import
 
 Azure Front Door Rules Engine's can be imported using the `resource id`, e.g.

--- a/website/docs/r/healthcare_fhir_service.html.markdown
+++ b/website/docs/r/healthcare_fhir_service.html.markdown
@@ -130,8 +130,8 @@ The following attributes are exported:
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the Healthcare FHIR Service.
-* `update` - (Defaults to 30 minutes) Used when updating the Healthcare FHIR Service.
+* `create` - (Defaults to 90 minutes) Used when creating the Healthcare FHIR Service.
+* `update` - (Defaults to 90 minutes) Used when updating the Healthcare FHIR Service.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Healthcare FHIR Service.
 * `delete` - (Defaults to 30 minutes) Used when deleting the Healthcare FHIR Service.
 

--- a/website/docs/r/healthcare_medtech_service.html.markdown
+++ b/website/docs/r/healthcare_medtech_service.html.markdown
@@ -98,10 +98,10 @@ An `identity` block exports the following:
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the Healthcare Med Tech Service.
-* `update` - (Defaults to 30 minutes) Used when updating the Healthcare Med Tech Service.
+* `create` - (Defaults to 90 minutes) Used when creating the Healthcare Med Tech Service.
+* `update` - (Defaults to 90 minutes) Used when updating the Healthcare Med Tech Service.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Healthcare Med Tech Service.
-* `delete` - (Defaults to 30 minutes) Used when deleting the Healthcare Med Tech Service.
+* `delete` - (Defaults to 90 minutes) Used when deleting the Healthcare Med Tech Service.
 
 ## Import
 

--- a/website/docs/r/healthcare_medtech_service_fhir_destination.html.markdown
+++ b/website/docs/r/healthcare_medtech_service_fhir_destination.html.markdown
@@ -72,10 +72,11 @@ The following arguments are supported:
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the Healthcare Med Tech Service Fhir Destination.
+* `create` - (Defaults to 90 minutes) Used when creating the Healthcare Med Tech Service Fhir Destination.
 * `update` - (Defaults to 30 minut es) Used when updating the Healthcare Med Tech Service Fhir Destination.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Healthcare Med Tech Service Fhir Destination.
-* `delete` - (Defaults to 30 minutes) Used when deleting the Healthcare Med Tech Service Fhir Destination.
+* `delete` - (Defaults to 90 minutes) Used when deleting the Healthcare Med Tech Service Fhir Destination.
+* `update` - (Defaults to 90 minutes) Used when updating the Healthcare Medtech Service Fhir Destination.
 
 ## Import
 

--- a/website/docs/r/hpc_cache.html.markdown
+++ b/website/docs/r/hpc_cache.html.markdown
@@ -198,9 +198,10 @@ The following attributes are exported:
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the HPC Cache.
+* `create` - (Defaults to 60 minutes) Used when creating the HPC Cache.
 * `read` - (Defaults to 5 minutes) Used when retrieving the HPC Cache.
-* `delete` - (Defaults to 30 minutes) Used when deleting the HPC Cache.
+* `delete` - (Defaults to 60 minutes) Used when deleting the HPC Cache.
+* `update` - (Defaults to 60 minutes) Used when updating the Hpc Cache.
 
 ## Import
 

--- a/website/docs/r/key_vault_certificate.html.markdown
+++ b/website/docs/r/key_vault_certificate.html.markdown
@@ -350,7 +350,7 @@ A `certificate_attribute` block exports the following:
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the Key Vault Certificate.
+* `create` - (Defaults to 60 minutes) Used when creating the Key Vault Certificate.
 * `update` - (Defaults to 30 minutes) Used when updating the Key Vault Certificate.
 * `read` - (Defaults to 30 minutes) Used when retrieving the Key Vault Certificate.
 * `delete` - (Defaults to 30 minutes) Used when deleting the Key Vault Certificate.

--- a/website/docs/r/key_vault_certificate_issuer.html.markdown
+++ b/website/docs/r/key_vault_certificate_issuer.html.markdown
@@ -74,6 +74,15 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `id` - The ID of the Key Vault Certificate Issuer.
 
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the Key Vault Certificate Issuer.
+* `create` - (Defaults to 30 minutes) Used when creating the Key Vault Certificate Issuer.
+* `update` - (Defaults to 30 minutes) Used when updating the Key Vault Certificate Issuer.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Key Vault Certificate Issuer.
+
 ## Import
 
 Key Vault Certificate Issuers can be imported using the `resource id`, e.g.

--- a/website/docs/r/linux_virtual_machine.html.markdown
+++ b/website/docs/r/linux_virtual_machine.html.markdown
@@ -379,6 +379,7 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 * `create` - (Defaults to 45 minutes) Used when creating the Linux Virtual Machine.
 * `update` - (Defaults to 45 minutes) Used when updating the Linux Virtual Machine.
 * `delete` - (Defaults to 45 minutes) Used when deleting the Linux Virtual Machine.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Linux Virtual Machine.
 
 ## Import
 

--- a/website/docs/r/machine_learning_inference_cluster.html.markdown
+++ b/website/docs/r/machine_learning_inference_cluster.html.markdown
@@ -184,6 +184,7 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 * `create` - (Defaults to 30 minutes) Used when creating the Machine Learning Inference Cluster.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Machine Learning Inference Cluster.
 * `delete` - (Defaults to 30 minutes) Used when deleting the Machine Learning Inference Cluster.
+* `update` - (Defaults to 30 minutes) Used when updating the Machine Learning Inference Cluster.
 
 ## Import
 

--- a/website/docs/r/mariadb_server.html.markdown
+++ b/website/docs/r/mariadb_server.html.markdown
@@ -92,7 +92,7 @@ The following attributes are exported:
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `create` - (Defaults to 60 minutes) Used when creating the MariaDB Server.
+* `create` - (Defaults to 90 minutes) Used when creating the MariaDB Server.
 * `update` - (Defaults to 60 minutes) Used when updating the MariaDB Server.
 * `read` - (Defaults to 5 minutes) Used when retrieving the MariaDB Server.
 * `delete` - (Defaults to 60 minutes) Used when deleting the MariaDB Server.

--- a/website/docs/r/monitor_private_link_scope.html.markdown
+++ b/website/docs/r/monitor_private_link_scope.html.markdown
@@ -44,10 +44,10 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `create` - (Defaults to 5 hours) Used when creating the Azure Monitor Private Link Scope.
+* `create` - (Defaults to 30 minutes) Used when creating the Azure Monitor Private Link Scope.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Azure Monitor Private Link Scope.
-* `update` - (Defaults to 5 hours) Used when updating the Azure Monitor Private Link Scope.
-* `delete` - (Defaults to 5 hours) Used when deleting the Azure Monitor Private Link Scope.
+* `update` - (Defaults to 30 minutes) Used when updating the Azure Monitor Private Link Scope.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Azure Monitor Private Link Scope.
 
 ## Import
 

--- a/website/docs/r/monitor_private_link_scoped_service.html.markdown
+++ b/website/docs/r/monitor_private_link_scoped_service.html.markdown
@@ -63,6 +63,7 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 * `create` - (Defaults to 30 minutes) Used when creating the Azure Monitor Private Link Scope.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Azure Monitor Private Link Scope.
 * `delete` - (Defaults to 30 minutes) Used when deleting the Azure Monitor Private Link Scope.
+* `update` - (Defaults to 30 minutes) Used when updating the Monitor Private Link Scoped Service.
 
 ## Import
 

--- a/website/docs/r/mssql_managed_database.html.markdown
+++ b/website/docs/r/mssql_managed_database.html.markdown
@@ -67,6 +67,14 @@ The following attributes are exported:
 
 * `id` - The Azure SQL Managed Database ID.
 
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the Mssql Managed Database.
+* `create` - (Defaults to 30 minutes) Used when creating the Mssql Managed Database.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Mssql Managed Database.
+
 ## Import
 
 SQL Managed Databases can be imported using the `resource id`, e.g.

--- a/website/docs/r/mssql_managed_instance_vulnerability_assessment.html.markdown
+++ b/website/docs/r/mssql_managed_instance_vulnerability_assessment.html.markdown
@@ -124,10 +124,10 @@ The following attributes are exported:
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the Vulnerability Assessment.
-* `update` - (Defaults to 30 minutes) Used when updating the Vulnerability Assessment.
+* `create` - (Defaults to 60 minutes) Used when creating the Vulnerability Assessment.
+* `update` - (Defaults to 60 minutes) Used when updating the Vulnerability Assessment.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Vulnerability Assessment.
-* `delete` - (Defaults to 30 minutes) Used when deleting the Vulnerability Assessment.
+* `delete` - (Defaults to 60 minutes) Used when deleting the Vulnerability Assessment.
 
 ## Import
 

--- a/website/docs/r/mssql_server_dns_alias.html.markdown
+++ b/website/docs/r/mssql_server_dns_alias.html.markdown
@@ -57,9 +57,9 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `create` - (Defaults to 5 minutes) Used when creating the MSSQL Server DNS Alias.
+* `create` - (Defaults to 30 minutes) Used when creating the MSSQL Server DNS Alias.
 * `read` - (Defaults to 5 minutes) Used when retrieving the MSSQL Server DNS Alias.
-* `delete` - (Defaults to 5 minutes) Used when deleting the MSSQL Server DNS Alias.
+* `delete` - (Defaults to 10 minutes) Used when deleting the MSSQL Server DNS Alias.
 
 ## Import
 

--- a/website/docs/r/mysql_server_key.html.markdown
+++ b/website/docs/r/mysql_server_key.html.markdown
@@ -100,10 +100,10 @@ The following attributes are exported in addition to the arguments listed above:
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the MySQL Server Key.
-* `update` - (Defaults to 30 minutes) Used when updating the MySQL Server Key.
+* `create` - (Defaults to 60 minutes) Used when creating the MySQL Server Key.
+* `update` - (Defaults to 60 minutes) Used when updating the MySQL Server Key.
 * `read` - (Defaults to 5 minutes) Used when retrieving the MySQL Server Key.
-* `delete` - (Defaults to 30 minutes) Used when deleting the MySQL Server Key.
+* `delete` - (Defaults to 60 minutes) Used when deleting the MySQL Server Key.
 
 ## Import
 

--- a/website/docs/r/netapp_volume.html.markdown
+++ b/website/docs/r/netapp_volume.html.markdown
@@ -198,10 +198,10 @@ The following attributes are exported:
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the NetApp Volume.
-* `update` - (Defaults to 30 minutes) Used when updating the NetApp Volume.
+* `create` - (Defaults to 60 minutes) Used when creating the NetApp Volume.
+* `update` - (Defaults to 60 minutes) Used when updating the NetApp Volume.
 * `read` - (Defaults to 5 minutes) Used when retrieving the NetApp Volume.
-* `delete` - (Defaults to 30 minutes) Used when deleting the NetApp Volume.
+* `delete` - (Defaults to 60 minutes) Used when deleting the NetApp Volume.
 
 ## Import
 

--- a/website/docs/r/orchestrated_virtual_machine_scale_set.html.markdown
+++ b/website/docs/r/orchestrated_virtual_machine_scale_set.html.markdown
@@ -457,10 +457,10 @@ In addition to all arguments above, the following attributes are exported:
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the Orchestrated Virtual Machine Scale Set.
-* `update` - (Defaults to 30 minutes) Used when updating the Orchestrated Virtual Machine Scale Set.
+* `create` - (Defaults to 60 minutes) Used when creating the Orchestrated Virtual Machine Scale Set.
+* `update` - (Defaults to 60 minutes) Used when updating the Orchestrated Virtual Machine Scale Set.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Orchestrated Virtual Machine Scale Set.
-* `delete` - (Defaults to 30 minutes) Used when deleting the Orchestrated Virtual Machine Scale Set.
+* `delete` - (Defaults to 60 minutes) Used when deleting the Orchestrated Virtual Machine Scale Set.
 
 ## Import
 

--- a/website/docs/r/postgresql_server_key.html.markdown
+++ b/website/docs/r/postgresql_server_key.html.markdown
@@ -106,10 +106,10 @@ The following attributes are exported in addition to the arguments listed above:
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the PostgreSQL Server Key.
-* `update` - (Defaults to 30 minutes) Used when updating the PostgreSQL Server Key.
+* `create` - (Defaults to 60 minutes) Used when creating the PostgreSQL Server Key.
+* `update` - (Defaults to 60 minutes) Used when updating the PostgreSQL Server Key.
 * `read` - (Defaults to 5 minutes) Used when retrieving the PostgreSQL Server Key.
-* `delete` - (Defaults to 30 minutes) Used when deleting the PostgreSQL Server Key.
+* `delete` - (Defaults to 60 minutes) Used when deleting the PostgreSQL Server Key.
 
 ## Import
 

--- a/website/docs/r/recovery_services_vault.html.markdown
+++ b/website/docs/r/recovery_services_vault.html.markdown
@@ -94,8 +94,8 @@ An `identity` block exports the following:
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the Recovery Services Vault.
-* `update` - (Defaults to 30 minutes) Used when updating the Recovery Services Vault.
+* `create` - (Defaults to 60 minutes) Used when creating the Recovery Services Vault.
+* `update` - (Defaults to 60 minutes) Used when updating the Recovery Services Vault.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Recovery Services Vault.
 * `delete` - (Defaults to 30 minutes) Used when deleting the Recovery Services Vault.
 

--- a/website/docs/r/redis_linked_server.html.markdown
+++ b/website/docs/r/redis_linked_server.html.markdown
@@ -90,10 +90,10 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the Redis.
+* `create` - (Defaults to 60 minutes) Used when creating the Redis.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Redis.
-* `update` - (Defaults to 30 minutes) Used when updating the Redis.
-* `delete` - (Defaults to 30 minutes) Used when deleting the Redis.
+* `update` - (Defaults to 60 minutes) Used when updating the Redis.
+* `delete` - (Defaults to 60 minutes) Used when deleting the Redis.
 
 ## Import
 

--- a/website/docs/r/resource_group.html.markdown
+++ b/website/docs/r/resource_group.html.markdown
@@ -45,10 +45,10 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `create` - (Defaults to 1 hour and 30 minutes) Used when creating the Resource Group.
+* `create` - (Defaults to 90 minutes) Used when creating the Resource Group.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Resource Group.
-* `update` - (Defaults to 1 hour and 30 minutes) Used when updating the Resource Group.
-* `delete` - (Defaults to 1 hour and 30 minutes) Used when deleting the Resource Group.
+* `update` - (Defaults to 90 minutes) Used when updating the Resource Group.
+* `delete` - (Defaults to 90 minutes) Used when deleting the Resource Group.
 
 ## Import
 

--- a/website/docs/r/role_definition.html.markdown
+++ b/website/docs/r/role_definition.html.markdown
@@ -78,7 +78,7 @@ The following attributes are exported:
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Role Definition.
-* `update` - (Defaults to 30 minutes) Used when updating the Role Definition.
+* `update` - (Defaults to 60 minutes) Used when updating the Role Definition.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Role Definition.
 * `delete` - (Defaults to 30 minutes) Used when deleting the Role Definition.
 

--- a/website/docs/r/security_center_setting.html.markdown
+++ b/website/docs/r/security_center_setting.html.markdown
@@ -40,10 +40,10 @@ The following attributes are exported:
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `create` - (Defaults to 60 minutes) Used when creating the Security Center Setting.
-* `update` - (Defaults to 60 minutes) Used when updating the Security Center Setting.
+* `create` - (Defaults to 10 minutes) Used when creating the Security Center Setting.
+* `update` - (Defaults to 10 minutes) Used when updating the Security Center Setting.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Security Center Setting.
-* `delete` - (Defaults to 60 minutes) Used when deleting the Security Center Setting.
+* `delete` - (Defaults to 10 minutes) Used when deleting the Security Center Setting.
 
 ## Import
 

--- a/website/docs/r/service_fabric_managed_cluster.html.markdown
+++ b/website/docs/r/service_fabric_managed_cluster.html.markdown
@@ -201,10 +201,10 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `create` - (Defaults to 1 hour and 30 minutes) Used when creating the Resource Group.
+* `create` - (Defaults to 90 minutes) Used when creating the Resource Group.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Resource Group.
-* `update` - (Defaults to 1 hour and 30 minutes) Used when updating the Resource Group.
-* `delete` - (Defaults to 1 hour and 30 minutes) Used when deleting the Resource Group.
+* `update` - (Defaults to 90 minutes) Used when updating the Resource Group.
+* `delete` - (Defaults to 90 minutes) Used when deleting the Resource Group.
 
 ## Import
 

--- a/website/docs/r/sql_managed_database.html.markdown
+++ b/website/docs/r/sql_managed_database.html.markdown
@@ -70,6 +70,15 @@ The following attributes are exported:
 
 * `id` - The SQL Managed Database ID.
 
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the Sql Managed Database.
+* `create` - (Defaults to 24 hours) Used when creating the Sql Managed Database.
+* `update` - (Defaults to 24 hours) Used when updating the Sql Managed Database.
+* `delete` - (Defaults to 24 hours) Used when deleting the Sql Managed Database.
+
 ## Import
 
 SQL Managed Databases can be imported using the `resource id`, e.g.

--- a/website/docs/r/sql_managed_instance.html.markdown
+++ b/website/docs/r/sql_managed_instance.html.markdown
@@ -275,6 +275,15 @@ The following attributes are exported:
 
 * `tenant_id` - The Tenant ID for the Service Principal associated with the Identity of this SQL Managed Instance.
 
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the Sql Managed Instance.
+* `create` - (Defaults to 24 hours) Used when creating the Sql Managed Instance.
+* `update` - (Defaults to 24 hours) Used when updating the Sql Managed Instance.
+* `delete` - (Defaults to 24 hours) Used when deleting the Sql Managed Instance.
+
 ## Import
 
 SQL Servers can be imported using the `resource id`, e.g.

--- a/website/docs/r/stream_analytics_cluster.html.markdown
+++ b/website/docs/r/stream_analytics_cluster.html.markdown
@@ -51,10 +51,10 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `create` - (Defaults to 1 hour) Used when creating the Stream Analytics.
+* `create` - (Defaults to 90 minutes) Used when creating the Stream Analytics.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Stream Analytics.
-* `update` - (Defaults to 1 hour) Used when updating the Stream Analytics.
-* `delete` - (Defaults to 1 hour) Used when deleting the Stream Analytics.
+* `update` - (Defaults to 90 minutes) Used when updating the Stream Analytics.
+* `delete` - (Defaults to 90 minutes) Used when deleting the Stream Analytics.
 
 ## Import
 

--- a/website/docs/r/virtual_desktop_host_pool_registration_info.html.markdown
+++ b/website/docs/r/virtual_desktop_host_pool_registration_info.html.markdown
@@ -54,10 +54,10 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `create` - (Defaults to 1 hour) Used when creating the AVD Registration Info.
+* `create` - (Defaults to 30 minutes) Used when creating the AVD Registration Info.
 * `read` - (Defaults to 5 minutes) Used when retrieving the AVD Registration Info.
-* `update` - (Defaults to 1 hour) Used when updating the AVD Registration Info.
-* `delete` - (Defaults to 1 hour) Used when deleting the AVD Registration Info.
+* `update` - (Defaults to 30 minutes) Used when updating the AVD Registration Info.
+* `delete` - (Defaults to 30 minutes) Used when deleting the AVD Registration Info.
 
 ## Import
 

--- a/website/docs/r/virtual_hub_bgp_connection.html.markdown
+++ b/website/docs/r/virtual_hub_bgp_connection.html.markdown
@@ -93,6 +93,7 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 * `create` - (Defaults to 30 minutes) Used when creating the Virtual Hub Bgp Connection.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Virtual Hub Bgp Connection.
 * `delete` - (Defaults to 30 minutes) Used when deleting the Virtual Hub Bgp Connection.
+* `update` - (Defaults to 30 minutes) Used when updating the Virtual Hub Bgp Connection.
 
 ## Import
 

--- a/website/docs/r/vmware_private_cloud__netapp_file_attachment.html.markdown
+++ b/website/docs/r/vmware_private_cloud__netapp_file_attachment.html.markdown
@@ -176,10 +176,10 @@ The following arguments are supported:
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `create` - (Defaults to 10 hours) Used when creating the VMware Private Cloud Netapp File Volume Attachment.
+* `create` - (Defaults to 30 minutes) Used when creating the VMware Private Cloud Netapp File Volume Attachment.
 * `read` - (Defaults to 5 minutes) Used when retrieving the VMware Private Cloud Netapp File Volume Attachment.
 * `update` - (Defaults to 10 hours) Used when updating the VMware Private Cloud Netapp File Volume Attachment.
-* `delete` - (Defaults to 10 hours) Used when deleting the VMware Private Cloud Netapp File Volume Attachment.
+* `delete` - (Defaults to 30 minutes) Used when deleting the VMware Private Cloud Netapp File Volume Attachment.
 
 ## Import
 

--- a/website/docs/r/windows_virtual_machine.html.markdown
+++ b/website/docs/r/windows_virtual_machine.html.markdown
@@ -388,6 +388,7 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 * `create` - (Defaults to 45 minutes) Used when creating the Windows Virtual Machine.
 * `update` - (Defaults to 45 minutes) Used when updating the Windows Virtual Machine.
 * `delete` - (Defaults to 45 minutes) Used when deleting the Windows Virtual Machine.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Windows Virtual Machine.
 
 ## Import
 


### PR DESCRIPTION
there are some resources' default timeout values updated in the schema but forgot to update the document. just update my tool to fix these values. and some resources' document just has no `## Timeouts` part, will also add it.