### PR TITLE
`document` - remove `tenant_id`in `azurerm_virutal_machine` which is not exported

### DIFF
--- a/website/docs/r/virtual_machine.html.markdown
+++ b/website/docs/r/virtual_machine.html.markdown
@@ -404,8 +404,6 @@ An `identity` block exports the following:
 
 * `principal_id` - The Principal ID associated with this Managed Service Identity.
 
-* `tenant_id` - The Tenant ID associated with this Managed Service Identity.
-
 -> You can access the Principal ID via `${azurerm_virtual_machine.example.identity.0.principal_id}`
 
 ## Timeouts


### PR DESCRIPTION
`tenant_id` is not exported in `azurerm_virutal_machine`. And since this resource is feature frozen, removing the property in document.
https://github.com/hashicorp/terraform-provider-azurerm/blob/f2a75a6a055fb4ad656a1e436d340d77b160fa1c/internal/services/legacy/virtual_machine_resource.go#L143-L175