### PR TITLE
`azurerm_windows_web_app_slot` - restore workaround for erroneous nodeVersion default value in some regions

### DIFF
--- a/internal/services/appservice/function_app_active_slot_resource_test.go
+++ b/internal/services/appservice/function_app_active_slot_resource_test.go
@@ -162,7 +162,7 @@ resource "azurerm_windows_function_app_slot" "update" {
 
   site_config {
     application_stack {
-      dotnet_version = "6"
+      dotnet_version = "v6.0"
     }
 
     cors {
@@ -368,7 +368,7 @@ resource "azurerm_windows_function_app" "test" {
 
   site_config {
     application_stack {
-      dotnet_version = "6"
+      dotnet_version = "v6.0"
     }
 
     cors {
@@ -400,7 +400,7 @@ resource "azurerm_windows_function_app_slot" "test" {
 
   site_config {
     application_stack {
-      dotnet_version = "6"
+      dotnet_version = "v6.0"
     }
 
     cors {

--- a/internal/services/appservice/function_app_function_resource_test.go
+++ b/internal/services/appservice/function_app_function_resource_test.go
@@ -311,7 +311,7 @@ resource "azurerm_windows_function_app" "test" {
 
   site_config {
     application_stack {
-      dotnet_version = "6"
+      dotnet_version = "v6.0"
     }
   }
 }

--- a/internal/services/appservice/windows_web_app_slot_resource.go
+++ b/internal/services/appservice/windows_web_app_slot_resource.go
@@ -516,10 +516,12 @@ func (r WindowsWebAppSlotResource) Read() sdk.ResourceFunc {
 			state.SiteConfig = helpers.FlattenSiteConfigWindowsAppSlot(webAppSiteConfig.SiteConfig, currentStack, healthCheckCount)
 
 			if nodeVer, ok := state.AppSettings["WEBSITE_NODE_DEFAULT_VERSION"]; ok {
-				if state.SiteConfig[0].ApplicationStack == nil {
-					state.SiteConfig[0].ApplicationStack = make([]helpers.ApplicationStackWindows, 0)
+				if nodeVer != "6.9.1" {
+					if state.SiteConfig[0].ApplicationStack == nil {
+						state.SiteConfig[0].ApplicationStack = make([]helpers.ApplicationStackWindows, 0)
+					}
+					state.SiteConfig[0].ApplicationStack[0].NodeVersion = nodeVer
 				}
-				state.SiteConfig[0].ApplicationStack[0].NodeVersion = nodeVer
 				delete(state.AppSettings, "WEBSITE_NODE_DEFAULT_VERSION")
 			}
 


### PR DESCRIPTION
Some regions appear to still return a default value for `nodeVersion` that is not valid and unexpected:
```
# (22 unchanged attributes hidden)
~ application_stack {
- node_version                 = "6.9.1" -> null
# (5 unchanged attributes hidden)
```
Fixes several tests related to `dotnetVersion`.