### PR TITLE
Tooling: hardcode go version for link-milestone action

### DIFF
--- a/.github/workflows/link-milestone.yaml
+++ b/.github/workflows/link-milestone.yaml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version-file: ./.go-version
+          go-version: '1.19.3'
       - run: |
           go install github.com/stephybun/link-milestone@latest
           link-milestone


### PR DESCRIPTION
Since we don't need to checkout the repository this action doesn't have access to the .go-version file, so the version would need to be hard coded for this action to work.