### PR TITLE
cache resource providers to reduce expensive api call

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -416,14 +416,13 @@ func providerConfigure(p *schema.Provider) schema.ConfigureContextFunc {
 		if !skipProviderRegistration {
 			// List all the available providers and their registration state to avoid unnecessary
 			// requests. This also lets us check if the provider credentials are correct.
-			providerList, err := client.Resource.ProvidersClient.List(ctx, nil, "")
+			availableResourceProviders, err := resourceproviders.CacheSupportedProviders(ctx, client.Resource.ProvidersClient)
 			if err != nil {
 				return nil, diag.Errorf("Unable to list provider registration status, it is possible that this is due to invalid "+
 					"credentials or the service principal does not have permission to use the Resource Manager API, Azure "+
 					"error: %s", err)
 			}
 
-			availableResourceProviders := providerList.Values()
 			requiredResourceProviders := resourceproviders.Required()
 
 			if err := resourceproviders.EnsureRegistered(ctx, *client.Resource.ProvidersClient, availableResourceProviders, requiredResourceProviders); err != nil {

--- a/internal/resourceproviders/azure.go
+++ b/internal/resourceproviders/azure.go
@@ -7,22 +7,10 @@ import (
 	"github.com/Azure/azure-sdk-for-go/profiles/2017-03-09/resources/mgmt/resources"
 )
 
-func availableResourceProviders(ctx context.Context, client *resources.ProvidersClient) (*[]string, error) {
-	providerNames := make([]string, 0)
-	providers, err := client.ListComplete(ctx, nil, "")
+func availableResourceProviders(ctx context.Context, client *resources.ProvidersClient) ([]resources.Provider, error) {
+	providers, err := client.List(ctx, nil, "")
 	if err != nil {
 		return nil, fmt.Errorf("listing Resource Providers: %+v", err)
 	}
-	for providers.NotDone() {
-		provider := providers.Value()
-		if provider.Namespace != nil {
-			providerNames = append(providerNames, *provider.Namespace)
-		}
-
-		if err := providers.NextWithContext(ctx); err != nil {
-			return nil, err
-		}
-	}
-
-	return &providerNames, nil
+	return providers.Values(), nil
 }

--- a/internal/resourceproviders/cache.go
+++ b/internal/resourceproviders/cache.go
@@ -8,16 +8,19 @@ import (
 )
 
 // cachedResourceProviders can be (validly) nil - as such this shouldn't be relied on
-var cachedResourceProviders *[]string
+var cachedResourceProviders *[]resources.Provider
 
 // CacheSupportedProviders attempts to retrieve the supported Resource Providers from the Resource Manager API
 // and caches them, for used in enhanced validation
-func CacheSupportedProviders(ctx context.Context, client *resources.ProvidersClient) {
+func CacheSupportedProviders(ctx context.Context, client *resources.ProvidersClient) ([]resources.Provider, error) {
+	if cachedResourceProviders != nil {
+		return *cachedResourceProviders, nil
+	}
 	providers, err := availableResourceProviders(ctx, client)
 	if err != nil {
 		log.Printf("[DEBUG] error retrieving providers: %s. Enhanced validation will be unavailable", err)
-		return
+		return nil, err
 	}
-
-	cachedResourceProviders = providers
+	cachedResourceProviders = &providers
+	return providers, nil
 }

--- a/internal/resourceproviders/validation.go
+++ b/internal/resourceproviders/validation.go
@@ -41,13 +41,19 @@ func enhancedValidation(i interface{}, k string) ([]string, []error) {
 
 	found := false
 	for _, provider := range *cachedResourceProviders {
-		if provider == v {
+		if provider.Namespace != nil && *provider.Namespace == v {
 			found = true
 		}
 	}
 
 	if !found {
-		providersJoined := strings.Join(*cachedResourceProviders, ", ")
+		providerNames := make([]string, 0)
+		for _, provider := range *cachedResourceProviders {
+			if provider.Namespace != nil {
+				providerNames = append(providerNames, *provider.Namespace)
+			}
+		}
+		providersJoined := strings.Join(providerNames, ", ")
 		return nil, []error{
 			fmt.Errorf("%q was not found in the list of supported Resource Providers: %q", v, providersJoined),
 		}

--- a/internal/resourceproviders/validation_test.go
+++ b/internal/resourceproviders/validation_test.go
@@ -3,7 +3,9 @@ package resourceproviders
 import (
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/profiles/2017-03-09/resources/mgmt/resources"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func TestEnhancedValidationDisabled(t *testing.T) {
@@ -68,7 +70,7 @@ func TestEnhancedValidationEnabled(t *testing.T) {
 		},
 	}
 	enhancedEnabled = true
-	cachedResourceProviders = &[]string{"Microsoft.Compute"}
+	cachedResourceProviders = &[]resources.Provider{{Namespace: utils.String("Microsoft.Compute")}}
 	defer func() {
 		enhancedEnabled = features.EnhancedValidationEnabled()
 		cachedResourceProviders = nil


### PR DESCRIPTION
When running azurerm provider initialize, there're two `GET https://management.azure.com/subscriptions/{subscription_id}/providers?api-version=2016-02-01` calls, which are very time consuming, each can take about 7 seconds.

The two API calls are used to ensure resource providers are registered and enhance resource provider's name validation.

This PR cached the results of the first request, so even with enabling the above 2 features, there'll only be one API request.

After:
Run terraform plan command with service principal authentication
```
Executed in    9.19 secs 
```
There's only one `/providers` API call
<img width="802" alt="image" src="https://user-images.githubusercontent.com/79895375/212824663-930a32fb-824f-473a-95f0-3207f196d9d8.png">


Before:
Run terraform plan command with service principal authentication
```
Executed in    16.01 secs 
```
There're two `/providers` API call
<img width="802" alt="image" src="https://user-images.githubusercontent.com/79895375/212825173-9766da1d-52c4-40fb-95ab-1d1f9b8b9029.png">
