### PR TITLE
Docs: fix missed properties in document of `automation`, `network`, `fluidrelay server`, etc.

### DIFF
--- a/internal/services/datadog/datadog_monitor_tag_rule_resource.go
+++ b/internal/services/datadog/datadog_monitor_tag_rule_resource.go
@@ -45,7 +45,7 @@ func resourceDatadogTagRules() *pluginsdk.Resource {
 			"name": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
-				Default:  utils.String("default"),
+				Default:  "default",
 			},
 
 			"log": {

--- a/website/docs/r/application_gateway.html.markdown
+++ b/website/docs/r/application_gateway.html.markdown
@@ -161,7 +161,7 @@ The following arguments are supported:
 
 * `trusted_root_certificate` - (Optional) One or more `trusted_root_certificate` blocks as defined below.
 
-* `ssl_policy` - (Optional) a `ssl policy` block as defined below.
+* `ssl_policy` - (Optional) a `ssl_policy` block as defined below.
 
 * `enable_http2` - (Optional) Is HTTP2 enabled on the application gateway resource? Defaults to `false`.
 
@@ -506,7 +506,7 @@ A `ssl_profile` block supports the following:
 
 * `verify_client_cert_issuer_dn` - (Optional) Should client certificate issuer DN be verified?  Defaults to `false`.
 
-* `ssl_policy` - (Optional) a `ssl policy` block as defined below.
+* `ssl_policy` - (Optional) a `ssl_policy` block as defined below.
 
 ---
 

--- a/website/docs/r/automation_module.html.markdown
+++ b/website/docs/r/automation_module.html.markdown
@@ -46,7 +46,7 @@ The following arguments are supported:
 
 * `automation_account_name` - (Required) The name of the automation account in which the Module is created. Changing this forces a new resource to be created.
 
-* `module_link` - (Required) The published Module link `module_link` block defined as blow.
+* `module_link` - (Required) A `module_link` block as defined blow.
 
 ---
 
@@ -54,13 +54,13 @@ The `module_link` block supports the following:
 
 * `uri` - (Required) The URI of the module content (zip or nupkg).
 
-* `hash` - (Optional) A `hash` block defined as below.
+* `hash` - (Optional) A `hash` block as defined below.
 
 ---
 
 The `hash` block supports the following:
 
-* `algorithm` - (Required) Specify the algorithm used for the hash content.
+* `algorithm` - (Required) Specifies the algorithm used for the hash content.
 
 * `value` - (Required) The hash value of the content.
 

--- a/website/docs/r/automation_module.html.markdown
+++ b/website/docs/r/automation_module.html.markdown
@@ -46,13 +46,23 @@ The following arguments are supported:
 
 * `automation_account_name` - (Required) The name of the automation account in which the Module is created. Changing this forces a new resource to be created.
 
-* `module_link` - (Required) The published Module link.
+* `module_link` - (Required) The published Module link `module_link` block defined as blow.
 
 ---
 
 The `module_link` block supports the following:
 
 * `uri` - (Required) The URI of the module content (zip or nupkg).
+
+* `hash` - (Optional) A `hash` block defined as below.
+
+---
+
+The `hash` block supports the following:
+
+* `algorithm` - (Required) Specify the algorithm used for the hash content.
+
+* `value` - (Required) The hash value of the content.
 
 ## Attributes Reference
 

--- a/website/docs/r/automation_runbook.html.markdown
+++ b/website/docs/r/automation_runbook.html.markdown
@@ -132,23 +132,23 @@ The `draft` block supports:
 
 * `edit_mode_enabled` - (Optional) Whether the draft in edit mode.
 
-* `content_link` - (Optional) The Draft Content Link defined as `publish_content_link` above.
+* `content_link` - (Optional) A `publish_content_link` block as defined above.
 
 * `output_types` - (Optional) Specifies the output types of the runbook.
 
-* `parameter` - (Optional) A list of `parameter` block as define below.
+* `parameters` - (Optional) A list of `parameters` block as define below.
 
 ---
 
-The `parameter` block supports:
+The `parameters` block supports:
 
 * `key` - (Required) The name of the parameter.
 
-* `type` - (Optional) Specifies the type of this parameter.
+* `type` - (Required) Specifies the type of this parameter.
 
 * `mandatory` - (Optional) Whether this parameter is mandatory.
 
-* `positioin` - (Optional) Specifies the position of the parameter.
+* `position` - (Optional) Specifies the position of the parameter.
 
 * `default_value` - (Optional) Specifies the default value of the parameter.
 

--- a/website/docs/r/automation_runbook.html.markdown
+++ b/website/docs/r/automation_runbook.html.markdown
@@ -136,7 +136,7 @@ The `draft` block supports:
 
 * `output_types` - (Optional) Specifies the output types of the runbook.
 
-* `parameters` - (Optional) A list of `parameters` block as define below.
+* `parameters` - (Optional) A list of `parameters` block as defined below.
 
 ---
 

--- a/website/docs/r/automation_software_update_configuration.html.markdown
+++ b/website/docs/r/automation_software_update_configuration.html.markdown
@@ -119,7 +119,7 @@ A `azure_query` block supports the following:
 
 * `tag_filter` - (Optional) Specifies how the specified tags to filter VMs. Possible values are `Any` and `All`.
 
-* `tags` - (Optional) A mapping of tags used for query filter.
+* `tags` - (Optional) A mapping of tags used for query filter defined as below.
 
 ---
 
@@ -175,11 +175,11 @@ A `schedule` block supports the following:
 
 * `advanced_month_days` - (Optional) List of days of the month that the job should execute on. Must be between `1` and `31`. `-1` for last day of the month. Only valid when frequency is `Month`.
 
-* `monthly_occurrence` - (Optional) List of occurrences of days within a month. Only valid when frequency is `Month`. The `monthly_occurrence` block supports fields documented below.
+* `monthly_occurrence` - (Optional) List of occurrences of days within a month. Only valid when frequency is `Month`. The `monthly_occurrence` block supports fields as defined below.
 
 ---
 
-The `monthly_occurrence` block supports:
+The `monthly_occurrence` block supports the following:
 
 * `day` - (Required) Day of the occurrence. Must be one of `Monday`, `Tuesday`, `Wednesday`, `Thursday`, `Friday`, `Saturday`, `Sunday`.
 

--- a/website/docs/r/automation_software_update_configuration.html.markdown
+++ b/website/docs/r/automation_software_update_configuration.html.markdown
@@ -119,7 +119,7 @@ A `azure_query` block supports the following:
 
 * `tag_filter` - (Optional) Specifies how the specified tags to filter VMs. Possible values are `Any` and `All`.
 
-* `tags` - (Optional) A mapping of tags used for query filter defined as below.
+* `tags` - (Optional) A mapping of tags used for query filter as defined below.
 
 ---
 

--- a/website/docs/r/express_route_port.html.markdown
+++ b/website/docs/r/express_route_port.html.markdown
@@ -84,9 +84,9 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `identity` - A `identity` block as defined below.
   
-* `link1` - A list of `link` block as defined below.
+* `link1` - A list of `link` blocks as defined below.
 
-* `link2` - A list of `link` block as defined below.
+* `link2` - A list of `link` blocks as defined below.
 
 * `guid` - The resource GUID of the Express Route Port.
   

--- a/website/docs/r/express_route_port.html.markdown
+++ b/website/docs/r/express_route_port.html.markdown
@@ -84,7 +84,9 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `identity` - A `identity` block as defined below.
   
-* `link` - A list of `link` block as defined below.
+* `link1` - A list of `link` block as defined below.
+
+* `link2` - A list of `link` block as defined below.
 
 * `guid` - The resource GUID of the Express Route Port.
   

--- a/website/docs/r/fluid_relay_servers.html.markdown
+++ b/website/docs/r/fluid_relay_servers.html.markdown
@@ -73,7 +73,7 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 ---
 
-`identity` exports the following:
+An `identity` block exports the following:
 
 * `principal_id` - The Principal ID for the Service Principal associated with the Identity of this Fluid Relay Server.
 

--- a/website/docs/r/nat_gateway.html.markdown
+++ b/website/docs/r/nat_gateway.html.markdown
@@ -56,10 +56,6 @@ The following arguments are supported:
 
 * `idle_timeout_in_minutes` - (Optional) The idle timeout which should be used in minutes. Defaults to `4`.
 
-* `public_ip_address_ids` - (Optional / **Deprecated in favour of `azurerm_nat_gateway_public_ip_association`**) A list of Public IP Address IDs which should be associated with the NAT Gateway resource.
-
-* `public_ip_prefix_ids` - (Optional) / **Deprecated in favour of `azurerm_nat_gateway_public_ip_prefix_association`**) A list of Public IP Prefix IDs which should be associated with the NAT Gateway resource.
-
 * `sku_name` - (Optional) The SKU which should be used. At this time the only supported value is `Standard`. Defaults to `Standard`.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource. 

