### PR TITLE
`azurerm_automation_account`:  `encryption.key_vault_key_id` should be optional

### DIFF
--- a/internal/services/automation/automation_account_resource.go
+++ b/internal/services/automation/automation_account_resource.go
@@ -86,7 +86,7 @@ func resourceAutomationAccount() *pluginsdk.Resource {
 
 						"key_vault_key_id": {
 							Type:         pluginsdk.TypeString,
-							Required:     true,
+							Optional:     true,
 							ValidateFunc: keyVaultValidate.NestedItemIdWithOptionalVersion,
 						},
 					},

--- a/internal/services/automation/automation_account_resource.go
+++ b/internal/services/automation/automation_account_resource.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
@@ -77,7 +78,6 @@ func resourceAutomationAccount() *pluginsdk.Resource {
 						"key_source": {
 							Type:     pluginsdk.TypeString,
 							Optional: true,
-							Computed: true,
 							ValidateFunc: validation.StringInSlice(
 								automationaccount.PossibleValuesForEncryptionKeySourceType(),
 								false,
@@ -376,6 +376,7 @@ func expandEncryption(encMap map[string]interface{}) (*automationaccount.Encrypt
 			UserAssignedIdentity: &id,
 		},
 	}
+	prop.KeySource = pointer.To(automationaccount.EncryptionKeySourceTypeMicrosoftPointAutomation)
 	if val, ok := encMap["key_source"].(string); ok && val != "" {
 		prop.KeySource = (*automationaccount.EncryptionKeySourceType)(&val)
 	}
@@ -383,6 +384,9 @@ func expandEncryption(encMap map[string]interface{}) (*automationaccount.Encrypt
 		keyId, err := keyVaultParse.ParseOptionallyVersionedNestedItemID(keyIdStr)
 		if err != nil {
 			return nil, err
+		}
+		if prop.KeySource == nil {
+			prop.KeySource = pointer.To(automationaccount.EncryptionKeySourceTypeMicrosoftPointKeyvault)
 		}
 		prop.KeyVaultProperties = &automationaccount.KeyVaultProperties{
 			KeyName:     utils.String(keyId.Name),

--- a/internal/services/automation/automation_account_resource_test.go
+++ b/internal/services/automation/automation_account_resource_test.go
@@ -335,6 +335,7 @@ resource "azurerm_key_vault" "test" {
       "List",
       "Delete",
       "Purge",
+      "GetRotationPolicy",
     ]
 
     secret_permissions = [

--- a/website/docs/r/automation_account.html.markdown
+++ b/website/docs/r/automation_account.html.markdown
@@ -72,7 +72,7 @@ An `encryption` block supports the following:
 
 * `key_source` - (Optional) The source of the encryption key. Possible values are `Microsoft.Automation` and `Microsoft.Keyvault`.
 
-* `key_vault_key_id` - (Required) The ID of the Key Vault Key which should be used to Encrypt the data in this Automation Account.
+* `key_vault_key_id` - (Optional) The ID of the Key Vault Key which should be used to Encrypt the data in this Automation Account. Required when `key_source` is set to `Microsoft.Keyvault`.
 
 ---
 

--- a/website/docs/r/automation_account.html.markdown
+++ b/website/docs/r/automation_account.html.markdown
@@ -52,7 +52,7 @@ The following arguments are supported:
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
-* `encryption` - (Optional) An `encryption` block as defined below.
+* `encryption` - (Optional) An `encryption` block as defined below. set as an empty block for `Microsoft.Automation` kind of encryption.
 
 ---
 
@@ -70,9 +70,9 @@ An `encryption` block supports the following:
 
 * `user_assigned_identity_id` - (Optional) The User Assigned Managed Identity ID to be used for accessing the Customer Managed Key for encryption.
 
-* `key_source` - (Optional) The source of the encryption key. Possible values are `Microsoft.Automation` and `Microsoft.Keyvault`.
+* `key_source` - (Optional **Deprecated**) The source of the encryption key. Possible values are `Microsoft.Automation` and `Microsoft.Keyvault`. This field will be set to `Microsoft.Keyvault` when `key_vault_key_id` is set. otherwise it will be `Microsoft.Automation`.
 
-* `key_vault_key_id` - (Optional) The ID of the Key Vault Key which should be used to Encrypt the data in this Automation Account. Required when `key_source` is set to `Microsoft.Keyvault`.
+* `key_vault_key_id` - (Optional) The ID of the Key Vault Key which should be used to Encrypt the data in this Automation Account.
 
 ---
 


### PR DESCRIPTION
It's no need to provide `key_vault_key_id` where key_source is `Microsoft.Keyvault`.

Fixes: https://github.com/hashicorp/terraform-provider-azurerm/issues/20421

```
--- PASS: TestAccAutomationAccount_encryption (395.20s)
PASS
```
