### PR TITLE
New Data Source: `azurerm_private_dns_resolver_dns_forwarding_ruleset`

### DIFF
--- a/internal/services/privatednsresolver/private_dns_resolver_dns_forwarding_ruleset_data_source.go
+++ b/internal/services/privatednsresolver/private_dns_resolver_dns_forwarding_ruleset_data_source.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/dnsresolver/2022-07-01/dnsforwardingrulesets"
@@ -78,22 +77,16 @@ func (r PrivateDNSResolverDnsForwardingRulesetDataSource) Read() sdk.ResourceFun
 				return fmt.Errorf("decoding: %+v", err)
 			}
 
-			var top int64 = 1
-			resp, err := client.ListByResourceGroupCompleteMatchingPredicate(ctx,
-				commonids.NewResourceGroupID(metadata.Client.Account.SubscriptionId, state.ResourceGroupName),
-				dnsforwardingrulesets.ListByResourceGroupOperationOptions{Top: &top},
-				dnsforwardingrulesets.DnsForwardingRulesetOperationPredicate{Name: &state.Name})
+			id := dnsforwardingrulesets.NewDnsForwardingRulesetID(
+				metadata.Client.Account.SubscriptionId, state.ResourceGroupName, state.Name)
+			resp, err := client.Get(ctx, id)
 			if err != nil {
-				return fmt.Errorf("retrieving %s: %+v", state.Name, err)
-			}
-			if len(resp.Items) != int(top) {
-				return fmt.Errorf("retrieving %s: resource not found", state.Name)
+				return fmt.Errorf("retrieving %s: %+v", id, err)
 			}
 
-			model := resp.Items[0]
-			id, err := dnsforwardingrulesets.ParseDnsForwardingRulesetID(*model.Id)
-			if err != nil {
-				return err
+			model := resp.Model
+			if model == nil {
+				return fmt.Errorf("retrieving %s: model was nil", id)
 			}
 
 			state.Location = location.Normalize(model.Location)

--- a/internal/services/privatednsresolver/private_dns_resolver_dns_forwarding_ruleset_data_source.go
+++ b/internal/services/privatednsresolver/private_dns_resolver_dns_forwarding_ruleset_data_source.go
@@ -1,0 +1,111 @@
+package privatednsresolver
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/dnsresolver/2022-07-01/dnsforwardingrulesets"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+type PrivateDNSResolverDnsForwardingRulesetDataSourceModel struct {
+	Name                         string            `tfschema:"name"`
+	ResourceGroupName            string            `tfschema:"resource_group_name"`
+	DnsResolverOutboundEndpoints []string          `tfschema:"private_dns_resolver_outbound_endpoint_ids"`
+	Location                     string            `tfschema:"location"`
+	Tags                         map[string]string `tfschema:"tags"`
+}
+
+type PrivateDNSResolverDnsForwardingRulesetDataSource struct{}
+
+var _ sdk.DataSource = PrivateDNSResolverDnsForwardingRulesetDataSource{}
+
+func (r PrivateDNSResolverDnsForwardingRulesetDataSource) ResourceType() string {
+	return "azurerm_private_dns_resolver_dns_forwarding_ruleset"
+}
+
+func (r PrivateDNSResolverDnsForwardingRulesetDataSource) ModelObject() interface{} {
+	return &PrivateDNSResolverDnsForwardingRulesetDataSourceModel{}
+}
+
+func (r PrivateDNSResolverDnsForwardingRulesetDataSource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+	return dnsforwardingrulesets.ValidateDnsForwardingRulesetID
+}
+
+func (r PrivateDNSResolverDnsForwardingRulesetDataSource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"resource_group_name": commonschema.ResourceGroupName(),
+	}
+}
+
+func (r PrivateDNSResolverDnsForwardingRulesetDataSource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"location": commonschema.LocationComputed(),
+
+		"private_dns_resolver_outbound_endpoint_ids": {
+			Type:     pluginsdk.TypeList,
+			Computed: true,
+			Elem: &pluginsdk.Schema{
+				Type: pluginsdk.TypeString,
+			},
+		},
+
+		"tags": tags.SchemaDataSource(),
+	}
+}
+
+func (r PrivateDNSResolverDnsForwardingRulesetDataSource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.PrivateDnsResolver.DnsForwardingRulesetsClient
+
+			var state PrivateDNSResolverDnsForwardingRulesetDataSourceModel
+			if err := metadata.Decode(&state); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			var top int64 = 1
+			resp, err := client.ListByResourceGroupCompleteMatchingPredicate(ctx,
+				commonids.NewResourceGroupID(metadata.Client.Account.SubscriptionId, state.ResourceGroupName),
+				dnsforwardingrulesets.ListByResourceGroupOperationOptions{Top: &top},
+				dnsforwardingrulesets.DnsForwardingRulesetOperationPredicate{Name: &state.Name})
+			if err != nil {
+				return fmt.Errorf("retrieving %s: %+v", state.Name, err)
+			}
+			if len(resp.Items) != int(top) {
+				return fmt.Errorf("retrieving %s: resource not found", state.Name)
+			}
+
+			model := resp.Items[0]
+			id, err := dnsforwardingrulesets.ParseDnsForwardingRulesetID(*model.Id)
+			if err != nil {
+				return err
+			}
+
+			state.Location = location.Normalize(model.Location)
+			state.DnsResolverOutboundEndpoints = flattenDnsResolverOutboundEndpoints(&model.Properties.DnsResolverOutboundEndpoints)
+
+			if model.Tags != nil {
+				state.Tags = *model.Tags
+			}
+
+			metadata.SetID(id)
+
+			return metadata.Encode(&state)
+		},
+	}
+}