--- a/website/docs/r/orbital_contact_profile.html.markdown
+++ b/website/docs/r/orbital_contact_profile.html.markdown
@@ -96,11 +96,13 @@ The following arguments are supported:
 
 * `minimum_elevation_degrees` - (Optional) Maximum elevation of the antenna during the contact in decimal degrees.
 
+* `tags` - (Optional) A mapping of tags to assign to the resource.
+
 ---
 
 A `links` block supports the following:
 
-* `channels` - (Required) A list of contact profile link channels. A `channel` block as defined below.
+* `channels` - (Required) A list of contact profile link channels. A `channels` block as defined below.
 
 * `direction` - (Required) Direction of the link. Possible values are `Uplink` and `Downlink`.
 

--- a/website/docs/r/orbital_spacecraft.html.markdown
+++ b/website/docs/r/orbital_spacecraft.html.markdown
@@ -55,9 +55,9 @@ The following arguments are supported:
 
 * `links` - (Required) A `links` block as defined below.
 
-* `two_line_elements` - (Required) A list of the two line elements(TLE), the first string in the list is the first line of TLE, the second one is the second line of TLE.
+* `two_line_elements` - (Required) A list of the two line elements (TLE), the first string being the first of the TLE, the second string being the second line of the TLE.
 
-* `title_line` - (Required) Title of the two line elements(TLE).
+* `title_line` - (Required) Title of the two line elements (TLE).
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 

