### PR TITLE
`azurerm_web_pubsub_hub` - modify event handler type from typeSet to TypeList to respect the user's input order

### DIFF
--- a/internal/services/signalr/web_pubsub_hub_resource.go
+++ b/internal/services/signalr/web_pubsub_hub_resource.go
@@ -54,7 +54,7 @@ func resourceWebPubSubHub() *pluginsdk.Resource {
 			"web_pubsub_id": commonschema.ResourceIDReferenceRequiredForceNew(webpubsub.WebPubSubId{}),
 
 			"event_handler": {
-				Type:     pluginsdk.TypeSet,
+				Type:     pluginsdk.TypeList,
 				Optional: true,
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
@@ -146,7 +146,7 @@ func resourceWebPubSubHubCreateUpdate(d *pluginsdk.ResourceData, meta interface{
 
 	parameters := webpubsub.WebPubSubHub{
 		Properties: webpubsub.WebPubSubHubProperties{
-			EventHandlers:          expandEventHandler(d.Get("event_handler").(*pluginsdk.Set).List()),
+			EventHandlers:          expandEventHandler(d.Get("event_handler").([]interface{})),
 			AnonymousConnectPolicy: &anonymousPolicyEnabled,
 		},
 	}

--- a/website/docs/r/web_pubsub_hub.html.markdown
+++ b/website/docs/r/web_pubsub_hub.html.markdown
@@ -71,6 +71,8 @@ The following arguments are supported:
 
 * `event_handler` - (Optional) An `event_handler` block as defined below.
 
+-> **NOTE:** User can change the order of `event_handler` to change the priority accordingly.
+
 ---
 
 An `event_handler` block supports the following:


### PR DESCRIPTION
fix https://github.com/hashicorp/terraform-provider-azurerm/issues/19876

Acc tests:
```
--- PASS: TestAccWebPubsubHub_basic (423.14s)
--- PASS: TestAccWebPubsubHub_complete (445.28s)
--- PASS: TestAccWebPubsubHub_usingAuthGuid (475.73s)
--- PASS: TestAccWebPubsubHub_requiresImport (503.86s)
--- PASS: TestAccWebPubsubHub_withMultipleEventhandlerSettingsUpdate (644.83s)
--- PASS: TestAccWebPubsubHub_withPropertyUpdate (657.24s)
--- PASS: TestAccWebPubsubHub_withAuthUpdate (661.78s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/signalr       662.563s

```