### PR TITLE
`azurerm_monitor_action_group` - fix failed tests phone number verification error

### DIFF
--- a/internal/services/monitor/monitor_action_group_resource_test.go
+++ b/internal/services/monitor/monitor_action_group_resource_test.go
@@ -556,7 +556,7 @@ resource "azurerm_monitor_action_group" "test" {
   sms_receiver {
     name         = "oncallmsg"
     country_code = "1"
-    phone_number = "1231231234"
+    phone_number = "2123456789"
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
@@ -702,7 +702,7 @@ resource "azurerm_monitor_action_group" "test" {
   voice_receiver {
     name         = "oncallmsg"
     country_code = "1"
-    phone_number = "1231231234"
+    phone_number = "2123456789"
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
@@ -972,12 +972,12 @@ resource "azurerm_monitor_action_group" "test" {
   sms_receiver {
     name         = "oncallmsg"
     country_code = "1"
-    phone_number = "1231231234"
+    phone_number = "2123456789"
   }
 
   sms_receiver {
     name         = "remotesupport"
-    country_code = "61"
+    country_code = "86"
     phone_number = "13888888888"
   }
 
@@ -1005,7 +1005,7 @@ resource "azurerm_monitor_action_group" "test" {
   voice_receiver {
     name         = "oncallvoice"
     country_code = "1"
-    phone_number = "1231231234"
+    phone_number = "2123456789"
   }
 
   logic_app_receiver {


### PR DESCRIPTION
change the test phone number to a valid one to fix below error caused by service API behavior change:
```
------- Stdout: -------
=== RUN   TestAccMonitorActionGroup_smsReceiver
=== PAUSE TestAccMonitorActionGroup_smsReceiver
=== CONT  TestAccMonitorActionGroup_smsReceiver
testcase.go:110: Step 1/2 error: Error running apply: exit status 1
Error: creating or updating Action Group: (Name "acctestActionGroup-230118001717630919" / Resource Group "acctestRG-230118001717630919"): insights.ActionGroupsClient#CreateOrUpdate: Failure responding to request: StatusCode=400 -- Original Error: autorest/azure: Service returned an error. Status=400 Code="PhoneNumberIsNotValid" Message="One or more phone number(s) provided is invalid. Please check the phone number(s) and try again."
with azurerm_monitor_action_group.test,
on terraform_plugin_test.tf line 22, in resource "azurerm_monitor_action_group" "test":
22: resource "azurerm_monitor_action_group" "test" {
--- FAIL: TestAccMonitorActionGroup_smsReceiver (89.27s)
FAIL
```

<img width="495" alt="image" src="https://user-images.githubusercontent.com/104055472/213108146-f5e0e414-7ac7-46e9-9014-e1599bbed444.png">
