### PR TITLE
azurerm_storage_queue: resource_manager_id towards documentation

### DIFF
--- a/website/docs/r/storage_queue.html.markdown
+++ b/website/docs/r/storage_queue.html.markdown
@@ -48,6 +48,8 @@ The following attributes are exported in addition to the arguments listed above:
 
 * `id` - The ID of the Storage Queue.
 
+* `resource_manager_id` - The Resource Manager ID of this Storage Queue.
+
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:


### PR DESCRIPTION
Based on this PR https://github.com/hashicorp/terraform-provider-azurerm/pull/19969.

This PR added an output attribute but it was not in the documentation. I needed it and searched existing issues and found it was already in the source code but not in the documentation.