### PR TITLE
`azurerm_media_live_event_output` - support for `rewind_window_duration` property

### DIFF
--- a/internal/services/media/media_live_output_resource_test.go
+++ b/internal/services/media/media_live_output_resource_test.go
@@ -144,6 +144,7 @@ resource "azurerm_media_live_event_output" "test" {
   manifest_name                = "testmanifest"
   output_snap_time_in_seconds  = 0
   hls_fragments_per_ts_segment = 5
+  rewind_window_duration       = "PT5M"
 }
 `, r.template(data))
 }

--- a/website/docs/r/media_live_output.html.markdown
+++ b/website/docs/r/media_live_output.html.markdown
@@ -96,7 +96,7 @@ The following arguments are supported:
 
 * `output_snap_time_in_seconds` - (Optional) The initial timestamp that the live output will start at, any content before this value will not be archived. Changing this forces a new Live Output to be created.
 
-* `rewind_windown_duration` - (Optional) `ISO 8601` time between 1 minute to the duration of archiveWindowLength to control seek-able window length during Live. The service won't use this property once LiveOutput stops. The archived VOD will have full content with original ArchiveWindowLength. For example, use `PT1H30M` to indicate 1 hour and 30 minutes of rewind window length. Service will use implicit default value 30m only if Live Event enables LL.
+* `rewind_windown_duration` - (Optional) `ISO 8601` time between 1 minute to the duration of `archive_window_duration` to control seek-able window length during Live. The service won't use this property once LiveOutput stops. The archived VOD will have full content with original ArchiveWindowLength. For example, use `PT1H30M` to indicate 1 hour and 30 minutes of rewind window length. Service will use implicit default value 30m only if Live Event enables LL. Changing this forces a new Live Output to be created.
 
 ## Attributes Reference
 

--- a/website/docs/r/media_live_output.html.markdown
+++ b/website/docs/r/media_live_output.html.markdown
@@ -70,6 +70,7 @@ resource "azurerm_media_live_event_output" "example" {
   manifest_name                = "testmanifest"
   output_snap_time_in_seconds  = 0
   hls_fragments_per_ts_segment = 5
+  rewind_window_duration       = "PT5M"
 }
 ```
 
@@ -94,6 +95,8 @@ The following arguments are supported:
 * `manifest_name` - (Optional) The manifest file name. If not provided, the service will generate one automatically. Changing this forces a new Live Output to be created.
 
 * `output_snap_time_in_seconds` - (Optional) The initial timestamp that the live output will start at, any content before this value will not be archived. Changing this forces a new Live Output to be created.
+
+* `rewind_windown_duration` - (Optional) `ISO 8601` time between 1 minute to the duration of archiveWindowLength to control seek-able window length during Live. The service won't use this property once LiveOutput stops. The archived VOD will have full content with original ArchiveWindowLength. For example, use `PT1H30M` to indicate 1 hour and 30 minutes of rewind window length. Service will use implicit default value 30m only if Live Event enables LL.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Reference:
- [Using rewindWindowLength](https://learn.microsoft.com/en-us/azure/media-services/latest/live-event-cloud-dvr-time-how-to#using-rewindwindowlength)
- [Swagger](https://github.com/Azure/azure-rest-api-specs/blob/02a19001f8bb179da6c73cd95750d37ac2cd474a/specification/mediaservices/resource-manager/Microsoft.Media/Streaming/stable/2022-08-01/streamingservice.json#L1490-L1494)

Test:
```
TF_ACC=1 go test -v ./internal/services/media -parallel 20 -test.run=TestAccLiveOutput_ -timeout 1440m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccLiveOutput_basic
=== PAUSE TestAccLiveOutput_basic
=== RUN   TestAccLiveOutput_requiresImport
=== PAUSE TestAccLiveOutput_requiresImport
=== RUN   TestAccLiveOutput_complete
=== PAUSE TestAccLiveOutput_complete
=== RUN   TestAccLiveOutput_update
=== PAUSE TestAccLiveOutput_update
=== CONT  TestAccLiveOutput_basic
=== CONT  TestAccLiveOutput_complete
=== CONT  TestAccLiveOutput_update
=== CONT  TestAccLiveOutput_requiresImport
--- PASS: TestAccLiveOutput_basic (279.46s)
--- PASS: TestAccLiveOutput_complete (281.52s)
--- PASS: TestAccLiveOutput_requiresImport (319.52s)
--- PASS: TestAccLiveOutput_update (400.61s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/media 402.257s

```