### PR TITLE
`azurerm_postgresql_flexible_server` - Fix test case failure with "HA is disabled for region westus2" issue

### DIFF
--- a/.teamcity/components/settings.kt
+++ b/.teamcity/components/settings.kt
@@ -148,7 +148,7 @@ var serviceTestConfigurationOverrides = mapOf(
         "eventhub" to testConfiguration(useDevTestSubscription = true),
         "firewall" to testConfiguration(useDevTestSubscription = true),
         "keyvault" to testConfiguration(useDevTestSubscription = true),
-        "postgres" to testConfiguration(useDevTestSubscription = true),
+        "postgres" to testConfiguration(locationOverride = LocationConfiguration("westeurope", "centralus", "eastus", false), useDevTestSubscription = true),
         "privatedns" to testConfiguration(useDevTestSubscription = true),
         "redis" to testConfiguration(useDevTestSubscription = true)
 )


### PR DESCRIPTION
Test case `TestAccFlexibleServerConfiguration_multiplePostgresqlFlexibleServerConfigurations` fails with the Zone-Redundant HA is disabled for region westus2. 

Per the [doc](https://learn.microsoft.com/en-us/azure/postgresql/flexible-server/overview#azure-regions),  the Zone-Redundant HA  is not supported in regions `westus2` and `eastus2`. Submitted this PR this update the teamcity configuration file to make the tests run in the available regions.