### PR TITLE
data `key_vault_secret`: add support for explicit Vault URI 

### DIFF
--- a/internal/services/keyvault/key_vault_secret_data_source_test.go
+++ b/internal/services/keyvault/key_vault_secret_data_source_test.go
@@ -63,6 +63,7 @@ func (KeyVaultSecretDataSource) complete(data acceptance.TestData) string {
 data "azurerm_key_vault_secret" "test" {
   name         = azurerm_key_vault_secret.test.name
   key_vault_id = azurerm_key_vault.test.id
+  key_vault_uri = azurerm_key_vault.vault_uri
 }
 `, KeyVaultSecretResource{}.complete(data))
 }

--- a/internal/services/keyvault/key_vault_secret_data_source_test.go
+++ b/internal/services/keyvault/key_vault_secret_data_source_test.go
@@ -63,7 +63,7 @@ func (KeyVaultSecretDataSource) complete(data acceptance.TestData) string {
 data "azurerm_key_vault_secret" "test" {
   name         = azurerm_key_vault_secret.test.name
   key_vault_id = azurerm_key_vault.test.id
-  key_vault_uri = azurerm_key_vault.vault_uri
+  key_vault_uri = azurerm_key_vault.test.vault_uri
 }
 `, KeyVaultSecretResource{}.complete(data))
 }

--- a/internal/services/keyvault/validate/vault_uri.go
+++ b/internal/services/keyvault/validate/vault_uri.go
@@ -1,0 +1,35 @@
+package validate
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+func VaultURI(v interface{}, k string) (warnings []string, errors []error) {
+	value := v.(string)
+
+	url, err := url.ParseRequestURI(value)
+	if err != nil || url == nil {
+		errors = append(errors, fmt.Errorf("%q may only contain a valid vault Uri", k))
+		return
+	}
+
+	// https://learn.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#dns-suffixes-for-base-url
+	dnsSuffixes := []string{
+		".vault.azure.net",
+		".vault.azure.cn",
+		".vault.usgovcloudapi.net",
+		".vault.microsoftazure.de",
+	}
+
+	for _, dnsSuffix := range dnsSuffixes {
+		if strings.HasSuffix(url.Host, dnsSuffix) {
+			return
+		}
+	}
+
+	errors = append(errors, fmt.Errorf("%q may only contain a valid vault Uri", k))
+
+	return
+}

--- a/internal/services/keyvault/validate/vault_uri_test.go
+++ b/internal/services/keyvault/validate/vault_uri_test.go
@@ -1,0 +1,46 @@
+package validate
+
+import (
+	"testing"
+)
+
+func TestValidateVaultURI(t *testing.T) {
+	cases := []struct {
+		Input       string
+		ExpectError bool
+	}{
+		{
+			Input:       "https://testkv.vault.azure.net/",
+			ExpectError: false,
+		},
+		{
+			Input:       "https://testkv.vault.azure.cn/",
+			ExpectError: false,
+		},
+		{
+			Input:       "https://testkv.vault.usgovcloudapi.net/",
+			ExpectError: false,
+		},
+		{
+			Input:       "https://testkv.vault.microsoftazure.de/",
+			ExpectError: false,
+		},
+		{
+			Input:       "https://abc",
+			ExpectError: true,
+		},
+		{
+			Input:       "https://^",
+			ExpectError: true,
+		},
+	}
+
+	for _, tc := range cases {
+		_, errors := VaultURI(tc.Input, "")
+
+		hasError := len(errors) > 0
+		if tc.ExpectError && !hasError {
+			t.Fatalf("Expected the Key Vault Uri to trigger a validation error for '%s'", tc.Input)
+		}
+	}
+}

--- a/website/docs/d/key_vault_secret.html.markdown
+++ b/website/docs/d/key_vault_secret.html.markdown
@@ -33,6 +33,8 @@ The following arguments are supported:
 
 * `key_vault_id` - (Required)  Specifies the ID of the Key Vault instance to fetch secret names from, available on the `azurerm_key_vault` Data Source / Resource.
 
+* `key_vault_uri` - Specifies the URI of the Key Vault instance to fetch secret names from, available on the `azurerm_key_vault` Data Source / Resource. Useful in case a client whose credentials are used in terraform does not have Read access over non-RBAC-enabled Key Vault Instance (so azurerm cannot dynamically fetch Vault URI), but does have - to its secrets.
+
 * `name` - (Required) Specifies the name of the Key Vault Secret.
 
 **NOTE:** The vault must be in the same subscription as the provider. If the vault is in another subscription, you must create an aliased provider for that subscription.


### PR DESCRIPTION
## Scenario

- There are two key vaults in different subscriptions, both are non-RBAC:
  - (1) key vault is used to store cross-subscription secrets (e.g. ACR credentials);
  - (2) is used to keep secrets that will be available to an AKS cluster;
- I need to copy some secrets from (1) to (2);
- Service Principal has broad access to the subscription where (2) is kept and very limited access to the subscription with (1) (basically, the SP can only read secrets from this particular key vault), and the request fails with the following reason:
  
  _Error: looking up Secret "secret-key" vault url from id "Vault: (Name \"my-key-vault\" / Resource Group \"my-resource-group\")": retrieving Vault: (Name "my-key-vault" / Resource Group "my-resource-group"): keyvault.VaultsClient#Get: Failure responding to request: StatusCode=403 -- Original Error: autorest/azure: Service returned an error. Status=403 Code="AuthorizationFailed" Message="The client '00000000-0000-0000-0000-000000000000' with object id '00000000-0000-0000-0000-000000000000' does not have authorization to perform action 'Microsoft.KeyVault/vaults/read' over scope '/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/my-resource-group/providers/Microsoft.KeyVault/vaults/my-key-vault' or the scope is invalid. If access was recently granted, please refresh your credentials."_

## Reasons for the error

Whenever the client inside azurerm needs to make a request to a key vault, it first tries to retrieve its “URI” through azure-sdk-for-go by calling `Get` method of the client. That’s where the request fails as the SP doesn't have `Read` access over (1) resource.

That call is needed, because `data` `azurerm_key_vault_secret` resource accepts only `key_vault_id`, and the ID doesn’t tell which of the clouds is being used while each of those clouds has its own key vault dns suffix ([Azure Key Vault Keys, Secrets, and Certificates Overview](https://learn.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#dns-suffixes-for-base-url)).

## Potential solution

IMO, it's worth having an option to explicitly pass `key_vault_uri` inside `data` `azurerm_key_vault_secret`. That will make the whole scenario possible as no `Get` requests will be needed.

## Special notes

Not sure if should explicitly check DNS prefixes in the validator (`VaultURI`).

## Acceptance tests

```
$ make acctests SERVICE='keyvault' TESTARGS='-run=TestAccDataSourceKeyVaultSecret_'  TESTTIMEOUT='60m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/keyvault -run=TestAccDataSourceKeyVaultSecret_ -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccDataSourceKeyVaultSecret_basic
=== PAUSE TestAccDataSourceKeyVaultSecret_basic
=== RUN   TestAccDataSourceKeyVaultSecret_complete
=== PAUSE TestAccDataSourceKeyVaultSecret_complete
=== CONT  TestAccDataSourceKeyVaultSecret_basic
=== CONT  TestAccDataSourceKeyVaultSecret_complete
--- PASS: TestAccDataSourceKeyVaultSecret_complete (364.73s)
--- PASS: TestAccDataSourceKeyVaultSecret_basic (367.79s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault      369.017s
```
