### PR TITLE
Add required field patterns_to_match to the example for azurerm_cdn_frontdoor_security_policy in the documentation

### DIFF
--- a/website/docs/r/cdn_frontdoor_security_policy.html.markdown
+++ b/website/docs/r/cdn_frontdoor_security_policy.html.markdown
@@ -63,6 +63,7 @@ resource "azurerm_cdn_frontdoor_security_policy" "example" {
         domain {
           cdn_frontdoor_domain_id = azurerm_cdn_frontdoor_custom_domain.domain1.id
         }
+        patterns_to_match = ["/*"]
       }
     }
   }


### PR DESCRIPTION
Adds patterns_to_match = ["/*"] to the example to avoid confusion as it is a required field for the association block.