### PR TITLE
`external_id` needs to reference tenant id when adding AAD group

### DIFF
--- a/website/docs/r/api_management_group.html.markdown
+++ b/website/docs/r/api_management_group.html.markdown
@@ -51,7 +51,7 @@ The following arguments are supported:
 
 * `description` - (Optional) The description of this API Management Group.
 
-* `external_id` - (Optional) The identifier of the external Group. For example, an Azure Active Directory group `aad://<tenant>.onmicrosoft.com/groups/<group object id>`. Changing this forces a new resource to be created.
+* `external_id` - (Optional) The identifier of the external Group. For example, an Azure Active Directory group `aad://<tenant id>/groups/<group object id>`. Changing this forces a new resource to be created.
 
 * `type` - (Optional) The type of this API Management Group. Possible values are `custom`, `external` and `system`. Default is `custom`. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
In the documentation it gives an example in the description saying `aad://<tenant>.onmicrosoft.com/groups/<group object id>`. For the group to actually work in APIM `external_id` needs to be `aad://<tenant id>/groups/<group object id>`. If not, I've experienced group membership not picked up by APIM.