### PR TITLE
New Resource `azurerm_media_services_account_filter`

### DIFF
--- a/internal/provider/services.go
+++ b/internal/provider/services.go
@@ -144,6 +144,7 @@ func SupportedTypedServices() []sdk.TypedServiceRegistration {
 		labservice.Registration{},
 		loadbalancer.Registration{},
 		loganalytics.Registration{},
+		media.Registration{},
 		monitor.Registration{},
 		mssql.Registration{},
 		network.Registration{},

--- a/internal/services/media/media_asset_filter_resource.go
+++ b/internal/services/media/media_asset_filter_resource.go
@@ -17,14 +17,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
-// define constants based on docs https://docs.microsoft.com/en-us/azure/media-services/latest/filters-concept
-const incrementsInASecond = 10000000
-
-const (
-	nanoSecondsInAIncrement = 100
-	milliSecondsInASecond   = 1000
-)
-
 func resourceMediaAssetFilter() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
 		Create: resourceMediaAssetFilterCreateUpdate,

--- a/internal/services/media/media_filter.go
+++ b/internal/services/media/media_filter.go
@@ -1,0 +1,9 @@
+package media
+
+// define constants based on docs https://docs.microsoft.com/en-us/azure/media-services/latest/filters-concept
+const incrementsInASecond = 10000000
+
+const (
+	nanoSecondsInAIncrement = 100
+	milliSecondsInASecond   = 1000
+)

--- a/internal/services/media/media_service_account_filter_resource.go
+++ b/internal/services/media/media_service_account_filter_resource.go
@@ -1,0 +1,465 @@
+package media
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-08-01/accountfilters"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+type AccountFilterModel struct {
+	Name                     string                  `tfschema:"name"`
+	ResourceGroupName        string                  `tfschema:"resource_group_name"`
+	MediaServicesAccountName string                  `tfschema:"media_services_account_name"`
+	FirstQualityBitrate      int64                   `tfschema:"first_quality_bitrate"`
+	PresentationTimeRange    []PresentationTimeRange `tfschema:"presentation_time_range"`
+	TrackSelection           []TrackSelection        `tfschema:"track_selection"`
+}
+
+type PresentationTimeRange struct {
+	EndInUnits                  int64 `tfschema:"end_in_units"`
+	ForceEnd                    bool  `tfschema:"force_end"`
+	LiveBackoffInUnits          int64 `tfschema:"live_backoff_in_units"`
+	PresentationWindowInUnits   int64 `tfschema:"presentation_window_in_units"`
+	StartInUnits                int64 `tfschema:"start_in_units"`
+	UnitTimescaleInMillisceonds int64 `tfschema:"unit_timescale_in_milliseconds"`
+}
+
+type TrackSelection struct {
+	Conditions []Condition `tfschema:"condition"`
+}
+
+type Condition struct {
+	Operation string `tfschema:"operation"`
+	Property  string `tfschema:"property"`
+	Value     string `tfschema:"value"`
+}
+
+type AccountFilterResource struct{}
+
+func (r AccountFilterResource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"resource_group_name": commonschema.ResourceGroupName(),
+
+		"media_services_account_name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"first_quality_bitrate": {
+			Type:         pluginsdk.TypeInt,
+			Optional:     true,
+			ValidateFunc: validation.IntAtLeast(1),
+		},
+
+		"presentation_time_range": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"end_in_units": {
+						Type:         pluginsdk.TypeInt,
+						Optional:     true,
+						ValidateFunc: validation.IntAtLeast(0),
+						AtLeastOneOf: []string{
+							"presentation_time_range.0.end_in_units", "presentation_time_range.0.force_end", "presentation_time_range.0.live_backoff_in_units",
+							"presentation_time_range.0.presentation_window_in_units", "presentation_time_range.0.start_in_units",
+						},
+					},
+
+					"force_end": {
+						Type:     pluginsdk.TypeBool,
+						Optional: true,
+						AtLeastOneOf: []string{
+							"presentation_time_range.0.end_in_units", "presentation_time_range.0.force_end", "presentation_time_range.0.live_backoff_in_units",
+							"presentation_time_range.0.presentation_window_in_units", "presentation_time_range.0.start_in_units",
+						},
+					},
+
+					"live_backoff_in_units": {
+						Type:         pluginsdk.TypeInt,
+						Optional:     true,
+						ValidateFunc: validation.IntAtLeast(0),
+						AtLeastOneOf: []string{
+							"presentation_time_range.0.end_in_units", "presentation_time_range.0.force_end", "presentation_time_range.0.live_backoff_in_units",
+							"presentation_time_range.0.presentation_window_in_units", "presentation_time_range.0.start_in_units",
+						},
+					},
+
+					"presentation_window_in_units": {
+						Type:         pluginsdk.TypeInt,
+						Optional:     true,
+						ValidateFunc: validation.IntAtLeast(0),
+						AtLeastOneOf: []string{
+							"presentation_time_range.0.end_in_units", "presentation_time_range.0.force_end", "presentation_time_range.0.live_backoff_in_units",
+							"presentation_time_range.0.presentation_window_in_units", "presentation_time_range.0.start_in_units",
+						},
+					},
+
+					"start_in_units": {
+						Type:         pluginsdk.TypeInt,
+						Optional:     true,
+						ValidateFunc: validation.IntAtLeast(0),
+						AtLeastOneOf: []string{
+							"presentation_time_range.0.end_in_units", "presentation_time_range.0.force_end", "presentation_time_range.0.live_backoff_in_units",
+							"presentation_time_range.0.presentation_window_in_units", "presentation_time_range.0.start_in_units",
+						},
+					},
+
+					"unit_timescale_in_milliseconds": {
+						Type:         pluginsdk.TypeInt,
+						Required:     true,
+						ValidateFunc: validation.IntAtLeast(1),
+					},
+				},
+			},
+		},
+
+		"track_selection": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"condition": {
+						Type:     pluginsdk.TypeList,
+						Required: true,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"operation": {
+									Type:     pluginsdk.TypeString,
+									Required: true,
+									ValidateFunc: validation.StringInSlice([]string{
+										string(accountfilters.FilterTrackPropertyCompareOperationEqual),
+										string(accountfilters.FilterTrackPropertyCompareOperationNotEqual),
+									}, false),
+								},
+
+								"property": {
+									Type:     pluginsdk.TypeString,
+									Required: true,
+									ValidateFunc: validation.StringInSlice([]string{
+										string(accountfilters.FilterTrackPropertyTypeBitrate),
+										string(accountfilters.FilterTrackPropertyTypeFourCC),
+										string(accountfilters.FilterTrackPropertyTypeLanguage),
+										string(accountfilters.FilterTrackPropertyTypeName),
+										string(accountfilters.FilterTrackPropertyTypeType),
+									}, false),
+								},
+
+								"value": {
+									Type:         pluginsdk.TypeString,
+									Required:     true,
+									ValidateFunc: validation.StringIsNotEmpty,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (r AccountFilterResource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{}
+}
+
+func (r AccountFilterResource) ResourceType() string {
+	return "azurerm_media_services_account_filter"
+}
+
+func (r AccountFilterResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+	return accountfilters.ValidateAccountFilterID
+}
+
+func (r AccountFilterResource) ModelObject() interface{} {
+	return &AccountFilterModel{}
+}
+
+func (r AccountFilterResource) Create() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			metadata.Logger.Info("Decoding state..")
+			var state AccountFilterModel
+			if err := metadata.Decode(&state); err != nil {
+				return err
+			}
+
+			client := metadata.Client.Media.V20220801Client.AccountFilters
+			subscriptionId := metadata.Client.Account.SubscriptionId
+
+			id := accountfilters.NewAccountFilterID(subscriptionId, state.ResourceGroupName, state.MediaServicesAccountName, state.Name)
+			metadata.Logger.Infof("creating %s", id)
+
+			existing, err := client.AccountFiltersGet(ctx, id)
+			if err != nil && !response.WasNotFound(existing.HttpResponse) {
+				return fmt.Errorf("checking for the presence of an existing %s: %+v", id, err)
+			}
+			if !response.WasNotFound(existing.HttpResponse) {
+				return metadata.ResourceRequiresImport(r.ResourceType(), id)
+			}
+
+			input := accountfilters.AccountFilter{
+				Name: utils.String(state.Name),
+				Properties: &accountfilters.MediaFilterProperties{
+					PresentationTimeRange: expandAccountFilterPresentationTimeRange(state.PresentationTimeRange),
+					Tracks:                expandAccountFilterTrackSelections(state.TrackSelection),
+				},
+			}
+			if state.FirstQualityBitrate != 0 {
+				input.Properties.FirstQuality = &accountfilters.FirstQuality{
+					Bitrate: state.FirstQualityBitrate,
+				}
+			}
+
+			if _, err = client.AccountFiltersCreateOrUpdate(ctx, id, input); err != nil {
+				return fmt.Errorf("creating %s: %+v", id, err)
+			}
+
+			metadata.SetID(id)
+			return nil
+		},
+		Timeout: 30 * time.Minute,
+	}
+}
+
+func (r AccountFilterResource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Media.V20220801Client.AccountFilters
+			id, err := accountfilters.ParseAccountFilterID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			metadata.Logger.Infof("retrieving %s", *id)
+			resp, err := client.AccountFiltersGet(ctx, *id)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					metadata.Logger.Infof("%s was not found - removing from state!", *id)
+					return metadata.MarkAsGone(id)
+				}
+				return fmt.Errorf("retrieving %s: %+v", *id, err)
+			}
+
+			if resp.Model == nil || resp.Model.Properties == nil {
+				return fmt.Errorf("retrieving %s: got empty Model", *id)
+			}
+			prop := resp.Model.Properties
+			var firstQualityBitrate int64
+			if prop.FirstQuality != nil {
+				firstQualityBitrate = prop.FirstQuality.Bitrate
+			}
+
+			return metadata.Encode(&AccountFilterModel{
+				Name:                     id.FilterName,
+				ResourceGroupName:        id.ResourceGroupName,
+				MediaServicesAccountName: id.AccountName,
+				FirstQualityBitrate:      firstQualityBitrate,
+				PresentationTimeRange:    flattenAccountFilterPresentationTimeRange(prop.PresentationTimeRange),
+				TrackSelection:           flattenAccountFilterTracks(prop.Tracks),
+			})
+		},
+		Timeout: 5 * time.Minute,
+	}
+}
+
+func (r AccountFilterResource) Update() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			id, err := accountfilters.ParseAccountFilterID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			metadata.Logger.Infof("updating %s..", *id)
+			client := metadata.Client.Media.V20220801Client.AccountFilters
+
+			var state AccountFilterModel
+			if err := metadata.Decode(&state); err != nil {
+				return err
+			}
+
+			resp, err := client.AccountFiltersGet(ctx, *id)
+			if err != nil {
+				return fmt.Errorf("retrieving %s: %+v", *id, err)
+			}
+			if resp.Model == nil || resp.Model.Properties == nil {
+				return fmt.Errorf("retrieving %s: got empty Model", *id)
+			}
+			existing := resp.Model
+
+			if metadata.ResourceData.HasChange("first_quality_bitrate") {
+				existing.Properties.FirstQuality = &accountfilters.FirstQuality{
+					Bitrate: state.FirstQualityBitrate,
+				}
+			}
+
+			if metadata.ResourceData.HasChange("presentation_time_range") {
+				existing.Properties.PresentationTimeRange = expandAccountFilterPresentationTimeRange(state.PresentationTimeRange)
+			}
+
+			if metadata.ResourceData.HasChange("track_selection") {
+				existing.Properties.Tracks = expandAccountFilterTrackSelections(state.TrackSelection)
+			}
+
+			if _, err := client.AccountFiltersCreateOrUpdate(ctx, *id, *existing); err != nil {
+				return fmt.Errorf("updating %s: %+v", *id, err)
+			}
+			return nil
+		},
+		Timeout: 30 * time.Minute,
+	}
+}
+
+func (r AccountFilterResource) Delete() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Media.V20220801Client.AccountFilters
+			id, err := accountfilters.ParseAccountFilterID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			metadata.Logger.Infof("deleting %s..", *id)
+			resp, err := client.AccountFiltersDelete(ctx, *id)
+			if err != nil && !response.WasNotFound(resp.HttpResponse) {
+				return fmt.Errorf("deleting %s: %+v", *id, err)
+			}
+			return nil
+		},
+		Timeout: 30 * time.Minute,
+	}
+}
+
+func expandAccountFilterPresentationTimeRange(input []PresentationTimeRange) *accountfilters.PresentationTimeRange {
+	if len(input) == 0 {
+		return nil
+	}
+
+	timeRange := input[0]
+	presentationTimeRange := &accountfilters.PresentationTimeRange{
+		ForceEndTimestamp: utils.Bool(timeRange.ForceEnd),
+		Timescale:         utils.Int64((incrementsInASecond * nanoSecondsInAIncrement) / milliSecondsInASecond / timeRange.UnitTimescaleInMillisceonds),
+	}
+
+	if timeRange.EndInUnits != 0 {
+		presentationTimeRange.EndTimestamp = utils.Int64(timeRange.EndInUnits * milliSecondsInASecond)
+	}
+
+	if timeRange.LiveBackoffInUnits != 0 {
+		presentationTimeRange.LiveBackoffDuration = utils.Int64(timeRange.LiveBackoffInUnits * milliSecondsInASecond)
+	}
+
+	if timeRange.PresentationWindowInUnits != 0 {
+		presentationTimeRange.PresentationWindowDuration = utils.Int64(timeRange.PresentationWindowInUnits * milliSecondsInASecond)
+	}
+
+	if timeRange.StartInUnits != 0 {
+		presentationTimeRange.StartTimestamp = utils.Int64(timeRange.StartInUnits * milliSecondsInASecond)
+	}
+
+	return presentationTimeRange
+}
+
+func flattenAccountFilterPresentationTimeRange(input *accountfilters.PresentationTimeRange) []PresentationTimeRange {
+	if input == nil {
+		return make([]PresentationTimeRange, 0)
+	}
+
+	var unitTimescaleInMillisceonds, endInUnits, startInUnits, liveBackoffInUnits, presentationWindowInUnits int64
+	var forceEnd bool
+	if input.Timescale != nil {
+		unitTimescaleInMillisceonds = (incrementsInASecond * nanoSecondsInAIncrement) / milliSecondsInASecond / *input.Timescale
+	}
+
+	if input.EndTimestamp != nil {
+		endInUnits = *input.EndTimestamp / milliSecondsInASecond
+	}
+
+	if input.ForceEndTimestamp != nil {
+		forceEnd = *input.ForceEndTimestamp
+	}
+
+	if input.LiveBackoffDuration != nil {
+		liveBackoffInUnits = *input.LiveBackoffDuration / milliSecondsInASecond
+	}
+
+	if input.PresentationWindowDuration != nil {
+		presentationWindowInUnits = *input.PresentationWindowDuration / milliSecondsInASecond
+	}
+
+	if input.StartTimestamp != nil {
+		startInUnits = *input.StartTimestamp / milliSecondsInASecond
+	}
+	return []PresentationTimeRange{
+		{
+			EndInUnits:                  endInUnits,
+			ForceEnd:                    forceEnd,
+			LiveBackoffInUnits:          liveBackoffInUnits,
+			PresentationWindowInUnits:   presentationWindowInUnits,
+			StartInUnits:                startInUnits,
+			UnitTimescaleInMillisceonds: unitTimescaleInMillisceonds,
+		},
+	}
+}
+
+func expandAccountFilterTrackSelections(input []TrackSelection) *[]accountfilters.FilterTrackSelection {
+	results := make([]accountfilters.FilterTrackSelection, 0)
+
+	for _, track := range input {
+		conditions := make([]accountfilters.FilterTrackPropertyCondition, 0)
+		for _, condition := range track.Conditions {
+			conditions = append(conditions, accountfilters.FilterTrackPropertyCondition{
+				Operation: accountfilters.FilterTrackPropertyCompareOperation(condition.Operation),
+				Property:  accountfilters.FilterTrackPropertyType(condition.Property),
+				Value:     condition.Value,
+			})
+		}
+		results = append(results, accountfilters.FilterTrackSelection{
+			TrackSelections: conditions,
+		})
+	}
+
+	return &results
+}
+
+func flattenAccountFilterTracks(input *[]accountfilters.FilterTrackSelection) []TrackSelection {
+	if input == nil {
+		return make([]TrackSelection, 0)
+	}
+
+	result := make([]TrackSelection, 0)
+	for _, track := range *input {
+		conditions := make([]Condition, 0)
+		for _, condition := range track.TrackSelections {
+			conditions = append(conditions, Condition{
+				Operation: string(condition.Operation),
+				Property:  string(condition.Property),
+				Value:     condition.Value,
+			})
+		}
+		result = append(result, TrackSelection{
+			Conditions: conditions,
+		})
+	}
+
+	return result
+}

