### PR TITLE
`azurerm_media_streaming_live_event` - support for `stream_options` property

### DIFF
--- a/internal/services/media/media_streaming_live_event_resource.go
+++ b/internal/services/media/media_streaming_live_event_resource.go
@@ -23,9 +23,9 @@ import (
 
 func resourceMediaLiveEvent() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
-		Create: resourceMediaLiveEventCreateUpdate,
+		Create: resourceMediaLiveEventCreate,
 		Read:   resourceMediaLiveEventRead,
-		Update: resourceMediaLiveEventCreateUpdate,
+		Update: resourceMediaLiveEventUpdate,
 		Delete: resourceMediaLiveEventDelete,
 
 		Timeouts: &pluginsdk.ResourceTimeout{
@@ -364,24 +364,22 @@ func resourceMediaLiveEvent() *pluginsdk.Resource {
 	}
 }
 
-func resourceMediaLiveEventCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+func resourceMediaLiveEventCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Media.V20220801Client.LiveEvents
 	subscriptionID := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
 	id := liveevents.NewLiveEventID(subscriptionID, d.Get("resource_group_name").(string), d.Get("media_services_account_name").(string), d.Get("name").(string))
-	if d.IsNewResource() {
-		existing, err := client.Get(ctx, id)
-		if err != nil {
-			if !response.WasNotFound(existing.HttpResponse) {
-				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
-			}
-		}
-
+	existing, err := client.Get(ctx, id)
+	if err != nil {
 		if !response.WasNotFound(existing.HttpResponse) {
-			return tf.ImportAsExistsError("azurerm_media_live_event", id.ID())
+			return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
 		}
+	}
+
+	if !response.WasNotFound(existing.HttpResponse) {
+		return tf.ImportAsExistsError("azurerm_media_live_event", id.ID())
 	}
 
 	t := d.Get("tags").(map[string]interface{})
@@ -433,21 +431,73 @@ func resourceMediaLiveEventCreateUpdate(d *pluginsdk.ResourceData, meta interfac
 		payload.Properties.UseStaticHostname = utils.Bool(useStaticHostName.(bool))
 	}
 
-	if d.IsNewResource() {
-		options := liveevents.CreateOperationOptions{
-			AutoStart: autoStart,
-		}
-		if err := client.CreateThenPoll(ctx, id, payload, options); err != nil {
-			return fmt.Errorf("creating %s: %+v", id, err)
-		}
-	} else {
-		// TODO: split this into a separate update method
-		if err := client.UpdateThenPoll(ctx, id, payload); err != nil {
-			return fmt.Errorf("updating %s: %+v", id, err)
-		}
+	options := liveevents.CreateOperationOptions{
+		AutoStart: autoStart,
+	}
+	if err := client.CreateThenPoll(ctx, id, payload, options); err != nil {
+		return fmt.Errorf("creating %s: %+v", id, err)
 	}
 
 	d.SetId(id.ID())
+
+	return resourceMediaLiveEventRead(d, meta)
+}
+
+func resourceMediaLiveEventUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Media.V20220801Client.LiveEvents
+	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := liveevents.ParseLiveEventID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Get(ctx, *id)
+	if err != nil {
+		return fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+
+	if resp.Model == nil || resp.Model.Properties == nil {
+		return fmt.Errorf("unexpected null model of %s", id)
+	}
+	existing := resp.Model
+
+	if d.HasChange("input") {
+		existing.Properties.Input = expandLiveEventInput(d.Get("input").([]interface{}))
+	}
+
+	if d.HasChange("cross_site_access_policy") {
+		existing.Properties.CrossSiteAccessPolicies = expandLiveEventCrossSiteAccessPolicies(d.Get("cross_site_access_policy").([]interface{}))
+	}
+
+	if d.HasChange("description") {
+		existing.Properties.Description = utils.String(d.Get("description").(string))
+	}
+
+	if d.HasChange("encoding") {
+		existing.Properties.Encoding = expandEncoding(d.Get("encoding").([]interface{}))
+	}
+
+	if d.HasChange("hostname_prefix") {
+		existing.Properties.HostnamePrefix = utils.String(d.Get("hostname_prefix").(string))
+	}
+
+	if d.HasChange("preview") {
+		existing.Properties.Preview = expandPreview(d.Get("preview").([]interface{}))
+	}
+
+	if d.HasChange("transcription_languages") {
+		existing.Properties.Transcriptions = expandTranscriptions(d.Get("transcription_languages").([]interface{}))
+	}
+
+	if d.HasChange("tags") {
+		existing.Tags = tags.Expand(d.Get("tags").(map[string]interface{}))
+	}
+
+	if err := client.UpdateThenPoll(ctx, *id, *existing); err != nil {
+		return fmt.Errorf("updating %s: %+v", id, err)
+	}
 
 	return resourceMediaLiveEventRead(d, meta)
 }

--- a/internal/services/media/media_streaming_live_event_resource_test.go
+++ b/internal/services/media/media_streaming_live_event_resource_test.go
@@ -45,6 +45,27 @@ func TestAccLiveEvent_requiresImport(t *testing.T) {
 	})
 }
 
