### PR TITLE
`document` - Fix wrong import commands

### DIFF
--- a/website/docs/r/app_configuration.html.markdown
+++ b/website/docs/r/app_configuration.html.markdown
@@ -272,5 +272,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 App Configurations can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_app_configuration.appconf /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/resourceGroup1/providers/Microsoft.AppConfiguration/configurationStores/appConf1
+terraform import azurerm_app_configuration.appconf /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup1/providers/Microsoft.AppConfiguration/configurationStores/appConf1
 ```

--- a/website/docs/r/application_insights_workbook_template.html.markdown
+++ b/website/docs/r/application_insights_workbook_template.html.markdown
@@ -142,5 +142,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Application Insights Workbook Template can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_application_insights_workbook_template.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup1/providers/Microsoft.Insights/workbooktemplates/resource1
+terraform import azurerm_application_insights_workbook_template.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup1/providers/Microsoft.Insights/workbookTemplates/resource1
 ```

--- a/website/docs/r/cdn_frontdoor_firewall_policy.html.markdown
+++ b/website/docs/r/cdn_frontdoor_firewall_policy.html.markdown
@@ -265,5 +265,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 Front Door Firewall Policies can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_cdn_frontdoor_firewall_policy.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup1/providers/Microsoft.Network/frontdoorWebApplicationFirewallPolicies/firewallPolicy1
+terraform import azurerm_cdn_frontdoor_firewall_policy.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup1/providers/Microsoft.Network/frontDoorWebApplicationFirewallPolicies/firewallPolicy1
 ```

--- a/website/docs/r/communication_service.html.markdown
+++ b/website/docs/r/communication_service.html.markdown
@@ -63,5 +63,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Communication Services can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_communication_service.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Communication/CommunicationServices/communicationService1
+terraform import azurerm_communication_service.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Communication/communicationServices/communicationService1
 ```

--- a/website/docs/r/dev_test_linux_virtual_machine.html.markdown
+++ b/website/docs/r/dev_test_linux_virtual_machine.html.markdown
@@ -159,5 +159,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Dev Test Linux Virtual Machines can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_dev_test_linux_virtual_machine.machine1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.DevTestLab/labs/lab1/virtualmachines/machine1
+terraform import azurerm_dev_test_linux_virtual_machine.machine1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.DevTestLab/labs/lab1/virtualMachines/machine1
 ```

--- a/website/docs/r/dev_test_policy.html.markdown
+++ b/website/docs/r/dev_test_policy.html.markdown
@@ -85,5 +85,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Dev Test Policies can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_dev_test_policy.policy1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.DevTestLab/labs/lab1/policysets/default/policies/policy1
+terraform import azurerm_dev_test_policy.policy1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.DevTestLab/labs/lab1/policySets/default/policies/policy1
 ```

--- a/website/docs/r/dev_test_virtual_network.html.markdown
+++ b/website/docs/r/dev_test_virtual_network.html.markdown
@@ -94,5 +94,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 DevTest Virtual Networks can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_dev_test_virtual_network.network1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.DevTestLab/labs/lab1/virtualnetworks/network1
+terraform import azurerm_dev_test_virtual_network.network1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.DevTestLab/labs/lab1/virtualNetworks/network1
 ```

--- a/website/docs/r/dev_test_windows_virtual_machine.html.markdown
+++ b/website/docs/r/dev_test_windows_virtual_machine.html.markdown
@@ -155,5 +155,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 DevTest Windows Virtual Machines can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_dev_test_windows_virtual_machine.machine1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.DevTestLab/labs/lab1/virtualmachines/machine1
+terraform import azurerm_dev_test_windows_virtual_machine.machine1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.DevTestLab/labs/lab1/virtualMachines/machine1
 ```

--- a/website/docs/r/disk_sas_token.html.markdown
+++ b/website/docs/r/disk_sas_token.html.markdown
@@ -74,5 +74,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Disk SAS Token can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_managed_disk_sas_token.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/microsoft.compute/disks/manageddisk1
+terraform import azurerm_managed_disk_sas_token.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Compute/disks/manageddisk1
 ```

--- a/website/docs/r/eventhub_namespace_schema_group.html.markdown
+++ b/website/docs/r/eventhub_namespace_schema_group.html.markdown
@@ -60,5 +60,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 Schema Group for a EventHub Namespace can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_eventhub_namespace_schema_group.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.EventHub/namespaces/namespace1/schemagroups/group1
+terraform import azurerm_eventhub_namespace_schema_group.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.EventHub/namespaces/namespace1/schemaGroups/group1
 ```

