### PR TITLE
azurerm_storage_account: fix environment check for `allow_nested_items_to_be_public`/`min_tls_version` checks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.1.2
 	github.com/hashicorp/go-azure-helpers v0.51.0
-	github.com/hashicorp/go-azure-sdk v0.20230210.1121632
+	github.com/hashicorp/go-azure-sdk v0.20230213.1173636-0.20230213214920-ce82c3ba5b2a
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/go-version v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -207,8 +207,8 @@ github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brv
 github.com/hashicorp/go-azure-helpers v0.12.0/go.mod h1:Zc3v4DNeX6PDdy7NljlYpnrdac1++qNW0I4U+ofGwpg=
 github.com/hashicorp/go-azure-helpers v0.51.0 h1:8KSDGkGnWH6zOT60R3KUqsi0fk1vA7AMunaOUJZMM6k=
 github.com/hashicorp/go-azure-helpers v0.51.0/go.mod h1:lsykLR4KjTUO7MiRmNWiTiX8QQtw3ILjyOvT0f5h3rw=
-github.com/hashicorp/go-azure-sdk v0.20230210.1121632 h1:WJr4kvQJI9M4GnlCFYteIFXqMk/TWNefoolNJz6zCIk=
-github.com/hashicorp/go-azure-sdk v0.20230210.1121632/go.mod h1:aHinadEuBi04I1i+yvpPMZUxvxRxl5JgBOwlzIIxozU=
+github.com/hashicorp/go-azure-sdk v0.20230213.1173636-0.20230213214920-ce82c3ba5b2a h1:NqkD0wK6NwvfdNuzaRJQR2adHg6NMKOc8SYaiNblpzg=
+github.com/hashicorp/go-azure-sdk v0.20230213.1173636-0.20230213214920-ce82c3ba5b2a/go.mod h1:aHinadEuBi04I1i+yvpPMZUxvxRxl5JgBOwlzIIxozU=
 github.com/hashicorp/go-checkpoint v0.5.0 h1:MFYpPZCnQqQTE18jFwSII6eUQrD/oxMFp3mlgcqk5mU=
 github.com/hashicorp/go-checkpoint v0.5.0/go.mod h1:7nfLNL10NsxqO4iWuW6tWW0HjZuDrwkBuEQsVcpCOgg=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=

