### PR TITLE
Doc:  `policy_set_definition`'s `policy_definition_id` should not use `policy_set_definition_id`

### DIFF
--- a/website/docs/r/policy_set_definition.html.markdown
+++ b/website/docs/r/policy_set_definition.html.markdown
@@ -70,7 +70,7 @@ The following arguments are supported:
 
 A `policy_definition_reference` block supports the following:
 
-* `policy_definition_id` - (Required) The ID of the policy definition or policy set definition that will be included in this policy set definition.
+* `policy_definition_id` - (Required) The ID of the policy definition that will be included in this policy set definition.
 
 * `parameter_values` - (Optional) Parameter values for the referenced policy rule. This field is a JSON string that allows you to assign parameters to this policy rule.
 


### PR DESCRIPTION
I tried locally and the server response error is as below, I believe we cannot use policy_set_definition_id for `policy_definition_id` property.

```
│ Error: creating Policy Set Definition "CIS_1_1": policy.SetDefinitionsClient#CreateOrUpdate: 
Failure responding to request: 
StatusCode=400 -- Original Error: autorest/azure: Service returned an error. Status=400 Code="InvalidCreatePolicySetDefinitionRequest"
 Message="The policy set definition 'CIS_1_1' request is invalid. Referenced policy definitions must be of type 'Microsoft.Authorization/policyDefinitions'."
```

Fixes: #19003 