--- a/website/docs/r/frontdoor.html.markdown
+++ b/website/docs/r/frontdoor.html.markdown
@@ -315,5 +315,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Front Doors can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_frontdoor.example /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/mygroup1/providers/Microsoft.Network/frontDoors/frontdoor1
+terraform import azurerm_frontdoor.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Network/frontDoors/frontdoor1
 ```

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -961,5 +961,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Managed Kubernetes Clusters can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_kubernetes_cluster.cluster1 /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/group1/providers/Microsoft.ContainerService/managedClusters/cluster1
+terraform import azurerm_kubernetes_cluster.cluster1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.ContainerService/managedClusters/cluster1
 ```

--- a/website/docs/r/kusto_cluster_customer_managed_key.html.markdown
+++ b/website/docs/r/kusto_cluster_customer_managed_key.html.markdown
@@ -116,5 +116,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Customer Managed Keys for a Kusto Cluster can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_kusto_cluster_customer_managed_key.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Kusto/Clusters/cluster1
+terraform import azurerm_kusto_cluster_customer_managed_key.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Kusto/clusters/cluster1
 ```

--- a/website/docs/r/kusto_cluster_managed_private_endpoint.html.markdown
+++ b/website/docs/r/kusto_cluster_managed_private_endpoint.html.markdown
@@ -82,5 +82,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Managed Private Endpoint for a Kusto Cluster can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_kusto_cluster_managed_private_endpoint.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Kusto/clusters/cluster1/managedPrivateEndpoints/managedPrivateEndpoint1
+terraform import azurerm_kusto_cluster_managed_private_endpoint.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Kusto/Clusters/cluster1/ManagedPrivateEndpoints/managedPrivateEndpoint1
 ```

--- a/website/docs/r/log_analytics_cluster.html.markdown
+++ b/website/docs/r/log_analytics_cluster.html.markdown
@@ -97,5 +97,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Log Analytics Clusters can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_log_analytics_cluster.example /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/group1/providers/Microsoft.OperationalInsights/clusters/cluster1
+terraform import azurerm_log_analytics_cluster.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.OperationalInsights/clusters/cluster1
 ```

--- a/website/docs/r/log_analytics_cluster_customer_managed_key.html.markdown
+++ b/website/docs/r/log_analytics_cluster_customer_managed_key.html.markdown
@@ -124,5 +124,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Log Analytics Cluster Customer Managed Keys can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_log_analytics_cluster_customer_managed_key.example /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/group1/providers/Microsoft.OperationalInsights/clusters/cluster1
+terraform import azurerm_log_analytics_cluster_customer_managed_key.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.OperationalInsights/clusters/cluster1
 ```

--- a/website/docs/r/log_analytics_data_export_rule.html.markdown
+++ b/website/docs/r/log_analytics_data_export_rule.html.markdown
@@ -82,5 +82,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Log Analytics Data Export Rule can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_log_analytics_data_export_rule.example /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/group1/providers/Microsoft.OperationalInsights/workspaces/workspace1/dataExports/dataExport1
+terraform import azurerm_log_analytics_data_export_rule.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.OperationalInsights/workspaces/workspace1/dataExports/dataExport1
 ```

--- a/website/docs/r/log_analytics_datasource_windows_event.html.markdown
+++ b/website/docs/r/log_analytics_datasource_windows_event.html.markdown
@@ -72,5 +72,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Log Analytics Windows Event DataSources can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_log_analytics_datasource_windows_event.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.OperationalInsights/workspaces/workspace1/datasources/datasource1
+terraform import azurerm_log_analytics_datasource_windows_event.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.OperationalInsights/workspaces/workspace1/dataSources/datasource1
 ```

