### PR TITLE
`azurerm_sentinel_data_connector_threat_intelligence_taxii` - Fix date format for `lookback_date`

### DIFF
--- a/internal/services/sentinel/azuresdkhacks/models.go
+++ b/internal/services/sentinel/azuresdkhacks/models.go
@@ -346,7 +346,7 @@ func (t *Time) UnmarshalJSON(data []byte) (err error) {
 	}
 
 	// This is the format that the service returns at this moment, which is not the expected format (RFC3339).
-	t.Time, err = time.Parse(`"1/2/2006 15:04:05 PM -07:00"`, string(data))
+	t.Time, err = time.Parse(`"01/02/2006 15:04:05"`, string(data))
 	return err
 }
 

--- a/internal/services/sentinel/sentinel_data_connector_threat_intelligence_taxii_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_threat_intelligence_taxii_test.go
@@ -77,6 +77,22 @@ func TestAccDataConnectorThreatIntelligenceTAXII_basic(t *testing.T) {
 	})
 }
 
+func TestAccDataConnectorThreatIntelligenceTAXII_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_sentinel_data_connector_threat_intelligence_taxii", "test")
+	r := NewDataConnectorThreatIntelligenceTAXIIResource()
+	r.preCheck(t, false)
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("user_name", "password"),
+	})
+}
+
 func TestAccDataConnectorThreatIntelligenceTAXII_update(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_sentinel_data_connector_threat_intelligence_taxii", "test")
 	r := NewDataConnectorThreatIntelligenceTAXIIResource()
@@ -154,6 +170,26 @@ resource "azurerm_sentinel_data_connector_threat_intelligence_taxii" "test" {
   collection_id              = "%s"
   user_name                  = "%s"
   password                   = "%s"
+  depends_on                 = [azurerm_log_analytics_solution.test]
+}
+`, template, data.RandomInteger, r.taxiiInfo.APIRootURL, r.taxiiInfo.CollectionID, r.taxiiInfo.UserName, r.taxiiInfo.Password)
+}
+
+func (r DataConnectorThreatIntelligenceTAXIIResource) complete(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_sentinel_data_connector_threat_intelligence_taxii" "test" {
+  name                       = "acctestDC-%d"
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  display_name               = "test_update"
+  api_root_url               = "%s"
+  collection_id              = "%s"
+  user_name                  = "%s"
+  password                   = "%s"
+  polling_frequency          = "OnceADay"
+  lookback_date              = "1990-01-01T00:00:00Z"
   depends_on                 = [azurerm_log_analytics_solution.test]
 }
 `, template, data.RandomInteger, r.taxiiInfo.APIRootURL, r.taxiiInfo.CollectionID, r.taxiiInfo.UserName, r.taxiiInfo.Password)


### PR DESCRIPTION
Fix the issue reported at https://github.com/hashicorp/terraform-provider-azurerm/pull/19209#issuecomment-1383885437. The issue is due to a *change* introduced at service side, which cause the date format changed. That service side *change* has now been reverted. But due to the original PR #19209 is implemented during the time when that *change* is in effect, we now need to modify the date format in this PR to align with current behavior of the service, which is not going to change until https://github.com/Azure/azure-rest-api-specs/issues/21487 is resolved.

## Test

```shell
💤  TF_ACC=1 go test -v -timeout=20h ./internal/services/sentinel -run=TestAccDataConnectorThreatIntelligenceTAXII_complete
=== RUN   TestAccDataConnectorThreatIntelligenceTAXII_complete
=== PAUSE TestAccDataConnectorThreatIntelligenceTAXII_complete
=== CONT  TestAccDataConnectorThreatIntelligenceTAXII_complete
--- PASS: TestAccDataConnectorThreatIntelligenceTAXII_complete (213.57s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/sentinel      213.584s
```