### PR TITLE
`azurerm_shared_image`: support `confidential_vm_supported` and `confidential_vm_enabled`

### DIFF
--- a/internal/services/compute/shared_image_resource.go
+++ b/internal/services/compute/shared_image_resource.go
@@ -677,8 +677,8 @@ func expandSharedImageFeatures(d *pluginsdk.ResourceData) *[]compute.GalleryImag
 
 	if cvmEnabled := d.Get("confidential_vm_enabled").(bool); cvmEnabled {
 		features = append(features, compute.GalleryImageFeature{
-			Name:  utils.String("ConfidentialVM"),
-			Value: utils.String("Enabled"),
+			Name:  utils.String("SecurityType"),
+			Value: utils.String("ConfidentialVM"),
 		})
 	}
 

--- a/internal/services/compute/shared_image_resource.go
+++ b/internal/services/compute/shared_image_resource.go
@@ -221,9 +221,24 @@ func resourceSharedImage() *pluginsdk.Resource {
 			},
 
 			"trusted_launch_enabled": {
-				Type:     pluginsdk.TypeBool,
-				Optional: true,
-				ForceNew: true,
+				Type:          pluginsdk.TypeBool,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"confidential_vm_supported", "confidential_vm_enabled"},
+			},
+
+			"confidential_vm_supported": {
+				Type:          pluginsdk.TypeBool,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"trusted_launch_enabled", "confidential_vm_enabled"},
+			},
+
+			"confidential_vm_enabled": {
+				Type:          pluginsdk.TypeBool,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"trusted_launch_enabled", "confidential_vm_supported"},
 			},
 
 			"accelerated_network_support_enabled": {
@@ -265,20 +280,6 @@ func resourceSharedImageCreateUpdate(d *pluginsdk.ResourceData, meta interface{}
 		}
 	}
 
-	var features []compute.GalleryImageFeature
-	if d.Get("trusted_launch_enabled").(bool) {
-		features = append(features, compute.GalleryImageFeature{
-			Name:  utils.String("SecurityType"),
-			Value: utils.String("TrustedLaunch"),
-		})
-	}
-	if d.Get("accelerated_network_support_enabled").(bool) {
-		features = append(features, compute.GalleryImageFeature{
-			Name:  utils.String("IsAcceleratedNetworkSupported"),
-			Value: utils.String("true"),
-		})
-	}
-
 	recommended, err := expandGalleryImageRecommended(d)
 	if err != nil {
 		return err
@@ -296,7 +297,7 @@ func resourceSharedImageCreateUpdate(d *pluginsdk.ResourceData, meta interface{}
 			OsType:              compute.OperatingSystemTypes(d.Get("os_type").(string)),
 			HyperVGeneration:    compute.HyperVGeneration(d.Get("hyper_v_generation").(string)),
 			PurchasePlan:        expandGalleryImagePurchasePlan(d.Get("purchase_plan").([]interface{})),
-			Features:            &features,
+			Features:            expandSharedImageFeatures(d),
 			Recommended:         recommended,
 		},
 		Tags: tags.Expand(d.Get("tags").(map[string]interface{})),
@@ -427,6 +428,8 @@ func resourceSharedImageRead(d *pluginsdk.ResourceData, meta interface{}) error 
 		}
 
 		trustedLaunchEnabled := false
+		cvmEnabled := false
+		cvmSupported := false
 		acceleratedNetworkSupportEnabled := false
 		if features := props.Features; features != nil {
 			for _, feature := range *features {
@@ -436,6 +439,8 @@ func resourceSharedImageRead(d *pluginsdk.ResourceData, meta interface{}) error 
 
 				if strings.EqualFold(*feature.Name, "SecurityType") {
 					trustedLaunchEnabled = strings.EqualFold(*feature.Value, "TrustedLaunch")
+					cvmSupported = strings.EqualFold(*feature.Value, "ConfidentialVmSupported")
+					cvmEnabled = strings.EqualFold(*feature.Value, "ConfidentialVm")
 				}
 
 				if strings.EqualFold(*feature.Name, "IsAcceleratedNetworkSupported") {
@@ -443,6 +448,8 @@ func resourceSharedImageRead(d *pluginsdk.ResourceData, meta interface{}) error 
 				}
 			}
 		}
+		d.Set("confidential_vm_supported", cvmSupported)
+		d.Set("confidential_vm_enabled", cvmEnabled)
 		d.Set("trusted_launch_enabled", trustedLaunchEnabled)
 		d.Set("accelerated_network_support_enabled", acceleratedNetworkSupportEnabled)
 	}
@@ -643,4 +650,37 @@ func expandGalleryImageRecommended(d *pluginsdk.ResourceData) (*compute.Recommen
 	}
 
 	return result, nil
