### PR TITLE
`azurerm_maintenance_configuration` - Fix casting nil panic

### DIFF
--- a/internal/services/maintenance/maintenance_configuration_resource.go
+++ b/internal/services/maintenance/maintenance_configuration_resource.go
@@ -422,7 +422,10 @@ func expandMaintenanceConfigurationInstallPatches(input []interface{}) *maintena
 		return nil
 	}
 
-	v := input[0].(map[string]interface{})
+	v, ok := input[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
 	rebootSetting := maintenanceconfigurations.RebootOptions(v["reboot"].(string))
 	installPatches := maintenanceconfigurations.InputPatchConfiguration{
 		WindowsParameters: expandMaintenanceConfigurationInstallPatchesWindows(v["windows"].([]interface{})),
@@ -461,7 +464,10 @@ func expandMaintenanceConfigurationInstallPatchesWindows(input []interface{}) *m
 		return nil
 	}
 
-	v := input[0].(map[string]interface{})
+	v, ok := input[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
 	windowsInput := maintenanceconfigurations.InputWindowsParameters{}
 	if v, ok := v["classifications_to_include"]; ok {
 		windowsInput.ClassificationsToInclude = utils.ExpandStringSlice(v.([]interface{}))
@@ -504,7 +510,10 @@ func expandMaintenanceConfigurationInstallPatchesLinux(input []interface{}) *mai
 		return nil
 	}
 
-	v := input[0].(map[string]interface{})
+	v, ok := input[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
 	linuxParameters := maintenanceconfigurations.InputLinuxParameters{}
 	if v, ok := v["classifications_to_include"]; ok {
 		linuxParameters.ClassificationsToInclude = utils.ExpandStringSlice(v.([]interface{}))

--- a/internal/services/maintenance/maintenance_configuration_resource_test.go
+++ b/internal/services/maintenance/maintenance_configuration_resource_test.go
@@ -47,6 +47,22 @@ func TestAccMaintenanceConfiguration_basicWithInGuestPatch(t *testing.T) {
 	})
 }
 
+func TestAccMaintenanceConfiguration_basicWithOnePatchOnly(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_maintenance_configuration", "test")
+	r := MaintenanceConfigurationResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic_onePatchOnly(data, true),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basic_onePatchOnly(data, false),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccMaintenanceConfiguration_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_maintenance_configuration", "test")
 	r := MaintenanceConfigurationResource{}
@@ -264,4 +280,49 @@ resource "azurerm_maintenance_configuration" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (MaintenanceConfigurationResource) basic_onePatchOnly(data acceptance.TestData, isLinux bool) string {
+	patch := `linux {
+      classifications_to_include = ["Critical", "Security"]
+    }`
+	if !isLinux {
+		patch = `windows {
+      classifications_to_include = ["Critical", "Security"]
+    }`
+	}
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-maint-%d"
+  location = "%s"
+}
+
+resource "azurerm_maintenance_configuration" "test" {
+  name                = "acctest-MC%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  scope               = "InGuestPatch"
+  visibility          = "Custom"
+
+  window {
+    start_date_time      = "5555-12-31 00:00"
+    expiration_date_time = "6666-12-31 00:00"
+    duration             = "02:00"
+    time_zone            = "Pacific Standard Time"
+    recur_every          = "2Days"
+  }
+
+  install_patches {
+    reboot = "IfRequired"
+    %s
+  }
+
+  in_guest_user_patch_mode = "User"
+
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, patch)
 }


### PR DESCRIPTION
This pull request fixed the casting nil panic issue mentioned by #20125 .

Two new acc tests were added.

Acc tests:

=== RUN   TestAccMaintenanceConfiguration_basic
=== PAUSE TestAccMaintenanceConfiguration_basic
=== CONT  TestAccMaintenanceConfiguration_basic
--- PASS: TestAccMaintenanceConfiguration_basic (254.06s)
=== RUN   TestAccMaintenanceConfiguration_basicWithInGuestPatch
=== PAUSE TestAccMaintenanceConfiguration_basicWithInGuestPatch
=== CONT  TestAccMaintenanceConfiguration_basicWithInGuestPatch
--- PASS: TestAccMaintenanceConfiguration_basicWithInGuestPatch (250.89s)
=== RUN   TestAccMaintenanceConfiguration_basicWithOnePatchOnly
=== PAUSE TestAccMaintenanceConfiguration_basicWithOnePatchOnly
=== CONT  TestAccMaintenanceConfiguration_basicWithOnePatchOnly
--- PASS: TestAccMaintenanceConfiguration_basicWithOnePatchOnly (354.19s)
=== RUN   TestAccMaintenanceConfiguration_requiresImport
=== PAUSE TestAccMaintenanceConfiguration_requiresImport
=== CONT  TestAccMaintenanceConfiguration_requiresImport
--- PASS: TestAccMaintenanceConfiguration_requiresImport (288.25s)
=== RUN   TestAccMaintenanceConfiguration_complete
=== PAUSE TestAccMaintenanceConfiguration_complete
=== CONT  TestAccMaintenanceConfiguration_complete
--- PASS: TestAccMaintenanceConfiguration_complete (255.98s)
=== RUN   TestAccMaintenanceConfiguration_update
=== PAUSE TestAccMaintenanceConfiguration_update
=== CONT  TestAccMaintenanceConfiguration_update
--- PASS: TestAccMaintenanceConfiguration_update (494.47s)
PASS