### PR TITLE
`azurerm_kubernetes_cluster_node_pool`: Allow multiple subnets within pool vnet (test + docs)

### DIFF
--- a/website/docs/r/kubernetes_cluster_node_pool.html.markdown
+++ b/website/docs/r/kubernetes_cluster_node_pool.html.markdown
@@ -150,8 +150,6 @@ The following arguments are supported:
 
 * `vnet_subnet_id` - (Optional) The ID of the Subnet where this Node Pool should exist. Changing this forces a new resource to be created.
 
--> **NOTE:** At this time the `vnet_subnet_id` must be the same for all node pools in the cluster
-
 ~> **NOTE:** A route table must be configured on this Subnet.
 
 * `windows_profile` - (Optional) A `windows_profile` block as documented below. Changing this forces a new resource to be created.


### PR DESCRIPTION
Fixes #20330

```bash
❯ go install && make acctests SERVICE='containers' TESTARGS='-run=TestAccKubernetesClusterNodePool_virtualNetworkMultipleSubnet'

==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/containers -run=TestAccKubernetesClusterNodePool_virtualNetworkMultipleSubnet -timeout 180m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccKubernetesClusterNodePool_virtualNetworkMultipleSubnet
=== PAUSE TestAccKubernetesClusterNodePool_virtualNetworkMultipleSubnet
=== CONT  TestAccKubernetesClusterNodePool_virtualNetworkMultipleSubnet
--- PASS: TestAccKubernetesClusterNodePool_virtualNetworkMultipleSubnet (1076.92s)
PASS
```