### PR TITLE
`azurerm_windows_web_app`,`azurerm_windows_web_app_slot`, `azurerm_windows_function_app`, `azurerm_windows_function_app_slot`, `azurerm_linux_web_app`,`azurerm_linux_web_app_slot`, `azurerm_linux_function_app`, `azurerm_linux_function_app_slot` - fix `ip_restriction` block cannot be removed issue

### DIFF
--- a/website/docs/r/linux_function_app.html.markdown
+++ b/website/docs/r/linux_function_app.html.markdown
@@ -338,6 +338,8 @@ An `ip_restriction` block supports the following:
 
 ~> **NOTE:** One and only one of `ip_address`, `service_tag` or `virtual_network_subnet_id` must be specified.
 
+~> **NOTE:** The default value set for `ip_restriction` that allowing all ip addresses will be added with the lowest priority 2147483647 if the block isn't specified by users.
+
 ---
 
 A `microsoft` block supports the following:

--- a/website/docs/r/linux_function_app_slot.html.markdown
+++ b/website/docs/r/linux_function_app_slot.html.markdown
@@ -464,6 +464,8 @@ An `ip_restriction` block supports the following:
 
 ~> **NOTE:** One and only one of `ip_address`, `service_tag` or `virtual_network_subnet_id` must be specified.
 
+~> **NOTE:** The default value set for `ip_restriction` that allowing all ip addresses will be added with the lowest priority 2147483647 if the block isn't specified by users.
+
 ---
 
 A `scm_ip_restriction` block supports the following:

--- a/website/docs/r/linux_web_app.html.markdown
+++ b/website/docs/r/linux_web_app.html.markdown
@@ -355,6 +355,8 @@ An `ip_restriction` block supports the following:
 
 ~> **NOTE:** One and only one of `ip_address`, `service_tag` or `virtual_network_subnet_id` must be specified.
 
+~> **NOTE:** The default value set for `ip_restriction` that allowing all ip addresses will be added with the lowest priority 2147483647 if the block isn't specified by users.
+
 ---
 
 A `logs` block supports the following:

--- a/website/docs/r/linux_web_app_slot.html.markdown
+++ b/website/docs/r/linux_web_app_slot.html.markdown
@@ -358,6 +358,8 @@ An `ip_restriction` block supports the following:
 
 ~> **NOTE:** One and only one of `ip_address`, `service_tag` or `virtual_network_subnet_id` must be specified.
 
+~> **NOTE:** The default value set for `ip_restriction` that allowing all ip addresses will be added with the lowest priority 2147483647 if the block isn't specified by users.
+
 ---
 
 A `logs` block supports the following:

--- a/website/docs/r/windows_function_app.html.markdown
+++ b/website/docs/r/windows_function_app.html.markdown
@@ -318,6 +318,8 @@ An `ip_restriction` block supports the following:
 
 ~> **NOTE:** One and only one of `ip_address`, `service_tag` or `virtual_network_subnet_id` must be specified.
 
+~> **NOTE:** The default value set for `ip_restriction` that allowing all ip addresses will be added with the lowest priority 2147483647 if the block isn't specified by users.
+
 ---
 
 A `microsoft` block supports the following:

--- a/website/docs/r/windows_function_app_slot.html.markdown
+++ b/website/docs/r/windows_function_app_slot.html.markdown
@@ -423,6 +423,8 @@ An `ip_restriction` block supports the following:
 
 ~> **NOTE:** One and only one of `ip_address`, `service_tag` or `virtual_network_subnet_id` must be specified.
 
+~> **NOTE:** The default value set for `ip_restriction` that allowing all ip addresses will be added with the lowest priority 2147483647 if the block isn't specified by users.
+
 ---
 
 A `scm_ip_restriction` block supports the following:

--- a/website/docs/r/windows_web_app.html.markdown
+++ b/website/docs/r/windows_web_app.html.markdown
@@ -374,6 +374,8 @@ A `ip_restriction` block supports the following:
 
 ~> **NOTE:** One and only one of `ip_address`, `service_tag` or `virtual_network_subnet_id` must be specified.
 
+~> **NOTE:** The default value set for `ip_restriction` that allowing all ip addresses will be added with the lowest priority 2147483647 if the block isn't specified by users.
+
 ---
 
 A `logs` block supports the following:

--- a/website/docs/r/windows_web_app_slot.html.markdown
+++ b/website/docs/r/windows_web_app_slot.html.markdown
@@ -372,6 +372,8 @@ A `ip_restriction` block supports the following:
 
 ~> **NOTE:** One and only one of `ip_address`, `service_tag` or `virtual_network_subnet_id` must be specified.
 
+~> **NOTE:** The default value set for `ip_restriction` that allowing all ip addresses will be added with the lowest priority 2147483647 if the block isn't specified by users.
+
 ---
 
 A `logs` block supports the following:


### PR DESCRIPTION
fix https://github.com/hashicorp/terraform-provider-azurerm/issues/18793

There is a default value for `ip_restriction`, we need to deal with it when user removes the block, otherwise, the set value cannot be override by null.

