### PR TITLE
`azurerm_recovery_services_vault` - add limit on `cross_region_restore_enabled`

### DIFF
--- a/internal/services/recoveryservices/recovery_services_vault_resource.go
+++ b/internal/services/recoveryservices/recovery_services_vault_resource.go
@@ -144,7 +144,7 @@ func resourceRecoveryServicesVault() *pluginsdk.Resource {
 
 		CustomizeDiff: pluginsdk.CustomDiffWithAll(
 			pluginsdk.ForceNewIfChange("cross_region_restore_enabled", func(ctx context.Context, old, new, meta interface{}) bool {
-				return old.(bool) == true && new.(bool) == false
+				return old.(bool) && !new.(bool)
 			}),
 		),
 	}

--- a/internal/services/recoveryservices/recovery_services_vault_resource.go
+++ b/internal/services/recoveryservices/recovery_services_vault_resource.go
@@ -141,6 +141,12 @@ func resourceRecoveryServicesVault() *pluginsdk.Resource {
 				Default:  true,
 			},
 		},
+
+		CustomizeDiff: pluginsdk.CustomDiffWithAll(
+			pluginsdk.ForceNewIfChange("cross_region_restore_enabled", func(ctx context.Context, old, new, meta interface{}) bool {
+				return old.(bool) == true && new.(bool) == false
+			}),
+		),
 	}
 }
 

--- a/website/docs/r/recovery_services_vault.html.markdown
+++ b/website/docs/r/recovery_services_vault.html.markdown
@@ -52,6 +52,8 @@ The following arguments are supported:
 
 * `cross_region_restore_enabled` - (Optional) Is cross region restore enabled for this Vault? Only can be `true`, when `storage_mode_type` is `GeoRedundant`. Defaults to `false`.
 
+-> **Note:** Once `cross_region_restore_enabled` is set to `true`, changing it back to `false` forces a new Recovery Service Vault to be created.
+
 * `soft_delete_enabled` - (Optional) Is soft delete enable for this Vault? Defaults to `true`.
 
 * `encryption` - (Optional) An `encryption` block as defined below. Required with `identity`.


### PR DESCRIPTION
fix #20373

