### PR TITLE
`azurerm_postgresql_flexible_server` - fix a potential panic

### DIFF
--- a/internal/services/postgres/postgresql_flexible_server_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_resource.go
@@ -81,6 +81,10 @@ func resourcePostgresqlFlexibleServer() *pluginsdk.Resource {
 				MaxItems: 1,
 				Optional: true,
 				Computed: true,
+				AtLeastOneOf: []string{
+					"authentication.0.active_directory_auth_enabled",
+					"authentication.0.password_auth_enabled",
+				},
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
 						"active_directory_auth_enabled": {


### PR DESCRIPTION
It will panic when `authentication` is specified with empty block. add a runtime check for it