### PR TITLE
`azurerm_postgresql_flexible_server` - support `replication_role` and new enum value `Replica` for `create_mode`

### DIFF
--- a/internal/services/postgres/postgresql_flexible_server_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_resource.go
@@ -139,6 +139,7 @@ func resourcePostgresqlFlexibleServer() *pluginsdk.Resource {
 				ValidateFunc: validation.StringInSlice([]string{
 					string(servers.CreateModeDefault),
 					string(servers.CreateModePointInTimeRestore),
+					string(servers.CreateModeReplica),
 				}, false),
 			},
 

--- a/internal/services/postgres/postgresql_flexible_server_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_resource.go
@@ -313,6 +313,12 @@ func resourcePostgresqlFlexibleServerCreate(d *pluginsdk.ResourceData, meta inte
 		}
 	}
 
+	if servers.CreateMode(createMode) == servers.CreateModeReplica {
+		if _, ok := d.GetOk("source_server_id"); !ok {
+			return fmt.Errorf("`source_server_id` is required when `create_mode` is `Replica`")
+		}
+	}
+
 	if createMode == "" || servers.CreateMode(createMode) == servers.CreateModeDefault {
 		if _, ok := d.GetOk("administrator_login"); !ok {
 			return fmt.Errorf("`administrator_login` is required when `create_mode` is `Default`")

--- a/internal/services/postgres/postgresql_flexible_server_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_resource.go
@@ -248,6 +248,30 @@ func resourcePostgresqlFlexibleServer() *pluginsdk.Resource {
 				Computed: true,
 			},
 
+			"replica_capacity": {
+				Type:     pluginsdk.TypeInt,
+				Optional: true,
+				ForceNew: true,
+				Default:  5,
+			},
+
+			"replication_role": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Default:  string(servers.ReplicationRolePrimary),
+				ValidateFunc: validation.StringInSlice([]string{
+					string(servers.ReplicationRoleAsyncReplica),
+					string(servers.ReplicationRoleGeoAsyncReplica),
+					string(servers.ReplicationRoleGeoSyncReplica),
+					string(servers.ReplicationRoleNone),
+					string(servers.ReplicationRolePrimary),
+					string(servers.ReplicationRoleSecondary),
+					string(servers.ReplicationRoleSyncReplica),
+					string(servers.ReplicationRoleWalReplica),
+				}, false),
+			},
+
 			"identity": commonschema.SystemAssignedUserAssignedIdentityOptional(),
 
 			"customer_managed_key": {
@@ -398,6 +422,15 @@ func resourcePostgresqlFlexibleServerCreate(d *pluginsdk.ResourceData, meta inte
 	}
 	parameters.Identity = identity
 
+	if v, ok := d.GetOk("replica_capacity"); ok {
+		parameters.Properties.ReplicaCapacity = utils.Int64(int64(v.(int)))
+	}
+
+	if v, ok := d.GetOk("replication_role"); ok {
+		replicationRole := servers.ReplicationRole(v.(string))
+		parameters.Properties.ReplicationRole = &replicationRole
+	}
+
 	if err = client.CreateThenPoll(ctx, id, parameters); err != nil {
 		return fmt.Errorf("creating %s: %+v", id, err)
 	}
@@ -463,6 +496,8 @@ func resourcePostgresqlFlexibleServerRead(d *pluginsdk.ResourceData, meta interf
 			d.Set("zone", props.AvailabilityZone)
 			d.Set("version", props.Version)
 			d.Set("fqdn", props.FullyQualifiedDomainName)
+			d.Set("replica_capacity", props.ReplicaCapacity)
+			d.Set("replication_role", props.ReplicationRole)
 
 			if network := props.Network; network != nil {
 				publicNetworkAccess := false
@@ -630,6 +665,11 @@ func resourcePostgresqlFlexibleServerUpdate(d *pluginsdk.ResourceData, meta inte
 			return fmt.Errorf("expanding `identity` for Mysql Flexible Server %s (Resource Group %q): %v", id.FlexibleServerName, id.ResourceGroupName, err)
 		}
 		parameters.Identity = identity
+	}
+
+	if d.HasChange("replication_role") {
+		replicationRole := servers.ReplicationRole(d.Get("replication_role").(string))
+		parameters.Properties.ReplicationRole = &replicationRole
 	}
 
 	if err = client.UpdateThenPoll(ctx, *id, parameters); err != nil {

--- a/internal/services/postgres/postgresql_flexible_server_resource_test.go
+++ b/internal/services/postgres/postgresql_flexible_server_resource_test.go
@@ -305,6 +305,13 @@ func TestAccPostgresqlFlexibleServer_replica(t *testing.T) {
 			),
 		},
 		data.ImportStep("administrator_password", "create_mode"),
+		{
+			Config: r.updateReplicationRole(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That("azurerm_postgresql_flexible_server.replica").ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("administrator_password", "create_mode"),
 	})
 }
 
@@ -812,6 +819,22 @@ resource "azurerm_postgresql_flexible_server" "replica" {
   zone                = "3"
   create_mode         = "Replica"
   source_server_id    = azurerm_postgresql_flexible_server.test.id
+}
+`, r.basic(data), data.RandomInteger)
+}
+
+func (r PostgresqlFlexibleServerResource) updateReplicationRole(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_postgresql_flexible_server" "replica" {
+  name                = "acctest-fs-replica-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  zone                = "3"
+  create_mode         = "Replica"
+  source_server_id    = azurerm_postgresql_flexible_server.test.id
+  replication_role    = "None"
 }
 `, r.basic(data), data.RandomInteger)
 }

