### PR TITLE
`azurerm_datadog_monitor_sso_configuration` - fix default value for `name` to be a literal string

### DIFF
--- a/internal/services/datadog/azurerm_datadog_monitor_sso_configuration.go
+++ b/internal/services/datadog/azurerm_datadog_monitor_sso_configuration.go
@@ -44,7 +44,7 @@ func resourceDatadogSingleSignOnConfigurations() *pluginsdk.Resource {
 			"name": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
-				Default:  utils.String("default"),
+				Default:  "default",
 			},
 
 			"enterprise_application_id": {

--- a/website/docs/r/datadog_monitor_sso_configuration.html.markdown
+++ b/website/docs/r/datadog_monitor_sso_configuration.html.markdown
@@ -37,7 +37,7 @@ The following arguments are supported:
 
 --- 
 
-* `name` - (Optional) The name of the SingleSignOn configuration. Defaults to `0xc000543690`.
+* `name` - (Optional) The name of the SingleSignOn configuration. Defaults to `default`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
why the origin default value is set to a pointer to a string? never seen such usage before.