### PR TITLE
`azurerm_active_directory_domain_service` - `domain_name` validation fix

### DIFF
--- a/internal/services/domainservices/active_directory_domain_service_resource.go
+++ b/internal/services/domainservices/active_directory_domain_service_resource.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"regexp"
 	"strings"
 	"time"
 
@@ -18,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/domainservices/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/domainservices/validate"
 	networkValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
@@ -59,13 +59,10 @@ func resourceActiveDirectoryDomainService() *pluginsdk.Resource {
 			"resource_group_name": commonschema.ResourceGroupName(),
 
 			"domain_name": {
-				Type:     pluginsdk.TypeString,
-				Required: true,
-				ForceNew: true,
-				ValidateFunc: validation.StringMatch(
-					regexp.MustCompile("^[0-9a-zA-Z][0-9a-zA-Z-]{1,13}[0-9a-zA-Z](.[0-9a-zA-Z-]+)+$"),
-					"domain_name must be a valid FQDN and the first element must be 15 or fewer characters",
-				),
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.DomainServiceName,
 			},
 
 			"initial_replica_set": {

--- a/internal/services/domainservices/validate/domain_service_name.go
+++ b/internal/services/domainservices/validate/domain_service_name.go
@@ -1,0 +1,21 @@
+package validate
+
+import (
+	"fmt"
+	"regexp"
+)
+
+func DomainServiceName(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	p := regexp.MustCompile(`^(([0-9a-zA-Z])|(([0-9a-zA-Z][0-9a-zA-Z-]{0,13}[0-9a-zA-Z])))(\.[0-9a-zA-Z-]+)+$`)
+	if !p.MatchString(v) {
+		errors = append(errors, fmt.Errorf("domain_name must be a valid FQDN and the first element must be 15 or fewer characters"))
+	}
+
+	return
+}

--- a/internal/services/domainservices/validate/domain_service_name_test.go
+++ b/internal/services/domainservices/validate/domain_service_name_test.go
@@ -1,0 +1,101 @@
+package validate
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDomainServiceName(t *testing.T) {
+	cases := []struct {
+		Input string
+		Valid bool
+	}{
+
+		{
+			// empty
+			Input: "",
+			Valid: false,
+		},
+
+		{
+			// one length subdomain of invalid char
+			Input: "-.com",
+			Valid: false,
+		},
+
+		{
+			// two length subdomain of invalid char (prefix)
+			Input: "-a.com",
+			Valid: false,
+		},
+
+		{
+			// two length subdomain of invalid char (suffix)
+			Input: "a-.com",
+			Valid: false,
+		},
+
+		{
+			// subdomain longer than 15
+			Input: strings.Repeat("a", 16) + ".com",
+			Valid: false,
+		},
+
+		{
+			// three length subdomain
+			Input: "aaa.com",
+			Valid: true,
+		},
+
+		{
+			// three length subdomain with dash
+			Input: "a-a.com",
+			Valid: true,
+		},
+
+		{
+			// wide length subdomain
+			Input: strings.Repeat("a", 15) + ".com",
+			Valid: true,
+		},
+
+		{
+			// one length subdomain
+			Input: "a.com",
+			Valid: true,
+		},
+
+		{
+			// two length subdomain
+			Input: "aa.com",
+			Valid: true,
+		},
+
+		{
+			// three length subdomain
+			Input: "aaa.com",
+			Valid: true,
+		},
+
+		{
+			// three length subdomain with dash
+			Input: "a-a.com",
+			Valid: true,
+		},
+
+		{
+			// wide length subdomain
+			Input: strings.Repeat("a", 14) + ".com",
+			Valid: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Logf("[DEBUG] Testing Value %s", tc.Input)
+		_, errors := DomainServiceName(tc.Input, "test")
+		valid := len(errors) == 0
+
+		if tc.Valid != valid {
+			t.Fatalf("Expected %t but got %t", tc.Valid, valid)
+		}
+	}
+}


### PR DESCRIPTION
There are two issues in the previous regexp:

1. Length of the first subdomain must be equal or greater than 3
2. The separator `.` is not escaped, which ends up to be a wildcard

Fix #20259