### PR TITLE
`azurerm_site_recovery_replicated_vm` - remove `network_interface.is_primary`

### DIFF
--- a/internal/services/recoveryservices/site_recovery_replicated_vm_resource.go
+++ b/internal/services/recoveryservices/site_recovery_replicated_vm_resource.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	keyVaultValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/recoveryservices/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/recoveryservices/validate"
@@ -213,7 +214,7 @@ func resourceSiteRecoveryReplicatedVM() *pluginsdk.Resource {
 }
 
 func networkInterfaceResource() *pluginsdk.Resource {
-	return &pluginsdk.Resource{
+	out := &pluginsdk.Resource{
 		Schema: map[string]*pluginsdk.Schema{
 			"source_network_interface_id": {
 				Type:         pluginsdk.TypeString,
@@ -241,6 +242,16 @@ func networkInterfaceResource() *pluginsdk.Resource {
 			},
 		},
 	}
+
+	if !features.FourPointOhBeta() {
+		out.Schema["is_primary"] = &pluginsdk.Schema{
+			Deprecated: "this property is not used and will be removed in version 4.0 of the provider",
+			Type:       pluginsdk.TypeBool,
+			Optional:   true,
+			Default:    false,
+		}
+	}
+	return out
 }
 
 func diskEncryptionResource() *pluginsdk.Resource {

--- a/internal/services/recoveryservices/site_recovery_replicated_vm_resource.go
+++ b/internal/services/recoveryservices/site_recovery_replicated_vm_resource.go
@@ -239,11 +239,6 @@ func networkInterfaceResource() *pluginsdk.Resource {
 				ForceNew:     false,
 				ValidateFunc: azure.ValidateResourceID,
 			},
-			"is_primary": {
-				Type:     pluginsdk.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
 		},
 	}
 }
@@ -435,10 +430,6 @@ func resourceSiteRecoveryReplicatedItemUpdateInternal(ctx context.Context, d *pl
 		targetStaticIp := vmNicInput["target_static_ip"].(string)
 		targetSubnetName := vmNicInput["target_subnet_name"].(string)
 		recoveryPublicIPAddressID := vmNicInput["recovery_public_ip_address_id"].(string)
-		isPrimary := vmNicInput["is_primary"].(bool)
-		if len(nicList) == 1 {
-			isPrimary = true
-		}
 
 		nicId := findNicId(state, sourceNicId)
 		if nicId == nil {
@@ -449,7 +440,7 @@ func resourceSiteRecoveryReplicatedItemUpdateInternal(ctx context.Context, d *pl
 				RecoverySubnetName:        &targetSubnetName,
 				RecoveryStaticIPAddress:   &targetStaticIp,
 				RecoveryPublicIPAddressId: &recoveryPublicIPAddressID,
-				IsPrimary:                 &isPrimary,
+				IsPrimary:                 utils.Bool(true), // currently we can only set one IPconfig for a nic, so we dont need to expose this to users.
 			},
 		}
 		vmNics = append(vmNics, replicationprotecteditems.VMNicInputDetails{

--- a/website/docs/r/site_recovery_replicated_vm.html.markdown
+++ b/website/docs/r/site_recovery_replicated_vm.html.markdown
@@ -282,8 +282,6 @@ A `network_interface` block supports the following:
 
 * `recovery_public_ip_address_id` - (Optional) Id of the public IP object to use when a failover is done.
 
-* `is_primary` - (Optional) If this is the primary network interface used for failover. If there is only one `network_interface` block, this is automatically set to `true`.
-
 ---
 
 The `target_disk_encryption` block supports:


### PR DESCRIPTION
this property is not for `network_interface` but for `ipconfig` (ipconfig is not exposed to users right now) which is only able to set one for a nic in our RP so it's better to set it to a fixed value.

To avoid breaking Set it to `deprecated`