+func TestAccLiveEvent_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_media_live_event", "test")
+	r := LiveEventResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeAggregateTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.update(data),
+			Check: acceptance.ComposeAggregateTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+	})
+}
+
 func TestAccLiveEvent_complete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_media_live_event", "test")
 	r := LiveEventResource{}
@@ -119,6 +140,53 @@ resource "azurerm_media_live_event" "import" {
   }
 }
 `, r.basic(data))
+}
+
+func (r LiveEventResource) update(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_media_live_event" "test" {
+  name                        = "Event-1"
+  resource_group_name         = azurerm_resource_group.test.name
+  media_services_account_name = azurerm_media_services_account.test.name
+  location                    = azurerm_resource_group.test.location
+  description                 = "Updated Description"
+
+  input {
+    streaming_protocol = "RTMP"
+    ip_access_control_allow {
+      name                 = "Test"
+      address              = "0.0.0.0"
+      subnet_prefix_length = 4
+    }
+  }
+
+  encoding {
+    type               = "Standard"
+    preset_name        = "Default720p"
+    stretch_mode       = "AutoSize"
+    key_frame_interval = "PT2S"
+  }
+
+  preview {
+    ip_access_control_allow {
+      name                 = "Allow"
+      address              = "0.0.0.0"
+      subnet_prefix_length = 4
+    }
+  }
+
+  use_static_hostname     = true
+  hostname_prefix         = "special-event-update"
+  stream_options = ["LowLatency"]
+  transcription_languages = ["en-GB"]
+
+  tags = {
+    env = "test"
+  }
+}
+`, r.template(data))
 }
 
 func (r LiveEventResource) complete(data acceptance.TestData) string {

--- a/internal/services/media/media_streaming_live_event_resource_test.go
+++ b/internal/services/media/media_streaming_live_event_resource_test.go
@@ -179,7 +179,7 @@ resource "azurerm_media_live_event" "test" {
 
   use_static_hostname     = true
   hostname_prefix         = "special-event-update"
-  stream_options = ["LowLatency"]
+  stream_options          = ["LowLatency"]
   transcription_languages = ["en-GB"]
 
   tags = {
@@ -226,7 +226,7 @@ resource "azurerm_media_live_event" "test" {
 
   use_static_hostname     = true
   hostname_prefix         = "special-event"
-  stream_options = ["LowLatency"]
+  stream_options          = ["LowLatency"]
   transcription_languages = ["en-US"]
 }
 `, r.template(data))

--- a/internal/services/media/media_streaming_live_event_resource_test.go
+++ b/internal/services/media/media_streaming_live_event_resource_test.go
@@ -158,6 +158,7 @@ resource "azurerm_media_live_event" "test" {
 
   use_static_hostname     = true
   hostname_prefix         = "special-event"
+  stream_options = ["LowLatency"]
   transcription_languages = ["en-US"]
 }
 `, r.template(data))

--- a/website/docs/r/media_live_event.html.markdown
+++ b/website/docs/r/media_live_event.html.markdown
@@ -68,6 +68,7 @@ resource "azurerm_media_live_event" "example" {
     }
   }
 
+  stream_options = ["LowLatency"]
   use_static_hostname     = true
   hostname_prefix         = "special-event"
   transcription_languages = ["en-US"]
@@ -101,6 +102,8 @@ The following arguments are supported:
 * `hostname_prefix` - (Optional) When `use_static_hostname` is set to true, the `hostname_prefix` specifies the first part of the hostname assigned to the live event preview and ingest endpoints. The final hostname would be a combination of this prefix, the media service account name and a short code for the Azure Media Services data center.
 
 * `preview` - (Optional) A `preview` block as defined below.
+
+* `stream_options` - (Optional) A list of options to use for the LiveEvent. Possible values are `Default`, `LowLatency`, `LowLatencyV2`. Please see more at this [document](https://learn.microsoft.com/en-us/azure/media-services/latest/live-event-latency-reference#lowlatency-and-lowlatencyv2-options). 
 
 * `tags` - (Optional) A mapping of tags which should be assigned to the Live Event.
 

--- a/website/docs/r/media_live_event.html.markdown
+++ b/website/docs/r/media_live_event.html.markdown
@@ -68,7 +68,7 @@ resource "azurerm_media_live_event" "example" {
     }
   }
 
-  stream_options = ["LowLatency"]
+  stream_options          = ["LowLatency"]
   use_static_hostname     = true
   hostname_prefix         = "special-event"
   transcription_languages = ["en-US"]
@@ -103,7 +103,7 @@ The following arguments are supported:
 
 * `preview` - (Optional) A `preview` block as defined below.
 
-* `stream_options` - (Optional) A list of options to use for the LiveEvent. Possible values are `Default`, `LowLatency`, `LowLatencyV2`. Please see more at this [document](https://learn.microsoft.com/en-us/azure/media-services/latest/live-event-latency-reference#lowlatency-and-lowlatencyv2-options). 
+* `stream_options` - (Optional) A list of options to use for the LiveEvent. Possible values are `Default`, `LowLatency`, `LowLatencyV2`. Please see more at this [document](https://learn.microsoft.com/en-us/azure/media-services/latest/live-event-latency-reference#lowlatency-and-lowlatencyv2-options). Changing this forces a new resource to be created.
 
 * `tags` - (Optional) A mapping of tags which should be assigned to the Live Event.
 


### PR DESCRIPTION
Reference:
- [Live Event Low Latency HLS](https://learn.microsoft.com/en-us/azure/media-services/latest/live-event-concept#low-latency-hls-and-dash-streaming-options)
- [Swagger File](https://github.com/Azure/azure-rest-api-specs/blob/64fe6ca10ff6a40a8c0c5bc82eb34486c202fee7/specification/mediaservices/resource-manager/Microsoft.Media/Streaming/stable/2021-11-01/streamingservice.json#L1711-L1720)

Test:
```
TF_ACC=1 go test -v ./internal/services/media -parallel 20 -test.run=TestAccLiveEvent_ -timeout 1440m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccLiveEvent_basic
=== PAUSE TestAccLiveEvent_basic
=== RUN   TestAccLiveEvent_requiresImport
=== PAUSE TestAccLiveEvent_requiresImport
=== RUN   TestAccLiveEvent_update
=== PAUSE TestAccLiveEvent_update
=== RUN   TestAccLiveEvent_complete
=== PAUSE TestAccLiveEvent_complete
=== CONT  TestAccLiveEvent_basic
=== CONT  TestAccLiveEvent_complete
=== CONT  TestAccLiveEvent_update
=== CONT  TestAccLiveEvent_requiresImport
--- PASS: TestAccLiveEvent_requiresImport (241.78s)
--- PASS: TestAccLiveEvent_basic (297.77s)
--- PASS: TestAccLiveEvent_complete (305.26s)
--- PASS: TestAccLiveEvent_update (321.51s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/media 322.769s
```