### PR TITLE
`azurerm_data_factory_linked_service_azure_blob_storage` - pass `connection_string` as string

### DIFF
--- a/internal/services/datafactory/data_factory_linked_service_azure_blob_storage_resource.go
+++ b/internal/services/datafactory/data_factory_linked_service_azure_blob_storage_resource.go
@@ -225,10 +225,7 @@ func resourceDataFactoryLinkedServiceBlobStorageCreateUpdate(d *pluginsdk.Resour
 	blobStorageProperties := &datafactory.AzureBlobStorageLinkedServiceTypeProperties{}
 
 	if v, ok := d.GetOk("connection_string"); ok {
-		blobStorageProperties.ConnectionString = &datafactory.SecureString{
-			Value: utils.String(v.(string)),
-			Type:  datafactory.TypeSecureString,
-		}
+		blobStorageProperties.ConnectionString = utils.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("sas_uri"); ok {


### PR DESCRIPTION
fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/19862

If we pass the `connect_string` as string type, the API will extract the `AccountKey` part and return it as encrypted credential, so there's no sensitive information leaked. And in the portal, user can see the account name and edit it.

<img width="1361" alt="image" src="https://user-images.githubusercontent.com/79895375/211247997-a28d264a-5b0e-4ccc-9a5c-d205268efd33.png">
