### PR TITLE
tooling: running `mkdocs` only when the contents of `./contributor` changes

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'contributing/**'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Currently this is running for every commit, which isn't needed - instead this can be run only when changes to these files are merged into `main`