### PR TITLE
`azurerm_automation_software_update_configuration` - fix `expiry_time` is optional/computed

### DIFF
--- a/internal/services/automation/automation_software_update_configuration.go
+++ b/internal/services/automation/automation_software_update_configuration.go
@@ -189,6 +189,9 @@ func (s *Schedule) ToSDKModel() *automation.SUCScheduleProperties {
 	}
 
 	parseTime := func(s string) *date.Time {
+		if s == "" {
+			return nil
+		}
 		t, _ := time.Parse(time.RFC3339, s)
 		return &date.Time{Time: t}
 	}
@@ -728,6 +731,7 @@ func (m SoftwareUpdateConfigurationResource) Arguments() map[string]*pluginsdk.S
 					"expiry_time": {
 						Type:             pluginsdk.TypeString,
 						Optional:         true,
+						Computed:         true,
 						DiffSuppressFunc: suppress.RFC3339MinuteTime,
 						ValidateFunc:     validation.IsRFC3339Time,
 					},

--- a/internal/services/automation/automation_software_update_configuration_test.go
+++ b/internal/services/automation/automation_software_update_configuration_test.go
@@ -132,7 +132,6 @@ resource "azurerm_automation_software_update_configuration" "test" {
   schedule {
     description         = "foo-schedule"
     start_time          = "%[3]s"
-    expiry_time         = "%[4]s"
     is_enabled          = true
     interval            = 1
     frequency           = "Hour"


### PR DESCRIPTION
Fixes: https://github.com/hashicorp/terraform-provider-azurerm/issues/19738

--- PASS: TestAccSoftwareUpdateConfiguration_basic (180.18s)
--- PASS: TestAccSoftwareUpdateConfiguration_update (153.46s)
PASS
