### PR TITLE
Batch Fix - convert sync call to async call for the existing resources

### DIFF
--- a/.teamcity/components/settings.kt
+++ b/.teamcity/components/settings.kt
@@ -107,6 +107,9 @@ var serviceTestConfigurationOverrides = mapOf(
         // netapp has a max of 10 accounts per subscription so lets limit it to 3 to account for broken ones, run Monday, Wednesday, Friday
         "netapp" to testConfiguration(parallelism = 3, daysOfWeek = "2,4,6", useDevTestSubscription = true),
 
+        // Orbital is only available in certain locations
+        "orbital" to testConfiguration(locationOverride = LocationConfiguration("eastus", "southcentralus", "westus2", false)),
+
         "policy" to testConfiguration(useAltSubscription = true),
 
         // Private DNS Resolver is only available in certain locations

--- a/internal/services/azurestackhci/stack_hci_cluster_resource.go
+++ b/internal/services/azurestackhci/stack_hci_cluster_resource.go
@@ -185,7 +185,7 @@ func resourceArmStackHCIClusterDelete(d *pluginsdk.ResourceData, meta interface{
 		return err
 	}
 
-	if _, err := client.Delete(ctx, *id); err != nil {
+	if err := client.DeleteThenPoll(ctx, *id); err != nil {
 		return fmt.Errorf("deleting %s: %+v", *id, err)
 	}
 

--- a/internal/services/databricks/databricks_access_connector_resource.go
+++ b/internal/services/databricks/databricks_access_connector_resource.go
@@ -96,8 +96,7 @@ func (r AccessConnectorResource) Create() sdk.ResourceFunc {
 				Identity: expandedIdentity,
 			}
 
-			_, err = client.CreateOrUpdate(ctx, id, accessConnector)
-			if err != nil {
+			if err = client.CreateOrUpdateThenPoll(ctx, id, accessConnector); err != nil {
 				return fmt.Errorf("creating %s: %+v", id, err)
 			}
 
@@ -131,8 +130,7 @@ func (r AccessConnectorResource) Update() sdk.ResourceFunc {
 				existing.Model.Tags = &state.Tags
 			}
 
-			_, err = client.CreateOrUpdate(ctx, *id, *existing.Model)
-			if err != nil {
+			if err = client.CreateOrUpdateThenPoll(ctx, *id, *existing.Model); err != nil {
 				return fmt.Errorf("updating %s: %+v", id, err)
 			}
 
@@ -192,8 +190,7 @@ func (r AccessConnectorResource) Delete() sdk.ResourceFunc {
 
 			client := metadata.Client.DataBricks.AccessConnectorClient
 
-			_, err = client.Delete(ctx, *id)
-			if err != nil {
+			if err = client.DeleteThenPoll(ctx, *id); err != nil {
 				return fmt.Errorf("deleting %s: %+v", *id, err)
 			}
 

--- a/internal/services/datadog/azurerm_datadog_monitor_sso_configuration.go
+++ b/internal/services/datadog/azurerm_datadog_monitor_sso_configuration.go
@@ -99,14 +99,8 @@ func resourceDatadogSingleSignOnConfigurationsCreateorUpdate(d *pluginsdk.Resour
 			EnterpriseAppID:   utils.String(enterpriseAppID),
 		},
 	}
-
-	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.MonitorName, configurationName, &body)
-	if err != nil {
+	if _, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.MonitorName, configurationName, &body); err != nil {
 		return fmt.Errorf("configuring SingleSignOn on Datadog Monitor %q (Resource Group %q): %+v", id.MonitorName, id.ResourceGroup, err)
-	}
-
-	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting on configuring SingleSignOn on Datadog Monitor %s: %+v", id, err)
 	}
 
 	d.SetId(ssoId)
@@ -172,14 +166,8 @@ func resourceDatadogSingleSignOnConfigurationsDelete(d *pluginsdk.ResourceData, 
 			EnterpriseAppID:   utils.String(enterpriseAppID),
 		},
 	}
-
-	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.MonitorName, id.SingleSignOnConfigurationName, &body)
-	if err != nil {
+	if _, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.MonitorName, id.SingleSignOnConfigurationName, &body); err != nil {
 		return fmt.Errorf("removing SingleSignOnConfiguration on Datadog Monitor %q (Resource Group %q): %+v", id.MonitorName, id.ResourceGroup, err)
-	}
-
-	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting on removing SingleSignOnConfiguration on Datadog Monitor %s: %+v", id, err)
 	}
 
 	return nil

--- a/internal/services/datadog/azurerm_datadog_monitor_sso_configuration.go
+++ b/internal/services/datadog/azurerm_datadog_monitor_sso_configuration.go
@@ -99,8 +99,14 @@ func resourceDatadogSingleSignOnConfigurationsCreateorUpdate(d *pluginsdk.Resour
 			EnterpriseAppID:   utils.String(enterpriseAppID),
 		},
 	}
