### PR TITLE
Update linux app readme example

### DIFF
--- a/website/docs/r/linux_function_app.html.markdown
+++ b/website/docs/r/linux_function_app.html.markdown
@@ -44,7 +44,7 @@ resource "azurerm_linux_function_app" "example" {
   location            = azurerm_resource_group.example.location
 
   storage_account_name       = azurerm_storage_account.example.name
-  storage_account_access_key = azurerm_storage_account.example.primary_connection_string
+  storage_account_access_key = azurerm_storage_account.example.primary_access_key
   service_plan_id            = azurerm_service_plan.example.id
 
   site_config {}


### PR DESCRIPTION
The readme had an example where they put in the connection string instead of the access key, this ends up in the wrong variable and breaks deployment towards the function.

Updating the example with proper syntax