### PR TITLE
New Data Source: `azurerm_private_dns_resolver`

### DIFF
--- a/internal/services/privatednsresolver/private_dns_resolver_data_source.go
+++ b/internal/services/privatednsresolver/private_dns_resolver_data_source.go
@@ -1,0 +1,105 @@
+package privatednsresolver
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/dnsresolver/2022-07-01/dnsresolvers"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+type PrivateDNSResolverDnsResolverDataSourceModel struct {
+	Name              string            `tfschema:"name"`
+	ResourceGroupName string            `tfschema:"resource_group_name"`
+	Location          string            `tfschema:"location"`
+	Tags              map[string]string `tfschema:"tags"`
+	VirtualNetworkId  string            `tfschema:"virtual_network_id"`
+}
+
+type PrivateDNSResolverDnsResolverDataSource struct{}
+
+var _ sdk.DataSource = PrivateDNSResolverDnsResolverDataSource{}
+
+func (r PrivateDNSResolverDnsResolverDataSource) ResourceType() string {
+	return "azurerm_private_dns_resolver"
+}
+
+func (r PrivateDNSResolverDnsResolverDataSource) ModelObject() interface{} {
+	return &PrivateDNSResolverDnsResolverDataSourceModel{}
+}
+
+func (r PrivateDNSResolverDnsResolverDataSource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+	return dnsresolvers.ValidateDnsResolverID
+}
+
+func (r PrivateDNSResolverDnsResolverDataSource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"resource_group_name": commonschema.ResourceGroupName(),
+	}
+}
+
+func (r PrivateDNSResolverDnsResolverDataSource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"location": commonschema.LocationComputed(),
+
+		"virtual_network_id": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"tags": tags.SchemaDataSource(),
+	}
+}
+
+func (r PrivateDNSResolverDnsResolverDataSource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.PrivateDnsResolver.DnsResolversClient
+
+			var state PrivateDNSResolverDnsResolverDataSourceModel
+			if err := metadata.Decode(&state); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			var top int64 = 1
+			resp, err := client.ListByResourceGroupCompleteMatchingPredicate(ctx,
+				commonids.NewResourceGroupID(metadata.Client.Account.SubscriptionId, state.ResourceGroupName),
+				dnsresolvers.ListByResourceGroupOperationOptions{Top: &top},
+				dnsresolvers.DnsResolverOperationPredicate{Name: &state.Name})
+			if err != nil || len(resp.Items) != int(top) {
+				return fmt.Errorf("retrieving %s: %+v", state.Name, err)
+			}
+
+			model := resp.Items[0]
+			id, err := dnsresolvers.ParseDnsResolverID(*model.Id)
+			if err != nil {
+				return err
+			}
+
+			state.Location = location.Normalize(model.Location)
+			state.VirtualNetworkId = model.Properties.VirtualNetwork.Id
+
+			if model.Tags != nil {
+				state.Tags = *model.Tags
+			}
+
+			metadata.SetID(id)
+
+			return metadata.Encode(&state)
+		},
+	}
+}

