### PR TITLE
`azurerm_virtual_network_gateway_connection`: fix accTest for `WithoutSharedKey`

### DIFF
--- a/internal/services/network/virtual_network_gateway_connection_resource_test.go
+++ b/internal/services/network/virtual_network_gateway_connection_resource_test.go
@@ -58,7 +58,7 @@ func TestAccVirtualNetworkGatewayConnection_sitetositeWithoutSharedKey(t *testin
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("shared_key"),
 	})
 }
 
@@ -396,6 +396,9 @@ resource "azurerm_local_network_gateway" "test" {
 }
 
 resource "azurerm_virtual_network_gateway_connection" "test" {
+  lifecycle {
+    ignore_changes = ["shared_key"]
+  }
   name                = "acctest-${var.random}"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name


### PR DESCRIPTION
The Server will response with a `shared_key` field with content even not provided in PUT request. so mark it as `computed`.

Current errror:

```
------- Stdout: -------
=== RUN   TestAccVirtualNetworkGatewayConnection_sitetositeWithoutSharedKey
=== PAUSE TestAccVirtualNetworkGatewayConnection_sitetositeWithoutSharedKey
=== CONT  TestAccVirtualNetworkGatewayConnection_sitetositeWithoutSharedKey
testcase.go:110: Step 1/2 error: After applying this test step, the plan was not empty.
stdout:
Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
~ update in-place
Terraform will perform the following actions:
# azurerm_virtual_network_gateway_connection.test will be updated in-place
~ resource "azurerm_virtual_network_gateway_connection" "test" {
id                                 = "/subscriptions/*******/resourceGroups/acctestRG-230209073430076333/providers/Microsoft.Network/connections/acctest-230209073430076333"
name                               = "acctest-230209073430076333"
- shared_key                         = (sensitive value)
# (13 unchanged attributes hidden)
}
Plan: 0 to add, 1 to change, 0 to destroy.
--- FAIL: TestAccVirtualNetworkGatewayConnection_sitetositeWithoutSharedKey (4076.87s)
FAIL

```

**TC PASS**

![image](https://user-images.githubusercontent.com/2633022/218392167-c887d89d-0f8c-4747-b4be-c3f712d18a70.png)

