### PR TITLE
`azurerm_hpc_cache` - add nil check when `usernameSource` is `None`

### DIFF
--- a/internal/services/hpccache/hpc_cache_resource.go
+++ b/internal/services/hpccache/hpc_cache_resource.go
@@ -593,7 +593,7 @@ func expandStorageCacheDirectorySettings(d *pluginsdk.ResourceData) *storagecach
 }
 
 func flattenStorageCacheDirectorySettings(d *pluginsdk.ResourceData, input *storagecache.CacheDirectorySettings) (ad, flatFile, ldap []interface{}, err error) {
-	if input == nil || input.UsernameDownload == nil {
+	if input == nil || input.UsernameDownload == nil || input.UsernameDownload.UsernameSource == storagecache.UsernameSourceNone {
 		return nil, nil, nil, nil
 	}
 


### PR DESCRIPTION
fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/18535

When users disable Directory Service outside of Terraform like Azure Portal, then the usernameSource property of directory service would be set to None. But currently TF only handled [LDAP/AD/File](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/internal/services/hpccache/hpc_cache_resource.go#L704) for usernameSource so that TF throws error in read operation.

After investigated, I found not setting directory Service Settings ("directoryServicesSettings": { }) and setting “usernameSource=None” have same meaning that is used to disable Directory Services. As currently TF already supported to disable directory service via not setting LDAP/AD/File in tf config. Hence, I assume we just need to update code to handle the exception handling for "usernameSource=None". So I raised this PR.

![image](https://user-images.githubusercontent.com/19754191/218365262-3c3ac486-2f5c-4bd2-b68e-427742b9b451.png)
