### PR TITLE
Fix missing/redundent props in doc

### DIFF
--- a/website/docs/r/active_directory_domain_service.html.markdown
+++ b/website/docs/r/active_directory_domain_service.html.markdown
@@ -248,7 +248,11 @@ In addition to all arguments above, the following attributes are exported:
 
 A `secure_ldap` block exports the following:
 
-* `external_access_ip_address` - The publicly routable IP address for LDAPS clients to connect to.
+* `certificate_expiry` - The expiry time of the certificate.
+
+* `certificate_thumbprint` - The thumbprint of the certificate.
+
+* `public_certificate` - The public certificate.
 
 ---
 
@@ -260,7 +264,7 @@ An `initial_replica_set` block exports the following:
 
 * `location` - The Azure location in which the initialreplica set resides.
 
-* `replica_set_id` - A unique ID for the replica set.
+* `id` - A unique ID for the replica set.
 
 * `service_status` - The current service status for the initial replica set.
 

--- a/website/docs/r/cdn_frontdoor_firewall_policy.html.markdown
+++ b/website/docs/r/cdn_frontdoor_firewall_policy.html.markdown
@@ -249,8 +249,6 @@ The following attributes are exported:
 
 * `id` - The ID of the Front Door Firewall Policy.
 
-* `location` - The Azure Region where this Front Door Firewall Policy exists.
-
 * `frontend_endpoint_ids` - The Front Door Profiles frontend endpoints associated with this Front Door Firewall Policy.
 
 ## Timeouts

--- a/website/docs/r/cdn_frontdoor_rule.html.markdown
+++ b/website/docs/r/cdn_frontdoor_rule.html.markdown
@@ -325,6 +325,8 @@ A `host_name_condition` block supports the following:
 
 * `transforms` - (Optional) A Conditional operator. Possible values include `Lowercase`, `RemoveNulls`, `Trim`, `Uppercase`, `UrlDecode` or `UrlEncode`. Details can be found in the `Condition Transform List` below.
 
+* `negate_condition` - (Optional) If `true` operator becomes the opposite of its value. Possible values `true` or `false`. Defaults to `false`. Details can be found in the `Condition Operator List` below.
+
 ---
 
 A `server_port_condition` block supports the following:

--- a/website/docs/r/frontdoor.html.markdown
+++ b/website/docs/r/frontdoor.html.markdown
@@ -97,6 +97,8 @@ The following arguments are supported:
 
 * `friendly_name` - (Optional) A friendly name for the Front Door service.
 
+* `backend_pool_settings` - (Optional) A `backend_pool_settings` block as defined below.
+
 * `frontend_endpoint` - (Required) A `frontend_endpoint` block as defined below.
 
 * `routing_rule` - (Required) A `routing_rule` block as defined below.
@@ -282,12 +284,6 @@ The `redirect_configuration` block supports the following:
 `frontend_endpoint` exports the following:
 
 * `id` - The ID of the Azure Front Door Frontend Endpoint.
-
-* `provisioning_state` - Provisioning state of the Front Door.
-
-* `provisioning_substate` - Provisioning substate of the Front Door
-
-[//]: *"* `web_application_firewall_policy_link_id` - (Optional) The `id` of the `web_application_firewall_policy_link` to use for this Frontend Endpoint."
 
 ---
 

--- a/website/docs/r/frontdoor_custom_https_configuration.html.markdown
+++ b/website/docs/r/frontdoor_custom_https_configuration.html.markdown
@@ -1,4 +1,4 @@
--frontdoor_custom_https_configuration--
+---
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_frontdoor_custom_https_configuration"

--- a/website/docs/r/frontdoor_custom_https_configuration.html.markdown
+++ b/website/docs/r/frontdoor_custom_https_configuration.html.markdown
@@ -1,4 +1,4 @@
----
+-frontdoor_custom_https_configuration--
 subcategory: "Network"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_frontdoor_custom_https_configuration"
@@ -96,8 +96,6 @@ resource "azurerm_frontdoor_custom_https_configuration" "example_custom_https_1"
 ```
 
 ## Argument Reference
-
-The `custom_https_configuration` block is also valid inside an `azurerm_frontdoor_custom_https_configuration`, which supports the following arguments:
 
 * `frontend_endpoint_id` - (Required) The ID of the Front Door Frontend Endpoint which this configuration refers to. Changing this forces a new resource to be created.
 

--- a/website/docs/r/frontdoor_rules_engine.html.markdown
+++ b/website/docs/r/frontdoor_rules_engine.html.markdown
@@ -115,6 +115,8 @@ The following arguments are supported:
 
 * `resource_group_name` - (Required) The name of the resource group. Changing this forces a new resource to be created.
 
+* `enabled` - (Optional) Whether this Rules engine configuration is enabled? Defaults to `true`.
+
 * `rule` - (Optional) A `rule` block as defined below.
 
 ---
@@ -125,7 +127,7 @@ The `rule` block supports the following:
 
 * `priority` - (Required) Priority of the rule, must be unique per rules engine definition.
 
-* `action` - (Optional) A `rule_action` block as defined below.
+* `action` - (Optional) An `action` block as defined below.
 
 * `match_condition` - (Optional) One or more `match_condition` block as defined below.
 

--- a/website/docs/r/storage_management_policy.html.markdown
+++ b/website/docs/r/storage_management_policy.html.markdown
@@ -96,7 +96,7 @@ The `rule` block supports the following:
 
 * `name` - (Required) The name of the rule. Rule name is case-sensitive. It must be unique within a policy.
 * `enabled` - (Required)  Boolean to specify whether the rule is enabled.
-* `filters` - (Optional) A `filter` block as documented below.
+* `filters` - (Optional) A `filters` block as documented below.
 * `actions` - (Required) An `actions` block as documented below.
 
 ---


### PR DESCRIPTION
This PR includes below changes:

## DomainServices

### azurerm_active_directory_domain_service

- [x] initial_replica_set.replica_set_id missed in code
- [x] secure_ldap.external_access_ip_address missed in code

## Storage

### azurerm_storage_management_policy

- [x] rule.filters not block missed in doc


## CDN

### azurerm_cdn_frontdoor_firewall_policy

- [x] location missed in code

### azurerm_cdn_frontdoor_rule

- [x] conditions.host_name_condition.negate_condition missed in doc

## FrontDoor

### azurerm_frontdoor_custom_https_configuration

- [x] custom_https_configuration.custom_https_configuration missed in code
- [x] custom_https_configuration.custom_https_provisioning_enabled missed in code
- [x] custom_https_configuration.frontend_endpoint_id missed in code
- [x] custom_https_provisioning_enabled missed in doc
- [x] frontend_endpoint_id missed in doc

### azurerm_frontdoor_rules_engine

- [x] enabled missed in doc
- [x] rule.action not block missed in doc

### azurerm_frontdoor

- [x] backend_pool_settings missed in doc
- [x] provisioning_state missed in code
- [x] provisioning_substate missed in code