### PR TITLE
internal/provider: adding unit tests to validate schema design

### DIFF
--- a/internal/provider/provider_schema_test.go
+++ b/internal/provider/provider_schema_test.go
@@ -6,8 +6,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
+
+// TODO: Data Sources and Resources cannot contain a field `name` with the default of `default`
 
 func TestDataSourcesHaveSensitiveFieldsMarkedAsSensitive(t *testing.T) {
 	provider := TestAzureProvider()
@@ -86,6 +90,114 @@ func schemaContainsSensitiveFieldsNotMarkedAsSensitive(input map[string]*plugins
 		if field.Type == pluginsdk.TypeSet && field.Elem != nil {
 			if val, ok := field.Elem.(*pluginsdk.Resource); ok && val.Schema != nil {
 				if err := schemaContainsSensitiveFieldsNotMarkedAsSensitive(val.Schema); err != nil {
+					return fmt.Errorf("the field %q is a Set: %+v", fieldName, err)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func TestDataSourcesHaveEnabledFieldsMarkedAsBooleans(t *testing.T) {
+	provider := TestAzureProvider()
+
+	// intentionally sorting these so the output is consistent
+	dataSourceNames := make([]string, 0)
+	for dataSourceName := range provider.DataSourcesMap {
+		dataSourceNames = append(dataSourceNames, dataSourceName)
+	}
+	sort.Strings(dataSourceNames)
+
+	for _, dataSourceName := range dataSourceNames {
+		dataSource := provider.DataSourcesMap[dataSourceName]
+		if err := schemaContainsEnabledFieldsNotDefinedAsABoolean(dataSource.Schema, map[string]struct{}{}); err != nil {
+			t.Fatalf("the Data Source %q contains an `_enabled` field which isn't defined as a boolean: %+v", dataSourceName, err)
+		}
+	}
+}
+
+func TestResourcesHaveEnabledFieldsMarkedAsBooleans(t *testing.T) {
+	provider := TestAzureProvider()
+
+	// intentionally sorting these so the output is consistent
+	resourceNames := make([]string, 0)
+	for resourceName := range provider.ResourcesMap {
+		resourceNames = append(resourceNames, resourceName)
+	}
+	sort.Strings(resourceNames)
+
+	// TODO: 4.0 - work through this list
+	resourceFieldsWhichNeedToBeAddressed := map[string]map[string]struct{}{
+		// 1: Fields which require renaming etc
+		"azurerm_datadog_monitor_sso_configuration": {
+			// should be fixed in 4.0, presumably ditching `_enabled` and adding Enum validation
+			"single_sign_on_enabled": {},
+		},
+		"azurerm_netapp_volume": {
+			// should be fixed in 4.0, presumably ditching `_enabled` and making this `protocols_to_use` or something?
+			"protocols_enabled": {},
+		},
+		"azurerm_kubernetes_cluster": {
+			// this either wants `enabled` removing, or to be marked as a false-positive
+			"transparent_huge_page_enabled": {},
+		},
+		"azurerm_kubernetes_cluster_node_pool": {
+			// this either wants `enabled` removing, or to be marked as a false-positive
+			"transparent_huge_page_enabled": {},
+		},
+
+		// 2: False Positives
+		"azurerm_iot_security_solution": {
+			// this is a list of recommendations
+			"recommendations_enabled": {},
+		},
+	}
+
+	for _, resourceName := range resourceNames {
+		resource := provider.ResourcesMap[resourceName]
+		fieldsToBeAddressed := resourceFieldsWhichNeedToBeAddressed[resourceName]
+
+		if err := schemaContainsEnabledFieldsNotDefinedAsABoolean(resource.Schema, fieldsToBeAddressed); err != nil {
+			t.Fatalf("the Resource %q contains an `_enabled` field which isn't defined as a boolean: %+v", resourceName, err)
+		}
+	}
+}
+
+func schemaContainsEnabledFieldsNotDefinedAsABoolean(input map[string]*schema.Schema, fieldsToBeAddressed map[string]struct{}) error {
+	// intentionally sorting these so the output is consistent
+	fieldNames := make([]string, 0)
+	for fieldName := range input {
+		fieldNames = append(fieldNames, fieldName)
+	}
+	sort.Strings(fieldNames)
+
+	for _, fieldName := range fieldNames {
+		key := strings.ToLower(fieldName)
+		field := input[fieldName]
+
+		if strings.HasSuffix(key, "_enabled") {
+			// @tombuildsstuff: we have some Resources which will need to be addressed in the next major version (v4.0)
+			// if this field name matches one we're intentionally ignoring, let's ignore it for now
+			if _, shouldIgnore := fieldsToBeAddressed[key]; shouldIgnore {
+				continue
+			}
+			if field.Type != pluginsdk.TypeBool {
+				return fmt.Errorf("field %q is an `_enabled` field so should be defined as a Boolean but got %+v", fieldName, field.Type)
+			}
+		}
+
+		if field.Type == pluginsdk.TypeList && field.Elem != nil {
+			if val, ok := field.Elem.(*pluginsdk.Resource); ok && val.Schema != nil {
+				if err := schemaContainsEnabledFieldsNotDefinedAsABoolean(val.Schema, fieldsToBeAddressed); err != nil {
+					return fmt.Errorf("the field %q is a List: %+v", fieldName, err)
+				}
+			}
+		}
+
+		if field.Type == pluginsdk.TypeSet && field.Elem != nil {
+			if val, ok := field.Elem.(*pluginsdk.Resource); ok && val.Schema != nil {
+				if err := schemaContainsEnabledFieldsNotDefinedAsABoolean(val.Schema, fieldsToBeAddressed); err != nil {
 					return fmt.Errorf("the field %q is a Set: %+v", fieldName, err)
 				}
 			}

--- a/internal/provider/provider_schema_test.go
+++ b/internal/provider/provider_schema_test.go
@@ -11,8 +11,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
-// TODO: Data Sources and Resources cannot contain a field `name` with the default of `default`
-
 func TestDataSourcesHaveSensitiveFieldsMarkedAsSensitive(t *testing.T) {
 	provider := TestAzureProvider()
 
@@ -198,6 +196,114 @@ func schemaContainsEnabledFieldsNotDefinedAsABoolean(input map[string]*schema.Sc
 		if field.Type == pluginsdk.TypeSet && field.Elem != nil {
 			if val, ok := field.Elem.(*pluginsdk.Resource); ok && val.Schema != nil {
 				if err := schemaContainsEnabledFieldsNotDefinedAsABoolean(val.Schema, fieldsToBeAddressed); err != nil {
+					return fmt.Errorf("the field %q is a Set: %+v", fieldName, err)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func TestDataSourcesDoNotContainANameFieldWithADefaultOfDefault(t *testing.T) {
+	provider := TestAzureProvider()
+
+	// intentionally sorting these so the output is consistent
+	dataSourceNames := make([]string, 0)
+	for dataSourceName := range provider.DataSourcesMap {
+		dataSourceNames = append(dataSourceNames, dataSourceName)
+	}
+	sort.Strings(dataSourceNames)
+
+	for _, dataSourceName := range dataSourceNames {
+		dataSource := provider.DataSourcesMap[dataSourceName]
+		if err := schemaContainsANameFieldWithADefaultValueOfDefault(dataSource.Schema, map[string]struct{}{}); err != nil {
+			t.Fatalf("the Data Source %q contains a `name` field with a default value of `default` - this Data Source should be exposed as part of the parent Data Source it's located within: %+v", dataSourceName, err)
+		}
+	}
+}
+
+func TestResourcesDoNotContainANameFieldWithADefaultOfDefault(t *testing.T) {
+	provider := TestAzureProvider()
+
+	// intentionally sorting these so the output is consistent
+	resourceNames := make([]string, 0)
+	for resourceName := range provider.ResourcesMap {
+		resourceNames = append(resourceNames, resourceName)
+	}
+	sort.Strings(resourceNames)
+
+	// TODO: 4.0 - work through this list
+	resourceFieldsWhichNeedToBeAddressed := map[string]map[string]struct{}{
+		// 1: to be addressed in 4.0
+		"azurerm_datadog_monitor_sso_configuration": {
+			// TODO: in 4.0 this resource probably wants embedding within `azurerm_datadog_monitor`
+			// which'll also need the Monitor resource to have Create call Update
+			"name": {},
+		},
+		"azurerm_datadog_monitor_tag_rule": {
+			// TODO: in 4.0 this resource probably wants embedding within `azurerm_datadog_monitor`
+			// which'll also need the Monitor resource to have Create call Update
+			"name": {},
+		},
+
+		// 2. False Positives?
+		"azurerm_redis_enterprise_database": {
+			"name": {},
+		},
+	}
+
+	for _, resourceName := range resourceNames {
+		resource := provider.ResourcesMap[resourceName]
+		fieldsToBeAddressed := resourceFieldsWhichNeedToBeAddressed[resourceName]
+
+		if err := schemaContainsANameFieldWithADefaultValueOfDefault(resource.Schema, fieldsToBeAddressed); err != nil {
+			t.Fatalf("the Resource %q contains a `name` field with a default value of `default` - this Resource should be exposed as part of the parent Resource it's located within: %+v", resourceName, err)
+		}
+	}
+}
+
+func schemaContainsANameFieldWithADefaultValueOfDefault(input map[string]*schema.Schema, fieldsToBeAddressed map[string]struct{}) error {
+	// intentionally sorting these so the output is consistent
+	fieldNames := make([]string, 0)
+	for fieldName := range input {
+		fieldNames = append(fieldNames, fieldName)
+	}
+	sort.Strings(fieldNames)
+
+	for _, fieldName := range fieldNames {
+		key := strings.ToLower(fieldName)
+		field := input[fieldName]
+
+		// @tombuildsstuff: we have some Resources which will need to be addressed in the next major version (v4.0)
+		// if this field name matches one we're intentionally ignoring, let's ignore it for now
+		if _, shouldIgnore := fieldsToBeAddressed[key]; shouldIgnore {
+			continue
+		}
+
+		if strings.EqualFold(key, "name") {
+			var defaultValue any
+			if field.Default != nil {
+				defaultValue = field.Default
+			}
+			if v, ok := defaultValue.(string); ok {
+				if strings.EqualFold(v, "default") {
+					return fmt.Errorf("field %q is a `name` field which contains a default value of `default`", fieldName)
+				}
+			}
+		}
+
+		if field.Type == pluginsdk.TypeList && field.Elem != nil {
+			if val, ok := field.Elem.(*pluginsdk.Resource); ok && val.Schema != nil {
+				if err := schemaContainsANameFieldWithADefaultValueOfDefault(val.Schema, fieldsToBeAddressed); err != nil {
+					return fmt.Errorf("the field %q is a List: %+v", fieldName, err)
+				}
+			}
+		}
+
+		if field.Type == pluginsdk.TypeSet && field.Elem != nil {
+			if val, ok := field.Elem.(*pluginsdk.Resource); ok && val.Schema != nil {
+				if err := schemaContainsANameFieldWithADefaultValueOfDefault(val.Schema, fieldsToBeAddressed); err != nil {
 					return fmt.Errorf("the field %q is a Set: %+v", fieldName, err)
 				}
 			}

--- a/internal/provider/provider_schema_test.go
+++ b/internal/provider/provider_schema_test.go
@@ -98,6 +98,12 @@ func schemaContainsSensitiveFieldsNotMarkedAsSensitive(input map[string]*plugins
 }
 
 func TestDataSourcesHaveEnabledFieldsMarkedAsBooleans(t *testing.T) {
+	// This test validates that Data Sources do not contain a field suffixed with `_enabled` that isn't a Boolean.
+	//
+	// If this test is failing due to a new Data Source/new field within an existing Data Source, it'd be worth validating
+	// the schema, since fields matching `{some_name}_enabled` should be Booleans. Should a Tri-State Boolean exist,
+	// this field likely wants the `_enabled` suffix removing, to make the example `{some_name}` instead (with
+	// validation for the possible values).
 	provider := TestAzureProvider()
 
 	// intentionally sorting these so the output is consistent
@@ -116,6 +122,12 @@ func TestDataSourcesHaveEnabledFieldsMarkedAsBooleans(t *testing.T) {
 }
 
 func TestResourcesHaveEnabledFieldsMarkedAsBooleans(t *testing.T) {
+	// This test validates that Resources do not contain a field suffixed with `_enabled` that isn't a Boolean.
+	//
+	// If this test is failing due to a new Resource/new field within an existing Resource, it'd be worth validating
+	// the schema, since fields matching `{some_name}_enabled` should be Booleans. Should a Tri-State Boolean exist,
+	// this field likely wants the `_enabled` suffix removing, to make the example `{some_name}` instead (with
+	// validation for the possible values).
 	provider := TestAzureProvider()
 
 	// intentionally sorting these so the output is consistent
@@ -206,6 +218,11 @@ func schemaContainsEnabledFieldsNotDefinedAsABoolean(input map[string]*schema.Sc
 }
 
 func TestDataSourcesDoNotContainANameFieldWithADefaultOfDefault(t *testing.T) {
+	// This test validates that Data Sources do not contain a field `name` with a default value of `default`, which
+	// would signify that only a single instance of this resource can be created and is related to the parent resource.
+	//
+	// If a new Data Sources is failing because of this test, rather than adding a new Data Sources, you likely want to
+	// embed the relevant structure (for example `sso_configuration {}`) within the parent Data Sources this is related to.
 	provider := TestAzureProvider()
 
 	// intentionally sorting these so the output is consistent
@@ -224,6 +241,11 @@ func TestDataSourcesDoNotContainANameFieldWithADefaultOfDefault(t *testing.T) {
 }
 
 func TestResourcesDoNotContainANameFieldWithADefaultOfDefault(t *testing.T) {
+	// This test validates that Resources do not contain a field `name` with a default value of `default`, which
+	// would signify that only a single instance of this resource can be created and is related to the parent resource.
+	//
+	// If a new Resource is failing because of this test, rather than adding a new Resource, you likely want to
+	// embed the relevant structure (for example `sso_configuration {}`) within the parent Resource this is related to.
 	provider := TestAzureProvider()
 
 	// intentionally sorting these so the output is consistent


### PR DESCRIPTION
This PR introduces a few unit tests to ensure we avoid resource design issues when creating new resources, both:

1. Ensuring that fields suffixed with `_enabled` are booleans (since that's the convention)
2. Ensuring that fields called `name` do not have a default value of `required` - since this means that this resource/data source has a 1:1 relationship with it's parent - and as such should be embedded within the parent resource/data source rather than being a separate resource/data source.

The unit tests validate both the Data Sources and Resources - and whilst there are a number of these resources today (which have an exception for now), we'll want to address this in v4.0, so I've left TODO's - however these unit tests will allow us to avoid these issues going forwards.