### PR TITLE
azurerm_storage_account_customer_managed_key - support ManagedHSM Key Vaults

### DIFF
--- a/internal/services/keyvault/client/client.go
+++ b/internal/services/keyvault/client/client.go
@@ -36,3 +36,9 @@ func (client Client) KeyVaultClientForSubscription(subscriptionId string) *keyva
 	client.options.ConfigureClient(&vaultsClient.Client, client.options.ResourceManagerAuthorizer)
 	return &vaultsClient
 }
+
+func (client Client) ManagedHsmClientForSubscription(subscriptionId string) *keyvault.ManagedHsmsClient {
+	managedHsmsClient := keyvault.NewManagedHsmsClientWithBaseURI(client.options.ResourceManagerEndpoint, subscriptionId)
+	client.options.ConfigureClient(&managedHsmsClient.Client, client.options.ResourceManagerAuthorizer)
+	return &managedHsmsClient
+}

--- a/internal/services/keyvault/key_vault_certificate_resource.go
+++ b/internal/services/keyvault/key_vault_certificate_resource.go
@@ -563,7 +563,7 @@ func resourceKeyVaultCertificateUpdate(d *schema.ResourceData, meta interface{})
 		return err
 	}
 
-	meta.(*clients.Client).KeyVault.AddToCache(*keyVaultId, id.KeyVaultBaseUrl)
+	meta.(*clients.Client).KeyVault.AddToCacheKeyVault(*keyVaultId, id.KeyVaultBaseUrl)
 
 	if d.HasChange("certificate") {
 		if v, ok := d.GetOk("certificate"); ok {

--- a/internal/services/keyvault/key_vault_data_source.go
+++ b/internal/services/keyvault/key_vault_data_source.go
@@ -201,7 +201,7 @@ func dataSourceKeyVaultRead(d *pluginsdk.ResourceData, meta interface{}) error {
 
 		d.Set("vault_uri", props.VaultURI)
 		if props.VaultURI != nil {
-			meta.(*clients.Client).KeyVault.AddToCache(id, *resp.Properties.VaultURI)
+			meta.(*clients.Client).KeyVault.AddToCacheKeyVault(id, *resp.Properties.VaultURI)
 		}
 
 		if sku := props.Sku; sku != nil {

--- a/internal/services/keyvault/key_vault_key_resource.go
+++ b/internal/services/keyvault/key_vault_key_resource.go
@@ -325,7 +325,7 @@ func resourceKeyVaultKeyUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 		return err
 	}
 
-	meta.(*clients.Client).KeyVault.AddToCache(*keyVaultId, id.KeyVaultBaseUrl)
+	meta.(*clients.Client).KeyVault.AddToCacheKeyVault(*keyVaultId, id.KeyVaultBaseUrl)
 
 	ok, err := keyVaultsClient.Exists(ctx, *keyVaultId)
 	if err != nil {

--- a/internal/services/keyvault/key_vault_resource.go
+++ b/internal/services/keyvault/key_vault_resource.go
@@ -373,7 +373,7 @@ func resourceKeyVaultCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 		return fmt.Errorf("retrieving %s: `properties.VaultUri` was nil", id)
 	}
 	d.SetId(id.ID())
-	meta.(*clients.Client).KeyVault.AddToCache(id, *read.Properties.VaultURI)
+	meta.(*clients.Client).KeyVault.AddToCacheKeyVault(id, *read.Properties.VaultURI)
 
 	if props := read.Properties; props != nil {
 		if vault := props.VaultURI; vault != nil {
@@ -651,7 +651,7 @@ func resourceKeyVaultRead(d *pluginsdk.ResourceData, meta interface{}) error {
 	}
 
 	props := *resp.Properties
-	meta.(*clients.Client).KeyVault.AddToCache(*id, *resp.Properties.VaultURI)
+	meta.(*clients.Client).KeyVault.AddToCacheKeyVault(*id, *resp.Properties.VaultURI)
 
 	d.Set("name", id.Name)
 	d.Set("resource_group_name", id.ResourceGroup)

--- a/internal/services/keyvault/key_vault_secret_resource.go
+++ b/internal/services/keyvault/key_vault_secret_resource.go
@@ -229,7 +229,7 @@ func resourceKeyVaultSecretUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 		return err
 	}
 
-	meta.(*clients.Client).KeyVault.AddToCache(*keyVaultId, id.KeyVaultBaseUrl)
+	meta.(*clients.Client).KeyVault.AddToCacheKeyVault(*keyVaultId, id.KeyVaultBaseUrl)
 
 	ok, err := keyVaultsClient.Exists(ctx, *keyVaultId)
 	if err != nil {


### PR DESCRIPTION
# DRAFT
---

This is part 2 of supporting Managed HSM Key Vaults for Storage Account Customer Managed Keys. The previous PR (#19801) only fixed the validation for the planning phase. I noticed that during execution there's also some parsing happening that only supports the regular Key Vault ID. This PR tries to add support for Managed HSM Key Vault IDs.

The reason I kept this in draft is that I'm not sure what the best approach would be. The existing code is tailored towards regular Key Vaults by the use of the `VaultId` struct. Parsing a HSM Key Vault ID results in a different struct (`ManagedHSMId`), even though both are structurally the same. Ideally I would have the `keyVaultParse.VaultID()` and `keyVaultParse.ManagedHSMID()` functions return the same struct, but since it's all generated I don't know how that could be done (if desirable at all).

So the alternative solution I chose now is that I parse the Managed HSM ID and then manually create a `VaultId` from its values, and then the rest of the code is left untouched. Since the API for either Key Vault type is the same this should work (and I'll try and validate it this time by executing a deployment locally using the new binary with this fix). However before it comes to that I would like to know if this approach is supported by the maintainers.