--- a/internal/services/privatednsresolver/private_dns_resolver_data_source_test.go
+++ b/internal/services/privatednsresolver/private_dns_resolver_data_source_test.go
@@ -1,0 +1,108 @@
+package privatednsresolver_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+)
+
+type PrivateDNSResolverDnsResolverDataSource struct{}
+
+func TestAccPrivateDNSResolverDnsResolverDataSource_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_private_dns_resolver", "test")
+	d := PrivateDNSResolverDnsResolverDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: d.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("name").Exists(),
+				check.That(data.ResourceName).Key("resource_group_name").Exists(),
+				check.That(data.ResourceName).Key("location").HasValue(location.Normalize(data.Locations.Primary)),
+				check.That(data.ResourceName).Key("virtual_network_id").Exists(),
+			),
+		},
+	})
+}
+
+func TestAccPrivateDNSResolverDnsResolverDataSource_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_private_dns_resolver", "test")
+	d := PrivateDNSResolverDnsResolverDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: d.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("name").Exists(),
+				check.That(data.ResourceName).Key("resource_group_name").Exists(),
+				check.That(data.ResourceName).Key("location").HasValue(location.Normalize(data.Locations.Primary)),
+				check.That(data.ResourceName).Key("virtual_network_id").Exists(),
+				check.That(data.ResourceName).Key("tags.key").HasValue("value"),
+			),
+		},
+	})
+}
+
+func (d PrivateDNSResolverDnsResolverDataSource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctest-rg-%[2]d"
+  location = "%[1]s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctest-rg-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  address_space       = ["10.0.0.0/16"]
+}
+`, data.Locations.Primary, data.RandomInteger)
+}
+
+func (d PrivateDNSResolverDnsResolverDataSource) basic(data acceptance.TestData) string {
+	template := d.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_private_dns_resolver" "test" {
+	name                = "acctest-dr-%d"
+	resource_group_name = azurerm_resource_group.test.name
+	location            = azurerm_resource_group.test.location
+	virtual_network_id  = azurerm_virtual_network.test.id
+}
+
+data "azurerm_private_dns_resolver" "test" {
+  name         		  = azurerm_private_dns_resolver.test.name
+  resource_group_name = azurerm_resource_group.test.name
+}
+`, template, data.RandomInteger)
+}
+
+func (d PrivateDNSResolverDnsResolverDataSource) complete(data acceptance.TestData) string {
+	template := d.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_private_dns_resolver" "test" {
+	name                = "acctest-dr-%d"
+	resource_group_name = azurerm_resource_group.test.name
+	location            = azurerm_resource_group.test.location
+	virtual_network_id  = azurerm_virtual_network.test.id
+	tags = {
+		key = "value"
+	}
+}
+
+data "azurerm_private_dns_resolver" "test" {
+  name         		  = azurerm_private_dns_resolver.test.name
+  resource_group_name = azurerm_resource_group.test.name
+}
+`, template, data.RandomInteger)
+}

--- a/internal/services/privatednsresolver/registration.go
+++ b/internal/services/privatednsresolver/registration.go
@@ -40,7 +40,9 @@ func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 
 // DataSources returns a list of Data Sources supported by this Service
 func (r Registration) DataSources() []sdk.DataSource {
-	return []sdk.DataSource{}
+	return []sdk.DataSource{
+		PrivateDNSResolverDnsResolverDataSource{},
+	}
 }
 
 // Resources returns a list of Resources supported by this Service

--- a/website/docs/d/private_dns_resolver.html.markdown
+++ b/website/docs/d/private_dns_resolver.html.markdown
@@ -1,0 +1,46 @@
+---
+subcategory: "Private DNS Resolver"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_private_dns_resolver"
+description: |-
+  Gets information about an existing Private DNS Resolver.
+---
+
+# Data Source: azurerm_private_dns_resolver
+
+Gets information about an existing Private DNS Resolver.
+
+## Example Usage
+
+```hcl
+data "azurerm_private_dns_resolver" "test" {
+  name                = "example"
+  resource_group_name = "example-resourcegroup-name"
+}
+```
+
+## Arguments Reference
+
+The following arguments are required:
+
+* `name` - Name of the Private DNS Resolver.
+
+* `resource_group_name` - Name of the Resource Group where the Private DNS Resolver exists.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `id` - ID of the DNS Resolver.
+
+* `location` - Azure Region where the Private DNS Resolver exists.
+
+* `virtual_network_id` - ID of the Virtual Network that is linked to the Private DNS Resolver.
+
+* `tags` - Mapping of tags which should be assigned to the Private DNS Resolver.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the Private DNS SRV Record.


### PR DESCRIPTION
``` txt
=== RUN   TestAccPrivateDNSResolverDnsResolverDataSource_basic
=== PAUSE TestAccPrivateDNSResolverDnsResolverDataSource_basic
=== CONT  TestAccPrivateDNSResolverDnsResolverDataSource_basic
--- PASS: TestAccPrivateDNSResolverDnsResolverDataSource_basic (237.69s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/privatednsresolver    238.850s

=== RUN   TestAccPrivateDNSResolverDnsResolverDataSource_complete
=== PAUSE TestAccPrivateDNSResolverDnsResolverDataSource_complete
=== CONT  TestAccPrivateDNSResolverDnsResolverDataSource_complete
--- PASS: TestAccPrivateDNSResolverDnsResolverDataSource_complete (204.24s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/privatednsresolver    205.390s
```