### PR TITLE
`azurerm_kubernetes_cluster` - Support for KMS arguments

### DIFF
--- a/internal/services/containers/kubernetes_cluster_data_source.go
+++ b/internal/services/containers/kubernetes_cluster_data_source.go
@@ -393,10 +393,6 @@ func dataSourceKubernetesCluster() *pluginsdk.Resource {
 							Type:     pluginsdk.TypeString,
 							Computed: true,
 						},
-						"key_vault_resource_id": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
 					},
 				},
 			},
@@ -860,7 +856,6 @@ func flattenKubernetesClusterDataSourceKeyVaultKms(input *managedclusters.AzureK
 		azureKeyVaultKms = append(azureKeyVaultKms, map[string]interface{}{
 			"key_vault_key_id":         input.KeyId,
 			"key_vault_network_access": input.KeyVaultNetworkAccess,
-			"key_vault_resource_id":    input.KeyVaultResourceId,
 		})
 	}
 

--- a/internal/services/containers/kubernetes_cluster_data_source.go
+++ b/internal/services/containers/kubernetes_cluster_data_source.go
@@ -380,6 +380,31 @@ func dataSourceKubernetesCluster() *pluginsdk.Resource {
 
 			"identity": commonschema.SystemOrUserAssignedIdentityComputed(),
 
+			"key_vault_kms": {
+				Type:     pluginsdk.TypeList,
+				Computed: true,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"enabled": {
+							Type:     pluginsdk.TypeBool,
+							Computed: true,
+						},
+						"key_id": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+						"key_vault_network_access": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+						"key_vault_resource_id": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+
 			"kubernetes_version": {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
@@ -718,6 +743,11 @@ func dataSourceKubernetesClusterRead(d *pluginsdk.ResourceData, meta interface{}
 				return fmt.Errorf("setting `agent_pool_profile`: %+v", err)
 			}
 
+			azureKeyVaultKms := flattenKubernetesClusterDataSourceKeyVaultKms(props.SecurityProfile.AzureKeyVaultKms)
+			if err := d.Set("key_vault_kms", azureKeyVaultKms); err != nil {
+				return fmt.Errorf("setting `key_vault_kms`: %+v", err)
+			}
+
 			kubeletIdentity, err := flattenKubernetesClusterDataSourceIdentityProfile(props.IdentityProfile)
 			if err != nil {
 				return err
@@ -825,6 +855,21 @@ func dataSourceKubernetesClusterRead(d *pluginsdk.ResourceData, meta interface{}
 	}
 
 	return nil
+}
+
+func flattenKubernetesClusterDataSourceKeyVaultKms(input *managedclusters.AzureKeyVaultKms) []interface{} {
+	azureKeyVaultKms := make([]interface{}, 0)
+
+	if input != nil {
+		azureKeyVaultKms = append(azureKeyVaultKms, map[string]interface{}{
+			"enabled":                  input.Enabled,
+			"key_id":                   input.KeyId,
+			"key_vault_network_access": input.KeyVaultNetworkAccess,
+			"key_vault_resource_id":    input.KeyVaultResourceId,
+		})
+	}
+
+	return azureKeyVaultKms
 }
 
 func flattenKubernetesClusterDataSourceStorageProfile(input *managedclusters.ManagedClusterStorageProfile) []interface{} {

--- a/internal/services/containers/kubernetes_cluster_data_source.go
+++ b/internal/services/containers/kubernetes_cluster_data_source.go
@@ -852,10 +852,20 @@ func dataSourceKubernetesClusterRead(d *pluginsdk.ResourceData, meta interface{}
 func flattenKubernetesClusterDataSourceKeyVaultKms(input *managedclusters.AzureKeyVaultKms) []interface{} {
 	azureKeyVaultKms := make([]interface{}, 0)
 
-	if input != nil && *input.Enabled {
+	if input != nil && input.Enabled != nil && *input.Enabled {
+		keyId := ""
+		if v := input.KeyId; v != nil {
+			keyId = *v
+		}
+
+		networkAccess := ""
+		if v := input.KeyVaultNetworkAccess; v != nil {
+			networkAccess = string(*v)
+		}
+
 		azureKeyVaultKms = append(azureKeyVaultKms, map[string]interface{}{
-			"key_vault_key_id":         input.KeyId,
-			"key_vault_network_access": input.KeyVaultNetworkAccess,
+			"key_vault_key_id":         keyId,
+			"key_vault_network_access": networkAccess,
 		})
 	}
 

--- a/internal/services/containers/kubernetes_cluster_data_source.go
+++ b/internal/services/containers/kubernetes_cluster_data_source.go
@@ -380,16 +380,12 @@ func dataSourceKubernetesCluster() *pluginsdk.Resource {
 
 			"identity": commonschema.SystemOrUserAssignedIdentityComputed(),
 
-			"key_vault_kms": {
+			"key_management_service": {
 				Type:     pluginsdk.TypeList,
 				Computed: true,
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
-						"enabled": {
-							Type:     pluginsdk.TypeBool,
-							Computed: true,
-						},
-						"key_id": {
+						"key_vault_key_id": {
 							Type:     pluginsdk.TypeString,
 							Computed: true,
 						},
@@ -744,8 +740,8 @@ func dataSourceKubernetesClusterRead(d *pluginsdk.ResourceData, meta interface{}
 			}
 
 			azureKeyVaultKms := flattenKubernetesClusterDataSourceKeyVaultKms(props.SecurityProfile.AzureKeyVaultKms)
-			if err := d.Set("key_vault_kms", azureKeyVaultKms); err != nil {
-				return fmt.Errorf("setting `key_vault_kms`: %+v", err)
+			if err := d.Set("key_management_service", azureKeyVaultKms); err != nil {
+				return fmt.Errorf("setting `key_management_service`: %+v", err)
 			}
 
 			kubeletIdentity, err := flattenKubernetesClusterDataSourceIdentityProfile(props.IdentityProfile)
@@ -860,10 +856,9 @@ func dataSourceKubernetesClusterRead(d *pluginsdk.ResourceData, meta interface{}
 func flattenKubernetesClusterDataSourceKeyVaultKms(input *managedclusters.AzureKeyVaultKms) []interface{} {
 	azureKeyVaultKms := make([]interface{}, 0)
 
-	if input != nil {
+	if input != nil && *input.Enabled {
 		azureKeyVaultKms = append(azureKeyVaultKms, map[string]interface{}{
-			"enabled":                  input.Enabled,
-			"key_id":                   input.KeyId,
+			"key_vault_key_id":         input.KeyId,
 			"key_vault_network_access": input.KeyVaultNetworkAccess,
 			"key_vault_resource_id":    input.KeyVaultResourceId,
 		})

--- a/website/docs/d/kubernetes_cluster.html.markdown
+++ b/website/docs/d/kubernetes_cluster.html.markdown
@@ -186,8 +186,6 @@ A `key_management_service` block supports the following:
 
 * `key_vault_network_access` - Network access of the key vault. The possible values are `Public` and `Private`. `Public` means the key vault allows public access from all networks. `Private` means the key vault disables public access and enables private link.
 
-* `key_vault_resource_id` - Resource ID of key vault. This in only relevant when `key_vault_network_access` is `Private`. When keyVaultNetworkAccess is `Public`, the field is empty.
-
 ---
 
 A `key_vault_secrets_provider` block exports the following:

--- a/website/docs/d/kubernetes_cluster.html.markdown
+++ b/website/docs/d/kubernetes_cluster.html.markdown
@@ -56,7 +56,7 @@ The following attributes are exported:
 
 * `ingress_application_gateway` - An `ingress_application_gateway` block as documented below.
 
-* `key_vault_kms` - A `key_vault_kms` block as documented below.
+* `key_management_service` - A `key_management_service` block as documented below.
 
 * `key_vault_secrets_provider` - A `key_vault_secrets_provider` block as documented below.
 
@@ -180,11 +180,9 @@ A `upgrade_settings` block exports the following:
 
 ---
 
-A `key_vault_kms` block supports the following:
+A `key_management_service` block supports the following:
 
-* `enabled` - Is Azure Key Vault key management service enabled?
-
-* `key_id` - Identifier of Azure Key Vault key. See [key identifier format](https://learn.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name) for more details.
+* `key_vault_key_id` - Identifier of Azure Key Vault key. See [key identifier format](https://learn.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name) for more details.
 
 * `key_vault_network_access` - Network access of the key vault. The possible values are `Public` and `Private`. `Public` means the key vault allows public access from all networks. `Private` means the key vault disables public access and enables private link.
 

--- a/website/docs/d/kubernetes_cluster.html.markdown
+++ b/website/docs/d/kubernetes_cluster.html.markdown
@@ -56,6 +56,8 @@ The following attributes are exported:
 
 * `ingress_application_gateway` - An `ingress_application_gateway` block as documented below.
 
+* `key_vault_kms` - A `key_vault_kms` block as documented below.
+
 * `key_vault_secrets_provider` - A `key_vault_secrets_provider` block as documented below.
 
 * `private_fqdn` - The FQDN of this Kubernetes Cluster when private link has been enabled. This name is only resolvable inside the Virtual Network where the Azure Kubernetes Service is located
@@ -175,6 +177,18 @@ An `azure_active_directory_role_based_access_control` block exports the followin
 A `upgrade_settings` block exports the following:
 
 * `max_surge` - The maximum number or percentage of nodes that will be added to the Node Pool size during an upgrade.
+
+---
+
+A `key_vault_kms` block supports the following:
+
+* `enabled` - Is Azure Key Vault key management service enabled?
+
+* `key_id` - Identifier of Azure Key Vault key. See [key identifier format](https://learn.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name) for more details.
+
+* `key_vault_network_access` - Network access of the key vault. The possible values are `Public` and `Private`. `Public` means the key vault allows public access from all networks. `Private` means the key vault disables public access and enables private link.
+
+* `key_vault_resource_id` - Resource ID of key vault. This in only relevant when `key_vault_network_access` is `Private`. When keyVaultNetworkAccess is `Public`, the field is empty.
 
 ---
 

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -127,7 +127,7 @@ In addition, one of either `identity` or `service_principal` blocks must be spec
 
 * `ingress_application_gateway` - (Optional) A `ingress_application_gateway` block as defined below.
 
-* `key_vault_kms` - (Optional) A `key_vault_kms` block as defined below. For more details, please visit [Key Management Service (KMS) etcd encryption to an AKS cluster](https://learn.microsoft.com/en-us/azure/aks/use-kms-etcd-encryption).
+* `key_management_service` - (Optional) A `key_management_service` block as defined below. For more details, please visit [Key Management Service (KMS) etcd encryption to an AKS cluster](https://learn.microsoft.com/en-us/azure/aks/use-kms-etcd-encryption).
 
 * `key_vault_secrets_provider` - (Optional) A `key_vault_secrets_provider` block as defined below. For more details, please visit [Azure Keyvault Secrets Provider for AKS](https://docs.microsoft.com/azure/aks/csi-secrets-store-driver).
 
@@ -462,11 +462,9 @@ An `identity` block supports the following:
 
 ---
 
-A `key_vault_kms` block supports the following:
+A `key_management_service` block supports the following:
 
-* `enabled` - (Optional) Whether to enable Azure Key Vault key management service. The default is `false`.
-
-* `key_id` - (Optional) Identifier of Azure Key Vault key. See [key identifier format](https://learn.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name) for more details. When Azure Key Vault key management service is enabled, this field is required and must be a valid key identifier. When `enabled` is `false`, leave the field empty.
+* `key_vault_key_id` - (Optional) Identifier of Azure Key Vault key. See [key identifier format](https://learn.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name) for more details. When Azure Key Vault key management service is enabled, this field is required and must be a valid key identifier. When `enabled` is `false`, leave the field empty.
 
 * `key_vault_network_access` - (Optional) Network access of the key vault
 Network access of key vault. The possible values are `Public` and `Private`. `Public` means the key vault allows public access from all networks. `Private` means the key vault disables public access and enables private link. The default value is `Public`.

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -127,6 +127,8 @@ In addition, one of either `identity` or `service_principal` blocks must be spec
 
 * `ingress_application_gateway` - (Optional) A `ingress_application_gateway` block as defined below.
 
+* `key_vault_kms` - (Optional) A `key_vault_kms` block as defined below. For more details, please visit [Key Management Service (KMS) etcd encryption to an AKS cluster](https://learn.microsoft.com/en-us/azure/aks/use-kms-etcd-encryption).
+
 * `key_vault_secrets_provider` - (Optional) A `key_vault_secrets_provider` block as defined below. For more details, please visit [Azure Keyvault Secrets Provider for AKS](https://docs.microsoft.com/azure/aks/csi-secrets-store-driver).
 
 * `kubelet_identity` - (Optional) A `kubelet_identity` block as defined below. Changing this forces a new resource to be created.
@@ -457,6 +459,19 @@ An `identity` block supports the following:
 * `identity_ids` - (Optional) Specifies a list of User Assigned Managed Identity IDs to be assigned to this Kubernetes Cluster.
 
 ~> **NOTE:** This is required when `type` is set to `UserAssigned`.
+
+---
+
+A `key_vault_kms` block supports the following:
+
+* `enabled` - (Optional) Whether to enable Azure Key Vault key management service. The default is `false`.
+
+* `key_id` - (Optional) Identifier of Azure Key Vault key. See [key identifier format](https://learn.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name) for more details. When Azure Key Vault key management service is enabled, this field is required and must be a valid key identifier. When `enabled` is `false`, leave the field empty.
+
+* `key_vault_network_access` - (Optional) Network access of the key vault
+Network access of key vault. The possible values are `Public` and `Private`. `Public` means the key vault allows public access from all networks. `Private` means the key vault disables public access and enables private link. The default value is `Public`.
+
+* `key_vault_resource_id` - (Optional) Resource ID of key vault. When `key_vault_network_access` is `Private`, this field is required and must be a valid resource ID. When `key_vault_network_access` is `Public`, leave the field empty.
 
 ---
 

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -469,8 +469,6 @@ A `key_management_service` block supports the following:
 * `key_vault_network_access` - (Optional) Network access of the key vault
 Network access of key vault. The possible values are `Public` and `Private`. `Public` means the key vault allows public access from all networks. `Private` means the key vault disables public access and enables private link. The default value is `Public`.
 
-* `key_vault_resource_id` - (Optional) Resource ID of key vault. When `key_vault_network_access` is `Private`, this field is required and must be a valid resource ID. When `key_vault_network_access` is `Public`, leave the field empty.
-
 ---
 
 A `key_vault_secrets_provider` block supports the following:


### PR DESCRIPTION
Resolves #17957

Our security guys at @swisspost asked to implement [Add Key Management Service (KMS) etcd encryption to an Azure Kubernetes Service (AKS) cluster](https://learn.microsoft.com/en-us/azure/aks/use-kms-etcd-encryption). Unfortunately the provider did not implement it, so I implemented it for us and the community :-).

Example of implementation:

```hcl
resource "azurerm_kubernetes_cluster" "aks" {
   
  # ...

  identity {
    type         = "UserAssigned"
    identity_ids = ["/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/rg-my-resource-group/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id-acctestaks"]
  }

  key_management_service {
    key_vault_key_id  = "https://kv-acctestaks.vault.azure.net/keys/acctestaks/dummykeyversion"
  }
}
```