### PR TITLE
`azurerm_express_route_port` - support for the `billing_type` property

### DIFF
--- a/internal/services/network/express_route_port_resource.go
+++ b/internal/services/network/express_route_port_resource.go
@@ -148,6 +148,16 @@ func resourceArmExpressRoutePort() *pluginsdk.Resource {
 
 			"identity": commonschema.UserAssignedIdentityOptional(),
 
+			"billing_type": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				Computed: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					string(network.ExpressRoutePortsBillingTypeMeteredData),
+					string(network.ExpressRoutePortsBillingTypeUnlimitedData),
+				}, false),
+			},
+
 			"link1": expressRoutePortSchema,
 
 			"link2": expressRoutePortSchema,
@@ -211,6 +221,10 @@ func resourceArmExpressRoutePortCreateUpdate(d *pluginsdk.ResourceData, meta int
 		},
 		Identity: expandedIdentity,
 		Tags:     tags.Expand(d.Get("tags").(map[string]interface{})),
+	}
+
+	if v, ok := d.GetOk("billing_type"); ok {
+		param.ExpressRoutePortPropertiesFormat.BillingType = network.ExpressRoutePortsBillingType(v.(string))
 	}
 
 	// The link properties can't be specified in first creation. It will result into either error (e.g. setting `adminState`) or being ignored (e.g. setting MACSec)
@@ -277,6 +291,7 @@ func resourceArmExpressRoutePortRead(d *pluginsdk.ResourceData, meta interface{}
 		d.Set("peering_location", prop.PeeringLocation)
 		d.Set("bandwidth_in_gbps", prop.BandwidthInGbps)
 		d.Set("encapsulation", prop.Encapsulation)
+		d.Set("billing_type", prop.BillingType)
 		link1, link2, err := flattenExpressRoutePortLinks(resp.Links)
 		if err != nil {
 			return fmt.Errorf("flattening links: %v", err)

--- a/internal/services/network/express_route_port_resource_test.go
+++ b/internal/services/network/express_route_port_resource_test.go
@@ -40,6 +40,7 @@ func TestAccAzureRMExpressRoutePort_basic(t *testing.T) {
 				check.That(data.ResourceName).Key("link2.0.rack_id").Exists(),
 				check.That(data.ResourceName).Key("link2.0.connector_type").Exists(),
 				check.That(data.ResourceName).Key("ethertype").Exists(),
+				check.That(data.ResourceName).Key("billing_type").Exists(),
 				check.That(data.ResourceName).Key("guid").Exists(),
 				check.That(data.ResourceName).Key("mtu").Exists(),
 			),
@@ -141,6 +142,7 @@ resource "azurerm_express_route_port" "test" {
   peering_location    = "Airtel-Chennai2-CLS"
   bandwidth_in_gbps   = 10
   encapsulation       = "Dot1Q"
+  billing_type        = "MeteredData"
   tags = {
     ENV = "Test"
   }

--- a/website/docs/r/express_route_port.html.markdown
+++ b/website/docs/r/express_route_port.html.markdown
@@ -70,6 +70,8 @@ A `link` block supports the following:
   
 * `macsec_cipher` - (Optional) The MACSec cipher used for this Express Route Port Link. Possible values are `GcmAes128` and `GcmAes256`. Defaults to `GcmAes128`.
 
+* `encapsulation` - (Optional) The billing type of the ExpressRoutePort resource. possible value are `MeteredData` and `UnlimitedData`.
+
 * `macsec_ckn_keyvault_secret_id` - (Optional) The ID of the Key Vault Secret that contains the MACSec CKN key for this Express Route Port Link.
 
 * `macsec_cak_keyvault_secret_id` - (Optional) The ID of the Key Vault Secret that contains the Mac security CAK key for this Express Route Port Link.

--- a/website/docs/r/express_route_port.html.markdown
+++ b/website/docs/r/express_route_port.html.markdown
@@ -70,7 +70,7 @@ A `link` block supports the following:
   
 * `macsec_cipher` - (Optional) The MACSec cipher used for this Express Route Port Link. Possible values are `GcmAes128` and `GcmAes256`. Defaults to `GcmAes128`.
 
-* `encapsulation` - (Optional) The billing type of the ExpressRoutePort resource. possible value are `MeteredData` and `UnlimitedData`.
+* `billing_type` - (Optional) The billing type of the Express Route Port. Possible values are `MeteredData` and `UnlimitedData`.
 
 * `macsec_ckn_keyvault_secret_id` - (Optional) The ID of the Key Vault Secret that contains the MACSec CKN key for this Express Route Port Link.
 


### PR DESCRIPTION
Support  config - `billing_type`

```log
=== RUN   TestAccAzureRMExpressRoutePort_basic
=== PAUSE TestAccAzureRMExpressRoutePort_basic
=== RUN   TestAccAzureRMExpressRoutePort_adminState
    express_route_port_resource_test.go:54: Enabling admin state will cause high cost, please set environment variable "ARM_TEST_EXPRESS_ROUTE_PORT_ADMIN_STATE" if you want to test it.
--- SKIP: TestAccAzureRMExpressRoutePort_adminState (0.00s)
=== RUN   TestAccAzureRMExpressRoutePort_requiresImport
=== PAUSE TestAccAzureRMExpressRoutePort_requiresImport
=== RUN   TestAccAzureRMExpressRoutePort_userAssignedIdentity
=== PAUSE TestAccAzureRMExpressRoutePort_userAssignedIdentity
=== RUN   TestAccAzureRMExpressRoutePort_linkCipher
=== PAUSE TestAccAzureRMExpressRoutePort_linkCipher
=== CONT  TestAccAzureRMExpressRoutePort_basic
=== CONT  TestAccAzureRMExpressRoutePort_requiresImport
=== CONT  TestAccAzureRMExpressRoutePort_userAssignedIdentity
=== CONT  TestAccAzureRMExpressRoutePort_linkCipher
--- PASS: TestAccAzureRMExpressRoutePort_userAssignedIdentity (395.27s)
--- PASS: TestAccAzureRMExpressRoutePort_basic (395.76s)
--- PASS: TestAccAzureRMExpressRoutePort_requiresImport (484.94s)
--- PASS: TestAccAzureRMExpressRoutePort_linkCipher (806.45s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/network       846.352s

```