--- a/website/docs/r/orbital_spacecraft.html.markdown
+++ b/website/docs/r/orbital_spacecraft.html.markdown
@@ -55,7 +55,15 @@ The following arguments are supported:
 
 * `links` - (Required) A `links` block as defined below.
 
+* `two_line_elements` - (Required) A list of the two line elements(TLE), the first string in the list is the first line of TLE, the second one is the second line of TLE.
+
+* `title_line` - (Required) Title of the two line elements(TLE).
+
+* `tags` - (Optional) A mapping of tags to assign to the resource.
+
 ---
+
+A `links` block supports the following:
 
 * `bandwidth_mhz` - (Required) Bandwidth in Mhz.
 
@@ -68,10 +76,6 @@ The following arguments are supported:
 * `name` - (Required) Name of the link. Changing this forces a new resource to be created.
 
 ---
-
-* `two_line_elements` - (Required) A list of the two line elements(TLE), the first string in the list is the first line of TLE, the second one is the second line of TLE.
-
-* `title_line` - (Required) Title of the two line elements(TLE).
 
 ## Attributes Reference
 

--- a/website/docs/r/route_filter.html.markdown
+++ b/website/docs/r/route_filter.html.markdown
@@ -39,7 +39,7 @@ The following arguments are supported:
 
 ---
 
-* `rule` - (Optional) A `rules` block as defined below.
+* `rule` - (Optional) A `rule` block as defined below.
 
 * `tags` - (Optional) A mapping of tags which should be assigned to the Route Filter.
 

