### PR TITLE
`azurerm_media_content_key_policy` - support for more features

### DIFF
--- a/internal/services/media/media_content_key_policy_resource.go
+++ b/internal/services/media/media_content_key_policy_resource.go
@@ -207,7 +207,7 @@ func resourceMediaContentKeyPolicy() *pluginsdk.Resource {
 													MaxItems: 1,
 													Elem: &pluginsdk.Resource{
 														Schema: map[string]*pluginsdk.Schema{
-															"best_effort": {
+															"best_effort_enforced": {
 																Type:     pluginsdk.TypeBool,
 																Optional: true,
 																Default:  false,
@@ -1379,7 +1379,7 @@ func expandExplicitAnalogTelevisionOutputRestriction(input []interface{}) *conte
 
 	restriction := input[0].(map[string]interface{})
 	result := &contentkeypolicies.ContentKeyPolicyPlayReadyExplicitAnalogTelevisionRestriction{
-		BestEffort:        restriction["best_effort"].(bool),
+		BestEffort:        restriction["best_effort_enforced"].(bool),
 		ConfigurationData: int64(restriction["control_bits"].(int)),
 	}
 
@@ -1393,8 +1393,8 @@ func flattenExplicitAnalogTelevisionOutputRestriction(input *contentkeypolicies.
 
 	return []interface{}{
 		map[string]interface{}{
-			"best_effort":  input.BestEffort,
-			"control_bits": input.ConfigurationData,
+			"best_effort_enforced": input.BestEffort,
+			"control_bits":         input.ConfigurationData,
 		},
 	}
 }

--- a/internal/services/media/media_content_key_policy_resource.go
+++ b/internal/services/media/media_content_key_policy_resource.go
@@ -187,12 +187,38 @@ func resourceMediaContentKeyPolicy() *pluginsdk.Resource {
 												"compressed_digital_audio_opl": {
 													Type:         pluginsdk.TypeInt,
 													Optional:     true,
-													ValidateFunc: validation.IntInSlice([]int{100, 150, 200}),
+													ValidateFunc: validation.IntInSlice([]int{100, 150, 200, 250, 300}),
+												},
+
+												"compressed_digital_video_opl": {
+													Type:         pluginsdk.TypeInt,
+													Optional:     true,
+													ValidateFunc: validation.IntInSlice([]int{400, 500}),
 												},
 
 												"digital_video_only_content_restriction": {
 													Type:     pluginsdk.TypeBool,
 													Optional: true,
+												},
+
+												"explicit_analog_television_output_restriction": {
+													Type:     pluginsdk.TypeList,
+													Optional: true,
+													MaxItems: 1,
+													Elem: &pluginsdk.Resource{
+														Schema: map[string]*pluginsdk.Schema{
+															"best_effort": {
+																Type:     pluginsdk.TypeBool,
+																Optional: true,
+																Default:  false,
+															},
+															"control_bits": {
+																Type:         pluginsdk.TypeInt,
+																Required:     true,
+																ValidateFunc: validation.IntBetween(0, 3),
+															},
+														},
+													},
 												},
 
 												"first_play_expiration": {
@@ -220,7 +246,7 @@ func resourceMediaContentKeyPolicy() *pluginsdk.Resource {
 												"uncompressed_digital_audio_opl": {
 													Type:         pluginsdk.TypeInt,
 													Optional:     true,
-													ValidateFunc: validation.IntInSlice([]int{100, 150, 250, 300}),
+													ValidateFunc: validation.IntInSlice([]int{100, 150, 200, 250, 300}),
 												},
 
 												"uncompressed_digital_video_opl": {
@@ -231,6 +257,7 @@ func resourceMediaContentKeyPolicy() *pluginsdk.Resource {
 											},
 										},
 									},
+
 									"relative_begin_date": {
 										Type:         pluginsdk.TypeString,
 										Optional:     true,
@@ -242,9 +269,26 @@ func resourceMediaContentKeyPolicy() *pluginsdk.Resource {
 										Optional:     true,
 										ValidateFunc: validation.IsRFC3339Time,
 									},
+
+									"security_level": {
+										Type:     pluginsdk.TypeString,
+										Optional: true,
+										ValidateFunc: validation.StringInSlice([]string{
+											string(contentkeypolicies.SecurityLevelSLOneFiveZero),
+											string(contentkeypolicies.SecurityLevelSLTwoThousand),
+											string(contentkeypolicies.SecurityLevelSLThreeThousand),
+										}, false),
+									},
 								},
 							},
 						},
+
+						"playready_response_custom_data": {
+							Type:         pluginsdk.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+
 						// lintignore:XS003
 						"fairplay_configuration": {
 							Type:     pluginsdk.TypeList,
@@ -315,6 +359,39 @@ func resourceMediaContentKeyPolicy() *pluginsdk.Resource {
 							MaxItems: 1,
 							Elem: &pluginsdk.Resource{
 								Schema: map[string]*pluginsdk.Schema{
+									// lintignore:XS003
+									"alternate_key": {
+										Type:     pluginsdk.TypeList,
+										Optional: true,
+										Elem: &pluginsdk.Resource{
+											Schema: map[string]*pluginsdk.Schema{
+												"symmetric_token_key": {
+													Type:         pluginsdk.TypeString,
+													Optional:     true,
+													ValidateFunc: validation.StringIsBase64,
+													Sensitive:    true,
+												},
+												"rsa_token_key_exponent": {
+													Type:         pluginsdk.TypeString,
+													Optional:     true,
+													ValidateFunc: validation.StringIsNotEmpty,
+													Sensitive:    true,
+												},
+												"rsa_token_key_modulus": {
+													Type:         pluginsdk.TypeString,
+													Optional:     true,
+													ValidateFunc: validation.StringIsNotEmpty,
+													Sensitive:    true,
+												},
+												"x509_token_key_raw": {
+													Type:         pluginsdk.TypeString,
+													Optional:     true,
+													ValidateFunc: validation.StringIsNotEmpty,
+													Sensitive:    true,
+												},
+											},
+										},
+									},
 									"audience": {
 										Type:         pluginsdk.TypeString,
 										Optional:     true,
@@ -384,6 +461,7 @@ func resourceMediaContentKeyPolicy() *pluginsdk.Resource {
 								},
 							},
 						},
+
 						"open_restriction_enabled": {
 							Type:     pluginsdk.TypeBool,
 							Optional: true,
@@ -536,6 +614,7 @@ func flattenPolicyOptions(input []contentkeypolicies.ContentKeyPolicyOption) ([]
 
 		clearKeyConfigurationEnabled := false
 		playReadyLicense := make([]interface{}, 0)
+		playReadyResponseCustomData := ""
 		widevineTemplate := ""
 		fairplayConfiguration := make([]interface{}, 0)
 
@@ -553,6 +632,9 @@ func flattenPolicyOptions(input []contentkeypolicies.ContentKeyPolicyOption) ([]
 
 		if v, ok := option.Configuration.(contentkeypolicies.ContentKeyPolicyPlayReadyConfiguration); ok {
 			playReadyLicense = flattenPlayReadyLicenses(v.Licenses)
+			if v.ResponseCustomData != nil {
+				playReadyResponseCustomData = *v.ResponseCustomData
+			}
 		}
 
 		if v, ok := option.Configuration.(contentkeypolicies.ContentKeyPolicyWidevineConfiguration); ok {
@@ -574,6 +656,7 @@ func flattenPolicyOptions(input []contentkeypolicies.ContentKeyPolicyOption) ([]
 			"playready_configuration_license": playReadyLicense,
 			"widevine_configuration_template": widevineTemplate,
 			"fairplay_configuration":          fairplayConfiguration,
+			"playready_response_custom_data":  playReadyResponseCustomData,
 			"open_restriction_enabled":        openRestrictionEnabled,
 			"token_restriction":               tokenRestriction,
 		})
@@ -629,6 +712,11 @@ func expandRestriction(option map[string]interface{}) (contentkeypolicies.Conten
 		}
 		contentKeyPolicyTokenRestriction.PrimaryVerificationKey = primaryVerificationKey
 
+		alternateVerificationKeys, err := expandAlternateVerificationKeys(tokenRestriction["alternate_key"].([]interface{}))
+		if err != nil {
+			return nil, err
+		}
+		contentKeyPolicyTokenRestriction.AlternateVerificationKeys = alternateVerificationKeys
 		return contentKeyPolicyTokenRestriction, nil
 	}
 
@@ -670,6 +758,7 @@ func flattenTokenRestriction(input contentkeypolicies.ContentKeyPolicyTokenRestr
 
 	return []interface{}{
 		map[string]interface{}{
+			"alternate_key":                      flattenAlternateVerificationKeys(input.AlternateVerificationKeys),
 			"audience":                           input.Audience,
 			"issuer":                             input.Issuer,
 			"token_type":                         string(input.RestrictionTokenType),
@@ -688,6 +777,7 @@ func expandConfiguration(input map[string]interface{}) (contentkeypolicies.Conte
 	fairPlayConfigurations := input["fairplay_configuration"].([]interface{})
 	playReadyConfigurationLicences := input["playready_configuration_license"].([]interface{})
 	widevineConfigurationTemplate := input["widevine_configuration_template"].(string)
+	playReadyResponseCustomData := input["playready_response_custom_data"].(string)
 
 	configurationCount := 0
 	if clearKeyConfigurationEnabled {
@@ -727,6 +817,9 @@ func expandConfiguration(input map[string]interface{}) (contentkeypolicies.Conte
 		}
 		playReadyConfiguration := &contentkeypolicies.ContentKeyPolicyPlayReadyConfiguration{
 			Licenses: *licenses,
+		}
+		if playReadyResponseCustomData != "" {
+			playReadyConfiguration.ResponseCustomData = utils.String(playReadyResponseCustomData)
 		}
 		return playReadyConfiguration, nil
 	}
@@ -781,6 +874,90 @@ func expandVerificationKey(input map[string]interface{}) (contentkeypolicies.Con
 	}
 
 	return nil, nil
+}
+
+func expandAlternateVerificationKeys(input []interface{}) (*[]contentkeypolicies.ContentKeyPolicyRestrictionTokenKey, error) {
+	if len(input) == 0 || input[0] == nil {
+		return nil, nil
+	}
+
+	result := make([]contentkeypolicies.ContentKeyPolicyRestrictionTokenKey, 0)
+	for _, v := range input {
+		tokenKeyRaw := v.(map[string]interface{})
+		symmetricTokenKey := tokenKeyRaw["symmetric_token_key"].(string)
+		rsaTokenKeyExponent := tokenKeyRaw["rsa_token_key_exponent"].(string)
+		rsaTokenKeyModulus := tokenKeyRaw["rsa_token_key_modulus"].(string)
+		x509TokenKeyRaw := tokenKeyRaw["x509_token_key_raw"].(string)
+
+		verificationKeyCount := 0
+		if rsaTokenKeyExponent != "" || rsaTokenKeyModulus != "" {
+			verificationKeyCount++
+		}
+		if symmetricTokenKey != "" {
+			verificationKeyCount++
+		}
+		if x509TokenKeyRaw != "" {
+			verificationKeyCount++
+		}
+		if verificationKeyCount != 1 {
+			return nil, fmt.Errorf("exactlly one type of token key must be set in the alternate verificaton keys")
+		}
+
+		if rsaTokenKeyExponent != "" || rsaTokenKeyModulus != "" {
+			result = append(result, &contentkeypolicies.ContentKeyPolicyRsaTokenKey{
+				Exponent: rsaTokenKeyExponent,
+				Modulus:  rsaTokenKeyModulus,
+			})
+		}
+		if symmetricTokenKey != "" {
+			result = append(result, &contentkeypolicies.ContentKeyPolicySymmetricTokenKey{
+				KeyValue: symmetricTokenKey,
+			})
+		}
+		if x509TokenKeyRaw != "" {
+			result = append(result, &contentkeypolicies.ContentKeyPolicyX509CertificateTokenKey{
+				RawBody: symmetricTokenKey,
+			})
+		}
+	}
+
+	return &result, nil
+}
+
+func flattenAlternateVerificationKeys(input *[]contentkeypolicies.ContentKeyPolicyRestrictionTokenKey) []interface{} {
+	if input == nil {
+		return make([]interface{}, 0)
+	}
+
+	result := make([]interface{}, 0)
+	for _, v := range *input {
+		symmetricToken := ""
+		rsaTokenKeyExponent := ""
+		rsaTokenKeyModulus := ""
+		x509TokenBodyRaw := ""
+		symmetricTokenKey, ok := v.(contentkeypolicies.ContentKeyPolicySymmetricTokenKey)
+		if ok {
+			symmetricToken = symmetricTokenKey.KeyValue
+		}
+
+		rsaTokenKey, ok := v.(contentkeypolicies.ContentKeyPolicyRsaTokenKey)
+		if ok {
+			rsaTokenKeyExponent = rsaTokenKey.Exponent
+			rsaTokenKeyModulus = rsaTokenKey.Modulus
+		}
+
+		x509CertificateTokenKey, ok := v.(contentkeypolicies.ContentKeyPolicyX509CertificateTokenKey)
+		if ok {
+			x509TokenBodyRaw = x509CertificateTokenKey.RawBody
+		}
+		result = append(result, map[string]interface{}{
+			"symmetric_token_key":    symmetricToken,
+			"x509_token_key_raw":     x509TokenBodyRaw,
+			"rsa_token_key_exponent": rsaTokenKeyExponent,
+			"rsa_token_key_modulus":  rsaTokenKeyModulus,
+		})
+	}
+	return result
 }
 
 func expandRequiredClaims(input []interface{}) *[]contentkeypolicies.ContentKeyPolicyTokenClaim {
@@ -996,6 +1173,11 @@ func expandPlayReadyLicenses(input []interface{}) (*[]contentkeypolicies.Content
 			playReadyLicense.RelativeExpirationDate = utils.String(v.(string))
 		}
 
+		if v := license["security_level"]; v != nil && v != "" {
+			securityLevel := contentkeypolicies.SecurityLevel(v.(string))
+			playReadyLicense.SecurityLevel = &securityLevel
+		}
+
 		results = append(results, playReadyLicense)
 	}
 
@@ -1046,6 +1228,11 @@ func flattenPlayReadyLicenses(input []contentkeypolicies.ContentKeyPolicyPlayRea
 			relativeExpirationDate = *v.RelativeExpirationDate
 		}
 
+		securityLevel := ""
+		if v.SecurityLevel != nil {
+			securityLevel = string(*v.SecurityLevel)
+		}
+
 		results = append(results, map[string]interface{}{
 			"allow_test_devices": v.AllowTestDevices,
 			"begin_date":         beginDate,
@@ -1058,6 +1245,7 @@ func flattenPlayReadyLicenses(input []contentkeypolicies.ContentKeyPolicyPlayRea
 			"relative_begin_date":                      relativeBeginDate,
 			"relative_expiration_date":                 relativeExpirationDate,
 			"play_right":                               playRight,
+			"security_level":                           securityLevel,
 		})
 	}
 
@@ -1069,8 +1257,10 @@ func expandPlayRight(input []interface{}) *contentkeypolicies.ContentKeyPolicyPl
 		return nil
 	}
 
-	playRight := &contentkeypolicies.ContentKeyPolicyPlayReadyPlayRight{}
 	playRightConfiguration := input[0].(map[string]interface{})
+	playRight := &contentkeypolicies.ContentKeyPolicyPlayReadyPlayRight{
+		ExplicitAnalogTelevisionOutputRestriction: expandExplicitAnalogTelevisionOutputRestriction(playRightConfiguration["explicit_analog_television_output_restriction"].([]interface{})),
+	}
 
 	if v := playRightConfiguration["agc_and_color_stripe_restriction"]; v != nil {
 		playRight.AgcAndColorStripeRestriction = utils.Int64(int64(v.(int)))
@@ -1086,6 +1276,10 @@ func expandPlayRight(input []interface{}) *contentkeypolicies.ContentKeyPolicyPl
 
 	if v := playRightConfiguration["compressed_digital_audio_opl"]; v != nil && v != 0 {
 		playRight.CompressedDigitalAudioOpl = utils.Int64(int64(v.(int)))
+	}
+
+	if v := playRightConfiguration["compressed_digital_video_opl"]; v != nil && v != 0 {
+		playRight.CompressedDigitalVideoOpl = utils.Int64(int64(v.(int)))
 	}
 
 	if v := playRightConfiguration["digital_video_only_content_restriction"]; v != nil {
@@ -1130,8 +1324,13 @@ func flattenPlayRight(input *contentkeypolicies.ContentKeyPolicyPlayReadyPlayRig
 	}
 
 	compressedDigitalAudioOpl := 0
-	if input.AnalogVideoOpl != nil {
+	if input.CompressedDigitalAudioOpl != nil {
 		compressedDigitalAudioOpl = int(*input.CompressedDigitalAudioOpl)
+	}
+
+	compressedDigitalVideoOpl := 0
+	if input.CompressedDigitalVideoOpl != nil {
+		compressedDigitalVideoOpl = int(*input.CompressedDigitalVideoOpl)
 	}
 
 	firstPlayExpiration := ""
@@ -1160,13 +1359,42 @@ func flattenPlayRight(input *contentkeypolicies.ContentKeyPolicyPlayReadyPlayRig
 			"allow_passing_video_content_to_unknown_output":            string(input.AllowPassingVideoContentToUnknownOutput),
 			"analog_video_opl":                                         analogVideoOpl,
 			"compressed_digital_audio_opl":                             compressedDigitalAudioOpl,
+			"compressed_digital_video_opl":                             compressedDigitalVideoOpl,
 			"digital_video_only_content_restriction":                   input.DigitalVideoOnlyContentRestriction,
+			"explicit_analog_television_output_restriction":            flattenExplicitAnalogTelevisionOutputRestriction(input.ExplicitAnalogTelevisionOutputRestriction),
 			"first_play_expiration":                                    firstPlayExpiration,
 			"image_constraint_for_analog_component_video_restriction":  input.ImageConstraintForAnalogComponentVideoRestriction,
 			"image_constraint_for_analog_computer_monitor_restriction": input.ImageConstraintForAnalogComputerMonitorRestriction,
 			"scms_restriction":                                         scmsRestriction,
 			"uncompressed_digital_audio_opl":                           uncompressedDigitalAudioOpl,
 			"uncompressed_digital_video_opl":                           uncompressedDigitalVideoOpl,
+		},
+	}
+}
+
+func expandExplicitAnalogTelevisionOutputRestriction(input []interface{}) *contentkeypolicies.ContentKeyPolicyPlayReadyExplicitAnalogTelevisionRestriction {
+	if len(input) == 0 || input[0] == nil {
+		return nil
+	}
+
+	restriction := input[0].(map[string]interface{})
+	result := &contentkeypolicies.ContentKeyPolicyPlayReadyExplicitAnalogTelevisionRestriction{
+		BestEffort:        restriction["best_effort"].(bool),
+		ConfigurationData: int64(restriction["control_bits"].(int)),
+	}
+
+	return result
+}
+
+func flattenExplicitAnalogTelevisionOutputRestriction(input *contentkeypolicies.ContentKeyPolicyPlayReadyExplicitAnalogTelevisionRestriction) []interface{} {
+	if input == nil {
+		return make([]interface{}, 0)
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"best_effort":  input.BestEffort,
+			"control_bits": input.ConfigurationData,
 		},
 	}
 }

--- a/internal/services/media/media_content_key_policy_resource_test.go
+++ b/internal/services/media/media_content_key_policy_resource_test.go
@@ -193,8 +193,8 @@ resource "azurerm_media_content_key_policy" "test" {
         compressed_digital_audio_opl                             = 250
         compressed_digital_video_opl                             = 400
         explicit_analog_television_output_restriction {
-          best_effort  = true
-          control_bits = 3
+          best_effort_enforced = true
+          control_bits         = 3
         }
       }
       license_type                             = "Persistent"

--- a/internal/services/media/media_content_key_policy_resource_test.go
+++ b/internal/services/media/media_content_key_policy_resource_test.go
@@ -31,6 +31,35 @@ func TestAccMediaContentKeyPolicy_basic(t *testing.T) {
 	})
 }
 
+func TestAccMediaContentKeyPolicy_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_media_content_key_policy", "test")
+	r := MediaContentKeyPolicyResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeAggregateTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeAggregateTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeAggregateTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccMediaContentKeyPolicy_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_media_content_key_policy", "test")
 	r := MediaContentKeyPolicyResource{}
@@ -146,10 +175,12 @@ resource "azurerm_media_content_key_policy" "test" {
     open_restriction_enabled = true
   }
   policy_option {
-    name = "playReady"
+    name                           = "playReady"
+    playready_response_custom_data = "test custom data"
     playready_configuration_license {
       allow_test_devices = true
       begin_date         = "2017-10-16T18:22:53Z"
+      security_level     = "SL150"
       play_right {
         scms_restriction                                         = 2
         digital_video_only_content_restriction                   = false
@@ -157,9 +188,14 @@ resource "azurerm_media_content_key_policy" "test" {
         image_constraint_for_analog_computer_monitor_restriction = false
         allow_passing_video_content_to_unknown_output            = "NotAllowed"
         uncompressed_digital_video_opl                           = 100
-        uncompressed_digital_audio_opl                           = 100
+        uncompressed_digital_audio_opl                           = 200
         analog_video_opl                                         = 150
-        compressed_digital_audio_opl                             = 150
+        compressed_digital_audio_opl                             = 250
+        compressed_digital_video_opl                             = 400
+        explicit_analog_television_output_restriction {
+          best_effort  = true
+          control_bits = 3
+        }
       }
       license_type                             = "Persistent"
       content_type                             = "UltraVioletDownload"
@@ -175,6 +211,13 @@ resource "azurerm_media_content_key_policy" "test" {
       audience                    = "urn:audience"
       token_type                  = "Swt"
       primary_symmetric_token_key = "AAAAAAAAAAAAAAAAAAAAAA=="
+      alternate_key {
+        rsa_token_key_exponent = "AQAB"
+        rsa_token_key_modulus  = "AQAD"
+      }
+      alternate_key {
+        symmetric_token_key = "BBAAAAAAAAAAAAAAAAAAAA=="
+      }
     }
   }
   policy_option {

--- a/website/docs/r/media_content_key_policy.html.markdown
+++ b/website/docs/r/media_content_key_policy.html.markdown
@@ -89,13 +89,13 @@ resource "azurerm_media_content_key_policy" "example" {
       audience                    = "urn:audience"
       token_type                  = "Swt"
       primary_symmetric_token_key = "AAAAAAAAAAAAAAAAAAAAAA=="
-    }
-    alternate_key {
-      rsa_token_key_exponent = "AQAB"
-      rsa_token_key_modulus  = "AQAD"
-    }
-    alternate_key {
-      symmetric_token_key = "BBAAAAAAAAAAAAAAAAAAAA=="
+      alternate_key {
+        rsa_token_key_exponent = "AQAB"
+        rsa_token_key_modulus  = "AQAD"
+      }
+      alternate_key {
+        symmetric_token_key = "BBAAAAAAAAAAAAAAAAAAAA=="
+      }
     }
   }
   policy_option {

--- a/website/docs/r/media_content_key_policy.html.markdown
+++ b/website/docs/r/media_content_key_policy.html.markdown
@@ -148,7 +148,7 @@ A `alternate_key` block supports the following:
 
 * `x509_token_key_raw` - (Optional) The raw data field of a certificate in PKCS 12 format (X509Certificate2 in .NET). Specifies a certificate for token validation.
 
--> **NOTE:** Each `alternate_key` block can only have one type of primary verification key: if you want use RSA you must provide `rsa_token_key_exponent` and `rsa_token_key_modulus`, if you want to use symmetric you need to provide `symmetric_token_key` and for x509 you must provide `x509_token_key_raw`. 
+-> **NOTE:** Each `alternate_key` block can only have one type of primary verification key: if you want to use RSA you must provide `rsa_token_key_exponent` and `rsa_token_key_modulus`, if you want to use symmetric you need to provide `symmetric_token_key` and for x509 you must provide `x509_token_key_raw`. 
 
 ---
 
@@ -194,7 +194,7 @@ A `play_right` block supports the following:
 
 * `compressed_digital_audio_opl` - (Optional) Specifies the output protection level for compressed digital audio.Supported values are `100`, `150`, `200`, `250` or `300`.
 
-* `compressed_digital_video_opl` - (Optional) Specifies the output protection level for compressed digital video.Supported values are `400` and `500`.
+* `compressed_digital_video_opl` - (Optional) Specifies the output protection level for compressed digital video. Supported values are `400` or `500`.
 
 * `digital_video_only_content_restriction` - (Optional) Enables the Image Constraint For Analog Component Video Restriction in the license.
 
@@ -240,7 +240,7 @@ A `playready_configuration_license` block supports the following:
 
 * `relative_expiration_date` - (Optional) The relative expiration date of license.
 
-* `security_level` - (Optional) The security level of the license. Possible values are `SL150`, `SL2000` and `SL3000`. Please see [this document](https://learn.microsoft.com/en-us/rest/api/media/content-key-policies/create-or-update?tabs=HTTP#securitylevel) for more information about security level. See [this document](https://learn.microsoft.com/en-us/azure/media-services/latest/drm-playready-license-template-concept#playready-sl3000-support) for more information about `SL3000` support.
+* `security_level` - (Optional) The security level of the PlayReady license. Possible values are `SL150`, `SL2000` and `SL3000`. Please see [this document](https://learn.microsoft.com/en-us/rest/api/media/content-key-policies/create-or-update?tabs=HTTP#securitylevel) for more information about security level. See [this document](https://learn.microsoft.com/en-us/azure/media-services/latest/drm-playready-license-template-concept#playready-sl3000-support) for more information about `SL3000` support.
 
 ---
 
@@ -262,7 +262,7 @@ A `policy_option` block supports the following:
 
 * `widevine_configuration_template` - (Optional) The Widevine template.
 
--> **NOTE:** Each policy_option can only have one type of configuration: `fairplay_configuration`,`clear_key_configuration_enabled`, `playready_configuration_license` or `widevine_configuration_template`. And is possible to assign only one type of restriction: `open_restriction_enabled` or `token_restriction`.
+-> **NOTE:** Each policy_option can only have one type of configuration: `fairplay_configuration`, `clear_key_configuration_enabled`, `playready_configuration_license` or `widevine_configuration_template`. And is possible to assign only one type of restriction: `open_restriction_enabled` or `token_restriction`.
 
 ---
 
@@ -276,7 +276,7 @@ A `required_claim` block supports the following:
 
 A `token_restriction` block supports the following:
 
-* `alternate_key` (Optional) one or more `alternate_key` block as defined above.
+* `alternate_key` (Optional) One or more `alternate_key` block as defined above.
 
 * `audience` - (Optional) The audience for the token.
 
@@ -296,7 +296,7 @@ A `token_restriction` block supports the following:
 
 * `token_type` - (Optional) The type of token. Supported values are `Jwt` or `Swt`.
 
--> **NOTE:** Each token_restriction can only have one type of primary verification key: if you want use RSA you must provide `primary_rsa_token_key_exponent` and `primary_rsa_token_key_modulus`, if you want to use symmetric you need to provide `primary_symmetric_token_key` and for x509 you must provide `primary_x509_token_key_raw`. For more information about Token access please refer to <https://docs.microsoft.com/azure/media-services/latest/content-protection-overview#controlling-content-access>
+-> **NOTE:** Each token_restriction can only have one type of primary verification key: if you want to use RSA you must provide `primary_rsa_token_key_exponent` and `primary_rsa_token_key_modulus`, if you want to use symmetric you need to provide `primary_symmetric_token_key` and for x509 you must provide `primary_x509_token_key_raw`. For more information about Token access please refer to <https://docs.microsoft.com/azure/media-services/latest/content-protection-overview#controlling-content-access>
 
 ---
 

--- a/website/docs/r/media_content_key_policy.html.markdown
+++ b/website/docs/r/media_content_key_policy.html.markdown
@@ -58,6 +58,7 @@ resource "azurerm_media_content_key_policy" "example" {
     playready_configuration_license {
       allow_test_devices = true
       begin_date         = "2017-10-16T18:22:53Z"
+      security_level     = "SL150"
       play_right {
         scms_restriction                                         = 2
         digital_video_only_content_restriction                   = false
@@ -67,7 +68,12 @@ resource "azurerm_media_content_key_policy" "example" {
         uncompressed_digital_video_opl                           = 100
         uncompressed_digital_audio_opl                           = 100
         analog_video_opl                                         = 150
-        compressed_digital_audio_opl                             = 150
+        compressed_digital_audio_opl                             = 250
+        compressed_digital_video_opl                             = 400
+        explicit_analog_television_output_restriction {
+          best_effort  = true
+          control_bits = 3
+        }
       }
       license_type                             = "Persistent"
       content_type                             = "UltraVioletDownload"
@@ -83,6 +89,13 @@ resource "azurerm_media_content_key_policy" "example" {
       audience                    = "urn:audience"
       token_type                  = "Swt"
       primary_symmetric_token_key = "AAAAAAAAAAAAAAAAAAAAAA=="
+    }
+    alternate_key {
+      rsa_token_key_exponent = "AQAB"
+      rsa_token_key_modulus  = "AQAD"
+    }
+    alternate_key {
+      symmetric_token_key = "BBAAAAAAAAAAAAAAAAAAAA=="
     }
   }
   policy_option {
@@ -125,6 +138,28 @@ The following arguments are supported:
 
 ---
 
+A `alternate_key` block supports the following:
+
+* `rsa_token_key_exponent` - (Optional) The RSA parameter exponent.
+
+* `rsa_token_key_modulus` - (Optional) The RSA parameter modulus.
+
+* `symmetric_token_key` - (Optional) The key value of the key. Specifies a symmetric key for token validation.
+
+* `x509_token_key_raw` - (Optional) The raw data field of a certificate in PKCS 12 format (X509Certificate2 in .NET). Specifies a certificate for token validation.
+
+-> **NOTE:** Each `alternate_key` block can only have one type of primary verification key: if you want use RSA you must provide `rsa_token_key_exponent` and `rsa_token_key_modulus`, if you want to use symmetric you need to provide `symmetric_token_key` and for x509 you must provide `x509_token_key_raw`. 
+
+---
+
+An `explicit_analog_television_output_restriction` block supports the following:
+
+* `best_effort` - (Optional) Indicates whether this restriction is enforced on a best effort basis. Possible values are `true` or `false`. Defaults to `false`. 
+
+* `control_bits` - (Required) The restriction control bits. Possible value is integer between `0` and `3` inclusive.
+
+---
+
 A `fairplay_configuration` block supports the following:
 
 * `ask` - (Optional) The key that must be used as FairPlay Application Secret key.
@@ -151,15 +186,19 @@ A `offline_rental_configuration` block supports the following:
 
 A `play_right` block supports the following:
 
-* `agc_and_color_stripe_restriction` - (Optional) Configures Automatic Gain Control (AGC) and Color Stripe in the license. Must be between 0 and 3 inclusive.
+* `agc_and_color_stripe_restriction` - (Optional) Configures Automatic Gain Control (AGC) and Color Stripe in the license. Must be between `0` and `3` inclusive.
 
 * `allow_passing_video_content_to_unknown_output` - (Optional) Configures Unknown output handling settings of the license. Supported values are `Allowed`, `AllowedWithVideoConstriction` or `NotAllowed`.
 
-* `analog_video_opl` - (Optional) Specifies the output protection level for compressed digital audio. Supported values are 100, 150 or 200.
+* `analog_video_opl` - (Optional) Specifies the output protection level for compressed digital audio. Supported values are `100`, `150` or `200`.
 
-* `compressed_digital_audio_opl` - (Optional) Specifies the output protection level for compressed digital audio.Supported values are 100, 150 or 200.
+* `compressed_digital_audio_opl` - (Optional) Specifies the output protection level for compressed digital audio.Supported values are `100`, `150`, `200`, `250` or `300`.
+
+* `compressed_digital_video_opl` - (Optional) Specifies the output protection level for compressed digital video.Supported values are `400` and `500`.
 
 * `digital_video_only_content_restriction` - (Optional) Enables the Image Constraint For Analog Component Video Restriction in the license.
+
+* `explicit_analog_television_output_restriction` - (Optional) An `explicit_analog_television_output_restriction` block as defined above.
 
 * `first_play_expiration` - (Optional) The amount of time that the license is valid after the license is first used to play content.
 
@@ -167,11 +206,11 @@ A `play_right` block supports the following:
 
 * `image_constraint_for_analog_computer_monitor_restriction` - (Optional) Enables the Image Constraint For Analog Component Video Restriction in the license.
 
-* `scms_restriction` - (Optional) Configures the Serial Copy Management System (SCMS) in the license. Must be between 0 and 3 inclusive.
+* `scms_restriction` - (Optional) Configures the Serial Copy Management System (SCMS) in the license. Must be between `0` and `3` inclusive.
 
-* `uncompressed_digital_audio_opl` - (Optional) Specifies the output protection level for uncompressed digital audio. Supported values are 100, 150, 250 or 300.
+* `uncompressed_digital_audio_opl` - (Optional) Specifies the output protection level for uncompressed digital audio. Supported values are `100`, `150`, `200`, `250` or `300`.
 
-* `uncompressed_digital_video_opl` - (Optional) Specifies the output protection level for uncompressed digital video. Supported values are 100, 150, 250 or 300.
+* `uncompressed_digital_video_opl` - (Optional) Specifies the output protection level for uncompressed digital video. Supported values are `100`, `250`, `270` or `300`.
 
 ---
 
@@ -182,9 +221,10 @@ A `playready_configuration_license` block supports the following:
 * `begin_date` - (Optional) The begin date of license.
 
 * `content_key_location_from_header_enabled` - (Optional) Specifies that the content key ID is in the PlayReady header.
+ 
 * `content_key_location_from_key_id` - (Optional) The content key ID. Specifies that the content key ID is specified in the PlayReady configuration.
 
--> **NOTE:** You can only specify one content key location. For example if you specify content_key_location_from_header_enabled in true, you shouldn't specify content_key_location_from_key_id and vice versa.
+-> **NOTE:** You can only specify one content key location. For example if you specify `content_key_location_from_header_enabled` in true, you shouldn't specify `content_key_location_from_key_id` and vice versa.
 
 * `content_type` - (Optional) The PlayReady content type. Supported values are `UltraVioletDownload`, `UltraVioletStreaming` or `Unspecified`.
 
@@ -200,6 +240,8 @@ A `playready_configuration_license` block supports the following:
 
 * `relative_expiration_date` - (Optional) The relative expiration date of license.
 
+* `security_level` - (Optional) The security level of the license. Possible values are `SL150`, `SL2000` and `SL3000`. Please see [this document](https://learn.microsoft.com/en-us/rest/api/media/content-key-policies/create-or-update?tabs=HTTP#securitylevel) for more information about security level. See [this document](https://learn.microsoft.com/en-us/azure/media-services/latest/drm-playready-license-template-concept#playready-sl3000-support) for more information about `SL3000` support.
+
 ---
 
 A `policy_option` block supports the following:
@@ -214,11 +256,13 @@ A `policy_option` block supports the following:
 
 * `playready_configuration_license` - (Optional) One or more `playready_configuration_license` blocks as defined above.
 
+* `playready_response_custom_data` - (Optional) The custom response data of the PlayReady configuration. This only applies when `playready_configuration_license` is specified.
+
 * `token_restriction` - (Optional) A `token_restriction` block as defined below.
 
 * `widevine_configuration_template` - (Optional) The Widevine template.
 
--> **NOTE:** Each policy_option can only have one type of configuration: fairplay_configuration,clear_key_configuration_enabled, playready_configuration_license or widevine_configuration_template. And is possible to assign only one type of restriction: open_restriction_enabled or token_restriction.
+-> **NOTE:** Each policy_option can only have one type of configuration: `fairplay_configuration`,`clear_key_configuration_enabled`, `playready_configuration_license` or `widevine_configuration_template`. And is possible to assign only one type of restriction: `open_restriction_enabled` or `token_restriction`.
 
 ---
 
@@ -232,15 +276,17 @@ A `required_claim` block supports the following:
 
 A `token_restriction` block supports the following:
 
+* `alternate_key` (Optional) one or more `alternate_key` block as defined above.
+
 * `audience` - (Optional) The audience for the token.
 
 * `issuer` - (Optional) The token issuer.
 
 * `open_id_connect_discovery_document` - (Optional) The OpenID connect discovery document.
 
-* `primary_rsa_token_key_exponent` - (Optional) The RSA Parameter exponent.
+* `primary_rsa_token_key_exponent` - (Optional) The RSA parameter exponent.
 
-* `primary_rsa_token_key_modulus` - (Optional) The RSA Parameter modulus.
+* `primary_rsa_token_key_modulus` - (Optional) The RSA parameter modulus.
 
 * `primary_symmetric_token_key` - (Optional) The key value of the key. Specifies a symmetric key for token validation.
 
@@ -250,7 +296,7 @@ A `token_restriction` block supports the following:
 
 * `token_type` - (Optional) The type of token. Supported values are `Jwt` or `Swt`.
 
--> **NOTE:** Each token_restriction can only have one type of primary verification key: if you want use RSA you must provide primary_rsa_token_key_exponent and primary_rsa_token_key_modulus, if you want to use symmetric you need to provide primary_symmetric_token_key and for x509 you must provide primary_x509_token_key_raw. For more information about Token access please refer to <https://docs.microsoft.com/azure/media-services/latest/content-protection-overview#controlling-content-access>
+-> **NOTE:** Each token_restriction can only have one type of primary verification key: if you want use RSA you must provide `primary_rsa_token_key_exponent` and `primary_rsa_token_key_modulus`, if you want to use symmetric you need to provide `primary_symmetric_token_key` and for x509 you must provide `primary_x509_token_key_raw`. For more information about Token access please refer to <https://docs.microsoft.com/azure/media-services/latest/content-protection-overview#controlling-content-access>
 
 ---
 
@@ -258,20 +304,20 @@ A `token_restriction` block supports the following:
 
 In addition to the Arguments listed above - the following Attributes are exported:
 
-* `id` - The ID of the Resource Group.
+* `id` - The ID of the Content Key Policy.
 
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the Resource Group.
-* `read` - (Defaults to 5 minutes) Used when retrieving the Resource Group.
-* `update` - (Defaults to 30 minutes) Used when updating the Resource Group.
-* `delete` - (Defaults to 30 minutes) Used when deleting the Resource Group.
+* `create` - (Defaults to 30 minutes) Used when creating the Content Key Policy.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Content Key Policy.
+* `update` - (Defaults to 30 minutes) Used when updating the Content Key Policy.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Content Key Policy.
 
 ## Import
 
-Resource Groups can be imported using the `resource id`, e.g.
+Content Key Policy can be imported using the `resource id`, e.g.
 
 ```shell
 terraform import azurerm_media_content_key_policy.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Media/mediaServices/account1/contentKeyPolicies/policy1


### PR DESCRIPTION
support for :
- `policy_option.playready_response_custom_data`
- `policy_option.playready_configuration_license.security_level`
- `policy_option.playready_configuration_license.play_right.compressed_digital_video_opl`
- `policy_option.playready_configuration_license.play_right.explicit_analog_television_output_restriction`
- `policy_option.token_restriction.alternate_key`

reference:
- [Content Key Policies Doc](https://learn.microsoft.com/en-us/azure/media-services/latest/drm-content-key-policy-concept)
- [Swagger File](https://github.com/Azure/azure-rest-api-specs/blob/13d172c85dac78b65d023dcd95097c383e38c048/specification/mediaservices/resource-manager/Microsoft.Media/Metadata/stable/2022-08-01/ContentKeyPolicies.json)

test:
```
TF_ACC=1 go test -v ./internal/services/media -parallel 20 -test.run=TestAccMediaContentKeyPolicy_ -timeout 1440m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccMediaContentKeyPolicy_basic
=== PAUSE TestAccMediaContentKeyPolicy_basic
=== RUN   TestAccMediaContentKeyPolicy_update
=== PAUSE TestAccMediaContentKeyPolicy_update
=== RUN   TestAccMediaContentKeyPolicy_requiresImport
=== PAUSE TestAccMediaContentKeyPolicy_requiresImport
=== RUN   TestAccMediaContentKeyPolicy_complete
=== PAUSE TestAccMediaContentKeyPolicy_complete
=== CONT  TestAccMediaContentKeyPolicy_basic
=== CONT  TestAccMediaContentKeyPolicy_requiresImport
=== CONT  TestAccMediaContentKeyPolicy_update
=== CONT  TestAccMediaContentKeyPolicy_complete
--- PASS: TestAccMediaContentKeyPolicy_basic (268.67s)
--- PASS: TestAccMediaContentKeyPolicy_complete (271.38s)
--- PASS: TestAccMediaContentKeyPolicy_requiresImport (303.59s)
--- PASS: TestAccMediaContentKeyPolicy_update (607.48s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/media 611.281s

```
