### PR TITLE
Test Case - update test cases of Netapp Volume to be tested on limited locations

### DIFF
--- a/.teamcity/components/settings.kt
+++ b/.teamcity/components/settings.kt
@@ -105,7 +105,7 @@ var serviceTestConfigurationOverrides = mapOf(
         "mysql" to testConfiguration(locationOverride = LocationConfiguration("westeurope", "francecentral", "eastus2", false), useDevTestSubscription = true),
 
         // netapp has a max of 10 accounts per subscription so lets limit it to 3 to account for broken ones, run Monday, Wednesday, Friday
-        "netapp" to testConfiguration(parallelism = 3, daysOfWeek = "2,4,6", useDevTestSubscription = true),
+        "netapp" to testConfiguration(parallelism = 3, daysOfWeek = "2,4,6", locationOverride = LocationConfiguration("westeurope", "eastus2", "westus2", false), useDevTestSubscription = true),
 
         // Orbital is only available in certain locations
         "orbital" to testConfiguration(locationOverride = LocationConfiguration("eastus", "southcentralus", "westus2", false)),


### PR DESCRIPTION
Hi Team,

Below only one failed test case is caused by that the newly added feature isn't registered for the subs in Teamcity and seems it always failed after [PR merge](https://github.com/hashicorp/terraform-provider-azurerm/pull/19669) / in previous Teamcity Daily Run. So I assume it's not related with this PR so that we can ignore it.

Note: Suggest your team to register this new feature for test subs in Teamcity via this [instruction](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/netapp_volume#zone). Thanks.

![image](https://user-images.githubusercontent.com/19754191/213364457-5f7a593c-c21e-487e-8b8f-f767026a4fb1.png)
