### PR TITLE
`azurerm_synapse_spark_pool` - support  `spark_version`  3.3

### DIFF
--- a/internal/services/synapse/synapse_spark_pool_resource.go
+++ b/internal/services/synapse/synapse_spark_pool_resource.go
@@ -213,6 +213,7 @@ func resourceSynapseSparkPool() *pluginsdk.Resource {
 					"2.4",
 					"3.1",
 					"3.2",
+					"3.3",
 				}, false),
 			},
 

--- a/internal/services/synapse/synapse_spark_pool_resource_test.go
+++ b/internal/services/synapse/synapse_spark_pool_resource_test.go
@@ -120,6 +120,14 @@ func TestAccSynapseSparkPool_sparkVersion(t *testing.T) {
 		},
 		// not returned by service
 		data.ImportStep("spark_events_folder", "spark_log_folder"),
+		{
+			Config: r.sparkVersion(data, "3.3"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		// not returned by service
+		data.ImportStep("spark_events_folder", "spark_log_folder"),
 	})
 }
 

--- a/website/docs/r/synapse_spark_pool.html.markdown
+++ b/website/docs/r/synapse_spark_pool.html.markdown
@@ -123,7 +123,7 @@ The following arguments are supported:
 
 * `spark_events_folder` - (Optional) The Spark events folder. Defaults to `/events`.
 
-* `spark_version` - (Optional) The Apache Spark version. Possible values are `2.4` and `3.1` and `3.2`. Defaults to `2.4`.
+* `spark_version` - (Optional) The Apache Spark version. Possible values are `2.4` , `3.1` , `3.2` and `3.3`. Defaults to `2.4`.
 
 * `tags` - (Optional) A mapping of tags which should be assigned to the Synapse Spark Pool.
 


### PR DESCRIPTION
Support  `spark_version`  3.3 as Microsoft documentation on Spark 3.3 availability: https://learn.microsoft.com/en-us/azure/synapse-analytics/spark/apache-spark-33-runtime

Fix #19854 .