--- a/website/docs/r/log_analytics_datasource_windows_performance_counter.html.markdown
+++ b/website/docs/r/log_analytics_datasource_windows_performance_counter.html.markdown
@@ -78,5 +78,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Log Analytics Windows Performance Counter DataSources can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_log_analytics_datasource_windows_performance_counter.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.OperationalInsights/workspaces/workspace1/datasources/datasource1
+terraform import azurerm_log_analytics_datasource_windows_performance_counter.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.OperationalInsights/workspaces/workspace1/dataSources/datasource1
 ```

--- a/website/docs/r/log_analytics_linked_storage_account.html.markdown
+++ b/website/docs/r/log_analytics_linked_storage_account.html.markdown
@@ -75,5 +75,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Log Analytics Linked Storage Accounts can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_log_analytics_linked_storage_account.example /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/group1/providers/Microsoft.OperationalInsights/workspaces/workspace1/linkedStorageAccounts/{dataSourceType}
+terraform import azurerm_log_analytics_linked_storage_account.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.OperationalInsights/workspaces/workspace1/linkedStorageAccounts/{dataSourceType}
 ```

--- a/website/docs/r/maintenance_configuration.html.markdown
+++ b/website/docs/r/maintenance_configuration.html.markdown
@@ -126,5 +126,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Maintenance Configuration can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_maintenance_configuration.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/microsoft.maintenance/maintenanceconfigurations/example-mc
+terraform import azurerm_maintenance_configuration.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Maintenance/maintenanceConfigurations/example-mc
 ```

--- a/website/docs/r/media_asset.html.markdown
+++ b/website/docs/r/media_asset.html.markdown
@@ -86,5 +86,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Media Assets can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_media_asset.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Media/mediaservices/account1/assets/asset1
+terraform import azurerm_media_asset.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Media/mediaServices/account1/assets/asset1
 ```

--- a/website/docs/r/media_asset_filter.html.markdown
+++ b/website/docs/r/media_asset_filter.html.markdown
@@ -168,5 +168,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Asset Filters can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_media_asset_filter.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Media/mediaservices/account1/assets/asset1/assetFilters/filter1
+terraform import azurerm_media_asset_filter.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Media/mediaServices/account1/assets/asset1/assetFilters/filter1
 ```

--- a/website/docs/r/media_content_key_policy.html.markdown
+++ b/website/docs/r/media_content_key_policy.html.markdown
@@ -274,5 +274,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Resource Groups can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_media_content_key_policy.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Media/mediaservices/account1/contentkeypolicies/policy1
+terraform import azurerm_media_content_key_policy.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Media/mediaServices/account1/contentKeyPolicies/policy1
 ```

--- a/website/docs/r/media_job.html.markdown
+++ b/website/docs/r/media_job.html.markdown
@@ -139,5 +139,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Media Jobs can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_media_job.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.Media/mediaservices/account1/transforms/transform1/jobs/job1
+terraform import azurerm_media_job.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.Media/mediaServices/account1/transforms/transform1/jobs/job1
 ```

--- a/website/docs/r/media_live_event.html.markdown
+++ b/website/docs/r/media_live_event.html.markdown
@@ -184,5 +184,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Live Events can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_media_live_event.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.Media/mediaservices/account1/liveevents/event1
+terraform import azurerm_media_live_event.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.Media/mediaServices/account1/liveEvents/event1
 ```

--- a/website/docs/r/media_live_output.html.markdown
+++ b/website/docs/r/media_live_output.html.markdown
@@ -115,5 +115,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Live Outputs can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_media_live_event_output.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Media/mediaservices/account1/liveevents/event1/liveoutputs/output1
+terraform import azurerm_media_live_event_output.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Media/mediaServices/account1/liveEvents/event1/liveOutputs/output1
 ```

--- a/website/docs/r/media_streaming_endpoint.html.markdown
+++ b/website/docs/r/media_streaming_endpoint.html.markdown
@@ -200,5 +200,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Streaming Endpoints can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_media_streaming_endpoint.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Media/mediaservices/service1/streamingendpoints/endpoint1
+terraform import azurerm_media_streaming_endpoint.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Media/mediaServices/service1/streamingEndpoints/endpoint1
 ```

--- a/website/docs/r/media_streaming_locator.html.markdown
+++ b/website/docs/r/media_streaming_locator.html.markdown
@@ -114,5 +114,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Streaming Locators can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_media_streaming_locator.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Media/mediaservices/account1/streaminglocators/locator1
+terraform import azurerm_media_streaming_locator.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Media/mediaServices/account1/streamingLocators/locator1
 ```

--- a/website/docs/r/media_streaming_policy.html.markdown
+++ b/website/docs/r/media_streaming_policy.html.markdown
@@ -179,5 +179,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Streaming Policies can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_media_streaming_policy.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Media/mediaservices/account1/streamingpolicies/policy1
+terraform import azurerm_media_streaming_policy.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Media/mediaServices/account1/streamingPolicies/policy1
 ```

