### PR TITLE
 `azurerm_container_app` - allow multiple `container` blocks

### DIFF
--- a/internal/services/containerapps/container_app_resource_test.go
+++ b/internal/services/containerapps/container_app_resource_test.go
@@ -158,6 +158,21 @@ func TestAccContainerAppResource_completeWithVNet(t *testing.T) {
 	})
 }
 
+func TestAccContainerAppResource_completeWithSidecar(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_container_app", "test")
+	r := ContainerAppResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.completeWithSidecar(data, "rev1"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccContainerAppResource_completeUpdate(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_container_app", "test")
 	r := ContainerAppResource{}
@@ -544,6 +559,132 @@ resource "azurerm_container_app" "test" {
   }
 }
 `, r.templateWithVnet(data), data.RandomInteger, revisionSuffix)
+}
+
+func (r ContainerAppResource) completeWithSidecar(data acceptance.TestData, revisionSuffix string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_container_app" "test" {
+  name                         = "acctest-capp-%[2]d"
+  resource_group_name          = azurerm_resource_group.test.name
+  container_app_environment_id = azurerm_container_app_environment.test.id
+  revision_mode                = "Single"
+
+  template {
+    container {
+      name   = "acctest-cont-sidecar-%[2]d"
+      image  = "jackofallops/azure-containerapps-python-acctest:v0.0.1"
+      cpu    = 0.25
+      memory = "0.5Gi"
+
+      readiness_probe {
+        transport = "HTTP"
+        port      = 5000
+      }
+
+      liveness_probe {
+        transport = "HTTP"
+        port      = 5000
+        path      = "/health"
+
+        header {
+          name  = "Cache-Control"
+          value = "no-cache"
+        }
+
+        initial_delay           = 5
+        timeout                 = 2
+        failure_count_threshold = 1
+      }
+
+      startup_probe {
+        transport = "TCP"
+        port      = 5000
+      }
+
+      volume_mounts {
+        name = azurerm_container_app_environment_storage.test.name
+        path = "/tmp/testdata"
+      }
+    }
+
+    container {
+      name   = "acctest-cont-%[2]d"
+      image  = "jackofallops/azure-containerapps-python-acctest:v0.0.1"
+      cpu    = 0.25
+      memory = "0.5Gi"
+
+      readiness_probe {
+        transport = "HTTP"
+        port      = 5000
+      }
+
+      liveness_probe {
+        transport = "HTTP"
+        port      = 5000
+        path      = "/health"
+
+        header {
+          name  = "Cache-Control"
+          value = "no-cache"
+        }
+
+        initial_delay           = 5
+        timeout                 = 2
+        failure_count_threshold = 1
+      }
+
+      startup_probe {
+        transport = "TCP"
+        port      = 5000
+      }
+
+      volume_mounts {
+        name = azurerm_container_app_environment_storage.test.name
+        path = "/tmp/testdata"
+      }
+    }
+
+    volume {
+      name         = azurerm_container_app_environment_storage.test.name
+      storage_type = "AzureFile"
+      storage_name = azurerm_container_app_environment_storage.test.name
+    }
+
+    min_replicas = 2
+    max_replicas = 3
+
+    revision_suffix = "%[3]s"
+  }
+
+  ingress {
+    allow_insecure_connections = true
+    target_port                = 5000
+    transport                  = "http"
+    traffic_weight {
+      latest_revision = true
+      percentage      = 100
+    }
+  }
+
+  registry {
+    server               = azurerm_container_registry.test.login_server
+    username             = azurerm_container_registry.test.admin_username
+    password_secret_name = "registry-password"
+  }
+
+  secret {
+    name  = "registry-password"
+    value = azurerm_container_registry.test.admin_password
+  }
+
+  tags = {
+    foo     = "Bar"
+    accTest = "1"
+  }
+}
+`, r.templatePlusExtras(data), data.RandomInteger, revisionSuffix)
 }
 
 func (r ContainerAppResource) completeChangedSecret(data acceptance.TestData, revisionSuffix string) string {

--- a/internal/services/containerapps/helpers/container_apps.go
+++ b/internal/services/containerapps/helpers/container_apps.go
@@ -620,7 +620,6 @@ func ContainerAppContainerSchema() *pluginsdk.Schema {
 		Type:     pluginsdk.TypeList,
 		Required: true,
 		MinItems: 1,
-		MaxItems: 1,
 		Elem: &pluginsdk.Resource{
 			Schema: map[string]*pluginsdk.Schema{
 				"name": {

--- a/website/docs/r/container_app.html.markdown
+++ b/website/docs/r/container_app.html.markdown
@@ -91,7 +91,7 @@ A `secret` block supports the following:
 
 A `template` block supports the following:
 
-* `container` - (Required) A `container` block as detailed below.
+* `container` - (Required) One or more `container` blocks as detailed below.
 
 * `max_replicas` - (Optional) The maximum number of replicas for this container.
 


### PR DESCRIPTION
**Summary**
A container app template may have multiple containers defined directly in Azure (for example, when using a sidecar pattern).  Ref: https://learn.microsoft.com/en-us/azure/container-apps/containers#multiple-containers

This PR corrects the provider code that limits the `container` list to maximum 1 item in the `azurerm_container_app` resource, introduces an additional test for the sidecar pattern and adjusts the documentation for the same argument.

**Acceptance Test Results**
Test command:
```
make acctests SERVICE='containerapps' TESTARGS='-run=TestAccContainerAppResource_' TESTTIMEOUT='60m'
```

Test results:
``` 
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/containerapps -run=TestAccContainerAppResource_ -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccContainerAppResource_basic
=== PAUSE TestAccContainerAppResource_basic
=== RUN   TestAccContainerAppResource_withSystemAssignedIdentity
=== PAUSE TestAccContainerAppResource_withSystemAssignedIdentity
=== RUN   TestAccContainerAppResource_withUserAssignedIdentity
=== PAUSE TestAccContainerAppResource_withUserAssignedIdentity
=== RUN   TestAccContainerAppResource_withIdentityUpdate
=== PAUSE TestAccContainerAppResource_withIdentityUpdate
=== RUN   TestAccContainerAppResource_basicUpdate
=== PAUSE TestAccContainerAppResource_basicUpdate
=== RUN   TestAccContainerAppResource_requiresImport
=== PAUSE TestAccContainerAppResource_requiresImport
=== RUN   TestAccContainerAppResource_complete
=== PAUSE TestAccContainerAppResource_complete
=== RUN   TestAccContainerAppResource_completeWithVNet
=== PAUSE TestAccContainerAppResource_completeWithVNet
=== RUN   TestAccContainerAppResource_completeWithSidecar
=== PAUSE TestAccContainerAppResource_completeWithSidecar
=== RUN   TestAccContainerAppResource_completeUpdate
=== PAUSE TestAccContainerAppResource_completeUpdate
=== RUN   TestAccContainerAppResource_secretRemoveShouldFail
=== PAUSE TestAccContainerAppResource_secretRemoveShouldFail
=== RUN   TestAccContainerAppResource_secretRemoveWithAddShouldFail
=== PAUSE TestAccContainerAppResource_secretRemoveWithAddShouldFail
=== CONT  TestAccContainerAppResource_basic
=== CONT  TestAccContainerAppResource_complete
=== CONT  TestAccContainerAppResource_requiresImport
=== CONT  TestAccContainerAppResource_basicUpdate
=== CONT  TestAccContainerAppResource_withIdentityUpdate
=== CONT  TestAccContainerAppResource_withUserAssignedIdentity
=== CONT  TestAccContainerAppResource_completeUpdate
=== CONT  TestAccContainerAppResource_secretRemoveWithAddShouldFail
--- PASS: TestAccContainerAppResource_withUserAssignedIdentity (1007.50s)
=== CONT  TestAccContainerAppResource_secretRemoveShouldFail
--- PASS: TestAccContainerAppResource_complete (1116.93s)
=== CONT  TestAccContainerAppResource_withSystemAssignedIdentity
--- PASS: TestAccContainerAppResource_requiresImport (1118.77s)
=== CONT  TestAccContainerAppResource_completeWithSidecar
--- PASS: TestAccContainerAppResource_basic (1132.15s)
=== CONT  TestAccContainerAppResource_completeWithVNet
--- PASS: TestAccContainerAppResource_secretRemoveWithAddShouldFail (1167.19s)
--- PASS: TestAccContainerAppResource_basicUpdate (1172.65s)
--- PASS: TestAccContainerAppResource_completeUpdate (1239.61s)
--- PASS: TestAccContainerAppResource_withIdentityUpdate (1654.05s)
--- PASS: TestAccContainerAppResource_secretRemoveShouldFail (798.59s)
--- PASS: TestAccContainerAppResource_completeWithSidecar (885.59s)
--- PASS: TestAccContainerAppResource_withSystemAssignedIdentity (947.69s)
--- PASS: TestAccContainerAppResource_completeWithVNet (1092.61s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/containerapps 2226.147s
```