### PR TITLE
New resource - `azurerm_application_insights_standard_web_test`

### DIFF
--- a/internal/services/applicationinsights/application_insights_standard_webtests_resource.go
+++ b/internal/services/applicationinsights/application_insights_standard_webtests_resource.go
@@ -631,7 +631,6 @@ func expandApplicationInsightsStandardWebTestValidations(input []interface{}, is
 		sslCheckEnabled = true
 	}
 	// if sslCheck not enabled, SSLCertRemainingLifetimeCheck cannot be enabled
-	
 	if v, ok := validationsInput["ssl_cert_remaining_lifetime"].(int); ok && sslCheckEnabled {
 		rules.SSLCertRemainingLifetimeCheck = utils.Int64(int64(v))
 	}

--- a/internal/services/applicationinsights/application_insights_standard_webtests_resource.go
+++ b/internal/services/applicationinsights/application_insights_standard_webtests_resource.go
@@ -1,0 +1,682 @@
+package applicationinsights
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	webtests "github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-06-15/webtestsapis"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+var _ sdk.Resource = ApplicationInsightsStandardWebTestResource{}
+
+type ApplicationInsightsStandardWebTestResource struct{}
+
+func (ApplicationInsightsStandardWebTestResource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.NoZeroValues,
+		},
+
+		"resource_group_name": commonschema.ResourceGroupName(),
+
+		"application_insights_id": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: azure.ValidateResourceID,
+		},
+
+		"location": commonschema.Location(),
+
+		"frequency": {
+			Type:     pluginsdk.TypeInt,
+			Optional: true,
+			Default:  300,
+			ValidateFunc: validation.IntInSlice([]int{
+				300,
+				600,
+				900,
+			}),
+		},
+
+		"timeout": {
+			Type:     pluginsdk.TypeInt,
+			Optional: true,
+			Default:  30,
+		},
+
+		"enabled": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+		},
+
+		"retry_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+		},
+
+		"request": {
+			Type:     pluginsdk.TypeList,
+			Required: true,
+			MaxItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"follow_redirects_enabled": {
+						Type:     pluginsdk.TypeBool,
+						Optional: true,
+						Default:  true,
+					},
+
+					"http_verb": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+						Default:  "GET",
+						ValidateFunc: validation.StringInSlice([]string{
+							"GET", "POST", "PUT", "PATCH", "DELETE",
+						}, false),
+					},
+
+					"parse_dependent_requests_enabled": {
+						Type:     pluginsdk.TypeBool,
+						Optional: true,
+						Default:  true,
+					},
+
+					"header": {
+						Type:     pluginsdk.TypeList,
+						Optional: true,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"name": {
+									Type:         pluginsdk.TypeString,
+									Required:     true,
+									ValidateFunc: validation.StringIsNotEmpty,
+								},
+								"value": {
+									Type:     pluginsdk.TypeString,
+									Required: true,
+								},
+							},
+						},
+					},
+
+					"body": {
+						Type:         pluginsdk.TypeString,
+						Optional:     true,
+						ValidateFunc: validation.StringIsNotEmpty,
+					},
+
+					"url": {
+						Type:         pluginsdk.TypeString,
+						Required:     true,
+						ValidateFunc: validation.StringIsNotEmpty,
+					},
+				},
+			},
+		},
+
+		"validation_rules": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			Computed: true,
+			MaxItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"expected_status_code": {
+						Type:     pluginsdk.TypeInt,
+						Optional: true,
+						Default:  200,
+					},
+
+					// Typo in API spec, issue: https://github.com/Azure/azure-rest-api-specs/issues/22136
+					// "ignore_status_code": {
+					// 	Type:     pluginsdk.TypeBool,
+					// 	Optional: true,
+					// 	Default:  false,
+					// },
+
+					"ssl_cert_remaining_lifetime": {
+						Type:     pluginsdk.TypeInt,
+						Optional: true,
+					},
+
+					"ssl_check_enabled": {
+						Type:     pluginsdk.TypeBool,
+						Optional: true,
+						Default:  false,
+					},
+
+					"content": {
+						Type:     pluginsdk.TypeList,
+						Optional: true,
+						MaxItems: 1,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"content_match": {
+									Type:         pluginsdk.TypeString,
+									Required:     true,
+									ValidateFunc: validation.StringIsNotEmpty,
+								},
+								"ignore_case": {
+									Type:     pluginsdk.TypeBool,
+									Optional: true,
+									Default:  false,
+								},
+								"pass_if_text_found": {
+									Type:     pluginsdk.TypeBool,
+									Optional: true,
+									Default:  false,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+
+		"geo_locations": {
+			Type:     pluginsdk.TypeList,
+			Required: true,
+			MinItems: 1,
+			Elem: &pluginsdk.Schema{
+				Type:             pluginsdk.TypeString,
+				ValidateFunc:     validation.StringIsNotEmpty,
+				StateFunc:        location.StateFunc,
+				DiffSuppressFunc: location.DiffSuppressFunc,
+			},
+		},
+
+		"description": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+		},
+
+		"tags": commonschema.Tags(),
+	}
+}
+
+func (ApplicationInsightsStandardWebTestResource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"synthetic_monitor_id": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+	}
+}
+
+func (ApplicationInsightsStandardWebTestResource) ModelObject() interface{} {
+	return nil
+}
+
+func (ApplicationInsightsStandardWebTestResource) ResourceType() string {
+	return "azurerm_application_insights_standard_web_test"
+}
+
+func (r ApplicationInsightsStandardWebTestResource) Create() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.AppInsights.StandardWebTestsClient
+
+			subscriptionId := metadata.Client.Account.SubscriptionId
+			name := metadata.ResourceData.Get("name").(string)
+			resourceGroupName := metadata.ResourceData.Get("resource_group_name").(string)
+			id := webtests.NewWebTestID(subscriptionId, resourceGroupName, name)
+
+			existing, err := client.WebTestsGet(ctx, id)
+			if err != nil && !response.WasNotFound(existing.HttpResponse) {
+				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+			}
+			if !response.WasNotFound(existing.HttpResponse) {
+				return metadata.ResourceRequiresImport(r.ResourceType(), id)
+			}
+
+			location := location.Normalize(metadata.ResourceData.Get("location").(string))
+			description := metadata.ResourceData.Get("description").(string)
+			frequency := int64(metadata.ResourceData.Get("frequency").(int))
+			timeout := int64(metadata.ResourceData.Get("timeout").(int))
+			isEnabled := metadata.ResourceData.Get("enabled").(bool)
+			retryEnabled := metadata.ResourceData.Get("retry_enabled").(bool)
+			geoLocationsRaw := metadata.ResourceData.Get("geo_locations").([]interface{})
+			geoLocations := expandApplicationInsightsStandardWebTestGeoLocations(geoLocationsRaw)
+
+			requestRaw := metadata.ResourceData.Get("request").([]interface{})
+			request := expandApplicationInsightsStandardWebTestRequest(requestRaw)
+
+			validationsRaw := metadata.ResourceData.Get("validation_rules").([]interface{})
+			validations := expandApplicationInsightsStandardWebTestValidations(validationsRaw)
+
+			appInsightsId, err := webtests.ParseComponentID(metadata.ResourceData.Get("application_insights_id").(string))
+			if err != nil {
+				return err
+			}
+			t := metadata.ResourceData.Get("tags").(map[string]interface{})
+			tagKey := fmt.Sprintf("hidden-link:%s", appInsightsId.ID())
+			t[tagKey] = "Resource"
+
+			param := webtests.WebTest{
+				Kind:     utils.ToPtr(webtests.WebTestKindStandard),
+				Location: location,
+				Properties: &webtests.WebTestProperties{
+					Description:        utils.String(description),
+					Enabled:            utils.Bool(isEnabled),
+					Frequency:          utils.Int64(frequency),
+					Kind:               webtests.WebTestKindStandard,
+					Locations:          geoLocations,
+					Name:               id.WebTestName,
+					RetryEnabled:       utils.Bool(retryEnabled),
+					SyntheticMonitorId: id.WebTestName,
+					Timeout:            utils.Int64(timeout),
+					Request:            &request,
+					ValidationRules:    &validations,
+				},
+				Tags: tags.Expand(t),
+			}
+			if _, err := client.WebTestsCreateOrUpdate(ctx, id, param); err != nil {
+				return fmt.Errorf("creating %s: %+v", id, err)
+			}
+
+			metadata.SetID(id)
+			return nil
+		},
+	}
+}
+
+func (r ApplicationInsightsStandardWebTestResource) Update() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.AppInsights.StandardWebTestsClient
+			id, err := webtests.ParseWebTestID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			location := location.Normalize(metadata.ResourceData.Get("location").(string))
+			description := metadata.ResourceData.Get("description").(string)
+			frequency := int64(metadata.ResourceData.Get("frequency").(int))
+			timeout := int64(metadata.ResourceData.Get("timeout").(int))
+			isEnabled := metadata.ResourceData.Get("enabled").(bool)
+			retryEnabled := metadata.ResourceData.Get("retry_enabled").(bool)
+
+			geoLocationsRaw := metadata.ResourceData.Get("geo_locations").([]interface{})
+			geoLocations := expandApplicationInsightsStandardWebTestGeoLocations(geoLocationsRaw)
+
+			requestRaw := metadata.ResourceData.Get("request").([]interface{})
+			request := expandApplicationInsightsStandardWebTestRequest(requestRaw)
+
+			validationsRaw := metadata.ResourceData.Get("validation_rules").([]interface{})
+			validations := expandApplicationInsightsStandardWebTestValidations(validationsRaw)
+
+			appInsightsId, err := webtests.ParseComponentID(metadata.ResourceData.Get("application_insights_id").(string))
+			if err != nil {
+				return err
+			}
+			t := metadata.ResourceData.Get("tags").(map[string]interface{})
+			tagKey := fmt.Sprintf("hidden-link:%s", appInsightsId.ID())
+			t[tagKey] = "Resource"
+
+			param := webtests.WebTest{
+				Kind:     utils.ToPtr(webtests.WebTestKindStandard),
+				Location: location,
+				Properties: &webtests.WebTestProperties{
+					Description:        utils.String(description),
+					Enabled:            utils.Bool(isEnabled),
+					Frequency:          utils.Int64(frequency),
+					Kind:               webtests.WebTestKindStandard,
+					Locations:          geoLocations,
+					Name:               id.WebTestName,
+					RetryEnabled:       utils.Bool(retryEnabled),
+					SyntheticMonitorId: id.WebTestName,
+					Timeout:            utils.Int64(timeout),
+					Request:            &request,
+					ValidationRules:    &validations,
+				},
+				Tags: tags.Expand(t),
+			}
+			if _, err := client.WebTestsCreateOrUpdate(ctx, *id, param); err != nil {
+				return fmt.Errorf("creating %s: %+v", id, err)
+			}
+
+			metadata.SetID(id)
+			return nil
+		},
+	}
+}
+
+func (ApplicationInsightsStandardWebTestResource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.AppInsights.StandardWebTestsClient
+
+			id, err := webtests.ParseWebTestID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.WebTestsGet(ctx, *id)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return metadata.MarkAsGone(id)
+				}
+
+				return fmt.Errorf("retrieving %s: %+v", id, err)
+			}
+
+			if model := resp.Model; model != nil {
+				appInsightsId := ""
+				if model.Tags != nil {
+					for i := range *model.Tags {
+						if strings.HasPrefix(i, "hidden-link") {
+							appInsightsId = strings.Split(i, ":")[1]
+						}
+					}
+				}
+
+				metadata.ResourceData.Set("application_insights_id", appInsightsId)
+				metadata.ResourceData.Set("name", id.WebTestName)
+				metadata.ResourceData.Set("resource_group_name", id.ResourceGroupName)
+				metadata.ResourceData.Set("location", location.NormalizeNilable(&model.Location))
+				if props := model.Properties; props != nil {
+					metadata.ResourceData.Set("synthetic_monitor_id", props.SyntheticMonitorId)
+					metadata.ResourceData.Set("description", props.Description)
+					metadata.ResourceData.Set("enabled", props.Enabled)
+					metadata.ResourceData.Set("frequency", props.Frequency)
+					metadata.ResourceData.Set("timeout", props.Timeout)
+					metadata.ResourceData.Set("retry_enabled", props.RetryEnabled)
+					if props.Request != nil {
+						request, err := flattenApplicationInsightsStandardWebTestRequest(*props.Request)
+						if err != nil {
+							return fmt.Errorf("setting `request`: %+v", err)
+						}
+						metadata.ResourceData.Set("request", request)
+					}
+					if props.ValidationRules != nil {
+						rules := flattenApplicationInsightsStandardWebTestValidations(*props.ValidationRules)
+						metadata.ResourceData.Set("validation_rules", rules)
+					}
+
+					if err := metadata.ResourceData.Set("geo_locations", flattenApplicationInsightsStandardWebTestGeoLocations(props.Locations)); err != nil {
+						return fmt.Errorf("setting `geo_locations`: %+v", err)
+					}
+				}
+				return tags.FlattenAndSet(metadata.ResourceData, model.Tags)
+			}
+
+			return nil
+		},
+	}
+}
+
+func (ApplicationInsightsStandardWebTestResource) Delete() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.AppInsights.StandardWebTestsClient
+
+			id, err := webtests.ParseWebTestID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			_, err = client.WebTestsDelete(ctx, *id)
+			if err != nil {
+				return fmt.Errorf("deleting %s: %+v", *id, err)
+			}
+
+			return nil
+		},
+	}
+}
+
+func (ApplicationInsightsStandardWebTestResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+	return webtests.ValidateWebTestID
+}
+
+func expandApplicationInsightsStandardWebTestRequest(input []interface{}) webtests.WebTestPropertiesRequest {
+	requestInput := input[0].(map[string]interface{})
+
+	followRedirects := true
+	if v, ok := requestInput["follow_redirects_enabled"].(bool); ok {
+		followRedirects = v
+	}
+	httpVerb := "GET"
+	if v, ok := requestInput["http_verb"].(string); ok {
+		httpVerb = v
+	}
+	parseDependentRequests := true
+	if v, ok := requestInput["parse_dependent_requests_enabled"].(bool); ok {
+		parseDependentRequests = v
+	}
+
+	request := webtests.WebTestPropertiesRequest{
+		FollowRedirects:        utils.Bool(followRedirects),
+		HTTPVerb:               utils.String(httpVerb),
+		ParseDependentRequests: utils.Bool(parseDependentRequests),
+	}
+
+	request.Headers = expandApplicationInsightsStandardWebTestRequestHeaders(requestInput["header"].([]interface{}))
+
+	if v, ok := requestInput["body"].(string); ok && v != "" {
+		request.RequestBody = utils.String(utils.Base64EncodeIfNot(v))
+	}
+	if v, ok := requestInput["url"].(string); ok {
+		request.RequestUrl = utils.String(v)
+	}
+
+	return request
+}
+
+func expandApplicationInsightsStandardWebTestRequestHeaders(input []interface{}) *[]webtests.HeaderField {
+	if len(input) == 0 || input[0] == nil {
+		return nil
+	}
+
+	headers := make([]webtests.HeaderField, len(input))
+
+	for i, v := range input {
+		header := v.(map[string]interface{})
+		headers[i] = webtests.HeaderField{
+			Key:   utils.String(header["name"].(string)),
+			Value: utils.String(header["value"].(string)),
+		}
+	}
+
+	return &headers
+}
+
+func flattenApplicationInsightsStandardWebTestRequest(req webtests.WebTestPropertiesRequest) ([]interface{}, error) {
+	result := make(map[string]interface{})
+
+	followRedirects := true
+	if req.FollowRedirects != nil {
+		followRedirects = *req.FollowRedirects
+	}
+	result["follow_redirects_enabled"] = followRedirects
+
+	httpVerb := "GET"
+	if req.HTTPVerb != nil {
+		httpVerb = *req.HTTPVerb
+	}
+	result["http_verb"] = httpVerb
+
+	parseDependentRequests := true
+	if req.ParseDependentRequests != nil {
+		parseDependentRequests = *req.ParseDependentRequests
+	}
+	result["parse_dependent_requests_enabled"] = parseDependentRequests
+
+	if req.RequestUrl != nil {
+		result["url"] = *req.RequestUrl
+	}
+	if req.RequestBody != nil {
+		body, err := base64.StdEncoding.DecodeString(*req.RequestBody)
+		if err != nil {
+			return nil, fmt.Errorf("decoding `body`: %+v", err)
+		}
+		result["body"] = string(body)
+	}
+	if req.Headers != nil {
+		result["header"] = flattenApplicationInsightsStandardWebTestRequestHeaders(req.Headers)
+	}
+
+	return []interface{}{result}, nil
+}
+
+func flattenApplicationInsightsStandardWebTestRequestHeaders(input *[]webtests.HeaderField) []interface{} {
+	result := make([]interface{}, 0)
+	if input == nil {
+		return result
+	}
+
+	headers := *input
+	if len(headers) == 0 {
+		return result
+	}
+
+	for _, v := range headers {
+		header := make(map[string]string, 2)
+		header["name"] = *v.Key
+		header["value"] = *v.Value
+		result = append(result, header)
+	}
+
+	return result
+}
+
+func flattenApplicationInsightsStandardWebTestValidations(rules webtests.WebTestPropertiesValidationRules) []interface{} {
+	result := make(map[string]interface{})
+
+	if rules.ExpectedHTTPStatusCode != nil {
+		result["expected_status_code"] = *rules.ExpectedHTTPStatusCode
+	}
+	// if rules.IgnoreHTTPSStatusCode != nil {
+	// 	result["ignore_status_code"] = *rules.IgnoreHTTPSStatusCode
+	// }
+	if rules.SSLCertRemainingLifetimeCheck != nil {
+		result["ssl_cert_remaining_lifetime"] = *rules.SSLCertRemainingLifetimeCheck
+	}
+	if rules.SSLCheck != nil {
+		result["ssl_check_enabled"] = *rules.SSLCheck
+	}
+
+	if rules.ContentValidation != nil {
+		result["content"] = flattenApplicationInsightsStandardWebTestContentValidations(rules.ContentValidation)
+	}
+
+	return []interface{}{result}
+}
+
+func flattenApplicationInsightsStandardWebTestContentValidations(input *webtests.WebTestPropertiesValidationRulesContentValidation) []interface{} {
+	result := make(map[string]interface{})
+
+	if input.ContentMatch != nil {
+		result["content_match"] = *input.ContentMatch
+	}
+	if input.IgnoreCase != nil {
+		result["ignore_case"] = *input.IgnoreCase
+	}
+	if input.PassIfTextFound != nil {
+		result["pass_if_text_found"] = *input.PassIfTextFound
+	}
+
+	return []interface{}{result}
+}
+
+func expandApplicationInsightsStandardWebTestValidations(input []interface{}) webtests.WebTestPropertiesValidationRules {
+	rules := webtests.WebTestPropertiesValidationRules{
+		ExpectedHTTPStatusCode: utils.Int64(200),
+		// IgnoreHTTPSStatusCode:  utils.Bool(false),
+		SSLCheck: utils.Bool(false),
+	}
+	if len(input) == 0 {
+		return rules
+	}
+
+	validationsInput := input[0].(map[string]interface{})
+	if v, ok := validationsInput["expected_status_code"].(int); ok {
+		rules.ExpectedHTTPStatusCode = utils.Int64(int64(v))
+	}
+	// if v, ok := validationsInput["ignore_status_code"].(bool); ok {
+	// 	rules.IgnoreHTTPSStatusCode = utils.Bool(v)
+	// }
+	if v, ok := validationsInput["ssl_cert_remaining_lifetime"].(int); ok {
+		rules.SSLCertRemainingLifetimeCheck = utils.Int64(int64(v))
+	}
+	if v, ok := validationsInput["ssl_check_enabled"].(bool); ok {
+		rules.SSLCheck = utils.Bool(v)
+	}
+	if contentValidation, ok := validationsInput["content"].([]interface{}); ok {
+		rules.ContentValidation = expandApplicationInsightsStandardWebTestContentValidations(contentValidation)
+	}
+
+	return rules
+}
+
+func expandApplicationInsightsStandardWebTestContentValidations(input []interface{}) *webtests.WebTestPropertiesValidationRulesContentValidation {
+	content := webtests.WebTestPropertiesValidationRulesContentValidation{}
+	if len(input) == 0 {
+		return &content
+	}
+
+	contentInput := input[0].(map[string]interface{})
+	content.ContentMatch = utils.String(contentInput["content_match"].(string))
+	if v, ok := contentInput["ignore_case"].(bool); ok {
+		content.IgnoreCase = utils.Bool(v)
+	}
+	if v, ok := contentInput["pass_if_text_found"].(bool); ok {
+		content.PassIfTextFound = utils.Bool(v)
+	}
+
+	return &content
+}
+
+func expandApplicationInsightsStandardWebTestGeoLocations(input []interface{}) []webtests.WebTestGeolocation {
+	locations := make([]webtests.WebTestGeolocation, 0)
+
+	for _, v := range input {
+		lc := v.(string)
+		loc := webtests.WebTestGeolocation{
+			Id: &lc,
+		}
+		locations = append(locations, loc)
+	}
+
+	return locations
+}
+
+func flattenApplicationInsightsStandardWebTestGeoLocations(input []webtests.WebTestGeolocation) []string {
+	results := make([]string, 0)
+	if input == nil {
+		return results
+	}
+
+	for _, prop := range input {
+		if prop.Id != nil {
+			results = append(results, azure.NormalizeLocation(*prop.Id))
+		}
+	}
+
+	return results
+}

