### PR TITLE
`azurerm_nginx_deployment`: use `standard_Monthly` sku for nginx deployment in AccTest

### DIFF
--- a/internal/services/nginx/nginx_certificate_resource_test.go
+++ b/internal/services/nginx/nginx_certificate_resource_test.go
@@ -134,7 +134,7 @@ resource "azurerm_subnet" "test" {
 resource "azurerm_nginx_deployment" "test" {
   name                     = "acctest-%[1]d"
   resource_group_name      = azurerm_resource_group.test.name
-  sku                      = "publicpreview_Monthly_gmz7xq9ge3py"
+  sku                      = "standard_Monthly"
   location                 = azurerm_resource_group.test.location
   diagnose_support_enabled = true
 

--- a/internal/services/nginx/nginx_configuration_resource_test.go
+++ b/internal/services/nginx/nginx_configuration_resource_test.go
@@ -214,7 +214,7 @@ resource "azurerm_subnet" "test" {
 resource "azurerm_nginx_deployment" "test" {
   name                = "acctest-%[1]d"
   resource_group_name = azurerm_resource_group.test.name
-  sku                 = "publicpreview_Monthly_gmz7xq9ge3py"
+  sku                 = "standard_Monthly"
   location            = azurerm_resource_group.test.location
 
   //message: "Conflict managed resource group name: tenant: -91a, subscription xxx, resource group example."

--- a/internal/services/nginx/nginx_deployment_resource_test.go
+++ b/internal/services/nginx/nginx_deployment_resource_test.go
@@ -86,7 +86,7 @@ func (a DeploymentResource) basic(data acceptance.TestData) string {
 resource "azurerm_nginx_deployment" "test" {
   name                     = "acctest-%[2]d"
   resource_group_name      = azurerm_resource_group.test.name
-  sku                      = "publicpreview_Monthly_gmz7xq9ge3py"
+  sku                      = "standard_Monthly"
   location                 = azurerm_resource_group.test.location
   diagnose_support_enabled = true
 
@@ -113,7 +113,7 @@ func (a DeploymentResource) update(data acceptance.TestData) string {
 resource "azurerm_nginx_deployment" "test" {
   name                     = "acctest-%[2]d"
   resource_group_name      = azurerm_resource_group.test.name
-  sku                      = "publicpreview_Monthly_gmz7xq9ge3py"
+  sku                      = "standard_Monthly"
   location                 = azurerm_resource_group.test.location
   diagnose_support_enabled = false
 
@@ -147,7 +147,7 @@ resource "azurerm_user_assigned_identity" "test" {
 resource "azurerm_nginx_deployment" "test" {
   name                = "acctest-%[2]d"
   resource_group_name = azurerm_resource_group.test.name
-  sku                 = "publicpreview_Monthly_gmz7xq9ge3py"
+  sku                 = "standard_Monthly"
   location            = azurerm_resource_group.test.location
 
   identity {


### PR DESCRIPTION
TC runs failure for SKU not supported anymore.

```
errorMessage":"Plan 'publicpreview' is defined as stop sell in offer 'f5-nginx-for-azure'. 
Availability not found with action Purchase for plan 'publicpreview' and offer 'f5-nginx-for-azure'
```


![image](https://user-images.githubusercontent.com/2633022/215368288-71710a74-ccd5-44c0-9920-d36ba7ee9e61.png)
