### PR TITLE
`azurerm_container_group` - Fix  dynamic setting `dns_config` crash issue

### DIFF
--- a/internal/services/containers/container_group_resource.go
+++ b/internal/services/containers/container_group_resource.go
@@ -1972,7 +1972,7 @@ func flattenContainerGroupDnsConfig(input *containerinstance.DnsConfiguration) [
 
 func expandContainerGroupDnsConfig(input interface{}) *containerinstance.DnsConfiguration {
 	dnsConfigRaw := input.([]interface{})
-	if len(dnsConfigRaw) > 0 {
+	if len(dnsConfigRaw) > 0 && dnsConfigRaw[0] != nil {
 		config := dnsConfigRaw[0].(map[string]interface{})
 
 		nameservers := []string{}


### PR DESCRIPTION
dnsConfigRaw[0] should be checked for nil before dnsConfigRaw[0].(map[string]interface{}) to fix #19989.