### PR TITLE
Update azurerm_public_ip for lifecycle rec

### DIFF
--- a/website/docs/r/public_ip.html.markdown
+++ b/website/docs/r/public_ip.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Manages a Public IP Address.
 
+~> **Note** If this resource is to be associated with a resource that requires disassociation before destruction (such as `azurerm_network_interface`) it is recommended to set the `lifecycle` argument `create_before_destroy = true`. Otherwise, it can fail to disassociate on destruction.
+
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
See https://github.com/hashicorp/terraform-provider-azurerm/issues/15483

Without setting `create_before_destroy = true` in `lifecycle` ahead of time, it is difficult to disassociate and destroy in the correct order.