--- a/internal/services/postgres/postgresql_flexible_server_resource_test.go
+++ b/internal/services/postgres/postgresql_flexible_server_resource_test.go
@@ -803,6 +803,7 @@ resource "azurerm_postgresql_flexible_server" "source" {
   location               = azurerm_resource_group.test.location
   administrator_login    = "adminTerraform"
   administrator_password = "QAZwsx123"
+  storage_mb             = 32768
   version                = "12"
   zone                   = "2"
   sku_name               = "GP_Standard_D2s_v3"

--- a/internal/services/postgres/postgresql_flexible_server_resource_test.go
+++ b/internal/services/postgres/postgresql_flexible_server_resource_test.go
@@ -797,18 +797,25 @@ func (r PostgresqlFlexibleServerResource) replica(data acceptance.TestData) stri
 	return fmt.Sprintf(`
 %s
 
-resource "azurerm_postgresql_flexible_server" "test" {
-  name                   = "acctest-fs-%d"
+resource "azurerm_postgresql_flexible_server" "source" {
+  name                   = "acctest-fssource-%d"
   resource_group_name    = azurerm_resource_group.test.name
   location               = azurerm_resource_group.test.location
   administrator_login    = "adminTerraform"
   administrator_password = "QAZwsx123"
-  storage_mb             = 32768
   version                = "12"
-  sku_name               = "GP_Standard_D2s_v3"
   zone                   = "2"
-  replication_role       = "Secondary"
-  replica_capacity       = 6
+  sku_name               = "GP_Standard_D2s_v3"
 }
-`, r.template(data), data.RandomInteger)
+
+resource "azurerm_postgresql_flexible_server" "test" {
+  name                   = "acctest-fsreplica-%d"
+  resource_group_name    = azurerm_resource_group.test.name
+  location               = azurerm_resource_group.test.location
+  version                = "12"
+  zone                   = "2"
+  create_mode            = "Replica"
+  source_server_id       = azurerm_postgresql_flexible_server.source.id
+}
+`, r.template(data), data.RandomInteger, data.RandomInteger)
 }

--- a/internal/services/postgres/postgresql_flexible_server_resource_test.go
+++ b/internal/services/postgres/postgresql_flexible_server_resource_test.go
@@ -816,7 +816,7 @@ resource "azurerm_postgresql_flexible_server" "replica" {
   name                = "acctest-fs-replica-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  zone                = "3"
+  zone                = "2"
   create_mode         = "Replica"
   source_server_id    = azurerm_postgresql_flexible_server.test.id
 }
@@ -831,7 +831,7 @@ resource "azurerm_postgresql_flexible_server" "replica" {
   name                = "acctest-fs-replica-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  zone                = "3"
+  zone                = "2"
   create_mode         = "Replica"
   source_server_id    = azurerm_postgresql_flexible_server.test.id
   replication_role    = "None"

--- a/website/docs/r/postgresql_flexible_server.html.markdown
+++ b/website/docs/r/postgresql_flexible_server.html.markdown
@@ -116,10 +116,6 @@ The following arguments are supported:
 
 * `point_in_time_restore_time_in_utc` - (Optional) The point in time to restore from `source_server_id` when `create_mode` is `PointInTimeRestore`. Changing this forces a new PostgreSQL Flexible Server to be created.
 
-* `replica_capacity` - (Optional) The allowed replica capacity for a PostgreSQL Flexible Server. Defaults to `5`. Changing this forces a new PostgreSQL Flexible Server to be created.
-
-* `replication_role` - (Optional) The replication role for the PostgreSQL Flexible Server. Possible values are `AsyncReplica`, `GeoAsyncReplica`, `GeoSyncReplica`, `None`, `Primary`, `Secondary`, `SyncReplica` and `WalReplica`. Defaults to `Primary`. Changing this forces a new PostgreSQL Flexible Server to be created.
-
 * `sku_name` - (Optional) The SKU Name for the PostgreSQL Flexible Server. The name of the SKU, follows the `tier` + `name` pattern (e.g. `B_Standard_B1ms`, `GP_Standard_D2s_v3`, `MO_Standard_E4s_v3`).
 
 * `source_server_id` - (Optional) The resource ID of the source PostgreSQL Flexible Server to be restored. Required when `create_mode` is `PointInTimeRestore`. Changing this forces a new PostgreSQL Flexible Server to be created.

--- a/website/docs/r/postgresql_flexible_server.html.markdown
+++ b/website/docs/r/postgresql_flexible_server.html.markdown
@@ -100,7 +100,7 @@ The following arguments are supported:
 
 * `geo_redundant_backup_enabled` - (Optional) Is Geo-Redundant backup enabled on the PostgreSQL Flexible Server. Defaults to `false`. Changing this forces a new PostgreSQL Flexible Server to be created.
 
-* `create_mode` - (Optional) The creation mode which can be used to restore or replicate existing servers. Possible values are `Default` and `PointInTimeRestore`. Changing this forces a new PostgreSQL Flexible Server to be created.
+* `create_mode` - (Optional) The creation mode which can be used to restore or replicate existing servers. Possible values are `Default`, `PointInTimeRestore` and `Replica`. Changing this forces a new PostgreSQL Flexible Server to be created.
 
 * `delegated_subnet_id` - (Optional) The ID of the virtual network subnet to create the PostgreSQL Flexible Server. The provided subnet should not have any other resource deployed in it and this subnet will be delegated to the PostgreSQL Flexible Server, if not already delegated. Changing this forces a new PostgreSQL Flexible Server to be created.
 

--- a/website/docs/r/postgresql_flexible_server.html.markdown
+++ b/website/docs/r/postgresql_flexible_server.html.markdown
@@ -116,6 +116,10 @@ The following arguments are supported:
 
 * `point_in_time_restore_time_in_utc` - (Optional) The point in time to restore from `source_server_id` when `create_mode` is `PointInTimeRestore`. Changing this forces a new PostgreSQL Flexible Server to be created.
 
+* `replication_role` - (Optional) The replication role for the PostgreSQL Flexible Server. Possible value is `None`.
+
+~> **NOTE:** The `replication_role` cannot be set while creating and only can be updated to `None` for replica server.
+
 * `sku_name` - (Optional) The SKU Name for the PostgreSQL Flexible Server. The name of the SKU, follows the `tier` + `name` pattern (e.g. `B_Standard_B1ms`, `GP_Standard_D2s_v3`, `MO_Standard_E4s_v3`).
 
 * `source_server_id` - (Optional) The resource ID of the source PostgreSQL Flexible Server to be restored. Required when `create_mode` is `PointInTimeRestore` or `Replica`. Changing this forces a new PostgreSQL Flexible Server to be created.

--- a/website/docs/r/postgresql_flexible_server.html.markdown
+++ b/website/docs/r/postgresql_flexible_server.html.markdown
@@ -118,7 +118,7 @@ The following arguments are supported:
 
 * `sku_name` - (Optional) The SKU Name for the PostgreSQL Flexible Server. The name of the SKU, follows the `tier` + `name` pattern (e.g. `B_Standard_B1ms`, `GP_Standard_D2s_v3`, `MO_Standard_E4s_v3`).
 
-* `source_server_id` - (Optional) The resource ID of the source PostgreSQL Flexible Server to be restored. Required when `create_mode` is `PointInTimeRestore`. Changing this forces a new PostgreSQL Flexible Server to be created.
+* `source_server_id` - (Optional) The resource ID of the source PostgreSQL Flexible Server to be restored. Required when `create_mode` is `PointInTimeRestore` or `Replica`. Changing this forces a new PostgreSQL Flexible Server to be created.
 
 * `storage_mb` - (Optional) The max storage allowed for the PostgreSQL Flexible Server. Possible values are `32768`, `65536`, `131072`, `262144`, `524288`, `1048576`, `2097152`, `4194304`, `8388608`, and `16777216`.
 

--- a/website/docs/r/postgresql_flexible_server.html.markdown
+++ b/website/docs/r/postgresql_flexible_server.html.markdown
@@ -116,6 +116,10 @@ The following arguments are supported:
 
 * `point_in_time_restore_time_in_utc` - (Optional) The point in time to restore from `source_server_id` when `create_mode` is `PointInTimeRestore`. Changing this forces a new PostgreSQL Flexible Server to be created.
 
+* `replica_capacity` - (Optional) The allowed replica capacity for a PostgreSQL Flexible Server. Defaults to `5`. Changing this forces a new PostgreSQL Flexible Server to be created.
+
+* `replication_role` - (Optional) The replication role for the PostgreSQL Flexible Server. Possible values are `AsyncReplica`, `GeoAsyncReplica`, `GeoSyncReplica`, `None`, `Primary`, `Secondary`, `SyncReplica` and `WalReplica`. Defaults to `Primary`. Changing this forces a new PostgreSQL Flexible Server to be created.
+
 * `sku_name` - (Optional) The SKU Name for the PostgreSQL Flexible Server. The name of the SKU, follows the `tier` + `name` pattern (e.g. `B_Standard_B1ms`, `GP_Standard_D2s_v3`, `MO_Standard_E4s_v3`).
 
 * `source_server_id` - (Optional) The resource ID of the source PostgreSQL Flexible Server to be restored. Required when `create_mode` is `PointInTimeRestore`. Changing this forces a new PostgreSQL Flexible Server to be created.


### PR DESCRIPTION
This PR is to support `replication_role` and new enum value `Replica` for `create_mode`.

Note: Below failed TCs are also failed in Teamcity Daily Run with same error. It's not related with this PR. So we can ignore it.
![image](https://user-images.githubusercontent.com/19754191/217477840-136d5cd0-fe7e-42c0-9a12-76942f2e10a9.png)