### PR TITLE
resourceproviders: no longer registering `Microsoft.ServiceFabricMesh` by default

### DIFF
--- a/internal/resourceproviders/required.go
+++ b/internal/resourceproviders/required.go
@@ -68,7 +68,6 @@ func Required() map[string]struct{} {
 		"Microsoft.SecurityInsights":        {},
 		"Microsoft.ServiceBus":              {},
 		"Microsoft.ServiceFabric":           {},
-		"Microsoft.ServiceFabricMesh":       {},
 		"Microsoft.Sql":                     {},
 		"Microsoft.Storage":                 {},
 		"Microsoft.StreamAnalytics":         {},


### PR DESCRIPTION
This service is deprecated and no longer registered by default, so this is currently being re-registered on startup.