### PR TITLE
`document` remove unsetable `resource_group_name` in `azurerm_iot_time_series_insights_access_policy`

### DIFF
--- a/website/docs/r/iot_time_series_insights_access_policy.html.markdown
+++ b/website/docs/r/iot_time_series_insights_access_policy.html.markdown
@@ -39,8 +39,6 @@ The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the Azure IoT Time Series Insights Access Policy. Changing this forces a new resource to be created. Must be globally unique.
 
-* `resource_group_name` - (Required) The name of the resource group in which to create the Azure IoT Time Series Insights Access Policy.
-
 * `time_series_insights_environment_id` - (Required) The resource ID of the Azure IoT Time Series Insights Environment in which to create the Azure IoT Time Series Insights Reference Data Set. Changing this forces a new resource to be created.
 
 * `principal_object_id` - (Required) The id of the principal in Azure Active Directory.


### PR DESCRIPTION
There is no `resource_group_name` in https://github.com/hashicorp/terraform-provider-azurerm/blob/main/internal/services/iottimeseriesinsights/iot_time_series_insights_access_policy_resource.go
It is retrieved from `time_series_insights_environment_id` instead