### PR TITLE
`azurerm_storage_account` - Support `allowed_copy_scope`

### DIFF
--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -828,6 +828,15 @@ func resourceStorageAccount() *pluginsdk.Resource {
 				},
 			},
 
+			"allowed_copy_scope": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					string(storage.AllowedCopyScopePrivateLink),
+					string(storage.AllowedCopyScopeAAD),
+				}, false),
+			},
+
 			"sftp_enabled": {
 				Type:     pluginsdk.TypeBool,
 				Optional: true,
@@ -1123,6 +1132,10 @@ func resourceStorageAccountCreate(d *pluginsdk.ResourceData, meta interface{}) e
 			SasPolicy:                    expandStorageAccountSASPolicy(d.Get("sas_policy").([]interface{})),
 			IsSftpEnabled:                &isSftpEnabled,
 		},
+	}
+
+	if v := d.Get("allowed_copy_scope").(string); v != "" {
+		parameters.AccountPropertiesCreateParameters.AllowedCopyScope = storage.AllowedCopyScope(v)
 	}
 
 	// For all Clouds except Public, China, and USGovernmentCloud, don't specify "allow_blob_public_access" and "min_tls_version" in request body.
@@ -1766,6 +1779,18 @@ func resourceStorageAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 		}
 	}
 
+	if d.HasChange("allowed_copy_scope") {
+		// TODO: Currently, due to Track1 SDK has no way to represent a `null` value in the payload - instead it will be omitted, `allowed_copy_scope` can not be disabled once enabled.
+		opts := storage.AccountUpdateParameters{
+			AccountPropertiesUpdateParameters: &storage.AccountPropertiesUpdateParameters{
+				AllowedCopyScope: storage.AllowedCopyScope(d.Get("allowed_copy_scope").(string)),
+			},
+		}
+		if _, err := client.Update(ctx, id.ResourceGroup, id.Name, opts); err != nil {
+			return fmt.Errorf("updating Azure Storage Account allowed_copy_scope %q: %+v", id.Name, err)
+		}
+	}
+
 	supportLevel := resolveStorageAccountServiceSupportLevel(storage.Kind(accountKind), storage.SkuTier(accountTier))
 
 	if d.HasChange("blob_properties") {
@@ -2101,6 +2126,7 @@ func resourceStorageAccountRead(d *pluginsdk.ResourceData, meta interface{}) err
 			return fmt.Errorf("setting `sas_policy`: %+v", err)
 		}
 
+		d.Set("allowed_copy_scope", props.AllowedCopyScope)
 		d.Set("sftp_enabled", props.IsSftpEnabled)
 	}
 

--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -166,6 +166,8 @@ The following arguments are supported:
 
 * `sas_policy` - (Optional) A `sas_policy` block as defined below.
 
+* `allowed_copy_scope` - (Optional) Restrict copy to and from Storage Accounts within an AAD tenant or with Private Links to the same VNet. Possible values are `AAD` and `PrivateLink`.
+
 * `sftp_enabled` - (Optional) Boolean, enable SFTP for the storage account
 
 -> **NOTE:** SFTP support requires `is_hns_enabled` set to `true`. [More information on SFTP support can be found here](https://learn.microsoft.com/azure/storage/blobs/secure-file-transfer-protocol-support). Defaults to `false`


### PR DESCRIPTION
Fix #19888

Note that this new `allowed_copy_scope` can't be unset once set (similar to the `sas_policy`), which is due to Track1 SDK has no way to represent a `null` value in the payload. Technically, we can support unsetting it by refactoring the update of the storage account to the get-then-put pattern, whilst that introduces a bigger impact, which I'd prefer another dedicated PR.

```shell
💢  TF_ACC=1 go test -v -timeout=20h ./internal/services/storage -run='TestAccStorageAccount_allowedCopyScope'
=== RUN   TestAccStorageAccount_allowedCopyScope
=== PAUSE TestAccStorageAccount_allowedCopyScope
=== CONT  TestAccStorageAccount_allowedCopyScope
--- PASS: TestAccStorageAccount_allowedCopyScope (228.88s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/storage       228.895s
```