--- a/website/docs/r/media_transform.html.markdown
+++ b/website/docs/r/media_transform.html.markdown
@@ -196,5 +196,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Transforms can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_media_transform.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Media/mediaservices/media1/transforms/transform1
+terraform import azurerm_media_transform.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Media/mediaServices/media1/transforms/transform1
 ```

--- a/website/docs/r/point_to_site_vpn_gateway.html.markdown
+++ b/website/docs/r/point_to_site_vpn_gateway.html.markdown
@@ -167,5 +167,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Point-to-Site VPN Gateway's can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_point_to_site_vpn_gateway.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Network/p2svpnGateways/gateway1
+terraform import azurerm_point_to_site_vpn_gateway.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Network/p2sVpnGateways/gateway1
 ```

--- a/website/docs/r/resource_deployment_script_azure_cli.html.markdown
+++ b/website/docs/r/resource_deployment_script_azure_cli.html.markdown
@@ -144,5 +144,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 Resource Deployment Script can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_resource_deployment_script_azure_cli.example /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/resourceGroup1/providers/Microsoft.Resources/deploymentScripts/script1
+terraform import azurerm_resource_deployment_script_azure_cli.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup1/providers/Microsoft.Resources/deploymentScripts/script1
 ```

--- a/website/docs/r/resource_deployment_script_azure_power_shell.html.markdown
+++ b/website/docs/r/resource_deployment_script_azure_power_shell.html.markdown
@@ -148,5 +148,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 Resource Deployment Script can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_resource_deployment_script_azure_power_shell.example /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/resourceGroup1/providers/Microsoft.Resources/deploymentScripts/script1
+terraform import azurerm_resource_deployment_script_azure_power_shell.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup1/providers/Microsoft.Resources/deploymentScripts/script1
 ```

--- a/website/docs/r/site_recovery_protection_container_mapping.html.markdown
+++ b/website/docs/r/site_recovery_protection_container_mapping.html.markdown
@@ -115,5 +115,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Site Recovery Protection Container Mappings can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_site_recovery_protection_container_mapping.mymapping /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-group-name/providers/Microsoft.RecoveryServices/vaults/recovery-vault-name
+terraform import azurerm_site_recovery_protection_container_mapping.mymapping /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resource-group-name/providers/Microsoft.RecoveryServices/vaults/recovery-vault-name/replicationFabrics/fabric1/replicationProtectionContainers/container1/replicationProtectionContainerMappings/mapping1
 ```

--- a/website/docs/r/sql_failover_group.html.markdown
+++ b/website/docs/r/sql_failover_group.html.markdown
@@ -128,5 +128,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 SQL Failover Groups can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_sql_failover_group.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Sql/servers/myserver/failovergroups/group1
+terraform import azurerm_sql_failover_group.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Sql/servers/myserver/failoverGroups/group1
 ```

--- a/website/docs/r/ssh_public_key.html.markdown
+++ b/website/docs/r/ssh_public_key.html.markdown
@@ -57,5 +57,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 SSH Public Keys can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_ssh_public_key.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Compute/SshPublicKeys/mySshPublicKeyName1
+terraform import azurerm_ssh_public_key.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Compute/sshPublicKeys/mySshPublicKeyName1
 ```

--- a/website/docs/r/stream_analytics_function_javascript_uda.html.markdown
+++ b/website/docs/r/stream_analytics_function_javascript_uda.html.markdown
@@ -100,5 +100,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Stream Analytics JavaScript UDA Functions can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_stream_analytics_function_javascript_uda.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.StreamAnalytics/streamingjobs/job1/functions/func1
+terraform import azurerm_stream_analytics_function_javascript_uda.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.StreamAnalytics/streamingJobs/job1/functions/func1
 ```

