### PR TITLE
Data Source: `azurerm_policy_definition` -  support for `mode` property

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -26,7 +26,7 @@ refreshenv
 
 You must run `Developing the Provider` commands in `bash` because `sh` scrips are invoked as part of these.
 
-You may hit issues with `make build` telling you every file needs to be formatted as a result of line endings. To avoid this issue set your git config using `git config --global core.autocrlf false`. The will tell git to use the source `LF` rather than the Windows default of `CRLF`.
+You may hit issues with `make build` telling you every file needs to be formatted as a result of line endings. To avoid this issue set your git config using `git config --global core.autocrlf false`. This will tell git to use the source `LF` rather than the Windows default of `CRLF`.
 
 You may get errors when cloning the repository on Windows that end with `Filename too long`. To avoid this issue set your git config using `git config --system core.longpaths true`. This will tell git to allow file names longer than 260 characters which is the default on Windows.
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -26,6 +26,10 @@ refreshenv
 
 You must run `Developing the Provider` commands in `bash` because `sh` scrips are invoked as part of these.
 
+You may hit issues with `make build` telling you every file needs to be formatted as a result of line endings. To avoid this issue set your git config using `git config --global core.autocrlf false`. The will tell git to use the source `LF` rather than the Windows default of `CRLF`.
+
+You may get errors when cloning the repository on Windows that end with `Filename too long`. To avoid this issue set your git config using `git config --system core.longpaths true`. This will tell git to allow file names longer than 260 characters which is the default on Windows.
+
 ## Developing the Provider
 
 If you wish to work on the provider, you'll first need [Go](http://www.golang.org) installed on your machine. You'll also need to correctly setup a [GOPATH](http://golang.org/doc/code.html#GOPATH), as well as adding `$GOPATH/bin` to your `$PATH`.

--- a/internal/services/policy/policy_definition_data_source.go
+++ b/internal/services/policy/policy_definition_data_source.go
@@ -79,6 +79,11 @@ func dataSourceArmPolicyDefinition() *pluginsdk.Resource {
 					Type: pluginsdk.TypeString,
 				},
 			},
+
+			"mode": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -122,6 +127,7 @@ func dataSourceArmPolicyDefinitionRead(d *pluginsdk.ResourceData, meta interface
 	d.Set("description", policyDefinition.Description)
 	d.Set("type", policyDefinition.Type)
 	d.Set("policy_type", policyDefinition.PolicyType)
+	d.Set("mode", policyDefinition.Mode)
 
 	policyRule := policyDefinition.PolicyRule.(map[string]interface{})
 	if policyRuleStr := flattenJSON(policyRule); policyRuleStr != "" {

--- a/internal/services/policy/policy_definition_data_source_test.go
+++ b/internal/services/policy/policy_definition_data_source_test.go
@@ -23,6 +23,7 @@ func TestAccDataSourceAzureRMPolicyDefinition_builtIn(t *testing.T) {
 				check.That(data.ResourceName).Key("display_name").HasValue("Allowed resource types"),
 				check.That(data.ResourceName).Key("type").HasValue("Microsoft.Authorization/policyDefinitions"),
 				check.That(data.ResourceName).Key("description").HasValue("This policy enables you to specify the resource types that your organization can deploy. Only resource types that support 'tags' and 'location' will be affected by this policy. To restrict all resources please duplicate this policy and change the 'mode' to 'All'."),
+				check.That(data.ResourceName).Key("mode").HasValue("Indexed"),
 			),
 		},
 	})
@@ -56,6 +57,7 @@ func TestAccDataSourceAzureRMPolicyDefinition_builtInByName(t *testing.T) {
 				check.That(data.ResourceName).Key("display_name").HasValue("Allowed resource types"),
 				check.That(data.ResourceName).Key("type").HasValue("Microsoft.Authorization/policyDefinitions"),
 				check.That(data.ResourceName).Key("description").HasValue("This policy enables you to specify the resource types that your organization can deploy. Only resource types that support 'tags' and 'location' will be affected by this policy. To restrict all resources please duplicate this policy and change the 'mode' to 'All'."),
+				check.That(data.ResourceName).Key("mode").HasValue("Indexed"),
 			),
 		},
 	})
@@ -90,6 +92,7 @@ func TestAccDataSourceAzureRMPolicyDefinition_customByDisplayName(t *testing.T) 
 				check.That(data.ResourceName).Key("policy_rule").HasValue("{\"if\":{\"not\":{\"field\":\"location\",\"in\":\"[parameters('allowedLocations')]\"}},\"then\":{\"effect\":\"audit\"}}"),
 				check.That(data.ResourceName).Key("parameters").HasValue("{\"allowedLocations\":{\"type\":\"Array\",\"metadata\":{\"description\":\"The list of allowed locations for resources.\",\"displayName\":\"Allowed locations\",\"strongType\":\"location\"}}}"),
 				check.That(data.ResourceName).Key("metadata").Exists(),