--- a/internal/services/privatednsresolver/private_dns_resolver_dns_forwarding_ruleset_data_source_test.go
+++ b/internal/services/privatednsresolver/private_dns_resolver_dns_forwarding_ruleset_data_source_test.go
@@ -28,110 +28,63 @@ func TestAccPrivateDNSResolverDnsForwardingRulesetDataSource_basic(t *testing.T)
 	})
 }
 
-func TestAccPrivateDNSResolverDnsForwardingRulesetDataSource_complete(t *testing.T) {
-	data := acceptance.BuildTestData(t, "data.azurerm_private_dns_resolver_dns_forwarding_ruleset", "test")
-	d := PrivateDNSResolverDnsForwardingRulesetDataSource{}
-
-	data.DataSourceTest(t, []acceptance.TestStep{
-		{
-			Config: d.complete(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).Key("name").Exists(),
-				check.That(data.ResourceName).Key("resource_group_name").Exists(),
-				check.That(data.ResourceName).Key("location").HasValue(location.Normalize(data.Locations.Primary)),
-				check.That(data.ResourceName).Key("private_dns_resolver_outbound_endpoint_ids.0").Exists(),
-				check.That(data.ResourceName).Key("tags.key").HasValue("value"),
-			),
-		},
-	})
-}
-
-func (d PrivateDNSResolverDnsForwardingRulesetDataSource) template(data acceptance.TestData) string {
+func (d PrivateDNSResolverDnsForwardingRulesetDataSource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
-  features {}
+	features {}
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctest-rg-%[2]d"
-  location = "%[1]s"
+	name     = "acctest-rg-%[2]d"
+	location = "%[1]s"
 }
 
 resource "azurerm_virtual_network" "test" {
-  name                = "acctest-rg-%[2]d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-  address_space       = ["10.0.0.0/16"]
+	name                = "acctest-rg-%[2]d"
+	resource_group_name = azurerm_resource_group.test.name
+	location            = azurerm_resource_group.test.location
+	address_space       = ["10.0.0.0/16"]
 }
 
 resource "azurerm_subnet" "test" {
-  name                 = "outbounddns"
-  resource_group_name  = azurerm_resource_group.test.name
-  virtual_network_name = azurerm_virtual_network.test.name
-  address_prefixes     = ["10.0.0.64/28"]
+	name                 = "outbounddns"
+	resource_group_name  = azurerm_resource_group.test.name
+	virtual_network_name = azurerm_virtual_network.test.name
+	address_prefixes     = ["10.0.0.64/28"]
 
-  delegation {
-    name = "Microsoft.Network.dnsResolvers"
-    service_delegation {
-      actions = ["Microsoft.Network/virtualNetworks/subnets/join/action"]
-      name    = "Microsoft.Network/dnsResolvers"
-    }
-  }
+	delegation {
+		name = "Microsoft.Network.dnsResolvers"
+		service_delegation {
+			actions = ["Microsoft.Network/virtualNetworks/subnets/join/action"]
+			name    = "Microsoft.Network/dnsResolvers"
+		}
+	}
 }
 
 resource "azurerm_private_dns_resolver" "test" {
-  name                = "acctest-dr-%[2]d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-  virtual_network_id  = azurerm_virtual_network.test.id
+	name                = "acctest-dr-%[2]d"
+	resource_group_name = azurerm_resource_group.test.name
+	location            = azurerm_resource_group.test.location
+	virtual_network_id  = azurerm_virtual_network.test.id
 }
 
 resource "azurerm_private_dns_resolver_outbound_endpoint" "test" {
-  name                    = "acctest-droe-%[2]d"
-  private_dns_resolver_id = azurerm_private_dns_resolver.test.id
-  location                = azurerm_private_dns_resolver.test.location
-  subnet_id               = azurerm_subnet.test.id
+	name                    = "acctest-droe-%[2]d"
+	private_dns_resolver_id = azurerm_private_dns_resolver.test.id
+	location                = azurerm_private_dns_resolver.test.location
+	subnet_id               = azurerm_subnet.test.id
+}
+
+resource "azurerm_private_dns_resolver_dns_forwarding_ruleset" "test" {
+	name                                       = "acctest-drdfr-%[2]d"
+	resource_group_name                        = azurerm_resource_group.test.name
+	location                                   = azurerm_resource_group.test.location
+	private_dns_resolver_outbound_endpoint_ids = [azurerm_private_dns_resolver_outbound_endpoint.test.id]
+}
+
+data "azurerm_private_dns_resolver_dns_forwarding_ruleset" "test" {
+	name         		  = azurerm_private_dns_resolver_dns_forwarding_ruleset.test.name
+	resource_group_name = azurerm_resource_group.test.name
 }
 `, data.Locations.Primary, data.RandomInteger)
-}
-
-func (d PrivateDNSResolverDnsForwardingRulesetDataSource) basic(data acceptance.TestData) string {
-	template := d.template(data)
-	return fmt.Sprintf(`
-				%s
-
-resource "azurerm_private_dns_resolver_dns_forwarding_ruleset" "test" {
-  name                                       = "acctest-drdfr-%d"
-  resource_group_name                        = azurerm_resource_group.test.name
-  location                                   = azurerm_resource_group.test.location
-  private_dns_resolver_outbound_endpoint_ids = [azurerm_private_dns_resolver_outbound_endpoint.test.id]
-}
-
-data "azurerm_private_dns_resolver_dns_forwarding_ruleset" "test" {
-	name         		  = azurerm_private_dns_resolver_dns_forwarding_ruleset.test.name
-	resource_group_name = azurerm_resource_group.test.name
-}
-`, template, data.RandomInteger)
-}
-
-func (d PrivateDNSResolverDnsForwardingRulesetDataSource) complete(data acceptance.TestData) string {
-	template := d.template(data)
-	return fmt.Sprintf(`
-			%s
-
-resource "azurerm_private_dns_resolver_dns_forwarding_ruleset" "test" {
-  name                                       = "acctest-drdfr-%d"
-  resource_group_name                        = azurerm_resource_group.test.name
-  location                                   = azurerm_resource_group.test.location
-  private_dns_resolver_outbound_endpoint_ids = [azurerm_private_dns_resolver_outbound_endpoint.test.id]
-  tags = {
-    key = "value"
-  }
-}
-
-data "azurerm_private_dns_resolver_dns_forwarding_ruleset" "test" {
-	name         		  = azurerm_private_dns_resolver_dns_forwarding_ruleset.test.name
-	resource_group_name = azurerm_resource_group.test.name
-}
-`, template, data.RandomInteger)
 }

--- a/internal/services/privatednsresolver/private_dns_resolver_dns_forwarding_ruleset_data_source_test.go
+++ b/internal/services/privatednsresolver/private_dns_resolver_dns_forwarding_ruleset_data_source_test.go
@@ -30,61 +30,11 @@ func TestAccPrivateDNSResolverDnsForwardingRulesetDataSource_basic(t *testing.T)
 
 func (d PrivateDNSResolverDnsForwardingRulesetDataSource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-	features {}
-}
-
-resource "azurerm_resource_group" "test" {
-	name     = "acctest-rg-%[2]d"
-	location = "%[1]s"
-}
-
-resource "azurerm_virtual_network" "test" {
-	name                = "acctest-rg-%[2]d"
-	resource_group_name = azurerm_resource_group.test.name
-	location            = azurerm_resource_group.test.location
-	address_space       = ["10.0.0.0/16"]
-}
-
-resource "azurerm_subnet" "test" {
-	name                 = "outbounddns"
-	resource_group_name  = azurerm_resource_group.test.name
-	virtual_network_name = azurerm_virtual_network.test.name
-	address_prefixes     = ["10.0.0.64/28"]
-
-	delegation {
-		name = "Microsoft.Network.dnsResolvers"
-		service_delegation {
-			actions = ["Microsoft.Network/virtualNetworks/subnets/join/action"]
-			name    = "Microsoft.Network/dnsResolvers"
-		}
-	}
-}
-
-resource "azurerm_private_dns_resolver" "test" {
-	name                = "acctest-dr-%[2]d"
-	resource_group_name = azurerm_resource_group.test.name
-	location            = azurerm_resource_group.test.location
-	virtual_network_id  = azurerm_virtual_network.test.id
-}
-
-resource "azurerm_private_dns_resolver_outbound_endpoint" "test" {
-	name                    = "acctest-droe-%[2]d"
-	private_dns_resolver_id = azurerm_private_dns_resolver.test.id
-	location                = azurerm_private_dns_resolver.test.location
-	subnet_id               = azurerm_subnet.test.id
-}
-
-resource "azurerm_private_dns_resolver_dns_forwarding_ruleset" "test" {
-	name                                       = "acctest-drdfr-%[2]d"
-	resource_group_name                        = azurerm_resource_group.test.name
-	location                                   = azurerm_resource_group.test.location
-	private_dns_resolver_outbound_endpoint_ids = [azurerm_private_dns_resolver_outbound_endpoint.test.id]
-}
+%s
 
 data "azurerm_private_dns_resolver_dns_forwarding_ruleset" "test" {
 	name         		  = azurerm_private_dns_resolver_dns_forwarding_ruleset.test.name
 	resource_group_name = azurerm_resource_group.test.name
 }
-`, data.Locations.Primary, data.RandomInteger)
+`, PrivateDNSResolverDnsForwardingRulesetResource{}.basic(data))
 }

--- a/internal/services/privatednsresolver/private_dns_resolver_dns_forwarding_ruleset_data_source_test.go
+++ b/internal/services/privatednsresolver/private_dns_resolver_dns_forwarding_ruleset_data_source_test.go
@@ -1,0 +1,137 @@
+package privatednsresolver_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+)
+
+type PrivateDNSResolverDnsForwardingRulesetDataSource struct{}
+
+func TestAccPrivateDNSResolverDnsForwardingRulesetDataSource_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_private_dns_resolver_dns_forwarding_ruleset", "test")
+	d := PrivateDNSResolverDnsForwardingRulesetDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: d.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("name").Exists(),
+				check.That(data.ResourceName).Key("resource_group_name").Exists(),
+				check.That(data.ResourceName).Key("location").HasValue(location.Normalize(data.Locations.Primary)),
+				check.That(data.ResourceName).Key("private_dns_resolver_outbound_endpoint_ids.0").Exists(),
+			),
+		},
+	})
+}
+
+func TestAccPrivateDNSResolverDnsForwardingRulesetDataSource_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_private_dns_resolver_dns_forwarding_ruleset", "test")
+	d := PrivateDNSResolverDnsForwardingRulesetDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: d.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("name").Exists(),
+				check.That(data.ResourceName).Key("resource_group_name").Exists(),
+				check.That(data.ResourceName).Key("location").HasValue(location.Normalize(data.Locations.Primary)),
+				check.That(data.ResourceName).Key("private_dns_resolver_outbound_endpoint_ids.0").Exists(),
+				check.That(data.ResourceName).Key("tags.key").HasValue("value"),
+			),
+		},
+	})
+}
+
+func (d PrivateDNSResolverDnsForwardingRulesetDataSource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctest-rg-%[2]d"
+  location = "%[1]s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctest-rg-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  address_space       = ["10.0.0.0/16"]
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "outbounddns"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.0.64/28"]
+
+  delegation {
+    name = "Microsoft.Network.dnsResolvers"
+    service_delegation {
+      actions = ["Microsoft.Network/virtualNetworks/subnets/join/action"]
+      name    = "Microsoft.Network/dnsResolvers"
+    }
+  }
+}
+
+resource "azurerm_private_dns_resolver" "test" {
+  name                = "acctest-dr-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  virtual_network_id  = azurerm_virtual_network.test.id
+}
+
+resource "azurerm_private_dns_resolver_outbound_endpoint" "test" {
+  name                    = "acctest-droe-%[2]d"
+  private_dns_resolver_id = azurerm_private_dns_resolver.test.id
+  location                = azurerm_private_dns_resolver.test.location
+  subnet_id               = azurerm_subnet.test.id
+}
+`, data.Locations.Primary, data.RandomInteger)
+}
+
+func (d PrivateDNSResolverDnsForwardingRulesetDataSource) basic(data acceptance.TestData) string {
+	template := d.template(data)
+	return fmt.Sprintf(`
+				%s
+
+resource "azurerm_private_dns_resolver_dns_forwarding_ruleset" "test" {
+  name                                       = "acctest-drdfr-%d"
+  resource_group_name                        = azurerm_resource_group.test.name
+  location                                   = azurerm_resource_group.test.location
+  private_dns_resolver_outbound_endpoint_ids = [azurerm_private_dns_resolver_outbound_endpoint.test.id]
+}
+
+data "azurerm_private_dns_resolver_dns_forwarding_ruleset" "test" {
+	name         		  = azurerm_private_dns_resolver_dns_forwarding_ruleset.test.name
+	resource_group_name = azurerm_resource_group.test.name
+}
+`, template, data.RandomInteger)
+}
+
+func (d PrivateDNSResolverDnsForwardingRulesetDataSource) complete(data acceptance.TestData) string {
+	template := d.template(data)
+	return fmt.Sprintf(`
+			%s
+
+resource "azurerm_private_dns_resolver_dns_forwarding_ruleset" "test" {
+  name                                       = "acctest-drdfr-%d"
+  resource_group_name                        = azurerm_resource_group.test.name
+  location                                   = azurerm_resource_group.test.location
+  private_dns_resolver_outbound_endpoint_ids = [azurerm_private_dns_resolver_outbound_endpoint.test.id]
+  tags = {
+    key = "value"
+  }
+}
+
+data "azurerm_private_dns_resolver_dns_forwarding_ruleset" "test" {
+	name         		  = azurerm_private_dns_resolver_dns_forwarding_ruleset.test.name
+	resource_group_name = azurerm_resource_group.test.name
+}
+`, template, data.RandomInteger)
+}

