### PR TITLE
New Data Source: `azurerm_private_dns_resolver_outbound_endpoint`

### DIFF
--- a/internal/services/privatednsresolver/private_dns_resolver_outbound_endpoint_data_source.go
+++ b/internal/services/privatednsresolver/private_dns_resolver_outbound_endpoint_data_source.go
@@ -84,21 +84,19 @@ func (r PrivateDNSResolverOutboundEndpointDataSource) Read() sdk.ResourceFunc {
 				return err
 			}
 
-			var top int64 = 1
-			resp, err := client.ListCompleteMatchingPredicate(ctx, *privateDnsResolverId,
-				outboundendpoints.ListOperationOptions{Top: &top},
-				outboundendpoints.OutboundEndpointOperationPredicate{Name: &state.Name})
+			id := outboundendpoints.NewOutboundEndpointID(
+				privateDnsResolverId.SubscriptionId,
+				privateDnsResolverId.ResourceGroupName,
+				privateDnsResolverId.DnsResolverName,
+				state.Name)
+			resp, err := client.Get(ctx, id)
 			if err != nil {
-				return fmt.Errorf("retrieving %s: %+v", state.Name, err)
-			}
-			if len(resp.Items) != int(top) {
-				return fmt.Errorf("retrieving %s: resource not found", state.Name)
+				return fmt.Errorf("retrieving %s: %+v", id, err)
 			}
 
-			model := resp.Items[0]
-			id, err := outboundendpoints.ParseOutboundEndpointID(*model.Id)
-			if err != nil {
-				return err
+			model := resp.Model
+			if model == nil {
+				return fmt.Errorf("retrieving %s: model was nil", id)
 			}
 
 			state.Location = location.Normalize(model.Location)

--- a/internal/services/privatednsresolver/private_dns_resolver_outbound_endpoint_data_source.go
+++ b/internal/services/privatednsresolver/private_dns_resolver_outbound_endpoint_data_source.go
@@ -1,0 +1,117 @@
+package privatednsresolver
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/dnsresolver/2022-07-01/dnsresolvers"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/dnsresolver/2022-07-01/outboundendpoints"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+type PrivateDNSResolverOutboundEndpointDataSourceModel struct {
+	Name                 string            `tfschema:"name"`
+	PrivateDNSResolverId string            `tfschema:"private_dns_resolver_id"`
+	Location             string            `tfschema:"location"`
+	SubnetId             string            `tfschema:"subnet_id"`
+	Tags                 map[string]string `tfschema:"tags"`
+}
+
+type PrivateDNSResolverOutboundEndpointDataSource struct{}
+
+var _ sdk.DataSource = PrivateDNSResolverOutboundEndpointDataSource{}
+
+func (r PrivateDNSResolverOutboundEndpointDataSource) ResourceType() string {
+	return "azurerm_private_dns_resolver_outbound_endpoint"
+}
+
+func (r PrivateDNSResolverOutboundEndpointDataSource) ModelObject() interface{} {
+	return &PrivateDNSResolverOutboundEndpointDataSourceModel{}
+}
+
+func (r PrivateDNSResolverOutboundEndpointDataSource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+	return outboundendpoints.ValidateOutboundEndpointID
+}
+
+func (r PrivateDNSResolverOutboundEndpointDataSource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"private_dns_resolver_id": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ValidateFunc: dnsresolvers.ValidateDnsResolverID,
+		},
+	}
+}
+
+func (r PrivateDNSResolverOutboundEndpointDataSource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"subnet_id": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"location": commonschema.LocationComputed(),
+
+		"tags": tags.SchemaDataSource(),
+	}
+}
+
+func (r PrivateDNSResolverOutboundEndpointDataSource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.PrivateDnsResolver.OutboundEndpointsClient
+
+			var state PrivateDNSResolverOutboundEndpointDataSourceModel
+			if err := metadata.Decode(&state); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			privateDnsResolverId, err := outboundendpoints.ParseDnsResolverID(state.PrivateDNSResolverId)
+			if err != nil {
+				return err
+			}
+
+			var top int64 = 1
+			resp, err := client.ListCompleteMatchingPredicate(ctx, *privateDnsResolverId,
+				outboundendpoints.ListOperationOptions{Top: &top},
+				outboundendpoints.OutboundEndpointOperationPredicate{Name: &state.Name})
+			if err != nil {
+				return fmt.Errorf("retrieving %s: %+v", state.Name, err)
+			}
+			if len(resp.Items) != int(top) {
+				return fmt.Errorf("retrieving %s: resource not found", state.Name)
+			}
+
+			model := resp.Items[0]
+			id, err := outboundendpoints.ParseOutboundEndpointID(*model.Id)
+			if err != nil {
+				return err
+			}
+
+			state.Location = location.Normalize(model.Location)
+			state.PrivateDNSResolverId = dnsresolvers.NewDnsResolverID(id.SubscriptionId, id.ResourceGroupName, id.DnsResolverName).ID()
+			state.SubnetId = model.Properties.Subnet.Id
+
+			if model.Tags != nil {
+				state.Tags = *model.Tags
+			}
+
+			metadata.SetID(id)
+
+			return metadata.Encode(&state)
+		},
+	}
+}

