### PR TITLE
`azurerm_databox_edge_device` - swap to typed sdk, add data source.

### DIFF
--- a/internal/provider/services.go
+++ b/internal/provider/services.go
@@ -131,6 +131,7 @@ func SupportedTypedServices() []sdk.TypedServiceRegistration {
 		cosmos.Registration{},
 		costmanagement.Registration{},
 		dashboard.Registration{},
+		databoxedge.Registration{},
 		databricks.Registration{},
 		digitaltwins.Registration{},
 		disks.Registration{},

--- a/internal/services/databoxedge/databox_edge_device_data_source.go
+++ b/internal/services/databoxedge/databox_edge_device_data_source.go
@@ -140,8 +140,7 @@ func (d EdgeDeviceDataSource) Read() sdk.ResourceFunc {
 			if err != nil {
 				if utils.ResponseWasNotFound(resp.Response) {
 					log.Printf("[INFO] %s was not found - removing from state", id)
-					metadata.MarkAsGone(id)
-					return nil
+					return metadata.MarkAsGone(id)
 				}
 				return fmt.Errorf("retrieving %s: %+v", id, err)
 			}
@@ -160,9 +159,7 @@ func (d EdgeDeviceDataSource) Read() sdk.ResourceFunc {
 
 			metadata.SetID(id)
 
-			metadata.Encode(&state)
-
-			return nil
+			return metadata.Encode(&state)
 		},
 	}
 }

--- a/internal/services/databoxedge/databox_edge_device_data_source.go
+++ b/internal/services/databoxedge/databox_edge_device_data_source.go
@@ -1,0 +1,168 @@
+package databoxedge
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/databoxedge/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/databoxedge/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+type EdgeDeviceDataSource struct{}
+
+var _ sdk.DataSource = EdgeDeviceDataSource{}
+
+func (d EdgeDeviceDataSource) Arguments() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validate.DataboxEdgeName,
+		},
+
+		"resource_group_name": commonschema.ResourceGroupName(),
+	}
+}
+
+func (d EdgeDeviceDataSource) Attributes() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+
+		"location": commonschema.LocationComputed(),
+
+		"sku_name": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"device_properties": {
+			Type:     pluginsdk.TypeList,
+			Computed: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"configured_role_types": {
+						Type:     pluginsdk.TypeList,
+						Computed: true,
+						Elem: &pluginsdk.Schema{
+							Type: pluginsdk.TypeString,
+						},
+					},
+
+					"culture": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+
+					"hcs_version": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+
+					"capacity": {
+						Type:     pluginsdk.TypeInt,
+						Computed: true,
+					},
+
+					"model": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+
+					"status": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+
+					"software_version": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+
+					"type": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+
+					"node_count": {
+						Type:     pluginsdk.TypeInt,
+						Computed: true,
+					},
+
+					"serial_number": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+
+					"time_zone": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
+				},
+			},
+		},
+
+		"tags": commonschema.TagsDataSource(),
+	}
+}
+
+func (d EdgeDeviceDataSource) ModelObject() interface{} {
+	return &EdgeDeviceModel{}
+}
+
+func (d EdgeDeviceDataSource) ResourceType() string {
+	return "azurerm_databox_edge_device"
+}
+
+func (d EdgeDeviceDataSource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			subscriptionId := metadata.Client.Account.SubscriptionId
+			client := metadata.Client.DataboxEdge.DeviceClient
+
+			var metaModel EdgeDeviceModel
+			if err := metadata.Decode(&metaModel); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			id := parse.NewDeviceID(subscriptionId, metaModel.ResourceGroupName, metaModel.Name)
+
+			resp, err := client.Get(ctx, id.DataBoxEdgeDeviceName, id.ResourceGroup)
+			if err != nil {
+				if utils.ResponseWasNotFound(resp.Response) {
+					log.Printf("[INFO] %s was not found - removing from state", id)
+					metadata.MarkAsGone(id)
+					return nil
+				}
+				return fmt.Errorf("retrieving %s: %+v", id, err)
+			}
+
+			state := EdgeDeviceModel{
+				Name:              id.DataBoxEdgeDeviceName,
+				ResourceGroupName: id.ResourceGroup,
+				Location:          location.NormalizeNilable(resp.Location),
+			}
+
+			if props := resp.DeviceProperties; props != nil {
+				state.DeviceProperties = flattenDeviceProperties(props)
+				state.SkuName = flattenDeviceSku(resp.Sku)
+				state.Tags = tags.ToTypedObject(resp.Tags)
+			}
+
+			metadata.SetID(id)
+
+			metadata.Encode(&state)
+
+			return nil
+		},
+	}
+}