+				check.That(data.ResourceName).Key("mode").HasValue("All"),
 			),
 		},
 	})
@@ -110,6 +113,7 @@ func TestAccDataSourceAzureRMPolicyDefinition_customByName(t *testing.T) {
 				check.That(data.ResourceName).Key("policy_rule").HasValue("{\"if\":{\"not\":{\"field\":\"location\",\"in\":\"[parameters('allowedLocations')]\"}},\"then\":{\"effect\":\"audit\"}}"),
 				check.That(data.ResourceName).Key("parameters").HasValue("{\"allowedLocations\":{\"type\":\"Array\",\"metadata\":{\"description\":\"The list of allowed locations for resources.\",\"displayName\":\"Allowed locations\",\"strongType\":\"location\"}}}"),
 				check.That(data.ResourceName).Key("metadata").Exists(),
+				check.That(data.ResourceName).Key("mode").HasValue("All"),
 			),
 		},
 	})

--- a/website/docs/d/policy_definition.html.markdown
+++ b/website/docs/d/policy_definition.html.markdown
@@ -50,6 +50,8 @@ output "id" {
 
 * `metadata` - Any Metadata defined in the Policy.
 
+* `mode` - The Mode of the Policy.
+
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:


### PR DESCRIPTION
### Summary

The `azurerm_policy_definition` is missing the `mode` property. 

The `mode` property needs to be referenced for certain use cases, such as when supplying non-compliance messages to a policy assignment. Non-compliance messages only support policy definitions with the `mode` set to `All` or `Indexed`. Therefore the mode needs to be checked prior to creating the message, particularly when assigning built in policy definitions.

This pull request adds the `mode` property to the data source.

### Acceptance Testing

Here is the command that was run:

`make acctests SERVICE='policy' TESTARGS='-run=TestAccDataSourceAzureRMPolicyDefinition_' TESTTIMEOUT='60m'`

Here is the output of a passing test run:

```
=== RUN   TestAccDataSourceAzureRMPolicyDefinition_builtIn
=== PAUSE TestAccDataSourceAzureRMPolicyDefinition_builtIn
=== RUN   TestAccDataSourceAzureRMPolicyDefinition_builtInLogAnalytics
=== PAUSE TestAccDataSourceAzureRMPolicyDefinition_builtInLogAnalytics
=== RUN   TestAccDataSourceAzureRMPolicyDefinition_builtInByName
=== PAUSE TestAccDataSourceAzureRMPolicyDefinition_builtInByName
=== RUN   TestAccDataSourceAzureRMPolicyDefinition_builtIn_AtManagementGroup
=== PAUSE TestAccDataSourceAzureRMPolicyDefinition_builtIn_AtManagementGroup
=== RUN   TestAccDataSourceAzureRMPolicyDefinition_customByDisplayName
=== PAUSE TestAccDataSourceAzureRMPolicyDefinition_customByDisplayName
=== RUN   TestAccDataSourceAzureRMPolicyDefinition_customByName
=== PAUSE TestAccDataSourceAzureRMPolicyDefinition_customByName
=== CONT  TestAccDataSourceAzureRMPolicyDefinition_builtIn
=== CONT  TestAccDataSourceAzureRMPolicyDefinition_builtIn_AtManagementGroup
=== CONT  TestAccDataSourceAzureRMPolicyDefinition_customByName
=== CONT  TestAccDataSourceAzureRMPolicyDefinition_customByDisplayName
=== CONT  TestAccDataSourceAzureRMPolicyDefinition_builtInByName
=== CONT  TestAccDataSourceAzureRMPolicyDefinition_builtInLogAnalytics
--- PASS: TestAccDataSourceAzureRMPolicyDefinition_builtInLogAnalytics (75.69s)
--- PASS: TestAccDataSourceAzureRMPolicyDefinition_builtInByName (85.57s)
--- PASS: TestAccDataSourceAzureRMPolicyDefinition_builtIn_AtManagementGroup (86.98s)
--- PASS: TestAccDataSourceAzureRMPolicyDefinition_builtIn (88.32s)
--- PASS: TestAccDataSourceAzureRMPolicyDefinition_customByName (189.82s)
--- PASS: TestAccDataSourceAzureRMPolicyDefinition_customByDisplayName (189.85s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/policy        191.275s
```