### PR TITLE
Docs: fix tf doc issues of `azurerm_media_asset_filter`, `azurerm_media_live_event_output`, `azurerm_sql_database`, `azurerm_analysis_services_server` and `azurerm_mssql_managed_instance_vulnerability_assessment`

### DIFF
--- a/website/docs/r/analysis_services_server.html.markdown
+++ b/website/docs/r/analysis_services_server.html.markdown
@@ -62,6 +62,8 @@ The following arguments are supported:
 
 * `ipv4_firewall_rule` - (Optional) One or more `ipv4_firewall_rule` block(s) as defined below.
 
+* `tags` - (Optional) A mapping of tags to assign to the resource.
+
 ---
 
 A `ipv4_firewall_rule` block supports the following:

--- a/website/docs/r/media_asset_filter.html.markdown
+++ b/website/docs/r/media_asset_filter.html.markdown
@@ -129,9 +129,17 @@ This value defines the latest live position that a client can seek to. Using thi
 
 * `unit_timescale_in_miliseconds` - (Optional) Specified as the number of miliseconds in one unit timescale. For example, if you want to set a `start_in_units` at 30 seconds, you would use a value of 30 when using the `unit_timescale_in_miliseconds` in 1000. Or if you want to set `start_in_units` in 30 miliseconds, you would use a value of 30 when using the `unit_timescale_in_miliseconds` in 1.  Applies timescale to `start_in_units`, `start_timescale` and `presentation_window_in_timescale` and `live_backoff_in_timescale`.
 
+
 ---
 
-A `selection` block supports the following:
+A `track_selection` block supports the following:
+
+* `condition` - (Required) One or more `condition` blocks as defined above.
+
+---
+
+
+A `condition` block supports the following:
 
 * `operation` - (Optional) The condition operation to test a track property against. Supported values are `Equal` and `NotEqual`.
 
@@ -139,11 +147,6 @@ A `selection` block supports the following:
 
 * `value` - (Optional) The track property value to match or not match.
 
----
-
-A `track_selection` block supports the following:
-
-* `condition` - (Required) One or more `condition` blocks as defined above.
 
 ## Attributes Reference
 

--- a/website/docs/r/media_live_output.html.markdown
+++ b/website/docs/r/media_live_output.html.markdown
@@ -93,7 +93,7 @@ The following arguments are supported:
 
 * `manifest_name` - (Optional) The manifest file name. If not provided, the service will generate one automatically. Changing this forces a new Live Output to be created.
 
-* `output_snap_timestamp_in_seconds` - (Optional) The initial timestamp that the live output will start at, any content before this value will not be archived. Changing this forces a new Live Output to be created.
+* `output_snap_time_in_seconds` - (Optional) The initial timestamp that the live output will start at, any content before this value will not be archived. Changing this forces a new Live Output to be created.
 
 ## Attributes Reference
 

--- a/website/docs/r/mssql_managed_instance_vulnerability_assessment.html.markdown
+++ b/website/docs/r/mssql_managed_instance_vulnerability_assessment.html.markdown
@@ -92,7 +92,7 @@ resource "azurerm_mssql_managed_instance_vulnerability_assessment" "example" {
 
 The following arguments are supported:
 
-* `manged_instance_id` - (Required) The id of the MS SQL Managed Instance. Changing this forces a new resource to be created.
+* `managed_instance_id` - (Required) The id of the MS SQL Managed Instance. Changing this forces a new resource to be created.
 
 * `storage_container_path` - (Required) A blob storage container path to hold the scan results (e.g. <https://myStorage.blob.core.windows.net/VaScans/>).
 

--- a/website/docs/r/sql_database.html.markdown
+++ b/website/docs/r/sql_database.html.markdown
@@ -104,8 +104,6 @@ The following arguments are supported:
 
 * `zone_redundant` - (Optional) Whether or not this database is zone redundant, which means the replicas of this database will be spread across multiple availability zones.
 
-* `extended_auditing_policy` - (Optional) A `extended_auditing_policy` block as defined below.
-
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ---
@@ -131,16 +129,6 @@ The `threat_detection_policy` block supports the following:
 * `retention_days` - (Optional) Specifies the number of days to keep in the Threat Detection audit logs.
 * `storage_account_access_key` - (Optional) Specifies the identifier key of the Threat Detection audit storage account. Required if `state` is `Enabled`.
 * `storage_endpoint` - (Optional) Specifies the blob storage endpoint (e.g. <https://example.blob.core.windows.net>). This blob storage will hold all Threat Detection audit logs. Required if `state` is `Enabled`.
-
----
-
-A `extended_auditing_policy` block supports the following:
-
-* `storage_account_access_key` - (Optional)  Specifies the access key to use for the auditing storage account.
-* `storage_endpoint` - (Optional) Specifies the blob storage endpoint (e.g. <https://example.blob.core.windows.net>).
-* `storage_account_access_key_is_secondary` - (Optional) Specifies whether `storage_account_access_key` value is the storage's secondary key.
-* `retention_in_days` - (Optional) Specifies the number of days to retain logs for in the storage account.
-* `log_monitoring_enabled` - (Optional) Enable audit events to Azure Monitor? To enable audit events to Log Analytics, please refer to the example which can be found in [the `./examples/sql-azure/sql_auditing_log_analytics` directory within the GitHub Repository](https://github.com/hashicorp/terraform-provider-azurerm/tree/main/examples/sql-azure/sql_auditing_log_analytics). To enable audit events to Eventhub, please refer to the example which can be found in [the `./examples/sql-azure/sql_auditing_eventhub` directory within the GitHub Repository](https://github.com/hashicorp/terraform-provider-azurerm/tree/main/examples/sql-azure/sql_auditing_eventhub).
 
 ## Attributes Reference
 

--- a/website/docs/r/sql_database.html.markdown
+++ b/website/docs/r/sql_database.html.markdown
@@ -12,8 +12,6 @@ Allows you to manage an Azure SQL Database
 
 -> **Note:** The `azurerm_sql_database` resource is deprecated in version 3.0 of the AzureRM provider and will be removed in version 4.0. Please use the [`azurerm_mssql_database`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/mssql_database) resource instead.
 
-~> **NOTE:** The Database Extended Auditing Policy Can be set inline here as well as with the [mssql_database_extended_auditing_policy resource](mssql_database_extended_auditing_policy.html) resource. You can only use one or the other and using both will cause a conflict.
-
 ## Example Usage
 
 ```hcl
@@ -48,15 +46,6 @@ resource "azurerm_sql_database" "example" {
   resource_group_name = azurerm_resource_group.example.name
   location            = azurerm_resource_group.example.location
   server_name         = azurerm_sql_server.example.name
-
-  extended_auditing_policy {
-    storage_endpoint                        = azurerm_storage_account.example.primary_blob_endpoint
-    storage_account_access_key              = azurerm_storage_account.example.primary_access_key
-    storage_account_access_key_is_secondary = true
-    retention_in_days                       = 6
-  }
-
-
 
   tags = {
     environment = "production"


### PR DESCRIPTION
Fix doc issues as follows:

- `azurerm_media_asset_filter`: `selection`  block should be corrected to  `condition`
-  `azurerm_media_live_event_output`: `output_snap_timestamp_in_seconds` should be corrected to `output_snap_time_in_seconds`
- `azurerm_sql_database`: the property `extended_auditing_policy` is not supported by `azurerm_sql_database`, all descriptions should be removed.
-  `azurerm_analysis_services_server `: add missed `tag`  property.
- `azurerm_mssql_managed_instance_vulnerability_assessment`: `manged_instance_id` should be corrected to `managed_instance_id`