### PR TITLE
Fix api_management_custom_domain timeout length that was too short

### DIFF
--- a/internal/services/apimanagement/api_management_custom_domain_resource.go
+++ b/internal/services/apimanagement/api_management_custom_domain_resource.go
@@ -32,10 +32,10 @@ func resourceApiManagementCustomDomain() *pluginsdk.Resource {
 		}),
 
 		Timeouts: &pluginsdk.ResourceTimeout{
-			Create: pluginsdk.DefaultTimeout(45 * time.Minute),
+			Create: pluginsdk.DefaultTimeout(60 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
-			Update: pluginsdk.DefaultTimeout(45 * time.Minute),
-			Delete: pluginsdk.DefaultTimeout(45 * time.Minute),
+			Update: pluginsdk.DefaultTimeout(60 * time.Minute),
+			Delete: pluginsdk.DefaultTimeout(60 * time.Minute),
 		},
 
 		Schema: map[string]*pluginsdk.Schema{

--- a/website/docs/r/api_management_custom_domain.html.markdown
+++ b/website/docs/r/api_management_custom_domain.html.markdown
@@ -176,10 +176,10 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `create` - (Defaults to 45 minutes) Used when creating the API Management Custom Domain.
+* `create` - (Defaults to 60 minutes) Used when creating the API Management Custom Domain.
 * `read` - (Defaults to 5 minutes) Used when retrieving the API Management Custom Domain.
-* `update` - (Defaults to 45 minutes) Used when updating the API Management Custom Domain.
-* `delete` - (Defaults to 45 minutes) Used when deleting the API Management Custom Domain.
+* `update` - (Defaults to 60 minutes) Used when updating the API Management Custom Domain.
+* `delete` - (Defaults to 60 minutes) Used when deleting the API Management Custom Domain.
 
 ## Import
 


### PR DESCRIPTION
Extended the timeout from 45 min to 60 min as it wasn't always able to finish within the 45 minutes. 

Fixes #20347 