### PR TITLE
`azurerm_monitor_data_collection_rule` - fix `counter_specifiers` doc

### DIFF
--- a/website/docs/r/monitor_data_collection_rule.html.markdown
+++ b/website/docs/r/monitor_data_collection_rule.html.markdown
@@ -190,7 +190,7 @@ A `log_analytics` block supports the following:
 
 A `performance_counter` block supports the following:
 
-* `counter_specifiers` - (Required) Specifies a list of specifier names of the performance counters you want to collect. Use a wildcard `*` to collect counters for all instances. To get a list of performance counters on Windows, run the command `typeperf`.
+* `counter_specifiers` - (Required) Specifies a list of specifier names of the performance counters you want to collect. To get a list of performance counters on Windows, run the command `typeperf`. Please see [this document](https://learn.microsoft.com/en-us/azure/azure-monitor/agents/data-sources-performance-counters#configure-performance-counters) for more information.
 
 * `name` - (Required) The name which should be used for this data source. This name should be unique across all data sources regardless of type within the Data Collection Rule.
 


### PR DESCRIPTION
resolves https://github.com/hashicorp/terraform-provider-azurerm/issues/20258
delete the sentence `Use a wildcard * to collect counters for all instances`, since it is confusing.