--- a/internal/services/media/media_service_account_filter_resource_test.go
+++ b/internal/services/media/media_service_account_filter_resource_test.go
@@ -1,0 +1,216 @@
+package media_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-08-01/accountfilters"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+type AccountFilterResource struct{}
+
+func TestAccMediaServicesAccountFilter_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_media_services_account_filter", "test")
+	r := AccountFilterResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccMediaServicesAccountFilter_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_media_services_account_filter", "test")
+	r := AccountFilterResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.RequiresImportErrorStep(r.requiresImport),
+	})
+}
+
+func TestAccMediaServicesAccountFilter_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_media_services_account_filter", "test")
+	r := AccountFilterResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccMediaServicesAccountFilter_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_media_services_account_filter", "test")
+	r := AccountFilterResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func (AccountFilterResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := accountfilters.ParseAccountFilterID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := clients.Media.V20220801Client.AccountFilters.AccountFiltersGet(ctx, *id)
+	if err != nil {
+		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
+	}
+
+	return utils.Bool(resp.Model != nil), nil
+}
+
+func (r AccountFilterResource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_media_services_account_filter" "test" {
+  name                        = "Filter-1"
+  resource_group_name         = azurerm_resource_group.test.name
+  media_services_account_name = azurerm_media_services_account.test.name
+}
+`, r.template(data))
+}
+
+func (r AccountFilterResource) requiresImport(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_media_services_account_filter" "import" {
+  name                        = azurerm_media_services_account_filter.test.name
+  resource_group_name         = azurerm_media_services_account_filter.test.resource_group_name
+  media_services_account_name = azurerm_media_services_account_filter.test.media_services_account_name
+}
+`, r.basic(data))
+}
+
+func (r AccountFilterResource) complete(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_media_services_account_filter" "test" {
+  name                        = "Filter-1"
+  resource_group_name         = azurerm_resource_group.test.name
+  media_services_account_name = azurerm_media_services_account.test.name
+  first_quality_bitrate       = 128000
+
+  presentation_time_range {
+    start_in_units                 = 0
+    end_in_units                   = 15
+    presentation_window_in_units   = 90
+    live_backoff_in_units          = 0
+    unit_timescale_in_milliseconds = 1000
+    force_end                      = false
+  }
+
+  track_selection {
+    condition {
+      property  = "Type"
+      operation = "Equal"
+      value     = "Audio"
+    }
+
+    condition {
+      property  = "Language"
+      operation = "NotEqual"
+      value     = "en"
+    }
+
+    condition {
+      property  = "FourCC"
+      operation = "NotEqual"
+      value     = "EC-3"
+    }
+  }
+
+  track_selection {
+    condition {
+      property  = "Type"
+      operation = "Equal"
+      value     = "Video"
+    }
+
+    condition {
+      property  = "Bitrate"
+      operation = "Equal"
+      value     = "3000000-5000000"
+    }
+  }
+}
+`, r.template(data))
+}
+
+func (AccountFilterResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-media-%d"
+  location = "%s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "acctestsa1%s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "GRS"
+}
+
+resource "azurerm_media_services_account" "test" {
+  name                = "acctestmsa%s"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  storage_account {
+    id         = azurerm_storage_account.test.id
+    is_primary = true
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString)
+}

--- a/internal/services/media/registration.go
+++ b/internal/services/media/registration.go
@@ -7,7 +7,10 @@ import (
 
 type Registration struct{}
 
-var _ sdk.UntypedServiceRegistrationWithAGitHubLabel = Registration{}
+var (
+	_ sdk.TypedServiceRegistrationWithAGitHubLabel   = Registration{}
+	_ sdk.UntypedServiceRegistrationWithAGitHubLabel = Registration{}
+)
 
 func (r Registration) AssociatedGitHubLabel() string {
 	return "service/media"
@@ -44,5 +47,15 @@ func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 		"azurerm_media_live_event":         resourceMediaLiveEvent(),
 		"azurerm_media_live_event_output":  resourceMediaLiveOutput(),
 		"azurerm_media_asset_filter":       resourceMediaAssetFilter(),
+	}
+}
+
+func (r Registration) DataSources() []sdk.DataSource {
+	return []sdk.DataSource{}
+}
+
+func (r Registration) Resources() []sdk.Resource {
+	return []sdk.Resource{
+		AccountFilterResource{},
 	}
 }

--- a/website/docs/r/media_services_account_filter.html.markdown
+++ b/website/docs/r/media_services_account_filter.html.markdown
@@ -116,7 +116,7 @@ A `presentation_time_range` block supports the following:
 * `end_in_units` - (Optional) The absolute end time boundary. Applies to Video on Demand (VoD).
 For the Live Streaming presentation, it is silently ignored and applied when the presentation ends and the stream becomes VoD. This is a long value that represents an absolute end point of the presentation, rounded to the closest next GOP start. The unit is defined by `unit_timescale_in_milliseconds`, so an `end_in_units` of 180 would be for 3 minutes. Use `start_in_units` and `end_in_units` to trim the fragments that will be in the playlist (manifest). For example, `start_in_units` set to 20 and `end_in_units` set to 60 using `unit_timescale_in_milliseconds` in 1000 will generate a playlist that contains fragments from between 20 seconds and 60 seconds of the VoD presentation. If a fragment straddles the boundary, the entire fragment will be included in the manifest.
 
-* `force_end` - (Optional) Indicates whether the `end_in_units` property must be present. If true, `end_in_units` must be specified or a bad request code is returned. Applies to Live Streaming only. Allowed values: false, true.
+* `force_end` - (Optional) Indicates whether the `end_in_units` property must be present. If true, `end_in_units` must be specified or a bad request code is returned. Applies to Live Streaming only. Allowed values: `false`, `true`.
 
 * `live_backoff_in_units` - (Optional) The relative to end right edge. Applies to Live Streaming only.
 This value defines the latest live position that a client can seek to. Using this property, you can delay live playback position and create a server-side buffer for players. The unit is defined by `unit_timescale_in_milliseconds`. The maximum live back off duration is 300 seconds. For example, a value of 20 means that the latest available content is 20 seconds delayed from the real live edge.
@@ -161,5 +161,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Account Filters can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_media_asset_filter.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Media/mediaservices/account1/assets/asset1/assetFilters/filter1
+terraform import azurerm_media_services_account_filter.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Media/mediaServices/account1/accountFilters/filter1
 ```

