### PR TITLE
`azurerm_kubernetes_cluster` - update version in test cases

### DIFF
--- a/internal/services/containers/kubernetes_cluster_auth_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_auth_resource_test.go
@@ -812,7 +812,7 @@ resource "azurerm_kubernetes_cluster" "test" {
 `, tenantId, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
 
-func (KubernetesClusterResource) roleBasedAccessControlAADManagedConfigVOneDotTwoFourDotThree(data acceptance.TestData, tenantId string) string {
+func (KubernetesClusterResource) roleBasedAccessControlAADManagedConfigVOneDotTwoFourDotNine(data acceptance.TestData, tenantId string) string {
 	return fmt.Sprintf(`
 variable "tenant_id" {
   default = "%s"
@@ -828,7 +828,7 @@ resource "azurerm_kubernetes_cluster" "test" {
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
   dns_prefix          = "acctestaks%d"
-  kubernetes_version  = "1.24.3"
+  kubernetes_version  = "1.24.9"
 
   linux_profile {
     admin_username = "acctestuser%d"

--- a/internal/services/containers/kubernetes_cluster_data_source_test.go
+++ b/internal/services/containers/kubernetes_cluster_data_source_test.go
@@ -70,13 +70,13 @@ func TestAccDataSourceKubernetesCluster_roleBasedAccessControl(t *testing.T) {
 	})
 }
 
-func TestAccDataSourceKubernetesCluster_roleBasedAccessControlAAD_VOneDotTwoFourDotThree(t *testing.T) {
+func TestAccDataSourceKubernetesCluster_roleBasedAccessControlAAD_VOneDotTwoFourDotNine(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_kubernetes_cluster", "test")
 	r := KubernetesClusterDataSource{}
 
 	data.DataSourceTest(t, []acceptance.TestStep{
 		{
-			Config: r.roleBasedAccessControlAADManagedConfigVOneDotTwoFourDotThree(data),
+			Config: r.roleBasedAccessControlAADManagedConfigVOneDotTwoFourDotNine(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("kube_config.#").HasValue("1"),
 				check.That(data.ResourceName).Key("kube_config.0.host").IsSet(),
@@ -583,7 +583,7 @@ data "azurerm_kubernetes_cluster" "test" {
 `, KubernetesClusterResource{}.roleBasedAccessControlConfig(data))
 }
 
-func (KubernetesClusterDataSource) roleBasedAccessControlAADManagedConfigVOneDotTwoFourDotThree(data acceptance.TestData) string {
+func (KubernetesClusterDataSource) roleBasedAccessControlAADManagedConfigVOneDotTwoFourDotNine(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -591,7 +591,7 @@ data "azurerm_kubernetes_cluster" "test" {
   name                = azurerm_kubernetes_cluster.test.name
   resource_group_name = azurerm_kubernetes_cluster.test.resource_group_name
 }
-`, KubernetesClusterResource{}.roleBasedAccessControlAADManagedConfigVOneDotTwoFourDotThree(data, ""))
+`, KubernetesClusterResource{}.roleBasedAccessControlAADManagedConfigVOneDotTwoFourDotNine(data, ""))
 }
 
 func (KubernetesClusterDataSource) localAccountDisabled(data acceptance.TestData, tenantId string) string {

--- a/internal/services/containers/kubernetes_cluster_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_resource_test.go
@@ -480,7 +480,7 @@ resource "azurerm_kubernetes_cluster" "test" {
   `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, maxSurge)
 }
 
-func TestAccResourceKubernetesCluster_roleBasedAccessControlAAD_VOneDotTwoFourDotThree(t *testing.T) {
+func TestAccResourceKubernetesCluster_roleBasedAccessControlAAD_VOneDotTwoFourDotNine(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
 	r := KubernetesClusterResource{}
 

--- a/internal/services/containers/kubernetes_cluster_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_resource_test.go
@@ -18,10 +18,10 @@ import (
 type KubernetesClusterResource struct{}
 
 var (
-	olderKubernetesVersion        = "1.23.12"
-	currentKubernetesVersion      = "1.24.3"
-	olderKubernetesVersionAlias   = "1.23"
-	currentKubernetesVersionAlias = "1.24"
+	olderKubernetesVersion        = "1.24.9"
+	currentKubernetesVersion      = "1.25.5"
+	olderKubernetesVersionAlias   = "1.24"
+	currentKubernetesVersionAlias = "1.25"
 )
 
 func TestAccKubernetesCluster_hostEncryption(t *testing.T) {
@@ -486,7 +486,7 @@ func TestAccResourceKubernetesCluster_roleBasedAccessControlAAD_VOneDotTwoFourDo
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.roleBasedAccessControlAADManagedConfigVOneDotTwoFourDotThree(data, ""),
+			Config: r.roleBasedAccessControlAADManagedConfigVOneDotTwoFourDotNine(data, ""),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("kube_config.#").HasValue("1"),
 				check.That(data.ResourceName).Key("kube_config.0.host").IsSet(),


### PR DESCRIPTION
```
=== RUN   TestAccDataSourceKubernetesCluster_roleBasedAccessControlAAD_VOneDotTwoFourDotNine
=== PAUSE TestAccDataSourceKubernetesCluster_roleBasedAccessControlAAD_VOneDotTwoFourDotNine
=== CONT  TestAccDataSourceKubernetesCluster_roleBasedAccessControlAAD_VOneDotTwoFourDotNine
--- PASS: TestAccDataSourceKubernetesCluster_roleBasedAccessControlAAD_VOneDotTwoFourDotNine (935.94s)
PASS

=== RUN   TestAccResourceKubernetesCluster_roleBasedAccessControlAAD_VOneDotTwoFourDotThree
=== PAUSE TestAccResourceKubernetesCluster_roleBasedAccessControlAAD_VOneDotTwoFourDotThree
=== CONT  TestAccResourceKubernetesCluster_roleBasedAccessControlAAD_VOneDotTwoFourDotThree
--- PASS: TestAccResourceKubernetesCluster_roleBasedAccessControlAAD_VOneDotTwoFourDotThree (860.79s)
PASS

```