### PR TITLE
Fix wrong replacement for azurerm_app_service in 3.0 upgrade guide

### DIFF
--- a/website/docs/guides/3.0-upgrade-guide.html.markdown
+++ b/website/docs/guides/3.0-upgrade-guide.html.markdown
@@ -216,7 +216,7 @@ Below we'll cover each of the Data Sources and Resources which will be affected 
 
 ### Data Source: `azurerm_app_service`
 
-The `azurerm_app_service` data source has been superseded by the `azurerm_linux_function_app` and `azurerm_windows_web_app` data sources. Whilst this resource will continue to be available in the 2.x and 3.x releases it is feature-frozen for compatibility purposes, will no longer receive any updates and will be removed in a future major release of the Azure Provider.
+The `azurerm_app_service` data source has been superseded by the `azurerm_linux_web_app` and `azurerm_windows_web_app` data sources. Whilst this resource will continue to be available in the 2.x and 3.x releases it is feature-frozen for compatibility purposes, will no longer receive any updates and will be removed in a future major release of the Azure Provider.
 
 ### Data Source: `azurerm_app_service_plan`
 


### PR DESCRIPTION
Fix the Data Source `azurerm_app_service` to show the correct replacement. 
https://discuss.hashicorp.com/t/error-in-azurerm-3-0-upgrade-guide/49351

----

In the 3.0 upgrade guide of azurerm there is an error in the data source of `azurerm_app_service`.
https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/3.0-upgrade-guide#data-source-azurerm_app_service
The info says that `azurerm_app_service` is superseded by `azurerm_linux_function_app` and `azurerm_windows_web_app`, but `azurerm_linux_function_app` should have been `azurerm_linux_web_app`.
Do I need to only warn people here, or should I also make a ticket on github?