### PR TITLE
`azurerm_key_vault` - use `virtual_network_rules` as block and add support for `ignore_missing_vnet_service_endpoint` property

### DIFF
--- a/internal/services/keyvault/key_vault_resource.go
+++ b/internal/services/keyvault/key_vault_resource.go
@@ -200,7 +200,7 @@ func resourceKeyVault() *pluginsdk.Resource {
 							ConflictsWith: []string{"network_acls.virtual_network_subnet_ids"},
 							Elem: &pluginsdk.Resource{
 								Schema: map[string]*pluginsdk.Schema{
-									"id": {
+									"subnet_id": {
 										Type:             pluginsdk.TypeString,
 										Required:         true,
 										DiffSuppressFunc: suppress.CaseDifference,
@@ -902,10 +902,9 @@ func expandKeyVaultNetworkAcls(input []interface{}) (*keyvault.NetworkRuleSet, [
 
 	networkRules := make([]keyvault.VirtualNetworkRule, 0)
 	// only one of virtual_network_subnet_ids or virtual_network_rules exists
-
 	for _, val := range v["virtual_network_rules"].([]interface{}) {
 		rawRule := val.(map[string]interface{})
-		id := rawRule["id"].(string)
+		id := rawRule["subnet_id"].(string)
 		subnetIds = append(subnetIds, id)
 		var ignore *bool
 		if ignoreVal, ok := rawRule["ignore_missing_vnet_service_endpoint_enabled"]; ok {
@@ -997,7 +996,7 @@ func flattenKeyVaultNetworkAcls(input *keyvault.NetworkRuleSet) []interface{} {
 			virtualNetworkSubnetIDs = append(virtualNetworkSubnetIDs, id)
 
 			rule := map[string]interface{}{}
-			rule["id"] = id
+			rule["subnet_id"] = id
 			if b := v.IgnoreMissingVnetServiceEndpoint; b != nil {
 				rule["ignore_missing_vnet_service_endpoint_enabled"] = *b
 			}

--- a/internal/services/keyvault/key_vault_resource_test.go
+++ b/internal/services/keyvault/key_vault_resource_test.go
@@ -612,10 +612,16 @@ resource "azurerm_key_vault" "test" {
   }
 
   network_acls {
-    default_action             = "Allow"
-    bypass                     = "AzureServices"
-    ip_rules                   = ["123.0.0.102/32", "123.0.0.101"]
-    virtual_network_subnet_ids = [azurerm_subnet.test_a.id]
+    default_action = "Allow"
+    bypass         = "AzureServices"
+    ip_rules       = ["123.0.0.102/32", "123.0.0.101"]
+    virtual_network_rules {
+      id = azurerm_subnet.test_a.id
+    }
+    virtual_network_rules {
+      id                                           = azurerm_subnet.test_b.id
+      ignore_missing_vnet_service_endpoint_enabled = true
+    }
   }
 }
 `, r.networkAclsTemplate(data), data.RandomInteger)

--- a/website/docs/r/key_vault.html.markdown
+++ b/website/docs/r/key_vault.html.markdown
@@ -141,7 +141,17 @@ A `network_acls` block supports the following:
 
 * `ip_rules` - (Optional) One or more IP Addresses, or CIDR Blocks which should be able to access the Key Vault.
 
-* `virtual_network_subnet_ids` - (Optional) One or more Subnet IDs which should be able to access this Key Vault.
+* `virtual_network_subnet_ids` - (Optional) One or more Subnet IDs which should be able to access this Key Vault. `virtual_network_rules` is preferred.
+
+* `virtual_network_rules` - (Optional) One or more `virtual_network_rules` blocks as defined below.
+
+---
+
+A `virtual_network_rules` block supports the following:
+
+* `id` - (Required) Specifies the subnet ID for this rule.
+
+* `ignore_missing_vnet_service_endpoint_enabled` - (Optional) Should ignore missing virtual network service endpoint for this rule.
 
 ---
 

--- a/website/docs/r/key_vault.html.markdown
+++ b/website/docs/r/key_vault.html.markdown
@@ -141,17 +141,15 @@ A `network_acls` block supports the following:
 
 * `ip_rules` - (Optional) One or more IP Addresses, or CIDR Blocks which should be able to access the Key Vault.
 
-* `virtual_network_subnet_ids` - (Optional) One or more Subnet IDs which should be able to access this Key Vault. `virtual_network_rules` is preferred.
-
 * `virtual_network_rules` - (Optional) One or more `virtual_network_rules` blocks as defined below.
 
 ---
 
 A `virtual_network_rules` block supports the following:
 
-* `id` - (Required) Specifies the subnet ID for this rule.
+* `subnet_id` - (Required) Specifies the subnet ID for this rule.
 
-* `ignore_missing_vnet_service_endpoint_enabled` - (Optional) Whether NRP will ignore the check if parent subnet has serviceEndpoints configured.
+* `ignore_missing_vnet_service_endpoint_enabled` - (Optional) Whether NRP will ignore the check if parent subnet has service endpoints configured.
 
 ---
 

--- a/website/docs/r/key_vault.html.markdown
+++ b/website/docs/r/key_vault.html.markdown
@@ -151,7 +151,7 @@ A `virtual_network_rules` block supports the following:
 
 * `id` - (Required) Specifies the subnet ID for this rule.
 
-* `ignore_missing_vnet_service_endpoint_enabled` - (Optional) Should ignore missing virtual network service endpoint for this rule.
+* `ignore_missing_vnet_service_endpoint_enabled` - (Optional) Whether NRP will ignore the check if parent subnet has serviceEndpoints configured.
 
 ---
 


### PR DESCRIPTION
**Looks like there is a problem in updating `ignore_missing_vnet_service_endpoint` property. it takes no effect on the exists keyvault resource**, so convert this PR to draft status. created an issue to track this: https://github.com/Azure/azure-rest-api-specs/issues/22128

`ignore_missing_vnet_service_endpoint` need support from version `2021-10-01`, and mark `virtual_network_subnet_ids` as deprecated.

https://github.com/Azure/azure-rest-api-specs/blob/63a4b37b66740087b113e00c1b32b2b9c98fd9db/specification/keyvault/resource-manager/Microsoft.KeyVault/stable/2021-10-01/keyvault.json#L1798-L1800

```
--- PASS: TestAccDataSourceKeyVault_networkAcls (543.73s)
```