### PR TITLE
Resource `azurerm_federated_identity_credential` - Fix generation of parent User Assigned Identity ID field

### DIFF
--- a/internal/services/managedidentity/federated_identity_credential_resource.go
+++ b/internal/services/managedidentity/federated_identity_credential_resource.go
@@ -141,7 +141,7 @@ func (r FederatedIdentityCredentialResource) Read() sdk.ResourceFunc {
 			if model := resp.Model; model != nil {
 				schema.Name = id.FederatedIdentityCredentialName
 				schema.ResourceGroupName = id.ResourceGroupName
-				parentId := commonids.NewUserAssignedIdentityID(id.SubscriptionId, id.ResourceGroupName, id.FederatedIdentityCredentialName)
+				parentId := commonids.NewUserAssignedIdentityID(id.SubscriptionId, id.ResourceGroupName, id.UserAssignedIdentityName)
 				schema.ResourceName = parentId.ID()
 				r.mapFederatedIdentityCredentialToFederatedIdentityCredentialResourceSchema(*model, &schema)
 			}


### PR DESCRIPTION
Resource `azurerm_federated_identity_credential` - Fix generation of parent User Assigned Identity ID field

When the provider read the state of existing `azurerm_federated_identity_credential` resources, it constructed the resource ID for its `parent_id` attribute using the wrong resource ID (its own name instead of the parent UserAssignedidentity name). Updating the call to construct the ID with the right parameter fixes the issue.

### Issues
Fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/20217

### Acceptance tests
Didn't add more tests because current tests catch the bug.

#### Output before fix

```sh
~/go/src/github.com/hashicorp/terraform-provider-azurerm (fed-identity-id-parentid-bug ✗) make acctests SERVICE='managedidentity' TESTARGS='-run=TestAccFederatedIdentityCredential_' TESTTIMEOUT='60m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/managedidentity -run=TestAccFederatedIdentityCredential_ -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccFederatedIdentityCredential_basic
=== PAUSE TestAccFederatedIdentityCredential_basic
=== RUN   TestAccFederatedIdentityCredential_requiresImport
=== PAUSE TestAccFederatedIdentityCredential_requiresImport
=== CONT  TestAccFederatedIdentityCredential_basic
=== CONT  TestAccFederatedIdentityCredential_requiresImport
    testcase.go:110: Step 1/2 error: After applying this test step, the plan was not empty.
        stdout:
        
        
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
        -/+ destroy and then create replacement
        
        Terraform will perform the following actions:
        
          # azurerm_federated_identity_credential.test must be replaced
        -/+ resource "azurerm_federated_identity_credential" "test" {
              ~ id                  = "/subscriptions/redacted/resourceGroups/acctestrg-230130095343561802/providers/Microsoft.ManagedIdentity/userAssignedIdentities/acctestuai-230130095343561802/federatedIdentityCredentials/acctest-230130095343561802" -> (known after apply)
                name                = "acctest-230130095343561802"
              ~ parent_id           = "/subscriptions/redacted/resourceGroups/acctestrg-230130095343561802/providers/Microsoft.ManagedIdentity/userAssignedIdentities/acctest-230130095343561802" -> "/subscriptions/redacted/resourceGroups/acctestrg-230130095343561802/providers/Microsoft.ManagedIdentity/userAssignedIdentities/acctestuai-230130095343561802" # forces replacement
                # (4 unchanged attributes hidden)
            }
        
        Plan: 1 to add, 0 to change, 1 to destroy.
=== CONT  TestAccFederatedIdentityCredential_basic
    testcase.go:110: Step 1/2 error: After applying this test step, the plan was not empty.
        stdout:
        
        
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
        -/+ destroy and then create replacement
        
        Terraform will perform the following actions:
        
          # azurerm_federated_identity_credential.test must be replaced
        -/+ resource "azurerm_federated_identity_credential" "test" {
              ~ id                  = "/subscriptions/redacted/resourceGroups/acctestrg-230130095343565984/providers/Microsoft.ManagedIdentity/userAssignedIdentities/acctestuai-230130095343565984/federatedIdentityCredentials/acctest-230130095343565984" -> (known after apply)
                name                = "acctest-230130095343565984"
              ~ parent_id           = "/subscriptions/redacted/resourceGroups/acctestrg-230130095343565984/providers/Microsoft.ManagedIdentity/userAssignedIdentities/acctest-230130095343565984" -> "/subscriptions/redacted/resourceGroups/acctestrg-230130095343565984/providers/Microsoft.ManagedIdentity/userAssignedIdentities/acctestuai-230130095343565984" # forces replacement
                # (4 unchanged attributes hidden)
            }
        
        Plan: 1 to add, 0 to change, 1 to destroy.
--- FAIL: TestAccFederatedIdentityCredential_requiresImport (162.81s)
--- FAIL: TestAccFederatedIdentityCredential_basic (165.10s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-azurerm/internal/services/managedidentity	167.745s
FAIL
make: *** [acctests] Error 1
```
#### Output after fix
```sh
~/go/src/github.com/hashicorp/terraform-provider-azurerm (fed-identity-id-parentid-bug ✗) make acctests SERVICE='managedidentity' TESTARGS='-run=TestAccFederatedIdentityCredential_' TESTTIMEOUT='60m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/managedidentity -run=TestAccFederatedIdentityCredential_ -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccFederatedIdentityCredential_basic
=== PAUSE TestAccFederatedIdentityCredential_basic
=== RUN   TestAccFederatedIdentityCredential_requiresImport
=== PAUSE TestAccFederatedIdentityCredential_requiresImport
=== CONT  TestAccFederatedIdentityCredential_basic
=== CONT  TestAccFederatedIdentityCredential_requiresImport
--- PASS: TestAccFederatedIdentityCredential_requiresImport (198.81s)
--- PASS: TestAccFederatedIdentityCredential_basic (238.94s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/managedidentity	240.128s
```