### PR TITLE
`azurerm_recovery_services_vault` - Fix incorrect go format code in the test code

### DIFF
--- a/internal/services/recoveryservices/recovery_services_vault_resource_test.go
+++ b/internal/services/recoveryservices/recovery_services_vault_resource_test.go
@@ -510,7 +510,7 @@ resource "azurerm_recovery_services_vault" "test" {
   location                      = azurerm_resource_group.test.location
   resource_group_name           = azurerm_resource_group.test.name
   sku                           = "Standard"
-  public_network_access_enabled = %v
+  public_network_access_enabled = %t
 
   soft_delete_enabled = false
 }


### PR DESCRIPTION
We'll encounter the following error when we executed `make terrafmt` for this repo:

```text
==> Fixing acceptance test terraform blocks code with terrafmt...
ERRO[2023-01-20 03:02:04] block 2 @ internal/services/recoveryservices/recovery_services_vault_resource_test.go:498 failed to process with: failed to parse hcl: internal/services/recoveryservices/recovery_services_vault_resource_test.go:15,35-36: Invalid expression; Expected the start of an expression, but found
 an invalid expression token.
provider "azurerm" {
}

resource "azurerm_resource_group" "test" {
  name     = "acctestRG-recovery-%d"
  location = "%s"
}

  name                          = "acctest-Vault-%d"
  location                      = azurerm_resource_group.test.location
  sku                           = "Standard"
  public_network_access_enabled = %v
  soft_delete_enabled = false
}
==> Fixing website terraform blocks code with terrafmt...
```

That's because there's a tiny go format string issue inside this test helper method. This pr fixed it and `make terrafmt` passed.

Acc test:

=== RUN   TestAccRecoveryServicesVault_TogglePublicNetworkAccessEnabled
=== PAUSE TestAccRecoveryServicesVault_TogglePublicNetworkAccessEnabled
=== CONT  TestAccRecoveryServicesVault_TogglePublicNetworkAccessEnabled
--- PASS: TestAccRecoveryServicesVault_TogglePublicNetworkAccessEnabled (905.78s)
PASS
