### PR TITLE
`azurerm_function_app_function` - support multiple file blocks

### DIFF
--- a/internal/services/appservice/function_app_function_resource.go
+++ b/internal/services/appservice/function_app_function_resource.go
@@ -479,7 +479,8 @@ func expandFunctionFiles(input []FunctionFiles) map[string]*string {
 	}
 	result := make(map[string]*string)
 	for _, v := range input {
-		result[v.Name] = &v.Content
+		content := v.Content
+		result[v.Name] = &content
 	}
 
 	return result


### PR DESCRIPTION
fixes #17266 

If you try to create a `azurerm_function_app_function` with mutiple `file` blocks, this results in the creation of a Function in Azure where the content of the last file will be used for all file names.

Currently, the _expandFunctionFiles_ function returns a map with the same value for all keys. Using a temp `Content` variable in the for loop solves the problem.