--- a/internal/services/privatednsresolver/private_dns_resolver_outbound_endpoint_data_source_test.go
+++ b/internal/services/privatednsresolver/private_dns_resolver_outbound_endpoint_data_source_test.go
@@ -30,54 +30,11 @@ func TestAccDNSResolverOutboundEndpointDataSource_basic(t *testing.T) {
 
 func (d DNSResolverOutboundEndpointDataSource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctest-rg-%[2]d"
-  location = "%[1]s"
-}
-
-resource "azurerm_virtual_network" "test" {
-  name                = "acctest-rg-%[2]d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-  address_space       = ["10.0.0.0/16"]
-}
-
-resource "azurerm_subnet" "test" {
-  name                 = "outbounddns"
-  resource_group_name  = azurerm_resource_group.test.name
-  virtual_network_name = azurerm_virtual_network.test.name
-  address_prefixes     = ["10.0.0.64/28"]
-
-  delegation {
-    name = "Microsoft.Network.dnsResolvers"
-    service_delegation {
-      actions = ["Microsoft.Network/virtualNetworks/subnets/join/action"]
-      name    = "Microsoft.Network/dnsResolvers"
-    }
-  }
-}
-
-resource "azurerm_private_dns_resolver" "test" {
-  name                = "acctest-dr-%[2]d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-  virtual_network_id  = azurerm_virtual_network.test.id
-}
-
-resource "azurerm_private_dns_resolver_outbound_endpoint" "test" {
-  name                    = "acctest-droe-%[2]d"
-  private_dns_resolver_id = azurerm_private_dns_resolver.test.id
-  location                = azurerm_private_dns_resolver.test.location
-  subnet_id               = azurerm_subnet.test.id
-}
+%s
 
 data "azurerm_private_dns_resolver_outbound_endpoint" "test" {
 	name         		    = azurerm_private_dns_resolver_outbound_endpoint.test.name
 	private_dns_resolver_id = azurerm_private_dns_resolver.test.id
 }
-`, data.Locations.Primary, data.RandomInteger)
+`, DNSResolverOutboundEndpointResource{}.basic(data))
 }

--- a/internal/services/privatednsresolver/private_dns_resolver_outbound_endpoint_data_source_test.go
+++ b/internal/services/privatednsresolver/private_dns_resolver_outbound_endpoint_data_source_test.go
@@ -28,25 +28,7 @@ func TestAccDNSResolverOutboundEndpointDataSource_basic(t *testing.T) {
 	})
 }
 
