### PR TITLE
`azurerm_mssql_managed_instance` - fix use `administrator_password` instead of `administrator_login_password` issue

### DIFF
--- a/internal/services/mssql/mssql_managed_instance_resource.go
+++ b/internal/services/mssql/mssql_managed_instance_resource.go
@@ -398,7 +398,7 @@ func (r MsSqlManagedInstanceResource) Update() sdk.ResourceFunc {
 				properties.MaintenanceConfigurationID = utils.String(maintenanceConfigId.ID())
 			}
 
-			if metadata.ResourceData.HasChange("administrator_password") {
+			if metadata.ResourceData.HasChange("administrator_login_password") {
 				properties.AdministratorLoginPassword = utils.String(state.AdministratorLoginPassword)
 			}
 


### PR DESCRIPTION
Use `administrator_password` instead of `administrator_login_password` when changing password issue which will cause the password could not be updated successfully. 

Fix #20181 .