### PR TITLE
Docs: Fix typo in filename and wrong `storage_container_id` in `azurerm_machine_learning_datastore_blobstorage` example

### DIFF
--- a/website/docs/r/machine_learning_datastore_blobstorage.html.markdown
+++ b/website/docs/r/machine_learning_datastore_blobstorage.html.markdown
@@ -69,7 +69,7 @@ resource "azurerm_storage_container" "example" {
 resource "azurerm_machine_learning_datastore_blobstorage" "example" {
   name                 = "example-datastore"
   workspace_id         = azurerm_machine_learning_workspace.example.id
-  storage_container_id = azurerm_storage_account.example.resource_manager_id
+  storage_container_id = azurerm_storage_container.example.resource_manager_id
   account_key          = azurerm_storage_account.example.primary_access_key
 }
 ```


### PR DESCRIPTION
- Corrected `storage_container_id` value in example in the docs
- fixed typo in markdown filename of `azurerm_machine_learning_datastore_blobstorage` documentation