-func TestAccDNSResolverOutboundEndpointDataSource_complete(t *testing.T) {
-	data := acceptance.BuildTestData(t, "data.azurerm_private_dns_resolver_outbound_endpoint", "test")
-	d := DNSResolverOutboundEndpointDataSource{}
-
-	data.DataSourceTest(t, []acceptance.TestStep{
-		{
-			Config: d.complete(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).Key("name").Exists(),
-				check.That(data.ResourceName).Key("private_dns_resolver_id").Exists(),
-				check.That(data.ResourceName).Key("location").HasValue(location.Normalize(data.Locations.Primary)),
-				check.That(data.ResourceName).Key("subnet_id").Exists(),
-				check.That(data.ResourceName).Key("tags.key").HasValue("value"),
-			),
-		},
-	})
-}
-
-func (d DNSResolverOutboundEndpointDataSource) template(data acceptance.TestData) string {
+func (d DNSResolverOutboundEndpointDataSource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -85,46 +67,17 @@ resource "azurerm_private_dns_resolver" "test" {
   location            = azurerm_resource_group.test.location
   virtual_network_id  = azurerm_virtual_network.test.id
 }
+
+resource "azurerm_private_dns_resolver_outbound_endpoint" "test" {
+  name                    = "acctest-droe-%[2]d"
+  private_dns_resolver_id = azurerm_private_dns_resolver.test.id
+  location                = azurerm_private_dns_resolver.test.location
+  subnet_id               = azurerm_subnet.test.id
+}
+
+data "azurerm_private_dns_resolver_outbound_endpoint" "test" {
+	name         		    = azurerm_private_dns_resolver_outbound_endpoint.test.name
+	private_dns_resolver_id = azurerm_private_dns_resolver.test.id
+}
 `, data.Locations.Primary, data.RandomInteger)
-}
-
-func (d DNSResolverOutboundEndpointDataSource) basic(data acceptance.TestData) string {
-	template := d.template(data)
-	return fmt.Sprintf(`
-				%s
-
-resource "azurerm_private_dns_resolver_outbound_endpoint" "test" {
-  name                    = "acctest-droe-%d"
-  private_dns_resolver_id = azurerm_private_dns_resolver.test.id
-  location                = azurerm_private_dns_resolver.test.location
-  subnet_id               = azurerm_subnet.test.id
-}
-
-data "azurerm_private_dns_resolver_outbound_endpoint" "test" {
-	name         		    = azurerm_private_dns_resolver_outbound_endpoint.test.name
-	private_dns_resolver_id = azurerm_private_dns_resolver.test.id
-}
-`, template, data.RandomInteger)
-}
-
-func (d DNSResolverOutboundEndpointDataSource) complete(data acceptance.TestData) string {
-	template := d.template(data)
-	return fmt.Sprintf(`
-			%s
-
-resource "azurerm_private_dns_resolver_outbound_endpoint" "test" {
-  name                    = "acctest-droe-%d"
-  private_dns_resolver_id = azurerm_private_dns_resolver.test.id
-  location                = azurerm_private_dns_resolver.test.location
-  subnet_id               = azurerm_subnet.test.id
-  tags = {
-    key = "value"
-  }
-}
-
-data "azurerm_private_dns_resolver_outbound_endpoint" "test" {
-	name         		    = azurerm_private_dns_resolver_outbound_endpoint.test.name
-	private_dns_resolver_id = azurerm_private_dns_resolver.test.id
-}
-`, template, data.RandomInteger)
 }

--- a/internal/services/privatednsresolver/private_dns_resolver_outbound_endpoint_data_source_test.go
+++ b/internal/services/privatednsresolver/private_dns_resolver_outbound_endpoint_data_source_test.go
@@ -1,0 +1,130 @@
+package privatednsresolver_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+)
+
+type DNSResolverOutboundEndpointDataSource struct{}
+
+func TestAccDNSResolverOutboundEndpointDataSource_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_private_dns_resolver_outbound_endpoint", "test")
+	d := DNSResolverOutboundEndpointDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: d.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("name").Exists(),
+				check.That(data.ResourceName).Key("private_dns_resolver_id").Exists(),
+				check.That(data.ResourceName).Key("location").HasValue(location.Normalize(data.Locations.Primary)),
+				check.That(data.ResourceName).Key("subnet_id").Exists(),
+			),
+		},
+	})
+}
+
+func TestAccDNSResolverOutboundEndpointDataSource_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_private_dns_resolver_outbound_endpoint", "test")
+	d := DNSResolverOutboundEndpointDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: d.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("name").Exists(),
+				check.That(data.ResourceName).Key("private_dns_resolver_id").Exists(),
+				check.That(data.ResourceName).Key("location").HasValue(location.Normalize(data.Locations.Primary)),
+				check.That(data.ResourceName).Key("subnet_id").Exists(),
+				check.That(data.ResourceName).Key("tags.key").HasValue("value"),
+			),
+		},
+	})
+}
+
+func (d DNSResolverOutboundEndpointDataSource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctest-rg-%[2]d"
+  location = "%[1]s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctest-rg-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  address_space       = ["10.0.0.0/16"]
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "outbounddns"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.0.64/28"]
+
+  delegation {
+    name = "Microsoft.Network.dnsResolvers"
+    service_delegation {
+      actions = ["Microsoft.Network/virtualNetworks/subnets/join/action"]
+      name    = "Microsoft.Network/dnsResolvers"
+    }
+  }
+}
+
+resource "azurerm_private_dns_resolver" "test" {
+  name                = "acctest-dr-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  virtual_network_id  = azurerm_virtual_network.test.id
+}
+`, data.Locations.Primary, data.RandomInteger)
+}
+
+func (d DNSResolverOutboundEndpointDataSource) basic(data acceptance.TestData) string {
+	template := d.template(data)
+	return fmt.Sprintf(`
+				%s
+
+resource "azurerm_private_dns_resolver_outbound_endpoint" "test" {
+  name                    = "acctest-droe-%d"
+  private_dns_resolver_id = azurerm_private_dns_resolver.test.id
+  location                = azurerm_private_dns_resolver.test.location
+  subnet_id               = azurerm_subnet.test.id
+}
+
+data "azurerm_private_dns_resolver_outbound_endpoint" "test" {
+	name         		    = azurerm_private_dns_resolver_outbound_endpoint.test.name
+	private_dns_resolver_id = azurerm_private_dns_resolver.test.id
+}
+`, template, data.RandomInteger)
+}
+
+func (d DNSResolverOutboundEndpointDataSource) complete(data acceptance.TestData) string {
+	template := d.template(data)
+	return fmt.Sprintf(`
+			%s
+
+resource "azurerm_private_dns_resolver_outbound_endpoint" "test" {
+  name                    = "acctest-droe-%d"
+  private_dns_resolver_id = azurerm_private_dns_resolver.test.id
+  location                = azurerm_private_dns_resolver.test.location
+  subnet_id               = azurerm_subnet.test.id
+  tags = {
+    key = "value"
+  }
+}
+
+data "azurerm_private_dns_resolver_outbound_endpoint" "test" {
+	name         		    = azurerm_private_dns_resolver_outbound_endpoint.test.name
+	private_dns_resolver_id = azurerm_private_dns_resolver.test.id
+}
+`, template, data.RandomInteger)
+}

