### PR TITLE
`azurerm_storage_blob_inventory_policy` -  add `exclude_prefixes` to `filter` resource block

### DIFF
--- a/internal/services/storage/storage_blob_inventory_policy_resource.go
+++ b/internal/services/storage/storage_blob_inventory_policy_resource.go
@@ -153,6 +153,17 @@ func storageBlobInventoryPolicyResourceSchema() map[string]*pluginsdk.Schema {
 								"prefix_match": {
 									Type:     pluginsdk.TypeSet,
 									Optional: true,
+									MaxItems: 10,
+									Elem: &pluginsdk.Schema{
+										Type:         pluginsdk.TypeString,
+										ValidateFunc: validation.StringIsNotEmpty,
+									},
+								},
+
+								"exclude_prefixes": {
+									Type:     pluginsdk.TypeSet,
+									Optional: true,
+									MaxItems: 10,
 									Elem: &pluginsdk.Schema{
 										Type:         pluginsdk.TypeString,
 										ValidateFunc: validation.StringIsNotEmpty,
@@ -287,6 +298,7 @@ func expandBlobInventoryPolicyFilter(input []interface{}) *storage.BlobInventory
 	v := input[0].(map[string]interface{})
 	return &storage.BlobInventoryPolicyFilter{
 		PrefixMatch:         utils.ExpandStringSlice(v["prefix_match"].(*pluginsdk.Set).List()),
+		ExcludePrefix:       utils.ExpandStringSlice(v["exclude_prefixes"].(*pluginsdk.Set).List()),
 		BlobTypes:           utils.ExpandStringSlice(v["blob_types"].(*pluginsdk.Set).List()),
 		IncludeBlobVersions: utils.Bool(v["include_blob_versions"].(bool)),
 		IncludeDeleted:      utils.Bool(v["include_deleted"].(bool)),
@@ -352,6 +364,7 @@ func flattenBlobInventoryPolicyFilter(input *storage.BlobInventoryPolicyFilter) 
 			"include_deleted":       includeDeleted,
 			"include_snapshots":     includeSnapshots,
 			"prefix_match":          utils.FlattenStringSlice(input.PrefixMatch),
+			"exclude_prefixes":      utils.FlattenStringSlice(input.ExcludePrefix),
 		},
 	}
 }

--- a/internal/services/storage/storage_blob_inventory_policy_resource_test.go
+++ b/internal/services/storage/storage_blob_inventory_policy_resource_test.go
@@ -219,7 +219,7 @@ resource "azurerm_storage_blob_inventory_policy" "test" {
       include_deleted       = true
       include_snapshots     = true
       prefix_match          = ["*/test"]
-	  exclude_prefixes      = ["syslog.log"]
+      exclude_prefixes      = ["syslog.log"]
     }
   }
 }
@@ -255,7 +255,7 @@ resource "azurerm_storage_blob_inventory_policy" "test" {
       include_blob_versions = true
       include_deleted       = true
       include_snapshots     = true
-      prefix_match          = ["*/test"]	  
+      prefix_match          = ["*/test"]
     }
   }
 

--- a/internal/services/storage/storage_blob_inventory_policy_resource_test.go
+++ b/internal/services/storage/storage_blob_inventory_policy_resource_test.go
@@ -219,6 +219,7 @@ resource "azurerm_storage_blob_inventory_policy" "test" {
       include_deleted       = true
       include_snapshots     = true
       prefix_match          = ["*/test"]
+	  exclude_prefixes      = ["syslog.log"]
     }
   }
 }
@@ -254,7 +255,7 @@ resource "azurerm_storage_blob_inventory_policy" "test" {
       include_blob_versions = true
       include_deleted       = true
       include_snapshots     = true
-      prefix_match          = ["*/test"]
+      prefix_match          = ["*/test"]	  
     }
   }
 

--- a/website/docs/r/storage_blob_inventory_policy.html.markdown
+++ b/website/docs/r/storage_blob_inventory_policy.html.markdown
@@ -85,7 +85,9 @@ A `filter` block supports the following:
 
 ~> **NOTE**: The `rules.*.schema_fields` for this rule has to include `Snapshot` so that you can specify the `include_snapshots`.
 
-* `prefix_match` - (Optional) A set of strings for blob prefixes to be matched.
+* `prefix_match` - (Optional) A set of strings for blob prefixes to be matched. Maximum of 10 blob prefixes.
+
+* `exclude_prefixes` - (Optional) A set of strings for blob prefixes to be excluded. Maximum of 10 blob prefixes.
 
 ---
 


### PR DESCRIPTION
Fixes [20276](https://github.com/hashicorp/terraform-provider-azurerm/issues/20276). 

In addition to it, adding API level check of maximum 10 strings to `prefix_match` filter. API reference [here](https://learn.microsoft.com/en-us/rest/api/storagerp/blob-inventory-policies/create-or-update?tabs=HTTP#blobinventorypolicyfilter)