### PR TITLE
azurerm_ip_group - support for firewall_ids, firewall_policy_ids

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ website/node_modules
 .terraform.lock.hcl
 
 website/vendor
+vendor/
 
 .vscode/
 

--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,6 @@ website/node_modules
 .terraform.lock.hcl
 
 website/vendor
-vendor/
 
 .vscode/
 

--- a/internal/services/firewall/firewall_application_rule_collection_resource.go
+++ b/internal/services/firewall/firewall_application_rule_collection_resource.go
@@ -147,8 +147,8 @@ func resourceFirewallApplicationRuleCollectionCreateUpdate(d *pluginsdk.Resource
 		return fmt.Errorf("expanding Firewall Application Rules: %+v", err)
 	}
 
-	locks.ByName(firewallName, azureFirewallResourceName)
-	defer locks.UnlockByName(firewallName, azureFirewallResourceName)
+	locks.ByName(firewallName, AzureFirewallResourceName)
+	defer locks.UnlockByName(firewallName, AzureFirewallResourceName)
 
 	firewall, err := client.Get(ctx, resourceGroup, firewallName)
 	if err != nil {
@@ -324,8 +324,8 @@ func resourceFirewallApplicationRuleCollectionDelete(d *pluginsdk.ResourceData, 
 		return err
 	}
 
-	locks.ByName(id.AzureFirewallName, azureFirewallResourceName)
-	defer locks.UnlockByName(id.AzureFirewallName, azureFirewallResourceName)
+	locks.ByName(id.AzureFirewallName, AzureFirewallResourceName)
+	defer locks.UnlockByName(id.AzureFirewallName, AzureFirewallResourceName)
 
 	firewall, err := client.Get(ctx, id.ResourceGroup, id.AzureFirewallName)
 	if err != nil {

--- a/internal/services/firewall/firewall_nat_rule_collection_resource.go
+++ b/internal/services/firewall/firewall_nat_rule_collection_resource.go
@@ -140,8 +140,8 @@ func resourceFirewallNatRuleCollectionCreateUpdate(d *pluginsdk.ResourceData, me
 	firewallName := d.Get("azure_firewall_name").(string)
 	resourceGroup := d.Get("resource_group_name").(string)
 
-	locks.ByName(firewallName, azureFirewallResourceName)
-	defer locks.UnlockByName(firewallName, azureFirewallResourceName)
+	locks.ByName(firewallName, AzureFirewallResourceName)
+	defer locks.UnlockByName(firewallName, AzureFirewallResourceName)
 
 	firewall, err := client.Get(ctx, resourceGroup, firewallName)
 	if err != nil {
@@ -322,8 +322,8 @@ func resourceFirewallNatRuleCollectionDelete(d *pluginsdk.ResourceData, meta int
 		return err
 	}
 
-	locks.ByName(id.AzureFirewallName, azureFirewallResourceName)
-	defer locks.UnlockByName(id.AzureFirewallName, azureFirewallResourceName)
+	locks.ByName(id.AzureFirewallName, AzureFirewallResourceName)
+	defer locks.UnlockByName(id.AzureFirewallName, AzureFirewallResourceName)
 
 	firewall, err := client.Get(ctx, id.ResourceGroup, id.AzureFirewallName)
 	if err != nil {

--- a/internal/services/firewall/firewall_network_rule_collection_resource.go
+++ b/internal/services/firewall/firewall_network_rule_collection_resource.go
@@ -142,8 +142,8 @@ func resourceFirewallNetworkRuleCollectionCreateUpdate(d *pluginsdk.ResourceData
 	firewallName := d.Get("azure_firewall_name").(string)
 	resourceGroup := d.Get("resource_group_name").(string)
 
-	locks.ByName(firewallName, azureFirewallResourceName)
-	defer locks.UnlockByName(firewallName, azureFirewallResourceName)
+	locks.ByName(firewallName, AzureFirewallResourceName)
+	defer locks.UnlockByName(firewallName, AzureFirewallResourceName)
 
 	firewall, err := client.Get(ctx, resourceGroup, firewallName)
 	if err != nil {
@@ -325,8 +325,8 @@ func resourceFirewallNetworkRuleCollectionDelete(d *pluginsdk.ResourceData, meta
 		return err
 	}
 
-	locks.ByName(id.AzureFirewallName, azureFirewallResourceName)
-	defer locks.UnlockByName(id.AzureFirewallName, azureFirewallResourceName)
+	locks.ByName(id.AzureFirewallName, AzureFirewallResourceName)
+	defer locks.UnlockByName(id.AzureFirewallName, AzureFirewallResourceName)
 
 	firewall, err := client.Get(ctx, id.ResourceGroup, id.AzureFirewallName)
 	if err != nil {

--- a/internal/services/firewall/firewall_policy_resource.go
+++ b/internal/services/firewall/firewall_policy_resource.go
@@ -25,7 +25,7 @@ import (
 	"github.com/tombuildsstuff/kermit/sdk/network/2022-05-01/network"
 )
 
-const azureFirewallPolicyResourceName = "azurerm_firewall_policy"
+const AzureFirewallPolicyResourceName = "azurerm_firewall_policy"
 
 func resourceFirewallPolicy() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
@@ -121,8 +121,8 @@ func resourceFirewallPolicyCreateUpdate(d *pluginsdk.ResourceData, meta interfac
 		}
 	}
 
-	locks.ByName(id.Name, azureFirewallPolicyResourceName)
-	defer locks.UnlockByName(id.Name, azureFirewallPolicyResourceName)
+	locks.ByName(id.Name, AzureFirewallPolicyResourceName)
+	defer locks.UnlockByName(id.Name, AzureFirewallPolicyResourceName)
 
 	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.Name, props)
 	if err != nil {
@@ -254,8 +254,8 @@ func resourceFirewallPolicyDelete(d *pluginsdk.ResourceData, meta interface{}) e
 		return err
 	}
 
-	locks.ByName(id.Name, azureFirewallPolicyResourceName)
-	defer locks.UnlockByName(id.Name, azureFirewallPolicyResourceName)
+	locks.ByName(id.Name, AzureFirewallPolicyResourceName)
+	defer locks.UnlockByName(id.Name, AzureFirewallPolicyResourceName)
 
 	future, err := client.Delete(ctx, id.ResourceGroup, id.Name)
 	if err != nil {

--- a/internal/services/firewall/firewall_policy_rule_collection_group_resource.go
+++ b/internal/services/firewall/firewall_policy_rule_collection_group_resource.go
@@ -442,8 +442,8 @@ func resourceFirewallPolicyRuleCollectionGroupCreateUpdate(d *pluginsdk.Resource
 		}
 	}
 
-	locks.ByName(policyId.Name, azureFirewallPolicyResourceName)
-	defer locks.UnlockByName(policyId.Name, azureFirewallPolicyResourceName)
+	locks.ByName(policyId.Name, AzureFirewallPolicyResourceName)
+	defer locks.UnlockByName(policyId.Name, AzureFirewallPolicyResourceName)
 
 	param := network.FirewallPolicyRuleCollectionGroup{
 		FirewallPolicyRuleCollectionGroupProperties: &network.FirewallPolicyRuleCollectionGroupProperties{
@@ -540,8 +540,8 @@ func resourceFirewallPolicyRuleCollectionGroupDelete(d *pluginsdk.ResourceData, 
 		return err
 	}
 
-	locks.ByName(id.FirewallPolicyName, azureFirewallPolicyResourceName)
-	defer locks.UnlockByName(id.FirewallPolicyName, azureFirewallPolicyResourceName)
+	locks.ByName(id.FirewallPolicyName, AzureFirewallPolicyResourceName)
+	defer locks.UnlockByName(id.FirewallPolicyName, AzureFirewallPolicyResourceName)
 
 	future, err := client.Delete(ctx, id.ResourceGroup, id.FirewallPolicyName, id.RuleCollectionGroupName)
 	if err != nil {

--- a/internal/services/firewall/firewall_resource.go
+++ b/internal/services/firewall/firewall_resource.go
@@ -503,8 +503,8 @@ func resourceFirewallDelete(d *pluginsdk.ResourceData, meta interface{}) error {
 		}
 	}
 
-	if policyId, ok := d.GetOk("firewall_policy_id"); ok {
-		id, _ := parse.FirewallPolicyID(policyId.(string))
+	if read.FirewallPolicy != nil && read.FirewallPolicy.ID != nil {
+		id, _ := parse.FirewallPolicyID(*read.FirewallPolicy.ID)
 		locks.ByName(id.Name, AzureFirewallPolicyResourceName)
 		defer locks.UnlockByName(id.Name, AzureFirewallPolicyResourceName)
 	}

--- a/internal/services/firewall/firewall_resource.go
+++ b/internal/services/firewall/firewall_resource.go
@@ -27,7 +27,7 @@ import (
 	"github.com/tombuildsstuff/kermit/sdk/network/2022-05-01/network"
 )
 
-var azureFirewallResourceName = "azurerm_firewall"
+var AzureFirewallResourceName = "azurerm_firewall"
 
 func resourceFirewall() *pluginsdk.Resource {
 	resource := pluginsdk.Resource{
@@ -327,8 +327,14 @@ func resourceFirewallCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 		}
 	}
 
-	locks.ByName(id.AzureFirewallName, azureFirewallResourceName)
-	defer locks.UnlockByName(id.AzureFirewallName, azureFirewallResourceName)
+	if policyId, ok := d.GetOk("firewall_policy_id"); ok {
+		id, _ := parse.FirewallPolicyID(policyId.(string))
+		locks.ByName(id.Name, AzureFirewallPolicyResourceName)
+		defer locks.UnlockByName(id.Name, AzureFirewallPolicyResourceName)
+	}
+
+	locks.ByName(id.AzureFirewallName, AzureFirewallResourceName)
+	defer locks.UnlockByName(id.AzureFirewallName, AzureFirewallResourceName)
 
 	locks.MultipleByName(vnetToLock, VirtualNetworkResourceName)
 	defer locks.UnlockMultipleByName(vnetToLock, VirtualNetworkResourceName)
@@ -497,8 +503,14 @@ func resourceFirewallDelete(d *pluginsdk.ResourceData, meta interface{}) error {
 		}
 	}
 
-	locks.ByName(id.AzureFirewallName, azureFirewallResourceName)
-	defer locks.UnlockByName(id.AzureFirewallName, azureFirewallResourceName)
+	if policyId, ok := d.GetOk("firewall_policy_id"); ok {
+		id, _ := parse.FirewallPolicyID(policyId.(string))
+		locks.ByName(id.Name, AzureFirewallPolicyResourceName)
+		defer locks.UnlockByName(id.Name, AzureFirewallPolicyResourceName)
+	}
+
+	locks.ByName(id.AzureFirewallName, AzureFirewallResourceName)
+	defer locks.UnlockByName(id.AzureFirewallName, AzureFirewallResourceName)
 
 	locks.MultipleByName(&virtualNetworkNamesToLock, VirtualNetworkResourceName)
 	defer locks.UnlockMultipleByName(&virtualNetworkNamesToLock, VirtualNetworkResourceName)

--- a/internal/services/network/ip_group_resource.go
+++ b/internal/services/network/ip_group_resource.go
@@ -52,7 +52,7 @@ func resourceIpGroup() *pluginsdk.Resource {
 			"resource_group_name": commonschema.ResourceGroupName(),
 
 			"firewall_ids": {
-				Type:     pluginsdk.TypeSet,
+				Type:     pluginsdk.TypeList,
 				Computed: true,
 				Elem: &pluginsdk.Schema{
 					Type: pluginsdk.TypeString,
@@ -60,7 +60,7 @@ func resourceIpGroup() *pluginsdk.Resource {
 			},
 
 			"firewall_policy_ids": {
-				Type:     pluginsdk.TypeSet,
+				Type:     pluginsdk.TypeList,
 				Computed: true,
 				Elem: &pluginsdk.Schema{
 					Type: pluginsdk.TypeString,

--- a/internal/services/network/ip_group_resource.go
+++ b/internal/services/network/ip_group_resource.go
@@ -88,13 +88,13 @@ func resourceIpGroupCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) er
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	for _, fw := range d.Get("firewall_ids").(*pluginsdk.Set).List() {
+	for _, fw := range d.Get("firewall_ids").([]interface{}) {
 		id, _ := firewallParse.FirewallID(fw.(string))
 		locks.ByName(id.AzureFirewallName, firewall.AzureFirewallResourceName)
 		defer locks.UnlockByName(id.AzureFirewallName, firewall.AzureFirewallResourceName)
 	}
 
-	for _, fwpol := range d.Get("firewall_policy_ids").(*pluginsdk.Set).List() {
+	for _, fwpol := range d.Get("firewall_policy_ids").([]interface{}) {
 		id, _ := firewallParse.FirewallPolicyID(fwpol.(string))
 		locks.ByName(id.Name, firewall.AzureFirewallPolicyResourceName)
 		defer locks.UnlockByName(id.Name, firewall.AzureFirewallPolicyResourceName)

--- a/internal/services/network/ip_group_resource_test.go
+++ b/internal/services/network/ip_group_resource_test.go
@@ -112,6 +112,31 @@ func TestAccIpGroup_update(t *testing.T) {
 	})
 }
 
+func TestAccIpGroup_updateWithAttachedPolicy(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_ip_group", "test1")
+	r := IPGroupResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.withAzurePolicy(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("cidrs.#").HasValue("1"),
+				check.That(data.ResourceName).Key("tags.%").HasValue("2"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.withAzurePolicyUpdate(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("cidrs.#").HasValue("2"),
+				check.That(data.ResourceName).Key("tags.%").HasValue("2"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (t IPGroupResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := parse.IpGroupID(state.ID)
 	if err != nil {
@@ -206,5 +231,237 @@ resource "azurerm_ip_group" "test" {
     cost_center = "MSFT"
   }
 }
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func (IPGroupResource) withAzurePolicy(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-network-%d"
+  location = "%s"
+}
+
+resource "azurerm_ip_group" "test1" {
+  name                = "acceptanceTestIpGroup1"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  cidrs = ["172.16.240.0/20"]
+
+  tags = {
+    environment = "Production"
+    cost_center = "MSFT"
+  }
+}
+
+resource "azurerm_ip_group" "test2" {
+  name                = "acceptanceTestIpGroup2"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  cidrs = ["172.17.240.0/20"]
+
+  tags = {
+    environment = "Production"
+    cost_center = "MSFT"
+  }
+}
+
+resource "azurerm_firewall_policy" "test" {
+  name                = "fwpol-test-policy"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_firewall_policy_rule_collection_group" "test" {
+  name               = "fwpol-test"
+  firewall_policy_id = azurerm_firewall_policy.test.id
+  priority           = 100
+
+  network_rule_collection {
+    name     = "network-rule-collection1"
+    priority = 100
+    action   = "Allow"
+    rule {
+      name                  = "network-rule-collection1-rule1"
+      protocols             = ["TCP"]
+      source_ip_groups      = [azurerm_ip_group.test1.id]
+      destination_ip_groups = [azurerm_ip_group.test2.id]
+      destination_ports     = ["443"]
+    }
+  }
+
+  network_rule_collection {
+    name     = "network-rule-collection2"
+    priority = 200
+    action   = "Allow"
+    rule {
+      name                  = "network-rule-collection1-rule1"
+      protocols             = ["TCP"]
+      source_ip_groups      = [azurerm_ip_group.test2.id]
+      destination_ip_groups = [azurerm_ip_group.test1.id]
+      destination_ports     = ["443"]
+    }
+  }
+}
+
+
+resource "azurerm_virtual_network" "test" {
+  name                = "testvnet"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "AzureFirewallSubnet"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.1.0/24"]
+}
+
+resource "azurerm_public_ip" "test" {
+  name                = "pip-fw"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+}
+
+resource "azurerm_firewall" "test" {
+  name                = "testfirewall"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku_name            = "AZFW_VNet"
+  sku_tier            = "Standard"
+
+	firewall_policy_id  = azurerm_firewall_policy.test.id
+
+  ip_configuration {
+    name                 = "configuration"
+    subnet_id            = azurerm_subnet.test.id
+    public_ip_address_id = azurerm_public_ip.test.id
+  }
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func (IPGroupResource) withAzurePolicyUpdate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-network-%d"
+  location = "%s"
+}
+
+resource "azurerm_ip_group" "test1" {
+  name                = "acceptanceTestIpGroup1"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  cidrs = ["172.16.240.0/20", "172.18.240.0/20"]
+
+  tags = {
+    environment = "Production"
+    cost_center = "MSFT"
+  }
+}
+
+resource "azurerm_ip_group" "test2" {
+  name                = "acceptanceTestIpGroup2"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  cidrs = ["172.17.240.0/20", "172.19.240.0/20"]
+
+  tags = {
+    environment = "Production"
+    cost_center = "MSFT"
+  }
+}
+
+resource "azurerm_firewall_policy" "test" {
+  name                = "fwpol-test-policy"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_firewall_policy_rule_collection_group" "test" {
+  name               = "fwpol-test"
+  firewall_policy_id = azurerm_firewall_policy.test.id
+  priority           = 100
+
+  network_rule_collection {
+    name     = "network-rule-collection1"
+    priority = 100
+    action   = "Allow"
+    rule {
+      name                  = "network-rule-collection1-rule1"
+      protocols             = ["TCP"]
+      source_ip_groups      = [azurerm_ip_group.test1.id]
+      destination_ip_groups = [azurerm_ip_group.test2.id]
+      destination_ports     = ["443"]
+    }
+  }
+
+  network_rule_collection {
+    name     = "network-rule-collection2"
+    priority = 200
+    action   = "Allow"
+    rule {
+      name                  = "network-rule-collection1-rule1"
+      protocols             = ["TCP"]
+      source_ip_groups      = [azurerm_ip_group.test2.id]
+      destination_ip_groups = [azurerm_ip_group.test1.id]
+      destination_ports     = ["443"]
+    }
+  }
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "testvnet"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "AzureFirewallSubnet"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.1.0/24"]
+}
+
+resource "azurerm_public_ip" "test" {
+  name                = "pip-fw"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+}
+
+resource "azurerm_firewall" "test" {
+  name                = "testfirewall"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku_name            = "AZFW_VNet"
+  sku_tier            = "Standard"
+
+	firewall_policy_id  = azurerm_firewall_policy.test.id
+
+  ip_configuration {
+    name                 = "configuration"
+    subnet_id            = azurerm_subnet.test.id
+    public_ip_address_id = azurerm_public_ip.test.id
+  }
+}
+
 `, data.RandomInteger, data.Locations.Primary)
 }

--- a/website/docs/r/ip_group.html.markdown
+++ b/website/docs/r/ip_group.html.markdown
@@ -4,7 +4,7 @@ layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_ip_group"
 description: |-
   Manages an IP group which contains a list of CIDRs and/or IP addresses.
-
+  
 ---
 
 # azurerm_ip_group
@@ -32,7 +32,7 @@ resource "azurerm_ip_group" "example" {
 }
 ```
 
-## Argument Reference
+## Arguments Reference
 
 The following arguments are supported:
 
@@ -48,9 +48,13 @@ The following arguments are supported:
 
 ## Attributes Reference
 
-The following attributes are exported:
+In addition to the Arguments listed above - the following Attributes are exported: 
 
-* `id` - The ID of the IP Group.
+* `id` - The ID of the IP group.
+
+* `firewall_ids` - A `firewall_ids` block as defined below.
+
+* `firewall_policy_ids` - A `firewall_policy_ids` block as defined below.
 
 ## Timeouts
 


### PR DESCRIPTION
Resolves #19843 

PS: If accepted and merged, could this be released into `v2.99`? The reason for the ask is that we use Azure CAF for landing zones and CAF is still using `v2` of the provider.