### PR TITLE
`azurerm_fluid_relay_server` - remove `orderer_endpoint` check in AccTest

### DIFF
--- a/internal/services/fluidrelay/fluid_relay_servers_resource_test.go
+++ b/internal/services/fluidrelay/fluid_relay_servers_resource_test.go
@@ -27,7 +27,6 @@ func TestAccFluidRelay_basic(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(f),
 				check.That(data.ResourceName).Key("frs_tenant_id").IsUUID(),
 				check.That(data.ResourceName).Key("primary_key").Exists(),
-				check.That(data.ResourceName).Key("orderer_endpoints.0").Exists(),
 				check.That(data.ResourceName).Key("service_endpoints.#").Exists(),
 			),
 		},
@@ -45,7 +44,6 @@ func TestAccFluidRelay_storageBasic(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(f),
 				check.That(data.ResourceName).Key("frs_tenant_id").IsUUID(),
-				check.That(data.ResourceName).Key("orderer_endpoints.0").Exists(),
 			),
 		},
 		data.ImportStep("storage_sku"),

--- a/website/docs/r/fluid_relay_servers.html.markdown
+++ b/website/docs/r/fluid_relay_servers.html.markdown
@@ -65,9 +65,9 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `secondary_key` - The secondary key for this server.
 
-* `orderer_endpoints` - An array of the Fluid Relay Orderer endpoints.
+* `orderer_endpoints` - An array of the Fluid Relay Orderer endpoints. This will be deprecated in future version of fluid relay server and will always be empty, [more details](https://learn.microsoft.com/en-us/azure/azure-fluid-relay/concepts/version-compatibility).
 
-* `storage_endpoints` - An array of storage endpoints for this Fluid Relay Server.
+* `storage_endpoints` - An array of storage endpoints for this Fluid Relay Server. This will be deprecated in future version of fluid relay server and will always be empty, [more details](https://learn.microsoft.com/en-us/azure/azure-fluid-relay/concepts/version-compatibility).
 
 * `service_endpoints` - An array of service endpoints for this Fluid Relay Server.
 


### PR DESCRIPTION
seems the API doesn't return an orderer_endpoint anymore from 5 Jan. so just remove this check to get it pass.


![image](https://user-images.githubusercontent.com/2633022/212622122-d0ad781f-eda4-493c-9096-4e31b5db8e32.png)

```
--- PASS: TestAccFluidRelay_basic (273.48s)
--- PASS: TestAccFluidRelayServer_requiresImport (172.00s)
--- PASS: TestAccFluidRelayServer_update (179.96s)
```