### PR TITLE
Parse Property Case Insensitively in `Read`

### DIFF
--- a/internal/services/apimanagement/api_management_subscription_resource.go
+++ b/internal/services/apimanagement/api_management_subscription_resource.go
@@ -247,7 +247,7 @@ func resourceApiManagementSubscriptionRead(d *pluginsdk.ResourceData, meta inter
 			if err == nil {
 				productId = parseId.ID()
 			} else {
-				parsedApiId, err := parse.ApiID(*props.Scope)
+				parsedApiId, err := parse.ApiIDInsensitively(*props.Scope)
 				if err != nil {
 					return fmt.Errorf("parsing scope into product/ api id %q: %+v", *props.Scope, err)
 				}

--- a/internal/services/appservice/function_app_hybrid_connection_resource.go
+++ b/internal/services/appservice/function_app_hybrid_connection_resource.go
@@ -231,12 +231,7 @@ func (r FunctionAppHybridConnectionResource) Read() sdk.ResourceFunc {
 				}
 
 				hybridConnectionsClient := metadata.Client.Relay.HybridConnectionsClient
-				hybridConnectionID, err := hybridconnections.ParseHybridConnectionIDInsensitively(appHybridConn.RelayId)
-				if err != nil {
-					return err
-				}
-
-				ruleID := hybridconnections.NewHybridConnectionAuthorizationRuleID(id.SubscriptionId, hybridConnectionID.ResourceGroupName, appHybridConn.ServiceBusNamespace, *existing.Name, appHybridConn.SendKeyName)
+				ruleID := hybridconnections.NewHybridConnectionAuthorizationRuleID(id.SubscriptionId, relayId.ResourceGroupName, appHybridConn.ServiceBusNamespace, *existing.Name, appHybridConn.SendKeyName)
 				keys, err := hybridConnectionsClient.ListKeys(ctx, ruleID)
 				if err != nil && keys.Model != nil {
 					appHybridConn.SendKeyValue = utils.NormalizeNilableString(keys.Model.PrimaryKey)

--- a/internal/services/appservice/function_app_hybrid_connection_resource.go
+++ b/internal/services/appservice/function_app_hybrid_connection_resource.go
@@ -220,7 +220,7 @@ func (r FunctionAppHybridConnectionResource) Read() sdk.ResourceFunc {
 
 			if appHybridConn.ServiceBusNamespace != "" && appHybridConn.SendKeyName != "" {
 				relayNamespaceClient := metadata.Client.Relay.NamespacesClient
-				relayId, err := hybridconnections.ParseHybridConnectionID(appHybridConn.RelayId)
+				relayId, err := hybridconnections.ParseHybridConnectionIDInsensitively(appHybridConn.RelayId)
 				if err != nil {
 					return err
 				}
@@ -231,7 +231,7 @@ func (r FunctionAppHybridConnectionResource) Read() sdk.ResourceFunc {
 				}
 
 				hybridConnectionsClient := metadata.Client.Relay.HybridConnectionsClient
-				hybridConnectionID, err := hybridconnections.ParseHybridConnectionID(appHybridConn.RelayId)
+				hybridConnectionID, err := hybridconnections.ParseHybridConnectionIDInsensitively(appHybridConn.RelayId)
 				if err != nil {
 					return err
 				}

--- a/internal/services/containers/container_group_resource.go
+++ b/internal/services/containers/container_group_resource.go
@@ -2009,7 +2009,7 @@ func flattenContainerGroupSubnets(input *[]containerinstance.ContainerGroupSubne
 			continue
 		}
 
-		id, err := networkParse.SubnetID(resourceRef.Id)
+		id, err := networkParse.SubnetIDInsensitively(resourceRef.Id)
 		if err != nil {
 			return nil, fmt.Errorf(`parsing subnet id %q: %v`, resourceRef.Id, err)
 		}

--- a/internal/services/disks/disk_pool_iscsi_target_lun_resource.go
+++ b/internal/services/disks/disk_pool_iscsi_target_lun_resource.go
@@ -175,7 +175,7 @@ func (d DiskPoolIscsiTargetLunModel) Read() sdk.ResourceFunc {
 			for _, lun := range *resp.Model.Properties.Luns {
 				if lun.ManagedDiskAzureResourceId == id.ManagedDiskId.ID() {
 					diskPoolId := diskpools.NewDiskPoolID(iscsiTargetId.SubscriptionId, iscsiTargetId.ResourceGroupName, iscsiTargetId.DiskPoolName)
-					diskId, err := disks.ParseDiskID(lun.ManagedDiskAzureResourceId)
+					diskId, err := disks.ParseDiskIDInsensitively(lun.ManagedDiskAzureResourceId)
 					if err != nil {
 						return fmt.Errorf("invalid managed disk id in iscsi target response %q : %q", iscsiTargetId.ID(), lun.ManagedDiskAzureResourceId)
 					}

--- a/internal/services/loganalytics/log_analytics_data_export_resource.go
+++ b/internal/services/loganalytics/log_analytics_data_export_resource.go
@@ -240,7 +240,7 @@ func flattenDataExportDestination(input *dataexport.Destination) (string, error)
 		if *input.Type == dataexport.TypeEventHub {
 			if input.MetaData != nil && input.MetaData.EventHubName != nil {
 				eventhubName := *input.MetaData.EventHubName
-				eventhubNamespaceId, err := eventhubs.ParseNamespaceID(resourceID)
+				eventhubNamespaceId, err := eventhubs.ParseNamespaceIDInsensitively(resourceID)
 				eventhubId := eventhubs.NewEventhubID(eventhubNamespaceId.SubscriptionId, eventhubNamespaceId.ResourceGroupName, eventhubNamespaceId.NamespaceName, eventhubName)
 				if err != nil {
 					return "", fmt.Errorf("parsing destination eventhub namespace ID error")

--- a/internal/services/machinelearning/machine_learning_inference_cluster_resource.go
+++ b/internal/services/machinelearning/machine_learning_inference_cluster_resource.go
@@ -235,7 +235,7 @@ func resourceAksInferenceClusterRead(d *pluginsdk.ResourceData, meta interface{}
 	aksComputeProperties := computeResource.Model.Properties.(machinelearningcomputes.AKS)
 
 	// Retrieve AKS Cluster ID
-	aksId, err := managedclusters.ParseManagedClusterID(*aksComputeProperties.ResourceId)
+	aksId, err := managedclusters.ParseManagedClusterIDInsensitively(*aksComputeProperties.ResourceId)
 	if err != nil {
 		return err
 	}

--- a/internal/services/monitor/monitor_aad_diagnostic_setting_resource.go
+++ b/internal/services/monitor/monitor_aad_diagnostic_setting_resource.go
@@ -221,7 +221,7 @@ func resourceMonitorAADDiagnosticSettingRead(d *pluginsdk.ResourceData, meta int
 	d.Set("eventhub_name", resp.EventHubName)
 	eventhubAuthorizationRuleId := ""
 	if resp.EventHubAuthorizationRuleID != nil && *resp.EventHubAuthorizationRuleID != "" {
-		parsedId, err := authRuleParse.ParseAuthorizationRuleID(*resp.EventHubAuthorizationRuleID)
+		parsedId, err := authRuleParse.ParseAuthorizationRuleIDInsensitively(*resp.EventHubAuthorizationRuleID)
 		if err != nil {
 			return err
 		}

--- a/internal/services/mssql/mssql_database_resource.go
+++ b/internal/services/mssql/mssql_database_resource.go
@@ -555,7 +555,7 @@ func resourceMsSqlDatabaseRead(d *pluginsdk.ResourceData, meta interface{}) erro
 
 		configurationName := ""
 		if v := props.MaintenanceConfigurationID; v != nil {
-			maintenanceConfigId, err := publicmaintenanceconfigurations.ParsePublicMaintenanceConfigurationID(*v)
+			maintenanceConfigId, err := publicmaintenanceconfigurations.ParsePublicMaintenanceConfigurationIDInsensitively(*v)
 			if err != nil {
 				return err
 			}

--- a/internal/services/mssql/mssql_elasticpool_resource.go
+++ b/internal/services/mssql/mssql_elasticpool_resource.go
@@ -308,7 +308,7 @@ func resourceMsSqlElasticPoolRead(d *pluginsdk.ResourceData, meta interface{}) e
 			return fmt.Errorf("setting `per_database_settings`: %+v", err)
 		}
 
-		maintenanceConfigId, err := publicmaintenanceconfigurations.ParsePublicMaintenanceConfigurationID(*properties.MaintenanceConfigurationID)
+		maintenanceConfigId, err := publicmaintenanceconfigurations.ParsePublicMaintenanceConfigurationIDInsensitively(*properties.MaintenanceConfigurationID)
 		if err != nil {
 			return err
 		}

--- a/internal/services/mssql/mssql_managed_instance_resource.go
+++ b/internal/services/mssql/mssql_managed_instance_resource.go
@@ -475,7 +475,7 @@ func (r MsSqlManagedInstanceResource) Read() sdk.ResourceFunc {
 					model.Fqdn = *props.FullyQualifiedDomainName
 				}
 				if props.MaintenanceConfigurationID != nil {
-					maintenanceConfigId, err := publicmaintenanceconfigurations.ParsePublicMaintenanceConfigurationID(*props.MaintenanceConfigurationID)
+					maintenanceConfigId, err := publicmaintenanceconfigurations.ParsePublicMaintenanceConfigurationIDInsensitively(*props.MaintenanceConfigurationID)
 					if err != nil {
 						return err
 					}

--- a/internal/services/mssql/mssql_virtual_network_rule_resource.go
+++ b/internal/services/mssql/mssql_virtual_network_rule_resource.go
@@ -151,7 +151,7 @@ func resourceMsSqlVirtualNetworkRuleRead(d *pluginsdk.ResourceData, meta interfa
 
 		subnetId := ""
 		if sid := props.VirtualNetworkSubnetID; sid != nil {
-			id, err := networkParse.SubnetID(*props.VirtualNetworkSubnetID)
+			id, err := networkParse.SubnetIDInsensitively(*props.VirtualNetworkSubnetID)
 			if err != nil {
 				return fmt.Errorf("parsing subnet ID returned by API %q: %+v", *sid, err)
 			}


### PR DESCRIPTION
Similar to #20206, use `Parse...IDInsensitively` to parse service response so that potential casing change at server side won't cause a failure to `Read`.