### PR TITLE
d/monitor_data_collection_rule: raising an error when the specified d…

### DIFF
--- a/internal/services/monitor/monitor_data_collection_rule_data_source.go
+++ b/internal/services/monitor/monitor_data_collection_rule_data_source.go
@@ -267,8 +267,7 @@ func (d DataCollectionRuleDataSource) Read() sdk.ResourceFunc {
 			resp, err := client.Get(ctx, id)
 			if err != nil {
 				if response.WasNotFound(resp.HttpResponse) {
-					metadata.Logger.Infof("%s was not found - removing from state!", id)
-					return metadata.MarkAsGone(id)
+					return fmt.Errorf("%s was not found", id)
 				}
 				return fmt.Errorf("retrieving %s: %+v", id, err)
 			}


### PR DESCRIPTION
…ata collection rule can't be found

Data Sources should be returning an error rather than marking the resource as "gone" (which in Resources means that the tracked resource has been deleted)