### PR TITLE
`azurerm_app_configuration_key` - fix no label regression issue

### DIFF
--- a/internal/services/appconfiguration/parse/app_configuration_key.go
+++ b/internal/services/appconfiguration/parse/app_configuration_key.go
@@ -44,10 +44,10 @@ func KeyId(input string) (*AppConfigurationKeyId, error) {
 		Label: label,
 	}
 
-	// Label will have a "%00" placeholder if we're dealing with an empty label,
-	// so we set the label to the expected value (empty string) and trim the input
-	// string, so we can properly extract the configuration store ID out of it.
-	if label == "%00" {
+	// Golang's URL parser will translate %00 to \000 (NUL). This will only happen if we're dealing with an empty
+	// label, so we set the label to the expected value (empty string) and trim the input string, so we can properly
+	// extract the configuration store ID out of it.
+	if label == "\000" {
 		appcfgID.Label = ""
 		input = strings.TrimSuffix(input, "%00")
 	}


### PR DESCRIPTION
the regression issue is related to PR https://github.com/hashicorp/terraform-provider-azurerm/pull/13859/files#diff-9204ececde6ddb41429768bb687c0f8689a19d9e0cbde70334185bf830bd647cR34 
 and https://github.com/hashicorp/terraform-provider-azurerm/pull/19900

reset this to be align with `azurerm_app_configuration_feature`: https://github.com/hashicorp/terraform-provider-azurerm/blob/d4e94927ae23ecf365af25eb31f698b7c3559260/internal/services/appconfiguration/parse/app_configuration_feature.go#L47-L56



