### PR TITLE
azurerm_storage_account_customer_managed_key - support ManagedHSM Key Vaults

### DIFF
--- a/internal/services/storage/storage_account_customer_managed_key_resource.go
+++ b/internal/services/storage/storage_account_customer_managed_key_resource.go
@@ -48,9 +48,14 @@ func resourceStorageAccountCustomerManagedKey() *pluginsdk.Resource {
 			},
 
 			"key_vault_id": {
-				Type:         pluginsdk.TypeString,
-				Required:     true,
-				ValidateFunc: keyVaultValidate.VaultID,
+				Type:     pluginsdk.TypeString,
+				Required: true,
+				ValidateFunc: validation.Any(
+					// Storage Account Customer Managed Keys support both Key Vault and Key Vault Managed HSM keys:
+					// https://learn.microsoft.com/en-us/azure/storage/common/customer-managed-keys-overview
+					keyVaultValidate.VaultID,
+					keyVaultValidate.ManagedHSMID,
+				),
 			},
 
 			"key_name": {


### PR DESCRIPTION
Dear maintainers,

As [per the Microsoft documentation](https://learn.microsoft.com/en-us/azure/storage/common/customer-managed-keys-overview) Storage Account Customer Managed Keys support regular Key Vault and Managed HSM Key Vaults. However, the Terraform AzureRM provider only validates if the `key_vault_id` property matches the format expected by regular Key Vault, and does not check for the Managed HSM ID format. This PR adds support for Managed HSM IDs.

Before this change:
```
│ Error: ID was missing the `vaults` element
│
│   with azurerm_storage_account_customer_managed_key.storage-cmk,
│   on storage-account.tf line 47, in resource "azurerm_storage_account_customer_managed_key" "storage-cmk":
│   47:   key_vault_id       = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/REDACTED/providers/Microsoft.KeyVault/managedHSMs/REDACTED"
```

After this change:
```
  # azurerm_storage_account_customer_managed_key.storage-cmk will be created
  + resource "azurerm_storage_account_customer_managed_key" "storage-cmk" {
      + id                 = (known after apply)
      + key_name           = "redacted"
      + key_vault_id       = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/REDACTED/providers/Microsoft.KeyVault/managedHSMs/REDACTED"
      + key_version        = "00000000000000000000000000000000"
      + storage_account_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/REDACTED/providers/Microsoft.Storage/storageAccounts/REDACTED"
    }
```