### PR TITLE
`azurerm_log_analytics_data_export_rule` - fix `destination_resource_id` doesn't accept Event Hub Namespace

### DIFF
--- a/internal/services/loganalytics/log_analytics_data_export_resource.go
+++ b/internal/services/loganalytics/log_analytics_data_export_resource.go
@@ -139,7 +139,7 @@ func resourceOperationalinsightsDataExportCreateUpdate(d *pluginsdk.ResourceData
 	if strings.Contains(destinationId, "Microsoft.EventHub/namespaces") {
 		eventhubNamespace, err := eventhubs.ParseNamespaceID(destinationId)
 		if err != nil {
-			return fmt.Errorf("parsing destination eventhub id error: %+v", err)
+			return fmt.Errorf("parsing destination eventhub namespaces id error: %+v", err)
 		}
 		parameters.Properties.Destination.ResourceId = eventhubNamespace.ID()
 	} else if strings.Contains(destinationId, "Microsoft.EventHub") {

--- a/internal/services/loganalytics/log_analytics_data_export_resource.go
+++ b/internal/services/loganalytics/log_analytics_data_export_resource.go
@@ -136,21 +136,24 @@ func resourceOperationalinsightsDataExportCreateUpdate(d *pluginsdk.ResourceData
 		},
 	}
 
-	if strings.Contains(destinationId, "Microsoft.EventHub/namespaces") {
-		eventhubNamespace, err := eventhubs.ParseNamespaceID(destinationId)
-		if err != nil {
-			return fmt.Errorf("parsing destination eventhub namespaces id error: %+v", err)
-		}
-		parameters.Properties.Destination.ResourceId = eventhubNamespace.ID()
-	} else if strings.Contains(destinationId, "Microsoft.EventHub") {
-		eventhubId, err := eventhubs.ParseEventhubID(destinationId)
-		if err != nil {
-			return fmt.Errorf("parsing destination eventhub id error: %+v", err)
-		}
-		destinationId = namespaces.NewNamespaceID(eventhubId.SubscriptionId, eventhubId.ResourceGroupName, eventhubId.NamespaceName).ID()
-		parameters.Properties.Destination.ResourceId = destinationId
-		parameters.Properties.Destination.MetaData = &dataexport.DestinationMetaData{
-			EventHubName: utils.String(eventhubId.EventHubName),
+	if strings.Contains(destinationId, "Microsoft.EventHub") {
+		_, err := eventhubs.ValidateNamespaceID(destinationId, "destination_resource_id")
+		if err == nil {
+			eventhubNamespace, err := eventhubs.ParseNamespaceID(destinationId)
+			if err != nil {
+				return fmt.Errorf("parsing destination eventhub namespaces id error: %+v", err)
+			}
+			parameters.Properties.Destination.ResourceId = eventhubNamespace.ID()
+		} else {
+			eventhubId, err := eventhubs.ParseEventhubID(destinationId)
+			if err != nil {
+				return fmt.Errorf("parsing destination eventhub id error: %+v", err)
+			}
+			destinationId = namespaces.NewNamespaceID(eventhubId.SubscriptionId, eventhubId.ResourceGroupName, eventhubId.NamespaceName).ID()
+			parameters.Properties.Destination.ResourceId = destinationId
+			parameters.Properties.Destination.MetaData = &dataexport.DestinationMetaData{
+				EventHubName: utils.String(eventhubId.EventHubName),
+			}
 		}
 	}
 

--- a/internal/services/loganalytics/log_analytics_data_export_resource.go
+++ b/internal/services/loganalytics/log_analytics_data_export_resource.go
@@ -136,7 +136,13 @@ func resourceOperationalinsightsDataExportCreateUpdate(d *pluginsdk.ResourceData
 		},
 	}
 
-	if strings.Contains(destinationId, "Microsoft.EventHub") {
+	if strings.Contains(destinationId, "Microsoft.EventHub/namespaces") {
+		eventhubNamespace, err := eventhubs.ParseNamespaceID(destinationId)
+		if err != nil {
+			return fmt.Errorf("parsing destination eventhub id error: %+v", err)
+		}
+		parameters.Properties.Destination.ResourceId = eventhubNamespace.ID()
+	} else if strings.Contains(destinationId, "Microsoft.EventHub") {
 		eventhubId, err := eventhubs.ParseEventhubID(destinationId)
 		if err != nil {
 			return fmt.Errorf("parsing destination eventhub id error: %+v", err)

--- a/internal/services/loganalytics/log_analytics_data_export_resource_test.go
+++ b/internal/services/loganalytics/log_analytics_data_export_resource_test.go
@@ -100,6 +100,21 @@ func TestAccLogAnalyticsDataExportRule_toEventhubs(t *testing.T) {
 	})
 }
 
+func TestAccLogAnalyticsDataExportRule_toEventhubNamespace(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_log_analytics_data_export_rule", "test")
+	r := LogAnalyticsDataExportRuleResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.toEventHubNamespace(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (t LogAnalyticsDataExportRuleResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := dataexport.ParseDataExportID(state.ID)
 	if err != nil {
@@ -224,6 +239,21 @@ resource "azurerm_log_analytics_data_export_rule" "test" {
   resource_group_name     = azurerm_resource_group.test.name
   workspace_resource_id   = azurerm_log_analytics_workspace.test.id
   destination_resource_id = azurerm_eventhub.test.id
+  table_names             = ["Heartbeat"]
+  enabled                 = true
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r LogAnalyticsDataExportRuleResource) toEventHubNamespace(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_log_analytics_data_export_rule" "test" {
+  name                    = "acctest-DER-%d"
+  resource_group_name     = azurerm_resource_group.test.name
+  workspace_resource_id   = azurerm_log_analytics_workspace.test.id
+  destination_resource_id = azurerm_eventhub_namespace.test.id
   table_names             = ["Heartbeat"]
   enabled                 = true
 }


### PR DESCRIPTION
Per the [doc](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/logs-data-export?tabs=portal#event-hubs), it is allowed to specify the event hub namespace for `destination_resource_id `.  Although terraform [doc](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_data_export_rule#destination_resource_id) describe the namespace is supported , in fact it is not. So submit this PR to support setting event hub namespace for `azurerm_log_analytics_data_export_rule`.

Fix #19861 