### PR TITLE
Fixes documents for `azurerm_batch_certificate` and `azurerm_private_dns_aaaa_record`

### DIFF
--- a/website/docs/r/batch_certificate.html.markdown
+++ b/website/docs/r/batch_certificate.html.markdown
@@ -64,7 +64,9 @@ The following arguments are supported:
 
 * `password` - (Optional) The password to access the certificate's private key. This can only be specified when `format` is `Pfx`.
 
-* `thumbprint` - (Required) The thumbprint of the certificate. At this time the only supported value is 'SHA1'. Changing this forces a new resource to be created.
+* `thumbprint` - (Required) The thumbprint of the certificate. Changing this forces a new resource to be created.
+
+* `thumbprint_algorithm` - (Required) The algorithm of the certificate thumbprint. At this time the only supported value is `SHA1`. Changing this forces a new resource to be created.
 
 ## Attributes Reference
 

--- a/website/docs/r/private_dns_aaaa_record.html.markdown
+++ b/website/docs/r/private_dns_aaaa_record.html.markdown
@@ -42,7 +42,7 @@ The following arguments are supported:
 
 * `zone_name` - (Required) Specifies the Private DNS Zone where the resource exists. Changing this forces a new resource to be created.
 
-* `TTL` - (Required) The Time To Live (TTL) of the DNS record in seconds.
+* `ttl` - (Required) The Time To Live (TTL) of the DNS record in seconds.
 
 * `records` - (Required) A list of IPv6 Addresses.
 


### PR DESCRIPTION
Fixes missing properties and corrects property name for `azurerm_batch_certificate` and `azurerm_private_dns_aaaa_record`