### PR TITLE
Handle `starting` power state in VM and disk

### DIFF
--- a/internal/services/compute/linux_virtual_machine_resource.go
+++ b/internal/services/compute/linux_virtual_machine_resource.go
@@ -1326,6 +1326,17 @@ func resourceLinuxVirtualMachineUpdate(d *pluginsdk.ResourceData, meta interface
 			case "stopped":
 				// VM already stopped, no shutdown needed anymore
 				shouldShutDown = false
+			case "starting":
+				// send a duplicate start command to ensure Virtual Machine is not in transitioning state which doesn't accept further command
+				log.Printf("[DEBUG] Starting %q", id)
+				future, err := client.Start(ctx, id.ResourceGroup, id.Name)
+				if err != nil {
+					return fmt.Errorf("sending Start to %q: %+v", id, err)
+				}
+
+				if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
+					return fmt.Errorf("waiting for Start of %q: %+v", id, err)
+				}
 			}
 		}
 	}

--- a/internal/services/compute/managed_disk_resource.go
+++ b/internal/services/compute/managed_disk_resource.go
@@ -839,6 +839,17 @@ func resourceManagedDiskUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 					shouldShutDown = false
 				case "stopped":
 					shouldShutDown = false
+				case "starting":
+					// send a duplicate start command to ensure Virtual Machine is not in transitioning state which doesn't accept further command
+					log.Printf("[DEBUG] Starting %q", virtualMachine)
+					future, err := vmClient.Start(ctx, virtualMachine.ResourceGroup, virtualMachine.Name)
+					if err != nil {
+						return fmt.Errorf("sending Start to %q: %+v", virtualMachine, err)
+					}
+
+					if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
+						return fmt.Errorf("waiting for Start of %q: %+v", virtualMachine, err)
+					}
 				}
 			}
 		}

--- a/internal/services/compute/virtual_machine_instance.go
+++ b/internal/services/compute/virtual_machine_instance.go
@@ -26,6 +26,8 @@ func virtualMachineShouldBeStarted(instanceView compute.VirtualMachineInstanceVi
 			state = strings.TrimPrefix(state, "powerstate/")
 			if strings.EqualFold(state, "running") {
 				return true
+			} else if strings.EqualFold(state, "starting") {
+				return true
 			}
 		}
 	}

--- a/internal/services/compute/virtual_machine_instance_test.go
+++ b/internal/services/compute/virtual_machine_instance_test.go
@@ -41,6 +41,11 @@ func TestVirtualMachineShouldBeStarted(t *testing.T) {
 			Expected: true,
 		},
 		{
+			Name:     "Starting",
+			Input:    buildInstanceViewStatus("ProvisioningStatus/succeeded", "PowerState/starting"),
+			Expected: true,
+		},
+		{
 			Name:     "Deallocated",
 			Input:    buildInstanceViewStatus("ProvisioningStatus/succeeded", "PowerState/deallocated"),
 			Expected: false,

--- a/internal/services/compute/windows_virtual_machine_resource.go
+++ b/internal/services/compute/windows_virtual_machine_resource.go
@@ -1370,6 +1370,7 @@ func resourceWindowsVirtualMachineUpdate(d *pluginsdk.ResourceData, meta interfa
 		update.UserData = utils.String(d.Get("user_data").(string))
 	}
 
+	timeout, _ := ctx.Deadline()
 	if instanceView.Statuses != nil {
 		for _, status := range *instanceView.Statuses {
 			if status.Code == nil {
@@ -1397,15 +1398,15 @@ func resourceWindowsVirtualMachineUpdate(d *pluginsdk.ResourceData, meta interfa
 				// VM already stopped, no shutdown needed anymore
 				shouldShutDown = false
 			case "starting":
-				// send a duplicate start command to ensure Virtual Machine is not in transitioning state which doesn't accept further command
-				log.Printf("[DEBUG] Starting %q", id)
-				future, err := client.Start(ctx, id.ResourceGroup, id.Name)
-				if err != nil {
-					return fmt.Errorf("sending Start to %q: %+v", id, err)
+				stateConf := &pluginsdk.StateChangeConf{
+					Pending:    []string{"starting"},
+					Target:     []string{"running"},
+					Refresh:    virtualMachinePowerStateRefreshFunc(ctx, client, *id),
+					MinTimeout: 10 * time.Second,
+					Timeout:    time.Until(timeout),
 				}
-
-				if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
-					return fmt.Errorf("waiting for Start of %q: %+v", id, err)
+				if _, err = stateConf.WaitForStateContext(ctx); err != nil {
+					return fmt.Errorf("waiting for power state to becoming running %s: %+v", id, err)
 				}
 			}
 		}

--- a/internal/services/compute/windows_virtual_machine_resource.go
+++ b/internal/services/compute/windows_virtual_machine_resource.go
@@ -1396,6 +1396,17 @@ func resourceWindowsVirtualMachineUpdate(d *pluginsdk.ResourceData, meta interfa
 			case "stopped":
 				// VM already stopped, no shutdown needed anymore
 				shouldShutDown = false
+			case "starting":
+				// send a duplicate start command to ensure Virtual Machine is not in transitioning state which doesn't accept further command
+				log.Printf("[DEBUG] Starting %q", id)
+				future, err := client.Start(ctx, id.ResourceGroup, id.Name)
+				if err != nil {
+					return fmt.Errorf("sending Start to %q: %+v", id, err)
+				}
+
+				if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
+					return fmt.Errorf("waiting for Start of %q: %+v", id, err)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
power state `starting` was not handled in VM and disk resource. Adding the missing power state