--- a/website/docs/r/stream_analytics_function_javascript_udf.html.markdown
+++ b/website/docs/r/stream_analytics_function_javascript_udf.html.markdown
@@ -94,5 +94,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Stream Analytics JavaScript UDF Functions can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_stream_analytics_function_javascript_udf.example /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/group1/providers/Microsoft.StreamAnalytics/streamingjobs/job1/functions/func1
+terraform import azurerm_stream_analytics_function_javascript_udf.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.StreamAnalytics/streamingJobs/job1/functions/func1
 ```

--- a/website/docs/r/stream_analytics_job.html.markdown
+++ b/website/docs/r/stream_analytics_job.html.markdown
@@ -137,5 +137,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Stream Analytics Job's can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_stream_analytics_job.example /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/group1/providers/Microsoft.StreamAnalytics/streamingjobs/job1
+terraform import azurerm_stream_analytics_job.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.StreamAnalytics/streamingJobs/job1
 ```

--- a/website/docs/r/stream_analytics_output_blob.html.markdown
+++ b/website/docs/r/stream_analytics_output_blob.html.markdown
@@ -126,5 +126,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Stream Analytics Outputs to Blob Storage can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_stream_analytics_output_blob.example /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/group1/providers/Microsoft.StreamAnalytics/streamingjobs/job1/outputs/output1
+terraform import azurerm_stream_analytics_output_blob.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.StreamAnalytics/streamingJobs/job1/outputs/output1
 ```

--- a/website/docs/r/stream_analytics_output_cosmosdb.html.markdown
+++ b/website/docs/r/stream_analytics_output_cosmosdb.html.markdown
@@ -105,5 +105,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Stream Analytics Outputs for CosmosDB can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_stream_analytics_output_cosmosdb.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.StreamAnalytics/streamingjobs/job1/outputs/output1
+terraform import azurerm_stream_analytics_output_cosmosdb.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.StreamAnalytics/streamingJobs/job1/outputs/output1
 ```

--- a/website/docs/r/stream_analytics_output_eventhub.html.markdown
+++ b/website/docs/r/stream_analytics_output_eventhub.html.markdown
@@ -118,5 +118,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Stream Analytics Outputs to an EventHub can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_stream_analytics_output_eventhub.example /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/group1/providers/Microsoft.StreamAnalytics/streamingjobs/job1/outputs/output1
+terraform import azurerm_stream_analytics_output_eventhub.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.StreamAnalytics/streamingJobs/job1/outputs/output1
 ```

--- a/website/docs/r/stream_analytics_output_function.html.markdown
+++ b/website/docs/r/stream_analytics_output_function.html.markdown
@@ -114,5 +114,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Stream Analytics Output Functions can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_stream_analytics_output_function.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.StreamAnalytics/streamingjobs/job1/outputs/output1
+terraform import azurerm_stream_analytics_output_function.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.StreamAnalytics/streamingJobs/job1/outputs/output1
 ```

--- a/website/docs/r/stream_analytics_output_mssql.html.markdown
+++ b/website/docs/r/stream_analytics_output_mssql.html.markdown
@@ -102,5 +102,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Stream Analytics Outputs to Microsoft SQL Server Database can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_stream_analytics_output_mssql.example /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/group1/providers/Microsoft.StreamAnalytics/streamingjobs/job1/outputs/output1
+terraform import azurerm_stream_analytics_output_mssql.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.StreamAnalytics/streamingJobs/job1/outputs/output1
 ```

--- a/website/docs/r/stream_analytics_output_powerbi.html.markdown
+++ b/website/docs/r/stream_analytics_output_powerbi.html.markdown
@@ -66,5 +66,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Stream Analytics Output to Power BI can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_stream_analytics_output_powerbi.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.StreamAnalytics/streamingjobs/job1/outputs/output1
+terraform import azurerm_stream_analytics_output_powerbi.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.StreamAnalytics/streamingJobs/job1/outputs/output1
 ```

--- a/website/docs/r/stream_analytics_output_servicebus_queue.html.markdown
+++ b/website/docs/r/stream_analytics_output_servicebus_queue.html.markdown
@@ -118,5 +118,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Stream Analytics Output ServiceBus Queue's can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_stream_analytics_output_servicebus_queue.example /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/group1/providers/Microsoft.StreamAnalytics/streamingjobs/job1/outputs/output1
+terraform import azurerm_stream_analytics_output_servicebus_queue.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.StreamAnalytics/streamingJobs/job1/outputs/output1
 ```

--- a/website/docs/r/stream_analytics_output_servicebus_topic.html.markdown
+++ b/website/docs/r/stream_analytics_output_servicebus_topic.html.markdown
@@ -119,5 +119,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Stream Analytics Output ServiceBus Topic's can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_stream_analytics_output_servicebus_topic.example /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/group1/providers/Microsoft.StreamAnalytics/streamingjobs/job1/outputs/output1
+terraform import azurerm_stream_analytics_output_servicebus_topic.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.StreamAnalytics/streamingJobs/job1/outputs/output1
 ```

