### PR TITLE
Added validations for admin_username linux and windows virtual machines according to Azure API

### DIFF
--- a/internal/services/compute/linux_virtual_machine_resource.go
+++ b/internal/services/compute/linux_virtual_machine_resource.go
@@ -68,7 +68,7 @@ func resourceLinuxVirtualMachine() *pluginsdk.Resource {
 				Type:         pluginsdk.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.StringIsNotEmpty,
+				ValidateFunc: computeValidate.LinuxAdminUsername,
 			},
 
 			"network_interface_ids": {

--- a/internal/services/compute/validate/linux_admin_username.go
+++ b/internal/services/compute/validate/linux_admin_username.go
@@ -1,0 +1,36 @@
+package validate
+
+import (
+	"fmt"
+	"strings"
+)
+
+// LinuxAdminUsername validates that admin_username meets the Azure API requirements for Linux Virtual Machines.
+func LinuxAdminUsername(i interface{}, k string) (warnings []string, errors []error) {
+	v, ok := i.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string but it wasn't", k))
+		return
+	}
+
+	// adminUsername must not be empty.
+	if strings.TrimSpace(v) == "" {
+		errors = append(errors, fmt.Errorf("%q must not be empty", k))
+		return
+	}
+
+	// adminUsername Max-length 64 characters.
+	if len(v) > 64 {
+		errors = append(errors, fmt.Errorf("%q most be between 1 and %d characters, got %d", k, 64, len(v)))
+	}
+
+	// adminUsername cannot match the following disallowed names.
+	disallowedNames := []string{"administrator", "admin", "user", "user1", "test", "user2", "test1", "user3", "admin1", "1", "123", "a", "actuser", "adm", "admin2", "aspnet", "backup", "console", "david", "guest", "john", "owner", "root", "server", "sql", "support", "support_388945a0", "sys", "test2", "test3", "user4", "user5"}
+	for _, value := range disallowedNames {
+		if value == v {
+			errors = append(errors, fmt.Errorf("%q specified is not allowed, got %q, cannot match: %q", k, v, strings.Join(disallowedNames, ", ")))
+		}
+	}
+
+	return
+}

--- a/internal/services/compute/validate/linux_admin_username_test.go
+++ b/internal/services/compute/validate/linux_admin_username_test.go
@@ -1,0 +1,51 @@
+package validate
+
+import "testing"
+
+func TestLinuxAdminUsername(t *testing.T) {
+	testData := []struct {
+		input    string
+		expected bool
+	}{
+		{
+			// empty
+			input:    "",
+			expected: false,
+		},
+		{
+			// basic example
+			input:    "juanjo",
+			expected: true,
+		},
+		{
+			// basic example with caps
+			input:    "JuanJo",
+			expected: true,
+		},
+		{
+			// can't use reserved words
+			input:    "administrator",
+			expected: false,
+		},
+		{
+			// can't be longer than 64 characters
+			input:    "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkjl",
+			expected: false,
+		},
+		{
+			// 64 characters its fine
+			input:    "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkj",
+			expected: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q..", v.input)
+
+		_, errors := LinuxAdminUsername(v.input, "admin_username")
+		actual := len(errors) == 0
+		if v.expected != actual {
+			t.Fatalf("Expected %t but got %t", v.expected, actual)
+		}
+	}
+}

--- a/internal/services/compute/validate/windows_admin_username.go
+++ b/internal/services/compute/validate/windows_admin_username.go
@@ -1,0 +1,42 @@
+package validate
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// WindowsAdminUsername validates that admin_username meets the Azure API requirements for Windows Virtual Machines.
+func WindowsAdminUsername(i interface{}, k string) (warnings []string, errors []error) {
+	v, ok := i.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string but it wasn't", k))
+		return
+	}
+
+	// adminUsername must not be empty.
+	if strings.TrimSpace(v) == "" {
+		errors = append(errors, fmt.Errorf("%q must not be empty", k))
+		return
+	}
+
+	// adminUsername Max-length 20 characters.
+	if len(v) > 20 {
+		errors = append(errors, fmt.Errorf("%q most be between 1 and %d characters, got %d", k, 20, len(v)))
+	}
+
+	// adminUsername cannot end with a dot
+	if match := regexp.MustCompile(`.*\.$`).Match([]byte(v)); match {
+		errors = append(errors, fmt.Errorf("%q cannot end with a dot", k))
+	}
+
+	// adminUsername cannot match the following disallowed names.
+	disallowedNames := []string{"administrator", "admin", "user", "user1", "test", "user2", "test1", "user3", "admin1", "1", "123", "a", "actuser", "adm", "admin2", "aspnet", "backup", "console", "david", "guest", "john", "owner", "root", "server", "sql", "support", "support_388945a0", "sys", "test2", "test3", "user4", "user5"}
+	for _, value := range disallowedNames {
+		if value == v {
+			errors = append(errors, fmt.Errorf("%q specified is not allowed, got %q, cannot match: %q", k, v, strings.Join(disallowedNames, ", ")))
+		}
+	}
+
+	return
+}

--- a/internal/services/compute/validate/windows_admin_username_test.go
+++ b/internal/services/compute/validate/windows_admin_username_test.go
@@ -1,0 +1,56 @@
+package validate
+
+import "testing"
+
+func TestWindowsAdminUsername(t *testing.T) {
+	testData := []struct {
+		input    string
+		expected bool
+	}{
+		{
+			// empty
+			input:    "",
+			expected: false,
+		},
+		{
+			// basic example
+			input:    "juanjo",
+			expected: true,
+		},
+		{
+			// basic example with caps
+			input:    "JuanJo",
+			expected: true,
+		},
+		{
+			// can't use reserved words
+			input:    "administrator",
+			expected: false,
+		},
+		{
+			// can't be longer than 20 characters
+			input:    "abcdefghijklmnopqrstuvwxyz",
+			expected: false,
+		},
+		{
+			// 20 characters its fine
+			input:    "abcdefghijklmnopqrst",
+			expected: true,
+		},
+		{
+			// cannot end in a dot
+			input:    "juanjo.",
+			expected: false,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q..", v.input)
+
+		_, errors := WindowsAdminUsername(v.input, "admin_username")
+		actual := len(errors) == 0
+		if v.expected != actual {
+			t.Fatalf("Expected %t but got %t", v.expected, actual)
+		}
+	}
+}

--- a/internal/services/compute/windows_virtual_machine_resource.go
+++ b/internal/services/compute/windows_virtual_machine_resource.go
@@ -77,7 +77,7 @@ func resourceWindowsVirtualMachine() *pluginsdk.Resource {
 				Type:         pluginsdk.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.StringIsNotEmpty,
+				ValidateFunc: computeValidate.WindowsAdminUsername,
 			},
 
 			"network_interface_ids": {


### PR DESCRIPTION
Related to #20400 

Added validations for `azurerm_linux_virtual_machine` and `azurerm_windows_virtual_machine` `admin_username` (adminUsername) to meet API restrictions and fail fast: https://learn.microsoft.com/en-us/rest/api/compute/virtual-machines/create-or-update?tabs=HTTP#osprofile  