### PR TITLE
container_group: sort environment variables

### DIFF
--- a/website/allowed-subcategories
+++ b/website/allowed-subcategories
@@ -92,3 +92,4 @@ Template
 Time Series Insights
 VMware (AVS)
 Video Analyzer
+Web PubSub


### PR DESCRIPTION
The environment variables for a container_group won't be sorted by default. This patch makes sure to sort them as well, or else the state will most of the time have changes that it tries to apply.