### PR TITLE
`azurerm_mssql_managed_instance` : fix acc test failure for priority changed after apply

### DIFF
--- a/internal/services/mssql/mssql_managed_instance_resource_test.go
+++ b/internal/services/mssql/mssql_managed_instance_resource_test.go
@@ -17,6 +17,11 @@ type MsSqlManagedInstanceResource struct{}
 
 const managedInstanceStaticRoutes = `
   route {
+    name           = "Microsoft.Sql-managedInstances_UseOnly_mi-OneDsCollector"
+    address_prefix = "OneDsCollector"
+    next_hop_type  = "Internet"
+  }
+  route {
     name           = "mi-13-64-11-nexthop-internet"
     address_prefix = "13.64.0.0/11"
     next_hop_type  = "Internet"

--- a/internal/services/mssql/mssql_managed_instance_resource_test.go
+++ b/internal/services/mssql/mssql_managed_instance_resource_test.go
@@ -1772,7 +1772,7 @@ resource "azurerm_network_security_rule" "deny_all_inbound_1" {
 
 resource "azurerm_network_security_rule" "allow_management_outbound_1" {
   name                        = "allow_management_outbound"
-  priority                    = 102
+  priority                    = 110
   direction                   = "Outbound"
   access                      = "Allow"
   protocol                    = "Tcp"
@@ -2007,7 +2007,7 @@ resource "azurerm_network_security_rule" "deny_all_inbound_2" {
 
 resource "azurerm_network_security_rule" "allow_management_outbound_2" {
   name                        = "allow_management_outbound"
-  priority                    = 102
+  priority                    = 110
   direction                   = "Outbound"
   access                      = "Allow"
   protocol                    = "Tcp"
@@ -2242,7 +2242,7 @@ resource "azurerm_network_security_rule" "deny_all_inbound_3" {
 
 resource "azurerm_network_security_rule" "allow_management_outbound_3" {
   name                        = "allow_management_outbound"
-  priority                    = 102
+  priority                    = 110
   direction                   = "Outbound"
   access                      = "Allow"
   protocol                    = "Tcp"


### PR DESCRIPTION
Fix acc test failures:
1.  The `priority` changes after terraform apply issue.
2.  The `OneDsCollector` route required by sql managed instance is missed issue.            

![image](https://user-images.githubusercontent.com/39109137/217471680-f0d3d55a-3845-4899-83a7-8f6f06f698e5.png)
     