### PR TITLE
`document` - remove redundant space in import commands

### DIFF
--- a/website/docs/r/mssql_database_vulnerability_assessment_rule_baseline.html.markdown
+++ b/website/docs/r/mssql_database_vulnerability_assessment_rule_baseline.html.markdown
@@ -126,5 +126,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Database Vulnerability Assessment Rule Baseline can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_mssql_database_vulnerability_assessment_rule_baseline.example  /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/acceptanceTestResourceGroup1/providers/Microsoft.Sql/servers/mssqlserver/databases/mysqldatabase/vulnerabilityAssessments/Default/rules/VA2065/baselines/master
+terraform import azurerm_mssql_database_vulnerability_assessment_rule_baseline.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/acceptanceTestResourceGroup1/providers/Microsoft.Sql/servers/mssqlserver/databases/mysqldatabase/vulnerabilityAssessments/Default/rules/VA2065/baselines/master
 ```

--- a/website/docs/r/mssql_managed_instance_security_alert_policy.html.markdown
+++ b/website/docs/r/mssql_managed_instance_security_alert_policy.html.markdown
@@ -259,5 +259,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 MS SQL Managed Instance Security Alert Policy can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_mssql_managed_instance_security_alert_policy.example  /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/acceptanceTestResourceGroup1/providers/Microsoft.Sql/managedInstances/instance1/securityAlertPolicies/Default
+terraform import azurerm_mssql_managed_instance_security_alert_policy.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/acceptanceTestResourceGroup1/providers/Microsoft.Sql/managedInstances/instance1/securityAlertPolicies/Default
 ```

--- a/website/docs/r/mssql_server_security_alert_policy.html.markdown
+++ b/website/docs/r/mssql_server_security_alert_policy.html.markdown
@@ -96,5 +96,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 MS SQL Server Security Alert Policy can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_mssql_server_security_alert_policy.example  /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/acceptanceTestResourceGroup1/providers/Microsoft.Sql/servers/mssqlserver/securityAlertPolicies/Default
+terraform import azurerm_mssql_server_security_alert_policy.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/acceptanceTestResourceGroup1/providers/Microsoft.Sql/servers/mssqlserver/securityAlertPolicies/Default
 ```

--- a/website/docs/r/resource_group_policy_exemption.html.markdown
+++ b/website/docs/r/resource_group_policy_exemption.html.markdown
@@ -83,5 +83,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Policy Exemptions can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_resource_group_policy_exemption.exemption1  /subscriptions/00000000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.Authorization/policyExemptions/exemption1
+terraform import azurerm_resource_group_policy_exemption.exemption1 /subscriptions/00000000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.Authorization/policyExemptions/exemption1
 ```

--- a/website/docs/r/subscription_policy_exemption.html.markdown
+++ b/website/docs/r/subscription_policy_exemption.html.markdown
@@ -80,5 +80,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Policy Exemptions can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_subscription_policy_exemption.exemption1  /subscriptions/00000000-0000-0000-000000000000/providers/Microsoft.Authorization/policyExemptions/exemption1
+terraform import azurerm_subscription_policy_exemption.exemption1 /subscriptions/00000000-0000-0000-000000000000/providers/Microsoft.Authorization/policyExemptions/exemption1
 ```

--- a/website/docs/r/synapse_sql_pool_security_alert_policy.html.markdown
+++ b/website/docs/r/synapse_sql_pool_security_alert_policy.html.markdown
@@ -125,5 +125,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Synapse SQL Pool Security Alert Policies can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_synapse_sql_pool_security_alert_policy.example  /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Synapse/workspaces/workspace1/sqlPools/sqlPool1/securityAlertPolicies/default
+terraform import azurerm_synapse_sql_pool_security_alert_policy.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Synapse/workspaces/workspace1/sqlPools/sqlPool1/securityAlertPolicies/default
 ```

--- a/website/docs/r/synapse_workspace_security_alert_policy.html.markdown
+++ b/website/docs/r/synapse_workspace_security_alert_policy.html.markdown
@@ -118,5 +118,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Synapse Workspace Security Alert Policies can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_synapse_workspace_security_alert_policy.example  /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Synapse/workspaces/workspace1/securityAlertPolicies/Default
+terraform import azurerm_synapse_workspace_security_alert_policy.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Synapse/workspaces/workspace1/securityAlertPolicies/Default
 ```


### PR DESCRIPTION
Removing extra space