### PR TITLE
[Fix] - `azurerm_machine_learning_workspace` - Remove `image_build_compute_name` forceNew constraint

### DIFF
--- a/internal/services/machinelearning/machine_learning_workspace_resource.go
+++ b/internal/services/machinelearning/machine_learning_workspace_resource.go
@@ -123,7 +123,6 @@ func resourceMachineLearningWorkspace() *pluginsdk.Resource {
 			"image_build_compute_name": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
-				ForceNew: true,
 			},
 
 			"description": {

--- a/internal/services/machinelearning/machine_learning_workspace_resource_test.go
+++ b/internal/services/machinelearning/machine_learning_workspace_resource_test.go
@@ -430,7 +430,7 @@ resource "azurerm_machine_learning_workspace" "test" {
   sku_name                      = "Basic"
   high_business_impact          = true
   public_network_access_enabled = true
-  image_build_compute_name      = "terraformCompute"
+  image_build_compute_name      = "terraformComputeUpdate"
 
   identity {
     type = "SystemAssigned"

--- a/website/docs/r/machine_learning_workspace.html.markdown
+++ b/website/docs/r/machine_learning_workspace.html.markdown
@@ -366,7 +366,7 @@ The following arguments are supported:
 
 ~> **NOTE:** `public_access_behind_virtual_network_enabled` is deprecated and will be removed in favour of the property `public_network_access_enabled`.
 
-* `image_build_compute_name` - (Optional) The compute name for image build of the Machine Learning Workspace. Changing this forces a new resource to be created.
+* `image_build_compute_name` - (Optional) The compute name for image build of the Machine Learning Workspace.
 
 * `description` - (Optional) The description of this Machine Learning Workspace.
 


### PR DESCRIPTION
`image_build_compute_name` can be updated, remove the `forceNew` constraint