### PR TITLE
`azurerm_public_ip` - fix ddos diff from old version

### DIFF
--- a/internal/services/network/public_ip_resource.go
+++ b/internal/services/network/public_ip_resource.go
@@ -73,9 +73,6 @@ func resourcePublicIp() *pluginsdk.Resource {
 					string(network.DdosSettingsProtectionModeVirtualNetworkInherited),
 				}, false),
 				Default: string(network.DdosSettingsProtectionModeVirtualNetworkInherited),
-				DiffSuppressFunc: func(_, old, new string, _ *pluginsdk.ResourceData) bool {
-					return old == "" && new == string(network.DdosSettingsProtectionModeVirtualNetworkInherited)
-				},
 			},
 
 			"ddos_protection_plan_id": {
@@ -340,12 +337,14 @@ func resourcePublicIpRead(d *pluginsdk.ResourceData, meta interface{}) error {
 			d.Set("domain_name_label", settings.DomainNameLabel)
 		}
 
+		ddosProtectionMode := string(network.DdosSettingsProtectionModeVirtualNetworkInherited)
 		if ddosSetting := props.DdosSettings; ddosSetting != nil {
-			d.Set("ddos_protection_mode", string(ddosSetting.ProtectionMode))
+			ddosProtectionMode = string(ddosSetting.ProtectionMode)
 			if subResource := ddosSetting.DdosProtectionPlan; subResource != nil {
 				d.Set("ddos_protection_plan_id", subResource.ID)
 			}
 		}
+		d.Set("ddos_protection_mode", ddosProtectionMode)
 
 		d.Set("ip_tags", flattenPublicIpPropsIpTags(props.IPTags))
 

--- a/internal/services/network/public_ip_resource.go
+++ b/internal/services/network/public_ip_resource.go
@@ -73,6 +73,9 @@ func resourcePublicIp() *pluginsdk.Resource {
 					string(network.DdosSettingsProtectionModeVirtualNetworkInherited),
 				}, false),
 				Default: string(network.DdosSettingsProtectionModeVirtualNetworkInherited),
+				DiffSuppressFunc: func(_, old, new string, _ *pluginsdk.ResourceData) bool {
+					return old == "" && new == string(network.DdosSettingsProtectionModeVirtualNetworkInherited)
+				},
 			},
 
 			"ddos_protection_plan_id": {


### PR DESCRIPTION
resolves #19855
`azurerm_public_ip` resource provisioned in 3.30 or older version of azurerm provider (network@2021-08-01) has no `ddos_protection_mode` property in (network@2022-05-01) API response, but newly provisioned resource will have `ddos_protection_mode = 'VirtualNetworkInherited'` as default value in API response. related to https://github.com/Azure/azure-rest-api-specs/issues/22068