### PR TITLE
`azurerm_monitor_aad_diagnostic_setting` - fix acc tests: add new log category

### DIFF
--- a/internal/services/monitor/monitor_aad_diagnostic_setting_resource_test.go
+++ b/internal/services/monitor/monitor_aad_diagnostic_setting_resource_test.go
@@ -257,6 +257,14 @@ resource "azurerm_monitor_aad_diagnostic_setting" "test" {
       days    = 1
     }
   }
+  log {
+    category = "EnrichedOffice365AuditLogs"
+    enabled  = false
+    retention_policy {
+      days    = 0
+      enabled = false
+    }
+  }
 }
 `, data.RandomInteger, data.Locations.Primary)
 }
@@ -375,6 +383,14 @@ resource "azurerm_monitor_aad_diagnostic_setting" "test" {
     retention_policy {
       enabled = true
       days    = 1
+    }
+  }
+  log {
+    category = "EnrichedOffice365AuditLogs"
+    enabled  = false
+    retention_policy {
+      days    = 0
+      enabled = false
     }
   }
 }
@@ -522,6 +538,14 @@ resource "azurerm_monitor_aad_diagnostic_setting" "test" {
       days    = 1
     }
   }
+  log {
+    category = "EnrichedOffice365AuditLogs"
+    enabled  = false
+    retention_policy {
+      days    = 0
+      enabled = false
+    }
+  }
 }
 `, data.RandomInteger, data.Locations.Primary)
 }
@@ -633,6 +657,14 @@ resource "azurerm_monitor_aad_diagnostic_setting" "test" {
     retention_policy {
       enabled = true
       days    = 1
+    }
+  }
+  log {
+    category = "EnrichedOffice365AuditLogs"
+    enabled  = false
+    retention_policy {
+      days    = 0
+      enabled = false
     }
   }
 }