--- a/internal/services/privatednsresolver/registration.go
+++ b/internal/services/privatednsresolver/registration.go
@@ -42,6 +42,7 @@ func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 func (r Registration) DataSources() []sdk.DataSource {
 	return []sdk.DataSource{
 		PrivateDNSResolverDnsResolverDataSource{},
+		PrivateDNSResolverOutboundEndpointDataSource{},
 	}
 }
 

--- a/website/docs/d/private_dns_resolver_outbound_endpoint.html.markdown
+++ b/website/docs/d/private_dns_resolver_outbound_endpoint.html.markdown
@@ -37,10 +37,10 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `subnet_id` - The ID of the Subnet that is linked to the Private DNS Resolver Outbound Endpoint.
 
-* `tags` - Mapping of tags assigned to the Private DNS Resolver Outbound Endpoint.
+* `tags` - The tags assigned to the Private DNS Resolver Outbound Endpoint.
 
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `read` - (Defaults to 5 minutes) Used when retrieving the Private DNS SRV Record.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Private DNS Resolver Outbound Endpoint.

--- a/website/docs/d/private_dns_resolver_outbound_endpoint.html.markdown
+++ b/website/docs/d/private_dns_resolver_outbound_endpoint.html.markdown
@@ -1,0 +1,46 @@
+---
+subcategory: "Private DNS Resolver"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_private_dns_resolver_outbound_endpoint"
+description: |-
+  Gets information about an existing Private DNS Resolver Outbound Endpoint.
+---
+
+# Data Source: azurerm_private_dns_resolver_outbound_endpoint
+
+Gets information about an existing Private DNS Resolver Outbound Endpoint.
+
+## Example Usage
+
+```hcl
+data "azurerm_private_dns_resolver_outbound_endpoint" "example" {
+  name                    = "example-endpoint"
+  private_dns_resolver_id = "example-private-dns-resolver-id"
+}
+```
+
+## Arguments Reference
+
+The following arguments are required:
+
+* `name` - Name of the Private DNS Resolver Outbound Endpoint.
+
+* `private_dns_resolver_id` - ID of the Private DNS Resolver Outbound Endpoint.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `id` - The ID of the Private DNS Resolver Outbound Endpoint.
+
+* `location` - Azure Region where the Private DNS Resolver Outbound Endpoint exists.
+
+* `subnet_id` - ID of the Subnet that is linked to the Private DNS Resolver Outbound Endpoint.
+
+* `tags` - Mapping of tags assigned to the Private DNS Resolver Outbound Endpoint.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the Private DNS SRV Record.