--- a/internal/services/databoxedge/databox_edge_device_data_source_test.go
+++ b/internal/services/databoxedge/databox_edge_device_data_source_test.go
@@ -17,7 +17,7 @@ func TestAccDataboxEdgeDeviceDataSource_complete(t *testing.T) {
 		{
 			Config: DataboxEdgeDeviceDataSource{}.complete(data),
 			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).Key("location").HasValue(data.Locations.Primary),
+				check.That(data.ResourceName).Key("location").Exists(),
 				check.That(data.ResourceName).Key("sku_name").HasValue("EdgeP_Base-Standard"),
 				check.That(data.ResourceName).Key("tags.%").HasValue("1"),
 			),

--- a/internal/services/databoxedge/databox_edge_device_data_source_test.go
+++ b/internal/services/databoxedge/databox_edge_device_data_source_test.go
@@ -1,0 +1,40 @@
+package databoxedge_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+)
+
+type DataboxEdgeDeviceDataSource struct{}
+
+func TestAccDataboxEdgeDeviceDataSource_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_databox_edge_device", "test")
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: DataboxEdgeDeviceDataSource{}.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("location").HasValue(data.Locations.Primary),
+				check.That(data.ResourceName).Key("sku_name").HasValue("EdgeP_Base-Standard"),
+				check.That(data.ResourceName).Key("tags.%").HasValue("1"),
+			),
+		},
+		data.ImportStep(),
+	},
+	)
+}
+
+func (r DataboxEdgeDeviceDataSource) complete(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_databox_edge_device" "test" {
+  name                = azurerm_databox_edge_device.test.name
+  resource_group_name = azurerm_databox_edge_device.test.resource_group_name
+}
+
+`, DataboxEdgeDeviceResource{}.complete(data))
+}

--- a/internal/services/databoxedge/databox_edge_device_resource.go
+++ b/internal/services/databoxedge/databox_edge_device_resource.go
@@ -211,8 +211,7 @@ func (r EdgeDeviceResource) Read() sdk.ResourceFunc {
 			if err != nil {
 				if utils.ResponseWasNotFound(resp.Response) {
 					log.Printf("[INFO] %s was not found - removing from state", id)
-					metadata.MarkAsGone(id)
-					return nil
+					return metadata.MarkAsGone(id)
 				}
 				return fmt.Errorf("retrieving %s: %+v", id, err)
 			}
@@ -231,9 +230,7 @@ func (r EdgeDeviceResource) Read() sdk.ResourceFunc {
 
 			metadata.SetID(id)
 
-			metadata.Encode(&state)
-
-			return nil
+			return metadata.Encode(&state)
 		},
 	}
 }

--- a/internal/services/databoxedge/databox_edge_device_resource.go
+++ b/internal/services/databoxedge/databox_edge_device_resource.go
@@ -1,6 +1,7 @@
 package databoxedge
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"time"
@@ -8,239 +9,291 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/databoxedge/mgmt/2020-12-01/databoxedge" // nolint: staticcheck
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/databoxedge/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/databoxedge/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
-func resourceDevice() *pluginsdk.Resource {
-	return &pluginsdk.Resource{
-		Create: resourceDeviceCreate,
-		Read:   resourceDeviceRead,
-		Update: resourceDeviceUpdate,
-		Delete: resourceDeviceDelete,
+type DevicePropertiesModel struct {
+	Capacity            int64    `tfschema:"capacity"`
+	ConfiguredRoleTypes []string `tfschema:"configured_role_types"`
+	Culture             string   `tfschema:"culture"`
+	HcsVersion          string   `tfschema:"hcs_version"`
+	Model               string   `tfschema:"model"`
+	NodeCount           int32    `tfschema:"node_count"`
+	SerialNumber        string   `tfschema:"serial_number"`
+	SoftwareVersion     string   `tfschema:"software_version"`
+	Status              string   `tfschema:"status"`
+	TimeZone            string   `tfschema:"time_zone"`
+	Type                string   `tfschema:"type"`
+}
+type EdgeDeviceModel struct {
+	DeviceProperties  []DevicePropertiesModel `tfschema:"device_properties"`
+	Location          string                  `tfschema:"location"`
+	Name              string                  `tfschema:"name"`
+	ResourceGroupName string                  `tfschema:"resource_group_name"`
+	SkuName           string                  `tfschema:"sku_name"`
+	Tags              map[string]string       `tfschema:"tags"`
+}
 
-		Timeouts: &pluginsdk.ResourceTimeout{
-			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
-			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
-			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
-			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
+type EdgeDeviceResource struct{}
+
+var _ sdk.ResourceWithUpdate = EdgeDeviceResource{}
+
+func (r EdgeDeviceResource) ModelObject() interface{} {
+	return &EdgeDeviceModel{}
+}
+
+func (r EdgeDeviceResource) ResourceType() string {
+	return "azurerm_databox_edge_device"
+}
+
+func (r EdgeDeviceResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+	return validate.DeviceID
+}
+
+func (r EdgeDeviceResource) Arguments() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validate.DataboxEdgeName,
 		},
 
-		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
-			_, err := parse.DeviceID(id)
-			return err
-		}),
+		"resource_group_name": commonschema.ResourceGroupName(),
 
-		Schema: map[string]*pluginsdk.Schema{
-			"name": {
-				Type:         pluginsdk.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validate.DataboxEdgeName,
-			},
+		"location": commonschema.Location(),
 
-			"resource_group_name": commonschema.ResourceGroupName(),
+		"sku_name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validate.DataboxEdgeDeviceSkuName,
+		},
 
-			"location": commonschema.Location(),
+		"tags": tags.Schema(),
+	}
+}
 
-			"sku_name": {
-				Type:         pluginsdk.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validate.DataboxEdgeDeviceSkuName,
-			},
-
-			"device_properties": {
-				Type:     pluginsdk.TypeList,
-				Computed: true,
-				Elem: &pluginsdk.Resource{
-					Schema: map[string]*pluginsdk.Schema{
-						"configured_role_types": {
-							Type:     pluginsdk.TypeList,
-							Computed: true,
-							Elem: &pluginsdk.Schema{
-								Type: pluginsdk.TypeString,
-							},
+func (r EdgeDeviceResource) Attributes() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"device_properties": {
+			Type:     pluginsdk.TypeList,
+			Computed: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"configured_role_types": {
+						Type:     pluginsdk.TypeList,
+						Computed: true,
+						Elem: &pluginsdk.Schema{
+							Type: pluginsdk.TypeString,
 						},
+					},
 
-						"culture": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
+					"culture": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
 
-						"hcs_version": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
+					"hcs_version": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
 
-						"capacity": {
-							Type:     pluginsdk.TypeInt,
-							Computed: true,
-						},
+					"capacity": {
+						Type:     pluginsdk.TypeInt,
+						Computed: true,
+					},
 
-						"model": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
+					"model": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
 
-						"status": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
+					"status": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
 
-						"software_version": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
+					"software_version": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
 
-						"type": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
+					"type": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
 
-						"node_count": {
-							Type:     pluginsdk.TypeInt,
-							Computed: true,
-						},
+					"node_count": {
+						Type:     pluginsdk.TypeInt,
+						Computed: true,
+					},
 
-						"serial_number": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
+					"serial_number": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
+					},
 
-						"time_zone": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
-						},
+					"time_zone": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
 					},
 				},
 			},
-
-			"tags": tags.Schema(),
 		},
 	}
 }
 
-func resourceDeviceCreate(d *pluginsdk.ResourceData, meta interface{}) error {
-	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
-	client := meta.(*clients.Client).DataboxEdge.DeviceClient
-	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
-	defer cancel()
+func (r EdgeDeviceResource) Create() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			subscriptionId := metadata.Client.Account.SubscriptionId
+			client := metadata.Client.DataboxEdge.DeviceClient
 
-	id := parse.NewDeviceID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
-	// sdk method is Get(ctx context.Context, deviceName string, resourceGroupName string)
-	existing, err := client.Get(ctx, id.DataBoxEdgeDeviceName, id.ResourceGroup)
-	if err != nil {
-		if !utils.ResponseWasNotFound(existing.Response) {
-			return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
-		}
-	}
-	if !utils.ResponseWasNotFound(existing.Response) {
-		return tf.ImportAsExistsError("azurerm_databox_edge_device", id.ID())
-	}
+			var metaModel EdgeDeviceModel
+			if err := metadata.Decode(&metaModel); err != nil {
+				return fmt.Errorf("decoding %+v", err)
+			}
 
-	dataBoxEdgeDevice := databoxedge.Device{
-		Location: utils.String(location.Normalize(d.Get("location").(string))),
-		Sku:      expandDeviceSku(d.Get("sku_name").(string)),
-		Tags:     tags.Expand(d.Get("tags").(map[string]interface{})),
-	}
-	future, err := client.CreateOrUpdate(ctx, id.DataBoxEdgeDeviceName, dataBoxEdgeDevice, id.ResourceGroup)
-	if err != nil {
-		return fmt.Errorf("creating %s: %+v", id, err)
-	}
+			id := parse.NewDeviceID(subscriptionId, metaModel.ResourceGroupName, metaModel.Name)
+			// sdk method is Get(ctx context.Context, deviceName string, resourceGroupName string)
+			existing, err := client.Get(ctx, id.DataBoxEdgeDeviceName, id.ResourceGroup)
+			if err != nil {
+				if !utils.ResponseWasNotFound(existing.Response) {
+					return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+				}
+			}
+			if !utils.ResponseWasNotFound(existing.Response) {
+				return tf.ImportAsExistsError("azurerm_databox_edge_device", id.ID())
+			}
 
-	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting for creation of %s: %+v", id, err)
-	}
+			dataBoxEdgeDevice := databoxedge.Device{
+				Location: utils.String(location.Normalize(metaModel.Location)),
+				Sku:      expandDeviceSku(metaModel.SkuName),
+				Tags:     tags.FromTypedObject(metaModel.Tags),
+			}
 
-	d.SetId(id.ID())
-	return resourceDeviceRead(d, meta)
-}
+			future, err := client.CreateOrUpdate(ctx, id.DataBoxEdgeDeviceName, dataBoxEdgeDevice, id.ResourceGroup)
+			if err != nil {
+				return fmt.Errorf("creating %s: %+v", id, err)
+			}
 
-func resourceDeviceRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).DataboxEdge.DeviceClient
-	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
-	defer cancel()
+			if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
+				return fmt.Errorf("waiting for creation of %s: %+v", id, err)
+			}
 
-	id, err := parse.DeviceID(d.Id())
-	if err != nil {
-		return err
-	}
-
-	resp, err := client.Get(ctx, id.DataBoxEdgeDeviceName, id.ResourceGroup)
-	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
-			log.Printf("[INFO] %s was not found - removing from state", *id)
-			d.SetId("")
+			metadata.SetID(id)
 			return nil
-		}
-		return fmt.Errorf("retrieving %s: %+v", *id, err)
+		},
 	}
-
-	d.Set("name", id.DataBoxEdgeDeviceName)
-	d.Set("resource_group_name", id.ResourceGroup)
-	d.Set("location", location.NormalizeNilable(resp.Location))
-
-	if props := resp.DeviceProperties; props != nil {
-		if err := d.Set("device_properties", flattenDeviceProperties(props)); err != nil {
-			return fmt.Errorf("flattening 'device_properties': %+v", err)
-		}
-	}
-
-	if err := d.Set("sku_name", flattenDeviceSku(resp.Sku)); err != nil {
-		return fmt.Errorf("setting `sku_name`: %+v", err)
-	}
-
-	return tags.FlattenAndSet(d, resp.Tags)
 }
 
-func resourceDeviceUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).DataboxEdge.DeviceClient
-	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
-	defer cancel()
+func (r EdgeDeviceResource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.DataboxEdge.DeviceClient
 
-	id, err := parse.DeviceID(d.Id())
-	if err != nil {
-		return err
+			id, err := parse.DeviceID(metadata.ResourceData.Id())
+			if err != nil {
+				return fmt.Errorf("parse: %+v", err)
+			}
+
+			resp, err := client.Get(ctx, id.DataBoxEdgeDeviceName, id.ResourceGroup)
+			if err != nil {
+				if utils.ResponseWasNotFound(resp.Response) {
+					log.Printf("[INFO] %s was not found - removing from state", id)
+					metadata.MarkAsGone(id)
+					return nil
+				}
+				return fmt.Errorf("retrieving %s: %+v", id, err)
+			}
+
+			state := EdgeDeviceModel{
+				Name:              id.DataBoxEdgeDeviceName,
+				ResourceGroupName: id.ResourceGroup,
+				Location:          location.NormalizeNilable(resp.Location),
+			}
+
+			if props := resp.DeviceProperties; props != nil {
+				state.DeviceProperties = flattenDeviceProperties(props)
+				state.SkuName = flattenDeviceSku(resp.Sku)
+				state.Tags = tags.ToTypedObject(resp.Tags)
+			}
+
+			metadata.SetID(id)
+
+			metadata.Encode(&state)
+
+			return nil
+		},
 	}
-
-	parameters := databoxedge.DevicePatch{}
-	if d.HasChange("tags") {
-		parameters.Tags = tags.Expand(d.Get("tags").(map[string]interface{}))
-	}
-
-	if _, err := client.Update(ctx, id.DataBoxEdgeDeviceName, parameters, id.ResourceGroup); err != nil {
-		return fmt.Errorf("updating %s: %+v", *id, err)
-	}
-
-	return resourceDeviceRead(d, meta)
 }
 
-func resourceDeviceDelete(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).DataboxEdge.DeviceClient
-	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
-	defer cancel()
+func (r EdgeDeviceResource) Update() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.DataboxEdge.DeviceClient
 
-	id, err := parse.DeviceID(d.Id())
-	if err != nil {
-		return err
-	}
+			id, err := parse.DeviceID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
 
-	future, err := client.Delete(ctx, id.DataBoxEdgeDeviceName, id.ResourceGroup)
-	if err != nil {
-		return fmt.Errorf("deleting %s: %+v", *id, err)
-	}
+			var metaModel EdgeDeviceModel
+			if err := metadata.Decode(&metaModel); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
 
-	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting for deletion of %s: %+v", *id, err)
+			parameters := databoxedge.DevicePatch{}
+			if metadata.ResourceData.HasChange("tags") {
+				parameters.Tags = tags.FromTypedObject(metaModel.Tags)
+			}
+
+			if _, err := client.Update(ctx, id.DataBoxEdgeDeviceName, parameters, id.ResourceGroup); err != nil {
+				return fmt.Errorf("updating %s: %+v", *id, err)
+			}
+
+			return nil
+		},
 	}
-	return nil
+}
+
+func (r EdgeDeviceResource) Delete() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.DataboxEdge.DeviceClient
+
+			id, err := parse.DeviceID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			var metaModel EdgeDeviceModel
+			if err := metadata.Decode(&metaModel); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+			future, err := client.Delete(ctx, id.DataBoxEdgeDeviceName, id.ResourceGroup)
+			if err != nil {
+				return fmt.Errorf("deleting %s: %+v", *id, err)
+			}
+
+			if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
+				return fmt.Errorf("waiting for deletion of %s: %+v", *id, err)
+			}
+			return nil
+		},
+	}
 }
 
 func expandDeviceSku(input string) *databoxedge.Sku {
@@ -259,8 +312,8 @@ func expandDeviceSku(input string) *databoxedge.Sku {
 	}
 }
 
-func flattenDeviceProperties(input *databoxedge.DeviceProperties) *[]interface{} {
-	output := make([]interface{}, 0)
+func flattenDeviceProperties(input *databoxedge.DeviceProperties) []DevicePropertiesModel {
+	output := make([]DevicePropertiesModel, 0)
 	configuredRoleTypes := make([]string, 0)
 
 	var status string
@@ -275,73 +328,73 @@ func flattenDeviceProperties(input *databoxedge.DeviceProperties) *[]interface{}
 	var timeZone string
 
 	if input != nil {
+		o := DevicePropertiesModel{}
 		if input.ConfiguredRoleTypes != nil {
 			for _, item := range *input.ConfiguredRoleTypes {
 				configuredRoleTypes = append(configuredRoleTypes, (string)(item))
 			}
+			o.ConfiguredRoleTypes = configuredRoleTypes
 		}
 
 		if input.DataBoxEdgeDeviceStatus != "" {
 			status = string(input.DataBoxEdgeDeviceStatus)
+			o.Status = status
 		}
 
 		if input.Culture != nil {
 			culture = *input.Culture
+			o.Culture = culture
 		}
 
 		if input.DeviceHcsVersion != nil {
 			hcsVersion = *input.DeviceHcsVersion
+			o.HcsVersion = hcsVersion
 		}
 
 		if input.DeviceLocalCapacity != nil {
 			capacity = *input.DeviceLocalCapacity
+			o.Capacity = capacity
 		}
 
 		if input.DeviceModel != nil {
 			model = *input.DeviceModel
+			o.Model = model
 		}
 
 		if input.DeviceSoftwareVersion != nil {
 			softwareVersion = *input.DeviceSoftwareVersion
+			o.SoftwareVersion = softwareVersion
 		}
 
 		if input.DeviceType != "" {
 			deviceType = string(input.DeviceType)
+			o.Type = deviceType
 		}
 
 		if input.NodeCount != nil {
 			nodeCount = *input.NodeCount
+			o.NodeCount = nodeCount
 		}
 
 		if input.SerialNumber != nil {
 			serialNumber = *input.SerialNumber
+			o.SerialNumber = serialNumber
 		}
 
 		if input.TimeZone != nil {
 			timeZone = *input.TimeZone
+			o.TimeZone = timeZone
 		}
+
+		output = append(output, o)
 	}
 
-	output = append(output, map[string]interface{}{
-		"configured_role_types": utils.FlattenStringSlice(&configuredRoleTypes),
-		"culture":               culture,
-		"hcs_version":           hcsVersion,
-		"capacity":              capacity,
-		"model":                 model,
-		"status":                status,
-		"software_version":      softwareVersion,
-		"type":                  deviceType,
-		"node_count":            nodeCount,
-		"serial_number":         serialNumber,
-		"time_zone":             timeZone,
-	})
-
-	return &output
+	return output
 }
 
-func flattenDeviceSku(input *databoxedge.Sku) *string {
+func flattenDeviceSku(input *databoxedge.Sku) string {
 	if input == nil {
-		return nil
+		return ""
 	}
 
 	var name databoxedge.SkuName
@@ -359,5 +412,5 @@ func flattenDeviceSku(input *databoxedge.Sku) *string {
 
 	skuName := fmt.Sprintf("%s-%s", name, tier)
 
-	return &skuName
+	return skuName
 }

--- a/internal/services/databoxedge/registration.go
+++ b/internal/services/databoxedge/registration.go
@@ -7,7 +7,10 @@ import (
 
 type Registration struct{}
 
-var _ sdk.UntypedServiceRegistrationWithAGitHubLabel = Registration{}
+var (
+	_ sdk.TypedServiceRegistrationWithAGitHubLabel   = Registration{}
+	_ sdk.UntypedServiceRegistrationWithAGitHubLabel = Registration{}
+)
 
 func (r Registration) AssociatedGitHubLabel() string {
 	return "service/databox-edge"
@@ -25,6 +28,18 @@ func (r Registration) WebsiteCategories() []string {
 	}
 }
 
+func (r Registration) DataSources() []sdk.DataSource {
+	return []sdk.DataSource{
+		EdgeDeviceDataSource{},
+	}
+}
+
+func (r Registration) Resources() []sdk.Resource {
+	return []sdk.Resource{
+		EdgeDeviceResource{},
+	}
+}
+
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
 	return map[string]*pluginsdk.Resource{}
@@ -33,7 +48,6 @@ func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
 // SupportedResources returns the supported Resources supported by this Service
 func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 	return map[string]*pluginsdk.Resource{
-		"azurerm_databox_edge_device": resourceDevice(),
-		"azurerm_databox_edge_order":  resourceOrder(),
+		"azurerm_databox_edge_order": resourceOrder(),
 	}
 }

--- a/website/docs/d/databox_edge_device.html.markdown
+++ b/website/docs/d/databox_edge_device.html.markdown
@@ -1,0 +1,76 @@
+---
+subcategory: "Databox Edge"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_databox_edge_device"
+description: |-
+  Get information about a Databox Edge Device.
+---
+
+# azurerm_databox_edge_device
+
+Get information about a Databox Edge Device.
+
+## Example Usage
+
+```hcl
+data "azurerm_databox_edge_device" "example" {
+  name                = "example-device"
+  resource_group_name = "example-rg"
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name which should be used for this Databox Edge Device. Changing this forces a new Databox Edge Device to be created.
+
+* `resource_group_name` - (Required) The name of the Resource Group where the Databox Edge Device should exist. Changing this forces a new Databox Edge Device to be created.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `id` - The ID of the Databox Edge Device.
+
+* `location` - The Azure Region where the Databox Edge Device should exist.
+
+* `sku_name` - The `sku_name` is comprised of two segments separated by a hyphen (e.g. `TEA_1Node_UPS_Heater-Standard`). The first segment of the `sku_name` defines the `name` of the SKU. The second segment defines the `tier` of the `sku_name`. For more information see the [product documentation]("https://docs.microsoft.com/dotnet/api/microsoft.azure.management.databoxedge.models.sku?view=azure-dotnet"). 
+
+* `device_properties` - A `device_properties` block as defined below.
+
+* `tags` - A mapping of tags which should be assigned to the Databox Edge Device.
+
+---
+
+The `device_properties` block exports the following:
+
+* `configured_role_types` - Type of compute roles configured.
+
+* `culture` - The Data Box Edge/Gateway device culture.
+
+* `hcs_version` - The device software version number of the device (e.g. 1.2.18105.6).
+
+* `capacity` - The Data Box Edge/Gateway device local capacity in MB.
+
+* `model` - The Data Box Edge/Gateway device model.
+
+* `software_version` - The Data Box Edge/Gateway device software version.
+
+* `status` - The status of the Data Box Edge/Gateway device.
+
+* `type` - The type of the Data Box Edge/Gateway device.
+
+* `node_count` - The number of nodes in the cluster.
+
+* `serial_number` - The Serial Number of Data Box Edge/Gateway device.
+
+* `time_zone` - The Data Box Edge/Gateway device timezone.
+
+---
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the Databox Edge Device.


### PR DESCRIPTION
Test
```
terraform-provider-azurerm ❯ TF_ACC=1 go test -v ./internal/services/databoxedge -run=TestAccDataboxEdgeDevice  -timeout=600m
=== RUN   TestAccDataboxEdgeDeviceDataSource_complete
=== PAUSE TestAccDataboxEdgeDeviceDataSource_complete
=== RUN   TestAccDataboxEdgeDevice_basic
=== PAUSE TestAccDataboxEdgeDevice_basic
=== RUN   TestAccDataboxEdgeDevice_requiresImport
=== PAUSE TestAccDataboxEdgeDevice_requiresImport
=== RUN   TestAccDataboxEdgeDevice_complete
=== PAUSE TestAccDataboxEdgeDevice_complete
=== RUN   TestAccDataboxEdgeDevice_update
=== PAUSE TestAccDataboxEdgeDevice_update
=== CONT  TestAccDataboxEdgeDeviceDataSource_complete
=== CONT  TestAccDataboxEdgeDevice_complete
=== CONT  TestAccDataboxEdgeDevice_requiresImport
=== CONT  TestAccDataboxEdgeDevice_basic
=== CONT  TestAccDataboxEdgeDevice_update
--- PASS: TestAccDataboxEdgeDevice_complete (190.55s)
--- PASS: TestAccDataboxEdgeDevice_basic (251.76s)
--- PASS: TestAccDataboxEdgeDeviceDataSource_complete (256.76s)
--- PASS: TestAccDataboxEdgeDevice_requiresImport (276.93s)
--- PASS: TestAccDataboxEdgeDevice_update (453.21s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/databoxedge	454.603s
```