### PR TITLE
`azurerm_batch_pool` - Fix terraform fails to execute(re-run) if `azure_batch_pool` is deleted outside of terraform

### DIFF
--- a/internal/services/batch/batch_pool_resource.go
+++ b/internal/services/batch/batch_pool_resource.go
@@ -1064,7 +1064,9 @@ func resourceBatchPoolRead(d *pluginsdk.ResourceData, meta interface{}) error {
 	resp, err := client.Get(ctx, id.ResourceGroup, id.BatchAccountName, id.Name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			return fmt.Errorf("%s was not found", *id)
+			log.Printf("[INFO] %s was not found - removing from state", *id)
+			d.SetId("")
+			return nil
 		}
 		return fmt.Errorf("retrieving %s: %+v", *id, err)
 	}


### PR DESCRIPTION
Fix #19770