### PR TITLE
Data source `azurerm_private_dns_resolver` - implement other review comments

### DIFF
--- a/internal/services/privatednsresolver/private_dns_resolver_data_source_test.go
+++ b/internal/services/privatednsresolver/private_dns_resolver_data_source_test.go
@@ -28,81 +28,13 @@ func TestAccPrivateDNSResolverDnsResolverDataSource_basic(t *testing.T) {
 	})
 }
 
-func TestAccPrivateDNSResolverDnsResolverDataSource_complete(t *testing.T) {
-	data := acceptance.BuildTestData(t, "data.azurerm_private_dns_resolver", "test")
-	d := PrivateDNSResolverDnsResolverDataSource{}
-
-	data.DataSourceTest(t, []acceptance.TestStep{
-		{
-			Config: d.complete(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).Key("name").Exists(),
-				check.That(data.ResourceName).Key("resource_group_name").Exists(),
-				check.That(data.ResourceName).Key("location").HasValue(location.Normalize(data.Locations.Primary)),
-				check.That(data.ResourceName).Key("virtual_network_id").Exists(),
-				check.That(data.ResourceName).Key("tags.key").HasValue("value"),
-			),
-		},
-	})
-}
-
-func (d PrivateDNSResolverDnsResolverDataSource) template(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctest-rg-%[2]d"
-  location = "%[1]s"
-}
-
-resource "azurerm_virtual_network" "test" {
-  name                = "acctest-rg-%[2]d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-  address_space       = ["10.0.0.0/16"]
-}
-`, data.Locations.Primary, data.RandomInteger)
-}
-
 func (d PrivateDNSResolverDnsResolverDataSource) basic(data acceptance.TestData) string {
-	template := d.template(data)
 	return fmt.Sprintf(`
 %s
-
-resource "azurerm_private_dns_resolver" "test" {
-  name                = "acctest-dr-%d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-  virtual_network_id  = azurerm_virtual_network.test.id
-}
 
 data "azurerm_private_dns_resolver" "test" {
   name                = azurerm_private_dns_resolver.test.name
   resource_group_name = azurerm_resource_group.test.name
 }
-`, template, data.RandomInteger)
-}
-
-func (d PrivateDNSResolverDnsResolverDataSource) complete(data acceptance.TestData) string {
-	template := d.template(data)
-	return fmt.Sprintf(`
-%s
-
-resource "azurerm_private_dns_resolver" "test" {
-  name                = "acctest-dr-%d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-  virtual_network_id  = azurerm_virtual_network.test.id
-  tags = {
-    key = "value"
-  }
-}
-
-data "azurerm_private_dns_resolver" "test" {
-  name                = azurerm_private_dns_resolver.test.name
-  resource_group_name = azurerm_resource_group.test.name
-}
-`, template, data.RandomInteger)
+`, PrivateDNSResolverDnsResolverResource{}.basic(data))
 }

--- a/website/docs/d/private_dns_resolver.html.markdown
+++ b/website/docs/d/private_dns_resolver.html.markdown
@@ -21,26 +21,26 @@ data "azurerm_private_dns_resolver" "test" {
 
 ## Arguments Reference
 
-The following arguments are required:
+The following arguments are supported:
 
-* `name` - Name of the Private DNS Resolver.
+* `name` - (Required) Name of the Private DNS Resolver.
 
-* `resource_group_name` - Name of the Resource Group where the Private DNS Resolver exists.
+* `resource_group_name` - (Required) Name of the Resource Group where the Private DNS Resolver exists.
 
 ## Attributes Reference
 
 In addition to the Arguments listed above - the following Attributes are exported:
 
-* `id` - ID of the DNS Resolver.
+* `id` - The ID of the DNS Resolver.
 
-* `location` - Azure Region where the Private DNS Resolver exists.
+* `location` - The Azure Region where the Private DNS Resolver exists.
 
-* `virtual_network_id` - ID of the Virtual Network that is linked to the Private DNS Resolver.
+* `virtual_network_id` - The ID of the Virtual Network that is linked to the Private DNS Resolver.
 
-* `tags` - Mapping of tags which should be assigned to the Private DNS Resolver.
+* `tags` - The tags assigned to the Private DNS Resolver.
 
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `read` - (Defaults to 5 minutes) Used when retrieving the Private DNS SRV Record.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Private DNS Resolver.


### PR DESCRIPTION
Implement same review comments as PR #19947.

``` txt
=== RUN   TestAccPrivateDNSResolverDnsResolverDataSource_basic
=== PAUSE TestAccPrivateDNSResolverDnsResolverDataSource_basic
=== CONT  TestAccPrivateDNSResolverDnsResolverDataSource_basic
--- PASS: TestAccPrivateDNSResolverDnsResolverDataSource_basic (149.38s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/privatednsresolver    150.544s
```