### PR TITLE
`document` - fix import command of `azurerm_api_management_identity_profider_aadb2c`

### DIFF
--- a/website/docs/r/api_management_identity_provider_aadb2c.html.markdown
+++ b/website/docs/r/api_management_identity_provider_aadb2c.html.markdown
@@ -99,5 +99,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 API Management Azure AD B2C Identity Providers can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_api_management_identity_provider_aadb2c.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.ApiManagement/service/service1/identityProviders/AadB2C
+terraform import azurerm_api_management_identity_provider_aadb2c.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.ApiManagement/service/service1/identityProviders/aadB2C
 ```


### PR DESCRIPTION
Captured error from import:
parsing Resource ID "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.ApiManagement/service/service1/identityProviders/AadB2C": this resource only supports Identity Provider Type "**aadB2C**"