--- a/internal/acceptance/required_test.go
+++ b/internal/acceptance/required_test.go
@@ -2,6 +2,7 @@ package acceptance
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
@@ -27,6 +28,7 @@ func TestAccEnsureRequiredResourceProvidersAreRegistered(t *testing.T) {
 		DisableTerraformPartnerID:   false,
 		// this test intentionally checks all the RP's are registered - so this is intentional
 		SkipProviderRegistration: true,
+		SubscriptionID:           os.Getenv("ARM_SUBSCRIPTION_ID"),
 	}
 	armClient, err := clients.Build(context.Background(), builder)
 	if err != nil {

--- a/internal/acceptance/testclient/client.go
+++ b/internal/acceptance/testclient/client.go
@@ -67,6 +67,7 @@ func Build() (*clients.Client, error) {
 			TerraformVersion:         os.Getenv("TERRAFORM_CORE_VERSION"),
 			Features:                 features.Default(),
 			StorageUseAzureAD:        false,
+			SubscriptionID:           os.Getenv("ARM_SUBSCRIPTION_ID"),
 		}
 
 		client, err := clients.Build(ctx, clientBuilder)

--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2021-09-01/storage" // nolint: staticcheck
 	azautorest "github.com/Azure/go-autorest/autorest"
-	autorestAzure "github.com/Azure/go-autorest/autorest/azure"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
@@ -19,6 +18,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2022-05-01/storageaccounts"
+	"github.com/hashicorp/go-azure-sdk/sdk/environments"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -1145,7 +1145,7 @@ func resourceStorageAccountCreate(d *pluginsdk.ResourceData, meta interface{}) e
 	// https://github.com/hashicorp/terraform-provider-azurerm/issues/8083
 	// USGovernmentCloud allow_blob_public_access and min_tls_version allowed as of issue 9128
 	// https://github.com/hashicorp/terraform-provider-azurerm/issues/9128
-	if envName != autorestAzure.PublicCloud.Name && envName != autorestAzure.USGovernmentCloud.Name && envName != autorestAzure.ChinaCloud.Name {
+	if envName != environments.AzurePublicCloud && envName != environments.AzureUSGovernmentCloud && envName != environments.AzureChinaCloud {
 		if allowBlobPublicAccess || minimumTLSVersion != string(storage.MinimumTLSVersionTLS10) {
 			return fmt.Errorf(`"allow_nested_items_to_be_public" and "min_tls_version" are not supported for a Storage Account located in %q`, envName)
 		}
@@ -1642,7 +1642,7 @@ func resourceStorageAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 		// https://github.com/hashicorp/terraform-provider-azurerm/issues/8083
 		// USGovernmentCloud "min_tls_version" allowed as of issue 9128
 		// https://github.com/hashicorp/terraform-provider-azurerm/issues/9128
-		if envName != autorestAzure.PublicCloud.Name && envName != autorestAzure.USGovernmentCloud.Name && envName != autorestAzure.ChinaCloud.Name {
+		if envName != environments.AzurePublicCloud && envName != environments.AzureUSGovernmentCloud && envName != environments.AzureChinaCloud {
 			if minimumTLSVersion != string(storage.MinimumTLSVersionTLS10) {
 				return fmt.Errorf(`"min_tls_version" is not supported for a Storage Account located in %q`, envName)
 			}
@@ -1666,7 +1666,7 @@ func resourceStorageAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 		// https://github.com/hashicorp/terraform-provider-azurerm/issues/7812
 		// USGovernmentCloud "allow_blob_public_access" allowed as of issue 9128
 		// https://github.com/hashicorp/terraform-provider-azurerm/issues/9128
-		if envName != autorestAzure.PublicCloud.Name && envName != autorestAzure.USGovernmentCloud.Name && envName != autorestAzure.ChinaCloud.Name {
+		if envName != environments.AzurePublicCloud && envName != environments.AzureUSGovernmentCloud && envName != environments.AzureChinaCloud {
 			if allowBlobPublicAccess {
 				return fmt.Errorf("allow_nested_items_to_be_public is not supported for a Storage Account located in %q", envName)
 			}
@@ -2016,7 +2016,7 @@ func resourceStorageAccountRead(d *pluginsdk.ResourceData, meta interface{}) err
 		// USGovernmentCloud "min_tls_version" allowed as of issue 9128
 		// https://github.com/hashicorp/terraform-provider-azurerm/issues/9128
 		envName := meta.(*clients.Client).Account.Environment.Name
-		if envName != autorestAzure.PublicCloud.Name && envName != autorestAzure.USGovernmentCloud.Name && envName != autorestAzure.ChinaCloud.Name {
+		if envName != environments.AzurePublicCloud && envName != environments.AzureUSGovernmentCloud && envName != environments.AzureChinaCloud {
 			d.Set("min_tls_version", string(storage.MinimumTLSVersionTLS10))
 		} else {
 			// For storage account created using old API, the response of GET call will not return "min_tls_version", either.

--- a/vendor/github.com/hashicorp/go-azure-sdk/sdk/environments/azure_china.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/sdk/environments/azure_china.go
@@ -1,7 +1,9 @@
 package environments
 
+const AzureChinaCloud = "China"
+
 func AzureChina() *Environment {
-	env := baseEnvironmentWithName("China")
+	env := baseEnvironmentWithName(AzureChinaCloud)
 
 	env.Authorization = &Authorization{
 		Audiences: []string{

--- a/vendor/github.com/hashicorp/go-azure-sdk/sdk/environments/azure_gov.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/sdk/environments/azure_gov.go
@@ -1,7 +1,9 @@
 package environments
 
+const AzureUSGovernmentCloud = "USGovernment"
+
 func AzureUSGovernment() *Environment {
-	env := baseEnvironmentWithName("USGovernment")
+	env := baseEnvironmentWithName(AzureUSGovernmentCloud)
 
 	env.Authorization = &Authorization{
 		Audiences: []string{

--- a/vendor/github.com/hashicorp/go-azure-sdk/sdk/environments/azure_public.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/sdk/environments/azure_public.go
@@ -1,7 +1,9 @@
 package environments
 
+const AzurePublicCloud = "Public"
+
 func AzurePublic() *Environment {
-	env := baseEnvironmentWithName("Public")
+	env := baseEnvironmentWithName(AzurePublicCloud)
 
 	env.Authorization = &Authorization{
 		Audiences: []string{

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -161,7 +161,7 @@ github.com/hashicorp/go-azure-helpers/resourcemanager/zones
 github.com/hashicorp/go-azure-helpers/resourceproviders
 github.com/hashicorp/go-azure-helpers/sender
 github.com/hashicorp/go-azure-helpers/storage
-# github.com/hashicorp/go-azure-sdk v0.20230210.1121632
+# github.com/hashicorp/go-azure-sdk v0.20230213.1173636-0.20230213214920-ce82c3ba5b2a
 ## explicit; go 1.19
 github.com/hashicorp/go-azure-sdk/resource-manager/aad/2021-05-01/domainservices
 github.com/hashicorp/go-azure-sdk/resource-manager/aadb2c/2021-04-01-preview


### PR DESCRIPTION
Also, add missing subscription ID to fix test client configurations.

Depends on https://github.com/hashicorp/go-azure-sdk/pull/302 and requires rebase before merging