### PR TITLE
azurerm_postgresql_flexible_server_configuration - restart server for static parameters

### DIFF
--- a/internal/services/postgres/postgresql_flexible_server_configuration_resource_test.go
+++ b/internal/services/postgres/postgresql_flexible_server_configuration_resource_test.go
@@ -159,6 +159,23 @@ func TestAccFlexibleServerConfiguration_multiplePostgresqlFlexibleServerConfigur
 	})
 }
 
+func TestAccFlexibleServerConfiguration_restartServerForStaticParameters(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_postgresql_flexible_server_configuration", "test")
+	r := PostgresqlFlexibleServerConfigurationResource{}
+	name := "cron.max_running_jobs"
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data, name, "5"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("name").HasValue(name),
+				check.That(data.ResourceName).Key("value").HasValue("5"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 // Helper functions for verification
 func (r PostgresqlFlexibleServerConfigurationResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := configurations.ParseConfigurationID(state.ID)

--- a/internal/services/postgres/postgresql_flexible_server_configuration_resource_test.go
+++ b/internal/services/postgres/postgresql_flexible_server_configuration_resource_test.go
@@ -173,6 +173,12 @@ func TestAccFlexibleServerConfiguration_restartServerForStaticParameters(t *test
 			),
 		},
 		data.ImportStep(),
+		{
+			Config: r.template(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				data.CheckWithClientForResource(r.checkReset(name), "azurerm_postgresql_flexible_server.test"),
+			),
+		},
 	})
 }
 


### PR DESCRIPTION
Service team raised a request to restart server after user sets the static parameters. So I submitted this PR to support it.

![image](https://user-images.githubusercontent.com/19754191/212805642-a283cc95-7144-4e0d-9f86-b864add70fd5.png)
