### PR TITLE
provider: adding a unit test to ensure that sensitive fields are marked as sensitive

### DIFF
--- a/internal/provider/provider_schema_test.go
+++ b/internal/provider/provider_schema_test.go
@@ -1,0 +1,96 @@
+package provider
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+func TestDataSourcesHaveSensitiveFieldsMarkedAsSensitive(t *testing.T) {
+	provider := TestAzureProvider()
+
+	// intentionally sorting these so the output is consistent
+	dataSourceNames := make([]string, 0)
+	for dataSourceName := range provider.DataSourcesMap {
+		dataSourceNames = append(dataSourceNames, dataSourceName)
+	}
+	sort.Strings(dataSourceNames)
+
+	for _, dataSourceName := range dataSourceNames {
+		dataSource := provider.DataSourcesMap[dataSourceName]
+		if err := schemaContainsSensitiveFieldsNotMarkedAsSensitive(t, dataSource.Schema); err != nil {
+			t.Fatalf("the Data Source %q contains a sensitive field which isn't marked as sensitive: %+v", dataSourceName, err)
+		}
+	}
+}
+
+func TestResourcesHaveSensitiveFieldsMarkedAsSensitive(t *testing.T) {
+	provider := TestAzureProvider()
+
+	// intentionally sorting these so the output is consistent
+	resourceNames := make([]string, 0)
+	for resourceName := range provider.ResourcesMap {
+		resourceNames = append(resourceNames, resourceName)
+	}
+	sort.Strings(resourceNames)
+
+	for _, resourceName := range resourceNames {
+		resource := provider.ResourcesMap[resourceName]
+		if err := schemaContainsSensitiveFieldsNotMarkedAsSensitive(t, resource.Schema); err != nil {
+			t.Fatalf("the Resource %q contains a sensitive field which isn't marked as sensitive: %+v", resourceName, err)
+		}
+	}
+}
+
+func schemaContainsSensitiveFieldsNotMarkedAsSensitive(t *testing.T, input map[string]*pluginsdk.Schema) error {
+	exactMatchFieldNames := []string{
+		"api_key",
+		"api_secret_key",
+		"password",
+		"private_key",
+		"ssh_private_key",
+	}
+
+	// intentionally sorting these so the output is consistent
+	fieldNames := make([]string, 0)
+	for fieldName := range input {
+		fieldNames = append(fieldNames, fieldName)
+	}
+	sort.Strings(fieldNames)
+
+	for _, fieldName := range fieldNames {
+		key := strings.ToLower(fieldName)
+		field := input[fieldName]
+
+		for _, val := range exactMatchFieldNames {
+			if strings.EqualFold(key, val) && !field.Sensitive {
+				return fmt.Errorf("field %q is a sensitive value and should be marked as Sensitive", fieldName)
+			}
+		}
+
+		if strings.HasSuffix(key, "_api_key") && field.Type == pluginsdk.TypeString && !field.Sensitive {
+			return fmt.Errorf("field %q is a sensitive value and should be marked as Sensitive", fieldName)
+		}
+
+		if field.Type == pluginsdk.TypeList && field.Elem != nil {
+			if val, ok := field.Elem.(*pluginsdk.Resource); ok && val.Schema != nil {
+				if err := schemaContainsSensitiveFieldsNotMarkedAsSensitive(t, val.Schema); err != nil {
+					return fmt.Errorf("the field %q is a List: %+v", fieldName, err)
+				}
+			}
+		}
+
+		if field.Type == pluginsdk.TypeSet && field.Elem != nil {
+			if val, ok := field.Elem.(*pluginsdk.Resource); ok && val.Schema != nil {
+				if err := schemaContainsSensitiveFieldsNotMarkedAsSensitive(t, val.Schema); err != nil {
+					return fmt.Errorf("the field %q is a Set: %+v", fieldName, err)
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/internal/provider/provider_schema_test.go
+++ b/internal/provider/provider_schema_test.go
@@ -21,7 +21,7 @@ func TestDataSourcesHaveSensitiveFieldsMarkedAsSensitive(t *testing.T) {
 
 	for _, dataSourceName := range dataSourceNames {
 		dataSource := provider.DataSourcesMap[dataSourceName]
-		if err := schemaContainsSensitiveFieldsNotMarkedAsSensitive(t, dataSource.Schema); err != nil {
+		if err := schemaContainsSensitiveFieldsNotMarkedAsSensitive(dataSource.Schema); err != nil {
 			t.Fatalf("the Data Source %q contains a sensitive field which isn't marked as sensitive: %+v", dataSourceName, err)
 		}
 	}
@@ -39,13 +39,13 @@ func TestResourcesHaveSensitiveFieldsMarkedAsSensitive(t *testing.T) {
 
 	for _, resourceName := range resourceNames {
 		resource := provider.ResourcesMap[resourceName]
-		if err := schemaContainsSensitiveFieldsNotMarkedAsSensitive(t, resource.Schema); err != nil {
+		if err := schemaContainsSensitiveFieldsNotMarkedAsSensitive(resource.Schema); err != nil {
 			t.Fatalf("the Resource %q contains a sensitive field which isn't marked as sensitive: %+v", resourceName, err)
 		}
 	}
 }
 
-func schemaContainsSensitiveFieldsNotMarkedAsSensitive(t *testing.T, input map[string]*pluginsdk.Schema) error {
+func schemaContainsSensitiveFieldsNotMarkedAsSensitive(input map[string]*pluginsdk.Schema) error {
 	exactMatchFieldNames := []string{
 		"api_key",
 		"api_secret_key",
@@ -77,7 +77,7 @@ func schemaContainsSensitiveFieldsNotMarkedAsSensitive(t *testing.T, input map[s
 
 		if field.Type == pluginsdk.TypeList && field.Elem != nil {
 			if val, ok := field.Elem.(*pluginsdk.Resource); ok && val.Schema != nil {
-				if err := schemaContainsSensitiveFieldsNotMarkedAsSensitive(t, val.Schema); err != nil {
+				if err := schemaContainsSensitiveFieldsNotMarkedAsSensitive(val.Schema); err != nil {
 					return fmt.Errorf("the field %q is a List: %+v", fieldName, err)
 				}
 			}
@@ -85,7 +85,7 @@ func schemaContainsSensitiveFieldsNotMarkedAsSensitive(t *testing.T, input map[s
 
 		if field.Type == pluginsdk.TypeSet && field.Elem != nil {
 			if val, ok := field.Elem.(*pluginsdk.Resource); ok && val.Schema != nil {
-				if err := schemaContainsSensitiveFieldsNotMarkedAsSensitive(t, val.Schema); err != nil {
+				if err := schemaContainsSensitiveFieldsNotMarkedAsSensitive(val.Schema); err != nil {
 					return fmt.Errorf("the field %q is a Set: %+v", fieldName, err)
 				}
 			}

--- a/internal/services/apimanagement/api_management_identity_provider_twitter_resource.go
+++ b/internal/services/apimanagement/api_management_identity_provider_twitter_resource.go
@@ -41,6 +41,7 @@ func resourceApiManagementIdentityProviderTwitter() *pluginsdk.Resource {
 			"api_key": {
 				Type:         pluginsdk.TypeString,
 				Required:     true,
+				Sensitive:    true,
 				ValidateFunc: validation.StringIsNotEmpty,
 			},
 

--- a/internal/services/batch/batch_pool_data_source.go
+++ b/internal/services/batch/batch_pool_data_source.go
@@ -293,8 +293,9 @@ func dataSourceBatchPool() *pluginsdk.Resource {
 							Computed: true,
 						},
 						"password": {
-							Type:     pluginsdk.TypeString,
-							Computed: true,
+							Type:      pluginsdk.TypeString,
+							Computed:  true,
+							Sensitive: true,
 						},
 						"elevation_level": {
 							Type:     pluginsdk.TypeString,
@@ -314,8 +315,9 @@ func dataSourceBatchPool() *pluginsdk.Resource {
 										Computed: true,
 									},
 									"ssh_private_key": {
-										Type:     pluginsdk.TypeString,
-										Computed: true,
+										Type:      pluginsdk.TypeString,
+										Computed:  true,
+										Sensitive: true,
 									},
 								},
 							},
@@ -433,8 +435,9 @@ func dataSourceBatchPool() *pluginsdk.Resource {
 										Computed: true,
 									},
 									"password": {
-										Type:     pluginsdk.TypeString,
-										Computed: true,
+										Type:      pluginsdk.TypeString,
+										Computed:  true,
+										Sensitive: true,
 									},
 								},
 							},

--- a/internal/services/containers/container_registry_task_resource.go
+++ b/internal/services/containers/container_registry_task_resource.go
@@ -548,6 +548,7 @@ func (r ContainerRegistryTaskResource) Arguments() map[string]*pluginsdk.Schema 
 								"password": {
 									Type:         pluginsdk.TypeString,
 									Optional:     true,
+									Sensitive:    true,
 									ValidateFunc: validation.StringIsNotEmpty,
 								},
 								"identity": {

--- a/internal/services/devtestlabs/dev_test_windows_virtual_machine_resource.go
+++ b/internal/services/devtestlabs/dev_test_windows_virtual_machine_resource.go
@@ -81,7 +81,8 @@ func resourceArmDevTestWindowsVirtualMachine() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeString,
 				Required: true,
 				// since this isn't returned from the API
-				ForceNew: true,
+				ForceNew:  true,
+				Sensitive: true,
 			},
 
 			"storage_type": {

--- a/internal/services/servicefabricmanaged/service_fabric_managed_cluster_resource.go
+++ b/internal/services/servicefabricmanaged/service_fabric_managed_cluster_resource.go
@@ -154,17 +154,15 @@ func (k ClusterResource) Arguments() map[string]*pluginsdk.Schema {
 				validation.StringMatch(regexp.MustCompile("^[^\\\\/\"\\[\\]:|<>+=;,?*$]{1,14}$"), "User names cannot contain special characters \\/\"\"[]:|<>+=;,$?*@")),
 		},
 		"password": {
-			Type:     pluginsdk.TypeString,
-			Optional: true,
+			Type:      pluginsdk.TypeString,
+			Optional:  true,
+			Sensitive: true,
 			ValidateFunc: validation.All(
 				validation.StringLenBetween(8, 123),
-				validation.StringIsNotWhiteSpace),
+				validation.StringIsNotWhiteSpace,
+			),
 		},
-		"resource_group_name": {
-			Type:         pluginsdk.TypeString,
-			Required:     true,
-			ValidateFunc: validation.StringIsNotWhiteSpace,
-		},
+		"resource_group_name": commonschema.ResourceGroupName(),
 
 		"node_type":      nodeTypeSchema(),
 		"authentication": authSchema(),

--- a/internal/services/springcloud/spring_cloud_configuration_service_resource.go
+++ b/internal/services/springcloud/spring_cloud_configuration_service_resource.go
@@ -105,12 +105,14 @@ func resourceSpringCloudConfigurationService() *pluginsdk.Resource {
 						"password": {
 							Type:         pluginsdk.TypeString,
 							Optional:     true,
+							Sensitive:    true,
 							ValidateFunc: validation.StringIsNotEmpty,
 						},
 
 						"private_key": {
 							Type:         pluginsdk.TypeString,
 							Optional:     true,
+							Sensitive:    true,
 							ValidateFunc: validation.StringIsNotEmpty,
 						},
 

--- a/internal/services/web/static_site_resource.go
+++ b/internal/services/web/static_site_resource.go
@@ -79,8 +79,9 @@ func resourceStaticSite() *pluginsdk.Resource {
 			"identity": commonschema.SystemAssignedUserAssignedIdentityOptional(),
 
 			"api_key": {
-				Type:     pluginsdk.TypeString,
-				Computed: true,
+				Type:      pluginsdk.TypeString,
+				Computed:  true,
+				Sensitive: true,
 			},
 
 			"tags": tags.Schema(),

--- a/website/docs/r/service_fabric_managed_cluster.html.markdown
+++ b/website/docs/r/service_fabric_managed_cluster.html.markdown
@@ -59,7 +59,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name which should be used for this Resource Group. Changing this forces a new Resource Group to be created.
 
-* `resource_group_name` - (Required) The name of the Resource Group where the Resource Group should exist.
+* `resource_group_name` - (Required) The name of the Resource Group where the Resource Group should exist. Changing this forces a new Resource Group to be created.
 
 ---
 


### PR DESCRIPTION
This PR introduces a unit test to validate that fields which should be marked as sensitive are actually marked as `Sensitive: true` in the Schema.

This PR also fixes these instances:

* Data Source: `azurerm_batch_pool` - the field `password` is now correctly marked as a sensitive value
* Data Source: `azurerm_batch_pool` - the field `ssh_private_key ` is now correctly marked as a sensitive value
* `azurerm_api_management_identity_provider_twitter` - the field `api_key` is now correctly marked as a sensitive value
* `azurerm_container_registry_task` - the field `password` is now correctly marked as a sensitive value
* `azurerm_dev_test_windows_virtual_machine` - the `password` field is now correctly marked as a sensitive value
* `azurerm_service_fabric_managed_cluster` - the `password` field is now correctly marked as a sensitive value
* `azurerm_service_fabric_managed_cluster` - the `resource_group_name` field is now correctly marked as ForceNew.
* `azurerm_spring_cloud_configuration_service ` - the field `password` is now correctly marked as a sensitive value
* `azurerm_spring_cloud_configuration_service ` - the field `private_key` is now correctly marked as a sensitive value
* `azurerm_static_site` - the field `api_key` is now correctly marked as a sensitive value