--- a/internal/services/privatednsresolver/registration.go
+++ b/internal/services/privatednsresolver/registration.go
@@ -41,6 +41,7 @@ func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 // DataSources returns a list of Data Sources supported by this Service
 func (r Registration) DataSources() []sdk.DataSource {
 	return []sdk.DataSource{
+		PrivateDNSResolverDnsForwardingRulesetDataSource{},
 		PrivateDNSResolverDnsResolverDataSource{},
 	}
 }

--- a/website/docs/d/private_dns_resolver_dns_forwarding_ruleset.html.markdown
+++ b/website/docs/d/private_dns_resolver_dns_forwarding_ruleset.html.markdown
@@ -21,11 +21,11 @@ data "azurerm_private_dns_resolver_dns_forwarding_ruleset" "example" {
 
 ## Arguments Reference
 
-The following arguments are required:
+The following arguments are supported:
 
-* `name` - Name of the existing Private DNS Resolver Dns Forwarding Ruleset.
+* `name` - (Required) Name of the existing Private DNS Resolver Dns Forwarding Ruleset.
 
-* `resource_group_name` - Name of the Resource Group where the Private DNS Resolver Dns Forwarding Ruleset exists.
+* `resource_group_name` - (Required) Name of the Resource Group where the Private DNS Resolver Dns Forwarding Ruleset exists.
 
 ## Attributes Reference
 
@@ -33,11 +33,11 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `id` - The ID of the Private DNS Resolver Dns Forwarding Ruleset.
 
-* `private_dns_resolver_outbound_endpoint_ids` - List of IDs of the Private DNS Resolver Outbound Endpoint that is linked to the Private DNS Resolver Dns Forwarding Ruleset.
+* `private_dns_resolver_outbound_endpoint_ids` - The IDs list of the Private DNS Resolver Outbound Endpoints that are linked to the Private DNS Resolver Dns Forwarding Ruleset.
 
-* `location` - Azure Region where the Private DNS Resolver Dns Forwarding Ruleset exists.
+* `location` - The Azure Region where the Private DNS Resolver Dns Forwarding Ruleset exists.
 
-* `tags` - Mapping of tags assigned to the Private DNS Resolver Dns Forwarding Ruleset.
+* `tags` - The tags assigned to the Private DNS Resolver Dns Forwarding Ruleset.
 
 ## Timeouts
 

--- a/website/docs/d/private_dns_resolver_dns_forwarding_ruleset.html.markdown
+++ b/website/docs/d/private_dns_resolver_dns_forwarding_ruleset.html.markdown
@@ -1,0 +1,46 @@
+---
+subcategory: "Private DNS Resolver"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_private_dns_resolver_dns_forwarding_ruleset"
+description: |-
+  Gets information about an existing Private DNS Resolver Dns Forwarding Ruleset.
+---
+
+# Data Source: azurerm_private_dns_resolver_dns_forwarding_ruleset
+
+Gets information about an existing Private DNS Resolver Dns Forwarding Ruleset.
+
+## Example Usage
+
+```hcl
+data "azurerm_private_dns_resolver_dns_forwarding_ruleset" "example" {
+  name                = "example-ruleset"
+  resource_group_name = "example-ruleset-resourcegroup"
+}
+```
+
+## Arguments Reference
+
+The following arguments are required:
+
+* `name` - Name of the existing Private DNS Resolver Dns Forwarding Ruleset.
+
+* `resource_group_name` - Name of the Resource Group where the Private DNS Resolver Dns Forwarding Ruleset exists.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `id` - The ID of the Private DNS Resolver Dns Forwarding Ruleset.
+
+* `private_dns_resolver_outbound_endpoint_ids` - List of IDs of the Private DNS Resolver Outbound Endpoint that is linked to the Private DNS Resolver Dns Forwarding Ruleset.
+
+* `location` - Azure Region where the Private DNS Resolver Dns Forwarding Ruleset exists.
+
+* `tags` - Mapping of tags assigned to the Private DNS Resolver Dns Forwarding Ruleset.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the Private DNS SRV Record.

--- a/website/docs/d/private_dns_resolver_dns_forwarding_ruleset.html.markdown
+++ b/website/docs/d/private_dns_resolver_dns_forwarding_ruleset.html.markdown
@@ -43,4 +43,4 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `read` - (Defaults to 5 minutes) Used when retrieving the Private DNS SRV Record.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Private DNS Resolver Dns Forwarding Ruleset.


### PR DESCRIPTION
``` txt
=== RUN   TestAccPrivateDNSResolverDnsForwardingRulesetDataSource_basic
=== PAUSE TestAccPrivateDNSResolverDnsForwardingRulesetDataSource_basic
=== CONT  TestAccPrivateDNSResolverDnsForwardingRulesetDataSource_basic
--- PASS: TestAccPrivateDNSResolverDnsForwardingRulesetDataSource_basic (420.20s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/privatednsresolver    421.452s

=== RUN   TestAccPrivateDNSResolverDnsForwardingRulesetDataSource_complete
=== PAUSE TestAccPrivateDNSResolverDnsForwardingRulesetDataSource_complete
=== CONT  TestAccPrivateDNSResolverDnsForwardingRulesetDataSource_complete
--- PASS: TestAccPrivateDNSResolverDnsForwardingRulesetDataSource_complete (629.67s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/privatednsresolver    630.873s
```