--- a/internal/services/mysql/mysql_flexible_server_resource_test.go
+++ b/internal/services/mysql/mysql_flexible_server_resource_test.go
@@ -1013,7 +1013,7 @@ resource "azurerm_key_vault_access_policy" "server" {
   tenant_id    = data.azurerm_client_config.current.tenant_id
   object_id    = azurerm_user_assigned_identity.test.principal_id
 
-  key_permissions    = ["Get", "List", "WrapKey", "UnwrapKey"]
+  key_permissions = ["Get", "List", "WrapKey", "UnwrapKey"]
 }
 
 resource "azurerm_key_vault_access_policy" "client" {
@@ -1021,7 +1021,7 @@ resource "azurerm_key_vault_access_policy" "client" {
   tenant_id    = data.azurerm_client_config.current.tenant_id
   object_id    = data.azurerm_client_config.current.object_id
 
-  key_permissions    = ["Get", "Create", "Delete", "List", "Restore", "Recover", "UnwrapKey", "WrapKey", "Purge", "Encrypt", "Decrypt", "Sign", "Verify"]
+  key_permissions = ["Get", "Create", "Delete", "List", "Restore", "Recover", "UnwrapKey", "WrapKey", "Purge", "Encrypt", "Decrypt", "Sign", "Verify"]
 }
 
 resource "azurerm_key_vault_key" "test" {
@@ -1070,12 +1070,12 @@ resource "azurerm_mysql_flexible_server" "test" {
 
   identity {
     type         = "UserAssigned"
-	identity_ids = [azurerm_user_assigned_identity.test.id]
+    identity_ids = [azurerm_user_assigned_identity.test.id]
   }
-	
+
   customer_managed_key {
-    key_vault_key_id                    = azurerm_key_vault_key.test.id
-    primary_user_assigned_identity_id   = azurerm_user_assigned_identity.test.id
+    key_vault_key_id                  = azurerm_key_vault_key.test.id
+    primary_user_assigned_identity_id = azurerm_user_assigned_identity.test.id
   }
 }
 `, r.cmkTemplate(data), data.RandomInteger)

--- a/internal/services/privatednsresolver/private_dns_resolver_data_source_test.go
+++ b/internal/services/privatednsresolver/private_dns_resolver_data_source_test.go
@@ -72,14 +72,14 @@ func (d PrivateDNSResolverDnsResolverDataSource) basic(data acceptance.TestData)
 %s
 
 resource "azurerm_private_dns_resolver" "test" {
-	name                = "acctest-dr-%d"
-	resource_group_name = azurerm_resource_group.test.name
-	location            = azurerm_resource_group.test.location
-	virtual_network_id  = azurerm_virtual_network.test.id
+  name                = "acctest-dr-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  virtual_network_id  = azurerm_virtual_network.test.id
 }
 
 data "azurerm_private_dns_resolver" "test" {
-  name         		  = azurerm_private_dns_resolver.test.name
+  name                = azurerm_private_dns_resolver.test.name
   resource_group_name = azurerm_resource_group.test.name
 }
 `, template, data.RandomInteger)
@@ -91,17 +91,17 @@ func (d PrivateDNSResolverDnsResolverDataSource) complete(data acceptance.TestDa
 %s
 
 resource "azurerm_private_dns_resolver" "test" {
-	name                = "acctest-dr-%d"
-	resource_group_name = azurerm_resource_group.test.name
-	location            = azurerm_resource_group.test.location
-	virtual_network_id  = azurerm_virtual_network.test.id
-	tags = {
-		key = "value"
-	}
+  name                = "acctest-dr-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  virtual_network_id  = azurerm_virtual_network.test.id
+  tags = {
+    key = "value"
+  }
 }
 
 data "azurerm_private_dns_resolver" "test" {
-  name         		  = azurerm_private_dns_resolver.test.name
+  name                = azurerm_private_dns_resolver.test.name
   resource_group_name = azurerm_resource_group.test.name
 }
 `, template, data.RandomInteger)


### PR DESCRIPTION
<details>

<summary>original failure </summary>

```hcl
------- Stdout: -------
=== RUN   TestAccMonitorAADDiagnosticSetting
=== RUN   TestAccMonitorAADDiagnosticSetting/basic
=== RUN   TestAccMonitorAADDiagnosticSetting/basic/storageAccount
testcase.go:117: Step 1/2 error: After applying this test step and performing a `terraform refresh`, the plan was not empty.
stdout
Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
~ update in-place
Terraform will perform the following actions:
# azurerm_monitor_aad_diagnostic_setting.test will be updated in-place
~ resource "azurerm_monitor_aad_diagnostic_setting" "test" {
id                 = "/providers/Microsoft.AADIAM/diagnosticSettings/acctest-DS-230110000917123965"
name               = "acctest-DS-230110000917123965"
# (1 unchanged attribute hidden)
- log {
- category = "EnrichedOffice365AuditLogs" -> null
- enabled  = false -> null
- retention_policy {
- days    = 0 -> null
- enabled = false -> null
}
}
# (13 unchanged blocks hidden)
}
Plan: 0 to add, 1 to change, 0 to destroy.
=== RUN   TestAccMonitorAADDiagnosticSetting/basic/eventhubDefault
testcase.go:117: Step 1/2 error: After applying this test step and performing a `terraform refresh`, the plan was not empty.
stdout
Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
~ update in-place
Terraform will perform the following actions:
# azurerm_monitor_aad_diagnostic_setting.test will be updated in-place
~ resource "azurerm_monitor_aad_diagnostic_setting" "test" {
id                             = "/providers/Microsoft.AADIAM/diagnosticSettings/acctest-DS-230110001239654473"
name                           = "acctest-DS-230110001239654473"
# (1 unchanged attribute hidden)
- log {
- category = "EnrichedOffice365AuditLogs" -> null
- enabled  = false -> null
- retention_policy {
- days    = 0 -> null
- enabled = false -> null
}
}
# (13 unchanged blocks hidden)
}
Plan: 0 to add, 1 to change, 0 to destroy.
=== RUN   TestAccMonitorAADDiagnosticSetting/basic/eventhub
testcase.go:117: Step 1/2 error: After applying this test step and performing a `terraform refresh`, the plan was not empty.
stdout
Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
~ update in-place
Terraform will perform the following actions:
# azurerm_monitor_aad_diagnostic_setting.test will be updated in-place
~ resource "azurerm_monitor_aad_diagnostic_setting" "test" {
id                             = "/providers/Microsoft.AADIAM/diagnosticSettings/acctest-DS-230110001940229071"
name                           = "acctest-DS-230110001940229071"
# (2 unchanged attributes hidden)
- log {
- category = "EnrichedOffice365AuditLogs" -> null
- enabled  = false -> null
- retention_policy {
- days    = 0 -> null
- enabled = false -> null
}
}
# (13 unchanged blocks hidden)
}
Plan: 0 to add, 1 to change, 0 to destroy.
=== RUN   TestAccMonitorAADDiagnosticSetting/basic/requiresImport
testcase.go:117: Step 1/2 error: After applying this test step and performing a `terraform refresh`, the plan was not empty.
stdout
Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
~ update in-place
Terraform will perform the following actions:
# azurerm_monitor_aad_diagnostic_setting.test will be updated in-place
~ resource "azurerm_monitor_aad_diagnostic_setting" "test" {
id                             = "/providers/Microsoft.AADIAM/diagnosticSettings/acctest-DS-230110002547481006"
name                           = "acctest-DS-230110002547481006"
# (2 unchanged attributes hidden)
- log {
- category = "EnrichedOffice365AuditLogs" -> null
- enabled  = false -> null
- retention_policy {
- days    = 0 -> null
- enabled = false -> null
}
}
# (13 unchanged blocks hidden)
}
Plan: 0 to add, 1 to change, 0 to destroy.
=== RUN   TestAccMonitorAADDiagnosticSetting/basic/logAnalyticsWorkspace
testcase.go:117: Step 1/2 error: After applying this test step and performing a `terraform refresh`, the plan was not empty.
stdout
Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
~ update in-place
Terraform will perform the following actions:
# azurerm_monitor_aad_diagnostic_setting.test will be updated in-place
~ resource "azurerm_monitor_aad_diagnostic_setting" "test" {
id                         = "/providers/Microsoft.AADIAM/diagnosticSettings/acctest-DS-230110003055830978"
name                       = "acctest-DS-230110003055830978"
# (1 unchanged attribute hidden)
- log {
- category = "EnrichedOffice365AuditLogs" -> null
- enabled  = false -> null
- retention_policy {
- days    = 0 -> null
- enabled = false -> null
}
}
# (13 unchanged blocks hidden)
}
Plan: 0 to add, 1 to change, 0 to destroy.
--- FAIL: TestAccMonitorAADDiagnosticSetting (1492.23s)
--- FAIL: TestAccMonitorAADDiagnosticSetting/basic (1492.23s)
--- FAIL: TestAccMonitorAADDiagnosticSetting/basic/storageAccount (202.53s)
--- FAIL: TestAccMonitorAADDiagnosticSetting/basic/eventhubDefault (420.57s)
--- FAIL: TestAccMonitorAADDiagnosticSetting/basic/eventhub (367.26s)
--- FAIL: TestAccMonitorAADDiagnosticSetting/basic/requiresImport (308.35s)
--- FAIL: TestAccMonitorAADDiagnosticSetting/basic/logAnalyticsWorkspace (193.53s)
FAIL
```


</details>

test:
![image](https://user-images.githubusercontent.com/104055472/211478673-417a157f-4055-4dbc-bab4-0c7ea0bf840b.png)