--- a/website/docs/r/stream_analytics_output_synapse.html.markdown
+++ b/website/docs/r/stream_analytics_output_synapse.html.markdown
@@ -104,5 +104,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 A Stream Analytics Output to an Azure Synapse Analytics Workspace can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_stream_analytics_output_synapse.example /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/group1/providers/Microsoft.StreamAnalytics/streamingjobs/job1/outputs/output1
+terraform import azurerm_stream_analytics_output_synapse.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.StreamAnalytics/streamingJobs/job1/outputs/output1
 ```

--- a/website/docs/r/stream_analytics_output_table.html.markdown
+++ b/website/docs/r/stream_analytics_output_table.html.markdown
@@ -93,5 +93,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Stream Analytics Output to Table can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_stream_analytics_output_table.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.StreamAnalytics/streamingjobs/job1/outputs/output1
+terraform import azurerm_stream_analytics_output_table.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.StreamAnalytics/streamingJobs/job1/outputs/output1
 ```

--- a/website/docs/r/stream_analytics_reference_input_blob.html.markdown
+++ b/website/docs/r/stream_analytics_reference_input_blob.html.markdown
@@ -115,5 +115,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Stream Analytics Reference Input Blob's can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_stream_analytics_reference_input_blob.example /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/group1/providers/Microsoft.StreamAnalytics/streamingjobs/job1/inputs/input1
+terraform import azurerm_stream_analytics_reference_input_blob.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.StreamAnalytics/streamingJobs/job1/inputs/input1
 ```

--- a/website/docs/r/stream_analytics_reference_input_mssql.html.markdown
+++ b/website/docs/r/stream_analytics_reference_input_mssql.html.markdown
@@ -104,5 +104,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Stream Analytics can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_stream_analytics_reference_input_mssql.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.StreamAnalytics/streamingjobs/job1/inputs/input1
+terraform import azurerm_stream_analytics_reference_input_mssql.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.StreamAnalytics/streamingJobs/job1/inputs/input1
 ```

--- a/website/docs/r/stream_analytics_stream_input_blob.html.markdown
+++ b/website/docs/r/stream_analytics_stream_input_blob.html.markdown
@@ -113,5 +113,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Stream Analytics Stream Input Blob's can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_stream_analytics_stream_input_blob.example /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/group1/providers/Microsoft.StreamAnalytics/streamingjobs/job1/inputs/input1
+terraform import azurerm_stream_analytics_stream_input_blob.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.StreamAnalytics/streamingJobs/job1/inputs/input1
 ```

--- a/website/docs/r/stream_analytics_stream_input_eventhub.html.markdown
+++ b/website/docs/r/stream_analytics_stream_input_eventhub.html.markdown
@@ -125,5 +125,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Stream Analytics Stream Input EventHub's can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_stream_analytics_stream_input_eventhub.example /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/group1/providers/Microsoft.StreamAnalytics/streamingjobs/job1/inputs/input1
+terraform import azurerm_stream_analytics_stream_input_eventhub.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.StreamAnalytics/streamingJobs/job1/inputs/input1
 ```

--- a/website/docs/r/stream_analytics_stream_input_eventhub_v2.html.markdown
+++ b/website/docs/r/stream_analytics_stream_input_eventhub_v2.html.markdown
@@ -122,5 +122,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Stream Analytics Stream Input EventHub's can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_stream_analytics_stream_input_eventhub_v2.example /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/group1/providers/Microsoft.StreamAnalytics/streamingjobs/job1/inputs/input1
+terraform import azurerm_stream_analytics_stream_input_eventhub_v2.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.StreamAnalytics/streamingJobs/job1/inputs/input1
 ```

--- a/website/docs/r/stream_analytics_stream_input_iothub.html.markdown
+++ b/website/docs/r/stream_analytics_stream_input_iothub.html.markdown
@@ -107,5 +107,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Stream Analytics Stream Input IoTHub's can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_stream_analytics_stream_input_iothub.example /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/group1/providers/Microsoft.StreamAnalytics/streamingjobs/job1/inputs/input1
+terraform import azurerm_stream_analytics_stream_input_iothub.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.StreamAnalytics/streamingJobs/job1/inputs/input1
 ```

