### PR TITLE
`azurerm_cosmosdb_sql_container` - Fix property `included_path` can not be removed issue

### DIFF
--- a/internal/services/cosmos/common/schema.go
+++ b/internal/services/cosmos/common/schema.go
@@ -116,7 +116,6 @@ func CosmosDbIndexingPolicySchema() *pluginsdk.Schema {
 				"included_path": {
 					Type:     pluginsdk.TypeList,
 					Optional: true,
-					Computed: true,
 					Elem: &pluginsdk.Resource{
 						Schema: map[string]*pluginsdk.Schema{
 							"path": {
@@ -130,7 +129,6 @@ func CosmosDbIndexingPolicySchema() *pluginsdk.Schema {
 				"excluded_path": {
 					Type:     pluginsdk.TypeList,
 					Optional: true,
-					Computed: true,
 					Elem: &pluginsdk.Resource{
 						Schema: map[string]*pluginsdk.Schema{
 							"path": {

--- a/internal/services/cosmos/cosmosdb_sql_container_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_sql_container_resource_test.go
@@ -550,7 +550,7 @@ resource "azurerm_cosmosdb_sql_container" "test" {
 `, CosmosSqlDatabaseResource{}.basic(data), data.RandomInteger, includedPath, excludedPath)
 }
 
-func (CosmosSqlContainerResource) indexing_policy_update_includedPath(data acceptance.TestData, includedPath, excludedPath string) string {
+func (CosmosSqlContainerResource) indexing_policy_update_includedPath(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -564,8 +564,8 @@ resource "azurerm_cosmosdb_sql_container" "test" {
   indexing_policy {
     indexing_mode = "none"
   }
-}
-`, CosmosSqlDatabaseResource{}.basic(data), data.RandomInteger, includedPath, excludedPath)
+}git 
+`, CosmosSqlDatabaseResource{}.basic(data), data.RandomInteger)
 }
 
 func (CosmosSqlContainerResource) partition_key_version(data acceptance.TestData, version int) string {

--- a/internal/services/cosmos/cosmosdb_sql_container_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_sql_container_resource_test.go
@@ -564,7 +564,7 @@ resource "azurerm_cosmosdb_sql_container" "test" {
   indexing_policy {
     indexing_mode = "none"
   }
-}git 
+}
 `, CosmosSqlDatabaseResource{}.basic(data), data.RandomInteger)
 }
 

--- a/internal/services/cosmos/cosmosdb_sql_container_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_sql_container_resource_test.go
@@ -181,7 +181,7 @@ func TestAccCosmosDbSqlContainer_indexing_policy(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
-			Config: r.indexing_policy_update_includedPath(data, "/includedPath02/*", "/excludedPath02/?"),
+			Config: r.indexing_policy_update_includedPath(data),
 			Check: acceptance.ComposeAggregateTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),

--- a/internal/services/cosmos/cosmosdb_sql_container_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_sql_container_resource_test.go
@@ -181,6 +181,13 @@ func TestAccCosmosDbSqlContainer_indexing_policy(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
+			Config: r.indexing_policy_update_includedPath(data, "/includedPath02/*", "/excludedPath02/?"),
+			Check: acceptance.ComposeAggregateTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
 			Config: r.basic(data),
 			Check: acceptance.ComposeAggregateTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
@@ -538,6 +545,24 @@ resource "azurerm_cosmosdb_sql_container" "test" {
     spatial_index {
       path = "/test/to/all/?"
     }
+  }
+}
+`, CosmosSqlDatabaseResource{}.basic(data), data.RandomInteger, includedPath, excludedPath)
+}
+
+func (CosmosSqlContainerResource) indexing_policy_update_includedPath(data acceptance.TestData, includedPath, excludedPath string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_cosmosdb_sql_container" "test" {
+  name                = "acctest-CSQLC-%[2]d"
+  resource_group_name = azurerm_cosmosdb_account.test.resource_group_name
+  account_name        = azurerm_cosmosdb_account.test.name
+  database_name       = azurerm_cosmosdb_sql_database.test.name
+  partition_key_path  = "/definition/id"
+
+  indexing_policy {
+    indexing_mode = "none"
   }
 }
 `, CosmosSqlDatabaseResource{}.basic(data), data.RandomInteger, includedPath, excludedPath)


### PR DESCRIPTION
When updating resource `azurerm_cosmosdb_sql_container`,updating `indexing_mode` to "None" and removing the `included_path` in tf config, the following error occurs:

_`included_path must not be set if indexing_mode is "None"`_


This is because property  `included_path` is optional and computed, it could not be removed. Submit this PR to remove the unnecessary computed for `included_path` to fix #19901.

Test Results:
--- PASS: TestAccCosmosDbSqlContainer_basic_serverless (983.58s)
--- PASS: TestAccCosmosDbSqlContainer_customConflictResolutionPolicy (996.80s)
--- PASS: TestAccCosmosDbSqlContainer_partition_key_version (1059.64s)
--- PASS: TestAccCosmosDbSqlContainer_basic (1073.45s)
--- PASS: TestAccCosmosDbSqlContainer_complete (1089.55s)
--- PASS: TestAccCosmosDbSqlContainer_update (1225.81s)
--- PASS: TestAccCosmosDbSqlContainer_autoscale (1386.93s)
--- PASS: TestAccCosmosDbSqlContainer_analyticalStorageTTL (1419.03s)
--- PASS: TestAccCosmosDbSqlContainer_indexing_policy (1761.23s)