-	if _, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.MonitorName, configurationName, &body); err != nil {
+
+	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.MonitorName, configurationName, &body)
+	if err != nil {
 		return fmt.Errorf("configuring SingleSignOn on Datadog Monitor %q (Resource Group %q): %+v", id.MonitorName, id.ResourceGroup, err)
+	}
+
+	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
+		return fmt.Errorf("waiting on configuring SingleSignOn on Datadog Monitor %s: %+v", id, err)
 	}
 
 	d.SetId(ssoId)
@@ -166,8 +172,14 @@ func resourceDatadogSingleSignOnConfigurationsDelete(d *pluginsdk.ResourceData, 
 			EnterpriseAppID:   utils.String(enterpriseAppID),
 		},
 	}
-	if _, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.MonitorName, id.SingleSignOnConfigurationName, &body); err != nil {
+
+	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.MonitorName, id.SingleSignOnConfigurationName, &body)
+	if err != nil {
 		return fmt.Errorf("removing SingleSignOnConfiguration on Datadog Monitor %q (Resource Group %q): %+v", id.MonitorName, id.ResourceGroup, err)
+	}
+
+	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
+		return fmt.Errorf("waiting on removing SingleSignOnConfiguration on Datadog Monitor %s: %+v", id, err)
 	}
 
 	return nil

--- a/internal/services/orbital/contact_profile_resource.go
+++ b/internal/services/orbital/contact_profile_resource.go
@@ -149,9 +149,10 @@ func (r ContactProfileResource) Create() sdk.ResourceFunc {
 				Tags:       &model.Tags,
 			}
 
-			if _, err := client.ContactProfilesCreateOrUpdate(ctx, id, contactProfile); err != nil {
+			if err := client.ContactProfilesCreateOrUpdateThenPoll(ctx, id, contactProfile); err != nil {
 				return fmt.Errorf("creating %s: %+v", id, err)
 			}
+
 			metadata.SetID(id)
 			return nil
 		},
@@ -216,11 +217,10 @@ func (r ContactProfileResource) Delete() sdk.ResourceFunc {
 
 			metadata.Logger.Infof("deleting %s", *id)
 
-			if resp, err := client.ContactProfilesDelete(ctx, *id); err != nil {
-				if !response.WasNotFound(resp.HttpResponse) {
-					return fmt.Errorf("deleting %s: %+v", *id, err)
-				}
+			if err := client.ContactProfilesDeleteThenPoll(ctx, *id); err != nil {
+				return fmt.Errorf("deleting %s: %+v", *id, err)
 			}
+
 			return nil
 		},
 	}
@@ -269,7 +269,8 @@ func (r ContactProfileResource) Update() sdk.ResourceFunc {
 					},
 					Tags: &state.Tags,
 				}
-				if _, err := client.ContactProfilesCreateOrUpdate(ctx, *id, contactProfile); err != nil {
+
+				if err := client.ContactProfilesCreateOrUpdateThenPoll(ctx, *id, contactProfile); err != nil {
 					return fmt.Errorf("updating %s: %+v", *id, err)
 				}
 			}

--- a/internal/services/orbital/contact_profile_resource.go
+++ b/internal/services/orbital/contact_profile_resource.go
@@ -149,10 +149,9 @@ func (r ContactProfileResource) Create() sdk.ResourceFunc {
 				Tags:       &model.Tags,
 			}
 
-			if err := client.ContactProfilesCreateOrUpdateThenPoll(ctx, id, contactProfile); err != nil {
+			if _, err := client.ContactProfilesCreateOrUpdate(ctx, id, contactProfile); err != nil {
 				return fmt.Errorf("creating %s: %+v", id, err)
 			}
-
 			metadata.SetID(id)
 			return nil
 		},
@@ -217,10 +216,11 @@ func (r ContactProfileResource) Delete() sdk.ResourceFunc {
 
 			metadata.Logger.Infof("deleting %s", *id)
 
-			if err := client.ContactProfilesDeleteThenPoll(ctx, *id); err != nil {
-				return fmt.Errorf("deleting %s: %+v", *id, err)
+			if resp, err := client.ContactProfilesDelete(ctx, *id); err != nil {
+				if !response.WasNotFound(resp.HttpResponse) {
+					return fmt.Errorf("deleting %s: %+v", *id, err)
+				}
 			}
-
 			return nil
 		},
 	}
@@ -269,8 +269,7 @@ func (r ContactProfileResource) Update() sdk.ResourceFunc {
 					},
 					Tags: &state.Tags,
 				}
