### PR TITLE
fixes #20351 - Update length to 64 for databricks_access_controller_name

### DIFF
--- a/internal/services/databricks/validate/access_connector_name.go
+++ b/internal/services/databricks/validate/access_connector_name.go
@@ -26,9 +26,9 @@ func AccessConnectorName(i interface{}, k string) (warnings []string, errors []e
 		errors = append(errors, fmt.Errorf("%q must be at least 1 character: %q", k, v))
 	}
 
-	// 3) The value must have a length of at most 30
-	if len(v) > 30 {
-		errors = append(errors, fmt.Errorf("%q must be no more than 30 characters: %q", k, v))
+	// 3) The value must have a length of at most 64
+	if len(v) > 64 {
+		errors = append(errors, fmt.Errorf("%q must be no more than 64 characters: %q", k, v))
 	}
 
 	// 4) Only alphanumeric characters, underscores, and hyphens are allowed.

--- a/internal/services/databricks/validate/access_connector_name_test.go
+++ b/internal/services/databricks/validate/access_connector_name_test.go
@@ -26,7 +26,7 @@ func TestAccessConnectorName(t *testing.T) {
 		},
 		{
 			Name:  "Maximum character length",
-			Input: "012345678901234567890123456789", // 30 chars
+			Input: "0123456789012345678901234567890123456789012345678901234567890123", // 64 chars
 		},
 
 		// Simple negative cases:
@@ -37,7 +37,7 @@ func TestAccessConnectorName(t *testing.T) {
 		},
 		{
 			Name:           "Above maximum character length",
-			Input:          "01234567890123456789012345678901", // 31 chars
+			Input:          "01234567890123456789012345678901234567890123456789012345678901234", // 65 chars
 			ExpectedErrors: []string{errMaxLen},
 		},
 		{

--- a/internal/services/databricks/validate/access_connector_name_test.go
+++ b/internal/services/databricks/validate/access_connector_name_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestAccessConnectorName(t *testing.T) {
 	const errEmpty = "cannot be an empty string"
-	const errMaxLen = "must be no more than 30 characters"
+	const errMaxLen = "must be no more than 64 characters"
 	const errAllowList = "can contain only alphanumeric characters, underscores, and hyphens"
 
 	cases := []struct {


### PR DESCRIPTION
Fixes #20351 