### PR TITLE
Fix the validation for Event Grid Topic Name

### DIFF
--- a/internal/services/eventgrid/eventgrid_domain_topic_resource.go
+++ b/internal/services/eventgrid/eventgrid_domain_topic_resource.go
@@ -41,8 +41,8 @@ func resourceEventGridDomainTopic() *pluginsdk.Resource {
 				ValidateFunc: validation.All(
 					validation.StringIsNotEmpty,
 					validation.StringMatch(
-						regexp.MustCompile("^[-a-zA-Z0-9]{3,50}$"),
-						"EventGrid domain name must be 3 - 50 characters long, contain only letters, numbers and hyphens.",
+						regexp.MustCompile("^[-a-zA-Z0-9]{3,128}$"),
+						"EventGrid domain topic name must be 3 - 128 characters long, contain only letters, numbers and hyphens.",
 					),
 				),
 			},


### PR DESCRIPTION
The validation is currently rejecting Event Grid Topic Names more than 50 characters in length, but the actual limit is 128 characters.

![image](https://user-images.githubusercontent.com/11717300/218064557-433a089b-9f21-41c9-86f6-5261568c4b10.png)
