### PR TITLE
Replace "primary_key" with "primary_connection_string"

### DIFF
--- a/website/docs/r/linux_function_app.html.markdown
+++ b/website/docs/r/linux_function_app.html.markdown
@@ -44,7 +44,7 @@ resource "azurerm_linux_function_app" "example" {
   location            = azurerm_resource_group.example.location
 
   storage_account_name       = azurerm_storage_account.example.name
-  storage_account_access_key = azurerm_storage_account.example.primary_access_key
+  storage_account_access_key = azurerm_storage_account.example.primary_connection_string
   service_plan_id            = azurerm_service_plan.example.id
 
   site_config {}


### PR DESCRIPTION
Following this example: https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/linux_function_app and using azurerm_storage_account.example.primary_access_key does not work - although it does not fail the Terraform. 

Attempts to upload a function to this function app will fail with a storage error.

Replace primary_access_key with primary_connection_string and it will work.