### PR TITLE
azurerm_postgresql_flexible_server - Add support for SameZone HA mode

### DIFF
--- a/internal/services/postgres/postgresql_flexible_server_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_resource.go
@@ -229,6 +229,7 @@ func resourcePostgresqlFlexibleServer() *pluginsdk.Resource {
 							Required: true,
 							ValidateFunc: validation.StringInSlice([]string{
 								string(servers.HighAvailabilityModeZoneRedundant),
+								string(servers.HighAvailabilityModeSameZone)
 							}, false),
 						},
 

--- a/internal/services/postgres/postgresql_flexible_server_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_resource.go
@@ -229,7 +229,7 @@ func resourcePostgresqlFlexibleServer() *pluginsdk.Resource {
 							Required: true,
 							ValidateFunc: validation.StringInSlice([]string{
 								string(servers.HighAvailabilityModeZoneRedundant),
-								string(servers.HighAvailabilityModeSameZone)
+								string(servers.HighAvailabilityModeSameZone),
 							}, false),
 						},
 

--- a/website/docs/r/postgresql_flexible_server.html.markdown
+++ b/website/docs/r/postgresql_flexible_server.html.markdown
@@ -180,7 +180,7 @@ A `maintenance_window` block supports the following:
 
 A `high_availability` block supports the following:
 
-* `mode` - (Required) The high availability mode for the PostgreSQL Flexible Server. The only possible value is `ZoneRedundant`.
+* `mode` - (Required) The high availability mode for the PostgreSQL Flexible Server. Possible value are `SameZone` or `ZoneRedundant`.
 
 * `standby_availability_zone` - (Optional) Specifies the Availability Zone in which the standby Flexible Server should be located.
 


### PR DESCRIPTION
According to Microsoft documentation, ZoneRedundant high-availability mode is blocked in some Azure regions (for new deployment).

To still have the ability to create PostgreSQL flexible servers in a high-availability configuration (without using AZ), this PR add the `SameZone` option in the allowed list.

PostgreSQL flexible servers API 2022-12-01 support this mode.

Reference: #17593