### PR TITLE
`azurerm_service_fabric_managed_cluster` - Fix potential panic when setting `node_type`

### DIFF
--- a/internal/services/servicefabricmanaged/service_fabric_managed_cluster_resource.go
+++ b/internal/services/servicefabricmanaged/service_fabric_managed_cluster_resource.go
@@ -768,9 +768,15 @@ func flattenNodetypeProperties(nt nodetype.NodeType) NodeType {
 		VmImageVersion:   utils.NormalizeNilableString(props.VMImageVersion),
 		VmInstanceCount:  props.VMInstanceCount,
 		VmSize:           utils.NormalizeNilableString(props.VMSize),
-		ApplicationPorts: fmt.Sprintf("%d-%d", props.ApplicationPorts.StartPort, props.ApplicationPorts.EndPort),
-		EphemeralPorts:   fmt.Sprintf("%d-%d", props.EphemeralPorts.StartPort, props.EphemeralPorts.EndPort),
 		Id:               utils.NormalizeNilableString(nt.Id),
+	}
+
+	if appPorts := props.ApplicationPorts; appPorts != nil {
+		out.ApplicationPorts = fmt.Sprintf("%d-%d", appPorts.StartPort, appPorts.EndPort)
+	}
+
+	if ephemeralPorts := props.EphemeralPorts; ephemeralPorts != nil {
+		out.EphemeralPorts = fmt.Sprintf("%d-%d", ephemeralPorts.StartPort, ephemeralPorts.EndPort)
 	}
 
 	if mpg := props.MultiplePlacementGroups; mpg != nil {


### PR DESCRIPTION
Issue is reported at: https://github.com/Azure/aztfy/issues/352, where the provider panics on reading a `azurerm_service_fabric_managed_cluster` during import.

This PR is a intuitive change, which means I'm not able to reproduce the issue...