### PR TITLE
`azurerm_app_service_source_control_token` - fix import command

### DIFF
--- a/website/docs/r/app_service_source_control_token.html.markdown
+++ b/website/docs/r/app_service_source_control_token.html.markdown
@@ -48,5 +48,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 App Service Source Control Token's can be imported using the `type`, e.g.
 
 ```shell
-terraform import azurerm_app_service_source_control_token.example /providers/Microsoft.Web/sourceControls/GitHub
+terraform import azurerm_app_service_source_control_token.example {type}
 ```


### PR DESCRIPTION
ID needs to be one of the value from `type` property
Error message:
`Error: parsing Resource ID "/providers/Microsoft.Web/sourceControls/GitHub": [expected id to be one of [BitBucket Dropbox GitHub OneDrive], got /providers/Microsoft.Web/sourceControls/GitHub]`