-
-				if err := client.ContactProfilesCreateOrUpdateThenPoll(ctx, *id, contactProfile); err != nil {
+				if _, err := client.ContactProfilesCreateOrUpdate(ctx, *id, contactProfile); err != nil {
 					return fmt.Errorf("updating %s: %+v", *id, err)
 				}
 			}

--- a/internal/services/orbital/spacecraft_resource.go
+++ b/internal/services/orbital/spacecraft_resource.go
@@ -125,7 +125,7 @@ func (r SpacecraftResource) Create() sdk.ResourceFunc {
 				Properties: &spacecraftProperties,
 				Tags:       &model.Tags,
 			}
-			if _, err = client.CreateOrUpdate(ctx, id, spacecraft); err != nil {
+			if err = client.CreateOrUpdateThenPoll(ctx, id, spacecraft); err != nil {
 				return fmt.Errorf("creating %s: %+v", id, err)
 			}
 			metadata.SetID(id)
@@ -191,11 +191,10 @@ func (r SpacecraftResource) Delete() sdk.ResourceFunc {
 
 			metadata.Logger.Infof("deleting %s", *id)
 
-			if resp, err := client.Delete(ctx, *id); err != nil {
-				if !response.WasNotFound(resp.HttpResponse) {
-					return fmt.Errorf("deleting %s: %+v", *id, err)
-				}
+			if err := client.DeleteThenPoll(ctx, *id); err != nil {
+				return fmt.Errorf("deleting %s: %+v", *id, err)
 			}
+
 			return nil
 		},
 	}
@@ -237,7 +236,8 @@ func (r SpacecraftResource) Update() sdk.ResourceFunc {
 					},
 					Tags: &state.Tags,
 				}
-				if _, err := client.CreateOrUpdate(ctx, *id, spacecraft); err != nil {
+
+				if err := client.CreateOrUpdateThenPoll(ctx, *id, spacecraft); err != nil {
 					return fmt.Errorf("updating %s: %+v", *id, err)
 				}
 			}

--- a/internal/services/serviceconnector/service_connector_app_service_resource.go
+++ b/internal/services/serviceconnector/service_connector_app_service_resource.go
@@ -225,11 +225,10 @@ func (r AppServiceConnectorResource) Delete() sdk.ResourceFunc {
 
 			metadata.Logger.Infof("deleting %s", *id)
 
-			if resp, err := client.LinkerDelete(ctx, *id); err != nil {
-				if !response.WasNotFound(resp.HttpResponse) {
-					return fmt.Errorf("deleting %s: %+v", *id, err)
-				}
+			if err := client.LinkerDeleteThenPoll(ctx, *id); err != nil {
+				return fmt.Errorf("deleting %s: %+v", *id, err)
 			}
+
 			return nil
 		},
 	}
@@ -274,9 +273,10 @@ func (r AppServiceConnectorResource) Update() sdk.ResourceFunc {
 				Properties: &linkerProps,
 			}
 
-			if _, err := client.LinkerUpdate(ctx, *id, props); err != nil {
+			if err := client.LinkerUpdateThenPoll(ctx, *id, props); err != nil {
 				return fmt.Errorf("updating %s: %+v", *id, err)
 			}
+
 			return nil
 		},
 	}

--- a/internal/services/serviceconnector/service_connector_app_service_resource.go
+++ b/internal/services/serviceconnector/service_connector_app_service_resource.go
@@ -225,11 +225,10 @@ func (r AppServiceConnectorResource) Delete() sdk.ResourceFunc {
 
 			metadata.Logger.Infof("deleting %s", *id)
 
-			if resp, err := client.LinkerDelete(ctx, *id); err != nil {
-				if !response.WasNotFound(resp.HttpResponse) {
-					return fmt.Errorf("deleting %s: %+v", *id, err)
-				}
+			if err := client.LinkerDeleteThenPoll(ctx, *id); err != nil {
+				return fmt.Errorf("deleting %s: %+v", *id, err)
 			}
+
 			return nil
 		},
 	}
@@ -274,7 +273,7 @@ func (r AppServiceConnectorResource) Update() sdk.ResourceFunc {
 				Properties: &linkerProps,
 			}
 
