### PR TITLE
fix: minor spelling mistakes in storage_management_policy docs

### DIFF
--- a/website/docs/d/storage_management_policy.html.markdown
+++ b/website/docs/d/storage_management_policy.html.markdown
@@ -67,7 +67,7 @@ The following arguments are supported:
 * `tier_to_cool_after_days_since_last_access_time_greater_than` - The age in days after last access time to tier blobs to cool storage. Supports blob currently at Hot tier.
 * `tier_to_archive_after_days_since_modification_greater_than` - The age in days after last modification to tier blobs to archive storage. Supports blob currently at Hot or Cool tier.
 * `tier_to_archive_after_days_since_last_access_time_greater_than` - The age in days after last access time to tier blobs to archive storage. Supports blob currently at Hot or Cool tier.
-* `tier_to_archive_after_days_since_last_tier_change_greater_than` - The age in days after last tier change to the blobs to skip to be archved.
+* `tier_to_archive_after_days_since_last_tier_change_greater_than` - The age in days after last tier change to the blobs to skip to be archived.
 * `delete_after_days_since_modification_greater_than` - The age in days after last modification to delete the blob.
 * `delete_after_days_since_last_access_time_greater_than` - The age in days after last access time to delete the blob.
 
@@ -76,7 +76,7 @@ The following arguments are supported:
 `snapshot` supports the following:
 
 * `change_tier_to_archive_after_days_since_creation` - The age in days after creation to tier blob snapshot to archive storage.
-* `tier_to_archive_after_days_since_last_tier_change_greater_than` - The age in days after last tier change to the blobs to skip to be archved.
+* `tier_to_archive_after_days_since_last_tier_change_greater_than` - The age in days after last tier change to the blobs to skip to be archived.
 * `change_tier_to_cool_after_days_since_creation` - The age in days after creation to tier blob snapshot to cool storage.
 * `delete_after_days_since_creation_greater_than` - The age in days after creation to delete the blob snapshot.
 
@@ -85,7 +85,7 @@ The following arguments are supported:
 `version` supports the following:
 
 * `change_tier_to_archive_after_days_since_creation` - The age in days after creation to tier blob version to archive storage.
-* `tier_to_archive_after_days_since_last_tier_change_greater_than` - The age in days after last tier change to the blobs to skip to be archved.
+* `tier_to_archive_after_days_since_last_tier_change_greater_than` - The age in days after last tier change to the blobs to skip to be archived.
 * `change_tier_to_cool_after_days_since_creation` - The age in days after creation to tier blob version to cool storage.
 * `delete_after_days_since_creation` - The age in days after creation to delete the blob version.
 


### PR DESCRIPTION
Fixed very minor spelling mistakes in the docs for `storage_management_policy` where `archived` was misspelt as `archved` several times.