--- a/website/docs/r/route_server.html.markdown
+++ b/website/docs/r/route_server.html.markdown
@@ -69,9 +69,13 @@ The following arguments are supported:
 
 -> **NOTE:** Azure Route Server requires a dedicated subnet named RouteServerSubnet. The subnet size has to be at least /27 or short prefix (such as /26 or /25) and cannot be attached to any security group, otherwise, you'll receive an error message when deploying the Route Server
 
+* `sku` - (Required) The SKU of the Route Server. The only possible value is `Standard`.
+
 * `public_ip_address_id` - (Required) The ID of the Public IP Address. This option is required since September 1st 2021. Changing this forces a new resource to be created.
 
 * `branch_to_branch_traffic_enabled` - (Optional)  Whether to enable route exchange between Azure Route Server and the gateway(s)
+
+* `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ## Attributes Reference
 

--- a/website/docs/r/subnet.html.markdown
+++ b/website/docs/r/subnet.html.markdown
@@ -105,7 +105,6 @@ The following attributes are exported:
 * `name` - (Required) The name of the subnet.
 * `resource_group_name` - (Required) The name of the resource group in which the subnet is created in.
 * `virtual_network_name` - (Required) The name of the virtual network in which the subnet is created in
-* `address_prefix` - (Deprecated) The address prefix for the subnet
 * `address_prefixes` - (Required) The address prefixes for the subnet
 
 ## Timeouts

--- a/website/docs/r/virtual_network_gateway.html.markdown
+++ b/website/docs/r/virtual_network_gateway.html.markdown
@@ -149,6 +149,8 @@ The following arguments are supported:
 
 * `bgp_settings` - (Optional) A `bgp_settings` block which is documented below. In this block the BGP specific settings can be defined.
 
+* `custom_route` - (Optional) A `custom_route` block as defined below. Specify a custom routes address space specified by the customer for virtual network gateway and VpnClient.
+
 * `generation` - (Optional) The Generation of the Virtual Network gateway. Possible values include `Generation1`, `Generation2` or `None`. Changing this forces a new resource to be created.
 
 -> **NOTE:** The available values depend on the `type` and `sku` arguments - where `Generation2` is only value for a `sku` larger than `VpnGw2` or `VpnGw2AZ`.
@@ -249,6 +251,14 @@ The `root_certificate` block supports:
     authority. The certificate must be provided in Base-64 encoded X.509 format
     (PEM). In particular, this argument *must not* include the
     `-----BEGIN CERTIFICATE-----` or `-----END CERTIFICATE-----` markers.
+
+---
+
+The `revoked_certificate` block supports:
+
+* `name` - (Required) Specify the name of the certificate resource.
+
+* `public_cert_data` - (Required) Specify the public data of the certificate.
 
 ---
 

--- a/website/docs/r/virtual_network_gateway.html.markdown
+++ b/website/docs/r/virtual_network_gateway.html.markdown
@@ -149,7 +149,7 @@ The following arguments are supported:
 
 * `bgp_settings` - (Optional) A `bgp_settings` block which is documented below. In this block the BGP specific settings can be defined.
 
-* `custom_route` - (Optional) A `custom_route` block as defined below. Specify a custom routes address space specified by the customer for virtual network gateway and VpnClient.
+* `custom_route` - (Optional) A `custom_route` block as defined below. Specifies a custom routes address space for a virtual network gateway and a VpnClient.
 
 * `generation` - (Optional) The Generation of the Virtual Network gateway. Possible values include `Generation1`, `Generation2` or `None`. Changing this forces a new resource to be created.
 
@@ -256,9 +256,9 @@ The `root_certificate` block supports:
 
 The `revoked_certificate` block supports:
 
-* `name` - (Required) Specify the name of the certificate resource.
+* `name` - (Required) Specifies the name of the certificate resource.
 
-* `public_cert_data` - (Required) Specify the public data of the certificate.
+* `public_cert_data` - (Required) Specifies the public data of the certificate.
 
 ---
 


### PR DESCRIPTION
fix document typos or missed properties of some RPs.