### PR TITLE
`azurerm_monitor_diagnostic_setting` - fix update issue 

### DIFF
--- a/internal/services/monitor/monitor_diagnostic_setting_resource.go
+++ b/internal/services/monitor/monitor_diagnostic_setting_resource.go
@@ -97,6 +97,7 @@ func resourceMonitorDiagnosticSetting() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
 				ForceNew: false,
+				Default:  "AzureDiagnostics",
 				ValidateFunc: validation.StringInSlice([]string{
 					"Dedicated",
 					"AzureDiagnostics", // Not documented in azure API, but some resource has skew. See: https://github.com/Azure/azure-rest-api-specs/issues/9281
@@ -286,18 +287,18 @@ func resourceMonitorDiagnosticSettingCreate(d *pluginsdk.ResourceData, meta inte
 		}
 	}
 
-	// if no logs/metrics are not enabled the API "creates" but 404's on Read
-	valid := false
+	// if no logs/metrics are enabled the API "creates" but 404's on Read
+	hasEnabledMetrics := false
 	if !hasEnabledLogs {
 		for _, v := range metrics {
 			if v.Enabled {
-				valid = true
+				hasEnabledMetrics = true
 				break
 			}
 		}
 	}
 
-	if !valid && !hasEnabledLogs {
+	if !hasEnabledMetrics && !hasEnabledLogs {
 		return fmt.Errorf("at least one type of Log or Metric must be enabled")
 	}
 
@@ -308,7 +309,7 @@ func resourceMonitorDiagnosticSettingCreate(d *pluginsdk.ResourceData, meta inte
 		},
 	}
 
-	valid = false
+	valid := false
 	eventHubAuthorizationRuleId := d.Get("eventhub_authorization_rule_id").(string)
 	eventHubName := d.Get("eventhub_name").(string)
 	if eventHubAuthorizationRuleId != "" {
@@ -363,13 +364,23 @@ func resourceMonitorDiagnosticSettingUpdate(d *pluginsdk.ResourceData, meta inte
 		return err
 	}
 
+	existing, err := client.Get(ctx, *id)
+	if err != nil {
+		return fmt.Errorf("retrieving Monitor Diagnostics Setting %q for Resource %q: %+v", id.Name, id.ResourceUri, err)
+	}
+	if existing.Model == nil || existing.Model.Properties == nil {
+		return fmt.Errorf("unexpected null model of Monitor Diagnostics Setting %q for Resource %q", id.Name, id.ResourceUri)
+	}
+
 	metricsRaw := d.Get("metric").(*pluginsdk.Set).List()
 	metrics := expandMonitorDiagnosticsSettingsMetrics(metricsRaw)
 
 	var logs []diagnosticsettings.LogSettings
 	hasEnabledLogs := false
+	logChanged := false
 	if !features.FourPointOhBeta() {
 		if d.HasChange("log") {
+			logChanged = true
 			logsRaw := d.Get("log").(*pluginsdk.Set).List()
 			logs = expandMonitorDiagnosticsSettingsLogs(logsRaw)
 			for _, v := range logs {
@@ -383,22 +394,31 @@ func resourceMonitorDiagnosticSettingUpdate(d *pluginsdk.ResourceData, meta inte
 
 	if d.HasChange("enabled_log") {
 		enabledLogs := d.Get("enabled_log").(*pluginsdk.Set).List()
-		logs = expandMonitorDiagnosticsSettingsEnabledLogs(enabledLogs)
-		hasEnabledLogs = true
+		if len(enabledLogs) > 0 {
+			logs = expandMonitorDiagnosticsSettingsEnabledLogs(enabledLogs)
+			hasEnabledLogs = true
+		}
+	} else if !logChanged && existing.Model.Properties.Logs != nil {
+		logs = *existing.Model.Properties.Logs
+		for _, v := range logs {
+			if v.Enabled {
+				hasEnabledLogs = true
+			}
+		}
 	}
 
-	// if no logs/metrics are not enabled the API "creates" but 404's on Read
-	valid := false
+	// if no logs/metrics are enabled the API "creates" but 404's on Read
+	hasEnabledMetrics := false
 	if !hasEnabledLogs {
 		for _, v := range metrics {
 			if v.Enabled {
-				valid = true
+				hasEnabledMetrics = true
 				break
 			}
 		}
 	}
 
-	if !valid && !hasEnabledLogs {
+	if !hasEnabledMetrics && !hasEnabledLogs {
 		return fmt.Errorf("at least one type of Log or Metric must be enabled")
 	}
 
@@ -455,7 +475,7 @@ func resourceMonitorDiagnosticSettingUpdate(d *pluginsdk.ResourceData, meta inte
 		},
 	}
 
-	valid = false
+	valid := false
 	eventHubAuthorizationRuleId := d.Get("eventhub_authorization_rule_id").(string)
 	eventHubName := d.Get("eventhub_name").(string)
 	if eventHubAuthorizationRuleId != "" {

--- a/internal/services/monitor/monitor_diagnostic_setting_resource_test.go
+++ b/internal/services/monitor/monitor_diagnostic_setting_resource_test.go
@@ -271,7 +271,6 @@ resource "azurerm_monitor_diagnostic_setting" "test" {
   target_resource_id             = azurerm_key_vault.test.id
   eventhub_authorization_rule_id = azurerm_eventhub_namespace_authorization_rule.test.id
   eventhub_name                  = azurerm_eventhub.test.name
-  log_analytics_destination_type = "AzureDiagnostics"
 
   log {
     category = "AuditEvent"
@@ -357,7 +356,6 @@ resource "azurerm_monitor_diagnostic_setting" "test" {
   target_resource_id             = azurerm_key_vault.test.id
   eventhub_authorization_rule_id = azurerm_eventhub_namespace_authorization_rule.test.id
   eventhub_name                  = azurerm_eventhub.test.name
-  log_analytics_destination_type = "AzureDiagnostics"
 
   log {
     category_group = "Audit"
@@ -390,6 +388,7 @@ resource "azurerm_monitor_diagnostic_setting" "test" {
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomIntOfLength(17))
 }
+
 func (r MonitorDiagnosticSettingResource) requiresImport(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
@@ -655,10 +654,9 @@ resource "azurerm_elastic_cloud_elasticsearch" "test" {
 }
 
 resource "azurerm_monitor_diagnostic_setting" "test" {
-  name                           = "acctest-DS-%[1]d"
-  target_resource_id             = azurerm_key_vault.test.id
-  partner_solution_id            = azurerm_elastic_cloud_elasticsearch.test.id
-  log_analytics_destination_type = "AzureDiagnostics"
+  name                = "acctest-DS-%[1]d"
+  target_resource_id  = azurerm_key_vault.test.id
+  partner_solution_id = azurerm_elastic_cloud_elasticsearch.test.id
 
   log {
     category = "AuditEvent"
@@ -723,10 +721,9 @@ resource "azurerm_key_vault" "test" {
 }
 
 resource "azurerm_monitor_diagnostic_setting" "test" {
-  name                           = "acctest-DS-%[1]d"
-  target_resource_id             = azurerm_key_vault.test.id
-  storage_account_id             = azurerm_storage_account.test.id
-  log_analytics_destination_type = "AzureDiagnostics"
+  name               = "acctest-DS-%[1]d"
+  target_resource_id = azurerm_key_vault.test.id
+  storage_account_id = azurerm_storage_account.test.id
 
   log {
     category = "AuditEvent"
@@ -789,10 +786,9 @@ resource "azurerm_storage_account" "test" {
 
 
 resource "azurerm_monitor_diagnostic_setting" "test" {
-  name                           = "acctest-DS-%[1]d"
-  target_resource_id             = data.azurerm_subscription.current.id
-  storage_account_id             = azurerm_storage_account.test.id
-  log_analytics_destination_type = "AzureDiagnostics"
+  name               = "acctest-DS-%[1]d"
+  target_resource_id = data.azurerm_subscription.current.id
+  storage_account_id = azurerm_storage_account.test.id
 
   log {
     category = "Administrative"

--- a/internal/services/monitor/monitor_diagnostic_setting_resource_test.go
+++ b/internal/services/monitor/monitor_diagnostic_setting_resource_test.go
@@ -153,6 +153,29 @@ func TestAccMonitorDiagnosticSetting_activityLog(t *testing.T) {
 	})
 }
 
+func TestAccMonitorDiagnosticSetting_logAnalyticsDestinationType(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_monitor_diagnostic_setting", "test")
+	r := MonitorDiagnosticSettingResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.logAnalyticsDestinationTypeOmit(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("log_analytics_destination_type").HasValue("AzureDiagnostics"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.logAnalyticsDestinationTypeUpdated(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("log_analytics_destination_type").HasValue("Dedicated"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccMonitorDiagnosticSetting_enabledLogs(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_monitor_diagnostic_setting", "test")
 	r := MonitorDiagnosticSettingResource{}
@@ -971,4 +994,272 @@ resource "azurerm_monitor_diagnostic_setting" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomIntOfLength(17))
+}
+
+func (MonitorDiagnosticSettingResource) logAnalyticsDestinationTypeOmit(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_client_config" "current" {
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_log_analytics_workspace" "test" {
+  name                = "acctest-LAW-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "PerGB2018"
+  retention_in_days   = 30
+}
+
+resource "azurerm_data_factory" "test" {
+  name                = "acctest-DF-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_monitor_diagnostic_setting" "test" {
+  name                       = "acctest-DS-%[1]d"
+  target_resource_id         = azurerm_data_factory.test.id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+
+  log {
+    category = "ActivityRuns"
+    retention_policy {
+      enabled = false
+      days    = 0
+    }
+  }
+
+  log {
+    category = "PipelineRuns"
+    retention_policy {
+      enabled = false
+      days    = 0
+    }
+  }
+
+  log {
+    category = "TriggerRuns"
+    retention_policy {
+      days    = 0
+      enabled = false
+    }
+  }
+
+  log {
+    category = "SSISIntegrationRuntimeLogs"
+    retention_policy {
+      days    = 0
+      enabled = false
+    }
+  }
+
+  log {
+    category = "SSISPackageEventMessageContext"
+    retention_policy {
+      days    = 0
+      enabled = false
+    }
+  }
+
+  log {
+    category = "SSISPackageEventMessages"
+    retention_policy {
+      days    = 0
+      enabled = false
+    }
+  }
+
+  log {
+    category = "SSISPackageExecutableStatistics"
+    retention_policy {
+      days    = 0
+      enabled = false
+    }
+  }
+
+  log {
+    category = "SSISPackageExecutionComponentPhases"
+    retention_policy {
+      days    = 0
+      enabled = false
+    }
+  }
+
+  log {
+    category = "SSISPackageExecutionDataStatistics"
+    retention_policy {
+      days    = 0
+      enabled = false
+    }
+  }
+
+  log {
+    category = "SandboxActivityRuns"
+    retention_policy {
+      days    = 0
+      enabled = false
+    }
+  }
+
+  log {
+    category = "SandboxPipelineRuns"
+    retention_policy {
+      days    = 0
+      enabled = false
+    }
+  }
+
+  metric {
+    category = "AllMetrics"
+    enabled  = false
+    retention_policy {
+      days    = 0
+      enabled = false
+    }
+  }
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func (MonitorDiagnosticSettingResource) logAnalyticsDestinationTypeUpdated(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_client_config" "current" {
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_log_analytics_workspace" "test" {
+  name                = "acctest-LAW-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "PerGB2018"
+  retention_in_days   = 30
+}
+
+resource "azurerm_data_factory" "test" {
+  name                = "acctest-DF-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_monitor_diagnostic_setting" "test" {
+  name                       = "acctest-DS-%[1]d"
+  target_resource_id         = azurerm_data_factory.test.id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+
+  log_analytics_destination_type = "Dedicated"
+
+  log {
+    category = "ActivityRuns"
+    retention_policy {
+      enabled = false
+      days    = 0
+    }
+  }
+
+  log {
+    category = "PipelineRuns"
+    retention_policy {
+      enabled = false
+      days    = 0
+    }
+  }
+
+  log {
+    category = "TriggerRuns"
+    retention_policy {
+      days    = 0
+      enabled = false
+    }
+  }
+
+  log {
+    category = "SSISIntegrationRuntimeLogs"
+    retention_policy {
+      days    = 0
+      enabled = false
+    }
+  }
+
+  log {
+    category = "SSISPackageEventMessageContext"
+    retention_policy {
+      days    = 0
+      enabled = false
+    }
+  }
+
+  log {
+    category = "SSISPackageEventMessages"
+    retention_policy {
+      days    = 0
+      enabled = false
+    }
+  }
+
+  log {
+    category = "SSISPackageExecutableStatistics"
+    retention_policy {
+      days    = 0
+      enabled = false
+    }
+  }
+
+  log {
+    category = "SSISPackageExecutionComponentPhases"
+    retention_policy {
+      days    = 0
+      enabled = false
+    }
+  }
+
+  log {
+    category = "SSISPackageExecutionDataStatistics"
+    retention_policy {
+      days    = 0
+      enabled = false
+    }
+  }
+
+  log {
+    category = "SandboxActivityRuns"
+    retention_policy {
+      days    = 0
+      enabled = false
+    }
+  }
+
+  log {
+    category = "SandboxPipelineRuns"
+    retention_policy {
+      days    = 0
+      enabled = false
+    }
+  }
+
+  metric {
+    category = "AllMetrics"
+    enabled  = false
+    retention_policy {
+      days    = 0
+      enabled = false
+    }
+  }
+}
+`, data.RandomInteger, data.Locations.Primary)
 }

--- a/website/docs/r/monitor_diagnostic_setting.html.markdown
+++ b/website/docs/r/monitor_diagnostic_setting.html.markdown
@@ -92,9 +92,9 @@ The following arguments are supported:
 
 -> **NOTE:** One of `eventhub_authorization_rule_id`, `log_analytics_workspace_id`, `partner_solution_id` and `storage_account_id` must be specified.
 
-* `log_analytics_destination_type` - (Optional) When set to 'Dedicated' logs sent to a Log Analytics workspace will go into resource specific tables, instead of the legacy AzureDiagnostics table.
+* `log_analytics_destination_type` - (Optional) Possible values are `AzureDiagnostics` and `Dedicated`, default to `AzureDiagnostics`. When set to `Dedicated`, logs sent to a Log Analytics workspace will go into resource specific tables, instead of the legacy AzureDiagnostics table.
 
--> **NOTE:** This setting will only have an effect if a `log_analytics_workspace_id` is provided, and the resource is available for resource-specific logs.  As of July 2019, this only includes Azure Data Factory. Please [see the documentation](https://docs.microsoft.com/azure/azure-monitor/platform/diagnostic-logs-stream-log-store#azure-diagnostics-vs-resource-specific) for more information.
+-> **NOTE:** This setting will only have an effect if a `log_analytics_workspace_id` is provided. Please see [resource types](https://learn.microsoft.com/en-us/azure/azure-monitor/reference/tables/azurediagnostics#resource-types) for services that use each method. Please [see the documentation](https://docs.microsoft.com/azure/azure-monitor/platform/diagnostic-logs-stream-log-store#azure-diagnostics-vs-resource-specific) for details on the differences between destination types.
 
 * `partner_solution_id` - (Optional) The ID of the market partner solution where Diagnostics Data should be sent. For potential partner integrations, [click to learn more about partner integration](https://learn.microsoft.com/en-us/azure/partner-solutions/overview).
 

--- a/website/docs/r/monitor_diagnostic_setting.html.markdown
+++ b/website/docs/r/monitor_diagnostic_setting.html.markdown
@@ -34,9 +34,8 @@ resource "azurerm_monitor_diagnostic_setting" "example" {
   target_resource_id = data.azurerm_key_vault.example.id
   storage_account_id = data.azurerm_storage_account.example.id
 
-  log {
+  enabled_log {
     category = "AuditEvent"
-    enabled  = false
 
     retention_policy {
       enabled = false
@@ -75,9 +74,11 @@ The following arguments are supported:
 
 * `log` - (Optional) One or more `log` blocks as defined below.
 
+-> **NOTE:** `log` has been superseded by `enabled_log` and will be removed in version 4.0 of the AzureRM Provider.
+
 * `enabled_log` - (Optional) One or more `enabled_log` blocks as defined below.
 
--> **NOTE:** At least one `log`, `enabled_log` or `metric` block must be specified.
+-> **NOTE:** At least one `log`, `enabled_log` or `metric` block must be specified. At least one type of Log or Metric must be enabled.
 
 * `log_analytics_workspace_id` - (Optional) Specifies the ID of a Log Analytics Workspace where Diagnostics Data should be sent.
 
@@ -85,7 +86,7 @@ The following arguments are supported:
 
 * `metric` - (Optional) One or more `metric` blocks as defined below.
 
--> **NOTE:** At least one `log` or `metric` block must be specified.
+-> **NOTE:** At least one `log`, `enabled_log` or `metric` block must be specified.
 
 * `storage_account_id` - (Optional) The ID of the Storage Account where logs should be sent. Changing this forces a new resource to be created.
 

--- a/website/docs/r/monitor_diagnostic_setting.html.markdown
+++ b/website/docs/r/monitor_diagnostic_setting.html.markdown
@@ -110,7 +110,7 @@ A `log` block supports the following:
 
 * `category_group` - (Optional) The name of a Diagnostic Log Category Group for this Resource.
 
--> **NOTE:** Not all resources have category groups available.****
+-> **NOTE:** Not all resources have category groups available.
 
 * `retention_policy` - (Optional) A `retention_policy` block as defined below.
 

--- a/website/docs/r/monitor_diagnostic_setting.html.markdown
+++ b/website/docs/r/monitor_diagnostic_setting.html.markdown
@@ -70,7 +70,7 @@ The following arguments are supported:
 
 -> **NOTE:** This can be sourced from [the `azurerm_eventhub_namespace_authorization_rule` resource](eventhub_namespace_authorization_rule.html) and is different from [a `azurerm_eventhub_authorization_rule` resource](eventhub_authorization_rule.html).
 
--> **NOTE:** One of `eventhub_authorization_rule_id`, `log_analytics_workspace_id`, `partner_solution_id` and `storage_account_id` must be specified.
+-> **NOTE:** At least one of `eventhub_authorization_rule_id`, `log_analytics_workspace_id`, `partner_solution_id` and `storage_account_id` must be specified.
 
 * `log` - (Optional) One or more `log` blocks as defined below.
 
@@ -82,7 +82,7 @@ The following arguments are supported:
 
 * `log_analytics_workspace_id` - (Optional) Specifies the ID of a Log Analytics Workspace where Diagnostics Data should be sent.
 
--> **NOTE:** One of `eventhub_authorization_rule_id`, `log_analytics_workspace_id`, `partner_solution_id` and `storage_account_id` must be specified.
+-> **NOTE:** At least one of `eventhub_authorization_rule_id`, `log_analytics_workspace_id`, `partner_solution_id` and `storage_account_id` must be specified.
 
 * `metric` - (Optional) One or more `metric` blocks as defined below.
 
@@ -90,7 +90,7 @@ The following arguments are supported:
 
 * `storage_account_id` - (Optional) The ID of the Storage Account where logs should be sent. Changing this forces a new resource to be created.
 
--> **NOTE:** One of `eventhub_authorization_rule_id`, `log_analytics_workspace_id`, `partner_solution_id` and `storage_account_id` must be specified.
+-> **NOTE:** At least one of `eventhub_authorization_rule_id`, `log_analytics_workspace_id`, `partner_solution_id` and `storage_account_id` must be specified.
 
 * `log_analytics_destination_type` - (Optional) Possible values are `AzureDiagnostics` and `Dedicated`, default to `AzureDiagnostics`. When set to `Dedicated`, logs sent to a Log Analytics workspace will go into resource specific tables, instead of the legacy AzureDiagnostics table.
 
@@ -98,7 +98,7 @@ The following arguments are supported:
 
 * `partner_solution_id` - (Optional) The ID of the market partner solution where Diagnostics Data should be sent. For potential partner integrations, [click to learn more about partner integration](https://learn.microsoft.com/en-us/azure/partner-solutions/overview).
 
--> **NOTE:** One of `eventhub_authorization_rule_id`, `log_analytics_workspace_id`, `partner_solution_id` and `storage_account_id` must be specified.
+-> **NOTE:** At least one of `eventhub_authorization_rule_id`, `log_analytics_workspace_id`, `partner_solution_id` and `storage_account_id` must be specified.
 
 ---
 

--- a/website/docs/r/monitor_diagnostic_setting.html.markdown
+++ b/website/docs/r/monitor_diagnostic_setting.html.markdown
@@ -74,7 +74,7 @@ The following arguments are supported:
 
 * `log` - (Optional) One or more `log` blocks as defined below.
 
--> **NOTE:** `log` has been superseded by `enabled_log` and will be removed in version 4.0 of the AzureRM Provider.
+-> **NOTE:** `log` is deprecated in favour of the `enabled_log` property and will be removed in version 4.0 of the AzureRM Provider.
 
 * `enabled_log` - (Optional) One or more `enabled_log` blocks as defined below.
 


### PR DESCRIPTION
Resolves https://github.com/hashicorp/terraform-provider-azurerm/issues/20019

- set `log_analytics_destination_type` default value to `AzureDiagnostics `  because of service API behaviour change
- fix `hasEnabledLog` logic and correctly set log in API payload when no `log` block or `enabled_log` block has change during resource update. Solve the `at least one type of Log or Metric must be enabled` error.