-			if _, err := client.LinkerUpdate(ctx, *id, props); err != nil {
+			if err := client.LinkerUpdateThenPoll(ctx, *id, props); err != nil {
 				return fmt.Errorf("updating %s: %+v", *id, err)
 			}
 			return nil

--- a/internal/services/serviceconnector/service_connector_app_service_resource.go
+++ b/internal/services/serviceconnector/service_connector_app_service_resource.go
@@ -225,10 +225,11 @@ func (r AppServiceConnectorResource) Delete() sdk.ResourceFunc {
 
 			metadata.Logger.Infof("deleting %s", *id)
 
-			if err := client.LinkerDeleteThenPoll(ctx, *id); err != nil {
-				return fmt.Errorf("deleting %s: %+v", *id, err)
+			if resp, err := client.LinkerDelete(ctx, *id); err != nil {
+				if !response.WasNotFound(resp.HttpResponse) {
+					return fmt.Errorf("deleting %s: %+v", *id, err)
+				}
 			}
-
 			return nil
 		},
 	}
@@ -273,7 +274,7 @@ func (r AppServiceConnectorResource) Update() sdk.ResourceFunc {
 				Properties: &linkerProps,
 			}
 
-			if err := client.LinkerUpdateThenPoll(ctx, *id, props); err != nil {
+			if _, err := client.LinkerUpdate(ctx, *id, props); err != nil {
 				return fmt.Errorf("updating %s: %+v", *id, err)
 			}
 			return nil

--- a/internal/services/serviceconnector/service_connector_spring_cloud_resource.go
+++ b/internal/services/serviceconnector/service_connector_spring_cloud_resource.go
@@ -226,11 +226,10 @@ func (r SpringCloudConnectorResource) Delete() sdk.ResourceFunc {
 
 			metadata.Logger.Infof("deleting %s", *id)
 
-			if resp, err := client.LinkerDelete(ctx, *id); err != nil {
-				if !response.WasNotFound(resp.HttpResponse) {
-					return fmt.Errorf("deleting %s: %+v", *id, err)
-				}
+			if err := client.LinkerDeleteThenPoll(ctx, *id); err != nil {
+				return fmt.Errorf("deleting %s: %+v", *id, err)
 			}
+
 			return nil
 		},
 	}
@@ -275,7 +274,7 @@ func (r SpringCloudConnectorResource) Update() sdk.ResourceFunc {
 				Properties: &linkerProps,
 			}
 
-			if _, err := client.LinkerUpdate(ctx, *id, props); err != nil {
+			if err := client.LinkerUpdateThenPoll(ctx, *id, props); err != nil {
 				return fmt.Errorf("updating %s: %+v", *id, err)
 			}
 			return nil

--- a/internal/services/streamanalytics/stream_analytics_cluster_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_cluster_resource.go
@@ -169,11 +169,10 @@ func (r ClusterResource) Delete() sdk.ResourceFunc {
 
 			metadata.Logger.Infof("deleting %s", *id)
 
-			if resp, err := client.Delete(ctx, *id); err != nil {
-				if !response.WasNotFound(resp.HttpResponse) {
-					return fmt.Errorf("deleting %s: %+v", *id, err)
-				}
+			if err := client.DeleteThenPoll(ctx, *id); err != nil {
+				return fmt.Errorf("deleting %s: %+v", *id, err)
 			}
+
 			return nil
 		},
 	}

--- a/website/allowed-subcategories
+++ b/website/allowed-subcategories
@@ -92,3 +92,4 @@ Template
 Time Series Insights
 VMware (AVS)
 Video Analyzer
+Web PubSub


### PR DESCRIPTION
This PR is to convert sync call to async call for the existing resources.

![image](https://user-images.githubusercontent.com/19754191/209520134-615ee220-bd80-46d9-b3ba-0944c8f8f1af.png)
![image](https://user-images.githubusercontent.com/19754191/209520267-baff76b2-d1b8-4be7-89d2-9ad4281c29ae.png)
![image](https://user-images.githubusercontent.com/19754191/209520374-017e1a68-48d0-49f8-b60b-d5600763bd5f.png)
![image](https://user-images.githubusercontent.com/19754191/209521516-1ef6e2ed-7850-4d6c-a767-36d65fd3b45b.png)
![image](https://user-images.githubusercontent.com/19754191/209521962-e53234ca-20e9-46bf-9591-d91d29e18c1c.png)
![image](https://user-images.githubusercontent.com/19754191/209525990-cea814d7-7d4d-493b-b2f7-1d33f4e3b7ee.png)
--- PASS: TestAccDatadogMonitorSSO_basic (382.93s)
--- PASS: TestAccDatadogMonitorSSO_update (690.72s)

Note: For TCs of DatadogMonitorSSO, I tested them on my local with limited test data since Teamcity would skip them.

Below failed TCs of ServiceConnector also failed with same error on Teamcity Daily Run. So below failed TCs aren't related with this PR. Our another colleague is working on them and confirms it's service API issue. So I assume we could skip them for this PR.
![image](https://user-images.githubusercontent.com/19754191/209524278-ecdff908-6d87-4065-b18f-c86ebcee7dd1.png)
