### PR TITLE
`azurerm_media_streaming_locator` - support for `filter_names` property

### DIFF
--- a/internal/services/media/media_streaming_locator_resource.go
+++ b/internal/services/media/media_streaming_locator_resource.go
@@ -151,6 +151,16 @@ func resourceMediaStreamingLocator() *pluginsdk.Resource {
 				ValidateFunc: validation.IsRFC3339Time,
 			},
 
+			"filter_names": {
+				Type:     pluginsdk.TypeList,
+				Optional: true,
+				ForceNew: true,
+				Elem: &pluginsdk.Schema{
+					Type:         pluginsdk.TypeString,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+			},
+
 			"start_time": {
 				Type:         pluginsdk.TypeString,
 				Optional:     true,
@@ -216,6 +226,10 @@ func resourceMediaStreamingLocatorCreate(d *pluginsdk.ResourceData, meta interfa
 			}
 			payload.Properties.SetEndTimeAsTime(endTime)
 		}
+	}
+
+	if filters, ok := d.GetOk("filter_names"); ok {
+		payload.Properties.Filters = utils.ExpandStringSlice(filters.([]interface{}))
 	}
 
 	if startTimeRaw, ok := d.GetOk("start_time"); ok {
@@ -287,6 +301,7 @@ func resourceMediaStreamingLocatorRead(d *pluginsdk.ResourceData, meta interface
 				endTime = t.Format(time.RFC3339)
 			}
 			d.Set("end_time", endTime)
+			d.Set("filter_names", utils.FlattenStringSlice(props.Filters))
 
 			startTime := ""
 			if props.StartTime != nil {

--- a/internal/services/media/media_streaming_locator_resource_test.go
+++ b/internal/services/media/media_streaming_locator_resource_test.go
@@ -141,6 +141,12 @@ func (r StreamingLocatorResource) complete(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
+resource "azurerm_media_services_account_filter" "test" {
+  name                        = "Filter-1"
+  resource_group_name         = azurerm_resource_group.test.name
+  media_services_account_name = azurerm_media_services_account.test.name
+}
+
 resource "azurerm_media_streaming_locator" "test" {
   name                        = "Job-1"
   resource_group_name         = azurerm_resource_group.test.name
@@ -151,6 +157,7 @@ resource "azurerm_media_streaming_locator" "test" {
   end_time                    = "2028-12-31T23:59:59Z"
   streaming_locator_id        = "90000000-0000-0000-0000-000000000000"
   alternative_media_id        = "my-Alternate-MediaID"
+  filter_names                = [azurerm_media_services_account_filter.test.name]
 }
 `, r.template(data))
 }

--- a/website/docs/r/media_streaming_locator.html.markdown
+++ b/website/docs/r/media_streaming_locator.html.markdown
@@ -84,7 +84,7 @@ The following arguments are supported:
 
 * `end_time` - (Optional) The end time of the Streaming Locator. Changing this forces a new Streaming Locator to be created.
 
-* `filter_names` - (Optional) A list of names of asset or account filters which apply to this Streaming Locator.
+* `filter_names` - (Optional) A list of names of asset or account filters which apply to this Streaming Locator. Changing this forces a new Streaming Locator to be created.
 
 * `start_time` - (Optional) The start time of the Streaming Locator. Changing this forces a new Streaming Locator to be created.
 

--- a/website/docs/r/media_streaming_locator.html.markdown
+++ b/website/docs/r/media_streaming_locator.html.markdown
@@ -37,6 +37,12 @@ resource "azurerm_media_services_account" "example" {
   }
 }
 
+resource "azurerm_media_services_account_filter" "example" {
+  name                        = "Filter1"
+  resource_group_name         = azurerm_resource_group.example.name
+  media_services_account_name = azurerm_media_services_account.example.name
+}
+
 resource "azurerm_media_asset" "example" {
   name                        = "Asset1"
   resource_group_name         = azurerm_resource_group.example.name
@@ -50,6 +56,7 @@ resource "azurerm_media_streaming_locator" "example" {
   media_services_account_name = azurerm_media_services_account.example.name
   asset_name                  = azurerm_media_asset.example.name
   streaming_policy_name       = "Predefined_ClearStreamingOnly"
+  filter_names                = [azurerm_media_services_account_filter.example.name]
 }
 ```
 
@@ -76,6 +83,8 @@ The following arguments are supported:
 * `default_content_key_policy_name` - (Optional) Name of the default Content Key Policy used by this Streaming Locator.Changing this forces a new Streaming Locator to be created.
 
 * `end_time` - (Optional) The end time of the Streaming Locator. Changing this forces a new Streaming Locator to be created.
+
+* `filter_names` - (Optional) A list of names of asset or account filters which apply to this Streaming Locator.
 
 * `start_time` - (Optional) The start time of the Streaming Locator. Changing this forces a new Streaming Locator to be created.
 


### PR DESCRIPTION
Reference:
- [Filter your HLS or DASH manifests on creation of Streaming Locator](https://learn.microsoft.com/en-us/azure/media-services/latest/filters-concept#filter-your-hls-or-dash-manifests-on-creation-of-streaming-locator)
- [Swagger File](https://github.com/Azure/azure-rest-api-specs/blob/5920340193de5e6cbfdc514218bd76a602c22b4b/specification/mediaservices/resource-manager/Microsoft.Media/Metadata/stable/2022-08-01/StreamingPoliciesAndStreamingLocators.json#L609-L615)

Test:
```
TF_ACC=1 go test -v ./internal/services/media -parallel 20 -test.run=TestAccStreamingLocator_ -timeout 1440m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccStreamingLocator_basic
=== PAUSE TestAccStreamingLocator_basic
=== RUN   TestAccStreamingLocator_requiresImport
=== PAUSE TestAccStreamingLocator_requiresImport
=== RUN   TestAccStreamingLocator_complete
=== PAUSE TestAccStreamingLocator_complete
=== RUN   TestAccStreamingLocator_update
=== PAUSE TestAccStreamingLocator_update
=== CONT  TestAccStreamingLocator_basic
=== CONT  TestAccStreamingLocator_complete
=== CONT  TestAccStreamingLocator_requiresImport
=== CONT  TestAccStreamingLocator_update
--- PASS: TestAccStreamingLocator_complete (269.66s)
--- PASS: TestAccStreamingLocator_basic (283.52s)
--- PASS: TestAccStreamingLocator_requiresImport (295.81s)
--- PASS: TestAccStreamingLocator_update (398.47s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/media 400.429s

```