### PR TITLE
Fix azurerm_storage_management_policy reporting filter as optional

### DIFF
--- a/internal/services/storage/storage_management_policy_resource.go
+++ b/internal/services/storage/storage_management_policy_resource.go
@@ -58,7 +58,7 @@ func resourceStorageManagementPolicy() *pluginsdk.Resource {
 						},
 						"filters": {
 							Type:     pluginsdk.TypeList,
-							Optional: true,
+							Required: true,
 							MaxItems: 1,
 							Elem: &pluginsdk.Resource{
 								Schema: map[string]*pluginsdk.Schema{

--- a/website/docs/r/storage_management_policy.html.markdown
+++ b/website/docs/r/storage_management_policy.html.markdown
@@ -96,7 +96,7 @@ The `rule` block supports the following:
 
 * `name` - (Required) The name of the rule. Rule name is case-sensitive. It must be unique within a policy.
 * `enabled` - (Required) Boolean to specify whether the rule is enabled.
-* `filters` - (Optional) A `filters` block as documented below.
+* `filters` - (Required) A `filters` block as documented below.
 * `actions` - (Required) An `actions` block as documented below.
 
 ---


### PR DESCRIPTION
Fixes #20447

The `azurerm_storage_management_policy` resource type reports the `filters` property as optional, but fails to deploy without it (and specifically its `blobType` field)

This is a naive fix and there may be a better alternative.