### PR TITLE
`azurerm_databricks_access_connector` : the `identity ` property should be optional rather than required

### DIFF
--- a/internal/services/databricks/databricks_access_connector_resource.go
+++ b/internal/services/databricks/databricks_access_connector_resource.go
@@ -42,7 +42,7 @@ func (r AccessConnectorResource) Arguments() map[string]*pluginsdk.Schema {
 
 		"resource_group_name": commonschema.ResourceGroupName(),
 
-		"identity": commonschema.SystemAssignedIdentityRequired(),
+		"identity": commonschema.SystemAssignedIdentityOptional(),
 
 		"tags": commonschema.Tags(),
 	}

--- a/internal/services/databricks/databricks_access_connector_resource_test.go
+++ b/internal/services/databricks/databricks_access_connector_resource_test.go
@@ -30,6 +30,21 @@ func TestAccDatabricksAccessConnector_basic(t *testing.T) {
 	})
 }
 
+func TestAccDatabricksAccessConnector_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_databricks_access_connector", "test")
+	r := DatabricksAccessConnectorResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccDatabricksAccessConnector_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_databricks_access_connector", "test")
 	r := DatabricksAccessConnectorResource{}
@@ -57,6 +72,28 @@ func (DatabricksAccessConnectorResource) Exists(ctx context.Context, clients *cl
 	}
 
 	return utils.Bool(resp.Model != nil), nil
+}
+
+func (DatabricksAccessConnectorResource) complete(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-databricks-%d"
+  location = "%s"
+}
+
+resource "azurerm_databricks_access_connector" "test" {
+  name                = "acctestDBAC%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  identity {
+    type = "SystemAssigned"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
 
 func (DatabricksAccessConnectorResource) basic(data acceptance.TestData) string {

--- a/internal/services/databricks/databricks_access_connector_resource_test.go
+++ b/internal/services/databricks/databricks_access_connector_resource_test.go
@@ -87,9 +87,6 @@ resource "azurerm_databricks_access_connector" "import" {
   name                = azurerm_databricks_access_connector.test.name
   resource_group_name = azurerm_databricks_access_connector.test.resource_group_name
   location            = azurerm_databricks_access_connector.test.location
-  identity {
-    type = "SystemAssigned"
-  }
 }
 `, template)
 }

--- a/internal/services/databricks/databricks_access_connector_resource_test.go
+++ b/internal/services/databricks/databricks_access_connector_resource_test.go
@@ -74,9 +74,6 @@ resource "azurerm_databricks_access_connector" "test" {
   name                = "acctestDBAC%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  identity {
-    type = "SystemAssigned"
-  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/website/docs/r/databricks_access_connector.html.markdown
+++ b/website/docs/r/databricks_access_connector.html.markdown
@@ -43,30 +43,33 @@ The following arguments are supported:
 
 * `location` - (Required) Specifies the supported Azure location where the resource has to be created. Changing this forces a new resource to be created.
 
-* `identity` - (Required) An `identity` block as defined below.
+* `identity` - (Optional) An `identity` block as defined below.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ---
 
 An `identity` block supports the following:
+
 * `type` - (Required) The type of identity to use for this Access Connector. `SystemAssigned` is the only possible value.
-* `principal_id` - (Optional) The object id of an existing principal. If not specified, a new system-assigned managed identity is created.
-* `tenant_id` - (Optional) The tenant id in which the principal resides.
 
 ## Attributes Reference
 
 The following attributes are exported:
 
 * `id` - The ID of the Databricks Access Connector in the Azure management plane.
+
 * `identity` - A list of `identity` blocks containing the system-assigned managed identities as defined below.
 
 ---
 
 An `identity` block exports the following:
-* `type` - (Required) The type of identity.
-* `principal_id` - The Principal Id associated with this system-assigned managed identity.
-* `tenant_id` - The Tenant Id associated with this system-assigned managed identity.
+
+* `type` - The type of identity.
+
+* `principal_id` - The Principal ID associated with this system-assigned managed identity.
+
+* `tenant_id` - The Tenant ID associated with this system-assigned managed identity.
 
 ## Timeouts
 


### PR DESCRIPTION
- After checking the API, the `identity` of `azurerm_databricks_access_connector` should be optional rather than required.
- Doc Fix: Removing the read-only properties `principal_id ` and `tenant_id ` of identity.


Fix #20308 .