### PR TITLE
Fix `azurerm_application_insights_standard_web_test`

### DIFF
--- a/internal/services/applicationinsights/application_insights_standard_webtests_resource.go
+++ b/internal/services/applicationinsights/application_insights_standard_webtests_resource.go
@@ -151,8 +151,9 @@ func (ApplicationInsightsStandardWebTestResource) Arguments() map[string]*plugin
 					// },
 
 					"ssl_cert_remaining_lifetime": {
-						Type:     pluginsdk.TypeInt,
-						Optional: true,
+						Type:         pluginsdk.TypeInt,
+						Optional:     true,
+						ValidateFunc: validation.IntBetween(1, 365),
 					},
 
 					"ssl_check_enabled": {
@@ -623,14 +624,14 @@ func expandApplicationInsightsStandardWebTestValidations(input []interface{}, is
 	// 	rules.IgnoreHTTPSStatusCode = utils.Bool(v)
 	// }
 
-	// if URL https, sslCheck cannot be enabled
+	// if URL http, sslCheck cannot be enabled
 	sslCheckEnabled := false
 	if v, ok := validationsInput["ssl_check_enabled"].(bool); ok && isHttps {
 		rules.SSLCheck = utils.Bool(v)
 		sslCheckEnabled = true
 	}
 	// if sslCheck not enabled, SSLCertRemainingLifetimeCheck cannot be enabled
-	if v, ok := validationsInput["ssl_cert_remaining_lifetime"].(int); ok && sslCheckEnabled {
+	if v, ok := validationsInput["ssl_cert_remaining_lifetime"].(int); ok && v != 0 && sslCheckEnabled {
 		rules.SSLCertRemainingLifetimeCheck = utils.Int64(int64(v))
 	}
 	if contentValidation, ok := validationsInput["content"].([]interface{}); ok {
@@ -643,7 +644,7 @@ func expandApplicationInsightsStandardWebTestValidations(input []interface{}, is
 func expandApplicationInsightsStandardWebTestContentValidations(input []interface{}) *webtests.WebTestPropertiesValidationRulesContentValidation {
 	content := webtests.WebTestPropertiesValidationRulesContentValidation{}
 	if len(input) == 0 {
-		return &content
+		return nil
 	}
 
 	contentInput := input[0].(map[string]interface{})

--- a/internal/services/applicationinsights/application_insights_standard_webtests_resource_test.go
+++ b/internal/services/applicationinsights/application_insights_standard_webtests_resource_test.go
@@ -96,9 +96,9 @@ resource "azurerm_application_insights_standard_web_test" "test" {
   request {
     url = "https://microsoft.com"
   }
-	validation_rules {
+  validation_rules {
     ssl_check_enabled = true
-	}
+  }
 
   lifecycle {
     ignore_changes = ["tags"]

--- a/internal/services/applicationinsights/application_insights_standard_webtests_resource_test.go
+++ b/internal/services/applicationinsights/application_insights_standard_webtests_resource_test.go
@@ -23,6 +23,15 @@ func TestAccApplicationInsightsStandardWebTest_basic(t *testing.T) {
 	})
 }
 
+func TestAccApplicationInsightsStandardWebTest_sslCheck(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_application_insights_standard_web_test", "test")
+	testResource := ApplicationInsightsStandardWebTestResource{}
+	data.ResourceTest(t, testResource, []acceptance.TestStep{
+		data.ApplyStep(testResource.sslCheckConfig, testResource),
+		data.ImportStep(),
+	})
+}
+
 func TestAccApplicationInsightsStandardWebTest_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_application_insights_standard_web_test", "test")
 	testResource := ApplicationInsightsStandardWebTestResource{}
@@ -57,6 +66,45 @@ func (ApplicationInsightsStandardWebTestResource) Exists(ctx context.Context, cl
 	}
 
 	return utils.Bool(resp.Model != nil && resp.Model.Properties != nil), nil
+}
+
+func (ApplicationInsightsStandardWebTestResource) sslCheckConfig(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-appinsights-%d"
+  location = "%s"
+}
+
+resource "azurerm_application_insights" "test" {
+  name                = "acctestappinsights-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  application_type    = "web"
+}
+
+resource "azurerm_application_insights_standard_web_test" "test" {
+  name                    = "acctestappinsightswebtests-%d"
+  location                = azurerm_resource_group.test.location
+  resource_group_name     = azurerm_resource_group.test.name
+  application_insights_id = azurerm_application_insights.test.id
+  geo_locations           = ["us-tx-sn1-azr"]
+
+  request {
+    url = "https://microsoft.com"
+  }
+	validation_rules {
+    ssl_check_enabled = true
+	}
+
+  lifecycle {
+    ignore_changes = ["tags"]
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }
 
 func (ApplicationInsightsStandardWebTestResource) basicConfig(data acceptance.TestData) string {

--- a/website/docs/r/application_insights_standard_web_test.html.markdown
+++ b/website/docs/r/application_insights_standard_web_test.html.markdown
@@ -115,7 +115,7 @@ A `validation_rules` block supports the following:
 
 * `expected_status_code` - (Optional) The expected status code of the response. Default is '200', '0' means 'response code < 400'
 
-* `ssl_cert_remaining_lifetime` - (Optional) The number of days of SSL certificate validity remaining for the checked endpoint. If the certificate has a shorter remaining lifetime left, the test will fail.
+* `ssl_cert_remaining_lifetime` - (Optional) The number of days of SSL certificate validity remaining for the checked endpoint. If the certificate has a shorter remaining lifetime left, the test will fail. This number should be between 1 and 365.
 
 * `ssl_check_enabled` - (Optional) Should the SSL check be enabled?
 


### PR DESCRIPTION
Fixes #20064

## AccTests
```bash
❯ go install && make acctests SERVICE='applicationinsights' TESTARGS='-run=TestAccApplicationInsightsStandardWebTest_'

==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/applicationinsights -run=TestAccApplicationInsightsStandardWebTest_ -timeout 180m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccApplicationInsightsStandardWebTest_basic
=== PAUSE TestAccApplicationInsightsStandardWebTest_basic
=== RUN   TestAccApplicationInsightsStandardWebTest_requiresImport
=== PAUSE TestAccApplicationInsightsStandardWebTest_requiresImport
=== RUN   TestAccApplicationInsightsStandardWebTest_complete
=== PAUSE TestAccApplicationInsightsStandardWebTest_complete
=== CONT  TestAccApplicationInsightsStandardWebTest_basic
=== CONT  TestAccApplicationInsightsStandardWebTest_complete
=== CONT  TestAccApplicationInsightsStandardWebTest_requiresImport
--- PASS: TestAccApplicationInsightsStandardWebTest_basic (183.80s)
--- PASS: TestAccApplicationInsightsStandardWebTest_requiresImport (203.03s)
--- PASS: TestAccApplicationInsightsStandardWebTest_complete (443.03s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/applicationinsights   444.901s
```