### PR TITLE
`azurerm_monitor_aad_diagnostic_setting` - parse `log_analytics_workspace_id` insensitively in Read

### DIFF
--- a/internal/services/monitor/monitor_aad_diagnostic_setting_resource.go
+++ b/internal/services/monitor/monitor_aad_diagnostic_setting_resource.go
@@ -232,7 +232,7 @@ func resourceMonitorAADDiagnosticSettingRead(d *pluginsdk.ResourceData, meta int
 
 	workspaceId := ""
 	if resp.WorkspaceID != nil && *resp.WorkspaceID != "" {
-		parsedId, err := workspaces.ParseWorkspaceID(*resp.WorkspaceID)
+		parsedId, err := workspaces.ParseWorkspaceIDInsensitively(*resp.WorkspaceID)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Using `Parse...IDInsensitively` so that possible casing change at server side won't cause a failure. In `Read()`, the value is captured and parsed then set to `log_analytics_workspace_id`, which has ValidateFunc: `workspaces.ValidateWorkspaceID` in schema to validate the value in config, so normalizing it shall not cause a diff.