--- a/website/docs/r/media_services_account_filter.html.markdown
+++ b/website/docs/r/media_services_account_filter.html.markdown
@@ -1,0 +1,165 @@
+---
+subcategory: "Media"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_media_services_account_filter"
+description: |-
+  Manages a Media Services Account Filter.
+---
+
+# azurerm_media_services_account_filter
+
+Manages a Media Services Account Filter.
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "media-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_storage_account" "example" {
+  name                     = "examplestoracc"
+  resource_group_name      = azurerm_resource_group.example.name
+  location                 = azurerm_resource_group.example.location
+  account_tier             = "Standard"
+  account_replication_type = "GRS"
+}
+
+resource "azurerm_media_services_account" "example" {
+  name                = "examplemediaacc"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+
+  storage_account {
+    id         = azurerm_storage_account.example.id
+    is_primary = true
+  }
+}
+
+resource "azurerm_media_asset_filter" "example" {
+  name                        = "Filter1"
+  resource_group_name         = azurerm_resource_group.test.name
+  media_services_account_name = azurerm_media_services_account.test.name
+  first_quality_bitrate       = 128000
+
+  presentation_time_range {
+    start_in_units                 = 0
+    end_in_units                   = 15
+    presentation_window_in_units   = 90
+    live_backoff_in_units          = 0
+    unit_timescale_in_milliseconds = 1000
+    force_end                      = false
+  }
+
+  track_selection {
+    condition {
+      property  = "Type"
+      operation = "Equal"
+      value     = "Audio"
+    }
+
+    condition {
+      property  = "Language"
+      operation = "NotEqual"
+      value     = "en"
+    }
+
+    condition {
+      property  = "FourCC"
+      operation = "NotEqual"
+      value     = "EC-3"
+    }
+  }
+
+
+  track_selection {
+    condition {
+      property  = "Type"
+      operation = "Equal"
+      value     = "Video"
+    }
+
+    condition {
+      property  = "Bitrate"
+      operation = "Equal"
+      value     = "3000000-5000000"
+    }
+  }
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name which should be used for this Account Filter. Changing this forces a new Account Filter to be created.
+
+* `resource_group_name` - (Required) The name of the Resource Group where the Account Filter should exist. Changing this forces a new Account Filter to be created.
+
+* `media_services_account_name` - (Required) The Media Services account name. Changing this forces a new Account Filter to be created.
+
+---
+
+* `first_quality_bitrate` - (Optional) The first quality bitrate. Sets the first video track to appear in the Live Streaming playlist to allow HLS native players to start downloading from this quality level at the beginning.
+
+* `presentation_time_range` - (Optional) A `presentation_time_range` block as defined below.
+
+* `track_selection` - (Optional) One or more `track_selection` blocks as defined below.
+
+---
+
+A `presentation_time_range` block supports the following:
+
+* `unit_timescale_in_milliseconds` - (Required) Specified as the number of milliseconds in one unit timescale. For example, if you want to set a `start_in_units` at 30 seconds, you would use a value of 30 when using the `unit_timescale_in_milliseconds` in 1000. Or if you want to set `start_in_units` in 30 milliseconds, you would use a value of 30 when using the `unit_timescale_in_milliseconds` in 1.  Applies timescale to `start_in_units`, `start_timescale` and `presentation_window_in_timescale` and `live_backoff_in_timescale`.
+ 
+* `end_in_units` - (Optional) The absolute end time boundary. Applies to Video on Demand (VoD).
+For the Live Streaming presentation, it is silently ignored and applied when the presentation ends and the stream becomes VoD. This is a long value that represents an absolute end point of the presentation, rounded to the closest next GOP start. The unit is defined by `unit_timescale_in_milliseconds`, so an `end_in_units` of 180 would be for 3 minutes. Use `start_in_units` and `end_in_units` to trim the fragments that will be in the playlist (manifest). For example, `start_in_units` set to 20 and `end_in_units` set to 60 using `unit_timescale_in_milliseconds` in 1000 will generate a playlist that contains fragments from between 20 seconds and 60 seconds of the VoD presentation. If a fragment straddles the boundary, the entire fragment will be included in the manifest.
+
+* `force_end` - (Optional) Indicates whether the `end_in_units` property must be present. If true, `end_in_units` must be specified or a bad request code is returned. Applies to Live Streaming only. Allowed values: false, true.
+
+* `live_backoff_in_units` - (Optional) The relative to end right edge. Applies to Live Streaming only.
+This value defines the latest live position that a client can seek to. Using this property, you can delay live playback position and create a server-side buffer for players. The unit is defined by `unit_timescale_in_milliseconds`. The maximum live back off duration is 300 seconds. For example, a value of 20 means that the latest available content is 20 seconds delayed from the real live edge.
+
+* `presentation_window_in_units` - (Optional) The relative to end sliding window. Applies to Live Streaming only. Use `presentation_window_in_units` to apply a sliding window of fragments to include in a playlist. The unit is defined by `unit_timescale_in_milliseconds`. For example, set  `presentation_window_in_units` to 120 to apply a two-minute sliding window. Media within 2 minutes of the live edge will be included in the playlist. If a fragment straddles the boundary, the entire fragment will be included in the playlist. The minimum presentation window duration is 60 seconds.
+
+* `start_in_units` - (Optional) The absolute start time boundary. Applies to Video on Demand (VoD) or Live Streaming. This is a long value that represents an absolute start point of the stream. The value gets rounded to the closest next GOP start. The unit is defined by `unit_timescale_in_milliseconds`, so a `start_in_units` of 15 would be for 15 seconds. Use `start_in_units` and `end_in_units` to trim the fragments that will be in the playlist (manifest). For example, `start_in_units` set to 20 and `end_in_units` set to 60 using `unit_timescale_in_milliseconds` in 1000 will generate a playlist that contains fragments from between 20 seconds and 60 seconds of the VoD presentation. If a fragment straddles the boundary, the entire fragment will be included in the manifest.
+
+---
+
+A `selection` block supports the following:
+
+* `operation` - (Required) The condition operation to test a track property against. Supported values are `Equal` and `NotEqual`.
+
+* `property` - (Required) The track property to compare. Supported values are `Bitrate`, `FourCC`, `Language`, `Name` and `Type`. Check [documentation](https://docs.microsoft.com/azure/media-services/latest/filters-concept) for more details.
+
+* `value` - (Required) The track property value to match or not match.
+
+---
+
+A `track_selection` block supports the following:
+
+* `condition` - (Required) One or more `condition` blocks as defined above.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `id` - The ID of the Account Filter.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Account Filter.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Account Filter.
+* `update` - (Defaults to 30 minutes) Used when updating the Account Filter.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Account Filter.
+
+## Import
+
+Account Filters can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_media_asset_filter.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Media/mediaservices/account1/assets/asset1/assetFilters/filter1
+```


### PR DESCRIPTION
Note that the schema of this resource is almost same with `azurerm_media_asset_filter`.

Ref: 
- [REST API specification](https://github.com/Azure/azure-rest-api-specs/blob/71121282e39bccae590462648e77bca283df6d2b/specification/mediaservices/resource-manager/Microsoft.Media/Metadata/stable/2022-08-01/AccountFilters.json)
- [media filter docs](https://learn.microsoft.com/en-us/azure/media-services/latest/filters-concept)

Test:
```
make acctests SERVICE="media" TESTARGS="-parallel 20 -test.run=TestAccMediaServicesAccountFilter_" TESTTIMEOUT='1440m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/media -parallel 20 -test.run=TestAccMediaServicesAccountFilter_ -timeout 1440m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccMediaServicesAccountFilter_basic
=== PAUSE TestAccMediaServicesAccountFilter_basic
=== RUN   TestAccMediaServicesAccountFilter_requiresImport
=== PAUSE TestAccMediaServicesAccountFilter_requiresImport
=== RUN   TestAccMediaServicesAccountFilter_complete
=== PAUSE TestAccMediaServicesAccountFilter_complete
=== RUN   TestAccMediaServicesAccountFilter_update
=== PAUSE TestAccMediaServicesAccountFilter_update
=== CONT  TestAccMediaServicesAccountFilter_basic
=== CONT  TestAccMediaServicesAccountFilter_complete
=== CONT  TestAccMediaServicesAccountFilter_requiresImport
=== CONT  TestAccMediaServicesAccountFilter_update
--- PASS: TestAccMediaServicesAccountFilter_complete (252.30s)
--- PASS: TestAccMediaServicesAccountFilter_basic (253.06s)
--- PASS: TestAccMediaServicesAccountFilter_requiresImport (286.93s)
--- PASS: TestAccMediaServicesAccountFilter_update (432.21s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/media 434.151s

```