--- a/internal/services/applicationinsights/application_insights_standard_webtests_resource_test.go
+++ b/internal/services/applicationinsights/application_insights_standard_webtests_resource_test.go
@@ -1,0 +1,209 @@
+package applicationinsights_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	webtests "github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-06-15/webtestsapis"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+type ApplicationInsightsStandardWebTestResource struct{}
+
+func TestAccApplicationInsightsStandardWebTest_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_application_insights_standard_web_test", "test")
+	testResource := ApplicationInsightsStandardWebTestResource{}
+	data.ResourceTest(t, testResource, []acceptance.TestStep{
+		data.ApplyStep(testResource.basicConfig, testResource),
+		data.ImportStep(),
+	})
+}
+
+func TestAccApplicationInsightsStandardWebTest_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_application_insights_standard_web_test", "test")
+	testResource := ApplicationInsightsStandardWebTestResource{}
+	data.ResourceTest(t, testResource, []acceptance.TestStep{
+		data.ApplyStep(testResource.basicConfig, testResource),
+		data.RequiresImportErrorStep(testResource.requiresImportConfig),
+	})
+}
+
+func TestAccApplicationInsightsStandardWebTest_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_application_insights_standard_web_test", "test")
+	testResource := ApplicationInsightsStandardWebTestResource{}
+	data.ResourceTest(t, testResource, []acceptance.TestStep{
+		data.ApplyStep(testResource.completeConfig, testResource),
+		data.ImportStep(),
+		data.ApplyStep(testResource.basicConfig, testResource),
+		data.ImportStep(),
+		data.ApplyStep(testResource.completeConfig, testResource),
+		data.ImportStep(),
+	})
+}
+
+func (ApplicationInsightsStandardWebTestResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := webtests.ParseWebTestID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.AppInsights.StandardWebTestsClient.WebTestsGet(ctx, *id)
+	if err != nil {
+		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
+	}
+
+	return utils.Bool(resp.Model != nil && resp.Model.Properties != nil), nil
+}
+
+func (ApplicationInsightsStandardWebTestResource) basicConfig(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-appinsights-%d"
+  location = "%s"
+}
+
+resource "azurerm_application_insights" "test" {
+  name                = "acctestappinsights-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  application_type    = "web"
+}
+
+resource "azurerm_application_insights_standard_web_test" "test" {
+  name                    = "acctestappinsightswebtests-%d"
+  location                = azurerm_resource_group.test.location
+  resource_group_name     = azurerm_resource_group.test.name
+  application_insights_id = azurerm_application_insights.test.id
+  geo_locations           = ["us-tx-sn1-azr"]
+
+  request {
+    follow_redirects_enabled         = false
+    http_verb                        = "GET"
+    parse_dependent_requests_enabled = false
+    url                              = "http://microsoft.com"
+
+    header {
+      name  = "x-header"
+      value = "testheader"
+    }
+    header {
+      name  = "x-header-2"
+      value = "testheader2"
+    }
+  }
+
+  lifecycle {
+    ignore_changes = ["tags"]
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}
+
+func (r ApplicationInsightsStandardWebTestResource) requiresImportConfig(data acceptance.TestData) string {
+	template := r.basicConfig(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_application_insights_standard_web_test" "import" {
+  name                    = azurerm_application_insights_standard_web_test.test.name
+  location                = azurerm_application_insights_standard_web_test.test.location
+  resource_group_name     = azurerm_application_insights_standard_web_test.test.resource_group_name
+  application_insights_id = azurerm_application_insights_standard_web_test.test.application_insights_id
+  geo_locations           = azurerm_application_insights_standard_web_test.test.geo_locations
+  request {
+    follow_redirects_enabled         = azurerm_application_insights_standard_web_test.test.request.0.follow_redirects_enabled
+    http_verb                        = azurerm_application_insights_standard_web_test.test.request.0.http_verb
+    parse_dependent_requests_enabled = azurerm_application_insights_standard_web_test.test.request.0.parse_dependent_requests_enabled
+    url                              = azurerm_application_insights_standard_web_test.test.request.0.url
+
+    header {
+      name  = azurerm_application_insights_standard_web_test.test.request.0.header.0.name
+      value = azurerm_application_insights_standard_web_test.test.request.0.header.0.value
+    }
+
+    header {
+      name  = azurerm_application_insights_standard_web_test.test.request.0.header.1.name
+      value = azurerm_application_insights_standard_web_test.test.request.0.header.1.value
+    }
+  }
+}
+`, template)
+}
+
+func (ApplicationInsightsStandardWebTestResource) completeConfig(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-appinsights-%d"
+  location = "%s"
+}
+
+resource "azurerm_application_insights" "test" {
+  name                = "acctestappinsights-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  application_type    = "web"
+}
+
+resource "azurerm_application_insights_standard_web_test" "test" {
+  name                    = "acctestappinsightswebtests-%d"
+  location                = azurerm_resource_group.test.location
+  resource_group_name     = azurerm_resource_group.test.name
+  application_insights_id = azurerm_application_insights.test.id
+  frequency               = 900
+  timeout                 = 120
+  enabled                 = true
+  description             = "web_test"
+  retry_enabled           = true
+  tags = {
+    ENV = "web_test"
+  }
+  geo_locations = ["us-tx-sn1-azr", "us-il-ch1-azr"]
+
+  request {
+    follow_redirects_enabled         = true
+    http_verb                        = "POST"
+    parse_dependent_requests_enabled = true
+    url                              = "https://microsoft.com"
+
+    body = "{\"test\": \"value\"}"
+
+    header {
+      name  = "x-header"
+      value = "testheader"
+    }
+    header {
+      name  = "x-header-2"
+      value = "testheaderupdated"
+    }
+  }
+  validation_rules {
+    expected_status_code = 200
+
+    ssl_cert_remaining_lifetime = 20
+    ssl_check_enabled           = true
+
+    content {
+      content_match      = "Unknown"
+      ignore_case        = true
+      pass_if_text_found = true
+    }
+  }
+
+  lifecycle {
+    ignore_changes = ["tags"]
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}

--- a/internal/services/applicationinsights/client/client.go
+++ b/internal/services/applicationinsights/client/client.go
@@ -4,6 +4,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/appinsights/mgmt/2020-02-02/insights" // nolint: staticcheck
 	workbooktemplates "github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2020-11-20/workbooktemplatesapis"
 	workbooks "github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-04-01/workbooksapis"
+	webtests "github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-06-15/webtestsapis"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/common"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/applicationinsights/azuresdkhacks"
 )
@@ -13,6 +14,7 @@ type Client struct {
 	APIKeysClient            *insights.APIKeysClient
 	ComponentsClient         *insights.ComponentsClient
 	WebTestsClient           *azuresdkhacks.WebTestsClient
+	StandardWebTestsClient   *webtests.WebTestsAPIsClient
 	BillingClient            *insights.ComponentCurrentBillingFeaturesClient
 	SmartDetectionRuleClient *insights.ProactiveDetectionConfigurationsClient
 	WorkbookClient           *workbooks.WorkbooksAPIsClient
@@ -32,6 +34,9 @@ func NewClient(o *common.ClientOptions) *Client {
 	webTestsClient := insights.NewWebTestsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&webTestsClient.Client, o.ResourceManagerAuthorizer)
 	webTestsWorkaroundClient := azuresdkhacks.NewWebTestsClient(webTestsClient)
+
+	standardWebTestsClient := webtests.NewWebTestsAPIsClientWithBaseURI(o.ResourceManagerEndpoint)
+	o.ConfigureClient(&standardWebTestsClient.Client, o.ResourceManagerAuthorizer)
 
 	billingClient := insights.NewComponentCurrentBillingFeaturesClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&billingClient.Client, o.ResourceManagerAuthorizer)
@@ -54,5 +59,6 @@ func NewClient(o *common.ClientOptions) *Client {
 		SmartDetectionRuleClient: &smartDetectionRuleClient,
 		WorkbookClient:           &workbookClient,
 		WorkbookTemplateClient:   &workbookTemplateClient,
+		StandardWebTestsClient:   &standardWebTestsClient,
 	}
 }

--- a/internal/services/applicationinsights/registration.go
+++ b/internal/services/applicationinsights/registration.go
@@ -42,7 +42,9 @@ func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 		"azurerm_application_insights":                      resourceApplicationInsights(),
 		"azurerm_application_insights_analytics_item":       resourceApplicationInsightsAnalyticsItem(),
 		"azurerm_application_insights_smart_detection_rule": resourceApplicationInsightsSmartDetectionRule(),
-		"azurerm_application_insights_web_test":             resourceApplicationInsightsWebTests(),
+
+		// TODO change in 4.0 to azurerm_application_insights_classic_web_test
+		"azurerm_application_insights_web_test": resourceApplicationInsightsWebTests(),
 	}
 }
 
@@ -56,5 +58,6 @@ func (r Registration) Resources() []sdk.Resource {
 	return []sdk.Resource{
 		ApplicationInsightsWorkbookResource{},
 		ApplicationInsightsWorkbookTemplateResource{},
+		ApplicationInsightsStandardWebTestResource{},
 	}
 }

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-06-15/webtestsapis/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-06-15/webtestsapis/README.md
@@ -1,0 +1,145 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-06-15/webtestsapis` Documentation
+
+The `webtestsapis` SDK allows for interaction with the Azure Resource Manager Service `applicationinsights` (API Version `2022-06-15`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-06-15/webtestsapis"
+```
+
+
+### Client Initialization
+
+```go
+client := webtestsapis.NewWebTestsAPIsClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `WebTestsAPIsClient.WebTestsCreateOrUpdate`
+
+```go
+ctx := context.TODO()
+id := webtestsapis.NewWebTestID("12345678-1234-9876-4563-123456789012", "example-resource-group", "webTestValue")
+
+payload := webtestsapis.WebTest{
+	// ...
+}
+
+
+read, err := client.WebTestsCreateOrUpdate(ctx, id, payload)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `WebTestsAPIsClient.WebTestsDelete`
+
+```go
+ctx := context.TODO()
+id := webtestsapis.NewWebTestID("12345678-1234-9876-4563-123456789012", "example-resource-group", "webTestValue")
+
+read, err := client.WebTestsDelete(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `WebTestsAPIsClient.WebTestsGet`
+
+```go
+ctx := context.TODO()
+id := webtestsapis.NewWebTestID("12345678-1234-9876-4563-123456789012", "example-resource-group", "webTestValue")
+
+read, err := client.WebTestsGet(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `WebTestsAPIsClient.WebTestsList`
+
+```go
+ctx := context.TODO()
+id := webtestsapis.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+
+// alternatively `client.WebTestsList(ctx, id)` can be used to do batched pagination
+items, err := client.WebTestsListComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `WebTestsAPIsClient.WebTestsListByComponent`
+
+```go
+ctx := context.TODO()
+id := webtestsapis.NewComponentID("12345678-1234-9876-4563-123456789012", "example-resource-group", "componentValue")
+
+// alternatively `client.WebTestsListByComponent(ctx, id)` can be used to do batched pagination
+items, err := client.WebTestsListByComponentComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `WebTestsAPIsClient.WebTestsListByResourceGroup`
+
+```go
+ctx := context.TODO()
+id := webtestsapis.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+
+// alternatively `client.WebTestsListByResourceGroup(ctx, id)` can be used to do batched pagination
+items, err := client.WebTestsListByResourceGroupComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `WebTestsAPIsClient.WebTestsUpdateTags`
+
+```go
+ctx := context.TODO()
+id := webtestsapis.NewWebTestID("12345678-1234-9876-4563-123456789012", "example-resource-group", "webTestValue")
+
+payload := webtestsapis.TagsResource{
+	// ...
+}
+
+
+read, err := client.WebTestsUpdateTags(ctx, id, payload)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-06-15/webtestsapis/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-06-15/webtestsapis/client.go
@@ -1,0 +1,18 @@
+package webtestsapis
+
+import "github.com/Azure/go-autorest/autorest"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type WebTestsAPIsClient struct {
+	Client  autorest.Client
+	baseUri string
+}
+
+func NewWebTestsAPIsClientWithBaseURI(endpoint string) WebTestsAPIsClient {
+	return WebTestsAPIsClient{
+		Client:  autorest.NewClientWithUserAgent(userAgent()),
+		baseUri: endpoint,
+	}
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-06-15/webtestsapis/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-06-15/webtestsapis/constants.go
@@ -1,0 +1,37 @@
+package webtestsapis
+
+import "strings"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type WebTestKind string
+
+const (
+	WebTestKindMultistep WebTestKind = "multistep"
+	WebTestKindPing      WebTestKind = "ping"
+	WebTestKindStandard  WebTestKind = "standard"
+)
+
+func PossibleValuesForWebTestKind() []string {
+	return []string{
+		string(WebTestKindMultistep),
+		string(WebTestKindPing),
+		string(WebTestKindStandard),
+	}
+}
+
+func parseWebTestKind(input string) (*WebTestKind, error) {
+	vals := map[string]WebTestKind{
+		"multistep": WebTestKindMultistep,
+		"ping":      WebTestKindPing,
+		"standard":  WebTestKindStandard,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := WebTestKind(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-06-15/webtestsapis/id_component.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-06-15/webtestsapis/id_component.go
@@ -1,0 +1,124 @@
+package webtestsapis
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = ComponentId{}
+
+// ComponentId is a struct representing the Resource ID for a Component
+type ComponentId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	ComponentName     string
+}
+
+// NewComponentID returns a new ComponentId struct
+func NewComponentID(subscriptionId string, resourceGroupName string, componentName string) ComponentId {
+	return ComponentId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		ComponentName:     componentName,
+	}
+}
+
+// ParseComponentID parses 'input' into a ComponentId
+func ParseComponentID(input string) (*ComponentId, error) {
+	parser := resourceids.NewParserFromResourceIdType(ComponentId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := ComponentId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.ComponentName, ok = parsed.Parsed["componentName"]; !ok {
+		return nil, fmt.Errorf("the segment 'componentName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ParseComponentIDInsensitively parses 'input' case-insensitively into a ComponentId
+// note: this method should only be used for API response data and not user input
+func ParseComponentIDInsensitively(input string) (*ComponentId, error) {
+	parser := resourceids.NewParserFromResourceIdType(ComponentId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := ComponentId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.ComponentName, ok = parsed.Parsed["componentName"]; !ok {
+		return nil, fmt.Errorf("the segment 'componentName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ValidateComponentID checks that 'input' can be parsed as a Component ID
+func ValidateComponentID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseComponentID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Component ID
+func (id ComponentId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Insights/components/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.ComponentName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Component ID
+func (id ComponentId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftInsights", "Microsoft.Insights", "Microsoft.Insights"),
+		resourceids.StaticSegment("staticComponents", "components", "components"),
+		resourceids.UserSpecifiedSegment("componentName", "componentValue"),
+	}
+}
+
+// String returns a human-readable description of this Component ID
+func (id ComponentId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Component Name: %q", id.ComponentName),
+	}
+	return fmt.Sprintf("Component (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-06-15/webtestsapis/id_webtest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-06-15/webtestsapis/id_webtest.go
@@ -1,0 +1,124 @@
+package webtestsapis
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = WebTestId{}
+
+// WebTestId is a struct representing the Resource ID for a Web Test
+type WebTestId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	WebTestName       string
+}
+
+// NewWebTestID returns a new WebTestId struct
+func NewWebTestID(subscriptionId string, resourceGroupName string, webTestName string) WebTestId {
+	return WebTestId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		WebTestName:       webTestName,
+	}
+}
+
+// ParseWebTestID parses 'input' into a WebTestId
+func ParseWebTestID(input string) (*WebTestId, error) {
+	parser := resourceids.NewParserFromResourceIdType(WebTestId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := WebTestId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.WebTestName, ok = parsed.Parsed["webTestName"]; !ok {
+		return nil, fmt.Errorf("the segment 'webTestName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ParseWebTestIDInsensitively parses 'input' case-insensitively into a WebTestId
+// note: this method should only be used for API response data and not user input
+func ParseWebTestIDInsensitively(input string) (*WebTestId, error) {
+	parser := resourceids.NewParserFromResourceIdType(WebTestId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := WebTestId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.WebTestName, ok = parsed.Parsed["webTestName"]; !ok {
+		return nil, fmt.Errorf("the segment 'webTestName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ValidateWebTestID checks that 'input' can be parsed as a Web Test ID
+func ValidateWebTestID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseWebTestID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Web Test ID
+func (id WebTestId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Insights/webTests/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.WebTestName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Web Test ID
+func (id WebTestId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftInsights", "Microsoft.Insights", "Microsoft.Insights"),
+		resourceids.StaticSegment("staticWebTests", "webTests", "webTests"),
+		resourceids.UserSpecifiedSegment("webTestName", "webTestValue"),
+	}
+}
+
+// String returns a human-readable description of this Web Test ID
+func (id WebTestId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Web Test Name: %q", id.WebTestName),
+	}
+	return fmt.Sprintf("Web Test (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-06-15/webtestsapis/method_webtestscreateorupdate_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-06-15/webtestsapis/method_webtestscreateorupdate_autorest.go
@@ -1,0 +1,69 @@
+package webtestsapis
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type WebTestsCreateOrUpdateOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *WebTest
+}
+
+// WebTestsCreateOrUpdate ...
+func (c WebTestsAPIsClient) WebTestsCreateOrUpdate(ctx context.Context, id WebTestId, input WebTest) (result WebTestsCreateOrUpdateOperationResponse, err error) {
+	req, err := c.preparerForWebTestsCreateOrUpdate(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "webtestsapis.WebTestsAPIsClient", "WebTestsCreateOrUpdate", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "webtestsapis.WebTestsAPIsClient", "WebTestsCreateOrUpdate", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForWebTestsCreateOrUpdate(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "webtestsapis.WebTestsAPIsClient", "WebTestsCreateOrUpdate", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForWebTestsCreateOrUpdate prepares the WebTestsCreateOrUpdate request.
+func (c WebTestsAPIsClient) preparerForWebTestsCreateOrUpdate(ctx context.Context, id WebTestId, input WebTest) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPut(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForWebTestsCreateOrUpdate handles the response to the WebTestsCreateOrUpdate request. The method always
+// closes the http.Response Body.
+func (c WebTestsAPIsClient) responderForWebTestsCreateOrUpdate(resp *http.Response) (result WebTestsCreateOrUpdateOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-06-15/webtestsapis/method_webtestsdelete_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-06-15/webtestsapis/method_webtestsdelete_autorest.go
@@ -1,0 +1,66 @@
+package webtestsapis
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type WebTestsDeleteOperationResponse struct {
+	HttpResponse *http.Response
+}
+
+// WebTestsDelete ...
+func (c WebTestsAPIsClient) WebTestsDelete(ctx context.Context, id WebTestId) (result WebTestsDeleteOperationResponse, err error) {
+	req, err := c.preparerForWebTestsDelete(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "webtestsapis.WebTestsAPIsClient", "WebTestsDelete", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "webtestsapis.WebTestsAPIsClient", "WebTestsDelete", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForWebTestsDelete(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "webtestsapis.WebTestsAPIsClient", "WebTestsDelete", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForWebTestsDelete prepares the WebTestsDelete request.
+func (c WebTestsAPIsClient) preparerForWebTestsDelete(ctx context.Context, id WebTestId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsDelete(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForWebTestsDelete handles the response to the WebTestsDelete request. The method always
+// closes the http.Response Body.
+func (c WebTestsAPIsClient) responderForWebTestsDelete(resp *http.Response) (result WebTestsDeleteOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusNoContent, http.StatusOK),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-06-15/webtestsapis/method_webtestsget_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-06-15/webtestsapis/method_webtestsget_autorest.go
@@ -1,0 +1,68 @@
+package webtestsapis
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type WebTestsGetOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *WebTest
+}
+
+// WebTestsGet ...
+func (c WebTestsAPIsClient) WebTestsGet(ctx context.Context, id WebTestId) (result WebTestsGetOperationResponse, err error) {
+	req, err := c.preparerForWebTestsGet(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "webtestsapis.WebTestsAPIsClient", "WebTestsGet", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "webtestsapis.WebTestsAPIsClient", "WebTestsGet", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForWebTestsGet(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "webtestsapis.WebTestsAPIsClient", "WebTestsGet", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForWebTestsGet prepares the WebTestsGet request.
+func (c WebTestsAPIsClient) preparerForWebTestsGet(ctx context.Context, id WebTestId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForWebTestsGet handles the response to the WebTestsGet request. The method always
+// closes the http.Response Body.
+func (c WebTestsAPIsClient) responderForWebTestsGet(resp *http.Response) (result WebTestsGetOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-06-15/webtestsapis/method_webtestslist_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-06-15/webtestsapis/method_webtestslist_autorest.go
@@ -1,0 +1,187 @@
+package webtestsapis
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type WebTestsListOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *[]WebTest
+
+	nextLink     *string
+	nextPageFunc func(ctx context.Context, nextLink string) (WebTestsListOperationResponse, error)
+}
+
+type WebTestsListCompleteResult struct {
+	Items []WebTest
+}
+
+func (r WebTestsListOperationResponse) HasMore() bool {
+	return r.nextLink != nil
+}
+
+func (r WebTestsListOperationResponse) LoadMore(ctx context.Context) (resp WebTestsListOperationResponse, err error) {
+	if !r.HasMore() {
+		err = fmt.Errorf("no more pages returned")
+		return
+	}
+	return r.nextPageFunc(ctx, *r.nextLink)
+}
+
+// WebTestsList ...
+func (c WebTestsAPIsClient) WebTestsList(ctx context.Context, id commonids.SubscriptionId) (resp WebTestsListOperationResponse, err error) {
+	req, err := c.preparerForWebTestsList(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "webtestsapis.WebTestsAPIsClient", "WebTestsList", nil, "Failure preparing request")
+		return
+	}
+
+	resp.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "webtestsapis.WebTestsAPIsClient", "WebTestsList", resp.HttpResponse, "Failure sending request")
+		return
+	}
+
+	resp, err = c.responderForWebTestsList(resp.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "webtestsapis.WebTestsAPIsClient", "WebTestsList", resp.HttpResponse, "Failure responding to request")
+		return
+	}
+	return
+}
+
+// preparerForWebTestsList prepares the WebTestsList request.
+func (c WebTestsAPIsClient) preparerForWebTestsList(ctx context.Context, id commonids.SubscriptionId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/providers/Microsoft.Insights/webTests", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// preparerForWebTestsListWithNextLink prepares the WebTestsList request with the given nextLink token.
+func (c WebTestsAPIsClient) preparerForWebTestsListWithNextLink(ctx context.Context, nextLink string) (*http.Request, error) {
+	uri, err := url.Parse(nextLink)
+	if err != nil {
+		return nil, fmt.Errorf("parsing nextLink %q: %+v", nextLink, err)
+	}
+	queryParameters := map[string]interface{}{}
+	for k, v := range uri.Query() {
+		if len(v) == 0 {
+			continue
+		}
+		val := v[0]
+		val = autorest.Encode("query", val)
+		queryParameters[k] = val
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(uri.Path),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForWebTestsList handles the response to the WebTestsList request. The method always
+// closes the http.Response Body.
+func (c WebTestsAPIsClient) responderForWebTestsList(resp *http.Response) (result WebTestsListOperationResponse, err error) {
+	type page struct {
+		Values   []WebTest `json:"value"`
+		NextLink *string   `json:"nextLink"`
+	}
+	var respObj page
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&respObj),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	result.Model = &respObj.Values
+	result.nextLink = respObj.NextLink
+	if respObj.NextLink != nil {
+		result.nextPageFunc = func(ctx context.Context, nextLink string) (result WebTestsListOperationResponse, err error) {
+			req, err := c.preparerForWebTestsListWithNextLink(ctx, nextLink)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "webtestsapis.WebTestsAPIsClient", "WebTestsList", nil, "Failure preparing request")
+				return
+			}
+
+			result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "webtestsapis.WebTestsAPIsClient", "WebTestsList", result.HttpResponse, "Failure sending request")
+				return
+			}
+
+			result, err = c.responderForWebTestsList(result.HttpResponse)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "webtestsapis.WebTestsAPIsClient", "WebTestsList", result.HttpResponse, "Failure responding to request")
+				return
+			}
+
+			return
+		}
+	}
+	return
+}
+
+// WebTestsListComplete retrieves all of the results into a single object
+func (c WebTestsAPIsClient) WebTestsListComplete(ctx context.Context, id commonids.SubscriptionId) (WebTestsListCompleteResult, error) {
+	return c.WebTestsListCompleteMatchingPredicate(ctx, id, WebTestOperationPredicate{})
+}
+
+// WebTestsListCompleteMatchingPredicate retrieves all of the results and then applied the predicate
+func (c WebTestsAPIsClient) WebTestsListCompleteMatchingPredicate(ctx context.Context, id commonids.SubscriptionId, predicate WebTestOperationPredicate) (resp WebTestsListCompleteResult, err error) {
+	items := make([]WebTest, 0)
+
+	page, err := c.WebTestsList(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading the initial page: %+v", err)
+		return
+	}
+	if page.Model != nil {
+		for _, v := range *page.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	for page.HasMore() {
+		page, err = page.LoadMore(ctx)
+		if err != nil {
+			err = fmt.Errorf("loading the next page: %+v", err)
+			return
+		}
+
+		if page.Model != nil {
+			for _, v := range *page.Model {
+				if predicate.Matches(v) {
+					items = append(items, v)
+				}
+			}
+		}
+	}
+
+	out := WebTestsListCompleteResult{
+		Items: items,
+	}
+	return out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-06-15/webtestsapis/method_webtestslistbycomponent_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-06-15/webtestsapis/method_webtestslistbycomponent_autorest.go
@@ -1,0 +1,186 @@
+package webtestsapis
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type WebTestsListByComponentOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *[]WebTest
+
+	nextLink     *string
+	nextPageFunc func(ctx context.Context, nextLink string) (WebTestsListByComponentOperationResponse, error)
+}
+
+type WebTestsListByComponentCompleteResult struct {
+	Items []WebTest
+}
+
+func (r WebTestsListByComponentOperationResponse) HasMore() bool {
+	return r.nextLink != nil
+}
+
+func (r WebTestsListByComponentOperationResponse) LoadMore(ctx context.Context) (resp WebTestsListByComponentOperationResponse, err error) {
+	if !r.HasMore() {
+		err = fmt.Errorf("no more pages returned")
+		return
+	}
+	return r.nextPageFunc(ctx, *r.nextLink)
+}
+
+// WebTestsListByComponent ...
+func (c WebTestsAPIsClient) WebTestsListByComponent(ctx context.Context, id ComponentId) (resp WebTestsListByComponentOperationResponse, err error) {
+	req, err := c.preparerForWebTestsListByComponent(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "webtestsapis.WebTestsAPIsClient", "WebTestsListByComponent", nil, "Failure preparing request")
+		return
+	}
+
+	resp.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "webtestsapis.WebTestsAPIsClient", "WebTestsListByComponent", resp.HttpResponse, "Failure sending request")
+		return
+	}
+
+	resp, err = c.responderForWebTestsListByComponent(resp.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "webtestsapis.WebTestsAPIsClient", "WebTestsListByComponent", resp.HttpResponse, "Failure responding to request")
+		return
+	}
+	return
+}
+
+// preparerForWebTestsListByComponent prepares the WebTestsListByComponent request.
+func (c WebTestsAPIsClient) preparerForWebTestsListByComponent(ctx context.Context, id ComponentId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/webTests", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// preparerForWebTestsListByComponentWithNextLink prepares the WebTestsListByComponent request with the given nextLink token.
+func (c WebTestsAPIsClient) preparerForWebTestsListByComponentWithNextLink(ctx context.Context, nextLink string) (*http.Request, error) {
+	uri, err := url.Parse(nextLink)
+	if err != nil {
+		return nil, fmt.Errorf("parsing nextLink %q: %+v", nextLink, err)
+	}
+	queryParameters := map[string]interface{}{}
+	for k, v := range uri.Query() {
+		if len(v) == 0 {
+			continue
+		}
+		val := v[0]
+		val = autorest.Encode("query", val)
+		queryParameters[k] = val
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(uri.Path),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForWebTestsListByComponent handles the response to the WebTestsListByComponent request. The method always
+// closes the http.Response Body.
+func (c WebTestsAPIsClient) responderForWebTestsListByComponent(resp *http.Response) (result WebTestsListByComponentOperationResponse, err error) {
+	type page struct {
+		Values   []WebTest `json:"value"`
+		NextLink *string   `json:"nextLink"`
+	}
+	var respObj page
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&respObj),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	result.Model = &respObj.Values
+	result.nextLink = respObj.NextLink
+	if respObj.NextLink != nil {
+		result.nextPageFunc = func(ctx context.Context, nextLink string) (result WebTestsListByComponentOperationResponse, err error) {
+			req, err := c.preparerForWebTestsListByComponentWithNextLink(ctx, nextLink)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "webtestsapis.WebTestsAPIsClient", "WebTestsListByComponent", nil, "Failure preparing request")
+				return
+			}
+
+			result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "webtestsapis.WebTestsAPIsClient", "WebTestsListByComponent", result.HttpResponse, "Failure sending request")
+				return
+			}
+
+			result, err = c.responderForWebTestsListByComponent(result.HttpResponse)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "webtestsapis.WebTestsAPIsClient", "WebTestsListByComponent", result.HttpResponse, "Failure responding to request")
+				return
+			}
+
+			return
+		}
+	}
+	return
+}
+
+// WebTestsListByComponentComplete retrieves all of the results into a single object
+func (c WebTestsAPIsClient) WebTestsListByComponentComplete(ctx context.Context, id ComponentId) (WebTestsListByComponentCompleteResult, error) {
+	return c.WebTestsListByComponentCompleteMatchingPredicate(ctx, id, WebTestOperationPredicate{})
+}
+
+// WebTestsListByComponentCompleteMatchingPredicate retrieves all of the results and then applied the predicate
+func (c WebTestsAPIsClient) WebTestsListByComponentCompleteMatchingPredicate(ctx context.Context, id ComponentId, predicate WebTestOperationPredicate) (resp WebTestsListByComponentCompleteResult, err error) {
+	items := make([]WebTest, 0)
+
+	page, err := c.WebTestsListByComponent(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading the initial page: %+v", err)
+		return
+	}
+	if page.Model != nil {
+		for _, v := range *page.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	for page.HasMore() {
+		page, err = page.LoadMore(ctx)
+		if err != nil {
+			err = fmt.Errorf("loading the next page: %+v", err)
+			return
+		}
+
+		if page.Model != nil {
+			for _, v := range *page.Model {
+				if predicate.Matches(v) {
+					items = append(items, v)
+				}
+			}
+		}
+	}
+
+	out := WebTestsListByComponentCompleteResult{
+		Items: items,
+	}
+	return out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-06-15/webtestsapis/method_webtestslistbyresourcegroup_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-06-15/webtestsapis/method_webtestslistbyresourcegroup_autorest.go
@@ -1,0 +1,187 @@
+package webtestsapis
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type WebTestsListByResourceGroupOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *[]WebTest
+
+	nextLink     *string
+	nextPageFunc func(ctx context.Context, nextLink string) (WebTestsListByResourceGroupOperationResponse, error)
+}
+
+type WebTestsListByResourceGroupCompleteResult struct {
+	Items []WebTest
+}
+
+func (r WebTestsListByResourceGroupOperationResponse) HasMore() bool {
+	return r.nextLink != nil
+}
+
+func (r WebTestsListByResourceGroupOperationResponse) LoadMore(ctx context.Context) (resp WebTestsListByResourceGroupOperationResponse, err error) {
+	if !r.HasMore() {
+		err = fmt.Errorf("no more pages returned")
+		return
+	}
+	return r.nextPageFunc(ctx, *r.nextLink)
+}
+
+// WebTestsListByResourceGroup ...
+func (c WebTestsAPIsClient) WebTestsListByResourceGroup(ctx context.Context, id commonids.ResourceGroupId) (resp WebTestsListByResourceGroupOperationResponse, err error) {
+	req, err := c.preparerForWebTestsListByResourceGroup(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "webtestsapis.WebTestsAPIsClient", "WebTestsListByResourceGroup", nil, "Failure preparing request")
+		return
+	}
+
+	resp.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "webtestsapis.WebTestsAPIsClient", "WebTestsListByResourceGroup", resp.HttpResponse, "Failure sending request")
+		return
+	}
+
+	resp, err = c.responderForWebTestsListByResourceGroup(resp.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "webtestsapis.WebTestsAPIsClient", "WebTestsListByResourceGroup", resp.HttpResponse, "Failure responding to request")
+		return
+	}
+	return
+}
+
+// preparerForWebTestsListByResourceGroup prepares the WebTestsListByResourceGroup request.
+func (c WebTestsAPIsClient) preparerForWebTestsListByResourceGroup(ctx context.Context, id commonids.ResourceGroupId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/providers/Microsoft.Insights/webTests", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// preparerForWebTestsListByResourceGroupWithNextLink prepares the WebTestsListByResourceGroup request with the given nextLink token.
+func (c WebTestsAPIsClient) preparerForWebTestsListByResourceGroupWithNextLink(ctx context.Context, nextLink string) (*http.Request, error) {
+	uri, err := url.Parse(nextLink)
+	if err != nil {
+		return nil, fmt.Errorf("parsing nextLink %q: %+v", nextLink, err)
+	}
+	queryParameters := map[string]interface{}{}
+	for k, v := range uri.Query() {
+		if len(v) == 0 {
+			continue
+		}
+		val := v[0]
+		val = autorest.Encode("query", val)
+		queryParameters[k] = val
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(uri.Path),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForWebTestsListByResourceGroup handles the response to the WebTestsListByResourceGroup request. The method always
+// closes the http.Response Body.
+func (c WebTestsAPIsClient) responderForWebTestsListByResourceGroup(resp *http.Response) (result WebTestsListByResourceGroupOperationResponse, err error) {
+	type page struct {
+		Values   []WebTest `json:"value"`
+		NextLink *string   `json:"nextLink"`
+	}
+	var respObj page
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&respObj),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	result.Model = &respObj.Values
+	result.nextLink = respObj.NextLink
+	if respObj.NextLink != nil {
+		result.nextPageFunc = func(ctx context.Context, nextLink string) (result WebTestsListByResourceGroupOperationResponse, err error) {
+			req, err := c.preparerForWebTestsListByResourceGroupWithNextLink(ctx, nextLink)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "webtestsapis.WebTestsAPIsClient", "WebTestsListByResourceGroup", nil, "Failure preparing request")
+				return
+			}
+
+			result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "webtestsapis.WebTestsAPIsClient", "WebTestsListByResourceGroup", result.HttpResponse, "Failure sending request")
+				return
+			}
+
+			result, err = c.responderForWebTestsListByResourceGroup(result.HttpResponse)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "webtestsapis.WebTestsAPIsClient", "WebTestsListByResourceGroup", result.HttpResponse, "Failure responding to request")
+				return
+			}
+
+			return
+		}
+	}
+	return
+}
+
+// WebTestsListByResourceGroupComplete retrieves all of the results into a single object
+func (c WebTestsAPIsClient) WebTestsListByResourceGroupComplete(ctx context.Context, id commonids.ResourceGroupId) (WebTestsListByResourceGroupCompleteResult, error) {
+	return c.WebTestsListByResourceGroupCompleteMatchingPredicate(ctx, id, WebTestOperationPredicate{})
+}
+
+// WebTestsListByResourceGroupCompleteMatchingPredicate retrieves all of the results and then applied the predicate
+func (c WebTestsAPIsClient) WebTestsListByResourceGroupCompleteMatchingPredicate(ctx context.Context, id commonids.ResourceGroupId, predicate WebTestOperationPredicate) (resp WebTestsListByResourceGroupCompleteResult, err error) {
+	items := make([]WebTest, 0)
+
+	page, err := c.WebTestsListByResourceGroup(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading the initial page: %+v", err)
+		return
+	}
+	if page.Model != nil {
+		for _, v := range *page.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	for page.HasMore() {
+		page, err = page.LoadMore(ctx)
+		if err != nil {
+			err = fmt.Errorf("loading the next page: %+v", err)
+			return
+		}
+
+		if page.Model != nil {
+			for _, v := range *page.Model {
+				if predicate.Matches(v) {
+					items = append(items, v)
+				}
+			}
+		}
+	}
+
+	out := WebTestsListByResourceGroupCompleteResult{
+		Items: items,
+	}
+	return out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-06-15/webtestsapis/method_webtestsupdatetags_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-06-15/webtestsapis/method_webtestsupdatetags_autorest.go
@@ -1,0 +1,69 @@
+package webtestsapis
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type WebTestsUpdateTagsOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *WebTest
+}
+
+// WebTestsUpdateTags ...
+func (c WebTestsAPIsClient) WebTestsUpdateTags(ctx context.Context, id WebTestId, input TagsResource) (result WebTestsUpdateTagsOperationResponse, err error) {
+	req, err := c.preparerForWebTestsUpdateTags(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "webtestsapis.WebTestsAPIsClient", "WebTestsUpdateTags", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "webtestsapis.WebTestsAPIsClient", "WebTestsUpdateTags", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForWebTestsUpdateTags(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "webtestsapis.WebTestsAPIsClient", "WebTestsUpdateTags", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForWebTestsUpdateTags prepares the WebTestsUpdateTags request.
+func (c WebTestsAPIsClient) preparerForWebTestsUpdateTags(ctx context.Context, id WebTestId, input TagsResource) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPatch(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForWebTestsUpdateTags handles the response to the WebTestsUpdateTags request. The method always
+// closes the http.Response Body.
+func (c WebTestsAPIsClient) responderForWebTestsUpdateTags(resp *http.Response) (result WebTestsUpdateTagsOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-06-15/webtestsapis/model_headerfield.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-06-15/webtestsapis/model_headerfield.go
@@ -1,0 +1,9 @@
+package webtestsapis
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type HeaderField struct {
+	Key   *string `json:"key,omitempty"`
+	Value *string `json:"value,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-06-15/webtestsapis/model_tagsresource.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-06-15/webtestsapis/model_tagsresource.go
@@ -1,0 +1,8 @@
+package webtestsapis
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type TagsResource struct {
+	Tags *map[string]string `json:"tags,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-06-15/webtestsapis/model_webtest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-06-15/webtestsapis/model_webtest.go
@@ -1,0 +1,14 @@
+package webtestsapis
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type WebTest struct {
+	Id         *string            `json:"id,omitempty"`
+	Kind       *WebTestKind       `json:"kind,omitempty"`
+	Location   string             `json:"location"`
+	Name       *string            `json:"name,omitempty"`
+	Properties *WebTestProperties `json:"properties,omitempty"`
+	Tags       *map[string]string `json:"tags,omitempty"`
+	Type       *string            `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-06-15/webtestsapis/model_webtestgeolocation.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-06-15/webtestsapis/model_webtestgeolocation.go
@@ -1,0 +1,8 @@
+package webtestsapis
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type WebTestGeolocation struct {
+	Id *string `json:"Id,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-06-15/webtestsapis/model_webtestproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-06-15/webtestsapis/model_webtestproperties.go
@@ -1,0 +1,20 @@
+package webtestsapis
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type WebTestProperties struct {
+	Configuration      *WebTestPropertiesConfiguration   `json:"Configuration,omitempty"`
+	Description        *string                           `json:"Description,omitempty"`
+	Enabled            *bool                             `json:"Enabled,omitempty"`
+	Frequency          *int64                            `json:"Frequency,omitempty"`
+	Kind               WebTestKind                       `json:"Kind"`
+	Locations          []WebTestGeolocation              `json:"Locations"`
+	Name               string                            `json:"Name"`
+	ProvisioningState  *string                           `json:"provisioningState,omitempty"`
+	Request            *WebTestPropertiesRequest         `json:"Request,omitempty"`
+	RetryEnabled       *bool                             `json:"RetryEnabled,omitempty"`
+	SyntheticMonitorId string                            `json:"SyntheticMonitorId"`
+	Timeout            *int64                            `json:"Timeout,omitempty"`
+	ValidationRules    *WebTestPropertiesValidationRules `json:"ValidationRules,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-06-15/webtestsapis/model_webtestpropertiesconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-06-15/webtestsapis/model_webtestpropertiesconfiguration.go
@@ -1,0 +1,8 @@
+package webtestsapis
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type WebTestPropertiesConfiguration struct {
+	WebTest *string `json:"WebTest,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-06-15/webtestsapis/model_webtestpropertiesrequest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-06-15/webtestsapis/model_webtestpropertiesrequest.go
@@ -1,0 +1,13 @@
+package webtestsapis
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type WebTestPropertiesRequest struct {
+	FollowRedirects        *bool          `json:"FollowRedirects,omitempty"`
+	HTTPVerb               *string        `json:"HttpVerb,omitempty"`
+	Headers                *[]HeaderField `json:"Headers,omitempty"`
+	ParseDependentRequests *bool          `json:"ParseDependentRequests,omitempty"`
+	RequestBody            *string        `json:"RequestBody,omitempty"`
+	RequestUrl             *string        `json:"RequestUrl,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-06-15/webtestsapis/model_webtestpropertiesvalidationrules.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-06-15/webtestsapis/model_webtestpropertiesvalidationrules.go
@@ -1,0 +1,12 @@
+package webtestsapis
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type WebTestPropertiesValidationRules struct {
+	ContentValidation             *WebTestPropertiesValidationRulesContentValidation `json:"ContentValidation,omitempty"`
+	ExpectedHTTPStatusCode        *int64                                             `json:"ExpectedHttpStatusCode,omitempty"`
+	IgnoreHTTPSStatusCode         *bool                                              `json:"IgnoreHttpsStatusCode,omitempty"`
+	SSLCertRemainingLifetimeCheck *int64                                             `json:"SSLCertRemainingLifetimeCheck,omitempty"`
+	SSLCheck                      *bool                                              `json:"SSLCheck,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-06-15/webtestsapis/model_webtestpropertiesvalidationrulescontentvalidation.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-06-15/webtestsapis/model_webtestpropertiesvalidationrulescontentvalidation.go
@@ -1,0 +1,10 @@
+package webtestsapis
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type WebTestPropertiesValidationRulesContentValidation struct {
+	ContentMatch    *string `json:"ContentMatch,omitempty"`
+	IgnoreCase      *bool   `json:"IgnoreCase,omitempty"`
+	PassIfTextFound *bool   `json:"PassIfTextFound,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-06-15/webtestsapis/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-06-15/webtestsapis/predicates.go
@@ -1,0 +1,29 @@
+package webtestsapis
+
+type WebTestOperationPredicate struct {
+	Id       *string
+	Location *string
+	Name     *string
+	Type     *string
+}
+
+func (p WebTestOperationPredicate) Matches(input WebTest) bool {
+
+	if p.Id != nil && (input.Id == nil && *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Location != nil && *p.Location != input.Location {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil && *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil && *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-06-15/webtestsapis/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-06-15/webtestsapis/version.go
@@ -1,0 +1,12 @@
+package webtestsapis
+
+import "fmt"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2022-06-15"
+
+func userAgent() string {
+	return fmt.Sprintf("hashicorp/go-azure-sdk/webtestsapis/%s", defaultApiVersion)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -190,6 +190,7 @@ github.com/hashicorp/go-azure-sdk/resource-manager/appconfiguration/2022-05-01/c
 github.com/hashicorp/go-azure-sdk/resource-manager/appconfiguration/2022-05-01/deletedconfigurationstores
 github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2020-11-20/workbooktemplatesapis
 github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-04-01/workbooksapis
+github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-06-15/webtestsapis
 github.com/hashicorp/go-azure-sdk/resource-manager/attestation/2020-10-01/attestationproviders
 github.com/hashicorp/go-azure-sdk/resource-manager/automation/2019-06-01/runbook
 github.com/hashicorp/go-azure-sdk/resource-manager/automation/2021-06-22/automationaccount

--- a/website/docs/r/application_insights_standard_web_test.html.markdown
+++ b/website/docs/r/application_insights_standard_web_test.html.markdown
@@ -1,0 +1,145 @@
+---
+subcategory: "Application Insights"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_application_insights_standard_web_test"
+description: |-
+  Manages a Application Insights Standard WebTest.
+---
+
+# azurerm_application_insights_standard_web_test
+
+Manages a Application Insights Standard WebTest.
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "rg-example"
+  location = "West Europe"
+}
+
+resource "azurerm_application_insights" "example" {
+  name                = "example"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  application_type    = "web"
+}
+
+resource "azurerm_application_insights_standard_web_test" "example" {
+  name                    = "example-test"
+  resource_group_name     = azurerm_resource_group.example.name
+  location                = "West Europe"
+  application_insights_id = azurerm_application_insights.example.id
+  geo_locations           = ["example"]
+
+  request {
+    url = "http://www.example.com"
+  }
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name which should be used for this Application Insights Standard WebTest. Changing this forces a new Application Insights Standard WebTest to be created.
+
+* `resource_group_name` - (Required) The name of the Resource Group where the Application Insights Standard WebTest should exist. Changing this forces a new Application Insights Standard WebTest to be created.
+
+* `location` - (Required) The Azure Region where the Application Insights Standard WebTest should exist. Changing this forces a new Application Insights Standard WebTest to be created. It needs to correlate with location of the parent resource (azurerm_application_insights)
+
+* `application_insights_id` - (Required) The ID of the Application Insights instance on which the WebTest operates. Changing this forces a new Application Insights Standard WebTest to be created.
+
+* `geo_locations` - (Required) Specifies a list of where to physically run the tests from to give global coverage for accessibility of your application.
+
+~> **Note:** [Valid options for geo locations are described here](https://docs.microsoft.com/azure/azure-monitor/app/monitor-web-app-availability#location-population-tags)
+
+* `request` - (Required) A `request` block as defined below.
+
+
+---
+
+* `description` - (Optional) Purpose/user defined descriptive test for this WebTest.
+
+* `enabled` - (Optional) Should the WebTest be enabled?
+
+* `frequency` - (Optional) Interval in seconds between test runs for this WebTest. Valid options are `300`, `600` and `900`. Defaults to `300`.
+
+* `retry_enabled` - (Optional) Should the retry on WebTest failure be enabled?
+
+* `tags` - (Optional) A mapping of tags which should be assigned to the Application Insights Standard WebTest.
+
+* `timeout` - (Optional) Seconds until this WebTest will timeout and fail. Default is `30`.
+
+* `validation_rules` - (Optional) A `validation_rules` block as defined below.
+
+---
+
+A `content` block supports the following:
+
+* `content_match` - (Required) A string value containing the content to match on.
+
+* `ignore_case` - (Optional) Ignore the casing in the `content_match` value.
+
+* `pass_if_text_found` - (Optional) If the content of `content_match` is found, pass the test. If set to `false`, the WebTest is failing if the content of `content_match` is found.
+
+---
+
+A `header` block supports the following:
+
+* `name` - (Required) The name which should be used for a header in the request.
+
+* `value` - (Required) The value which should be used for a header in the request.
+
+---
+
+A `request` block supports the following:
+
+* `url` - (Required) The WebTest request URL.
+
+* `body` - (Optional) The WebTest request body.
+
+* `follow_redirects_enabled` - (Optional) Should the following of redirects be enabled?
+
+* `header` - (Optional) One or more `header` blocks as defined above.
+
+* `http_verb` - (Optional) Which HTTP verb to use for the call. Options are 'GET', 'POST', 'PUT', 'PATCH', and 'DELETE'.
+
+* `parse_dependent_requests_enabled` - (Optional) Should the parsing of dependend requests be enabled?
+
+---
+
+A `validation_rules` block supports the following:
+
+* `content` - (Optional) A `content` block as defined above.
+
+* `expected_status_code` - (Optional) The expected status code of the response. Default is '200', '0' means 'response code < 400'
+
+* `ssl_cert_remaining_lifetime` - (Optional) The number of days of SSL certificate validity remaining for the checked endpoint. If the certificate has a shorter remaining lifetime left, the test will fail.
+
+* `ssl_check_enabled` - (Optional) Should the SSL check be enabled?
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported: 
+
+* `id` - The ID of the Application Insights Standard WebTest.
+
+* `synthetic_monitor_id` - Unique ID of this WebTest. This is typically the same value as the Name field.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Application Insights Standard WebTest.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Application Insights Standard WebTest.
+* `update` - (Defaults to 30 minutes) Used when updating the Application Insights Standard WebTest.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Application Insights Standard WebTest.
+
+## Import
+
+Application Insights Standard WebTests can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_application_insights_standard_web_test.example /subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Insights/webTests/appinsightswebtest
+```


### PR DESCRIPTION
Fixes #14184

Implemented as a separate resource, as Classic Webtests (`azurerm_application_insights_web_test`) are configured with a few lines of XML, and Standard Webtest are completely modelled.

Implemented in the UI as 2 different options:
<img width="297" alt="Screenshot 2023-01-09 at 20 21 42" src="https://user-images.githubusercontent.com/8375124/211658706-27a099fc-5690-4805-b06f-d90dd36a9665.png">


## Acceptance tests
```
❯ go install && make acctests SERVICE='applicationinsights' TESTARGS='-run=TestAccApplicationInsightsStandardWebTest_'

==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/applicationinsights -run=TestAccApplicationInsightsStandardWebTest_ -timeout 180m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccApplicationInsightsStandardWebTest_basic
=== PAUSE TestAccApplicationInsightsStandardWebTest_basic
=== RUN   TestAccApplicationInsightsStandardWebTest_requiresImport
=== PAUSE TestAccApplicationInsightsStandardWebTest_requiresImport
=== RUN   TestAccApplicationInsightsStandardWebTest_complete
=== PAUSE TestAccApplicationInsightsStandardWebTest_complete
=== CONT  TestAccApplicationInsightsStandardWebTest_basic
=== CONT  TestAccApplicationInsightsStandardWebTest_complete
=== CONT  TestAccApplicationInsightsStandardWebTest_requiresImport
--- PASS: TestAccApplicationInsightsStandardWebTest_basic (170.91s)
--- PASS: TestAccApplicationInsightsStandardWebTest_requiresImport (184.64s)
--- PASS: TestAccApplicationInsightsStandardWebTest_complete (369.44s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/applicationinsights   371.229s
```