--- a/website/docs/r/virtual_desktop_host_pool.html.markdown
+++ b/website/docs/r/virtual_desktop_host_pool.html.markdown
@@ -123,5 +123,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Virtual Desktop Host Pools can be imported using the `resource id`, e.g.
 
 ```text
-terraform import azurerm_virtual_desktop_host_pool.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myGroup1/providers/Microsoft.DesktopVirtualization/hostpools/myhostpool
+terraform import azurerm_virtual_desktop_host_pool.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myGroup1/providers/Microsoft.DesktopVirtualization/hostPools/myhostpool
 ```

--- a/website/docs/r/virtual_desktop_workspace.html.markdown
+++ b/website/docs/r/virtual_desktop_workspace.html.markdown
@@ -68,5 +68,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Virtual Desktop Workspaces can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_virtual_desktop_workspace.example /subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/myGroup1/providers/Microsoft.DesktopVirtualization/workspaces/myworkspace
+terraform import azurerm_virtual_desktop_workspace.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myGroup1/providers/Microsoft.DesktopVirtualization/workspaces/myworkspace
 ```

--- a/website/docs/r/virtual_desktop_workspace_application_group_association.html.markdown
+++ b/website/docs/r/virtual_desktop_workspace_application_group_association.html.markdown
@@ -78,7 +78,7 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Associations between Virtual Desktop Workspaces and Virtual Desktop Application Groups can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_virtual_desktop_workspace_application_group_association.association1 "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/myGroup1/providers/Microsoft.DesktopVirtualization/workspaces/myworkspace|/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myGroup1/providers/Microsoft.DesktopVirtualization/applicationGroups/myapplicationgroup"
+terraform import azurerm_virtual_desktop_workspace_application_group_association.association1 "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myGroup1/providers/Microsoft.DesktopVirtualization/workspaces/myworkspace|/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myGroup1/providers/Microsoft.DesktopVirtualization/applicationGroups/myapplicationgroup"
 ```
 
 -> **NOTE:** This ID is specific to Terraform - and is of the format `{virtualDesktopWorkspaceID}|{virtualDesktopApplicationGroupID}`.

--- a/website/docs/r/vmware_netapp_volume_attachment.html.markdown
+++ b/website/docs/r/vmware_netapp_volume_attachment.html.markdown
@@ -186,5 +186,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 VMware Private Clouds Netapp File Volume Attachment can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_vmware_netapp_volume_attachment.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.AVS/PrivateClouds/privateCloud1/clusters/Cluster1/dataStores/datastore1
+terraform import azurerm_vmware_netapp_volume_attachment.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.AVS/privateClouds/privateCloud1/clusters/Cluster1/dataStores/datastore1
 ```

--- a/website/docs/r/vmware_private_cloud.html.markdown
+++ b/website/docs/r/vmware_private_cloud.html.markdown
@@ -132,5 +132,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 VMware Private Clouds can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_vmware_private_cloud.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.AVS/PrivateClouds/privateCloud1
+terraform import azurerm_vmware_private_cloud.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.AVS/privateClouds/privateCloud1
 ```

--- a/website/docs/r/web_pubsub_hub.html.markdown
+++ b/website/docs/r/web_pubsub_hub.html.markdown
@@ -120,5 +120,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Web Pubsub Hub can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_web_pubsub_hub.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.SignalRService/webPubsub/webpubsub1/hubs/webpubsubhub1
+terraform import azurerm_web_pubsub_hub.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.SignalRService/webPubSub/webPubSub1/hubs/webPubSubhub1
 ```

--- a/website/docs/r/web_pubsub_shared_private_link.html.markdown
+++ b/website/docs/r/web_pubsub_shared_private_link.html.markdown
@@ -102,5 +102,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Web Pubsub Shared Private Link Resource can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_web_pubsub_shared_private_link_resource.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.SignalRService/webPubsub/webpubsub1/sharedPrivateLinkResources/resource1
+terraform import azurerm_web_pubsub_shared_private_link_resource.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.SignalRService/webPubSub/webPubSub1/sharedPrivateLinkResources/resource1
 ```


### PR DESCRIPTION
Fixing below two issues in the import command in documents (mostly casing issue)
- ID was missing the "..."
- expected the segment "..." to be "..."