+}
+
+func expandSharedImageFeatures(d *pluginsdk.ResourceData) *[]compute.GalleryImageFeature {
+	var features []compute.GalleryImageFeature
+	if d.Get("accelerated_network_support_enabled").(bool) {
+		features = append(features, compute.GalleryImageFeature{
+			Name:  utils.String("IsAcceleratedNetworkSupported"),
+			Value: utils.String("true"),
+		})
+	}
+
+	if tvmEnabled := d.Get("trusted_launch_enabled").(bool); tvmEnabled {
+		features = append(features, compute.GalleryImageFeature{
+			Name:  utils.String("SecurityType"),
+			Value: utils.String("TrustedLaunch"),
+		})
+	}
+
+	if cvmSupported := d.Get("confidential_vm_supported").(bool); cvmSupported {
+		features = append(features, compute.GalleryImageFeature{
+			Name:  utils.String("SecurityType"),
+			Value: utils.String("ConfidentialVmSupported"),
+		})
+	}
+
+	if cvmEnabled := d.Get("confidential_vm_enabled").(bool); cvmEnabled {
+		features = append(features, compute.GalleryImageFeature{
+			Name:  utils.String("ConfidentialVM"),
+			Value: utils.String("Enabled"),
+		})
+	}
+
+	return &features
 }

--- a/internal/services/compute/shared_image_resource_test.go
+++ b/internal/services/compute/shared_image_resource_test.go
@@ -127,6 +127,34 @@ func TestAccSharedImage_withTrustedLaunchEnabled(t *testing.T) {
 	})
 }
 
+func TestAccSharedImage_withConfidentialVM(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_shared_image", "test")
+	r := SharedImageResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.withConfidentialVM(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccSharedImage_withConfidentialVMSupported(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_shared_image", "test")
+	r := SharedImageResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.withConfidentialVmSupported(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccSharedImage_withAcceleratedNetworkSupportEnabled(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_shared_image", "test")
 	r := SharedImageResource{}
@@ -499,6 +527,76 @@ resource "azurerm_shared_image" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, hyperVGen, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
+func (SharedImageResource) withConfidentialVmSupported(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_shared_image_gallery" "test" {
+  name                = "acctestsig%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_shared_image" "test" {
+  name                      = "acctestimg%[1]d"
+  gallery_name              = azurerm_shared_image_gallery.test.name
+  resource_group_name       = azurerm_resource_group.test.name
+  location                  = azurerm_resource_group.test.location
+  os_type                   = "Linux"
+  hyper_v_generation        = "V2"
+  confidential_vm_supported = true
+
+  identifier {
+    publisher = "AccTesPublisher%[1]d"
+    offer     = "AccTesOffer%[1]d"
+    sku       = "AccTesSku%[1]d"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func (SharedImageResource) withConfidentialVM(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_shared_image_gallery" "test" {
+  name                = "acctestsig%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_shared_image" "test" {
+  name                    = "acctestimg%[1]d"
+  gallery_name            = azurerm_shared_image_gallery.test.name
+  resource_group_name     = azurerm_resource_group.test.name
+  location                = azurerm_resource_group.test.location
+  os_type                 = "Linux"
+  hyper_v_generation      = "V2"
+  confidential_vm_enabled = true
+
+  identifier {
+    publisher = "AccTesPublisher%[1]d"
+    offer     = "AccTesOffer%[1]d"
+    sku       = "AccTesSku%[1]d"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary)
 }
 
 func (SharedImageResource) withTrustedLaunchEnabled(data acceptance.TestData) string {

--- a/website/docs/r/shared_image.html.markdown
+++ b/website/docs/r/shared_image.html.markdown
@@ -96,6 +96,12 @@ The following arguments are supported:
 
 * `trusted_launch_enabled` - (Optional) Specifies if Trusted Launch has to be enabled for the Virtual Machine created from the Shared Image. Changing this forces a new resource to be created.
 
+* `confidential_vm_supported` - (Optional) Specifies if supports creation of both Confidential virtual machines and Gen2 virtual machines with standard security from a compatible Gen2 OS disk VHD or Gen2 Managed image. Changing this forces a new resource to be created.
+
+* `confidential_vm_enabled` - (Optional) Specifies if Confidential Virtual Machines enabled. It will enable all the features of trusted, with higher confidentiality features for isolate machines or encrypted data. Available for Gen2 machines. Changing this forces a new resource to be created.
+
+-> **Note:**: Only one of `trusted_launch_enabled`, `confidential_vm_supported` and `confidential_vm_enabled` could only be specified.
+
 * `accelerated_network_support_enabled` - (Optional) Specifies if the Shared Image supports Accelerated Network. Changing this forces a new resource to be created.
 
 * `tags` - (Optional) A mapping of tags to assign to the Shared Image.


### PR DESCRIPTION
because `security_type` support more than `trustedLaunch`, make the old one `trusted_launch_enabled` as deprecated and add new property `security_type`

<img width="650" alt="Screenshot 2023-02-01 at 17 31 14" src="https://user-images.githubusercontent.com/51212351/216004678-71cfead8-6742-4aaf-a851-c0d893f86ac8.png">