--- a/website/docs/d/private_dns_resolver_outbound_endpoint.html.markdown
+++ b/website/docs/d/private_dns_resolver_outbound_endpoint.html.markdown
@@ -21,11 +21,11 @@ data "azurerm_private_dns_resolver_outbound_endpoint" "example" {
 
 ## Arguments Reference
 
-The following arguments are required:
+The following arguments are supported:
 
-* `name` - Name of the Private DNS Resolver Outbound Endpoint.
+* `name` - (Required) Name of the Private DNS Resolver Outbound Endpoint.
 
-* `private_dns_resolver_id` - ID of the Private DNS Resolver Outbound Endpoint.
+* `private_dns_resolver_id` - (Required) ID of the Private DNS Resolver Outbound Endpoint.
 
 ## Attributes Reference
 
@@ -33,9 +33,9 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `id` - The ID of the Private DNS Resolver Outbound Endpoint.
 
-* `location` - Azure Region where the Private DNS Resolver Outbound Endpoint exists.
+* `location` - The Azure Region where the Private DNS Resolver Outbound Endpoint exists.
 
-* `subnet_id` - ID of the Subnet that is linked to the Private DNS Resolver Outbound Endpoint.
+* `subnet_id` - The ID of the Subnet that is linked to the Private DNS Resolver Outbound Endpoint.
 
 * `tags` - Mapping of tags assigned to the Private DNS Resolver Outbound Endpoint.
 


### PR DESCRIPTION
``` txt
=== RUN   TestAccDNSResolverOutboundEndpointDataSource_basic
=== PAUSE TestAccDNSResolverOutboundEndpointDataSource_basic
=== CONT  TestAccDNSResolverOutboundEndpointDataSource_basic
--- PASS: TestAccDNSResolverOutboundEndpointDataSource_basic (379.92s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/privatednsresolver    381.122s

=== RUN   TestAccDNSResolverOutboundEndpointDataSource_complete
=== PAUSE TestAccDNSResolverOutboundEndpointDataSource_complete
=== CONT  TestAccDNSResolverOutboundEndpointDataSource_complete
--- PASS: TestAccDNSResolverOutboundEndpointDataSource_complete (408.35s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/privatednsresolver    409.547s
```