test
---
```
terraform-provider-azurerm ❯ TF_ACC=1 go test -v ./internal/services/recoveryservices -run=TestAccRecoveryServicesVault -timeout=600m -parallel 20
=== RUN   TestAccRecoveryServicesVault_basic
=== PAUSE TestAccRecoveryServicesVault_basic
=== RUN   TestAccRecoveryServicesVault_ToggleCrossRegionRestore
=== PAUSE TestAccRecoveryServicesVault_ToggleCrossRegionRestore
=== RUN   TestAccRecoveryServicesVault_basicWithCrossRegionRestoreAndWrongStorageType
=== PAUSE TestAccRecoveryServicesVault_basicWithCrossRegionRestoreAndWrongStorageType
=== RUN   TestAccRecoveryServicesVault_zrs
=== PAUSE TestAccRecoveryServicesVault_zrs
=== RUN   TestAccRecoveryServicesVault_complete
=== PAUSE TestAccRecoveryServicesVault_complete
=== RUN   TestAccRecoveryServicesVault_update
=== PAUSE TestAccRecoveryServicesVault_update
=== RUN   TestAccRecoveryServicesVault_requiresImport
=== PAUSE TestAccRecoveryServicesVault_requiresImport
=== RUN   TestAccRecoveryServicesVault_SystemAssignedIdentity
=== PAUSE TestAccRecoveryServicesVault_SystemAssignedIdentity
=== RUN   TestAccRecoveryServicesVault_UserAssignedIdentity
=== PAUSE TestAccRecoveryServicesVault_UserAssignedIdentity
=== RUN   TestAccRecoveryServicesVault_immutability
=== PAUSE TestAccRecoveryServicesVault_immutability
=== RUN   TestAccRecoveryServicesVault_softDelete
=== PAUSE TestAccRecoveryServicesVault_softDelete
=== RUN   TestAccRecoveryServicesVault_storageModeType
=== PAUSE TestAccRecoveryServicesVault_storageModeType
=== RUN   TestAccRecoveryServicesVault_crossRegionRestore
=== PAUSE TestAccRecoveryServicesVault_crossRegionRestore
=== RUN   TestAccRecoveryServicesVault_sku
=== PAUSE TestAccRecoveryServicesVault_sku
=== RUN   TestAccRecoveryServicesVault_updateSkuWithExistingEncryption
=== PAUSE TestAccRecoveryServicesVault_updateSkuWithExistingEncryption
=== RUN   TestAccRecoveryServicesVault_encryptionWithKeyVaultKey
=== PAUSE TestAccRecoveryServicesVault_encryptionWithKeyVaultKey
=== RUN   TestAccRecoveryServicesVault_turnOnEncryptionWithKeyVaultKey
=== PAUSE TestAccRecoveryServicesVault_turnOnEncryptionWithKeyVaultKey
=== RUN   TestAccRecoveryServicesVault_turnOffEncryptionWithKeyVaultKeyShouldHaveClearlyErrorMessage
=== PAUSE TestAccRecoveryServicesVault_turnOffEncryptionWithKeyVaultKeyShouldHaveClearlyErrorMessage
=== RUN   TestAccRecoveryServicesVault_changeInfrastructureEncryptionEnabledShouldHaveClearlyErrorMessage
=== PAUSE TestAccRecoveryServicesVault_changeInfrastructureEncryptionEnabledShouldHaveClearlyErrorMessage
=== RUN   TestAccRecoveryServicesVault_encryptionWithInfrastructureEncryption
=== PAUSE TestAccRecoveryServicesVault_encryptionWithInfrastructureEncryption
=== RUN   TestAccRecoveryServicesVault_switchEncryptionKeyVaultKey
=== PAUSE TestAccRecoveryServicesVault_switchEncryptionKeyVaultKey
=== RUN   TestAccRecoveryServicesVault_encryptionWithUserAssignedIdentity
=== PAUSE TestAccRecoveryServicesVault_encryptionWithUserAssignedIdentity
=== RUN   TestAccRecoveryServicesVault_TogglePublicNetworkAccessEnabled
=== PAUSE TestAccRecoveryServicesVault_TogglePublicNetworkAccessEnabled
=== CONT  TestAccRecoveryServicesVault_basic
=== CONT  TestAccRecoveryServicesVault_crossRegionRestore
=== CONT  TestAccRecoveryServicesVault_changeInfrastructureEncryptionEnabledShouldHaveClearlyErrorMessage
=== CONT  TestAccRecoveryServicesVault_requiresImport
=== CONT  TestAccRecoveryServicesVault_immutability
=== CONT  TestAccRecoveryServicesVault_storageModeType
=== CONT  TestAccRecoveryServicesVault_softDelete
=== CONT  TestAccRecoveryServicesVault_TogglePublicNetworkAccessEnabled
=== CONT  TestAccRecoveryServicesVault_switchEncryptionKeyVaultKey
=== CONT  TestAccRecoveryServicesVault_encryptionWithInfrastructureEncryption
=== CONT  TestAccRecoveryServicesVault_UserAssignedIdentity
=== CONT  TestAccRecoveryServicesVault_SystemAssignedIdentity
=== CONT  TestAccRecoveryServicesVault_encryptionWithKeyVaultKey
=== CONT  TestAccRecoveryServicesVault_turnOffEncryptionWithKeyVaultKeyShouldHaveClearlyErrorMessage
=== CONT  TestAccRecoveryServicesVault_turnOnEncryptionWithKeyVaultKey
=== CONT  TestAccRecoveryServicesVault_updateSkuWithExistingEncryption
=== CONT  TestAccRecoveryServicesVault_sku
=== CONT  TestAccRecoveryServicesVault_zrs
=== CONT  TestAccRecoveryServicesVault_update
=== CONT  TestAccRecoveryServicesVault_complete
--- PASS: TestAccRecoveryServicesVault_complete (373.54s)
=== CONT  TestAccRecoveryServicesVault_basicWithCrossRegionRestoreAndWrongStorageType
--- PASS: TestAccRecoveryServicesVault_zrs (384.73s)
=== CONT  TestAccRecoveryServicesVault_ToggleCrossRegionRestore
--- PASS: TestAccRecoveryServicesVault_SystemAssignedIdentity (395.75s)
=== CONT  TestAccRecoveryServicesVault_encryptionWithUserAssignedIdentity
--- PASS: TestAccRecoveryServicesVault_UserAssignedIdentity (396.36s)
--- PASS: TestAccRecoveryServicesVault_basic (397.66s)
--- PASS: TestAccRecoveryServicesVault_requiresImport (403.84s)
--- PASS: TestAccRecoveryServicesVault_basicWithCrossRegionRestoreAndWrongStorageType (162.99s)
--- PASS: TestAccRecoveryServicesVault_storageModeType (561.08s)
--- PASS: TestAccRecoveryServicesVault_crossRegionRestore (567.36s)
--- PASS: TestAccRecoveryServicesVault_encryptionWithInfrastructureEncryption (685.84s)
--- PASS: TestAccRecoveryServicesVault_encryptionWithKeyVaultKey (691.26s)
--- PASS: TestAccRecoveryServicesVault_updateSkuWithExistingEncryption (727.12s)
--- PASS: TestAccRecoveryServicesVault_update (754.45s)
--- PASS: TestAccRecoveryServicesVault_immutability (762.92s)
--- PASS: TestAccRecoveryServicesVault_turnOffEncryptionWithKeyVaultKeyShouldHaveClearlyErrorMessage (763.32s)
--- PASS: TestAccRecoveryServicesVault_changeInfrastructureEncryptionEnabledShouldHaveClearlyErrorMessage (807.63s)
--- PASS: TestAccRecoveryServicesVault_TogglePublicNetworkAccessEnabled (857.93s)
--- PASS: TestAccRecoveryServicesVault_turnOnEncryptionWithKeyVaultKey (904.68s)
--- PASS: TestAccRecoveryServicesVault_switchEncryptionKeyVaultKey (947.68s)
--- PASS: TestAccRecoveryServicesVault_softDelete (1003.63s)
--- PASS: TestAccRecoveryServicesVault_encryptionWithUserAssignedIdentity (622.59s)
--- PASS: TestAccRecoveryServicesVault_sku (1043.60s)
--- PASS: TestAccRecoveryServicesVault_ToggleCrossRegionRestore (815.07s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/recoveryservices      1201.107s
```