### PR TITLE
`App Service` - Add authV2 to Web Apps

### DIFF
--- a/internal/services/appservice/helpers/auth_v2_schema.go
+++ b/internal/services/appservice/helpers/auth_v2_schema.go
@@ -1111,24 +1111,22 @@ func expandCustomOIDCAuthV2Settings(input []CustomOIDCAuthV2Settings) map[string
 		provider := &web.CustomOpenIDConnectProvider{
 			Enabled: pointer.To(true),
 			Registration: &web.OpenIDConnectRegistration{
-				ClientID:         pointer.To(v.ClientId),
-				ClientCredential: nil,
+				ClientID: pointer.To(v.ClientId),
+				ClientCredential: &web.OpenIDConnectClientCredential{
+					Method:                  web.ClientCredentialMethodClientSecretPost,
+					ClientSecretSettingName: pointer.To(fmt.Sprintf("%s_PROVIDER_AUTHENTICATION_SECRET", strings.ToUpper(v.Name))),
+				},
 				OpenIDConnectConfiguration: &web.OpenIDConnectConfig{
 					WellKnownOpenIDConfiguration: pointer.To(v.OpenIDConfigurationEndpoint),
 				},
 			},
 			Login: &web.OpenIDConnectLogin{
-				NameClaimType: nil,
-				Scopes:        nil,
+				Scopes: pointer.To(v.Scopes),
 			},
 		}
 
 		if v.NameClaimType != "" {
 			provider.Login.NameClaimType = pointer.To(v.NameClaimType)
-
-		}
-		if len(v.Scopes) > 0 {
-			provider.Login.Scopes = &v.Scopes
 		}
 
 		result[v.Name] = provider

--- a/internal/services/appservice/helpers/auth_v2_schema.go
+++ b/internal/services/appservice/helpers/auth_v2_schema.go
@@ -90,7 +90,7 @@ func AuthV2SettingsSchema() *pluginsdk.Schema {
 					Type:     pluginsdk.TypeString,
 					Optional: true,
 					// ValidateFunc: validation.StringInSlice([]string{}, false), // TODO - find the correct strings for the Auth names
-					Description: "The Default Authentication Provider to use when more than one is specified and the `unauthenticated_action` is set to `RedirectToLoginPage`.",
+					Description: "The Default Authentication Provider to use when the `unauthenticated_action` is set to `RedirectToLoginPage`.",
 				},
 
 				"excluded_paths": {
@@ -499,7 +499,11 @@ func expandAppleAuthV2Settings(input []AppleAuthV2Settings) *web.Apple {
 		return result
 	}
 
-	return nil
+	return &web.Apple{
+		AppleProperties: &web.AppleProperties{
+			Enabled: utils.Bool(true),
+		},
+	}
 }
 
 func flattenAppleAuthV2Settings(input *web.Apple) []AppleAuthV2Settings {
@@ -829,7 +833,9 @@ func expandAadAuthV2Settings(input []AadAuthV2Settings) *web.AzureActiveDirector
 		return result
 	}
 
-	return nil
+	return &web.AzureActiveDirectory{
+		Enabled: utils.Bool(true),
+	}
 }
 
 func flattenAadAuthV2Settings(input *web.AzureActiveDirectory) []AadAuthV2Settings {
@@ -1359,11 +1365,13 @@ func expandFacebookAuthV2Settings(input []FacebookAuthV2Settings) *web.Facebook 
 		return result
 	}
 
-	return nil
+	return &web.Facebook{
+		Enabled: utils.Bool(true),
+	}
 }
 
 func flattenFacebookAuthV2Settings(input *web.Facebook) []FacebookAuthV2Settings {
-	if input == nil || !utils.NormaliseNilableBool(input.Enabled) {
+	if input == nil {
 		return nil
 	}
 
@@ -1377,7 +1385,7 @@ func flattenFacebookAuthV2Settings(input *web.Facebook) []FacebookAuthV2Settings
 			result.AppSecretSettingName = utils.NormalizeNilableString(reg.AppSecretSettingName)
 		}
 	}
-	if login := input.Login; login != nil && login.Scopes != nil {
+	if login := input.Login; login != nil && login.Scopes != nil && len(*login.Scopes) != 0 {
 		result.LoginScopes = *login.Scopes
 	}
 
@@ -1485,7 +1493,11 @@ func expandGitHubAuthV2Settings(input []GithubAuthV2Settings) *web.GitHub {
 		return result
 	}
 
-	return nil
+	return &web.GitHub{
+		GitHubProperties: &web.GitHubProperties{
+			Enabled: utils.Bool(true),
+		},
+	}
 }
 
 func flattenGitHubAuthV2Settings(input *web.GitHub) []GithubAuthV2Settings {
@@ -1642,7 +1654,11 @@ func expandGoogleAuthV2Settings(input []GoogleAuthV2Settings) *web.Google {
 		return result
 	}
 
-	return nil
+	return &web.Google{
+		GoogleProperties: &web.GoogleProperties{
+			Enabled: utils.Bool(true),
+		},
+	}
 }
 
 func flattenGoogleAuthV2Settings(input *web.Google) []GoogleAuthV2Settings {
@@ -1793,7 +1809,11 @@ func expandMicrosoftAuthV2Settings(input []MicrosoftAuthV2Settings) *web.LegacyM
 		return result
 	}
 
-	return nil
+	return &web.LegacyMicrosoftAccount{
+		LegacyMicrosoftAccountProperties: &web.LegacyMicrosoftAccountProperties{
+			Enabled: utils.Bool(true),
+		},
+	}
 }
 
 func flattenMicrosoftAuthV2Settings(input *web.LegacyMicrosoftAccount) []MicrosoftAuthV2Settings {
@@ -1900,7 +1920,11 @@ func expandTwitterAuthV2Settings(input []TwitterAuthV2Settings) *web.Twitter {
 		return result
 	}
 
-	return nil
+	return &web.Twitter{
+		TwitterProperties: &web.TwitterProperties{
+			Enabled: utils.Bool(true),
+		},
+	}
 }
 
 func flattenTwitterAuthV2Settings(input *web.Twitter) []TwitterAuthV2Settings {

--- a/internal/services/appservice/helpers/auth_v2_schema.go
+++ b/internal/services/appservice/helpers/auth_v2_schema.go
@@ -28,8 +28,8 @@ type AuthV2Settings struct {
 	FacebookAuth             []FacebookAuthV2Settings     `tfschema:"facebook_v2"`
 	GithubAuth               []GithubAuthV2Settings       `tfschema:"github_v2"`
 	GoogleAuth               []GoogleAuthV2Settings       `tfschema:"google_v2"`
-	MicrosoftAuth            []MicrosoftAuthV2Settings    `tfschema:"microsoft"`
-	TwitterAuth              []TwitterAuthV2Settings      `tfschema:"twitter"`
+	MicrosoftAuth            []MicrosoftAuthV2Settings    `tfschema:"microsoft_v2"`
+	TwitterAuth              []TwitterAuthV2Settings      `tfschema:"twitter_v2"`
 	// Login
 	Login []AuthV2Login `tfschema:"login"`
 	// HTTPSettings
@@ -116,9 +116,9 @@ func AuthV2SettingsSchema() *pluginsdk.Schema {
 
 				"google_v2": GoogleAuthV2SettingsSchema(),
 
-				"microsoft": MicrosoftAuthV2SettingsSchema(),
+				"microsoft_v2": MicrosoftAuthV2SettingsSchema(),
 
-				"twitter": TwitterAuthV2SettingsSchema(),
+				"twitter_v2": TwitterAuthV2SettingsSchema(),
 
 				"login": authV2LoginSchema(),
 
@@ -230,9 +230,9 @@ func AuthV2SettingsComputedSchema() *pluginsdk.Schema {
 
 				"google_v2": GoogleAuthV2SettingsSchemaComputed(),
 
-				"microsoft": MicrosoftAuthV2SettingsSchemaComputed(),
+				"microsoft_v2": MicrosoftAuthV2SettingsSchemaComputed(),
 
-				"twitter": TwitterAuthV2SettingsSchemaComputed(),
+				"twitter_v2": TwitterAuthV2SettingsSchemaComputed(),
 
 				"login": authV2LoginSchemaComputed(),
 
@@ -574,8 +574,8 @@ func AppleAuthV2SettingsSchema() *pluginsdk.Schema {
 			"auth_settings_v2.0.facebook_v2",
 			"auth_settings_v2.0.github_v2",
 			"auth_settings_v2.0.google_v2",
-			"auth_settings_v2.0.microsoft",
-			"auth_settings_v2.0.twitter",
+			"auth_settings_v2.0.microsoft_v2",
+			"auth_settings_v2.0.twitter_v2",
 		},
 		Elem: &pluginsdk.Resource{
 			Schema: map[string]*pluginsdk.Schema{
@@ -702,8 +702,8 @@ func AadAuthV2SettingsSchema() *pluginsdk.Schema {
 			"auth_settings_v2.0.facebook_v2",
 			"auth_settings_v2.0.github_v2",
 			"auth_settings_v2.0.google_v2",
-			"auth_settings_v2.0.microsoft",
-			"auth_settings_v2.0.twitter",
+			"auth_settings_v2.0.microsoft_v2",
+			"auth_settings_v2.0.twitter_v2",
 		},
 		Elem: &pluginsdk.Resource{
 			Schema: map[string]*pluginsdk.Schema{
@@ -726,8 +726,8 @@ func AadAuthV2SettingsSchema() *pluginsdk.Schema {
 					Optional:     true,
 					ValidateFunc: validation.StringIsNotEmpty,
 					ExactlyOneOf: []string{
-						"auth_settings_v2.0.active_directory.0.client_secret_setting_name",
-						"auth_settings_v2.0.active_directory.0.client_secret_certificate_thumbprint",
+						"auth_settings_v2.0.active_directory_v2.0.client_secret_setting_name",
+						"auth_settings_v2.0.active_directory_v2.0.client_secret_certificate_thumbprint",
 					},
 					Description: "The App Setting name that contains the client secret of the Client.",
 				},
@@ -737,8 +737,8 @@ func AadAuthV2SettingsSchema() *pluginsdk.Schema {
 					Optional:     true,
 					ValidateFunc: validation.StringIsNotEmpty,
 					ExactlyOneOf: []string{
-						"auth_settings_v2.0.active_directory.0.client_secret_setting_name",
-						"auth_settings_v2.0.active_directory.0.client_secret_certificate_thumbprint",
+						"auth_settings_v2.0.active_directory_v2.0.client_secret_setting_name",
+						"auth_settings_v2.0.active_directory_v2.0.client_secret_certificate_thumbprint",
 					},
 					Description: "The thumbprint of the certificate used for signing purposes.",
 				},
@@ -1026,8 +1026,8 @@ func StaticWebAppAuthV2SettingsSchema() *pluginsdk.Schema {
 			"auth_settings_v2.0.facebook_v2",
 			"auth_settings_v2.0.github_v2",
 			"auth_settings_v2.0.google_v2",
-			"auth_settings_v2.0.microsoft",
-			"auth_settings_v2.0.twitter",
+			"auth_settings_v2.0.microsoft_v2",
+			"auth_settings_v2.0.twitter_v2",
 		},
 		Elem: &pluginsdk.Resource{
 			Schema: map[string]*pluginsdk.Schema{
@@ -1116,8 +1116,8 @@ func CustomOIDCAuthV2SettingsSchema() *pluginsdk.Schema {
 			"auth_settings_v2.0.facebook_v2",
 			"auth_settings_v2.0.github_v2",
 			"auth_settings_v2.0.google_v2",
-			"auth_settings_v2.0.microsoft",
-			"auth_settings_v2.0.twitter",
+			"auth_settings_v2.0.microsoft_v2",
+			"auth_settings_v2.0.twitter_v2",
 		},
 		Elem: &pluginsdk.Resource{
 			Schema: map[string]*pluginsdk.Schema{
@@ -1373,8 +1373,8 @@ func FacebookAuthV2SettingsSchema() *pluginsdk.Schema {
 			"auth_settings_v2.0.facebook_v2",
 			"auth_settings_v2.0.github_v2",
 			"auth_settings_v2.0.google_v2",
-			"auth_settings_v2.0.microsoft",
-			"auth_settings_v2.0.twitter",
+			"auth_settings_v2.0.microsoft_v2",
+			"auth_settings_v2.0.twitter_v2",
 		},
 		Elem: &pluginsdk.Resource{
 			Schema: map[string]*pluginsdk.Schema{
@@ -1507,8 +1507,8 @@ func GithubAuthV2SettingsSchema() *pluginsdk.Schema {
 			"auth_settings_v2.0.facebook_v2",
 			"auth_settings_v2.0.github_v2",
 			"auth_settings_v2.0.google_v2",
-			"auth_settings_v2.0.microsoft",
-			"auth_settings_v2.0.twitter",
+			"auth_settings_v2.0.microsoft_v2",
+			"auth_settings_v2.0.twitter_v2",
 		},
 		Elem: &pluginsdk.Resource{
 			Schema: map[string]*pluginsdk.Schema{
@@ -1628,8 +1628,8 @@ func GoogleAuthV2SettingsSchema() *pluginsdk.Schema {
 			"auth_settings_v2.0.facebook_v2",
 			"auth_settings_v2.0.github_v2",
 			"auth_settings_v2.0.google_v2",
-			"auth_settings_v2.0.microsoft",
-			"auth_settings_v2.0.twitter",
+			"auth_settings_v2.0.microsoft_v2",
+			"auth_settings_v2.0.twitter_v2",
 		},
 		Elem: &pluginsdk.Resource{
 			Schema: map[string]*pluginsdk.Schema{
@@ -1776,8 +1776,8 @@ func MicrosoftAuthV2SettingsSchema() *pluginsdk.Schema {
 			"auth_settings_v2.0.facebook_v2",
 			"auth_settings_v2.0.github_v2",
 			"auth_settings_v2.0.google_v2",
-			"auth_settings_v2.0.microsoft",
-			"auth_settings_v2.0.twitter",
+			"auth_settings_v2.0.microsoft_v2",
+			"auth_settings_v2.0.twitter_v2",
 		},
 		Elem: &pluginsdk.Resource{
 			Schema: map[string]*pluginsdk.Schema{
@@ -1911,8 +1911,8 @@ func TwitterAuthV2SettingsSchema() *pluginsdk.Schema {
 			"auth_settings_v2.0.facebook_v2",
 			"auth_settings_v2.0.github_v2",
 			"auth_settings_v2.0.google_v2",
-			"auth_settings_v2.0.microsoft",
-			"auth_settings_v2.0.twitter",
+			"auth_settings_v2.0.microsoft_v2",
+			"auth_settings_v2.0.twitter_v2",
 		},
 		Elem: &pluginsdk.Resource{
 			Schema: map[string]*pluginsdk.Schema{

--- a/internal/services/appservice/helpers/auth_v2_schema.go
+++ b/internal/services/appservice/helpers/auth_v2_schema.go
@@ -21,13 +21,13 @@ type AuthV2Settings struct {
 	DefaultAuthProvider   string   `tfschema:"default_provider"`
 	ExcludedPaths         []string `tfschema:"excluded_paths"`
 	// IdentityProviders
-	AppleAuth                []AppleAuthV2Settings        `tfschema:"apple"`
-	AzureActiveDirectoryAuth []AadAuthV2Settings          `tfschema:"active_directory"`
-	AzureStaticWebAuth       []StaticWebAppAuthV2Settings `tfschema:"azure_static_web_app"`
-	CustomOIDCAuth           []CustomOIDCAuthV2Settings   `tfschema:"custom_oidc"`
-	FacebookAuth             []FacebookAuthV2Settings     `tfschema:"facebook"`
-	GithubAuth               []GithubAuthV2Settings       `tfschema:"github"`
-	GoogleAuth               []GoogleAuthV2Settings       `tfschema:"google"`
+	AppleAuth                []AppleAuthV2Settings        `tfschema:"apple_v2"`
+	AzureActiveDirectoryAuth []AadAuthV2Settings          `tfschema:"active_directory_v2"`
+	AzureStaticWebAuth       []StaticWebAppAuthV2Settings `tfschema:"azure_static_web_app_v2"`
+	CustomOIDCAuth           []CustomOIDCAuthV2Settings   `tfschema:"custom_oidc_v2"`
+	FacebookAuth             []FacebookAuthV2Settings     `tfschema:"facebook_v2"`
+	GithubAuth               []GithubAuthV2Settings       `tfschema:"github_v2"`
+	GoogleAuth               []GoogleAuthV2Settings       `tfschema:"google_v2"`
 	MicrosoftAuth            []MicrosoftAuthV2Settings    `tfschema:"microsoft"`
 	TwitterAuth              []TwitterAuthV2Settings      `tfschema:"twitter"`
 	// Login
@@ -102,19 +102,19 @@ func AuthV2SettingsSchema() *pluginsdk.Schema {
 					Description: "The paths which should be excluded from the `unauthenticated_action` when it is set to `RedirectToLoginPage`.",
 				},
 
-				"apple": AppleAuthV2SettingsSchema(),
+				"apple_v2": AppleAuthV2SettingsSchema(),
 
-				"active_directory": AadAuthV2SettingsSchema(),
+				"active_directory_v2": AadAuthV2SettingsSchema(),
 
-				"azure_static_web_app": StaticWebAppAuthV2SettingsSchema(),
+				"azure_static_web_app_v2": StaticWebAppAuthV2SettingsSchema(),
 
-				"custom_oidc": CustomOIDCAuthV2SettingsSchema(),
+				"custom_oidc_v2": CustomOIDCAuthV2SettingsSchema(),
 
-				"facebook": FacebookAuthV2SettingsSchema(),
+				"facebook_v2": FacebookAuthV2SettingsSchema(),
 
-				"github": GithubAuthV2SettingsSchema(),
+				"github_v2": GithubAuthV2SettingsSchema(),
 
-				"google": GoogleAuthV2SettingsSchema(),
+				"google_v2": GoogleAuthV2SettingsSchema(),
 
 				"microsoft": MicrosoftAuthV2SettingsSchema(),
 
@@ -216,19 +216,19 @@ func AuthV2SettingsComputedSchema() *pluginsdk.Schema {
 					Description: "The paths which are excluded from the `unauthenticated_action` when it is set to `RedirectToLoginPage`.",
 				},
 
-				"apple": AppleAuthV2SettingsSchemaComputed(),
+				"apple_v2": AppleAuthV2SettingsSchemaComputed(),
 
-				"active_directory": AadAuthV2SettingsSchemaComputed(),
+				"active_directory_v2": AadAuthV2SettingsSchemaComputed(),
 
-				"azure_static_web_app": StaticWebAppAuthV2SettingsSchemaComputed(),
+				"azure_static_web_app_v2": StaticWebAppAuthV2SettingsSchemaComputed(),
 
-				"custom_oidc": CustomOIDCAuthV2SettingsSchemaComputed(),
+				"custom_oidc_v2": CustomOIDCAuthV2SettingsSchemaComputed(),
 
-				"facebook": FacebookAuthV2SettingsSchemaComputed(),
+				"facebook_v2": FacebookAuthV2SettingsSchemaComputed(),
 
-				"github": GithubAuthV2SettingsSchemaComputed(),
+				"github_v2": GithubAuthV2SettingsSchemaComputed(),
 
-				"google": GoogleAuthV2SettingsSchemaComputed(),
+				"google_v2": GoogleAuthV2SettingsSchemaComputed(),
 
 				"microsoft": MicrosoftAuthV2SettingsSchemaComputed(),
 
@@ -317,7 +317,7 @@ func authV2LoginSchema() *pluginsdk.Schema {
 					Optional:     true,
 					ValidateFunc: validation.StringIsNotEmpty,
 					ConflictsWith: []string{
-						"auth_v2_settings.0.login.0.token_store_sas_setting_name",
+						"auth_settings_v2.0.login.0.token_store_sas_setting_name",
 					},
 					Description: "The directory path in the App Filesystem in which the tokens will be stored.",
 				},
@@ -326,7 +326,7 @@ func authV2LoginSchema() *pluginsdk.Schema {
 					Type:     pluginsdk.TypeString,
 					Optional: true,
 					ConflictsWith: []string{
-						"auth_v2_settings.0.login.0.token_store_path",
+						"auth_settings_v2.0.login.0.token_store_path",
 					},
 					ValidateFunc: validation.StringIsNotEmpty,
 					Description:  "The name of the app setting which contains the SAS URL of the blob storage containing the tokens.",
@@ -567,15 +567,15 @@ func AppleAuthV2SettingsSchema() *pluginsdk.Schema {
 		Optional: true,
 		MaxItems: 1,
 		AtLeastOneOf: []string{
-			"auth_v2_settings.0.apple",
-			"auth_v2_settings.0.active_directory",
-			"auth_v2_settings.0.azure_static_web_app",
-			"auth_v2_settings.0.custom_oidc",
-			"auth_v2_settings.0.facebook",
-			"auth_v2_settings.0.github",
-			"auth_v2_settings.0.google",
-			"auth_v2_settings.0.microsoft",
-			"auth_v2_settings.0.twitter",
+			"auth_settings_v2.0.apple_v2",
+			"auth_settings_v2.0.active_directory_v2",
+			"auth_settings_v2.0.azure_static_web_app_v2",
+			"auth_settings_v2.0.custom_oidc_v2",
+			"auth_settings_v2.0.facebook_v2",
+			"auth_settings_v2.0.github_v2",
+			"auth_settings_v2.0.google_v2",
+			"auth_settings_v2.0.microsoft",
+			"auth_settings_v2.0.twitter",
 		},
 		Elem: &pluginsdk.Resource{
 			Schema: map[string]*pluginsdk.Schema{
@@ -695,15 +695,15 @@ func AadAuthV2SettingsSchema() *pluginsdk.Schema {
 		Optional: true,
 		MaxItems: 1,
 		AtLeastOneOf: []string{
-			"auth_v2_settings.0.apple",
-			"auth_v2_settings.0.active_directory",
-			"auth_v2_settings.0.azure_static_web_app",
-			"auth_v2_settings.0.custom_oidc",
-			"auth_v2_settings.0.facebook",
-			"auth_v2_settings.0.github",
-			"auth_v2_settings.0.google",
-			"auth_v2_settings.0.microsoft",
-			"auth_v2_settings.0.twitter",
+			"auth_settings_v2.0.apple_v2",
+			"auth_settings_v2.0.active_directory_v2",
+			"auth_settings_v2.0.azure_static_web_app_v2",
+			"auth_settings_v2.0.custom_oidc_v2",
+			"auth_settings_v2.0.facebook_v2",
+			"auth_settings_v2.0.github_v2",
+			"auth_settings_v2.0.google_v2",
+			"auth_settings_v2.0.microsoft",
+			"auth_settings_v2.0.twitter",
 		},
 		Elem: &pluginsdk.Resource{
 			Schema: map[string]*pluginsdk.Schema{
@@ -726,8 +726,8 @@ func AadAuthV2SettingsSchema() *pluginsdk.Schema {
 					Optional:     true,
 					ValidateFunc: validation.StringIsNotEmpty,
 					ExactlyOneOf: []string{
-						"auth_v2_settings.0.active_directory.0.client_secret_setting_name",
-						"auth_v2_settings.0.active_directory.0.client_secret_certificate_thumbprint",
+						"auth_settings_v2.0.active_directory.0.client_secret_setting_name",
+						"auth_settings_v2.0.active_directory.0.client_secret_certificate_thumbprint",
 					},
 					Description: "The App Setting name that contains the client secret of the Client.",
 				},
@@ -737,8 +737,8 @@ func AadAuthV2SettingsSchema() *pluginsdk.Schema {
 					Optional:     true,
 					ValidateFunc: validation.StringIsNotEmpty,
 					ExactlyOneOf: []string{
-						"auth_v2_settings.0.active_directory.0.client_secret_setting_name",
-						"auth_v2_settings.0.active_directory.0.client_secret_certificate_thumbprint",
+						"auth_settings_v2.0.active_directory.0.client_secret_setting_name",
+						"auth_settings_v2.0.active_directory.0.client_secret_certificate_thumbprint",
 					},
 					Description: "The thumbprint of the certificate used for signing purposes.",
 				},
@@ -1019,15 +1019,15 @@ func StaticWebAppAuthV2SettingsSchema() *pluginsdk.Schema {
 		Optional: true,
 		MaxItems: 1,
 		AtLeastOneOf: []string{
-			"auth_v2_settings.0.apple",
-			"auth_v2_settings.0.active_directory",
-			"auth_v2_settings.0.azure_static_web_app",
-			"auth_v2_settings.0.custom_oidc",
-			"auth_v2_settings.0.facebook",
-			"auth_v2_settings.0.github",
-			"auth_v2_settings.0.google",
-			"auth_v2_settings.0.microsoft",
-			"auth_v2_settings.0.twitter",
+			"auth_settings_v2.0.apple_v2",
+			"auth_settings_v2.0.active_directory_v2",
+			"auth_settings_v2.0.azure_static_web_app_v2",
+			"auth_settings_v2.0.custom_oidc_v2",
+			"auth_settings_v2.0.facebook_v2",
+			"auth_settings_v2.0.github_v2",
+			"auth_settings_v2.0.google_v2",
+			"auth_settings_v2.0.microsoft",
+			"auth_settings_v2.0.twitter",
 		},
 		Elem: &pluginsdk.Resource{
 			Schema: map[string]*pluginsdk.Schema{
@@ -1109,15 +1109,15 @@ func CustomOIDCAuthV2SettingsSchema() *pluginsdk.Schema {
 		Type:     pluginsdk.TypeList,
 		Optional: true,
 		AtLeastOneOf: []string{
-			"auth_v2_settings.0.apple",
-			"auth_v2_settings.0.active_directory",
-			"auth_v2_settings.0.azure_static_web_app",
-			"auth_v2_settings.0.custom_oidc",
-			"auth_v2_settings.0.facebook",
-			"auth_v2_settings.0.github",
-			"auth_v2_settings.0.google",
-			"auth_v2_settings.0.microsoft",
-			"auth_v2_settings.0.twitter",
+			"auth_settings_v2.0.apple_v2",
+			"auth_settings_v2.0.active_directory_v2",
+			"auth_settings_v2.0.azure_static_web_app_v2",
+			"auth_settings_v2.0.custom_oidc_v2",
+			"auth_settings_v2.0.facebook_v2",
+			"auth_settings_v2.0.github_v2",
+			"auth_settings_v2.0.google_v2",
+			"auth_settings_v2.0.microsoft",
+			"auth_settings_v2.0.twitter",
 		},
 		Elem: &pluginsdk.Resource{
 			Schema: map[string]*pluginsdk.Schema{
@@ -1366,15 +1366,15 @@ func FacebookAuthV2SettingsSchema() *pluginsdk.Schema {
 		Optional: true,
 		MaxItems: 1,
 		AtLeastOneOf: []string{
-			"auth_v2_settings.0.apple",
-			"auth_v2_settings.0.active_directory",
-			"auth_v2_settings.0.azure_static_web_app",
-			"auth_v2_settings.0.custom_oidc",
-			"auth_v2_settings.0.facebook",
-			"auth_v2_settings.0.github",
-			"auth_v2_settings.0.google",
-			"auth_v2_settings.0.microsoft",
-			"auth_v2_settings.0.twitter",
+			"auth_settings_v2.0.apple_v2",
+			"auth_settings_v2.0.active_directory_v2",
+			"auth_settings_v2.0.azure_static_web_app_v2",
+			"auth_settings_v2.0.custom_oidc_v2",
+			"auth_settings_v2.0.facebook_v2",
+			"auth_settings_v2.0.github_v2",
+			"auth_settings_v2.0.google_v2",
+			"auth_settings_v2.0.microsoft",
+			"auth_settings_v2.0.twitter",
 		},
 		Elem: &pluginsdk.Resource{
 			Schema: map[string]*pluginsdk.Schema{
@@ -1500,15 +1500,15 @@ func GithubAuthV2SettingsSchema() *pluginsdk.Schema {
 		Optional: true,
 		MaxItems: 1,
 		AtLeastOneOf: []string{
-			"auth_v2_settings.0.apple",
-			"auth_v2_settings.0.active_directory",
-			"auth_v2_settings.0.azure_static_web_app",
-			"auth_v2_settings.0.custom_oidc",
-			"auth_v2_settings.0.facebook",
-			"auth_v2_settings.0.github",
-			"auth_v2_settings.0.google",
-			"auth_v2_settings.0.microsoft",
-			"auth_v2_settings.0.twitter",
+			"auth_settings_v2.0.apple_v2",
+			"auth_settings_v2.0.active_directory_v2",
+			"auth_settings_v2.0.azure_static_web_app_v2",
+			"auth_settings_v2.0.custom_oidc_v2",
+			"auth_settings_v2.0.facebook_v2",
+			"auth_settings_v2.0.github_v2",
+			"auth_settings_v2.0.google_v2",
+			"auth_settings_v2.0.microsoft",
+			"auth_settings_v2.0.twitter",
 		},
 		Elem: &pluginsdk.Resource{
 			Schema: map[string]*pluginsdk.Schema{
@@ -1621,15 +1621,15 @@ func GoogleAuthV2SettingsSchema() *pluginsdk.Schema {
 		Optional: true,
 		MaxItems: 1,
 		AtLeastOneOf: []string{
-			"auth_v2_settings.0.apple",
-			"auth_v2_settings.0.active_directory",
-			"auth_v2_settings.0.azure_static_web_app",
-			"auth_v2_settings.0.custom_oidc",
-			"auth_v2_settings.0.facebook",
-			"auth_v2_settings.0.github",
-			"auth_v2_settings.0.google",
-			"auth_v2_settings.0.microsoft",
-			"auth_v2_settings.0.twitter",
+			"auth_settings_v2.0.apple_v2",
+			"auth_settings_v2.0.active_directory_v2",
+			"auth_settings_v2.0.azure_static_web_app_v2",
+			"auth_settings_v2.0.custom_oidc_v2",
+			"auth_settings_v2.0.facebook_v2",
+			"auth_settings_v2.0.github_v2",
+			"auth_settings_v2.0.google_v2",
+			"auth_settings_v2.0.microsoft",
+			"auth_settings_v2.0.twitter",
 		},
 		Elem: &pluginsdk.Resource{
 			Schema: map[string]*pluginsdk.Schema{
@@ -1769,15 +1769,15 @@ func MicrosoftAuthV2SettingsSchema() *pluginsdk.Schema {
 		Optional: true,
 		MaxItems: 1,
 		AtLeastOneOf: []string{
-			"auth_v2_settings.0.apple",
-			"auth_v2_settings.0.active_directory",
-			"auth_v2_settings.0.azure_static_web_app",
-			"auth_v2_settings.0.custom_oidc",
-			"auth_v2_settings.0.facebook",
-			"auth_v2_settings.0.github",
-			"auth_v2_settings.0.google",
-			"auth_v2_settings.0.microsoft",
-			"auth_v2_settings.0.twitter",
+			"auth_settings_v2.0.apple_v2",
+			"auth_settings_v2.0.active_directory_v2",
+			"auth_settings_v2.0.azure_static_web_app_v2",
+			"auth_settings_v2.0.custom_oidc_v2",
+			"auth_settings_v2.0.facebook_v2",
+			"auth_settings_v2.0.github_v2",
+			"auth_settings_v2.0.google_v2",
+			"auth_settings_v2.0.microsoft",
+			"auth_settings_v2.0.twitter",
 		},
 		Elem: &pluginsdk.Resource{
 			Schema: map[string]*pluginsdk.Schema{
@@ -1904,15 +1904,15 @@ func TwitterAuthV2SettingsSchema() *pluginsdk.Schema {
 		Optional: true,
 		MaxItems: 1,
 		AtLeastOneOf: []string{
-			"auth_v2_settings.0.apple",
-			"auth_v2_settings.0.active_directory",
-			"auth_v2_settings.0.azure_static_web_app",
-			"auth_v2_settings.0.custom_oidc",
-			"auth_v2_settings.0.facebook",
-			"auth_v2_settings.0.github",
-			"auth_v2_settings.0.google",
-			"auth_v2_settings.0.microsoft",
-			"auth_v2_settings.0.twitter",
+			"auth_settings_v2.0.apple_v2",
+			"auth_settings_v2.0.active_directory_v2",
+			"auth_settings_v2.0.azure_static_web_app_v2",
+			"auth_settings_v2.0.custom_oidc_v2",
+			"auth_settings_v2.0.facebook_v2",
+			"auth_settings_v2.0.github_v2",
+			"auth_settings_v2.0.google_v2",
+			"auth_settings_v2.0.microsoft",
+			"auth_settings_v2.0.twitter",
 		},
 		Elem: &pluginsdk.Resource{
 			Schema: map[string]*pluginsdk.Schema{

--- a/internal/services/appservice/helpers/auth_v2_schema.go
+++ b/internal/services/appservice/helpers/auth_v2_schema.go
@@ -166,6 +166,109 @@ func AuthV2SettingsSchema() *pluginsdk.Schema {
 		},
 	}
 }
+func AuthV2SettingsComputedSchema() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Computed: true,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"auth_enabled": {
+					Type:        pluginsdk.TypeBool,
+					Computed:    true,
+					Description: "Is the AuthV2 Settings be enabled.",
+				},
+
+				"runtime_version": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The Runtime Version of the Authentication and Authorisation feature of this App.",
+				},
+
+				"config_file_path": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The path to the App Auth settings.",
+				},
+
+				"require_authentication": {
+					Type:        pluginsdk.TypeBool,
+					Computed:    true,
+					Description: "Is the authentication flow used for all requests.",
+				},
+
+				"unauthenticated_action": {
+					Type:     pluginsdk.TypeString,
+					Computed: true,
+				},
+
+				"default_provider": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The Default Authentication Provider used when the `unauthenticated_action` is set to `RedirectToLoginPage`.",
+				},
+
+				"excluded_paths": {
+					Type:     pluginsdk.TypeList,
+					Computed: true,
+					Elem: &pluginsdk.Schema{
+						Type: pluginsdk.TypeString,
+					},
+					Description: "The paths which are excluded from the `unauthenticated_action` when it is set to `RedirectToLoginPage`.",
+				},
+
+				"apple": AppleAuthV2SettingsSchemaComputed(),
+
+				"active_directory": AadAuthV2SettingsSchemaComputed(),
+
+				"azure_static_web_app": StaticWebAppAuthV2SettingsSchemaComputed(),
+
+				"custom_oidc": CustomOIDCAuthV2SettingsSchemaComputed(),
+
+				"facebook": FacebookAuthV2SettingsSchemaComputed(),
+
+				"github": GithubAuthV2SettingsSchemaComputed(),
+
+				"google": GoogleAuthV2SettingsSchemaComputed(),
+
+				"microsoft": MicrosoftAuthV2SettingsSchemaComputed(),
+
+				"twitter": TwitterAuthV2SettingsSchemaComputed(),
+
+				"login": authV2LoginSchemaComputed(),
+
+				"require_https": {
+					Type:        pluginsdk.TypeBool,
+					Computed:    true,
+					Description: "Is HTTPS required on connections?",
+				},
+
+				"http_route_api_prefix": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The prefix that precedes all the authentication and authorisation paths.",
+				},
+
+				"forward_proxy_convention": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The convention used to determine the url of the request made.",
+				},
+
+				"forward_proxy_custom_host_header_name": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The name of the header containing the host of the request.",
+				},
+
+				"forward_proxy_custom_scheme_header_name": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The name of the header containing the scheme of the request.",
+				},
+			},
+		},
+	}
+}
 
 type AuthV2Login struct {
 	LogoutEndpoint                string   `tfschema:"logout_endpoint"`
@@ -276,6 +379,84 @@ func authV2LoginSchema() *pluginsdk.Schema {
 					Optional:    true,
 					Default:     "00:05:00",
 					Description: "The time after the request is made when the nonce should expire.",
+				},
+			},
+		},
+	}
+}
+
+func authV2LoginSchemaComputed() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Computed: true,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"logout_endpoint": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The endpoint to which logout requests are made.",
+				},
+
+				"token_store_enabled": {
+					Type:        pluginsdk.TypeBool,
+					Computed:    true,
+					Description: "Is the Token Store configuration Enabled.",
+				},
+
+				"token_refresh_extension_time": {
+					Type:        pluginsdk.TypeFloat,
+					Computed:    true,
+					Description: "The number of hours after session token expiration that a session token can be used to call the token refresh API.",
+				},
+
+				"token_store_path": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The directory path in the App Filesystem in which the tokens are stored.",
+				},
+
+				"token_store_sas_setting_name": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The name of the app setting which contains the SAS URL of the blob storage containing the tokens.",
+				},
+
+				"preserve_url_fragments_for_logins": {
+					Type:        pluginsdk.TypeBool,
+					Computed:    true,
+					Description: "Are the fragments from the request be preserved after the login request is made.",
+				},
+
+				"allowed_external_redirect_urls": {
+					Type:     pluginsdk.TypeList,
+					Computed: true,
+					Elem: &pluginsdk.Schema{
+						Type: pluginsdk.TypeString,
+					},
+					Description: "External URLs that can be redirected to as part of logging in or logging out of the app. This is an advanced setting typically only needed by Windows Store application backends. **Note:** URLs within the current domain are always implicitly allowed.",
+				},
+
+				"cookie_expiration_convention": {
+					Type:     pluginsdk.TypeString,
+					Computed: true,
+				},
+
+				"cookie_expiration_time": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The time after the request is made when the session cookie will expire.",
+				},
+
+				"validate_nonce": {
+					Type:        pluginsdk.TypeBool,
+					Computed:    true,
+					Description: "Is the nonce be validated while completing the login flow.",
+				},
+
+				"nonce_expiration_time": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The time after the request is made when the nonce will expire.",
 				},
 			},
 		},
@@ -427,8 +608,7 @@ func AppleAuthV2SettingsSchema() *pluginsdk.Schema {
 func AppleAuthV2SettingsSchemaComputed() *pluginsdk.Schema {
 	return &pluginsdk.Schema{
 		Type:     pluginsdk.TypeList,
-		Optional: true,
-		MaxItems: 1,
+		Computed: true,
 		Elem: &pluginsdk.Resource{
 			Schema: map[string]*pluginsdk.Schema{
 				"client_id": {
@@ -645,7 +825,6 @@ func AadAuthV2SettingsSchemaComputed() *pluginsdk.Schema {
 	return &pluginsdk.Schema{
 		Type:     pluginsdk.TypeList,
 		Computed: true,
-		MaxItems: 1,
 		Elem: &pluginsdk.Resource{
 			Schema: map[string]*pluginsdk.Schema{
 				"client_id": {
@@ -866,8 +1045,7 @@ func StaticWebAppAuthV2SettingsSchema() *pluginsdk.Schema {
 func StaticWebAppAuthV2SettingsSchemaComputed() *pluginsdk.Schema {
 	return &pluginsdk.Schema{
 		Type:     pluginsdk.TypeList,
-		Optional: true,
-		MaxItems: 1,
+		Computed: true,
 		Elem: &pluginsdk.Resource{
 			Schema: map[string]*pluginsdk.Schema{
 				"client_id": {
@@ -1023,7 +1201,7 @@ func CustomOIDCAuthV2SettingsSchema() *pluginsdk.Schema {
 func CustomOIDCAuthV2SettingsSchemaComputed() *pluginsdk.Schema {
 	return &pluginsdk.Schema{
 		Type:     pluginsdk.TypeList,
-		Optional: true,
+		Computed: true,
 		Elem: &pluginsdk.Resource{
 			Schema: map[string]*pluginsdk.Schema{
 				"name": {
@@ -1238,27 +1416,24 @@ func FacebookAuthV2SettingsSchema() *pluginsdk.Schema {
 func FacebookAuthV2SettingsSchemaComputed() *pluginsdk.Schema {
 	return &pluginsdk.Schema{
 		Type:     pluginsdk.TypeList,
-		Optional: true,
-		MaxItems: 1,
+		Computed: true,
 		Elem: &pluginsdk.Resource{
 			Schema: map[string]*pluginsdk.Schema{
 				"app_id": {
-					Type:         pluginsdk.TypeString,
-					Required:     true,
-					ValidateFunc: validation.StringIsNotEmpty,
-					Description:  "The App ID of the Facebook app used for login.",
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The App ID of the Facebook app used for login.",
 				},
 
 				"app_secret_setting_name": {
-					Type:         pluginsdk.TypeString,
-					Required:     true,
-					ValidateFunc: validation.StringIsNotEmpty,
-					Description:  "The app setting name that contains the `app_secret` value used for Facebook Login.",
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The app setting name that contains the `app_secret` value used for Facebook Login.",
 				},
 
 				"oauth_scopes": {
 					Type:     pluginsdk.TypeList,
-					Optional: true,
+					Computed: true,
 					Elem: &pluginsdk.Schema{
 						Type: pluginsdk.TypeString,
 					},
@@ -1365,8 +1540,7 @@ func GithubAuthV2SettingsSchema() *pluginsdk.Schema {
 func GithubAuthV2SettingsSchemaComputed() *pluginsdk.Schema {
 	return &pluginsdk.Schema{
 		Type:     pluginsdk.TypeList,
-		Optional: true,
-		MaxItems: 1,
+		Computed: true,
 		Elem: &pluginsdk.Resource{
 			Schema: map[string]*pluginsdk.Schema{
 				"client_id": {
@@ -1500,8 +1674,7 @@ func GoogleAuthV2SettingsSchema() *pluginsdk.Schema {
 func GoogleAuthV2SettingsSchemaComputed() *pluginsdk.Schema {
 	return &pluginsdk.Schema{
 		Type:     pluginsdk.TypeList,
-		Optional: true,
-		MaxItems: 1,
+		Computed: true,
 		Elem: &pluginsdk.Resource{
 			Schema: map[string]*pluginsdk.Schema{
 				"client_id": {
@@ -1648,27 +1821,24 @@ func MicrosoftAuthV2SettingsSchema() *pluginsdk.Schema {
 func MicrosoftAuthV2SettingsSchemaComputed() *pluginsdk.Schema {
 	return &pluginsdk.Schema{
 		Type:     pluginsdk.TypeList,
-		Optional: true,
-		MaxItems: 1,
+		Computed: true,
 		Elem: &pluginsdk.Resource{
 			Schema: map[string]*pluginsdk.Schema{
 				"client_id": {
-					Type:         pluginsdk.TypeString,
-					Required:     true,
-					ValidateFunc: validation.StringIsNotEmpty,
-					Description:  "The OAuth 2.0 client ID that was created for the app used for authentication.",
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The OAuth 2.0 client ID that was created for the app used for authentication.",
 				},
 
 				"client_secret_setting_name": {
-					Type:         pluginsdk.TypeString,
-					Required:     true,
-					ValidateFunc: validation.StringIsNotEmpty,
-					Description:  "The app setting name containing the OAuth 2.0 client secret that was created for the app used for authentication.",
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The app setting name containing the OAuth 2.0 client secret that was created for the app used for authentication.",
 				},
 
 				"oauth_scopes": {
 					Type:     pluginsdk.TypeList,
-					Optional: true,
+					Computed: true,
 					Elem: &pluginsdk.Schema{
 						Type: pluginsdk.TypeString,
 					},
@@ -1765,8 +1935,7 @@ func TwitterAuthV2SettingsSchema() *pluginsdk.Schema {
 func TwitterAuthV2SettingsSchemaComputed() *pluginsdk.Schema {
 	return &pluginsdk.Schema{
 		Type:     pluginsdk.TypeList,
-		Optional: true,
-		MaxItems: 1,
+		Computed: true,
 		Elem: &pluginsdk.Resource{
 			Schema: map[string]*pluginsdk.Schema{
 				"consumer_key": {

--- a/internal/services/appservice/helpers/auth_v2_schema.go
+++ b/internal/services/appservice/helpers/auth_v2_schema.go
@@ -1,0 +1,2051 @@
+package helpers
+
+import (
+	"fmt"
+	"github.com/Azure/azure-sdk-for-go/services/web/mgmt/2021-02-01/web"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+	"strings"
+)
+
+type AuthV2Settings struct {
+	// Platform
+	AuthEnabled    bool   `tfschema:"auth_enabled"`
+	RuntimeVersion string `tfschema:"runtime_version"`
+	ConfigFilePath string `tfschema:"config_file_path"`
+	// Global
+	RequireAuth           bool     `tfschema:"require_authentication"`
+	UnauthenticatedAction string   `tfschema:"unauthenticated_action"`
+	DefaultAuthProvider   string   `tfschema:"default_provider"`
+	ExcludedPaths         []string `tfschema:"excluded_paths"`
+	// IdentityProviders
+	AppleAuth                []AppleAuthV2Settings        `tfschema:"apple"`
+	AzureActiveDirectoryAuth []AadAuthV2Settings          `tfschema:"active_directory"`
+	AzureStaticWebAuth       []StaticWebAppAuthV2Settings `tfschema:"azure_static_web_app"`
+	CustomOIDCAuth           []CustomOIDCAuthV2Settings   `tfschema:"custom_oidc"`
+	FacebookAuth             []FacebookAuthV2Settings     `tfschema:"facebook"`
+	GithubAuth               []GithubAuthV2Settings       `tfschema:"github"`
+	GoogleAuth               []GoogleAuthV2Settings       `tfschema:"google"`
+	MicrosoftAuth            []MicrosoftAuthV2Settings    `tfschema:"microsoft"`
+	TwitterAuth              []TwitterAuthV2Settings      `tfschema:"twitter"`
+	// Login
+	Login []AuthV2Login `tfschema:"login"`
+	// HTTPSettings
+	RequireHTTPS                       bool   `tfschema:"require_https"`
+	HttpRoutesAPIPrefix                string `tfschema:"http_route_api_prefix"`
+	ForwardProxyConvention             string `tfschema:"forward_proxy_convention"`
+	ForwardProxyCustomHostHeaderName   string `tfschema:"forward_proxy_custom_host_header_name"`
+	ForwardProxyCustomSchemeHeaderName string `tfschema:"forward_proxy_custom_scheme_header_name"`
+}
+
+func AuthV2SettingsSchema() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"auth_enabled": {
+					Type:        pluginsdk.TypeBool,
+					Optional:    true,
+					Description: "Should the AuthV2 Settings be enabled. Defaults to `false`",
+				},
+
+				"runtime_version": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					Default:      `~1`,
+					ValidateFunc: validation.StringIsNotEmpty,
+					Description:  "The Runtime Version of the Authentication and Authorisation feature of this App. Defaults to `~1`",
+				},
+
+				"config_file_path": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+					Description:  "The path to the App Auth settings. **Note:** Relative Paths are evaluated from the Site Root directory.",
+				},
+
+				"require_authentication": {
+					Type:        pluginsdk.TypeBool,
+					Default:     true,
+					Optional:    true,
+					Description: "Should the authentication flow be used for all requests. Defaults to `true`",
+				},
+
+				"unauthenticated_action": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+					Default:  string(web.UnauthenticatedClientActionV2RedirectToLoginPage),
+					ValidateFunc: validation.StringInSlice([]string{
+						string(web.UnauthenticatedClientActionV2RedirectToLoginPage),
+						string(web.UnauthenticatedClientActionV2AllowAnonymous),
+						string(web.UnauthenticatedClientActionV2Return401),
+						string(web.UnauthenticatedClientActionV2Return403),
+					}, false),
+				},
+
+				"default_provider": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+					// ValidateFunc: validation.StringInSlice([]string{}, false), // TODO - find the correct strings for the Auth names
+					Description: "The Default Authentication Provider to use when more than one is specified and the `unauthenticated_action` is set to `RedirectToLoginPage`.",
+				},
+
+				"excluded_paths": {
+					Type:     pluginsdk.TypeList,
+					Optional: true,
+					Elem: &pluginsdk.Schema{
+						Type: pluginsdk.TypeString,
+					},
+					Description: "The paths which should be excluded from the `unauthenticated_action` when it is set to `RedirectToLoginPage`.",
+				},
+
+				"apple": AppleAuthV2SettingsSchema(),
+
+				"active_directory": AadAuthV2SettingsSchema(),
+
+				"azure_static_web_app": StaticWebAppAuthV2SettingsSchema(),
+
+				"custom_oidc": CustomOIDCAuthV2SettingsSchema(),
+
+				"facebook": FacebookAuthV2SettingsSchema(),
+
+				"github": GithubAuthV2SettingsSchema(),
+
+				"google": GoogleAuthV2SettingsSchema(),
+
+				"microsoft": MicrosoftAuthV2SettingsSchema(),
+
+				"twitter": TwitterAuthV2SettingsSchema(),
+
+				"login": authV2LoginSchema(),
+
+				"require_https": {
+					Type:        pluginsdk.TypeBool,
+					Optional:    true,
+					Default:     true,
+					Description: "Should HTTPS be required on connections? Defaults to true.",
+				},
+
+				"http_route_api_prefix": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					Default:      "/.auth",
+					ValidateFunc: validation.StringIsNotEmpty,
+					Description:  "The prefix that should precede all the authentication and authorisation paths. Defaults to `/.auth`",
+				},
+
+				"forward_proxy_convention": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+					Default:  string(web.ForwardProxyConventionNoProxy),
+					ValidateFunc: validation.StringInSlice([]string{
+						string(web.ForwardProxyConventionNoProxy),
+						string(web.ForwardProxyConventionCustom),
+						string(web.ForwardProxyConventionStandard),
+					}, false),
+					Description: "The convention used to determine the url of the request made. Possible values include 'ForwardProxyConventionNoProxy', 'ForwardProxyConventionStandard', 'ForwardProxyConventionCustom'. Defaults to `ForwardProxyConventionNoProxy`.",
+				},
+
+				"forward_proxy_custom_host_header_name": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+					Description:  "The name of the header containing the host of the request.",
+				},
+
+				"forward_proxy_custom_scheme_header_name": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+					Description:  "The name of the header containing the scheme of the request.",
+				},
+			},
+		},
+	}
+}
+
+type AuthV2Login struct {
+	LogoutEndpoint                string   `tfschema:"logout_endpoint"`
+	TokenStoreEnabled             bool     `tfschema:"token_store_enabled"`
+	TokenRefreshExtension         float64  `tfschema:"token_refresh_extension_time"`
+	TokenFilesystemPath           string   `tfschema:"token_store_path"`
+	TokenBlobStorageSAS           string   `tfschema:"token_store_sas_setting_name"`
+	PreserveURLFragmentsForLogins bool     `tfschema:"preserve_url_fragments_for_logins"`
+	AllowedExternalRedirectURLs   []string `tfschema:"allowed_external_redirect_urls"`
+	CookieExpirationConvention    string   `tfschema:"cookie_expiration_convention"`
+	CookieExpirationTime          string   `tfschema:"cookie_expiration_time"`
+	ValidateNonce                 bool     `tfschema:"validate_nonce"`
+	NonceExpirationTime           string   `tfschema:"nonce_expiration_time"`
+}
+
+func authV2LoginSchema() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		MaxItems: 1,
+		Required: true,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"logout_endpoint": {
+					Type:        pluginsdk.TypeString,
+					Optional:    true,
+					Description: "The endpoint to which logout requests should be made.",
+				},
+
+				"token_store_enabled": {
+					Type:        pluginsdk.TypeBool,
+					Computed:    true,
+					Description: "Is the Token Store configuration Enabled. True if one of `token_store_path` or `token_store_sas_setting_name` are set to a non-empty value, otherwise `false`.",
+				},
+
+				"token_refresh_extension_time": {
+					Type:         pluginsdk.TypeFloat,
+					Optional:     true,
+					Default:      72,
+					ValidateFunc: validation.FloatAtLeast(1),
+					Description:  "The number of hours after session token expiration that a session token can be used to call the token refresh API. Defaults to `72` hours.",
+				},
+
+				"token_store_path": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+					ConflictsWith: []string{
+						"auth_v2_settings.0.login.0.token_store_sas_setting_name",
+					},
+					Description: "The directory path in the App Filesystem in which the tokens will be stored.",
+				},
+
+				"token_store_sas_setting_name": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+					ConflictsWith: []string{
+						"auth_v2_settings.0.login.0.token_store_path",
+					},
+					ValidateFunc: validation.StringIsNotEmpty,
+					Description:  "The name of the app setting which contains the SAS URL of the blob storage containing the tokens.",
+				},
+
+				"preserve_url_fragments_for_logins": {
+					Type:        pluginsdk.TypeBool,
+					Optional:    true,
+					Default:     false,
+					Description: "Should the fragments from the request be preserved after the login request is made. Defaults to `false`",
+				},
+
+				"allowed_external_redirect_urls": {
+					Type:     pluginsdk.TypeList,
+					Optional: true,
+					Elem: &pluginsdk.Schema{
+						Type:         pluginsdk.TypeString,
+						ValidateFunc: validation.StringIsNotEmpty,
+					},
+					Description: "External URLs that can be redirected to as part of logging in or logging out of the app. This is an advanced setting typically only needed by Windows Store application backends. **Note:** URLs within the current domain are always implicitly allowed.",
+				},
+
+				"cookie_expiration_convention": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+					Default:  string(web.CookieExpirationConventionFixedTime),
+					ValidateFunc: validation.StringInSlice([]string{
+						string(web.CookieExpirationConventionIdentityProviderDerived),
+						string(web.CookieExpirationConventionFixedTime),
+					}, false),
+				},
+
+				"cookie_expiration_time": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+					Default:  "08:00:00",
+					// ValidateFunc: // TODO - Find the allowed strings / values for validation
+					Description: "The time after the request is made when the session cookie should expire.",
+				},
+
+				"validate_nonce": {
+					Type:        pluginsdk.TypeBool,
+					Optional:    true,
+					Default:     true,
+					Description: "Should the nonce be validated while completing the login flow. Defaults to `true`",
+				},
+
+				"nonce_expiration_time": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+					Default:  "00:05:00",
+					// ValidateFunc: TODO
+					Description: "The time after the request is made when the nonce should expire.",
+				},
+			},
+		},
+	}
+}
+
+func expandAuthV2LoginSettings(input []AuthV2Login) *web.Login {
+	if len(input) == 0 {
+		return nil
+	}
+	login := input[0]
+	result := &web.Login{
+		TokenStore: &web.TokenStore{
+			Enabled: utils.Bool(false),
+		},
+		PreserveURLFragmentsForLogins: utils.Bool(login.PreserveURLFragmentsForLogins),
+		Nonce: &web.Nonce{
+			ValidateNonce:           nil,
+			NonceExpirationInterval: nil,
+		},
+	}
+
+	if login.TokenFilesystemPath != "" || login.TokenBlobStorageSAS != "" {
+		result.TokenStore.Enabled = utils.Bool(true)
+		if login.TokenFilesystemPath != "" {
+			result.TokenStore.FileSystem = &web.FileSystemTokenStore{
+				Directory: utils.String(login.TokenFilesystemPath),
+			}
+		}
+		if login.TokenBlobStorageSAS != "" {
+			result.TokenStore.AzureBlobStorage = &web.BlobStorageTokenStore{
+				BlobStorageTokenStoreProperties: &web.BlobStorageTokenStoreProperties{
+					SasURLSettingName: utils.String(login.TokenBlobStorageSAS),
+				},
+			}
+		}
+	}
+
+	if login.LogoutEndpoint != "" {
+		result.Routes = &web.LoginRoutes{
+			LogoutEndpoint: utils.String(login.LogoutEndpoint),
+		}
+	}
+	result.TokenStore.TokenRefreshExtensionHours = utils.Float(login.TokenRefreshExtension)
+	if login.TokenFilesystemPath != "" {
+		result.TokenStore.FileSystem = &web.FileSystemTokenStore{
+			Directory: utils.String(login.TokenFilesystemPath),
+		}
+	}
+	if login.TokenBlobStorageSAS != "" {
+		result.TokenStore.AzureBlobStorage = &web.BlobStorageTokenStore{
+			BlobStorageTokenStoreProperties: &web.BlobStorageTokenStoreProperties{
+				SasURLSettingName: utils.String(login.TokenBlobStorageSAS),
+			},
+		}
+	}
+	if len(login.AllowedExternalRedirectURLs) > 0 {
+		result.AllowedExternalRedirectUrls = &login.AllowedExternalRedirectURLs
+	}
+	if login.CookieExpirationTime != "" || login.CookieExpirationConvention != "" {
+		result.CookieExpiration = &web.CookieExpiration{}
+		if login.CookieExpirationTime != "" {
+			result.CookieExpiration.TimeToExpiration = utils.String(login.CookieExpirationTime)
+		}
+		if login.CookieExpirationConvention != "" {
+			result.CookieExpiration.Convention = web.CookieExpirationConvention(login.CookieExpirationConvention)
+		}
+	}
+
+	result.Nonce = &web.Nonce{
+		ValidateNonce: utils.Bool(login.ValidateNonce),
+	}
+
+	if login.NonceExpirationTime != "" {
+		if login.NonceExpirationTime != "" {
+			result.Nonce.NonceExpirationInterval = utils.String(login.NonceExpirationTime)
+		}
+	}
+
+	return result
+}
+
+func flattenAuthV2LoginSettings(input *web.Login) []AuthV2Login {
+	if input == nil {
+		return []AuthV2Login{{}}
+	}
+	result := AuthV2Login{
+		PreserveURLFragmentsForLogins: utils.NormaliseNilableBool(input.PreserveURLFragmentsForLogins),
+		AllowedExternalRedirectURLs:   nil,
+	}
+	if routes := input.Routes; routes != nil {
+		result.LogoutEndpoint = utils.NormalizeNilableString(routes.LogoutEndpoint)
+	}
+	if token := input.TokenStore; token != nil {
+		result.TokenRefreshExtension = utils.NormalizeNilableFloat(token.TokenRefreshExtensionHours)
+		if fs := token.FileSystem; fs != nil {
+			result.TokenFilesystemPath = utils.NormalizeNilableString(fs.Directory)
+		}
+		if bs := token.AzureBlobStorage; bs != nil && bs.BlobStorageTokenStoreProperties != nil {
+			result.TokenBlobStorageSAS = utils.NormalizeNilableString(bs.SasURLSettingName)
+		}
+	}
+
+	if nonce := input.Nonce; nonce != nil {
+		result.NonceExpirationTime = utils.NormalizeNilableString(nonce.NonceExpirationInterval)
+		result.ValidateNonce = utils.NormaliseNilableBool(nonce.ValidateNonce)
+	}
+
+	if cookie := input.CookieExpiration; cookie != nil {
+		result.CookieExpirationConvention = string(cookie.Convention)
+		result.CookieExpirationTime = utils.NormalizeNilableString(cookie.TimeToExpiration)
+	}
+
+	if input.AllowedExternalRedirectUrls != nil {
+		result.AllowedExternalRedirectURLs = *input.AllowedExternalRedirectUrls
+	}
+
+	return []AuthV2Login{result}
+}
+
+type AppleAuthV2Settings struct {
+	ClientId                string   `tfschema:"client_id"`
+	ClientSecretSettingName string   `tfschema:"client_secret_setting_name"`
+	LoginScopes             []string `tfschema:"login_scopes"`
+}
+
+func AppleAuthV2SettingsSchema() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		AtLeastOneOf: []string{
+			"auth_v2_settings.0.apple",
+			"auth_v2_settings.0.active_directory",
+			"auth_v2_settings.0.azure_static_web_app",
+			"auth_v2_settings.0.custom_oidc",
+			"auth_v2_settings.0.facebook",
+			"auth_v2_settings.0.github",
+			"auth_v2_settings.0.google",
+			"auth_v2_settings.0.microsoft",
+			"auth_v2_settings.0.twitter",
+		},
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"client_id": {
+					Type:         pluginsdk.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+					Description:  "The OpenID Connect Client ID for the Apple web application.",
+				},
+
+				"client_secret_setting_name": {
+					Type:         pluginsdk.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+					Description:  "The app setting name that contains the `client_secret` value used for Apple Login.",
+				},
+
+				"login_scopes": {
+					Type:     pluginsdk.TypeList,
+					Optional: true,
+					Elem: &pluginsdk.Schema{
+						Type: pluginsdk.TypeString,
+					},
+					Description: "Specifies a list of OAuth 2.0 scopes that will be requested as part of Apple Sign-In authentication. If not specified, \"openid\", \"profile\", and \"email\" are used as default scopes.",
+				},
+			},
+		},
+	}
+}
+
+func AppleAuthV2SettingsSchemaComputed() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"client_id": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The OpenID Connect Client ID for the Apple web application.",
+				},
+
+				"client_secret_setting_name": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The app setting name that contains the `client_secret` value used for Apple Login.",
+				},
+
+				"login_scopes": {
+					Type:     pluginsdk.TypeList,
+					Computed: true,
+					Elem: &pluginsdk.Schema{
+						Type: pluginsdk.TypeString,
+					},
+					Description: "Specifies a list of OAuth 2.0 scopes that will be requested as part of Apple Sign-In authentication. If not specified, \"openid\", \"profile\", and \"email\" are used as default scopes.",
+				},
+			},
+		},
+	}
+}
+
+func expandAppleAuthV2Settings(input []AppleAuthV2Settings) *web.Apple {
+	if len(input) == 1 {
+		apple := input[0]
+		result := &web.Apple{
+			AppleProperties: &web.AppleProperties{
+				Enabled: utils.Bool(true),
+				Registration: &web.AppleRegistration{
+					ClientID:                utils.String(apple.ClientId),
+					ClientSecretSettingName: utils.String(apple.ClientSecretSettingName),
+				},
+				Login: &web.LoginScopes{},
+			},
+		}
+		if len(apple.LoginScopes) > 0 {
+			result.AppleProperties.Login.Scopes = &apple.LoginScopes
+		}
+
+		return result
+	}
+
+	return nil
+}
+
+func flattenAppleAuthV2Settings(input *web.Apple) []AppleAuthV2Settings {
+	if input == nil || input.AppleProperties == nil {
+		return nil
+	}
+	result := AppleAuthV2Settings{
+		ClientId:                "",
+		ClientSecretSettingName: "",
+		LoginScopes:             nil,
+	}
+
+	props := *input.AppleProperties
+	if reg := props.Registration; reg != nil {
+		result.ClientId = utils.NormalizeNilableString(reg.ClientID)
+		result.ClientSecretSettingName = utils.NormalizeNilableString(reg.ClientSecretSettingName)
+	}
+	if loginScopes := props.Login; loginScopes != nil && loginScopes.Scopes != nil {
+		result.LoginScopes = *loginScopes.Scopes
+	}
+
+	return []AppleAuthV2Settings{result}
+}
+
+type AadAuthV2Settings struct {
+	TenantAuthURI                     string            `tfschema:"tenant_auth_endpoint"` // Maps to OpenIDIssuer, takes the form `https://login.microsoftonline.com/v2.0/{tenant-guid}/`
+	ClientId                          string            `tfschema:"client_id"`
+	ClientSecretSettingName           string            `tfschema:"client_secret_setting_name"`
+	ClientSecretCertificateThumbprint string            `tfschema:"client_secret_certificate_thumbprint"`
+	LoginParameters                   map[string]string `tfschema:"login_parameters"`
+	DisableWWWAuth                    bool              `tfschema:"disable_www_authentication"`
+	JWTAllowedGroups                  []string          `tfschema:"jwt_allowed_groups"`
+	JWTAllowedClientApps              []string          `tfschema:"jwt_allowed_client_applications"`
+	AllowedApplications               []string          `tfschema:"allowed_applications"`
+	AllowedAudiences                  []string          `tfschema:"allowed_audiences"`
+	AllowedIdentities                 []string          `tfschema:"allowed_identities"`
+	AllowedGroups                     []string          `tfschema:"allowed_groups"`
+}
+
+func AadAuthV2SettingsSchema() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		AtLeastOneOf: []string{
+			"auth_v2_settings.0.apple",
+			"auth_v2_settings.0.active_directory",
+			"auth_v2_settings.0.azure_static_web_app",
+			"auth_v2_settings.0.custom_oidc",
+			"auth_v2_settings.0.facebook",
+			"auth_v2_settings.0.github",
+			"auth_v2_settings.0.google",
+			"auth_v2_settings.0.microsoft",
+			"auth_v2_settings.0.twitter",
+		},
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"client_id": {
+					Type:         pluginsdk.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+					Description:  "The ID of the Client to use to authenticate with Azure Active Directory.",
+				},
+
+				"tenant_auth_endpoint": {
+					Type:         pluginsdk.TypeString,
+					Required:     true,
+					ValidateFunc: validation.IsURLWithHTTPorHTTPS,
+					Description:  "The Azure Tenant Endpoint for the Authenticating Tenant. e.g. `https://login.microsoftonline.com/v2.0/{tenant-guid}/`",
+				},
+
+				"client_secret_setting_name": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+					ExactlyOneOf: []string{
+						"auth_v2_settings.0.active_directory.0.client_secret_setting_name",
+						"auth_v2_settings.0.active_directory.0.client_secret_certificate_thumbprint",
+					},
+					Description: "The App Setting name that contains the client secret of the Client.",
+				},
+
+				"client_secret_certificate_thumbprint": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+					ExactlyOneOf: []string{
+						"auth_v2_settings.0.active_directory.0.client_secret_setting_name",
+						"auth_v2_settings.0.active_directory.0.client_secret_certificate_thumbprint",
+					},
+					Description: "The thumbprint of the certificate used for signing purposes.",
+				},
+
+				"jwt_allowed_groups": {
+					Type:     pluginsdk.TypeList,
+					Optional: true,
+					Elem: &pluginsdk.Schema{
+						Type:         pluginsdk.TypeString,
+						ValidateFunc: validation.StringIsNotEmpty,
+					},
+					Description: "A list of Allowed Groups in the JWT Claim.",
+				},
+
+				"jwt_allowed_client_applications": {
+					Type:     pluginsdk.TypeList,
+					Optional: true,
+					Elem: &pluginsdk.Schema{
+						Type:         pluginsdk.TypeString,
+						ValidateFunc: validation.StringIsNotEmpty,
+					},
+					Description: "A list of Allowed Client Applications in the JWT Claim.",
+				},
+
+				"disable_www_authentication": {
+					Type:        pluginsdk.TypeBool,
+					Optional:    true,
+					Description: "Should the www-authenticate provider should be omitted from the request? Defaults to `false`",
+				},
+
+				"allowed_groups": {
+					Type:     pluginsdk.TypeList,
+					Optional: true,
+					Elem: &pluginsdk.Schema{
+						Type:         pluginsdk.TypeString,
+						ValidateFunc: validation.StringIsNotEmpty,
+					},
+					Description: "The list of allowed Group Names for the Default Authorisation Policy.",
+				},
+
+				"allowed_identities": {
+					Type:     pluginsdk.TypeList,
+					Optional: true,
+					Elem: &pluginsdk.Schema{
+						Type:         pluginsdk.TypeString,
+						ValidateFunc: validation.StringIsNotEmpty, // TODO - Can we use identity Validation here?
+					},
+					Description: "The list of allowed Identities for the Default Authorisation Policy.",
+				},
+
+				"allowed_applications": {
+					Type:     pluginsdk.TypeList,
+					Optional: true,
+					Elem: &pluginsdk.Schema{
+						Type:         pluginsdk.TypeString,
+						ValidateFunc: validation.StringIsNotEmpty, // TODO - Can we use identity Validation here?
+					},
+					Description: "The list of allowed Applications for the Default Authorisation Policy.",
+				},
+
+				"login_parameters": {
+					Type:     pluginsdk.TypeMap,
+					Optional: true,
+					Elem: &pluginsdk.Schema{
+						Type: pluginsdk.TypeString,
+					},
+					Description: "A map of key-value pairs to send to the Authorisation Endpoint when a user logs in.",
+				},
+
+				"allowed_audiences": {
+					Type:     pluginsdk.TypeList,
+					Optional: true,
+					Elem: &pluginsdk.Schema{
+						Type: pluginsdk.TypeString,
+					},
+					Description: "Specifies a list of Allowed audience values to consider when validating JWTs issued by Azure Active Directory.",
+				},
+			},
+		},
+	}
+}
+
+func AadAuthV2SettingsSchemaComputed() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Computed: true,
+		MaxItems: 1,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"client_id": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The ID of the Client to use to authenticate with Azure Active Directory.",
+				},
+
+				"tenant_id": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The Azure Tenant URI for the Authenticating Tenant. e.g. `https://login.microsoftonline.com/v2.0/{tenant-guid}/`",
+				},
+
+				"client_secret_setting_name": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The App Setting name that contains the client secret of the Client.",
+				},
+
+				"client_secret_certificate_thumbprint": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The thumbprint of the certificate used for signing purposes.",
+				},
+
+				"jwt_allowed_groups": {
+					Type:     pluginsdk.TypeList,
+					Computed: true,
+					Elem: &pluginsdk.Schema{
+						Type: pluginsdk.TypeString,
+					},
+					Description: "A list of Allowed Groups in the JWT Claim.",
+				},
+
+				"jwt_allowed_client_applications": {
+					Type:     pluginsdk.TypeList,
+					Computed: true,
+					Elem: &pluginsdk.Schema{
+						Type: pluginsdk.TypeString,
+					},
+					Description: "A list of Allowed Client Applications in the JWT Claim.",
+				},
+
+				"allowed_groups": {
+					Type:     pluginsdk.TypeList,
+					Computed: true,
+					Elem: &pluginsdk.Schema{
+						Type: pluginsdk.TypeString,
+					},
+				},
+
+				"allowed_identities": {
+					Type:     pluginsdk.TypeList,
+					Computed: true,
+					Elem: &pluginsdk.Schema{
+						Type: pluginsdk.TypeString,
+					},
+				},
+
+				"allowed_applications": {
+					Type:     pluginsdk.TypeList,
+					Computed: true,
+					Elem: &pluginsdk.Schema{
+						Type: pluginsdk.TypeString,
+					},
+				},
+
+				"login_parameters": {
+					Type:     pluginsdk.TypeMap,
+					Computed: true,
+					Elem: &pluginsdk.Schema{
+						Type: pluginsdk.TypeString,
+					},
+				},
+
+				"allowed_audiences": {
+					Type:     pluginsdk.TypeList,
+					Computed: true,
+					Elem: &pluginsdk.Schema{
+						Type: pluginsdk.TypeString,
+					},
+					Description: "Specifies a list of Allowed audience values to consider when validating JWTs issued by Azure Active Directory.",
+				},
+			},
+		},
+	}
+}
+
+func expandAadAuthV2Settings(input []AadAuthV2Settings) *web.AzureActiveDirectory {
+	if len(input) == 1 {
+		aad := input[0]
+		result := &web.AzureActiveDirectory{
+			Enabled: utils.Bool(true),
+			Registration: &web.AzureActiveDirectoryRegistration{
+				AzureActiveDirectoryRegistrationProperties: &web.AzureActiveDirectoryRegistrationProperties{
+					OpenIDIssuer: utils.String(aad.TenantAuthURI),
+					ClientID:     utils.String(aad.ClientId),
+				},
+			},
+			Login: &web.AzureActiveDirectoryLogin{
+				AzureActiveDirectoryLoginProperties: &web.AzureActiveDirectoryLoginProperties{
+					DisableWWWAuthenticate: utils.Bool(aad.DisableWWWAuth),
+				},
+			},
+			Validation: &web.AzureActiveDirectoryValidation{
+				AzureActiveDirectoryValidationProperties: &web.AzureActiveDirectoryValidationProperties{
+					JwtClaimChecks: &web.JwtClaimChecks{},
+					DefaultAuthorizationPolicy: &web.DefaultAuthorizationPolicy{
+						AllowedPrincipals: &web.AllowedPrincipals{
+							AllowedPrincipalsProperties: &web.AllowedPrincipalsProperties{},
+						},
+					},
+				},
+			},
+		}
+
+		if aad.ClientSecretCertificateThumbprint != "" {
+			result.Registration.ClientSecretCertificateThumbprint = utils.String(aad.ClientSecretCertificateThumbprint)
+		} else {
+			result.Registration.ClientSecretSettingName = utils.String(aad.ClientSecretSettingName)
+		}
+
+		if len(aad.LoginParameters) > 0 {
+			params := make([]string, 0)
+			for k, v := range aad.LoginParameters {
+				params = append(params, fmt.Sprintf("%s=%s", k, v))
+			}
+			result.Login.LoginParameters = &params
+		}
+
+		if len(aad.JWTAllowedGroups) > 0 {
+			result.Validation.AzureActiveDirectoryValidationProperties.JwtClaimChecks.AllowedGroups = &aad.JWTAllowedGroups
+		}
+		if len(aad.JWTAllowedClientApps) > 0 {
+			result.Validation.AzureActiveDirectoryValidationProperties.JwtClaimChecks.AllowedClientApplications = &aad.JWTAllowedClientApps
+		}
+		if len(aad.AllowedAudiences) > 0 {
+			result.Validation.AllowedAudiences = &aad.AllowedAudiences
+		}
+		if len(aad.AllowedGroups) > 0 {
+			result.Validation.AzureActiveDirectoryValidationProperties.DefaultAuthorizationPolicy.AllowedPrincipals.AllowedPrincipalsProperties.Groups = &aad.AllowedGroups
+		}
+		if len(aad.AllowedIdentities) > 0 {
+			result.Validation.AzureActiveDirectoryValidationProperties.DefaultAuthorizationPolicy.AllowedPrincipals.AllowedPrincipalsProperties.Identities = &aad.AllowedIdentities
+		}
+		if len(aad.AllowedApplications) > 0 {
+			result.Validation.AzureActiveDirectoryValidationProperties.DefaultAuthorizationPolicy.AllowedApplications = &aad.AllowedApplications
+		}
+
+		return result
+	}
+
+	return nil
+}
+
+func flattenAadAuthV2Settings(input *web.AzureActiveDirectory) []AadAuthV2Settings {
+	if input == nil || input.Registration == nil {
+		return nil
+	}
+
+	result := AadAuthV2Settings{}
+
+	if reg := input.Registration; reg != nil && reg.AzureActiveDirectoryRegistrationProperties != nil {
+		result.TenantAuthURI = utils.NormalizeNilableString(reg.OpenIDIssuer)
+		result.ClientId = utils.NormalizeNilableString(reg.ClientID)
+		result.ClientSecretSettingName = utils.NormalizeNilableString(reg.ClientSecretSettingName)
+		result.ClientSecretCertificateThumbprint = utils.NormalizeNilableString(reg.ClientSecretCertificateThumbprint)
+	}
+
+	if login := input.Login; login != nil && login.AzureActiveDirectoryLoginProperties != nil {
+		result.DisableWWWAuth = utils.NormaliseNilableBool(login.DisableWWWAuthenticate)
+		if loginParamsRaw := login.LoginParameters; loginParamsRaw != nil {
+			loginParams := make(map[string]string)
+			for _, v := range *loginParamsRaw {
+				parts := strings.Split(v, "=")
+				if len(parts) == 2 && parts[0] != "" {
+					loginParams[parts[0]] = parts[1]
+				}
+			}
+			result.LoginParameters = loginParams
+		}
+
+	}
+
+	if validationRaw := input.Validation; validationRaw != nil && validationRaw.AzureActiveDirectoryValidationProperties != nil {
+		if validationRaw.AllowedAudiences != nil {
+			result.AllowedAudiences = *validationRaw.AllowedAudiences
+		}
+		if jwt := validationRaw.JwtClaimChecks; jwt != nil {
+			if jwt.AllowedGroups != nil {
+				result.JWTAllowedGroups = *jwt.AllowedGroups
+			}
+			if jwt.AllowedClientApplications != nil {
+				result.JWTAllowedClientApps = *jwt.AllowedClientApplications
+			}
+		}
+		if defaultPolicy := validationRaw.DefaultAuthorizationPolicy; defaultPolicy != nil {
+			if defaultPolicy.AllowedApplications != nil {
+				result.AllowedApplications = *defaultPolicy.AllowedApplications
+			}
+			if defaultPolicy.AllowedPrincipals != nil && defaultPolicy.AllowedPrincipals.AllowedPrincipalsProperties != nil {
+				if defaultPolicy.AllowedPrincipals.AllowedPrincipalsProperties.Groups != nil {
+					result.AllowedGroups = *defaultPolicy.AllowedPrincipals.AllowedPrincipalsProperties.Groups
+				}
+				if defaultPolicy.AllowedPrincipals.AllowedPrincipalsProperties.Identities != nil {
+					result.AllowedIdentities = *defaultPolicy.AllowedPrincipals.AllowedPrincipalsProperties.Identities
+				}
+			}
+		}
+	}
+
+	return []AadAuthV2Settings{result}
+}
+
+type StaticWebAppAuthV2Settings struct {
+	ClientId string `tfschema:"client_id"`
+}
+
+func StaticWebAppAuthV2SettingsSchema() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		AtLeastOneOf: []string{
+			"auth_v2_settings.0.apple",
+			"auth_v2_settings.0.active_directory",
+			"auth_v2_settings.0.azure_static_web_app",
+			"auth_v2_settings.0.custom_oidc",
+			"auth_v2_settings.0.facebook",
+			"auth_v2_settings.0.github",
+			"auth_v2_settings.0.google",
+			"auth_v2_settings.0.microsoft",
+			"auth_v2_settings.0.twitter",
+		},
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"client_id": {
+					Type:         pluginsdk.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+					Description:  "The ID of the Client to use to authenticate with Azure Static Web App Authentication.",
+				},
+			},
+		},
+	}
+}
+
+func StaticWebAppAuthV2SettingsSchemaComputed() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"client_id": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The ID of the Client used to authenticate with Azure Static Web App Authentication.",
+				},
+			},
+		},
+	}
+}
+
+func expandStaticWebAppAuthV2Settings(input []StaticWebAppAuthV2Settings) *web.AzureStaticWebApps {
+	if len(input) == 1 {
+		swa := input[0]
+		return &web.AzureStaticWebApps{
+			AzureStaticWebAppsProperties: &web.AzureStaticWebAppsProperties{
+				Enabled: utils.Bool(true),
+				Registration: &web.AzureStaticWebAppsRegistration{
+					ClientID: utils.String(swa.ClientId),
+				},
+			},
+		}
+	}
+
+	return nil
+}
+
+func flattenStaticWebAppAuthV2Settings(input *web.AzureStaticWebApps) []StaticWebAppAuthV2Settings {
+	if input == nil {
+		return nil
+	}
+
+	result := StaticWebAppAuthV2Settings{}
+
+	if props := input.AzureStaticWebAppsProperties; props != nil && utils.NormaliseNilableBool(props.Enabled) {
+		if props.Registration != nil {
+			result.ClientId = utils.NormalizeNilableString(props.Registration.ClientID)
+		}
+	}
+
+	return []StaticWebAppAuthV2Settings{result}
+}
+
+type CustomOIDCAuthV2Settings struct {
+	Name                        string   `tfschema:"name"`
+	ClientId                    string   `tfschema:"client_id"`
+	ClientCredentialMethod      string   `tfschema:"client_credential_method"`
+	ClientSecretSettingName     string   `tfschema:"client_secret_setting_name"`
+	AuthorizationEndpoint       string   `tfschema:"authorisation_endpoint"`
+	TokenEndpoint               string   `tfschema:"token_endpoint"`
+	IssuerEndpoint              string   `tfschema:"issuer_endpoint"`
+	CertificationURI            string   `tfschema:"certification_uri"`
+	OpenIDConfigurationEndpoint string   `tfschema:"openid_configuration_endpoint"`
+	NameClaimType               string   `tfschema:"name_claim_type"`
+	Scopes                      []string `tfschema:"scopes"`
+}
+
+func CustomOIDCAuthV2SettingsSchema() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		AtLeastOneOf: []string{
+			"auth_v2_settings.0.apple",
+			"auth_v2_settings.0.active_directory",
+			"auth_v2_settings.0.azure_static_web_app",
+			"auth_v2_settings.0.custom_oidc",
+			"auth_v2_settings.0.facebook",
+			"auth_v2_settings.0.github",
+			"auth_v2_settings.0.google",
+			"auth_v2_settings.0.microsoft",
+			"auth_v2_settings.0.twitter",
+		},
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"name": {
+					Type:         pluginsdk.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+					Description:  "The name of the Custom OIDC Authentication Provider.",
+				},
+
+				"client_id": {
+					Type:         pluginsdk.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+					Description:  "The ID of the Client to use to authenticate with this Custom OIDC.",
+				},
+
+				"openid_configuration_endpoint": {
+					Type:        pluginsdk.TypeString,
+					Required:    true,
+					Description: "The endpoint that contains all the configuration endpoints for this Custom OIDC provider.",
+				},
+
+				"name_claim_type": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+					Description:  "The name of the claim that contains the users name.",
+				},
+
+				"scopes": {
+					Type:     pluginsdk.TypeList,
+					Optional: true,
+					Elem: &pluginsdk.Schema{
+						Type:         pluginsdk.TypeString,
+						ValidateFunc: validation.StringIsNotEmpty,
+					},
+					Description: "The list of the scopes that should be requested while authenticating.",
+				},
+
+				"client_credential_method": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The Client Credential Method used. Currently the only supported value is `ClientSecretPost`",
+				},
+
+				"client_secret_setting_name": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The App Setting name that contains the secret for this Custom OIDC Client.",
+				},
+
+				"authorisation_endpoint": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The endpoint to make the Authorisation Request.",
+				},
+
+				"token_endpoint": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The endpoint used to request a Token.",
+				},
+
+				"issuer_endpoint": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The endpoint that issued the Token.",
+				},
+
+				"certification_uri": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The endpoint that provides the keys necessary to validate the token.",
+				},
+			},
+		},
+	}
+}
+
+func CustomOIDCAuthV2SettingsSchemaComputed() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"name": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The name of the Custom OIDC Authentication Provider.",
+				},
+
+				"client_id": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The ID of the Client used to authenticate with this Custom OIDC.",
+				},
+
+				"name_claim_type": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The name of the claim that contains the users name.",
+				},
+
+				"openid_configuration_endpoint": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The endpoint that contains all the configuration endpoints for this Custom OIDC provider.",
+				},
+
+				"scopes": {
+					Type:     pluginsdk.TypeList,
+					Computed: true,
+					Elem: &pluginsdk.Schema{
+						Type: pluginsdk.TypeString,
+					},
+					Description: "The list of the scopes that should be requested while authenticating.",
+				},
+
+				"client_credential_method": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The Client Credential Method used. Currently the only supported value is `ClientSecretPost`",
+				},
+
+				"client_secret_setting_name": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The App Setting name that contains the secret for this Custom OIDC Client.",
+				},
+
+				"authorisation_endpoint": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The endpoint to make the Authorisation Request.",
+				},
+
+				"token_endpoint": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The endpoint used to request a Token.",
+				},
+
+				"issuer_endpoint": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The endpoint that issued the Token.",
+				},
+
+				"certification_uri": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The endpoint that provides the keys necessary to validate the token.",
+				},
+			},
+		},
+	}
+}
+
+func expandCustomOIDCAuthV2Settings(input []CustomOIDCAuthV2Settings) map[string]*web.CustomOpenIDConnectProvider {
+	if len(input) == 0 {
+		return nil
+	}
+	result := make(map[string]*web.CustomOpenIDConnectProvider)
+	for _, v := range input {
+		if v.Name == "" {
+			continue
+		}
+		provider := &web.CustomOpenIDConnectProvider{
+			CustomOpenIDConnectProviderProperties: &web.CustomOpenIDConnectProviderProperties{
+				Enabled: utils.Bool(true),
+				Registration: &web.OpenIDConnectRegistration{
+					ClientID:         utils.String(v.ClientId),
+					ClientCredential: nil,
+					OpenIDConnectConfiguration: &web.OpenIDConnectConfig{
+						WellKnownOpenIDConfiguration: utils.String(v.OpenIDConfigurationEndpoint),
+					},
+				},
+				Login: &web.OpenIDConnectLogin{
+					NameClaimType: nil,
+					Scopes:        nil,
+				},
+			},
+		}
+
+		if v.NameClaimType != "" {
+			provider.Login.NameClaimType = utils.String(v.NameClaimType)
+
+		}
+		if len(v.Scopes) > 0 {
+			provider.Login.Scopes = &v.Scopes
+		}
+
+		result[v.Name] = provider
+	}
+
+	return result
+}
+
+func flattenCustomOIDCAuthV2Settings(input map[string]*web.CustomOpenIDConnectProvider) []CustomOIDCAuthV2Settings {
+	if len(input) == 0 {
+		return nil
+	}
+
+	result := make([]CustomOIDCAuthV2Settings, 0)
+	for k, v := range input {
+		if props := v.CustomOpenIDConnectProviderProperties; props == nil || props.Enabled == nil || !*props.Enabled {
+			continue
+		} else {
+			provider := CustomOIDCAuthV2Settings{
+				Name: k,
+			}
+			if reg := props.Registration; reg != nil {
+				provider.ClientId = utils.NormalizeNilableString(reg.ClientID)
+				if reg.ClientCredential != nil {
+					provider.ClientSecretSettingName = utils.NormalizeNilableString(reg.ClientCredential.ClientSecretSettingName)
+					provider.ClientCredentialMethod = string(reg.ClientCredential.Method)
+				}
+				if config := reg.OpenIDConnectConfiguration; config != nil {
+					provider.OpenIDConfigurationEndpoint = utils.NormalizeNilableString(config.WellKnownOpenIDConfiguration)
+					provider.AuthorizationEndpoint = utils.NormalizeNilableString(config.AuthorizationEndpoint)
+					provider.TokenEndpoint = utils.NormalizeNilableString(config.TokenEndpoint)
+					provider.IssuerEndpoint = utils.NormalizeNilableString(config.Issuer)
+					provider.CertificationURI = utils.NormalizeNilableString(config.CertificationURI)
+				}
+			}
+			if login := props.Login; login != nil {
+				if login.Scopes != nil {
+					provider.Scopes = *login.Scopes
+				}
+				provider.NameClaimType = utils.NormalizeNilableString(login.NameClaimType)
+			}
+			result = append(result, provider)
+		}
+	}
+
+	return result
+}
+
+type FacebookAuthV2Settings struct {
+	AppId                string   `tfschema:"app_id"`
+	AppSecretSettingName string   `tfschema:"app_secret_setting_name"`
+	LoginScopes          []string `tfschema:"login_scopes"`
+	GraphAPIVersion      string   `tfschema:"graph_api_version"`
+}
+
+func FacebookAuthV2SettingsSchema() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		AtLeastOneOf: []string{
+			"auth_v2_settings.0.apple",
+			"auth_v2_settings.0.active_directory",
+			"auth_v2_settings.0.azure_static_web_app",
+			"auth_v2_settings.0.custom_oidc",
+			"auth_v2_settings.0.facebook",
+			"auth_v2_settings.0.github",
+			"auth_v2_settings.0.google",
+			"auth_v2_settings.0.microsoft",
+			"auth_v2_settings.0.twitter",
+		},
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"app_id": {
+					Type:         pluginsdk.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+					Description:  "The App ID of the Facebook app used for login.",
+				},
+
+				"app_secret_setting_name": {
+					Type:         pluginsdk.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+					Description:  "The app setting name that contains the `app_secret` value used for Facebook Login.",
+				},
+
+				"graph_api_version": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					Computed:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+					Description:  "The version of the Facebook API to be used while logging in.",
+				},
+
+				"login_scopes": {
+					Type:     pluginsdk.TypeList,
+					Optional: true,
+					Elem: &pluginsdk.Schema{
+						Type: pluginsdk.TypeString,
+					},
+					Description: "Specifies a list of scopes to be requested as part of Facebook Login authentication.",
+				},
+			},
+		},
+	}
+}
+
+func FacebookAuthV2SettingsSchemaComputed() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"app_id": {
+					Type:         pluginsdk.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+					Description:  "The App ID of the Facebook app used for login.",
+				},
+
+				"app_secret_setting_name": {
+					Type:         pluginsdk.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+					Description:  "The app setting name that contains the `app_secret` value used for Facebook Login.",
+				},
+
+				"oauth_scopes": {
+					Type:     pluginsdk.TypeList,
+					Optional: true,
+					Elem: &pluginsdk.Schema{
+						Type: pluginsdk.TypeString,
+					},
+					Description: "Specifies a list of OAuth 2.0 scopes to be requested as part of Facebook Login authentication.",
+				},
+			},
+		},
+	}
+}
+
+func expandFacebookAuthV2Settings(input []FacebookAuthV2Settings) *web.Facebook {
+	if len(input) == 1 {
+		facebook := input[0]
+		result := &web.Facebook{
+			Enabled: utils.Bool(true),
+			Registration: &web.AppRegistration{
+				AppRegistrationProperties: &web.AppRegistrationProperties{
+					AppID:                utils.String(facebook.AppId),
+					AppSecretSettingName: utils.String(facebook.AppSecretSettingName),
+				},
+			},
+		}
+
+		if facebook.GraphAPIVersion != "" {
+			result.GraphAPIVersion = utils.String(facebook.GraphAPIVersion)
+		}
+		if len(facebook.LoginScopes) > 0 {
+			result.Login = &web.LoginScopes{
+				Scopes: &facebook.LoginScopes,
+			}
+		}
+
+		return result
+	}
+
+	return nil
+}
+
+func flattenFacebookAuthV2Settings(input *web.Facebook) []FacebookAuthV2Settings {
+	if input == nil || !utils.NormaliseNilableBool(input.Enabled) {
+		return nil
+	}
+
+	result := FacebookAuthV2Settings{
+		GraphAPIVersion: utils.NormalizeNilableString(input.GraphAPIVersion),
+	}
+
+	if reg := input.Registration; reg != nil {
+		if reg.AppRegistrationProperties != nil {
+			result.AppId = utils.NormalizeNilableString(reg.AppID)
+			result.AppSecretSettingName = utils.NormalizeNilableString(reg.AppSecretSettingName)
+		}
+	}
+	if login := input.Login; login != nil && login.Scopes != nil {
+		result.LoginScopes = *login.Scopes
+	}
+
+	return []FacebookAuthV2Settings{result}
+}
+
+type GithubAuthV2Settings struct {
+	ClientId                string   `tfschema:"client_id"`
+	ClientSecretSettingName string   `tfschema:"client_secret_setting_name"`
+	LoginScopes             []string `tfschema:"login_scopes"`
+}
+
+func GithubAuthV2SettingsSchema() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		AtLeastOneOf: []string{
+			"auth_v2_settings.0.apple",
+			"auth_v2_settings.0.active_directory",
+			"auth_v2_settings.0.azure_static_web_app",
+			"auth_v2_settings.0.custom_oidc",
+			"auth_v2_settings.0.facebook",
+			"auth_v2_settings.0.github",
+			"auth_v2_settings.0.google",
+			"auth_v2_settings.0.microsoft",
+			"auth_v2_settings.0.twitter",
+		},
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"client_id": {
+					Type:        pluginsdk.TypeString,
+					Required:    true,
+					Description: "The ID of the GitHub app used for login.",
+				},
+
+				"client_secret_setting_name": {
+					Type:        pluginsdk.TypeString,
+					Required:    true,
+					Description: "The app setting name that contains the `client_secret` value used for GitHub Login.",
+				},
+
+				"login_scopes": {
+					Type:     pluginsdk.TypeList,
+					Optional: true,
+					Elem: &pluginsdk.Schema{
+						Type: pluginsdk.TypeString,
+					},
+					Description: "Specifies a list of OAuth 2.0 scopes that will be requested as part of GitHub Login authentication.",
+				},
+			},
+		},
+	}
+}
+
+func GithubAuthV2SettingsSchemaComputed() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"client_id": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The ID of the GitHub app used for login.",
+				},
+
+				"client_secret_setting_name": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The app setting name that contains the `client_secret` value used for GitHub Login.",
+				},
+
+				"login_scopes": {
+					Type:     pluginsdk.TypeList,
+					Computed: true,
+					Elem: &pluginsdk.Schema{
+						Type: pluginsdk.TypeString,
+					},
+					Description: "Specifies a list of OAuth 2.0 scopes that will be requested as part of GitHub Login authentication.",
+				},
+			},
+		},
+	}
+}
+
+func expandGitHubAuthV2Settings(input []GithubAuthV2Settings) *web.GitHub {
+	if len(input) == 1 {
+		github := input[0]
+		result := &web.GitHub{
+			GitHubProperties: &web.GitHubProperties{
+				Enabled: utils.Bool(true),
+				Registration: &web.ClientRegistration{
+					ClientID:                utils.String(github.ClientId),
+					ClientSecretSettingName: utils.String(github.ClientSecretSettingName),
+				},
+				Login: &web.LoginScopes{},
+			},
+		}
+		if len(github.LoginScopes) > 0 {
+			result.GitHubProperties.Login = &web.LoginScopes{Scopes: &github.LoginScopes}
+		}
+
+		return result
+	}
+
+	return nil
+}
+
+func flattenGitHubAuthV2Settings(input *web.GitHub) []GithubAuthV2Settings {
+	if input == nil || input.GitHubProperties == nil {
+		return nil
+	}
+
+	props := *input.GitHubProperties
+	if props.Enabled == nil || !*props.Enabled {
+		return nil
+	}
+
+	result := GithubAuthV2Settings{}
+
+	if reg := props.Registration; reg != nil {
+		result.ClientId = utils.NormalizeNilableString(reg.ClientID)
+		result.ClientSecretSettingName = utils.NormalizeNilableString(reg.ClientSecretSettingName)
+	}
+	if login := props.Login; login != nil && login.Scopes != nil {
+		result.LoginScopes = *login.Scopes
+	}
+
+	return []GithubAuthV2Settings{result}
+}
+
+type GoogleAuthV2Settings struct {
+	ClientId                string   `tfschema:"client_id"`
+	ClientSecretSettingName string   `tfschema:"client_secret_setting_name"`
+	AllowedAudiences        []string `tfschema:"allowed_audiences"`
+	LoginScopes             []string `tfschema:"login_scopes"`
+}
+
+func GoogleAuthV2SettingsSchema() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		AtLeastOneOf: []string{
+			"auth_v2_settings.0.apple",
+			"auth_v2_settings.0.active_directory",
+			"auth_v2_settings.0.azure_static_web_app",
+			"auth_v2_settings.0.custom_oidc",
+			"auth_v2_settings.0.facebook",
+			"auth_v2_settings.0.github",
+			"auth_v2_settings.0.google",
+			"auth_v2_settings.0.microsoft",
+			"auth_v2_settings.0.twitter",
+		},
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"client_id": {
+					Type:         pluginsdk.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+					Description:  "The OpenID Connect Client ID for the Google web application.",
+				},
+
+				"client_secret_setting_name": {
+					Type:         pluginsdk.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+					Description:  "The app setting name that contains the `client_secret` value used for Google Login.",
+				},
+
+				"allowed_audiences": {
+					Type:     pluginsdk.TypeList,
+					Optional: true,
+					Elem: &pluginsdk.Schema{
+						Type:         pluginsdk.TypeString,
+						ValidateFunc: validation.StringIsNotEmpty,
+					},
+					Description: "Specifies a list of Allowed Audiences that will be requested as part of Google Sign-In authentication.",
+				},
+
+				"login_scopes": {
+					Type:     pluginsdk.TypeList,
+					Optional: true,
+					Elem: &pluginsdk.Schema{
+						Type:         pluginsdk.TypeString,
+						ValidateFunc: validation.StringIsNotEmpty,
+					},
+					Description: "Specifies a list of Login scopes that will be requested as part of Google Sign-In authentication.",
+				},
+			},
+		},
+	}
+}
+
+func GoogleAuthV2SettingsSchemaComputed() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"client_id": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The OpenID Connect Client ID for the Google web application.",
+				},
+
+				"client_secret_setting_name": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The app setting name that contains the `client_secret` value used for Google Login.",
+				},
+
+				"allowed_audiences": {
+					Type:     pluginsdk.TypeList,
+					Computed: true,
+					Elem: &pluginsdk.Schema{
+						Type: pluginsdk.TypeString,
+					},
+					Description: "Specifies a list of Allowed Audiences that will be requested as part of Google Sign-In authentication. If not specified, \"openid\", \"profile\", and \"email\" are used as default scopes.",
+				},
+
+				"login_scopes": {
+					Type:     pluginsdk.TypeList,
+					Computed: true,
+					Elem: &pluginsdk.Schema{
+						Type: pluginsdk.TypeString,
+					},
+					Description: "The list of OAuth 2.0 scopes requested as part of Google Sign-In authentication. If not specified, \"openid\", \"profile\", and \"email\" are used as default scopes.",
+				},
+			},
+		},
+	}
+}
+
+func expandGoogleAuthV2Settings(input []GoogleAuthV2Settings) *web.Google {
+	if len(input) == 1 {
+		google := input[0]
+		result := &web.Google{
+			GoogleProperties: &web.GoogleProperties{
+				Enabled: utils.Bool(true),
+				Registration: &web.ClientRegistration{
+					ClientID:                utils.String(google.ClientId),
+					ClientSecretSettingName: utils.String(google.ClientSecretSettingName),
+				},
+			},
+		}
+
+		if len(google.AllowedAudiences) != 0 {
+			result.GoogleProperties.Validation = &web.AllowedAudiencesValidation{
+				AllowedAudiences: &google.AllowedAudiences,
+			}
+		}
+		if len(google.LoginScopes) != 0 {
+			result.GoogleProperties.Login = &web.LoginScopes{
+				Scopes: &google.LoginScopes,
+			}
+		}
+
+		return result
+	}
+
+	return nil
+}
+
+func flattenGoogleAuthV2Settings(input *web.Google) []GoogleAuthV2Settings {
+	if input == nil || input.GoogleProperties == nil {
+		return nil
+	}
+
+	props := *input.GoogleProperties
+	if props.Enabled == nil || !*props.Enabled {
+		return nil
+	}
+
+	result := GoogleAuthV2Settings{}
+
+	if reg := props.Registration; reg != nil {
+		result.ClientId = utils.NormalizeNilableString(reg.ClientID)
+		result.ClientSecretSettingName = utils.NormalizeNilableString(reg.ClientSecretSettingName)
+	}
+	if login := input.Login; login != nil && login.Scopes != nil {
+		result.LoginScopes = *login.Scopes
+	}
+	if val := input.Validation; val != nil && val.AllowedAudiences != nil {
+		result.LoginScopes = *val.AllowedAudiences
+	}
+
+	return []GoogleAuthV2Settings{result}
+}
+
+type MicrosoftAuthV2Settings struct {
+	ClientId                string   `tfschema:"client_id"`
+	ClientSecretSettingName string   `tfschema:"client_secret_setting_name"`
+	AllowedAudiences        []string `tfschema:"allowed_audiences"`
+	LoginScopes             []string `tfschema:"login_scopes"`
+}
+
+func MicrosoftAuthV2SettingsSchema() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		AtLeastOneOf: []string{
+			"auth_v2_settings.0.apple",
+			"auth_v2_settings.0.active_directory",
+			"auth_v2_settings.0.azure_static_web_app",
+			"auth_v2_settings.0.custom_oidc",
+			"auth_v2_settings.0.facebook",
+			"auth_v2_settings.0.github",
+			"auth_v2_settings.0.google",
+			"auth_v2_settings.0.microsoft",
+			"auth_v2_settings.0.twitter",
+		},
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"client_id": {
+					Type:         pluginsdk.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+					Description:  "The OAuth 2.0 client ID that was created for the app used for authentication.",
+				},
+
+				"client_secret_setting_name": {
+					Type:         pluginsdk.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+					Description:  "The app setting name containing the OAuth 2.0 client secret that was created for the app used for authentication.",
+				},
+
+				"allowed_audiences": {
+					Type:     pluginsdk.TypeList,
+					Optional: true,
+					Elem: &pluginsdk.Schema{
+						Type:         pluginsdk.TypeString,
+						ValidateFunc: validation.StringIsNotEmpty,
+					},
+					Description: "Specifies a list of Allowed Audiences that will be requested as part of Microsoft Sign-In authentication.",
+				},
+
+				"login_scopes": {
+					Type:     pluginsdk.TypeList,
+					Optional: true,
+					Elem: &pluginsdk.Schema{
+						Type: pluginsdk.TypeString,
+					},
+					Description: "The list of Login scopes that will be requested as part of Microsoft Account authentication.",
+				},
+			},
+		},
+	}
+}
+
+func MicrosoftAuthV2SettingsSchemaComputed() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"client_id": {
+					Type:         pluginsdk.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+					Description:  "The OAuth 2.0 client ID that was created for the app used for authentication.",
+				},
+
+				"client_secret_setting_name": {
+					Type:         pluginsdk.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+					Description:  "The app setting name containing the OAuth 2.0 client secret that was created for the app used for authentication.",
+				},
+
+				"oauth_scopes": {
+					Type:     pluginsdk.TypeList,
+					Optional: true,
+					Elem: &pluginsdk.Schema{
+						Type: pluginsdk.TypeString,
+					},
+					Description: "The list of OAuth 2.0 scopes that will be requested as part of Microsoft Account authentication. If not specified, `wl.basic` is used as the default scope.",
+				},
+			},
+		},
+	}
+}
+
+func expandMicrosoftAuthV2Settings(input []MicrosoftAuthV2Settings) *web.LegacyMicrosoftAccount {
+	if len(input) == 1 {
+		msft := input[0]
+		result := &web.LegacyMicrosoftAccount{
+			LegacyMicrosoftAccountProperties: &web.LegacyMicrosoftAccountProperties{
+				Enabled: utils.Bool(true),
+				Registration: &web.ClientRegistration{
+					ClientID:                utils.String(msft.ClientId),
+					ClientSecretSettingName: utils.String(msft.ClientSecretSettingName),
+				},
+			},
+		}
+		if len(msft.AllowedAudiences) != 0 {
+			result.LegacyMicrosoftAccountProperties.Validation = &web.AllowedAudiencesValidation{
+				AllowedAudiences: &msft.AllowedAudiences,
+			}
+		}
+		if len(msft.LoginScopes) != 0 {
+			result.LegacyMicrosoftAccountProperties.Login = &web.LoginScopes{
+				Scopes: &msft.LoginScopes,
+			}
+		}
+
+		return result
+	}
+
+	return nil
+}
+
+func flattenMicrosoftAuthV2Settings(input *web.LegacyMicrosoftAccount) []MicrosoftAuthV2Settings {
+	if input == nil || input.LegacyMicrosoftAccountProperties == nil {
+		return nil
+	}
+
+	props := *input.LegacyMicrosoftAccountProperties
+	if props.Enabled == nil || !*props.Enabled {
+		return nil
+	}
+
+	result := MicrosoftAuthV2Settings{}
+
+	if reg := props.Registration; reg != nil {
+		result.ClientId = utils.NormalizeNilableString(reg.ClientID)
+		result.ClientSecretSettingName = utils.NormalizeNilableString(reg.ClientSecretSettingName)
+	}
+	if login := input.Login; login != nil && login.Scopes != nil {
+		result.LoginScopes = *login.Scopes
+	}
+	if val := input.Validation; val != nil && val.AllowedAudiences != nil {
+		result.LoginScopes = *val.AllowedAudiences
+	}
+
+	return []MicrosoftAuthV2Settings{result}
+}
+
+type TwitterAuthV2Settings struct {
+	ConsumerKey               string `tfschema:"consumer_key"`
+	ConsumerSecretSettingName string `tfschema:"consumer_secret_setting_name"`
+}
+
+func TwitterAuthV2SettingsSchema() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		AtLeastOneOf: []string{
+			"auth_v2_settings.0.apple",
+			"auth_v2_settings.0.active_directory",
+			"auth_v2_settings.0.azure_static_web_app",
+			"auth_v2_settings.0.custom_oidc",
+			"auth_v2_settings.0.facebook",
+			"auth_v2_settings.0.github",
+			"auth_v2_settings.0.google",
+			"auth_v2_settings.0.microsoft",
+			"auth_v2_settings.0.twitter",
+		},
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"consumer_key": {
+					Type:        pluginsdk.TypeString,
+					Required:    true,
+					Description: "The OAuth 1.0a consumer key of the Twitter application used for sign-in.",
+				},
+
+				"consumer_secret_setting_name": {
+					Type:        pluginsdk.TypeString,
+					Required:    true,
+					Description: "The app setting name that contains the OAuth 1.0a consumer secret of the Twitter application used for sign-in.",
+				},
+			},
+		},
+	}
+}
+
+func TwitterAuthV2SettingsSchemaComputed() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"consumer_key": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The OAuth 1.0a consumer key of the Twitter application used for sign-in.",
+				},
+
+				"consumer_secret_setting_name": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The app setting name that contains the OAuth 1.0a consumer secret of the Twitter application used for sign-in.",
+				},
+			},
+		},
+	}
+}
+
+func expandTwitterAuthV2Settings(input []TwitterAuthV2Settings) *web.Twitter {
+	if len(input) == 1 {
+		twitter := input[0]
+		result := &web.Twitter{
+			TwitterProperties: &web.TwitterProperties{
+				Enabled: utils.Bool(true),
+				Registration: &web.TwitterRegistration{
+					ConsumerKey:               utils.String(twitter.ConsumerKey),
+					ConsumerSecretSettingName: utils.String(twitter.ConsumerSecretSettingName),
+				},
+			},
+		}
+
+		return result
+	}
+
+	return nil
+}
+
+func flattenTwitterAuthV2Settings(input *web.Twitter) []TwitterAuthV2Settings {
+	if input == nil || input.TwitterProperties == nil {
+		return nil
+	}
+
+	props := *input.TwitterProperties
+	if utils.NormaliseNilableBool(props.Enabled) {
+		result := TwitterAuthV2Settings{}
+		if reg := props.Registration; reg != nil {
+			result.ConsumerKey = utils.NormalizeNilableString(reg.ConsumerKey)
+			result.ConsumerSecretSettingName = utils.NormalizeNilableString(reg.ConsumerSecretSettingName)
+		}
+		return []TwitterAuthV2Settings{result}
+	}
+
+	return nil
+}
+
+func ExpandAuthV2Settings(input []AuthV2Settings) *web.SiteAuthSettingsV2 {
+	result := &web.SiteAuthSettingsV2{}
+	if len(input) != 1 {
+		return result
+	}
+
+	settings := input[0]
+
+	props := &web.SiteAuthSettingsV2Properties{
+		Platform: &web.AuthPlatform{
+			Enabled: utils.Bool(settings.AuthEnabled),
+		},
+		GlobalValidation: &web.GlobalValidation{
+			RequireAuthentication: utils.Bool(settings.RequireAuth),
+		},
+		IdentityProviders: &web.IdentityProviders{
+			AzureActiveDirectory:         expandAadAuthV2Settings(settings.AzureActiveDirectoryAuth),
+			Facebook:                     expandFacebookAuthV2Settings(settings.FacebookAuth),
+			GitHub:                       expandGitHubAuthV2Settings(settings.GithubAuth),
+			Google:                       expandGoogleAuthV2Settings(settings.GoogleAuth),
+			Twitter:                      expandTwitterAuthV2Settings(settings.TwitterAuth),
+			CustomOpenIDConnectProviders: expandCustomOIDCAuthV2Settings(settings.CustomOIDCAuth),
+			LegacyMicrosoftAccount:       expandMicrosoftAuthV2Settings(settings.MicrosoftAuth),
+			Apple:                        expandAppleAuthV2Settings(settings.AppleAuth),
+			AzureStaticWebApps:           expandStaticWebAppAuthV2Settings(settings.AzureStaticWebAuth),
+		},
+		Login: expandAuthV2LoginSettings(settings.Login),
+		HTTPSettings: &web.HTTPSettings{
+			RequireHTTPS: utils.Bool(settings.RequireHTTPS),
+			ForwardProxy: &web.ForwardProxy{
+				Convention: web.ForwardProxyConvention(settings.ForwardProxyConvention),
+			},
+		},
+	}
+
+	// Platform
+	if settings.RuntimeVersion != "" {
+		props.Platform.RuntimeVersion = utils.String(settings.RuntimeVersion)
+	}
+	if settings.ConfigFilePath != "" {
+		props.Platform.ConfigFilePath = utils.String(settings.ConfigFilePath)
+	}
+
+	// Global
+	if settings.UnauthenticatedAction != "" {
+		props.GlobalValidation.UnauthenticatedClientAction = web.UnauthenticatedClientActionV2(settings.UnauthenticatedAction)
+	}
+	if settings.DefaultAuthProvider != "" {
+		props.GlobalValidation.RedirectToProvider = utils.String(settings.DefaultAuthProvider)
+	}
+	if len(settings.ExcludedPaths) > 0 {
+		props.GlobalValidation.ExcludedPaths = &settings.ExcludedPaths
+	}
+
+	// HTTP
+	if settings.ForwardProxyCustomHostHeaderName != "" {
+		props.HTTPSettings.ForwardProxy.CustomHostHeaderName = utils.String(settings.ForwardProxyCustomHostHeaderName)
+	}
+	if settings.ForwardProxyCustomSchemeHeaderName != "" {
+		props.HTTPSettings.ForwardProxy.CustomProtoHeaderName = utils.String(settings.ForwardProxyCustomSchemeHeaderName)
+	}
+	if settings.HttpRoutesAPIPrefix != "" {
+		props.HTTPSettings = &web.HTTPSettings{
+			Routes: &web.HTTPSettingsRoutes{
+				APIPrefix: utils.String(settings.HttpRoutesAPIPrefix),
+			},
+		}
+	}
+
+	result.SiteAuthSettingsV2Properties = props
+
+	return result
+}
+
+func FlattenAuthV2Settings(input web.SiteAuthSettingsV2) []AuthV2Settings {
+	if input.SiteAuthSettingsV2Properties == nil {
+		return nil
+	}
+
+	settings := *input.SiteAuthSettingsV2Properties
+
+	result := AuthV2Settings{}
+
+	if platform := settings.Platform; platform != nil {
+		result.AuthEnabled = utils.NormaliseNilableBool(platform.Enabled)
+		result.RuntimeVersion = utils.NormalizeNilableString(platform.RuntimeVersion)
+		result.ConfigFilePath = utils.NormalizeNilableString(platform.ConfigFilePath)
+	}
+
+	if global := settings.GlobalValidation; global != nil {
+		result.RequireAuth = utils.NormaliseNilableBool(global.RequireAuthentication)
+		result.UnauthenticatedAction = string(global.UnauthenticatedClientAction)
+		result.DefaultAuthProvider = utils.NormalizeNilableString(global.RedirectToProvider)
+		if global.ExcludedPaths != nil && len(*global.ExcludedPaths) > 0 {
+			result.ExcludedPaths = *global.ExcludedPaths
+		}
+	}
+
+	if http := settings.HTTPSettings; http != nil {
+		result.RequireHTTPS = utils.NormaliseNilableBool(http.RequireHTTPS)
+		if http.Routes != nil {
+			result.HttpRoutesAPIPrefix = utils.NormalizeNilableString(http.Routes.APIPrefix)
+		}
+		if fp := http.ForwardProxy; fp != nil {
+			result.ForwardProxyConvention = string(fp.Convention)
+			result.ForwardProxyCustomHostHeaderName = utils.NormalizeNilableString(fp.CustomHostHeaderName)
+			result.ForwardProxyCustomSchemeHeaderName = utils.NormalizeNilableString(fp.CustomProtoHeaderName)
+		}
+	}
+
+	if login := settings.Login; login != nil {
+		result.Login = flattenAuthV2LoginSettings(login)
+	}
+
+	if authProviders := settings.IdentityProviders; authProviders != nil {
+		result.AppleAuth = flattenAppleAuthV2Settings(authProviders.Apple)
+		result.AzureActiveDirectoryAuth = flattenAadAuthV2Settings(authProviders.AzureActiveDirectory)
+		result.AzureStaticWebAuth = flattenStaticWebAppAuthV2Settings(authProviders.AzureStaticWebApps)
+		result.CustomOIDCAuth = flattenCustomOIDCAuthV2Settings(authProviders.CustomOpenIDConnectProviders)
+		result.FacebookAuth = flattenFacebookAuthV2Settings(authProviders.Facebook)
+		result.GithubAuth = flattenGitHubAuthV2Settings(authProviders.GitHub)
+		result.GoogleAuth = flattenGoogleAuthV2Settings(authProviders.Google)
+		result.MicrosoftAuth = flattenMicrosoftAuthV2Settings(authProviders.LegacyMicrosoftAccount)
+		result.TwitterAuth = flattenTwitterAuthV2Settings(authProviders.Twitter)
+	}
+
+	return []AuthV2Settings{result}
+}

--- a/internal/services/appservice/helpers/auth_v2_schema.go
+++ b/internal/services/appservice/helpers/auth_v2_schema.go
@@ -1435,7 +1435,13 @@ func FacebookAuthV2SettingsSchemaComputed() *pluginsdk.Schema {
 					Description: "The app setting name that contains the `app_secret` value used for Facebook Login.",
 				},
 
-				"oauth_scopes": {
+				"graph_api_version": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The version of the Facebook API to be used while logging in.",
+				},
+
+				"login_scopes": {
 					Type:     pluginsdk.TypeList,
 					Computed: true,
 					Elem: &pluginsdk.Schema{
@@ -1840,13 +1846,22 @@ func MicrosoftAuthV2SettingsSchemaComputed() *pluginsdk.Schema {
 					Description: "The app setting name containing the OAuth 2.0 client secret that was created for the app used for authentication.",
 				},
 
-				"oauth_scopes": {
+				"allowed_audiences": {
 					Type:     pluginsdk.TypeList,
 					Computed: true,
 					Elem: &pluginsdk.Schema{
 						Type: pluginsdk.TypeString,
 					},
-					Description: "The list of OAuth 2.0 scopes that will be requested as part of Microsoft Account authentication. If not specified, `wl.basic` is used as the default scope.",
+					Description: "Specifies a list of Allowed Audiences that will be requested as part of Microsoft Sign-In authentication.",
+				},
+
+				"login_scopes": {
+					Type:     pluginsdk.TypeList,
+					Computed: true,
+					Elem: &pluginsdk.Schema{
+						Type: pluginsdk.TypeString,
+					},
+					Description: "The list of Login scopes that will be requested as part of Microsoft Account authentication.",
 				},
 			},
 		},

--- a/internal/services/appservice/helpers/auth_v2_schema.go
+++ b/internal/services/appservice/helpers/auth_v2_schema.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/web/mgmt/2021-03-01/web" // nolint: staticcheck
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/appservice/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 )
@@ -84,6 +85,7 @@ func AuthV2SettingsSchema() *pluginsdk.Schema {
 						string(web.UnauthenticatedClientActionV2Return401),
 						string(web.UnauthenticatedClientActionV2Return403),
 					}, false),
+					Description: "The action to take for requests made without authentication. Possible values include `RedirectToLoginPage`, `AllowAnonymous`, `Return401`, and `Return403`. Defaults to `RedirectToLoginPage`.",
 				},
 
 				"default_provider": {
@@ -146,7 +148,7 @@ func AuthV2SettingsSchema() *pluginsdk.Schema {
 						string(web.ForwardProxyConventionCustom),
 						string(web.ForwardProxyConventionStandard),
 					}, false),
-					Description: "The convention used to determine the url of the request made. Possible values include 'ForwardProxyConventionNoProxy', 'ForwardProxyConventionStandard', 'ForwardProxyConventionCustom'. Defaults to `ForwardProxyConventionNoProxy`.",
+					Description: "The convention used to determine the url of the request made. Possible values include `ForwardProxyConventionNoProxy`, `ForwardProxyConventionStandard`, `ForwardProxyConventionCustom`. Defaults to `ForwardProxyConventionNoProxy`",
 				},
 
 				"forward_proxy_custom_host_header_name": {
@@ -336,7 +338,7 @@ func authV2LoginSchema() *pluginsdk.Schema {
 					Type:        pluginsdk.TypeBool,
 					Optional:    true,
 					Default:     false,
-					Description: "Should the fragments from the request be preserved after the login request is made. Defaults to `false`",
+					Description: "Should the fragments from the request be preserved after the login request is made. Defaults to `false`.",
 				},
 
 				"allowed_external_redirect_urls": {
@@ -357,28 +359,30 @@ func authV2LoginSchema() *pluginsdk.Schema {
 						string(web.CookieExpirationConventionIdentityProviderDerived),
 						string(web.CookieExpirationConventionFixedTime),
 					}, false),
+					Description: "The method by which cookies expire. Possible values include: `FixedTime`, and `IdentityProviderDerived`. Defaults to `FixedTime`.",
 				},
 
 				"cookie_expiration_time": {
-					Type:     pluginsdk.TypeString,
-					Optional: true,
-					Default:  "08:00:00",
-					// ValidateFunc: // TODO - Find the allowed strings / values for validation
-					Description: "The time after the request is made when the session cookie should expire.",
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					Default:      "08:00:00",
+					ValidateFunc: validate.TimeInterval,
+					Description:  "The time after the request is made when the session cookie should expire. Defaults to `08:00:00`.",
 				},
 
 				"validate_nonce": {
 					Type:        pluginsdk.TypeBool,
 					Optional:    true,
 					Default:     true,
-					Description: "Should the nonce be validated while completing the login flow. Defaults to `true`",
+					Description: "Should the nonce be validated while completing the login flow. Defaults to `true`.",
 				},
 
 				"nonce_expiration_time": {
-					Type:        pluginsdk.TypeString,
-					Optional:    true,
-					Default:     "00:05:00",
-					Description: "The time after the request is made when the nonce should expire.",
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					Default:      "00:05:00",
+					ValidateFunc: validate.TimeInterval,
+					Description:  "The time after the request is made when the nonce should expire. Defaults to `00:05:00`.",
 				},
 			},
 		},
@@ -680,7 +684,7 @@ type AadAuthV2Settings struct {
 	ClientSecretSettingName           string            `tfschema:"client_secret_setting_name"`
 	ClientSecretCertificateThumbprint string            `tfschema:"client_secret_certificate_thumbprint"`
 	LoginParameters                   map[string]string `tfschema:"login_parameters"`
-	DisableWWWAuth                    bool              `tfschema:"disable_www_authentication"`
+	DisableWWWAuth                    bool              `tfschema:"www_authentication_disabled"`
 	JWTAllowedGroups                  []string          `tfschema:"jwt_allowed_groups"`
 	JWTAllowedClientApps              []string          `tfschema:"jwt_allowed_client_applications"`
 	AllowedApplications               []string          `tfschema:"allowed_applications"`
@@ -718,7 +722,7 @@ func AadAuthV2SettingsSchema() *pluginsdk.Schema {
 					Type:         pluginsdk.TypeString,
 					Required:     true,
 					ValidateFunc: validation.IsURLWithHTTPorHTTPS,
-					Description:  "The Azure Tenant Endpoint for the Authenticating Tenant. e.g. `https://login.microsoftonline.com/v2.0/{tenant-guid}/`",
+					Description:  "The Azure Tenant Endpoint for the Authenticating Tenant. e.g. `https://login.microsoftonline.com/v2.0/{tenant-guid}/`.",
 				},
 
 				"client_secret_setting_name": {
@@ -763,7 +767,7 @@ func AadAuthV2SettingsSchema() *pluginsdk.Schema {
 					Description: "A list of Allowed Client Applications in the JWT Claim.",
 				},
 
-				"disable_www_authentication": {
+				"www_authentication_disabled": {
 					Type:        pluginsdk.TypeBool,
 					Optional:    true,
 					Description: "Should the www-authenticate provider should be omitted from the request? Defaults to `false`",
@@ -1161,7 +1165,7 @@ func CustomOIDCAuthV2SettingsSchema() *pluginsdk.Schema {
 				"client_credential_method": {
 					Type:        pluginsdk.TypeString,
 					Computed:    true,
-					Description: "The Client Credential Method used. Currently the only supported value is `ClientSecretPost`",
+					Description: "The Client Credential Method used. Currently the only supported value is `ClientSecretPost`.",
 				},
 
 				"client_secret_setting_name": {

--- a/internal/services/appservice/helpers/auto_heal.go
+++ b/internal/services/appservice/helpers/auto_heal.go
@@ -197,7 +197,7 @@ func autoHealTriggerSchemaWindows() *pluginsdk.Schema {
 							"interval": {
 								Type:         pluginsdk.TypeString,
 								Required:     true,
-								ValidateFunc: validate.AutoHealInterval, // TODO should be hh:mm:ss - This is too loose, need to improve
+								ValidateFunc: validate.TimeInterval, // TODO should be hh:mm:ss - This is too loose, need to improve
 							},
 						},
 					},
@@ -229,7 +229,7 @@ func autoHealTriggerSchemaWindows() *pluginsdk.Schema {
 							"interval": {
 								Type:         pluginsdk.TypeString,
 								Required:     true,
-								ValidateFunc: validate.AutoHealInterval,
+								ValidateFunc: validate.TimeInterval,
 							},
 
 							"sub_status": {
@@ -260,13 +260,13 @@ func autoHealTriggerSchemaWindows() *pluginsdk.Schema {
 							"time_taken": {
 								Type:         pluginsdk.TypeString,
 								Required:     true,
-								ValidateFunc: validate.AutoHealInterval,
+								ValidateFunc: validate.TimeInterval,
 							},
 
 							"interval": {
 								Type:         pluginsdk.TypeString,
 								Required:     true,
-								ValidateFunc: validate.AutoHealInterval,
+								ValidateFunc: validate.TimeInterval,
 							},
 
 							"count": {

--- a/internal/services/appservice/helpers/shared_schema.go
+++ b/internal/services/appservice/helpers/shared_schema.go
@@ -374,7 +374,6 @@ func AuthSettingsSchema() *pluginsdk.Schema {
 	return &pluginsdk.Schema{
 		Type:     pluginsdk.TypeList,
 		Optional: true,
-		Computed: true,
 		MaxItems: 1,
 		Elem: &pluginsdk.Resource{
 			Schema: map[string]*pluginsdk.Schema{
@@ -1280,8 +1279,8 @@ func ExpandAuthSettings(auth []AuthSettings) *web.SiteAuthSettings {
 }
 
 func FlattenAuthSettings(auth web.SiteAuthSettings) []AuthSettings {
-	if auth.SiteAuthSettingsProperties == nil {
-		return nil
+	if auth.SiteAuthSettingsProperties == nil || !pointer.From(auth.Enabled) || strings.ToLower(pointer.From(auth.ConfigVersion)) != "v1" {
+		return []AuthSettings{}
 	}
 
 	props := *auth.SiteAuthSettingsProperties

--- a/internal/services/appservice/linux_web_app_data_source.go
+++ b/internal/services/appservice/linux_web_app_data_source.go
@@ -26,6 +26,7 @@ type LinuxWebAppDataSourceModel struct {
 	ServicePlanId                 string                     `tfschema:"service_plan_id"`
 	AppSettings                   map[string]string          `tfschema:"app_settings"`
 	AuthSettings                  []helpers.AuthSettings     `tfschema:"auth_settings"`
+	AuthV2Settings                []helpers.AuthV2Settings   `tfschema:"auth_v2_settings"`
 	Backup                        []helpers.Backup           `tfschema:"backup"`
 	ClientAffinityEnabled         bool                       `tfschema:"client_affinity_enabled"`
 	ClientCertEnabled             bool                       `tfschema:"client_certificate_enabled"`
@@ -95,6 +96,8 @@ func (r LinuxWebAppDataSource) Attributes() map[string]*pluginsdk.Schema {
 		},
 
 		"auth_settings": helpers.AuthSettingsSchemaComputed(),
+
+		"auth_v2_settings": helpers.AuthV2SettingsComputedSchema(),
 
 		"backup": helpers.BackupSchemaComputed(),
 
@@ -236,6 +239,11 @@ func (r LinuxWebAppDataSource) Read() sdk.ResourceFunc {
 				return fmt.Errorf("reading Auth Settings for Linux %s: %+v", id, err)
 			}
 
+			authV2, err := client.GetAuthSettingsV2(ctx, id.ResourceGroup, id.SiteName)
+			if err != nil {
+				return fmt.Errorf("reading authV2 settings for Linux %s: %+v", id, err)
+			}
+
 			backup, err := client.GetBackupConfiguration(ctx, id.ResourceGroup, id.SiteName)
 			if err != nil {
 				if !utils.ResponseWasNotFound(backup.Response) {
@@ -314,6 +322,8 @@ func (r LinuxWebAppDataSource) Read() sdk.ResourceFunc {
 			}
 
 			webApp.AuthSettings = helpers.FlattenAuthSettings(auth)
+
+			webApp.AuthV2Settings = helpers.FlattenAuthV2Settings(authV2)
 
 			webApp.Backup = helpers.FlattenBackupConfig(backup)
 

--- a/internal/services/appservice/linux_web_app_data_source.go
+++ b/internal/services/appservice/linux_web_app_data_source.go
@@ -26,7 +26,7 @@ type LinuxWebAppDataSourceModel struct {
 	ServicePlanId                 string                     `tfschema:"service_plan_id"`
 	AppSettings                   map[string]string          `tfschema:"app_settings"`
 	AuthSettings                  []helpers.AuthSettings     `tfschema:"auth_settings"`
-	AuthV2Settings                []helpers.AuthV2Settings   `tfschema:"auth_v2_settings"`
+	AuthV2Settings                []helpers.AuthV2Settings   `tfschema:"auth_settings_v2"`
 	Backup                        []helpers.Backup           `tfschema:"backup"`
 	ClientAffinityEnabled         bool                       `tfschema:"client_affinity_enabled"`
 	ClientCertEnabled             bool                       `tfschema:"client_certificate_enabled"`
@@ -97,7 +97,7 @@ func (r LinuxWebAppDataSource) Attributes() map[string]*pluginsdk.Schema {
 
 		"auth_settings": helpers.AuthSettingsSchemaComputed(),
 
-		"auth_v2_settings": helpers.AuthV2SettingsComputedSchema(),
+		"auth_settings_v2": helpers.AuthV2SettingsComputedSchema(),
 
 		"backup": helpers.BackupSchemaComputed(),
 

--- a/internal/services/appservice/linux_web_app_data_source_test.go
+++ b/internal/services/appservice/linux_web_app_data_source_test.go
@@ -57,5 +57,5 @@ data azurerm_linux_web_app test {
   name                = azurerm_linux_web_app.test.name
   resource_group_name = azurerm_linux_web_app.test.resource_group_name
 }
-`, LinuxWebAppResource{}.authV2Multi(data))
+`, LinuxWebAppResource{}.completeAuthV2(data))
 }

--- a/internal/services/appservice/linux_web_app_data_source_test.go
+++ b/internal/services/appservice/linux_web_app_data_source_test.go
@@ -24,6 +24,20 @@ func TestAccLinuxWebAppDataSource_complete(t *testing.T) {
 	})
 }
 
+func TestAccLinuxWebAppDataSource_completeAuthV2(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_linux_web_app", "test")
+	d := LinuxWebAppDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: d.completeAuthV2(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("location").HasValue(data.Locations.Primary),
+			),
+		},
+	})
+}
+
 func (LinuxWebAppDataSource) complete(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
@@ -33,4 +47,15 @@ data azurerm_linux_web_app test {
   resource_group_name = azurerm_linux_web_app.test.resource_group_name
 }
 `, LinuxWebAppResource{}.complete(data))
+}
+
+func (LinuxWebAppDataSource) completeAuthV2(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data azurerm_linux_web_app test {
+  name                = azurerm_linux_web_app.test.name
+  resource_group_name = azurerm_linux_web_app.test.resource_group_name
+}
+`, LinuxWebAppResource{}.authV2Multi(data))
 }

--- a/internal/services/appservice/linux_web_app_resource.go
+++ b/internal/services/appservice/linux_web_app_resource.go
@@ -33,7 +33,7 @@ type LinuxWebAppModel struct {
 	AppSettings                   map[string]string          `tfschema:"app_settings"`
 	StickySettings                []helpers.StickySettings   `tfschema:"sticky_settings"`
 	AuthSettings                  []helpers.AuthSettings     `tfschema:"auth_settings"`
-	AuthV2Settings                []helpers.AuthV2Settings   `tfschema:"auth_v2_settings"`
+	AuthV2Settings                []helpers.AuthV2Settings   `tfschema:"auth_settings_v2"`
 	Backup                        []helpers.Backup           `tfschema:"backup"`
 	ClientAffinityEnabled         bool                       `tfschema:"client_affinity_enabled"`
 	ClientCertEnabled             bool                       `tfschema:"client_certificate_enabled"`
@@ -94,7 +94,7 @@ func (r LinuxWebAppResource) Arguments() map[string]*pluginsdk.Schema {
 
 		"auth_settings": helpers.AuthSettingsSchema(),
 
-		"auth_v2_settings": helpers.AuthV2SettingsSchema(),
+		"auth_settings_v2": helpers.AuthV2SettingsSchema(),
 
 		"backup": helpers.BackupSchema(),
 
@@ -800,7 +800,7 @@ func (r LinuxWebAppResource) Update() sdk.ResourceFunc {
 				}
 			}
 
-			if metadata.ResourceData.HasChange("auth_v2_settings") {
+			if metadata.ResourceData.HasChange("auth_settings_v2") {
 				authV2Update := helpers.ExpandAuthV2Settings(state.AuthV2Settings)
 				if _, err := client.UpdateAuthSettingsV2(ctx, id.ResourceGroup, id.SiteName, *authV2Update); err != nil {
 					return fmt.Errorf("updating AuthV2 Settings for Linux %s: %+v", id, err)

--- a/internal/services/appservice/linux_web_app_resource.go
+++ b/internal/services/appservice/linux_web_app_resource.go
@@ -383,11 +383,11 @@ func (r LinuxWebAppResource) Create() sdk.ResourceFunc {
 
 			authv2 := helpers.ExpandAuthV2Settings(webApp.AuthV2Settings)
 			if authv2.SiteAuthSettingsV2Properties != nil {
-				resp, err := client.UpdateAuthSettingsV2(ctx, id.ResourceGroup, id.SiteName, *authv2)
-				if err != nil {
+				if resp, err := client.UpdateAuthSettingsV2(ctx, id.ResourceGroup, id.SiteName, *authv2); err != nil {
 					return fmt.Errorf("updating AuthV2 settings for Linux %s: %+v", id, err)
+				} else {
+					metadata.Logger.Infof("[STEBUG] resp is %+v", resp)
 				}
-				metadata.Logger.Infof("[STEBUG] resp: %#v", resp)
 			}
 
 			if metadata.ResourceData.HasChange("logs") {

--- a/internal/services/appservice/linux_web_app_resource.go
+++ b/internal/services/appservice/linux_web_app_resource.go
@@ -780,7 +780,8 @@ func (r LinuxWebAppResource) Update() sdk.ResourceFunc {
 
 			if metadata.ResourceData.HasChange("auth_settings") {
 				authUpdate := helpers.ExpandAuthSettings(state.AuthSettings)
-				if authUpdate.SiteAuthSettingsProperties == nil && metadata.ResourceData.HasChange("auth_v2_settings") {
+				// (@jackofallops) - in the case of a removal of this block, we need to zero these settings
+				if authUpdate.SiteAuthSettingsProperties == nil {
 					authUpdate.SiteAuthSettingsProperties = &web.SiteAuthSettingsProperties{
 						Enabled:                           pointer.To(false),
 						ClientSecret:                      pointer.To(""),

--- a/internal/services/appservice/linux_web_app_resource.go
+++ b/internal/services/appservice/linux_web_app_resource.go
@@ -3,12 +3,12 @@ package appservice
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/web/mgmt/2021-03-01/web" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"

--- a/internal/services/appservice/linux_web_app_resource.go
+++ b/internal/services/appservice/linux_web_app_resource.go
@@ -384,10 +384,8 @@ func (r LinuxWebAppResource) Create() sdk.ResourceFunc {
 
 			authv2 := helpers.ExpandAuthV2Settings(webApp.AuthV2Settings)
 			if authv2.SiteAuthSettingsV2Properties != nil {
-				if resp, err := client.UpdateAuthSettingsV2(ctx, id.ResourceGroup, id.SiteName, *authv2); err != nil {
+				if _, err = client.UpdateAuthSettingsV2(ctx, id.ResourceGroup, id.SiteName, *authv2); err != nil {
 					return fmt.Errorf("updating AuthV2 settings for Linux %s: %+v", id, err)
-				} else {
-					metadata.Logger.Infof("[STEBUG] resp is %+v", resp)
 				}
 			}
 

--- a/internal/services/appservice/linux_web_app_resource_authv2_test.go
+++ b/internal/services/appservice/linux_web_app_resource_authv2_test.go
@@ -177,6 +177,30 @@ func TestAccLinuxWebApp_authV2Update(t *testing.T) {
 	})
 }
 
+func TestAccLinuxWebApp_authV2UpgradeFromV1(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_web_app", "test")
+	r := LinuxWebAppResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("kind").HasValue("app,linux"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.completeAuthV2(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("kind").HasValue("app,linux"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (r LinuxWebAppResource) authV2AzureActiveDirectory(data acceptance.TestData) string {
 	secretSettingName := "MICROSOFT_PROVIDER_AUTHENTICATION_SECRET"
 	secretSettingValue := os.Getenv("ARM_CLIENT_SECRET")
@@ -241,10 +265,6 @@ resource "azurerm_linux_web_app" "test" {
 
   app_settings = {
     "%[3]s" = "%[4]s"
-  }
-
-  sticky_settings {
-    app_setting_names = ["%[3]s"]
   }
 
   auth_v2_settings {
@@ -602,4 +622,201 @@ resource "azurerm_linux_web_app" "test" {
 `, r.baseTemplate(data), data.RandomInteger, secretSettingValue)
 }
 
-// update
+func (r LinuxWebAppResource) completeAuthV2(data acceptance.TestData) string {
+	secretSettingValue := "902D17F6-FD6B-4E44-BABB-58E788DCD907"
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_linux_web_app" "test" {
+  name                = "acctestWA-%[2]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  service_plan_id     = azurerm_service_plan.test.id
+
+  app_settings = {
+    "foo"                                      = "bar"
+    "APPLE_PROVIDER_AUTHENTICATION_SECRET"     = "%[3]s"
+    "FACEBOOK_PROVIDER_AUTHENTICATION_SECRET"  = "%[3]s"
+    "GITHUB_PROVIDER_AUTHENTICATION_SECRET"    = "%[3]s"
+    "GOOGLE_PROVIDER_AUTHENTICATION_SECRET"    = "%[3]s"
+    "MICROSOFT_PROVIDER_AUTHENTICATION_SECRET" = "%[3]s"
+    "TWITTER_PROVIDER_AUTHENTICATION_SECRET"   = "%[3]s"
+  }
+
+  auth_v2_settings {
+    auth_enabled           = true
+    unauthenticated_action = "RedirectToLoginPage"
+
+    apple {
+      client_id                  = "testAppleID"
+      client_secret_setting_name = "APPLE_PROVIDER_AUTHENTICATION_SECRET"
+    }
+
+    facebook {
+      app_id                  = "testFacebookID"
+      app_secret_setting_name = "FACEBOOK_PROVIDER_AUTHENTICATION_SECRET"
+    }
+
+    github {
+      client_id                  = "testGithubID"
+      client_secret_setting_name = "GITHUB_PROVIDER_AUTHENTICATION_SECRET"
+    }
+
+    google {
+      client_id                  = "testGoogleID"
+      client_secret_setting_name = "GOOGLE_PROVIDER_AUTHENTICATION_SECRET"
+    }
+
+    microsoft {
+      client_id                  = "testMSFTID"
+      client_secret_setting_name = "MICROSOFT_PROVIDER_AUTHENTICATION_SECRET"
+    }
+
+    twitter {
+      consumer_key                 = "testTwitterKey"
+      consumer_secret_setting_name = "TWITTER_PROVIDER_AUTHENTICATION_SECRET"
+    }
+
+    login {}
+  }
+
+  backup {
+    name                = "acctest"
+    storage_account_url = "https://${azurerm_storage_account.test.name}.blob.core.windows.net/${azurerm_storage_container.test.name}${data.azurerm_storage_account_sas.test.sas}&sr=b"
+    schedule {
+      frequency_interval = 1
+      frequency_unit     = "Day"
+    }
+  }
+
+  logs {
+    application_logs {
+      file_system_level = "Warning"
+      azure_blob_storage {
+        level             = "Information"
+        sas_url           = "http://x.com/"
+        retention_in_days = 2
+      }
+    }
+
+    http_logs {
+      azure_blob_storage {
+        sas_url           = "https://${azurerm_storage_account.test.name}.blob.core.windows.net/${azurerm_storage_container.test.name}${data.azurerm_storage_account_sas.test.sas}&sr=b"
+        retention_in_days = 3
+      }
+    }
+  }
+
+  client_affinity_enabled            = true
+  client_certificate_enabled         = true
+  client_certificate_mode            = "Optional"
+  client_certificate_exclusion_paths = "/foo;/bar;/hello;/world"
+
+  connection_string {
+    name  = "First"
+    value = "first-connection-string"
+    type  = "Custom"
+  }
+
+  connection_string {
+    name  = "Second"
+    value = "some-postgresql-connection-string"
+    type  = "PostgreSQL"
+  }
+
+  enabled    = false
+  https_only = true
+
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.test.id]
+  }
+
+  site_config {
+    always_on = true
+    // api_management_config_id = // TODO
+    app_command_line = "/sbin/myserver -b 0.0.0.0"
+    default_documents = [
+      "first.html",
+      "second.jsp",
+      "third.aspx",
+      "hostingstart.html",
+    ]
+    http2_enabled               = true
+    scm_use_main_ip_restriction = true
+    local_mysql_enabled         = true
+    managed_pipeline_mode       = "Integrated"
+    remote_debugging_enabled    = true
+    remote_debugging_version    = "VS2019"
+    use_32_bit_worker           = false
+    websockets_enabled          = true
+    ftps_state                  = "FtpsOnly"
+    health_check_path           = "/health"
+    worker_count                = 1
+    minimum_tls_version         = "1.1"
+    scm_minimum_tls_version     = "1.1"
+    cors {
+      allowed_origins = [
+        "http://www.contoso.com",
+        "www.contoso.com",
+      ]
+
+      support_credentials = true
+    }
+
+    container_registry_use_managed_identity       = true
+    container_registry_managed_identity_client_id = azurerm_user_assigned_identity.test.client_id
+
+    auto_heal_enabled = true
+
+    auto_heal_setting {
+      trigger {
+        status_code {
+          status_code_range = "500"
+          interval          = "00:01:00"
+          count             = 10
+        }
+      }
+
+      action {
+        action_type                    = "Recycle"
+        minimum_process_execution_time = "00:05:00"
+      }
+    }
+  }
+
+  sticky_settings {
+    connection_string_names = ["First", "Third"]
+    
+    app_setting_names = [
+      "foo",
+      "APPLE_PROVIDER_AUTHENTICATION_SECRET",
+      "FACEBOOK_PROVIDER_AUTHENTICATION_SECRET",
+      "GITHUB_PROVIDER_AUTHENTICATION_SECRET",
+      "GOOGLE_PROVIDER_AUTHENTICATION_SECRET",
+      "MICROSOFT_PROVIDER_AUTHENTICATION_SECRET",
+      "TWITTER_PROVIDER_AUTHENTICATION_SECRET",
+    ]
+  }
+
+
+  storage_account {
+    name         = "files"
+    type         = "AzureFiles"
+    account_name = azurerm_storage_account.test.name
+    share_name   = azurerm_storage_share.test.name
+    access_key   = azurerm_storage_account.test.primary_access_key
+    mount_path   = "/storage/files"
+  }
+
+  tags = {
+    Environment = "AccTest"
+    foo         = "bar"
+  }
+}
+`, r.templateWithStorageAccount(data), data.RandomInteger, secretSettingValue)
+}

--- a/internal/services/appservice/linux_web_app_resource_authv2_test.go
+++ b/internal/services/appservice/linux_web_app_resource_authv2_test.go
@@ -50,7 +50,7 @@ func TestAccLinuxWebApp_authV2CustomOIDC(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("kind").HasValue("app,linux"),
-				check.That(data.ResourceName).Key("auth_settings_v2.0.custom_oidc.0.client_secret_setting_name").HasValue("TESTCUSTOM_PROVIDER_AUTHENTICATION_SECRET"),
+				check.That(data.ResourceName).Key("auth_settings_v2.0.custom_oidc_v2.0.client_secret_setting_name").HasValue("TESTCUSTOM_PROVIDER_AUTHENTICATION_SECRET"),
 			),
 		},
 		data.ImportStep(),

--- a/internal/services/appservice/linux_web_app_resource_authv2_test.go
+++ b/internal/services/appservice/linux_web_app_resource_authv2_test.go
@@ -1,0 +1,117 @@
+package appservice_test
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"os"
+	"testing"
+)
+
+func TestAccLinuxWebApp_authV2Basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_web_app", "test")
+	r := LinuxWebAppResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.authV2(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("kind").HasValue("app,linux"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+func TestAccLinuxWebApp_authV2WithApple(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_web_app", "test")
+	r := LinuxWebAppResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.authV2Apple(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("kind").HasValue("app,linux"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func (r LinuxWebAppResource) authV2(data acceptance.TestData) string {
+	secretSettingName := "MICROSOFT_PROVIDER_AUTHENTICATION_SECRET"
+	secretSettingValue := os.Getenv("ARM_CLIENT_SECRET")
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_linux_web_app" "test" {
+  name                = "acctestLWA-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  service_plan_id     = azurerm_service_plan.test.id
+
+  site_config {}
+
+  app_settings = {
+    "%[3]s" = "%[4]s" 
+  }
+
+  auth_v2_settings {
+    auth_enabled = true
+    unauthenticated_action = "Return401"
+    active_directory {
+      client_id = data.azurerm_client_config.current.client_id
+      client_secret_setting_name = "%[3]s"      
+      tenant_auth_endpoint = "https://sts.windows.net/%[5]s/v2.0"
+    }
+    login {}
+  }
+}
+`, r.baseTemplate(data), data.RandomInteger, secretSettingName, secretSettingValue, data.Client().TenantID)
+}
+
+func (r LinuxWebAppResource) authV2Apple(data acceptance.TestData) string {
+	secretSettingName := "APPLE_PROVIDER_AUTHENTICATION_SECRET"
+	secretSettingValue := "902D17F6-FD6B-4E44-BABB-58E788DCD907"
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_linux_web_app" "test" {
+  name                = "acctestLWA-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  service_plan_id     = azurerm_service_plan.test.id
+
+  site_config {}
+
+  app_settings = {
+    "%[3]s" = "%[4]s" 
+  }
+
+  auth_v2_settings {
+    auth_enabled = true
+    unauthenticated_action = "Return401"
+    
+    apple {
+      client_id = "testAppleID"
+      client_secret_setting_name = "%[3]s"
+    }
+
+    login {}
+  }
+}
+`, r.baseTemplate(data), data.RandomInteger, secretSettingName, secretSettingValue)
+}

--- a/internal/services/appservice/linux_web_app_resource_authv2_test.go
+++ b/internal/services/appservice/linux_web_app_resource_authv2_test.go
@@ -101,8 +101,13 @@ resource "azurerm_linux_web_app" "test" {
     "%[3]s" = "%[4]s" 
   }
 
+  sticky_settings {
+    app_setting_names       = ["%[3]s"]
+  }
+
   auth_v2_settings {
     auth_enabled = true
+    default_provider = "apple"
     unauthenticated_action = "Return401"
     
     apple {

--- a/internal/services/appservice/linux_web_app_resource_authv2_test.go
+++ b/internal/services/appservice/linux_web_app_resource_authv2_test.go
@@ -232,7 +232,7 @@ resource "azurerm_linux_web_app" "test" {
   auth_settings_v2 {
     auth_enabled           = true
     unauthenticated_action = "Return401"
-    active_directory {
+    active_directory_v2 {
       client_id                  = data.azurerm_client_config.current.client_id
       client_secret_setting_name = "%[3]s"
       tenant_auth_endpoint       = "https://sts.windows.net/%[5]s/v2.0"
@@ -271,7 +271,7 @@ resource "azurerm_linux_web_app" "test" {
     auth_enabled           = true
     unauthenticated_action = "Return401"
 
-    apple {
+    apple_v2 {
       client_id                  = "testAppleID"
       client_secret_setting_name = "%[3]s"
     }
@@ -316,7 +316,7 @@ resource "azurerm_linux_web_app" "test" {
     auth_enabled           = true
     unauthenticated_action = "Return401"
 
-    custom_oidc {
+    custom_oidc_v2 {
       name                          = "testcustom"
       client_id                     = "testCustomID"
       openid_configuration_endpoint = "https://oidc.testcustom.contoso.com/auth"
@@ -360,7 +360,7 @@ resource "azurerm_linux_web_app" "test" {
     auth_enabled           = true
     unauthenticated_action = "RedirectToLoginPage"
 
-    facebook {
+    facebook_v2 {
       app_id                  = "testFacebookID"
       app_secret_setting_name = "%[3]s"
     }
@@ -403,7 +403,7 @@ resource "azurerm_linux_web_app" "test" {
     auth_enabled           = true
     unauthenticated_action = "RedirectToLoginPage"
 
-    github {
+    github_v2 {
       client_id                  = "testGithubID"
       client_secret_setting_name = "%[3]s"
     }
@@ -446,7 +446,7 @@ resource "azurerm_linux_web_app" "test" {
     auth_enabled           = true
     unauthenticated_action = "RedirectToLoginPage"
 
-    google {
+    google_v2 {
       client_id                  = "testGoogleID"
       client_secret_setting_name = "%[3]s"
     }
@@ -489,7 +489,7 @@ resource "azurerm_linux_web_app" "test" {
     auth_enabled           = true
     unauthenticated_action = "RedirectToLoginPage"
 
-    microsoft {
+    microsoft_v2 {
       client_id                  = "testMSFTID"
       client_secret_setting_name = "%[3]s"
     }
@@ -532,7 +532,7 @@ resource "azurerm_linux_web_app" "test" {
     auth_enabled           = true
     unauthenticated_action = "RedirectToLoginPage"
 
-    twitter {
+    twitter_v2 {
       consumer_key                 = "testTwitterKey"
       consumer_secret_setting_name = "%[3]s"
     }
@@ -586,32 +586,32 @@ resource "azurerm_linux_web_app" "test" {
     auth_enabled           = true
     unauthenticated_action = "RedirectToLoginPage"
 
-    apple {
+    apple_v2 {
       client_id                  = "testAppleID"
       client_secret_setting_name = "APPLE_PROVIDER_AUTHENTICATION_SECRET"
     }
 
-    facebook {
+    facebook_v2 {
       app_id                  = "testFacebookID"
       app_secret_setting_name = "FACEBOOK_PROVIDER_AUTHENTICATION_SECRET"
     }
 
-    github {
+    github_v2 {
       client_id                  = "testGithubID"
       client_secret_setting_name = "GITHUB_PROVIDER_AUTHENTICATION_SECRET"
     }
 
-    google {
+    google_v2 {
       client_id                  = "testGoogleID"
       client_secret_setting_name = "GOOGLE_PROVIDER_AUTHENTICATION_SECRET"
     }
 
-    microsoft {
+    microsoft_v2 {
       client_id                  = "testMSFTID"
       client_secret_setting_name = "MICROSOFT_PROVIDER_AUTHENTICATION_SECRET"
     }
 
-    twitter {
+    twitter_v2 {
       consumer_key                 = "testTwitterKey"
       consumer_secret_setting_name = "TWITTER_PROVIDER_AUTHENTICATION_SECRET"
     }
@@ -651,32 +651,32 @@ resource "azurerm_linux_web_app" "test" {
     auth_enabled           = true
     unauthenticated_action = "RedirectToLoginPage"
 
-    apple {
+    apple_v2 {
       client_id                  = "testAppleID"
       client_secret_setting_name = "APPLE_PROVIDER_AUTHENTICATION_SECRET"
     }
 
-    facebook {
+    facebook_v2 {
       app_id                  = "testFacebookID"
       app_secret_setting_name = "FACEBOOK_PROVIDER_AUTHENTICATION_SECRET"
     }
 
-    github {
+    github_v2 {
       client_id                  = "testGithubID"
       client_secret_setting_name = "GITHUB_PROVIDER_AUTHENTICATION_SECRET"
     }
 
-    google {
+    google_v2 {
       client_id                  = "testGoogleID"
       client_secret_setting_name = "GOOGLE_PROVIDER_AUTHENTICATION_SECRET"
     }
 
-    microsoft {
+    microsoft_v2 {
       client_id                  = "testMSFTID"
       client_secret_setting_name = "MICROSOFT_PROVIDER_AUTHENTICATION_SECRET"
     }
 
-    twitter {
+    twitter_v2 {
       consumer_key                 = "testTwitterKey"
       consumer_secret_setting_name = "TWITTER_PROVIDER_AUTHENTICATION_SECRET"
     }

--- a/internal/services/appservice/linux_web_app_resource_authv2_test.go
+++ b/internal/services/appservice/linux_web_app_resource_authv2_test.go
@@ -791,7 +791,7 @@ resource "azurerm_linux_web_app" "test" {
 
   sticky_settings {
     connection_string_names = ["First", "Third"]
-    
+
     app_setting_names = [
       "foo",
       "APPLE_PROVIDER_AUTHENTICATION_SECRET",

--- a/internal/services/appservice/linux_web_app_resource_authv2_test.go
+++ b/internal/services/appservice/linux_web_app_resource_authv2_test.go
@@ -102,12 +102,11 @@ resource "azurerm_linux_web_app" "test" {
   }
 
   sticky_settings {
-    app_setting_names       = ["%[3]s"]
+    app_setting_names = ["%[3]s"]
   }
 
   auth_v2_settings {
     auth_enabled = true
-    default_provider = "apple"
     unauthenticated_action = "Return401"
     
     apple {

--- a/internal/services/appservice/linux_web_app_resource_authv2_test.go
+++ b/internal/services/appservice/linux_web_app_resource_authv2_test.go
@@ -50,7 +50,7 @@ func TestAccLinuxWebApp_authV2CustomOIDC(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("kind").HasValue("app,linux"),
-				check.That(data.ResourceName).Key("auth_v2_settings.0.custom_oidc.0.client_secret_setting_name").HasValue("TESTCUSTOM_PROVIDER_AUTHENTICATION_SECRET"),
+				check.That(data.ResourceName).Key("auth_settings_v2.0.custom_oidc.0.client_secret_setting_name").HasValue("TESTCUSTOM_PROVIDER_AUTHENTICATION_SECRET"),
 			),
 		},
 		data.ImportStep(),
@@ -229,7 +229,7 @@ resource "azurerm_linux_web_app" "test" {
     app_setting_names = ["%[3]s"]
   }
 
-  auth_v2_settings {
+  auth_settings_v2 {
     auth_enabled           = true
     unauthenticated_action = "Return401"
     active_directory {
@@ -267,7 +267,7 @@ resource "azurerm_linux_web_app" "test" {
     "%[3]s" = "%[4]s"
   }
 
-  auth_v2_settings {
+  auth_settings_v2 {
     auth_enabled           = true
     unauthenticated_action = "Return401"
 
@@ -312,7 +312,7 @@ resource "azurerm_linux_web_app" "test" {
     app_setting_names = ["%[3]s"]
   }
 
-  auth_v2_settings {
+  auth_settings_v2 {
     auth_enabled           = true
     unauthenticated_action = "Return401"
 
@@ -356,7 +356,7 @@ resource "azurerm_linux_web_app" "test" {
     app_setting_names = ["%[3]s"]
   }
 
-  auth_v2_settings {
+  auth_settings_v2 {
     auth_enabled           = true
     unauthenticated_action = "RedirectToLoginPage"
 
@@ -399,7 +399,7 @@ resource "azurerm_linux_web_app" "test" {
     app_setting_names = ["%[3]s"]
   }
 
-  auth_v2_settings {
+  auth_settings_v2 {
     auth_enabled           = true
     unauthenticated_action = "RedirectToLoginPage"
 
@@ -442,7 +442,7 @@ resource "azurerm_linux_web_app" "test" {
     app_setting_names = ["%[3]s"]
   }
 
-  auth_v2_settings {
+  auth_settings_v2 {
     auth_enabled           = true
     unauthenticated_action = "RedirectToLoginPage"
 
@@ -485,7 +485,7 @@ resource "azurerm_linux_web_app" "test" {
     app_setting_names = ["%[3]s"]
   }
 
-  auth_v2_settings {
+  auth_settings_v2 {
     auth_enabled           = true
     unauthenticated_action = "RedirectToLoginPage"
 
@@ -528,7 +528,7 @@ resource "azurerm_linux_web_app" "test" {
     app_setting_names = ["%[3]s"]
   }
 
-  auth_v2_settings {
+  auth_settings_v2 {
     auth_enabled           = true
     unauthenticated_action = "RedirectToLoginPage"
 
@@ -582,7 +582,7 @@ resource "azurerm_linux_web_app" "test" {
     ]
   }
 
-  auth_v2_settings {
+  auth_settings_v2 {
     auth_enabled           = true
     unauthenticated_action = "RedirectToLoginPage"
 
@@ -647,7 +647,7 @@ resource "azurerm_linux_web_app" "test" {
     "TWITTER_PROVIDER_AUTHENTICATION_SECRET"   = "%[3]s"
   }
 
-  auth_v2_settings {
+  auth_settings_v2 {
     auth_enabled           = true
     unauthenticated_action = "RedirectToLoginPage"
 

--- a/internal/services/appservice/linux_web_app_resource_authv2_test.go
+++ b/internal/services/appservice/linux_web_app_resource_authv2_test.go
@@ -2,10 +2,10 @@ package appservice_test
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
-	"os"
-	"testing"
 )
 
 func TestAccLinuxWebApp_authV2AzureActiveDirectory(t *testing.T) {
@@ -203,7 +203,7 @@ func TestAccLinuxWebApp_authV2UpgradeFromV1(t *testing.T) {
 
 func (r LinuxWebAppResource) authV2AzureActiveDirectory(data acceptance.TestData) string {
 	secretSettingName := "MICROSOFT_PROVIDER_AUTHENTICATION_SECRET"
-	secretSettingValue := os.Getenv("ARM_CLIENT_SECRET")
+	secretSettingValue := "902D17F6-FD6B-4E44-BABB-58E788DCD907"
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}

--- a/internal/services/appservice/linux_web_app_resource_authv2_test.go
+++ b/internal/services/appservice/linux_web_app_resource_authv2_test.go
@@ -8,13 +8,13 @@ import (
 	"testing"
 )
 
-func TestAccLinuxWebApp_authV2Basic(t *testing.T) {
+func TestAccLinuxWebApp_authV2AzureActiveDirectory(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_linux_web_app", "test")
 	r := LinuxWebAppResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.authV2(data),
+			Config: r.authV2AzureActiveDirectory(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("kind").HasValue("app,linux"),
@@ -23,7 +23,8 @@ func TestAccLinuxWebApp_authV2Basic(t *testing.T) {
 		data.ImportStep(),
 	})
 }
-func TestAccLinuxWebApp_authV2WithApple(t *testing.T) {
+
+func TestAccLinuxWebApp_authV2Apple(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_linux_web_app", "test")
 	r := LinuxWebAppResource{}
 
@@ -39,7 +40,103 @@ func TestAccLinuxWebApp_authV2WithApple(t *testing.T) {
 	})
 }
 
-func (r LinuxWebAppResource) authV2(data acceptance.TestData) string {
+func TestAccLinuxWebApp_authV2Facebook(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_web_app", "test")
+	r := LinuxWebAppResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.authV2Facebook(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("kind").HasValue("app,linux"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccLinuxWebApp_authV2Github(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_web_app", "test")
+	r := LinuxWebAppResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.authV2Github(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("kind").HasValue("app,linux"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccLinuxWebApp_authV2Google(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_web_app", "test")
+	r := LinuxWebAppResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.authV2Google(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("kind").HasValue("app,linux"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccLinuxWebApp_authV2Microsoft(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_web_app", "test")
+	r := LinuxWebAppResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.authV2Microsoft(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("kind").HasValue("app,linux"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccLinuxWebApp_authV2Twitter(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_web_app", "test")
+	r := LinuxWebAppResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.authV2Twitter(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("kind").HasValue("app,linux"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccLinuxWebApp_authV2MultipleAuths(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_web_app", "test")
+	r := LinuxWebAppResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.authV2Multi(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("kind").HasValue("app,linux"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func (r LinuxWebAppResource) authV2AzureActiveDirectory(data acceptance.TestData) string {
 	secretSettingName := "MICROSOFT_PROVIDER_AUTHENTICATION_SECRET"
 	secretSettingValue := os.Getenv("ARM_CLIENT_SECRET")
 	return fmt.Sprintf(`
@@ -61,6 +158,10 @@ resource "azurerm_linux_web_app" "test" {
 
   app_settings = {
     "%[3]s" = "%[4]s" 
+  }
+
+  sticky_settings {
+    app_setting_names = ["%[3]s"]
   }
 
   auth_v2_settings {
@@ -119,3 +220,309 @@ resource "azurerm_linux_web_app" "test" {
 }
 `, r.baseTemplate(data), data.RandomInteger, secretSettingName, secretSettingValue)
 }
+
+// static web app?
+
+// custom OIDC?
+
+// FACEBOOK_PROVIDER_AUTHENTICATION_SECRET
+func (r LinuxWebAppResource) authV2Facebook(data acceptance.TestData) string {
+	secretSettingName := "FACEBOOK_PROVIDER_AUTHENTICATION_SECRET"
+	secretSettingValue := "902D17F6-FD6B-4E44-BABB-58E788DCD907"
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_linux_web_app" "test" {
+  name                = "acctestLWA-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  service_plan_id     = azurerm_service_plan.test.id
+
+  site_config {}
+
+  app_settings = {
+    "%[3]s" = "%[4]s" 
+  }
+
+  sticky_settings {
+    app_setting_names = ["%[3]s"]
+  }
+
+  auth_v2_settings {
+    auth_enabled           = true
+    unauthenticated_action = "RedirectToLoginPage"
+    
+    facebook {
+      app_id                  = "testFacebookID"
+      app_secret_setting_name = "%[3]s"
+    }
+
+    login {}
+  }
+}
+`, r.baseTemplate(data), data.RandomInteger, secretSettingName, secretSettingValue)
+}
+
+// GITHUB_PROVIDER_AUTHENTICATION_SECRET
+func (r LinuxWebAppResource) authV2Github(data acceptance.TestData) string {
+	secretSettingName := "GITHUB_PROVIDER_AUTHENTICATION_SECRET"
+	secretSettingValue := "902D17F6-FD6B-4E44-BABB-58E788DCD907"
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_linux_web_app" "test" {
+  name                = "acctestLWA-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  service_plan_id     = azurerm_service_plan.test.id
+
+  site_config {}
+
+  app_settings = {
+    "%[3]s" = "%[4]s" 
+  }
+
+  sticky_settings {
+    app_setting_names = ["%[3]s"]
+  }
+
+  auth_v2_settings {
+    auth_enabled           = true
+    unauthenticated_action = "RedirectToLoginPage"
+    
+    github {
+      client_id                  = "testGithubID"
+      client_secret_setting_name = "%[3]s"
+    }
+
+    login {}
+  }
+}
+`, r.baseTemplate(data), data.RandomInteger, secretSettingName, secretSettingValue)
+}
+
+// GOOGLE_PROVIDER_AUTHENTICATION_SECRET
+func (r LinuxWebAppResource) authV2Google(data acceptance.TestData) string {
+	secretSettingName := "GOOGLE_PROVIDER_AUTHENTICATION_SECRET"
+	secretSettingValue := "902D17F6-FD6B-4E44-BABB-58E788DCD907"
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_linux_web_app" "test" {
+  name                = "acctestLWA-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  service_plan_id     = azurerm_service_plan.test.id
+
+  site_config {}
+
+  app_settings = {
+    "%[3]s" = "%[4]s" 
+  }
+
+  sticky_settings {
+    app_setting_names = ["%[3]s"]
+  }
+
+  auth_v2_settings {
+    auth_enabled           = true
+    unauthenticated_action = "RedirectToLoginPage"
+    
+    google {
+      client_id                  = "testGoogleID"
+      client_secret_setting_name = "%[3]s"
+    }
+
+    login {}
+  }
+}
+`, r.baseTemplate(data), data.RandomInteger, secretSettingName, secretSettingValue)
+}
+
+// MICROSOFT_PROVIDER_AUTHENTICATION_SECRET
+func (r LinuxWebAppResource) authV2Microsoft(data acceptance.TestData) string {
+	secretSettingName := "MICROSOFT_PROVIDER_AUTHENTICATION_SECRET"
+	secretSettingValue := "902D17F6-FD6B-4E44-BABB-58E788DCD907"
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_linux_web_app" "test" {
+  name                = "acctestLWA-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  service_plan_id     = azurerm_service_plan.test.id
+
+  site_config {}
+
+  app_settings = {
+    "%[3]s" = "%[4]s" 
+  }
+
+  sticky_settings {
+    app_setting_names = ["%[3]s"]
+  }
+
+  auth_v2_settings {
+    auth_enabled           = true
+    unauthenticated_action = "RedirectToLoginPage"
+    
+    microsoft {
+      client_id                  = "testMSFTID"
+      client_secret_setting_name = "%[3]s"
+    }
+
+    login {}
+  }
+}
+`, r.baseTemplate(data), data.RandomInteger, secretSettingName, secretSettingValue)
+}
+
+// TWITTER_PROVIDER_AUTHENTICATION_SECRET
+func (r LinuxWebAppResource) authV2Twitter(data acceptance.TestData) string {
+	secretSettingName := "TWITTER_PROVIDER_AUTHENTICATION_SECRET"
+	secretSettingValue := "902D17F6-FD6B-4E44-BABB-58E788DCD907"
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_linux_web_app" "test" {
+  name                = "acctestLWA-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  service_plan_id     = azurerm_service_plan.test.id
+
+  site_config {}
+
+  app_settings = {
+    "%[3]s" = "%[4]s" 
+  }
+
+  sticky_settings {
+    app_setting_names = ["%[3]s"]
+  }
+
+  auth_v2_settings {
+    auth_enabled           = true
+    unauthenticated_action = "RedirectToLoginPage"
+    
+    twitter {
+      consumer_key                 = "testTwitterKey"
+      consumer_secret_setting_name = "%[3]s"
+    }
+
+    login {}
+  }
+}
+`, r.baseTemplate(data), data.RandomInteger, secretSettingName, secretSettingValue)
+}
+
+// multi / Complete
+func (r LinuxWebAppResource) authV2Multi(data acceptance.TestData) string {
+	secretSettingValue := "902D17F6-FD6B-4E44-BABB-58E788DCD907"
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_linux_web_app" "test" {
+  name                = "acctestLWA-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  service_plan_id     = azurerm_service_plan.test.id
+
+  site_config {}
+
+  app_settings = {
+    "APPLE_PROVIDER_AUTHENTICATION_SECRET"     = "%[3]s"
+    "FACEBOOK_PROVIDER_AUTHENTICATION_SECRET"  = "%[3]s"
+    "GITHUB_PROVIDER_AUTHENTICATION_SECRET"    = "%[3]s"
+	"GOOGLE_PROVIDER_AUTHENTICATION_SECRET"    = "%[3]s"
+    "MICROSOFT_PROVIDER_AUTHENTICATION_SECRET" = "%[3]s"
+    "TWITTER_PROVIDER_AUTHENTICATION_SECRET"   = "%[3]s" 
+  }
+
+  sticky_settings {
+    app_setting_names = [
+      "APPLE_PROVIDER_AUTHENTICATION_SECRET",
+      "FACEBOOK_PROVIDER_AUTHENTICATION_SECRET",
+      "GITHUB_PROVIDER_AUTHENTICATION_SECRET",
+      "GOOGLE_PROVIDER_AUTHENTICATION_SECRET", 
+      "MICROSOFT_PROVIDER_AUTHENTICATION_SECRET", 
+      "TWITTER_PROVIDER_AUTHENTICATION_SECRET",
+    ]
+  }
+
+  auth_v2_settings {
+    auth_enabled           = true
+    unauthenticated_action = "RedirectToLoginPage"
+
+    apple {
+      client_id                  = "testAppleID"
+      client_secret_setting_name = "APPLE_PROVIDER_AUTHENTICATION_SECRET"
+    }
+
+    facebook {
+      app_id                  = "testFacebookID"
+      app_secret_setting_name = "FACEBOOK_PROVIDER_AUTHENTICATION_SECRET"
+    }
+
+    github {
+      client_id                  = "testGithubID"
+      client_secret_setting_name = "GITHUB_PROVIDER_AUTHENTICATION_SECRET"
+    }
+
+    google {
+      client_id                  = "testGoogleID"
+      client_secret_setting_name = "GOOGLE_PROVIDER_AUTHENTICATION_SECRET"
+    }
+
+    microsoft {
+      client_id                  = "testMSFTID"
+      client_secret_setting_name = "MICROSOFT_PROVIDER_AUTHENTICATION_SECRET"
+    }
+
+    twitter {
+      consumer_key                 = "testTwitterKey"
+      consumer_secret_setting_name = "TWITTER_PROVIDER_AUTHENTICATION_SECRET"
+    }
+
+    login {}
+  }
+}
+`, r.baseTemplate(data), data.RandomInteger, secretSettingValue)
+}
+
+// update

--- a/internal/services/appservice/linux_web_app_resource_authv2_test.go
+++ b/internal/services/appservice/linux_web_app_resource_authv2_test.go
@@ -289,6 +289,7 @@ resource "azurerm_linux_web_app" "test" {
 
     apple_v2 {
       client_id                  = "testAppleID"
+      client_secret_setting_name = "%[3]s"
     }
 
     login {}

--- a/internal/services/appservice/linux_web_app_slot_resource.go
+++ b/internal/services/appservice/linux_web_app_slot_resource.go
@@ -105,6 +105,8 @@ func (r LinuxWebAppSlotResource) Arguments() map[string]*pluginsdk.Schema {
 
 		"auth_settings": helpers.AuthSettingsSchema(),
 
+		"auth_v2_settings": helpers.AuthV2SettingsSchema(),
+
 		"backup": helpers.BackupSchema(),
 
 		"client_affinity_enabled": {

--- a/internal/services/appservice/linux_web_app_slot_resource.go
+++ b/internal/services/appservice/linux_web_app_slot_resource.go
@@ -31,6 +31,7 @@ type LinuxWebAppSlotModel struct {
 	ServicePlanID                 string                              `tfschema:"service_plan_id"`
 	AppSettings                   map[string]string                   `tfschema:"app_settings"`
 	AuthSettings                  []helpers.AuthSettings              `tfschema:"auth_settings"`
+	AuthV2Settings                []helpers.AuthV2Settings            `tfschema:"auth_v2_settings"`
 	Backup                        []helpers.Backup                    `tfschema:"backup"`
 	ClientAffinityEnabled         bool                                `tfschema:"client_affinity_enabled"`
 	ClientCertEnabled             bool                                `tfschema:"client_certificate_enabled"`
@@ -358,6 +359,13 @@ func (r LinuxWebAppSlotResource) Create() sdk.ResourceFunc {
 				}
 			}
 
+			authv2 := helpers.ExpandAuthV2Settings(webAppSlot.AuthV2Settings)
+			if authv2.SiteAuthSettingsV2Properties != nil {
+				if _, err = client.UpdateAuthSettingsV2Slot(ctx, id.ResourceGroup, id.SiteName, *authv2, id.SlotName); err != nil {
+					return fmt.Errorf("updating AuthV2 settings for Linux %s: %+v", id, err)
+				}
+			}
+
 			if metadata.ResourceData.HasChange("logs") {
 				logsConfig := helpers.ExpandLogsConfig(webAppSlot.LogsConfig)
 				if logsConfig.SiteLogsConfigProperties != nil {
@@ -436,6 +444,14 @@ func (r LinuxWebAppSlotResource) Read() sdk.ResourceFunc {
 			auth, err := client.GetAuthSettingsSlot(ctx, id.ResourceGroup, id.SiteName, id.SlotName)
 			if err != nil {
 				return fmt.Errorf("reading Auth Settings for Linux %s: %+v", id, err)
+			}
+
+			var authV2 web.SiteAuthSettingsV2
+			if pointer.From(auth.ConfigVersion) == "v2" {
+				authV2, err = client.GetAuthSettingsV2Slot(ctx, id.ResourceGroup, id.SiteName, id.SlotName)
+				if err != nil {
+					return fmt.Errorf("reading authV2 settings for Linux %s: %+v", *id, err)
+				}
 			}
 
 			backup, err := client.GetBackupConfigurationSlot(ctx, id.ResourceGroup, id.SiteName, id.SlotName)
@@ -531,6 +547,8 @@ func (r LinuxWebAppSlotResource) Read() sdk.ResourceFunc {
 			}
 
 			state.AuthSettings = helpers.FlattenAuthSettings(auth)
+
+			state.AuthV2Settings = helpers.FlattenAuthV2Settings(authV2)
 
 			state.Backup = helpers.FlattenBackupConfig(backup)
 
@@ -714,11 +732,35 @@ func (r LinuxWebAppSlotResource) Update() sdk.ResourceFunc {
 				}
 			}
 
+			updateLogs := false
+
 			if metadata.ResourceData.HasChange("auth_settings") {
 				authUpdate := helpers.ExpandAuthSettings(state.AuthSettings)
+				if authUpdate.SiteAuthSettingsProperties == nil && metadata.ResourceData.HasChange("auth_v2_settings") {
+					authUpdate.SiteAuthSettingsProperties = &web.SiteAuthSettingsProperties{
+						Enabled:                           pointer.To(false),
+						ClientSecret:                      pointer.To(""),
+						ClientSecretSettingName:           pointer.To(""),
+						ClientSecretCertificateThumbprint: pointer.To(""),
+						GoogleClientSecret:                pointer.To(""),
+						FacebookAppSecret:                 pointer.To(""),
+						GitHubClientSecret:                pointer.To(""),
+						TwitterConsumerSecret:             pointer.To(""),
+						MicrosoftAccountClientSecret:      pointer.To(""),
+					}
+					updateLogs = true
+				}
 				if _, err := client.UpdateAuthSettingsSlot(ctx, id.ResourceGroup, id.SiteName, *authUpdate, id.SlotName); err != nil {
 					return fmt.Errorf("updating Auth Settings for Linux %s: %+v", id, err)
 				}
+			}
+
+			if metadata.ResourceData.HasChange("auth_v2_settings") {
+				authV2Update := helpers.ExpandAuthV2Settings(state.AuthV2Settings)
+				if _, err := client.UpdateAuthSettingsV2Slot(ctx, id.ResourceGroup, id.SiteName, *authV2Update, id.SlotName); err != nil {
+					return fmt.Errorf("updating AuthV2 Settings for Linux %s: %+v", id, err)
+				}
+				updateLogs = true
 			}
 
 			if metadata.ResourceData.HasChange("backup") {
@@ -737,7 +779,7 @@ func (r LinuxWebAppSlotResource) Update() sdk.ResourceFunc {
 				}
 			}
 
-			if metadata.ResourceData.HasChange("logs") {
+			if metadata.ResourceData.HasChange("logs") || updateLogs {
 				logsUpdate := helpers.ExpandLogsConfig(state.LogsConfig)
 				if logsUpdate.SiteLogsConfigProperties == nil {
 					logsUpdate = helpers.DisabledLogsConfig() // The API is update only, so we need to send an update with everything switched of when a user removes the "logs" block

--- a/internal/services/appservice/linux_web_app_slot_resource.go
+++ b/internal/services/appservice/linux_web_app_slot_resource.go
@@ -738,7 +738,7 @@ func (r LinuxWebAppSlotResource) Update() sdk.ResourceFunc {
 
 			if metadata.ResourceData.HasChange("auth_settings") {
 				authUpdate := helpers.ExpandAuthSettings(state.AuthSettings)
-				if authUpdate.SiteAuthSettingsProperties == nil && metadata.ResourceData.HasChange("auth_v2_settings") {
+				if authUpdate.SiteAuthSettingsProperties == nil {
 					authUpdate.SiteAuthSettingsProperties = &web.SiteAuthSettingsProperties{
 						Enabled:                           pointer.To(false),
 						ClientSecret:                      pointer.To(""),

--- a/internal/services/appservice/linux_web_app_slot_resource.go
+++ b/internal/services/appservice/linux_web_app_slot_resource.go
@@ -31,7 +31,7 @@ type LinuxWebAppSlotModel struct {
 	ServicePlanID                 string                              `tfschema:"service_plan_id"`
 	AppSettings                   map[string]string                   `tfschema:"app_settings"`
 	AuthSettings                  []helpers.AuthSettings              `tfschema:"auth_settings"`
-	AuthV2Settings                []helpers.AuthV2Settings            `tfschema:"auth_v2_settings"`
+	AuthV2Settings                []helpers.AuthV2Settings            `tfschema:"auth_settings_v2"`
 	Backup                        []helpers.Backup                    `tfschema:"backup"`
 	ClientAffinityEnabled         bool                                `tfschema:"client_affinity_enabled"`
 	ClientCertEnabled             bool                                `tfschema:"client_certificate_enabled"`
@@ -105,7 +105,7 @@ func (r LinuxWebAppSlotResource) Arguments() map[string]*pluginsdk.Schema {
 
 		"auth_settings": helpers.AuthSettingsSchema(),
 
-		"auth_v2_settings": helpers.AuthV2SettingsSchema(),
+		"auth_settings_v2": helpers.AuthV2SettingsSchema(),
 
 		"backup": helpers.BackupSchema(),
 
@@ -757,7 +757,7 @@ func (r LinuxWebAppSlotResource) Update() sdk.ResourceFunc {
 				}
 			}
 
-			if metadata.ResourceData.HasChange("auth_v2_settings") {
+			if metadata.ResourceData.HasChange("auth_settings_v2") {
 				authV2Update := helpers.ExpandAuthV2Settings(state.AuthV2Settings)
 				if _, err := client.UpdateAuthSettingsV2Slot(ctx, id.ResourceGroup, id.SiteName, *authV2Update, id.SlotName); err != nil {
 					return fmt.Errorf("updating AuthV2 Settings for Linux %s: %+v", id, err)

--- a/internal/services/appservice/linux_web_app_slot_resource_authv2_test.go
+++ b/internal/services/appservice/linux_web_app_slot_resource_authv2_test.go
@@ -1,0 +1,59 @@
+package appservice_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+)
+
+func TestAccLinuxWebAppSlot_withAuthV2AzureActiveDirectory(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_web_app_slot", "test")
+	r := LinuxWebAppSlotResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.withAuthV2AzureActiveDirectory(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func (r LinuxWebAppSlotResource) withAuthV2AzureActiveDirectory(data acceptance.TestData) string {
+	secretSettingName := "MICROSOFT_PROVIDER_AUTHENTICATION_SECRET"
+	secretSettingValue := "902D17F6-FD6B-4E44-BABB-58E788DCD907"
+
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_linux_web_app_slot" "test" {
+  name           = "acctestWAS-%d"
+  app_service_id = azurerm_linux_web_app.test.id
+
+  site_config {}
+
+  app_settings = {
+    "%[3]s" = "%[4]s"
+  }
+
+  auth_v2_settings {
+    auth_enabled           = true
+    unauthenticated_action = "Return401"
+    active_directory {
+      client_id                  = data.azurerm_client_config.current.client_id
+      client_secret_setting_name = "%[3]s"
+      tenant_auth_endpoint       = "https://sts.windows.net/%[5]s/v2.0"
+    }
+    login {}
+  }
+}
+`, r.baseTemplate(data), data.RandomInteger, secretSettingName, secretSettingValue, data.Client().TenantID)
+}

--- a/internal/services/appservice/linux_web_app_slot_resource_authv2_test.go
+++ b/internal/services/appservice/linux_web_app_slot_resource_authv2_test.go
@@ -190,7 +190,7 @@ resource "azurerm_linux_web_app_slot" "test" {
     auth_enabled           = true
     unauthenticated_action = "Return401"
 
-    apple {
+    apple_v2 {
       client_id                  = "testAppleID"
       client_secret_setting_name = "%[3]s"
     }
@@ -226,7 +226,7 @@ resource "azurerm_linux_web_app_slot" "test" {
     auth_enabled           = true
     unauthenticated_action = "Return401"
 
-    custom_oidc {
+    custom_oidc_v2 {
       name                          = "testcustom"
       client_id                     = "testCustomID"
       openid_configuration_endpoint = "https://oidc.testcustom.contoso.com/auth"
@@ -299,7 +299,7 @@ resource "azurerm_linux_web_app_slot" "test" {
     auth_enabled           = true
     unauthenticated_action = "RedirectToLoginPage"
 
-    github {
+    github_v2 {
       client_id                  = "testGithubID"
       client_secret_setting_name = "%[3]s"
     }
@@ -335,7 +335,7 @@ resource "azurerm_linux_web_app_slot" "test" {
     auth_enabled           = true
     unauthenticated_action = "RedirectToLoginPage"
 
-    google {
+    google_v2 {
       client_id                  = "testGoogleID"
       client_secret_setting_name = "%[3]s"
     }
@@ -371,7 +371,7 @@ resource "azurerm_linux_web_app_slot" "test" {
     auth_enabled           = true
     unauthenticated_action = "RedirectToLoginPage"
 
-    microsoft {
+    microsoft_v2 {
       client_id                  = "testMSFTID"
       client_secret_setting_name = "%[3]s"
     }
@@ -407,7 +407,7 @@ resource "azurerm_linux_web_app_slot" "test" {
     auth_enabled           = true
     unauthenticated_action = "RedirectToLoginPage"
 
-    twitter {
+    twitter_v2 {
       consumer_key                 = "testTwitterKey"
       consumer_secret_setting_name = "%[3]s"
     }
@@ -447,7 +447,7 @@ resource "azurerm_linux_web_app_slot" "test" {
     auth_enabled           = true
     unauthenticated_action = "RedirectToLoginPage"
 
-    apple {
+    apple_v2 {
       client_id                  = "testAppleID"
       client_secret_setting_name = "APPLE_PROVIDER_AUTHENTICATION_SECRET"
     }
@@ -457,22 +457,22 @@ resource "azurerm_linux_web_app_slot" "test" {
       app_secret_setting_name = "FACEBOOK_PROVIDER_AUTHENTICATION_SECRET"
     }
 
-    github {
+    github_v2 {
       client_id                  = "testGithubID"
       client_secret_setting_name = "GITHUB_PROVIDER_AUTHENTICATION_SECRET"
     }
 
-    google {
+    google_v2 {
       client_id                  = "testGoogleID"
       client_secret_setting_name = "GOOGLE_PROVIDER_AUTHENTICATION_SECRET"
     }
 
-    microsoft {
+    microsoft_v2 {
       client_id                  = "testMSFTID"
       client_secret_setting_name = "MICROSOFT_PROVIDER_AUTHENTICATION_SECRET"
     }
 
-    twitter {
+    twitter_v2 {
       consumer_key                 = "testTwitterKey"
       consumer_secret_setting_name = "TWITTER_PROVIDER_AUTHENTICATION_SECRET"
     }
@@ -509,7 +509,7 @@ resource "azurerm_linux_web_app_slot" "test" {
     auth_enabled           = true
     unauthenticated_action = "RedirectToLoginPage"
 
-    apple {
+    apple_v2 {
       client_id                  = "testAppleID"
       client_secret_setting_name = "APPLE_PROVIDER_AUTHENTICATION_SECRET"
     }
@@ -519,22 +519,22 @@ resource "azurerm_linux_web_app_slot" "test" {
       app_secret_setting_name = "FACEBOOK_PROVIDER_AUTHENTICATION_SECRET"
     }
 
-    github {
+    github_v2 {
       client_id                  = "testGithubID"
       client_secret_setting_name = "GITHUB_PROVIDER_AUTHENTICATION_SECRET"
     }
 
-    google {
+    google_v2 {
       client_id                  = "testGoogleID"
       client_secret_setting_name = "GOOGLE_PROVIDER_AUTHENTICATION_SECRET"
     }
 
-    microsoft {
+    microsoft_v2 {
       client_id                  = "testMSFTID"
       client_secret_setting_name = "MICROSOFT_PROVIDER_AUTHENTICATION_SECRET"
     }
 
-    twitter {
+    twitter_v2 {
       consumer_key                 = "testTwitterKey"
       consumer_secret_setting_name = "TWITTER_PROVIDER_AUTHENTICATION_SECRET"
     }

--- a/internal/services/appservice/linux_web_app_slot_resource_authv2_test.go
+++ b/internal/services/appservice/linux_web_app_slot_resource_authv2_test.go
@@ -14,7 +14,7 @@ func TestAccLinuxWebAppSlot_withAuthV2AzureActiveDirectory(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.withAuthV2AzureActiveDirectory(data),
+			Config: r.authV2AzureActiveDirectory(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -23,7 +23,112 @@ func TestAccLinuxWebAppSlot_withAuthV2AzureActiveDirectory(t *testing.T) {
 	})
 }
 
-func (r LinuxWebAppSlotResource) withAuthV2AzureActiveDirectory(data acceptance.TestData) string {
+func TestAccLinuxWebAppSlot_withAuthV2Apple(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_web_app_slot", "test")
+	r := LinuxWebAppSlotResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.authV2Apple(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccLinuxWebAppSlot_withAuthV2CustomOIDC(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_web_app_slot", "test")
+	r := LinuxWebAppSlotResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.authV2CustomOIDC(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccLinuxWebAppSlot_withAuthV2Facebook(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_web_app_slot", "test")
+	r := LinuxWebAppSlotResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.authV2Facebook(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccLinuxWebAppSlot_withAuthV2Google(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_web_app_slot", "test")
+	r := LinuxWebAppSlotResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.authV2Google(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccLinuxWebAppSlot_withAuthV2Microsoft(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_web_app_slot", "test")
+	r := LinuxWebAppSlotResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.authV2Microsoft(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccLinuxWebAppSlot_withAuthV2Twitter(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_web_app_slot", "test")
+	r := LinuxWebAppSlotResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.authV2Twitter(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccLinuxWebAppSlot_withAuthV2MultipleAuths(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_web_app_slot", "test")
+	r := LinuxWebAppSlotResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.authV2Multi(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func (r LinuxWebAppSlotResource) authV2AzureActiveDirectory(data acceptance.TestData) string {
 	secretSettingName := "MICROSOFT_PROVIDER_AUTHENTICATION_SECRET"
 	secretSettingValue := "902D17F6-FD6B-4E44-BABB-58E788DCD907"
 
@@ -56,4 +161,514 @@ resource "azurerm_linux_web_app_slot" "test" {
   }
 }
 `, r.baseTemplate(data), data.RandomInteger, secretSettingName, secretSettingValue, data.Client().TenantID)
+}
+
+func (r LinuxWebAppSlotResource) authV2Apple(data acceptance.TestData) string {
+	secretSettingName := "APPLE_PROVIDER_AUTHENTICATION_SECRET"
+	secretSettingValue := "902D17F6-FD6B-4E44-BABB-58E788DCD907"
+
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_linux_web_app_slot" "test" {
+  name           = "acctestWAS-%d"
+  app_service_id = azurerm_linux_web_app.test.id
+
+  site_config {}
+
+  app_settings = {
+    "%[3]s" = "%[4]s"
+  }
+
+  auth_v2_settings {
+    auth_enabled           = true
+    unauthenticated_action = "Return401"
+
+    apple {
+      client_id                  = "testAppleID"
+      client_secret_setting_name = "%[3]s"
+    }
+
+    login {}
+  }
+}
+`, r.baseTemplate(data), data.RandomInteger, secretSettingName, secretSettingValue, data.Client().TenantID)
+}
+
+func (r LinuxWebAppSlotResource) authV2CustomOIDC(data acceptance.TestData) string {
+	secretSettingName := "TESTCUSTOM_PROVIDER_AUTHENTICATION_SECRET"
+	secretSettingValue := "902D17F6-FD6B-4E44-BABB-58E788DCD907"
+
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_linux_web_app_slot" "test" {
+  name           = "acctestWAS-%d"
+  app_service_id = azurerm_linux_web_app.test.id
+
+  site_config {}
+
+  app_settings = {
+    "%[3]s" = "%[4]s"
+  }
+
+  auth_v2_settings {
+    auth_enabled           = true
+    unauthenticated_action = "Return401"
+
+    custom_oidc {
+      name                          = "testcustom"
+      client_id                     = "testCustomID"
+      openid_configuration_endpoint = "https://oidc.testcustom.contoso.com/auth"
+    }
+
+    login {}
+  }
+}
+`, r.baseTemplate(data), data.RandomInteger, secretSettingName, secretSettingValue, data.Client().TenantID)
+}
+
+func (r LinuxWebAppSlotResource) authV2Facebook(data acceptance.TestData) string {
+	secretSettingName := "FACEBOOK_PROVIDER_AUTHENTICATION_SECRET"
+	secretSettingValue := "902D17F6-FD6B-4E44-BABB-58E788DCD907"
+
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_linux_web_app_slot" "test" {
+  name           = "acctestWAS-%d"
+  app_service_id = azurerm_linux_web_app.test.id
+
+  site_config {}
+
+  app_settings = {
+    "%[3]s" = "%[4]s"
+  }
+
+  auth_v2_settings {
+    auth_enabled           = true
+    unauthenticated_action = "RedirectToLoginPage"
+
+    facebook {
+      app_id                  = "testFacebookID"
+      app_secret_setting_name = "%[3]s"
+    }
+
+    login {}
+  }
+}
+`, r.baseTemplate(data), data.RandomInteger, secretSettingName, secretSettingValue, data.Client().TenantID)
+}
+
+func (r LinuxWebAppSlotResource) authV2Github(data acceptance.TestData) string {
+	secretSettingName := "GITHUB_PROVIDER_AUTHENTICATION_SECRET"
+	secretSettingValue := "902D17F6-FD6B-4E44-BABB-58E788DCD907"
+
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_linux_web_app_slot" "test" {
+  name           = "acctestWAS-%d"
+  app_service_id = azurerm_linux_web_app.test.id
+
+  site_config {}
+
+  app_settings = {
+    "%[3]s" = "%[4]s"
+  }
+
+  auth_v2_settings {
+    auth_enabled           = true
+    unauthenticated_action = "RedirectToLoginPage"
+
+    github {
+      client_id                  = "testGithubID"
+      client_secret_setting_name = "%[3]s"
+    }
+
+    login {}
+  }
+}
+`, r.baseTemplate(data), data.RandomInteger, secretSettingName, secretSettingValue, data.Client().TenantID)
+}
+
+func (r LinuxWebAppSlotResource) authV2Google(data acceptance.TestData) string {
+	secretSettingName := "GOOGLE_PROVIDER_AUTHENTICATION_SECRET"
+	secretSettingValue := "902D17F6-FD6B-4E44-BABB-58E788DCD907"
+
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_linux_web_app_slot" "test" {
+  name           = "acctestWAS-%d"
+  app_service_id = azurerm_linux_web_app.test.id
+
+  site_config {}
+
+  app_settings = {
+    "%[3]s" = "%[4]s"
+  }
+
+  auth_v2_settings {
+    auth_enabled           = true
+    unauthenticated_action = "RedirectToLoginPage"
+
+    google {
+      client_id                  = "testGoogleID"
+      client_secret_setting_name = "%[3]s"
+    }
+
+    login {}
+  }
+}
+`, r.baseTemplate(data), data.RandomInteger, secretSettingName, secretSettingValue, data.Client().TenantID)
+}
+
+func (r LinuxWebAppSlotResource) authV2Microsoft(data acceptance.TestData) string {
+	secretSettingName := "MICROSOFT_PROVIDER_AUTHENTICATION_SECRET"
+	secretSettingValue := "902D17F6-FD6B-4E44-BABB-58E788DCD907"
+
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_linux_web_app_slot" "test" {
+  name           = "acctestWAS-%d"
+  app_service_id = azurerm_linux_web_app.test.id
+
+  site_config {}
+
+  app_settings = {
+    "%[3]s" = "%[4]s"
+  }
+
+  auth_v2_settings {
+    auth_enabled           = true
+    unauthenticated_action = "RedirectToLoginPage"
+
+    microsoft {
+      client_id                  = "testMSFTID"
+      client_secret_setting_name = "%[3]s"
+    }
+
+    login {}
+  }
+}
+`, r.baseTemplate(data), data.RandomInteger, secretSettingName, secretSettingValue, data.Client().TenantID)
+}
+
+func (r LinuxWebAppSlotResource) authV2Twitter(data acceptance.TestData) string {
+	secretSettingName := "TWITTER_PROVIDER_AUTHENTICATION_SECRET"
+	secretSettingValue := "902D17F6-FD6B-4E44-BABB-58E788DCD907"
+
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_linux_web_app_slot" "test" {
+  name           = "acctestWAS-%d"
+  app_service_id = azurerm_linux_web_app.test.id
+
+  site_config {}
+
+  app_settings = {
+    "%[3]s" = "%[4]s"
+  }
+
+  auth_v2_settings {
+    auth_enabled           = true
+    unauthenticated_action = "RedirectToLoginPage"
+
+    twitter {
+      consumer_key                 = "testTwitterKey"
+      consumer_secret_setting_name = "%[3]s"
+    }
+
+    login {}
+  }
+}
+`, r.baseTemplate(data), data.RandomInteger, secretSettingName, secretSettingValue, data.Client().TenantID)
+}
+
+func (r LinuxWebAppSlotResource) authV2Multi(data acceptance.TestData) string {
+	secretSettingValue := "902D17F6-FD6B-4E44-BABB-58E788DCD907"
+
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_linux_web_app_slot" "test" {
+  name           = "acctestWAS-%[2]d"
+  app_service_id = azurerm_linux_web_app.test.id
+
+  site_config {}
+
+  app_settings = {
+    "APPLE_PROVIDER_AUTHENTICATION_SECRET"     = "%[3]s"
+    "FACEBOOK_PROVIDER_AUTHENTICATION_SECRET"  = "%[3]s"
+    "GITHUB_PROVIDER_AUTHENTICATION_SECRET"    = "%[3]s"
+    "GOOGLE_PROVIDER_AUTHENTICATION_SECRET"    = "%[3]s"
+    "MICROSOFT_PROVIDER_AUTHENTICATION_SECRET" = "%[3]s"
+    "TWITTER_PROVIDER_AUTHENTICATION_SECRET"   = "%[3]s"
+  }
+
+  sticky_settings {
+    app_setting_names = [
+      "APPLE_PROVIDER_AUTHENTICATION_SECRET",
+      "FACEBOOK_PROVIDER_AUTHENTICATION_SECRET",
+      "GITHUB_PROVIDER_AUTHENTICATION_SECRET",
+      "GOOGLE_PROVIDER_AUTHENTICATION_SECRET",
+      "MICROSOFT_PROVIDER_AUTHENTICATION_SECRET",
+      "TWITTER_PROVIDER_AUTHENTICATION_SECRET",
+    ]
+  }
+
+  auth_v2_settings {
+    auth_enabled           = true
+    unauthenticated_action = "RedirectToLoginPage"
+
+    apple {
+      client_id                  = "testAppleID"
+      client_secret_setting_name = "APPLE_PROVIDER_AUTHENTICATION_SECRET"
+    }
+
+    facebook {
+      app_id                  = "testFacebookID"
+      app_secret_setting_name = "FACEBOOK_PROVIDER_AUTHENTICATION_SECRET"
+    }
+
+    github {
+      client_id                  = "testGithubID"
+      client_secret_setting_name = "GITHUB_PROVIDER_AUTHENTICATION_SECRET"
+    }
+
+    google {
+      client_id                  = "testGoogleID"
+      client_secret_setting_name = "GOOGLE_PROVIDER_AUTHENTICATION_SECRET"
+    }
+
+    microsoft {
+      client_id                  = "testMSFTID"
+      client_secret_setting_name = "MICROSOFT_PROVIDER_AUTHENTICATION_SECRET"
+    }
+
+    twitter {
+      consumer_key                 = "testTwitterKey"
+      consumer_secret_setting_name = "TWITTER_PROVIDER_AUTHENTICATION_SECRET"
+    }
+
+    login {}
+  }
+}
+`, r.baseTemplate(data), data.RandomInteger, secretSettingValue)
+}
+
+func (r LinuxWebAppSlotResource) completeAuthV2(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_linux_web_app_slot" "test" {
+  name           = "acctestWAS-%d"
+  app_service_id = azurerm_linux_web_app.test.id
+
+  app_settings = {
+    "foo"                                      = "bar"
+    "APPLE_PROVIDER_AUTHENTICATION_SECRET"     = "%[3]s"
+    "FACEBOOK_PROVIDER_AUTHENTICATION_SECRET"  = "%[3]s"
+    "GITHUB_PROVIDER_AUTHENTICATION_SECRET"    = "%[3]s"
+    "GOOGLE_PROVIDER_AUTHENTICATION_SECRET"    = "%[3]s"
+    "MICROSOFT_PROVIDER_AUTHENTICATION_SECRET" = "%[3]s"
+    "TWITTER_PROVIDER_AUTHENTICATION_SECRET"   = "%[3]s"
+  }
+
+  auth_v2_settings {
+    auth_enabled           = true
+    unauthenticated_action = "RedirectToLoginPage"
+
+    apple {
+      client_id                  = "testAppleID"
+      client_secret_setting_name = "APPLE_PROVIDER_AUTHENTICATION_SECRET"
+    }
+
+    facebook {
+      app_id                  = "testFacebookID"
+      app_secret_setting_name = "FACEBOOK_PROVIDER_AUTHENTICATION_SECRET"
+    }
+
+    github {
+      client_id                  = "testGithubID"
+      client_secret_setting_name = "GITHUB_PROVIDER_AUTHENTICATION_SECRET"
+    }
+
+    google {
+      client_id                  = "testGoogleID"
+      client_secret_setting_name = "GOOGLE_PROVIDER_AUTHENTICATION_SECRET"
+    }
+
+    microsoft {
+      client_id                  = "testMSFTID"
+      client_secret_setting_name = "MICROSOFT_PROVIDER_AUTHENTICATION_SECRET"
+    }
+
+    twitter {
+      consumer_key                 = "testTwitterKey"
+      consumer_secret_setting_name = "TWITTER_PROVIDER_AUTHENTICATION_SECRET"
+    }
+
+    login {}
+  }
+
+  backup {
+    name                = "acctest"
+    storage_account_url = "https://${azurerm_storage_account.test.name}.blob.core.windows.net/${azurerm_storage_container.test.name}${data.azurerm_storage_account_sas.test.sas}&sr=b"
+    schedule {
+      frequency_interval = 1
+      frequency_unit     = "Day"
+    }
+  }
+
+  logs {
+    application_logs {
+      file_system_level = "Warning"
+      azure_blob_storage {
+        level             = "Information"
+        sas_url           = "http://x.com/"
+        retention_in_days = 2
+      }
+    }
+
+    http_logs {
+      azure_blob_storage {
+        sas_url           = "https://${azurerm_storage_account.test.name}.blob.core.windows.net/${azurerm_storage_container.test.name}${data.azurerm_storage_account_sas.test.sas}&sr=b"
+        retention_in_days = 3
+      }
+    }
+  }
+
+  client_affinity_enabled            = true
+  client_certificate_enabled         = true
+  client_certificate_mode            = "Optional"
+  client_certificate_exclusion_paths = "/foo;/bar;/hello;/world"
+
+  connection_string {
+    name  = "First"
+    value = "first-connection-string"
+    type  = "Custom"
+  }
+
+  connection_string {
+    name  = "Second"
+    value = "some-postgresql-connection-string"
+    type  = "PostgreSQL"
+  }
+
+  enabled    = false
+  https_only = true
+
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.test.id]
+  }
+
+  site_config {
+    always_on        = true
+    app_command_line = "/sbin/myserver -b 0.0.0.0"
+    default_documents = [
+      "first.html",
+      "second.jsp",
+      "third.aspx",
+      "hostingstart.html",
+    ]
+    http2_enabled               = true
+    scm_use_main_ip_restriction = true
+    local_mysql_enabled         = true
+    managed_pipeline_mode       = "Integrated"
+    remote_debugging_enabled    = true
+    remote_debugging_version    = "VS2019"
+    use_32_bit_worker           = true
+    websockets_enabled          = true
+    ftps_state                  = "FtpsOnly"
+    health_check_path           = "/health"
+    worker_count                = 1
+    minimum_tls_version         = "1.1"
+    scm_minimum_tls_version     = "1.1"
+    cors {
+      allowed_origins = [
+        "http://www.contoso.com",
+        "www.contoso.com",
+      ]
+
+      support_credentials = true
+    }
+
+    container_registry_use_managed_identity       = true
+    container_registry_managed_identity_client_id = azurerm_user_assigned_identity.test.client_id
+
+    auto_swap_slot_name = "Production"
+    auto_heal_enabled   = true
+
+    auto_heal_setting {
+      trigger {
+        status_code {
+          status_code_range = "500"
+          interval          = "00:01:00"
+          count             = 10
+        }
+      }
+
+      action {
+        action_type                    = "Recycle"
+        minimum_process_execution_time = "00:05:00"
+      }
+    }
+  }
+
+  storage_account {
+    name         = "files"
+    type         = "AzureFiles"
+    account_name = azurerm_storage_account.test.name
+    share_name   = azurerm_storage_share.test.name
+    access_key   = azurerm_storage_account.test.primary_access_key
+    mount_path   = "/storage/files"
+  }
+
+  tags = {
+    Environment = "AccTest"
+    foo         = "bar"
+  }
+}
+`, r.templateWithStorageAccount(data), data.RandomInteger, data.Client().TenantID)
 }

--- a/internal/services/appservice/linux_web_app_slot_resource_authv2_test.go
+++ b/internal/services/appservice/linux_web_app_slot_resource_authv2_test.go
@@ -68,6 +68,21 @@ func TestAccLinuxWebAppSlot_withAuthV2Facebook(t *testing.T) {
 	})
 }
 
+func TestAccLinuxWebAppSlot_withAuthV2Github(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_web_app_slot", "test")
+	r := LinuxWebAppSlotResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.authV2Github(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccLinuxWebAppSlot_withAuthV2Google(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_linux_web_app_slot", "test")
 	r := LinuxWebAppSlotResource{}
@@ -481,185 +496,4 @@ resource "azurerm_linux_web_app_slot" "test" {
   }
 }
 `, r.baseTemplate(data), data.RandomInteger, secretSettingValue)
-}
-
-func (r LinuxWebAppSlotResource) completeAuthV2(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-%s
-
-resource "azurerm_linux_web_app_slot" "test" {
-  name           = "acctestWAS-%d"
-  app_service_id = azurerm_linux_web_app.test.id
-
-  app_settings = {
-    "foo"                                      = "bar"
-    "APPLE_PROVIDER_AUTHENTICATION_SECRET"     = "%[3]s"
-    "FACEBOOK_PROVIDER_AUTHENTICATION_SECRET"  = "%[3]s"
-    "GITHUB_PROVIDER_AUTHENTICATION_SECRET"    = "%[3]s"
-    "GOOGLE_PROVIDER_AUTHENTICATION_SECRET"    = "%[3]s"
-    "MICROSOFT_PROVIDER_AUTHENTICATION_SECRET" = "%[3]s"
-    "TWITTER_PROVIDER_AUTHENTICATION_SECRET"   = "%[3]s"
-  }
-
-  auth_settings_v2 {
-    auth_enabled           = true
-    unauthenticated_action = "RedirectToLoginPage"
-
-    apple_v2 {
-      client_id                  = "testAppleID"
-      client_secret_setting_name = "APPLE_PROVIDER_AUTHENTICATION_SECRET"
-    }
-
-    facebook_v2 {
-      app_id                  = "testFacebookID"
-      app_secret_setting_name = "FACEBOOK_PROVIDER_AUTHENTICATION_SECRET"
-    }
-
-    github_v2 {
-      client_id                  = "testGithubID"
-      client_secret_setting_name = "GITHUB_PROVIDER_AUTHENTICATION_SECRET"
-    }
-
-    google_v2 {
-      client_id                  = "testGoogleID"
-      client_secret_setting_name = "GOOGLE_PROVIDER_AUTHENTICATION_SECRET"
-    }
-
-    microsoft_v2 {
-      client_id                  = "testMSFTID"
-      client_secret_setting_name = "MICROSOFT_PROVIDER_AUTHENTICATION_SECRET"
-    }
-
-    twitter_v2 {
-      consumer_key                 = "testTwitterKey"
-      consumer_secret_setting_name = "TWITTER_PROVIDER_AUTHENTICATION_SECRET"
-    }
-
-    login {}
-  }
-
-  backup {
-    name                = "acctest"
-    storage_account_url = "https://${azurerm_storage_account.test.name}.blob.core.windows.net/${azurerm_storage_container.test.name}${data.azurerm_storage_account_sas.test.sas}&sr=b"
-    schedule {
-      frequency_interval = 1
-      frequency_unit     = "Day"
-    }
-  }
-
-  logs {
-    application_logs {
-      file_system_level = "Warning"
-      azure_blob_storage {
-        level             = "Information"
-        sas_url           = "http://x.com/"
-        retention_in_days = 2
-      }
-    }
-
-    http_logs {
-      azure_blob_storage {
-        sas_url           = "https://${azurerm_storage_account.test.name}.blob.core.windows.net/${azurerm_storage_container.test.name}${data.azurerm_storage_account_sas.test.sas}&sr=b"
-        retention_in_days = 3
-      }
-    }
-  }
-
-  client_affinity_enabled            = true
-  client_certificate_enabled         = true
-  client_certificate_mode            = "Optional"
-  client_certificate_exclusion_paths = "/foo;/bar;/hello;/world"
-
-  connection_string {
-    name  = "First"
-    value = "first-connection-string"
-    type  = "Custom"
-  }
-
-  connection_string {
-    name  = "Second"
-    value = "some-postgresql-connection-string"
-    type  = "PostgreSQL"
-  }
-
-  enabled    = false
-  https_only = true
-
-  identity {
-    type         = "UserAssigned"
-    identity_ids = [azurerm_user_assigned_identity.test.id]
-  }
-
-  site_config {
-    always_on        = true
-    app_command_line = "/sbin/myserver -b 0.0.0.0"
-    default_documents = [
-      "first.html",
-      "second.jsp",
-      "third.aspx",
-      "hostingstart.html",
-    ]
-    http2_enabled               = true
-    scm_use_main_ip_restriction = true
-    local_mysql_enabled         = true
-    managed_pipeline_mode       = "Integrated"
-    remote_debugging_enabled    = true
-    remote_debugging_version    = "VS2019"
-    use_32_bit_worker           = true
-    websockets_enabled          = true
-    ftps_state                  = "FtpsOnly"
-    health_check_path           = "/health"
-    worker_count                = 1
-    minimum_tls_version         = "1.1"
-    scm_minimum_tls_version     = "1.1"
-    cors {
-      allowed_origins = [
-        "http://www.contoso.com",
-        "www.contoso.com",
-      ]
-
-      support_credentials = true
-    }
-
-    container_registry_use_managed_identity       = true
-    container_registry_managed_identity_client_id = azurerm_user_assigned_identity.test.client_id
-
-    auto_swap_slot_name = "Production"
-    auto_heal_enabled   = true
-
-    auto_heal_setting {
-      trigger {
-        status_code {
-          status_code_range = "500"
-          interval          = "00:01:00"
-          count             = 10
-        }
-      }
-
-      action {
-        action_type                    = "Recycle"
-        minimum_process_execution_time = "00:05:00"
-      }
-    }
-  }
-
-  storage_account {
-    name         = "files"
-    type         = "AzureFiles"
-    account_name = azurerm_storage_account.test.name
-    share_name   = azurerm_storage_share.test.name
-    access_key   = azurerm_storage_account.test.primary_access_key
-    mount_path   = "/storage/files"
-  }
-
-  tags = {
-    Environment = "AccTest"
-    foo         = "bar"
-  }
-}
-`, r.templateWithStorageAccount(data), data.RandomInteger, data.Client().TenantID)
 }

--- a/internal/services/appservice/linux_web_app_slot_resource_authv2_test.go
+++ b/internal/services/appservice/linux_web_app_slot_resource_authv2_test.go
@@ -154,7 +154,7 @@ resource "azurerm_linux_web_app_slot" "test" {
   auth_settings_v2 {
     auth_enabled           = true
     unauthenticated_action = "Return401"
-    active_directory {
+    active_directory_v2 {
       client_id                  = data.azurerm_client_config.current.client_id
       client_secret_setting_name = "%[3]s"
       tenant_auth_endpoint       = "https://sts.windows.net/%[5]s/v2.0"
@@ -263,7 +263,7 @@ resource "azurerm_linux_web_app_slot" "test" {
     auth_enabled           = true
     unauthenticated_action = "RedirectToLoginPage"
 
-    facebook {
+    facebook_v2 {
       app_id                  = "testFacebookID"
       app_secret_setting_name = "%[3]s"
     }
@@ -452,7 +452,7 @@ resource "azurerm_linux_web_app_slot" "test" {
       client_secret_setting_name = "APPLE_PROVIDER_AUTHENTICATION_SECRET"
     }
 
-    facebook {
+    facebook_v2 {
       app_id                  = "testFacebookID"
       app_secret_setting_name = "FACEBOOK_PROVIDER_AUTHENTICATION_SECRET"
     }
@@ -514,7 +514,7 @@ resource "azurerm_linux_web_app_slot" "test" {
       client_secret_setting_name = "APPLE_PROVIDER_AUTHENTICATION_SECRET"
     }
 
-    facebook {
+    facebook_v2 {
       app_id                  = "testFacebookID"
       app_secret_setting_name = "FACEBOOK_PROVIDER_AUTHENTICATION_SECRET"
     }

--- a/internal/services/appservice/linux_web_app_slot_resource_authv2_test.go
+++ b/internal/services/appservice/linux_web_app_slot_resource_authv2_test.go
@@ -139,6 +139,8 @@ provider "azurerm" {
 
 %s
 
+data "azurerm_client_config" "current" {}
+
 resource "azurerm_linux_web_app_slot" "test" {
   name           = "acctestWAS-%d"
   app_service_id = azurerm_linux_web_app.test.id
@@ -149,7 +151,7 @@ resource "azurerm_linux_web_app_slot" "test" {
     "%[3]s" = "%[4]s"
   }
 
-  auth_v2_settings {
+  auth_settings_v2 {
     auth_enabled           = true
     unauthenticated_action = "Return401"
     active_directory {
@@ -184,7 +186,7 @@ resource "azurerm_linux_web_app_slot" "test" {
     "%[3]s" = "%[4]s"
   }
 
-  auth_v2_settings {
+  auth_settings_v2 {
     auth_enabled           = true
     unauthenticated_action = "Return401"
 
@@ -220,7 +222,7 @@ resource "azurerm_linux_web_app_slot" "test" {
     "%[3]s" = "%[4]s"
   }
 
-  auth_v2_settings {
+  auth_settings_v2 {
     auth_enabled           = true
     unauthenticated_action = "Return401"
 
@@ -257,7 +259,7 @@ resource "azurerm_linux_web_app_slot" "test" {
     "%[3]s" = "%[4]s"
   }
 
-  auth_v2_settings {
+  auth_settings_v2 {
     auth_enabled           = true
     unauthenticated_action = "RedirectToLoginPage"
 
@@ -293,7 +295,7 @@ resource "azurerm_linux_web_app_slot" "test" {
     "%[3]s" = "%[4]s"
   }
 
-  auth_v2_settings {
+  auth_settings_v2 {
     auth_enabled           = true
     unauthenticated_action = "RedirectToLoginPage"
 
@@ -329,7 +331,7 @@ resource "azurerm_linux_web_app_slot" "test" {
     "%[3]s" = "%[4]s"
   }
 
-  auth_v2_settings {
+  auth_settings_v2 {
     auth_enabled           = true
     unauthenticated_action = "RedirectToLoginPage"
 
@@ -365,7 +367,7 @@ resource "azurerm_linux_web_app_slot" "test" {
     "%[3]s" = "%[4]s"
   }
 
-  auth_v2_settings {
+  auth_settings_v2 {
     auth_enabled           = true
     unauthenticated_action = "RedirectToLoginPage"
 
@@ -401,7 +403,7 @@ resource "azurerm_linux_web_app_slot" "test" {
     "%[3]s" = "%[4]s"
   }
 
-  auth_v2_settings {
+  auth_settings_v2 {
     auth_enabled           = true
     unauthenticated_action = "RedirectToLoginPage"
 
@@ -441,18 +443,7 @@ resource "azurerm_linux_web_app_slot" "test" {
     "TWITTER_PROVIDER_AUTHENTICATION_SECRET"   = "%[3]s"
   }
 
-  sticky_settings {
-    app_setting_names = [
-      "APPLE_PROVIDER_AUTHENTICATION_SECRET",
-      "FACEBOOK_PROVIDER_AUTHENTICATION_SECRET",
-      "GITHUB_PROVIDER_AUTHENTICATION_SECRET",
-      "GOOGLE_PROVIDER_AUTHENTICATION_SECRET",
-      "MICROSOFT_PROVIDER_AUTHENTICATION_SECRET",
-      "TWITTER_PROVIDER_AUTHENTICATION_SECRET",
-    ]
-  }
-
-  auth_v2_settings {
+  auth_settings_v2 {
     auth_enabled           = true
     unauthenticated_action = "RedirectToLoginPage"
 
@@ -514,7 +505,7 @@ resource "azurerm_linux_web_app_slot" "test" {
     "TWITTER_PROVIDER_AUTHENTICATION_SECRET"   = "%[3]s"
   }
 
-  auth_v2_settings {
+  auth_settings_v2 {
     auth_enabled           = true
     unauthenticated_action = "RedirectToLoginPage"
 

--- a/internal/services/appservice/linux_web_app_slot_resource_test.go
+++ b/internal/services/appservice/linux_web_app_slot_resource_test.go
@@ -2245,7 +2245,7 @@ resource "azurerm_service_plan" "test3" {
 
 resource "azurerm_linux_web_app_slot" "test" {
   name           = "acctestWAS-%[2]d"
-  app_service_id = azurerm_linux_web_app.test2.id
+  app_service_id = azurerm_linux_web_app.test.id
 
   service_plan_id = azurerm_service_plan.test3.id
 

--- a/internal/services/appservice/linux_web_app_slot_resource_test.go
+++ b/internal/services/appservice/linux_web_app_slot_resource_test.go
@@ -2245,7 +2245,7 @@ resource "azurerm_service_plan" "test3" {
 
 resource "azurerm_linux_web_app_slot" "test" {
   name           = "acctestWAS-%[2]d"
-  app_service_id = azurerm_linux_web_app.test3.id
+  app_service_id = azurerm_linux_web_app.test2.id
 
   service_plan_id = azurerm_service_plan.test3.id
 

--- a/internal/services/appservice/validate/auto_heal_interval.go
+++ b/internal/services/appservice/validate/auto_heal_interval.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 )
 
-func AutoHealInterval(i interface{}, k string) (warnings []string, errors []error) {
+func TimeInterval(i interface{}, k string) (warnings []string, errors []error) {
 	v, ok := i.(string)
 	if !ok {
 		errors = append(errors, fmt.Errorf("expected type of %q to be string", k))

--- a/internal/services/appservice/validate/auto_heal_interval_test.go
+++ b/internal/services/appservice/validate/auto_heal_interval_test.go
@@ -31,7 +31,7 @@ func TestAutoHealInterval(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Logf("[DEBUG] Testing Value %s", tc.Input)
-		_, errors := AutoHealInterval(tc.Input, "test")
+		_, errors := TimeInterval(tc.Input, "test")
 		valid := len(errors) == 0
 
 		if tc.Valid != valid {

--- a/internal/services/appservice/windows_web_app_data_source.go
+++ b/internal/services/appservice/windows_web_app_data_source.go
@@ -26,6 +26,7 @@ type WindowsWebAppDataSourceModel struct {
 	ServicePlanId                 string                      `tfschema:"service_plan_id"`
 	AppSettings                   map[string]string           `tfschema:"app_settings"`
 	AuthSettings                  []helpers.AuthSettings      `tfschema:"auth_settings"`
+	AuthV2Settings                []helpers.AuthV2Settings    `tfschema:"auth_v2_settings"`
 	Backup                        []helpers.Backup            `tfschema:"backup"`
 	ClientAffinityEnabled         bool                        `tfschema:"client_affinity_enabled"`
 	ClientCertEnabled             bool                        `tfschema:"client_certificate_enabled"`
@@ -221,6 +222,11 @@ func (d WindowsWebAppDataSource) Read() sdk.ResourceFunc {
 				return fmt.Errorf("reading Auth Settings for Windows %s: %+v", id, err)
 			}
 
+			authV2, err := client.GetAuthSettingsV2(ctx, id.ResourceGroup, id.SiteName)
+			if err != nil {
+				return fmt.Errorf("reading authV2 settings for Linux %s: %+v", id, err)
+			}
+
 			backup, err := client.GetBackupConfiguration(ctx, id.ResourceGroup, id.SiteName)
 			if err != nil {
 				if !utils.ResponseWasNotFound(backup.Response) {
@@ -306,6 +312,8 @@ func (d WindowsWebAppDataSource) Read() sdk.ResourceFunc {
 			}
 
 			webApp.AuthSettings = helpers.FlattenAuthSettings(auth)
+
+			webApp.AuthV2Settings = helpers.FlattenAuthV2Settings(authV2)
 
 			webApp.Backup = helpers.FlattenBackupConfig(backup)
 

--- a/internal/services/appservice/windows_web_app_data_source.go
+++ b/internal/services/appservice/windows_web_app_data_source.go
@@ -92,6 +92,8 @@ func (d WindowsWebAppDataSource) Attributes() map[string]*pluginsdk.Schema {
 
 		"auth_settings": helpers.AuthSettingsSchemaComputed(),
 
+		"auth_settings_v2": helpers.AuthV2SettingsComputedSchema(),
+
 		"backup": helpers.BackupSchemaComputed(),
 
 		"client_affinity_enabled": {

--- a/internal/services/appservice/windows_web_app_data_source.go
+++ b/internal/services/appservice/windows_web_app_data_source.go
@@ -26,7 +26,7 @@ type WindowsWebAppDataSourceModel struct {
 	ServicePlanId                 string                      `tfschema:"service_plan_id"`
 	AppSettings                   map[string]string           `tfschema:"app_settings"`
 	AuthSettings                  []helpers.AuthSettings      `tfschema:"auth_settings"`
-	AuthV2Settings                []helpers.AuthV2Settings    `tfschema:"auth_v2_settings"`
+	AuthV2Settings                []helpers.AuthV2Settings    `tfschema:"auth_settings_v2"`
 	Backup                        []helpers.Backup            `tfschema:"backup"`
 	ClientAffinityEnabled         bool                        `tfschema:"client_affinity_enabled"`
 	ClientCertEnabled             bool                        `tfschema:"client_certificate_enabled"`

--- a/internal/services/appservice/windows_web_app_data_source_test.go
+++ b/internal/services/appservice/windows_web_app_data_source_test.go
@@ -24,6 +24,20 @@ func TestAccWindowsWebAppDataSource_complete(t *testing.T) {
 	})
 }
 
+func TestAccWindowsWebAppDataSource_completeAuthV2(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_windows_web_app", "test")
+	d := WindowsWebAppDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: d.completeAuthV2(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("location").HasValue(data.Locations.Primary),
+			),
+		},
+	})
+}
+
 func (WindowsWebAppDataSource) complete(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
@@ -33,4 +47,15 @@ data azurerm_windows_web_app test {
   resource_group_name = azurerm_windows_web_app.test.resource_group_name
 }
 `, WindowsWebAppResource{}.complete(data))
+}
+
+func (WindowsWebAppDataSource) completeAuthV2(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data azurerm_windows_web_app test {
+  name                = azurerm_windows_web_app.test.name
+  resource_group_name = azurerm_windows_web_app.test.resource_group_name
+}
+`, WindowsWebAppResource{}.completeAuthV2(data))
 }

--- a/internal/services/appservice/windows_web_app_resource.go
+++ b/internal/services/appservice/windows_web_app_resource.go
@@ -839,7 +839,7 @@ func (r WindowsWebAppResource) Update() sdk.ResourceFunc {
 					updateLogs = true
 				}
 				if _, err := client.UpdateAuthSettings(ctx, id.ResourceGroup, id.SiteName, *authUpdate); err != nil {
-					return fmt.Errorf("updating Auth Settings for Linux %s: %+v", id, err)
+					return fmt.Errorf("updating Auth Settings for Windows %s: %+v", id, err)
 				}
 			}
 

--- a/internal/services/appservice/windows_web_app_resource.go
+++ b/internal/services/appservice/windows_web_app_resource.go
@@ -33,7 +33,7 @@ type WindowsWebAppModel struct {
 	AppSettings                   map[string]string           `tfschema:"app_settings"`
 	StickySettings                []helpers.StickySettings    `tfschema:"sticky_settings"`
 	AuthSettings                  []helpers.AuthSettings      `tfschema:"auth_settings"`
-	AuthV2Settings                []helpers.AuthV2Settings    `tfschema:"auth_v2_settings"`
+	AuthV2Settings                []helpers.AuthV2Settings    `tfschema:"auth_settings_v2"`
 	Backup                        []helpers.Backup            `tfschema:"backup"`
 	ClientAffinityEnabled         bool                        `tfschema:"client_affinity_enabled"`
 	ClientCertEnabled             bool                        `tfschema:"client_certificate_enabled"`
@@ -92,7 +92,7 @@ func (r WindowsWebAppResource) Arguments() map[string]*pluginsdk.Schema {
 
 		"auth_settings": helpers.AuthSettingsSchema(),
 
-		"auth_v2_settings": helpers.AuthV2SettingsSchema(),
+		"auth_settings_v2": helpers.AuthV2SettingsSchema(),
 
 		"backup": helpers.BackupSchema(),
 
@@ -843,7 +843,7 @@ func (r WindowsWebAppResource) Update() sdk.ResourceFunc {
 				}
 			}
 
-			if metadata.ResourceData.HasChange("auth_v2_settings") {
+			if metadata.ResourceData.HasChange("auth_settings_v2") {
 				authV2Update := helpers.ExpandAuthV2Settings(state.AuthV2Settings)
 				if _, err := client.UpdateAuthSettingsV2(ctx, id.ResourceGroup, id.SiteName, *authV2Update); err != nil {
 					return fmt.Errorf("updating AuthV2 Settings for Linux %s: %+v", id, err)

--- a/internal/services/appservice/windows_web_app_resource.go
+++ b/internal/services/appservice/windows_web_app_resource.go
@@ -92,6 +92,8 @@ func (r WindowsWebAppResource) Arguments() map[string]*pluginsdk.Schema {
 
 		"auth_settings": helpers.AuthSettingsSchema(),
 
+		"auth_v2_settings": helpers.AuthV2SettingsSchema(),
+
 		"backup": helpers.BackupSchema(),
 
 		"client_affinity_enabled": {

--- a/internal/services/appservice/windows_web_app_resource.go
+++ b/internal/services/appservice/windows_web_app_resource.go
@@ -488,7 +488,7 @@ func (r WindowsWebAppResource) Read() sdk.ResourceFunc {
 			if pointer.From(auth.ConfigVersion) == "v2" {
 				authV2, err = client.GetAuthSettingsV2(ctx, id.ResourceGroup, id.SiteName)
 				if err != nil {
-					return fmt.Errorf("reading authV2 settings for Linux %s: %+v", *id, err)
+					return fmt.Errorf("reading authV2 settings for Windows %s: %+v", *id, err)
 				}
 			}
 

--- a/internal/services/appservice/windows_web_app_resource.go
+++ b/internal/services/appservice/windows_web_app_resource.go
@@ -399,7 +399,7 @@ func (r WindowsWebAppResource) Create() sdk.ResourceFunc {
 			authv2 := helpers.ExpandAuthV2Settings(webApp.AuthV2Settings)
 			if authv2.SiteAuthSettingsV2Properties != nil {
 				if _, err = client.UpdateAuthSettingsV2(ctx, id.ResourceGroup, id.SiteName, *authv2); err != nil {
-					return fmt.Errorf("updating AuthV2 settings for Linux %s: %+v", id, err)
+					return fmt.Errorf("updating AuthV2 settings for Windows %s: %+v", id, err)
 				}
 			}
 

--- a/internal/services/appservice/windows_web_app_resource.go
+++ b/internal/services/appservice/windows_web_app_resource.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/web/mgmt/2021-03-01/web" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
@@ -32,6 +33,7 @@ type WindowsWebAppModel struct {
 	AppSettings                   map[string]string           `tfschema:"app_settings"`
 	StickySettings                []helpers.StickySettings    `tfschema:"sticky_settings"`
 	AuthSettings                  []helpers.AuthSettings      `tfschema:"auth_settings"`
+	AuthV2Settings                []helpers.AuthV2Settings    `tfschema:"auth_v2_settings"`
 	Backup                        []helpers.Backup            `tfschema:"backup"`
 	ClientAffinityEnabled         bool                        `tfschema:"client_affinity_enabled"`
 	ClientCertEnabled             bool                        `tfschema:"client_certificate_enabled"`
@@ -254,7 +256,7 @@ func (r WindowsWebAppResource) Create() sdk.ResourceFunc {
 			}
 
 			availabilityRequest := web.ResourceNameAvailabilityRequest{
-				Name: utils.String(webApp.Name),
+				Name: pointer.To(webApp.Name),
 				Type: web.CheckNameResourceTypesMicrosoftWebsites,
 			}
 
@@ -286,8 +288,8 @@ func (r WindowsWebAppResource) Create() sdk.ResourceFunc {
 						}
 					}
 				}
-				availabilityRequest.Name = utils.String(fmt.Sprintf("%s.%s", webApp.Name, nameSuffix))
-				availabilityRequest.IsFqdn = utils.Bool(true)
+				availabilityRequest.Name = pointer.To(fmt.Sprintf("%s.%s", webApp.Name, nameSuffix))
+				availabilityRequest.IsFqdn = pointer.To(true)
 			}
 
 			checkName, err := client.CheckNameAvailability(ctx, availabilityRequest)
@@ -318,30 +320,30 @@ func (r WindowsWebAppResource) Create() sdk.ResourceFunc {
 			}
 
 			siteEnvelope := web.Site{
-				Location: utils.String(webApp.Location),
+				Location: pointer.To(webApp.Location),
 				Tags:     tags.FromTypedObject(webApp.Tags),
 				Identity: expandedIdentity,
 				SiteProperties: &web.SiteProperties{
-					ServerFarmID:          utils.String(webApp.ServicePlanId),
-					Enabled:               utils.Bool(webApp.Enabled),
-					HTTPSOnly:             utils.Bool(webApp.HttpsOnly),
+					ServerFarmID:          pointer.To(webApp.ServicePlanId),
+					Enabled:               pointer.To(webApp.Enabled),
+					HTTPSOnly:             pointer.To(webApp.HttpsOnly),
 					SiteConfig:            siteConfig,
-					ClientAffinityEnabled: utils.Bool(webApp.ClientAffinityEnabled),
-					ClientCertEnabled:     utils.Bool(webApp.ClientCertEnabled),
+					ClientAffinityEnabled: pointer.To(webApp.ClientAffinityEnabled),
+					ClientCertEnabled:     pointer.To(webApp.ClientCertEnabled),
 					ClientCertMode:        web.ClientCertMode(webApp.ClientCertMode),
 				},
 			}
 
 			if webApp.KeyVaultReferenceIdentityID != "" {
-				siteEnvelope.SiteProperties.KeyVaultReferenceIdentity = utils.String(webApp.KeyVaultReferenceIdentityID)
+				siteEnvelope.SiteProperties.KeyVaultReferenceIdentity = pointer.To(webApp.KeyVaultReferenceIdentityID)
 			}
 
 			if webApp.VirtualNetworkSubnetID != "" {
-				siteEnvelope.SiteProperties.VirtualNetworkSubnetID = utils.String(webApp.VirtualNetworkSubnetID)
+				siteEnvelope.SiteProperties.VirtualNetworkSubnetID = pointer.To(webApp.VirtualNetworkSubnetID)
 			}
 
 			if webApp.ClientCertExclusionPaths != "" {
-				siteEnvelope.ClientCertExclusionPaths = utils.String(webApp.ClientCertExclusionPaths)
+				siteEnvelope.ClientCertExclusionPaths = pointer.To(webApp.ClientCertExclusionPaths)
 			}
 
 			future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.SiteName, siteEnvelope)
@@ -365,7 +367,7 @@ func (r WindowsWebAppResource) Create() sdk.ResourceFunc {
 
 			appSettings := helpers.ExpandAppSettingsForUpdate(webApp.AppSettings)
 			if metadata.ResourceData.HasChange("site_config.0.health_check_eviction_time_in_min") {
-				appSettings.Properties["WEBSITE_HEALTHCHECK_MAXPINGFAILURES"] = utils.String(strconv.Itoa(webApp.SiteConfig[0].HealthCheckEvictionTime))
+				appSettings.Properties["WEBSITE_HEALTHCHECK_MAXPINGFAILURES"] = pointer.To(strconv.Itoa(webApp.SiteConfig[0].HealthCheckEvictionTime))
 			}
 
 			if appSettings != nil {
@@ -389,6 +391,13 @@ func (r WindowsWebAppResource) Create() sdk.ResourceFunc {
 			if auth.SiteAuthSettingsProperties != nil {
 				if _, err := client.UpdateAuthSettings(ctx, id.ResourceGroup, id.SiteName, *auth); err != nil {
 					return fmt.Errorf("setting Authorisation Settings for %s: %+v", id, err)
+				}
+			}
+
+			authv2 := helpers.ExpandAuthV2Settings(webApp.AuthV2Settings)
+			if authv2.SiteAuthSettingsV2Properties != nil {
+				if _, err = client.UpdateAuthSettingsV2(ctx, id.ResourceGroup, id.SiteName, *authv2); err != nil {
+					return fmt.Errorf("updating AuthV2 settings for Linux %s: %+v", id, err)
 				}
 			}
 
@@ -473,6 +482,14 @@ func (r WindowsWebAppResource) Read() sdk.ResourceFunc {
 				return fmt.Errorf("reading Auth Settings for Windows %s: %+v", id, err)
 			}
 
+			var authV2 web.SiteAuthSettingsV2
+			if pointer.From(auth.ConfigVersion) == "v2" {
+				authV2, err = client.GetAuthSettingsV2(ctx, id.ResourceGroup, id.SiteName)
+				if err != nil {
+					return fmt.Errorf("reading authV2 settings for Linux %s: %+v", *id, err)
+				}
+			}
+
 			backup, err := client.GetBackupConfiguration(ctx, id.ResourceGroup, id.SiteName)
 			if err != nil {
 				if !utils.ResponseWasNotFound(backup.Response) {
@@ -528,21 +545,22 @@ func (r WindowsWebAppResource) Read() sdk.ResourceFunc {
 			state := WindowsWebAppModel{
 				Name:                        id.SiteName,
 				ResourceGroup:               id.ResourceGroup,
-				ServicePlanId:               utils.NormalizeNilableString(props.ServerFarmID),
+				ServicePlanId:               pointer.From(props.ServerFarmID),
 				Location:                    location.NormalizeNilable(webApp.Location),
 				AuthSettings:                helpers.FlattenAuthSettings(auth),
+				AuthV2Settings:              helpers.FlattenAuthV2Settings(authV2),
 				Backup:                      helpers.FlattenBackupConfig(backup),
-				ClientAffinityEnabled:       utils.NormaliseNilableBool(props.ClientAffinityEnabled),
-				ClientCertEnabled:           utils.NormaliseNilableBool(props.ClientCertEnabled),
+				ClientAffinityEnabled:       pointer.From(props.ClientAffinityEnabled),
+				ClientCertEnabled:           pointer.From(props.ClientCertEnabled),
 				ClientCertMode:              string(props.ClientCertMode),
-				ClientCertExclusionPaths:    utils.NormalizeNilableString(props.ClientCertExclusionPaths),
+				ClientCertExclusionPaths:    pointer.From(props.ClientCertExclusionPaths),
 				ConnectionStrings:           helpers.FlattenConnectionStrings(connectionStrings),
-				CustomDomainVerificationId:  utils.NormalizeNilableString(props.CustomDomainVerificationID),
-				DefaultHostname:             utils.NormalizeNilableString(props.DefaultHostName),
-				Enabled:                     utils.NormaliseNilableBool(props.Enabled),
-				HttpsOnly:                   utils.NormaliseNilableBool(props.HTTPSOnly),
-				KeyVaultReferenceIdentityID: utils.NormalizeNilableString(props.KeyVaultReferenceIdentity),
-				Kind:                        utils.NormalizeNilableString(webApp.Kind),
+				CustomDomainVerificationId:  pointer.From(props.CustomDomainVerificationID),
+				DefaultHostname:             pointer.From(props.DefaultHostName),
+				Enabled:                     pointer.From(props.Enabled),
+				HttpsOnly:                   pointer.From(props.HTTPSOnly),
+				KeyVaultReferenceIdentityID: pointer.From(props.KeyVaultReferenceIdentity),
+				Kind:                        pointer.From(webApp.Kind),
 				LogsConfig:                  helpers.FlattenLogsConfig(logsConfig),
 				SiteCredentials:             helpers.FlattenSiteCredentials(siteCredentials),
 				StorageAccounts:             helpers.FlattenStorageAccounts(storageAccounts),
@@ -550,7 +568,7 @@ func (r WindowsWebAppResource) Read() sdk.ResourceFunc {
 				Tags:                        tags.ToTypedObject(webApp.Tags),
 			}
 
-			if subnetId := utils.NormalizeNilableString(props.VirtualNetworkSubnetID); subnetId != "" {
+			if subnetId := pointer.From(props.VirtualNetworkSubnetID); subnetId != "" {
 				state.VirtualNetworkSubnetID = subnetId
 			}
 
@@ -667,7 +685,7 @@ func (r WindowsWebAppResource) Update() sdk.ResourceFunc {
 			}
 			if metadata.ResourceData.HasChange("service_plan_id") {
 				serviceFarmId = state.ServicePlanId
-				existing.SiteProperties.ServerFarmID = utils.String(serviceFarmId)
+				existing.SiteProperties.ServerFarmID = pointer.To(serviceFarmId)
 				servicePlanChange = true
 			}
 			servicePlanId, err := parse.ServicePlanID(serviceFarmId)
@@ -681,22 +699,22 @@ func (r WindowsWebAppResource) Update() sdk.ResourceFunc {
 			}
 
 			if metadata.ResourceData.HasChange("enabled") {
-				existing.SiteProperties.Enabled = utils.Bool(state.Enabled)
+				existing.SiteProperties.Enabled = pointer.To(state.Enabled)
 			}
 			if metadata.ResourceData.HasChange("https_only") {
-				existing.SiteProperties.HTTPSOnly = utils.Bool(state.HttpsOnly)
+				existing.SiteProperties.HTTPSOnly = pointer.To(state.HttpsOnly)
 			}
 			if metadata.ResourceData.HasChange("client_affinity_enabled") {
-				existing.SiteProperties.ClientAffinityEnabled = utils.Bool(state.ClientAffinityEnabled)
+				existing.SiteProperties.ClientAffinityEnabled = pointer.To(state.ClientAffinityEnabled)
 			}
 			if metadata.ResourceData.HasChange("client_certificate_enabled") {
-				existing.SiteProperties.ClientCertEnabled = utils.Bool(state.ClientCertEnabled)
+				existing.SiteProperties.ClientCertEnabled = pointer.To(state.ClientCertEnabled)
 			}
 			if metadata.ResourceData.HasChange("client_certificate_mode") {
 				existing.SiteProperties.ClientCertMode = web.ClientCertMode(state.ClientCertMode)
 			}
 			if metadata.ResourceData.HasChange("client_certificate_exclusion_paths") {
-				existing.SiteProperties.ClientCertExclusionPaths = utils.String(state.ClientCertExclusionPaths)
+				existing.SiteProperties.ClientCertExclusionPaths = pointer.To(state.ClientCertExclusionPaths)
 			}
 
 			if metadata.ResourceData.HasChange("identity") {
@@ -708,7 +726,7 @@ func (r WindowsWebAppResource) Update() sdk.ResourceFunc {
 			}
 
 			if metadata.ResourceData.HasChange("key_vault_reference_identity_id") {
-				existing.KeyVaultReferenceIdentity = utils.String(state.KeyVaultReferenceIdentityID)
+				existing.KeyVaultReferenceIdentity = pointer.To(state.KeyVaultReferenceIdentityID)
 			}
 
 			if metadata.ResourceData.HasChange("tags") {
@@ -724,7 +742,7 @@ func (r WindowsWebAppResource) Update() sdk.ResourceFunc {
 					var empty *string
 					existing.SiteProperties.VirtualNetworkSubnetID = empty
 				} else {
-					existing.SiteProperties.VirtualNetworkSubnetID = utils.String(subnetId)
+					existing.SiteProperties.VirtualNetworkSubnetID = pointer.To(subnetId)
 				}
 			}
 
@@ -752,7 +770,7 @@ func (r WindowsWebAppResource) Update() sdk.ResourceFunc {
 			}
 
 			siteMetadata := web.StringDictionary{Properties: map[string]*string{}}
-			siteMetadata.Properties["CURRENT_STACK"] = utils.String(currentStack)
+			siteMetadata.Properties["CURRENT_STACK"] = pointer.To(currentStack)
 			if _, err := client.UpdateMetadata(ctx, id.ResourceGroup, id.SiteName, siteMetadata); err != nil {
 				return fmt.Errorf("setting Site Metadata for Current Stack on Windows %s: %+v", id, err)
 			}
@@ -760,7 +778,7 @@ func (r WindowsWebAppResource) Update() sdk.ResourceFunc {
 			// (@jackofallops) - App Settings can clobber logs configuration so must be updated before we send any Log updates
 			if metadata.ResourceData.HasChange("app_settings") || metadata.ResourceData.HasChange("site_config.0.health_check_eviction_time_in_min") {
 				appSettingsUpdate := helpers.ExpandAppSettingsForUpdate(state.AppSettings)
-				appSettingsUpdate.Properties["WEBSITE_HEALTHCHECK_MAXPINGFAILURES"] = utils.String(strconv.Itoa(state.SiteConfig[0].HealthCheckEvictionTime))
+				appSettingsUpdate.Properties["WEBSITE_HEALTHCHECK_MAXPINGFAILURES"] = pointer.To(strconv.Itoa(state.SiteConfig[0].HealthCheckEvictionTime))
 				if _, err := client.UpdateApplicationSettings(ctx, id.ResourceGroup, id.SiteName, *appSettingsUpdate); err != nil {
 					return fmt.Errorf("updating App Settings for Windows %s: %+v", id, err)
 				}
@@ -800,11 +818,35 @@ func (r WindowsWebAppResource) Update() sdk.ResourceFunc {
 				}
 			}
 
+			updateLogs := false
+
 			if metadata.ResourceData.HasChange("auth_settings") {
 				authUpdate := helpers.ExpandAuthSettings(state.AuthSettings)
-				if _, err := client.UpdateAuthSettings(ctx, id.ResourceGroup, id.SiteName, *authUpdate); err != nil {
-					return fmt.Errorf("updating Auth Settings for Windows %s: %+v", id, err)
+				if authUpdate.SiteAuthSettingsProperties == nil && metadata.ResourceData.HasChange("auth_v2_settings") {
+					authUpdate.SiteAuthSettingsProperties = &web.SiteAuthSettingsProperties{
+						Enabled:                           pointer.To(false),
+						ClientSecret:                      pointer.To(""),
+						ClientSecretSettingName:           pointer.To(""),
+						ClientSecretCertificateThumbprint: pointer.To(""),
+						GoogleClientSecret:                pointer.To(""),
+						FacebookAppSecret:                 pointer.To(""),
+						GitHubClientSecret:                pointer.To(""),
+						TwitterConsumerSecret:             pointer.To(""),
+						MicrosoftAccountClientSecret:      pointer.To(""),
+					}
+					updateLogs = true
 				}
+				if _, err := client.UpdateAuthSettings(ctx, id.ResourceGroup, id.SiteName, *authUpdate); err != nil {
+					return fmt.Errorf("updating Auth Settings for Linux %s: %+v", id, err)
+				}
+			}
+
+			if metadata.ResourceData.HasChange("auth_v2_settings") {
+				authV2Update := helpers.ExpandAuthV2Settings(state.AuthV2Settings)
+				if _, err := client.UpdateAuthSettingsV2(ctx, id.ResourceGroup, id.SiteName, *authV2Update); err != nil {
+					return fmt.Errorf("updating AuthV2 Settings for Linux %s: %+v", id, err)
+				}
+				updateLogs = true
 			}
 
 			if metadata.ResourceData.HasChange("backup") {
@@ -824,7 +866,7 @@ func (r WindowsWebAppResource) Update() sdk.ResourceFunc {
 				}
 			}
 
-			if metadata.ResourceData.HasChange("logs") {
+			if metadata.ResourceData.HasChange("logs") || updateLogs {
 				logsUpdate := helpers.ExpandLogsConfig(state.LogsConfig)
 				if logsUpdate.SiteLogsConfigProperties == nil {
 					logsUpdate = helpers.DisabledLogsConfig() // The API is update only, so we need to send an update with everything switched of when a user removes the "logs" block

--- a/internal/services/appservice/windows_web_app_resource.go
+++ b/internal/services/appservice/windows_web_app_resource.go
@@ -824,7 +824,7 @@ func (r WindowsWebAppResource) Update() sdk.ResourceFunc {
 
 			if metadata.ResourceData.HasChange("auth_settings") {
 				authUpdate := helpers.ExpandAuthSettings(state.AuthSettings)
-				if authUpdate.SiteAuthSettingsProperties == nil && metadata.ResourceData.HasChange("auth_v2_settings") {
+				if authUpdate.SiteAuthSettingsProperties == nil {
 					authUpdate.SiteAuthSettingsProperties = &web.SiteAuthSettingsProperties{
 						Enabled:                           pointer.To(false),
 						ClientSecret:                      pointer.To(""),

--- a/internal/services/appservice/windows_web_app_resource_authv2_test.go
+++ b/internal/services/appservice/windows_web_app_resource_authv2_test.go
@@ -47,7 +47,7 @@ func TestAccWindowsWebApp_authV2CustomOIDC(t *testing.T) {
 			Config: r.authV2CustomOIDC(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("auth_v2_settings.0.custom_oidc.0.client_secret_setting_name").HasValue("TESTCUSTOM_PROVIDER_AUTHENTICATION_SECRET"),
+				check.That(data.ResourceName).Key("auth_settings_v2.0.custom_oidc.0.client_secret_setting_name").HasValue("TESTCUSTOM_PROVIDER_AUTHENTICATION_SECRET"),
 			),
 		},
 		data.ImportStep(),
@@ -215,7 +215,7 @@ resource "azurerm_windows_web_app" "test" {
     app_setting_names = ["%[3]s"]
   }
 
-  auth_v2_settings {
+  auth_settings_v2 {
     auth_enabled           = true
     unauthenticated_action = "Return401"
     active_directory {
@@ -256,7 +256,7 @@ resource "azurerm_windows_web_app" "test" {
     app_setting_names = ["%[3]s"]
   }
 
-  auth_v2_settings {
+  auth_settings_v2 {
     auth_enabled           = true
     unauthenticated_action = "Return401"
 
@@ -298,7 +298,7 @@ resource "azurerm_windows_web_app" "test" {
     app_setting_names = ["%[3]s"]
   }
 
-  auth_v2_settings {
+  auth_settings_v2 {
     auth_enabled           = true
     unauthenticated_action = "Return401"
 
@@ -341,7 +341,7 @@ resource "azurerm_windows_web_app" "test" {
     app_setting_names = ["%[3]s"]
   }
 
-  auth_v2_settings {
+  auth_settings_v2 {
     auth_enabled           = true
     unauthenticated_action = "RedirectToLoginPage"
 
@@ -383,7 +383,7 @@ resource "azurerm_windows_web_app" "test" {
     app_setting_names = ["%[3]s"]
   }
 
-  auth_v2_settings {
+  auth_settings_v2 {
     auth_enabled           = true
     unauthenticated_action = "RedirectToLoginPage"
 
@@ -425,7 +425,7 @@ resource "azurerm_windows_web_app" "test" {
     app_setting_names = ["%[3]s"]
   }
 
-  auth_v2_settings {
+  auth_settings_v2 {
     auth_enabled           = true
     unauthenticated_action = "RedirectToLoginPage"
 
@@ -467,7 +467,7 @@ resource "azurerm_windows_web_app" "test" {
     app_setting_names = ["%[3]s"]
   }
 
-  auth_v2_settings {
+  auth_settings_v2 {
     auth_enabled           = true
     unauthenticated_action = "RedirectToLoginPage"
 
@@ -509,7 +509,7 @@ resource "azurerm_windows_web_app" "test" {
     app_setting_names = ["%[3]s"]
   }
 
-  auth_v2_settings {
+  auth_settings_v2 {
     auth_enabled           = true
     unauthenticated_action = "RedirectToLoginPage"
 
@@ -562,7 +562,7 @@ resource "azurerm_windows_web_app" "test" {
     ]
   }
 
-  auth_v2_settings {
+  auth_settings_v2 {
     auth_enabled           = true
     unauthenticated_action = "RedirectToLoginPage"
 
@@ -629,7 +629,7 @@ resource "azurerm_windows_web_app" "test" {
     "TWITTER_PROVIDER_AUTHENTICATION_SECRET"   = "%[3]s"
   }
 
-  auth_v2_settings {
+  auth_settings_v2 {
     auth_enabled           = true
     unauthenticated_action = "RedirectToLoginPage"
 
@@ -808,5 +808,5 @@ resource "azurerm_windows_web_app" "test" {
     foo         = "bar"
   }
 }
-`, r.baseTemplate(data), data.RandomInteger, secretSettingName, secretSettingValue)
+`, r.templateWithStorageAccount(data), data.RandomInteger, secretSettingName, secretSettingValue)
 }

--- a/internal/services/appservice/windows_web_app_resource_authv2_test.go
+++ b/internal/services/appservice/windows_web_app_resource_authv2_test.go
@@ -47,7 +47,7 @@ func TestAccWindowsWebApp_authV2CustomOIDC(t *testing.T) {
 			Config: r.authV2CustomOIDC(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("auth_settings_v2.0.custom_oidc.0.client_secret_setting_name").HasValue("TESTCUSTOM_PROVIDER_AUTHENTICATION_SECRET"),
+				check.That(data.ResourceName).Key("auth_settings_v2.0.custom_oidc_v2.0.client_secret_setting_name").HasValue("TESTCUSTOM_PROVIDER_AUTHENTICATION_SECRET"),
 			),
 		},
 		data.ImportStep(),

--- a/internal/services/appservice/windows_web_app_resource_authv2_test.go
+++ b/internal/services/appservice/windows_web_app_resource_authv2_test.go
@@ -8,48 +8,45 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 )
 
-func TestAccLinuxWebApp_authV2AzureActiveDirectory(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_linux_web_app", "test")
-	r := LinuxWebAppResource{}
+func TestAccWindowsWebApp_authV2AzureActiveDirectory(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_web_app", "test")
+	r := WindowsWebAppResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.authV2AzureActiveDirectory(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("kind").HasValue("app,linux"),
 			),
 		},
 		data.ImportStep(),
 	})
 }
 
-func TestAccLinuxWebApp_authV2Apple(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_linux_web_app", "test")
-	r := LinuxWebAppResource{}
+func TestAccWindowsWebApp_authV2Apple(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_web_app", "test")
+	r := WindowsWebAppResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.authV2Apple(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("kind").HasValue("app,linux"),
 			),
 		},
 		data.ImportStep(),
 	})
 }
 
-func TestAccLinuxWebApp_authV2CustomOIDC(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_linux_web_app", "test")
-	r := LinuxWebAppResource{}
+func TestAccWindowsWebApp_authV2CustomOIDC(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_web_app", "test")
+	r := WindowsWebAppResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.authV2CustomOIDC(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("kind").HasValue("app,linux"),
 				check.That(data.ResourceName).Key("auth_v2_settings.0.custom_oidc.0.client_secret_setting_name").HasValue("TESTCUSTOM_PROVIDER_AUTHENTICATION_SECRET"),
 			),
 		},
@@ -57,112 +54,105 @@ func TestAccLinuxWebApp_authV2CustomOIDC(t *testing.T) {
 	})
 }
 
-func TestAccLinuxWebApp_authV2Facebook(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_linux_web_app", "test")
-	r := LinuxWebAppResource{}
+func TestAccWindowsWebApp_authV2Facebook(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_web_app", "test")
+	r := WindowsWebAppResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.authV2Facebook(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("kind").HasValue("app,linux"),
 			),
 		},
 		data.ImportStep(),
 	})
 }
 
-func TestAccLinuxWebApp_authV2Github(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_linux_web_app", "test")
-	r := LinuxWebAppResource{}
+func TestAccWindowsWebApp_authV2Github(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_web_app", "test")
+	r := WindowsWebAppResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.authV2Github(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("kind").HasValue("app,linux"),
 			),
 		},
 		data.ImportStep(),
 	})
 }
 
-func TestAccLinuxWebApp_authV2Google(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_linux_web_app", "test")
-	r := LinuxWebAppResource{}
+func TestAccWindowsWebApp_authV2Google(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_web_app", "test")
+	r := WindowsWebAppResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.authV2Google(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("kind").HasValue("app,linux"),
 			),
 		},
 		data.ImportStep(),
 	})
 }
 
-func TestAccLinuxWebApp_authV2Microsoft(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_linux_web_app", "test")
-	r := LinuxWebAppResource{}
+func TestAccWindowsWebApp_authV2Microsoft(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_web_app", "test")
+	r := WindowsWebAppResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.authV2Microsoft(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("kind").HasValue("app,linux"),
 			),
 		},
 		data.ImportStep(),
 	})
 }
 
-func TestAccLinuxWebApp_authV2Twitter(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_linux_web_app", "test")
-	r := LinuxWebAppResource{}
+func TestAccWindowsWebApp_authV2Twitter(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_web_app", "test")
+	r := WindowsWebAppResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.authV2Twitter(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("kind").HasValue("app,linux"),
 			),
 		},
 		data.ImportStep(),
 	})
 }
 
-func TestAccLinuxWebApp_authV2MultipleAuths(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_linux_web_app", "test")
-	r := LinuxWebAppResource{}
+func TestAccWindowsWebApp_authV2MultipleAuths(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_web_app", "test")
+	r := WindowsWebAppResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.authV2Multi(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("kind").HasValue("app,linux"),
 			),
 		},
 		data.ImportStep(),
 	})
 }
 
-func TestAccLinuxWebApp_authV2Update(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_linux_web_app", "test")
-	r := LinuxWebAppResource{}
+func TestAccWindowsWebApp_authV2Update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_web_app", "test")
+	r := WindowsWebAppResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.authV2Apple(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("kind").HasValue("app,linux"),
 			),
 		},
 		data.ImportStep(),
@@ -170,23 +160,21 @@ func TestAccLinuxWebApp_authV2Update(t *testing.T) {
 			Config: r.authV2Facebook(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("kind").HasValue("app,linux"),
 			),
 		},
 		data.ImportStep(),
 	})
 }
 
-func TestAccLinuxWebApp_authV2UpgradeFromV1(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_linux_web_app", "test")
-	r := LinuxWebAppResource{}
+func TestAccWindowsWebApp_authV2UpgradeFromV1(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_web_app", "test")
+	r := WindowsWebAppResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.complete(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("kind").HasValue("app,linux"),
 			),
 		},
 		data.ImportStep(),
@@ -194,16 +182,16 @@ func TestAccLinuxWebApp_authV2UpgradeFromV1(t *testing.T) {
 			Config: r.completeAuthV2(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("kind").HasValue("app,linux"),
 			),
 		},
 		data.ImportStep(),
 	})
 }
 
-func (r LinuxWebAppResource) authV2AzureActiveDirectory(data acceptance.TestData) string {
+func (r WindowsWebAppResource) authV2AzureActiveDirectory(data acceptance.TestData) string {
 	secretSettingName := "MICROSOFT_PROVIDER_AUTHENTICATION_SECRET"
 	secretSettingValue := "902D17F6-FD6B-4E44-BABB-58E788DCD907"
+
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -211,10 +199,8 @@ provider "azurerm" {
 
 %s
 
-data "azurerm_client_config" "current" {}
-
-resource "azurerm_linux_web_app" "test" {
-  name                = "acctestLWA-%d"
+resource "azurerm_windows_web_app" "test" {
+  name                = "acctestWA-%[2]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   service_plan_id     = azurerm_service_plan.test.id
@@ -243,9 +229,10 @@ resource "azurerm_linux_web_app" "test" {
 `, r.baseTemplate(data), data.RandomInteger, secretSettingName, secretSettingValue, data.Client().TenantID)
 }
 
-func (r LinuxWebAppResource) authV2Apple(data acceptance.TestData) string {
+func (r WindowsWebAppResource) authV2Apple(data acceptance.TestData) string {
 	secretSettingName := "APPLE_PROVIDER_AUTHENTICATION_SECRET"
 	secretSettingValue := "902D17F6-FD6B-4E44-BABB-58E788DCD907"
+
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -253,10 +240,8 @@ provider "azurerm" {
 
 %s
 
-data "azurerm_client_config" "current" {}
-
-resource "azurerm_linux_web_app" "test" {
-  name                = "acctestLWA-%d"
+resource "azurerm_windows_web_app" "test" {
+  name                = "acctestWA-%[2]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   service_plan_id     = azurerm_service_plan.test.id
@@ -265,6 +250,10 @@ resource "azurerm_linux_web_app" "test" {
 
   app_settings = {
     "%[3]s" = "%[4]s"
+  }
+
+  sticky_settings {
+    app_setting_names = ["%[3]s"]
   }
 
   auth_v2_settings {
@@ -282,11 +271,10 @@ resource "azurerm_linux_web_app" "test" {
 `, r.baseTemplate(data), data.RandomInteger, secretSettingName, secretSettingValue)
 }
 
-// static web app? - Need to add test when Static Web Apps are deployable from TF.
-
-func (r LinuxWebAppResource) authV2CustomOIDC(data acceptance.TestData) string {
+func (r WindowsWebAppResource) authV2CustomOIDC(data acceptance.TestData) string {
 	secretSettingName := "TESTCUSTOM_PROVIDER_AUTHENTICATION_SECRET"
 	secretSettingValue := "902D17F6-FD6B-4E44-BABB-58E788DCD907"
+
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -294,10 +282,8 @@ provider "azurerm" {
 
 %s
 
-data "azurerm_client_config" "current" {}
-
-resource "azurerm_linux_web_app" "test" {
-  name                = "acctestLWA-%d"
+resource "azurerm_windows_web_app" "test" {
+  name                = "acctestWA-%[2]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   service_plan_id     = azurerm_service_plan.test.id
@@ -328,9 +314,10 @@ resource "azurerm_linux_web_app" "test" {
 `, r.baseTemplate(data), data.RandomInteger, secretSettingName, secretSettingValue)
 }
 
-func (r LinuxWebAppResource) authV2Facebook(data acceptance.TestData) string {
+func (r WindowsWebAppResource) authV2Facebook(data acceptance.TestData) string {
 	secretSettingName := "FACEBOOK_PROVIDER_AUTHENTICATION_SECRET"
 	secretSettingValue := "902D17F6-FD6B-4E44-BABB-58E788DCD907"
+
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -338,10 +325,8 @@ provider "azurerm" {
 
 %s
 
-data "azurerm_client_config" "current" {}
-
-resource "azurerm_linux_web_app" "test" {
-  name                = "acctestLWA-%d"
+resource "azurerm_windows_web_app" "test" {
+  name                = "acctestWA-%[2]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   service_plan_id     = azurerm_service_plan.test.id
@@ -371,9 +356,10 @@ resource "azurerm_linux_web_app" "test" {
 `, r.baseTemplate(data), data.RandomInteger, secretSettingName, secretSettingValue)
 }
 
-func (r LinuxWebAppResource) authV2Github(data acceptance.TestData) string {
+func (r WindowsWebAppResource) authV2Github(data acceptance.TestData) string {
 	secretSettingName := "GITHUB_PROVIDER_AUTHENTICATION_SECRET"
 	secretSettingValue := "902D17F6-FD6B-4E44-BABB-58E788DCD907"
+
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -381,10 +367,8 @@ provider "azurerm" {
 
 %s
 
-data "azurerm_client_config" "current" {}
-
-resource "azurerm_linux_web_app" "test" {
-  name                = "acctestLWA-%d"
+resource "azurerm_windows_web_app" "test" {
+  name                = "acctestWA-%[2]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   service_plan_id     = azurerm_service_plan.test.id
@@ -414,9 +398,10 @@ resource "azurerm_linux_web_app" "test" {
 `, r.baseTemplate(data), data.RandomInteger, secretSettingName, secretSettingValue)
 }
 
-func (r LinuxWebAppResource) authV2Google(data acceptance.TestData) string {
+func (r WindowsWebAppResource) authV2Google(data acceptance.TestData) string {
 	secretSettingName := "GOOGLE_PROVIDER_AUTHENTICATION_SECRET"
 	secretSettingValue := "902D17F6-FD6B-4E44-BABB-58E788DCD907"
+
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -424,10 +409,8 @@ provider "azurerm" {
 
 %s
 
-data "azurerm_client_config" "current" {}
-
-resource "azurerm_linux_web_app" "test" {
-  name                = "acctestLWA-%d"
+resource "azurerm_windows_web_app" "test" {
+  name                = "acctestWA-%[2]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   service_plan_id     = azurerm_service_plan.test.id
@@ -457,9 +440,10 @@ resource "azurerm_linux_web_app" "test" {
 `, r.baseTemplate(data), data.RandomInteger, secretSettingName, secretSettingValue)
 }
 
-func (r LinuxWebAppResource) authV2Microsoft(data acceptance.TestData) string {
+func (r WindowsWebAppResource) authV2Microsoft(data acceptance.TestData) string {
 	secretSettingName := "MICROSOFT_PROVIDER_AUTHENTICATION_SECRET"
 	secretSettingValue := "902D17F6-FD6B-4E44-BABB-58E788DCD907"
+
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -467,10 +451,8 @@ provider "azurerm" {
 
 %s
 
-data "azurerm_client_config" "current" {}
-
-resource "azurerm_linux_web_app" "test" {
-  name                = "acctestLWA-%d"
+resource "azurerm_windows_web_app" "test" {
+  name                = "acctestWA-%[2]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   service_plan_id     = azurerm_service_plan.test.id
@@ -500,9 +482,10 @@ resource "azurerm_linux_web_app" "test" {
 `, r.baseTemplate(data), data.RandomInteger, secretSettingName, secretSettingValue)
 }
 
-func (r LinuxWebAppResource) authV2Twitter(data acceptance.TestData) string {
+func (r WindowsWebAppResource) authV2Twitter(data acceptance.TestData) string {
 	secretSettingName := "TWITTER_PROVIDER_AUTHENTICATION_SECRET"
 	secretSettingValue := "902D17F6-FD6B-4E44-BABB-58E788DCD907"
+
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -510,10 +493,8 @@ provider "azurerm" {
 
 %s
 
-data "azurerm_client_config" "current" {}
-
-resource "azurerm_linux_web_app" "test" {
-  name                = "acctestLWA-%d"
+resource "azurerm_windows_web_app" "test" {
+  name                = "acctestWA-%[2]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   service_plan_id     = azurerm_service_plan.test.id
@@ -543,8 +524,9 @@ resource "azurerm_linux_web_app" "test" {
 `, r.baseTemplate(data), data.RandomInteger, secretSettingName, secretSettingValue)
 }
 
-func (r LinuxWebAppResource) authV2Multi(data acceptance.TestData) string {
+func (r WindowsWebAppResource) authV2Multi(data acceptance.TestData) string {
 	secretSettingValue := "902D17F6-FD6B-4E44-BABB-58E788DCD907"
+
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -552,10 +534,8 @@ provider "azurerm" {
 
 %s
 
-data "azurerm_client_config" "current" {}
-
-resource "azurerm_linux_web_app" "test" {
-  name                = "acctestLWA-%d"
+resource "azurerm_windows_web_app" "test" {
+  name                = "acctestWA-%[2]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   service_plan_id     = azurerm_service_plan.test.id
@@ -622,8 +602,10 @@ resource "azurerm_linux_web_app" "test" {
 `, r.baseTemplate(data), data.RandomInteger, secretSettingValue)
 }
 
-func (r LinuxWebAppResource) completeAuthV2(data acceptance.TestData) string {
+func (r WindowsWebAppResource) completeAuthV2(data acceptance.TestData) string {
+	secretSettingName := "APPLE_PROVIDER_AUTHENTICATION_SECRET"
 	secretSettingValue := "902D17F6-FD6B-4E44-BABB-58E788DCD907"
+
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -631,7 +613,7 @@ provider "azurerm" {
 
 %s
 
-resource "azurerm_linux_web_app" "test" {
+resource "azurerm_windows_web_app" "test" {
   name                = "acctestWA-%[2]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
@@ -713,7 +695,6 @@ resource "azurerm_linux_web_app" "test" {
 
   client_affinity_enabled            = true
   client_certificate_enabled         = true
-  client_certificate_mode            = "Optional"
   client_certificate_exclusion_paths = "/foo;/bar;/hello;/world"
 
   connection_string {
@@ -772,6 +753,17 @@ resource "azurerm_linux_web_app" "test" {
 
     auto_heal_enabled = true
 
+    virtual_application {
+      virtual_path  = "/"
+      physical_path = "site\\wwwroot"
+      preload       = true
+
+      virtual_directory {
+        virtual_path  = "/stuff"
+        physical_path = "site\\stuff"
+      }
+    }
+
     auto_heal_setting {
       trigger {
         status_code {
@@ -808,7 +800,7 @@ resource "azurerm_linux_web_app" "test" {
     account_name = azurerm_storage_account.test.name
     share_name   = azurerm_storage_share.test.name
     access_key   = azurerm_storage_account.test.primary_access_key
-    mount_path   = "/storage/files"
+    mount_path   = "/mounts/files"
   }
 
   tags = {
@@ -816,5 +808,5 @@ resource "azurerm_linux_web_app" "test" {
     foo         = "bar"
   }
 }
-`, r.templateWithStorageAccount(data), data.RandomInteger, secretSettingValue)
+`, r.baseTemplate(data), data.RandomInteger, secretSettingName, secretSettingValue)
 }

--- a/internal/services/appservice/windows_web_app_resource_authv2_test.go
+++ b/internal/services/appservice/windows_web_app_resource_authv2_test.go
@@ -218,7 +218,7 @@ resource "azurerm_windows_web_app" "test" {
   auth_settings_v2 {
     auth_enabled           = true
     unauthenticated_action = "Return401"
-    active_directory {
+    active_directory_v2 {
       client_id                  = data.azurerm_client_config.current.client_id
       client_secret_setting_name = "%[3]s"
       tenant_auth_endpoint       = "https://sts.windows.net/%[5]s/v2.0"
@@ -260,7 +260,7 @@ resource "azurerm_windows_web_app" "test" {
     auth_enabled           = true
     unauthenticated_action = "Return401"
 
-    apple {
+    apple_v2 {
       client_id                  = "testAppleID"
       client_secret_setting_name = "%[3]s"
     }
@@ -302,7 +302,7 @@ resource "azurerm_windows_web_app" "test" {
     auth_enabled           = true
     unauthenticated_action = "Return401"
 
-    custom_oidc {
+    custom_oidc_v2 {
       name                          = "testcustom"
       client_id                     = "testCustomID"
       openid_configuration_endpoint = "https://oidc.testcustom.contoso.com/auth"
@@ -345,7 +345,7 @@ resource "azurerm_windows_web_app" "test" {
     auth_enabled           = true
     unauthenticated_action = "RedirectToLoginPage"
 
-    facebook {
+    facebook_v2 {
       app_id                  = "testFacebookID"
       app_secret_setting_name = "%[3]s"
     }
@@ -387,7 +387,7 @@ resource "azurerm_windows_web_app" "test" {
     auth_enabled           = true
     unauthenticated_action = "RedirectToLoginPage"
 
-    github {
+    github_v2 {
       client_id                  = "testGithubID"
       client_secret_setting_name = "%[3]s"
     }
@@ -429,7 +429,7 @@ resource "azurerm_windows_web_app" "test" {
     auth_enabled           = true
     unauthenticated_action = "RedirectToLoginPage"
 
-    google {
+    google_v2 {
       client_id                  = "testGoogleID"
       client_secret_setting_name = "%[3]s"
     }
@@ -471,7 +471,7 @@ resource "azurerm_windows_web_app" "test" {
     auth_enabled           = true
     unauthenticated_action = "RedirectToLoginPage"
 
-    microsoft {
+    microsoft_v2 {
       client_id                  = "testMSFTID"
       client_secret_setting_name = "%[3]s"
     }
@@ -513,7 +513,7 @@ resource "azurerm_windows_web_app" "test" {
     auth_enabled           = true
     unauthenticated_action = "RedirectToLoginPage"
 
-    twitter {
+    twitter_v2 {
       consumer_key                 = "testTwitterKey"
       consumer_secret_setting_name = "%[3]s"
     }
@@ -566,32 +566,32 @@ resource "azurerm_windows_web_app" "test" {
     auth_enabled           = true
     unauthenticated_action = "RedirectToLoginPage"
 
-    apple {
+    apple_v2 {
       client_id                  = "testAppleID"
       client_secret_setting_name = "APPLE_PROVIDER_AUTHENTICATION_SECRET"
     }
 
-    facebook {
+    facebook_v2 {
       app_id                  = "testFacebookID"
       app_secret_setting_name = "FACEBOOK_PROVIDER_AUTHENTICATION_SECRET"
     }
 
-    github {
+    github_v2 {
       client_id                  = "testGithubID"
       client_secret_setting_name = "GITHUB_PROVIDER_AUTHENTICATION_SECRET"
     }
 
-    google {
+    google_v2 {
       client_id                  = "testGoogleID"
       client_secret_setting_name = "GOOGLE_PROVIDER_AUTHENTICATION_SECRET"
     }
 
-    microsoft {
+    microsoft_v2 {
       client_id                  = "testMSFTID"
       client_secret_setting_name = "MICROSOFT_PROVIDER_AUTHENTICATION_SECRET"
     }
 
-    twitter {
+    twitter_v2 {
       consumer_key                 = "testTwitterKey"
       consumer_secret_setting_name = "TWITTER_PROVIDER_AUTHENTICATION_SECRET"
     }
@@ -633,32 +633,32 @@ resource "azurerm_windows_web_app" "test" {
     auth_enabled           = true
     unauthenticated_action = "RedirectToLoginPage"
 
-    apple {
+    apple_v2 {
       client_id                  = "testAppleID"
       client_secret_setting_name = "APPLE_PROVIDER_AUTHENTICATION_SECRET"
     }
 
-    facebook {
+    facebook_v2 {
       app_id                  = "testFacebookID"
       app_secret_setting_name = "FACEBOOK_PROVIDER_AUTHENTICATION_SECRET"
     }
 
-    github {
+    github_v2 {
       client_id                  = "testGithubID"
       client_secret_setting_name = "GITHUB_PROVIDER_AUTHENTICATION_SECRET"
     }
 
-    google {
+    google_v2 {
       client_id                  = "testGoogleID"
       client_secret_setting_name = "GOOGLE_PROVIDER_AUTHENTICATION_SECRET"
     }
 
-    microsoft {
+    microsoft_v2 {
       client_id                  = "testMSFTID"
       client_secret_setting_name = "MICROSOFT_PROVIDER_AUTHENTICATION_SECRET"
     }
 
-    twitter {
+    twitter_v2 {
       consumer_key                 = "testTwitterKey"
       consumer_secret_setting_name = "TWITTER_PROVIDER_AUTHENTICATION_SECRET"
     }

--- a/internal/services/appservice/windows_web_app_resource_authv2_test.go
+++ b/internal/services/appservice/windows_web_app_resource_authv2_test.go
@@ -199,6 +199,8 @@ provider "azurerm" {
 
 %s
 
+data "azurerm_client_config" "current" {}
+
 resource "azurerm_windows_web_app" "test" {
   name                = "acctestWA-%[2]d"
   location            = azurerm_resource_group.test.location

--- a/internal/services/appservice/windows_web_app_slot_resource.go
+++ b/internal/services/appservice/windows_web_app_slot_resource.go
@@ -105,6 +105,8 @@ func (r WindowsWebAppSlotResource) Arguments() map[string]*pluginsdk.Schema {
 
 		"auth_settings": helpers.AuthSettingsSchema(),
 
+		"auth_v2_settings": helpers.AuthV2SettingsSchema(),
+
 		"backup": helpers.BackupSchema(),
 
 		"client_affinity_enabled": {

--- a/internal/services/appservice/windows_web_app_slot_resource.go
+++ b/internal/services/appservice/windows_web_app_slot_resource.go
@@ -784,7 +784,7 @@ func (r WindowsWebAppSlotResource) Update() sdk.ResourceFunc {
 					updateLogs = true
 				}
 				if _, err := client.UpdateAuthSettingsSlot(ctx, id.ResourceGroup, id.SiteName, *authUpdate, id.SlotName); err != nil {
-					return fmt.Errorf("updating Auth Settings for Linux %s: %+v", id, err)
+					return fmt.Errorf("updating Auth Settings for Windows %s: %+v", id, err)
 				}
 			}
 

--- a/internal/services/appservice/windows_web_app_slot_resource.go
+++ b/internal/services/appservice/windows_web_app_slot_resource.go
@@ -769,7 +769,7 @@ func (r WindowsWebAppSlotResource) Update() sdk.ResourceFunc {
 
 			if metadata.ResourceData.HasChange("auth_settings") {
 				authUpdate := helpers.ExpandAuthSettings(state.AuthSettings)
-				if authUpdate.SiteAuthSettingsProperties == nil && metadata.ResourceData.HasChange("auth_v2_settings") {
+				if authUpdate.SiteAuthSettingsProperties == nil {
 					authUpdate.SiteAuthSettingsProperties = &web.SiteAuthSettingsProperties{
 						Enabled:                           pointer.To(false),
 						ClientSecret:                      pointer.To(""),

--- a/internal/services/appservice/windows_web_app_slot_resource.go
+++ b/internal/services/appservice/windows_web_app_slot_resource.go
@@ -31,6 +31,7 @@ type WindowsWebAppSlotModel struct {
 	ServicePlanID                 string                                `tfschema:"service_plan_id"`
 	AppSettings                   map[string]string                     `tfschema:"app_settings"`
 	AuthSettings                  []helpers.AuthSettings                `tfschema:"auth_settings"`
+	AuthV2Settings                []helpers.AuthV2Settings              `tfschema:"auth_v2_settings"`
 	Backup                        []helpers.Backup                      `tfschema:"backup"`
 	ClientAffinityEnabled         bool                                  `tfschema:"client_affinity_enabled"`
 	ClientCertEnabled             bool                                  `tfschema:"client_certificate_enabled"`
@@ -359,6 +360,13 @@ func (r WindowsWebAppSlotResource) Create() sdk.ResourceFunc {
 				}
 			}
 
+			authv2 := helpers.ExpandAuthV2Settings(webAppSlot.AuthV2Settings)
+			if authv2.SiteAuthSettingsV2Properties != nil {
+				if _, err = client.UpdateAuthSettingsV2Slot(ctx, id.ResourceGroup, id.SiteName, *authv2, id.SlotName); err != nil {
+					return fmt.Errorf("updating AuthV2 settings for Linux %s: %+v", id, err)
+				}
+			}
+
 			if metadata.ResourceData.HasChange("logs") {
 				logsConfig := helpers.ExpandLogsConfig(webAppSlot.LogsConfig)
 				if logsConfig.SiteLogsConfigProperties != nil {
@@ -442,6 +450,14 @@ func (r WindowsWebAppSlotResource) Read() sdk.ResourceFunc {
 				return fmt.Errorf("reading Auth Settings for Windows %s: %+v", id, err)
 			}
 
+			var authV2 web.SiteAuthSettingsV2
+			if pointer.From(auth.ConfigVersion) == "v2" {
+				authV2, err = client.GetAuthSettingsV2Slot(ctx, id.ResourceGroup, id.SiteName, id.SlotName)
+				if err != nil {
+					return fmt.Errorf("reading authV2 settings for Linux %s: %+v", *id, err)
+				}
+			}
+
 			backup, err := client.GetBackupConfigurationSlot(ctx, id.ResourceGroup, id.SiteName, id.SlotName)
 			if err != nil {
 				if !utils.ResponseWasNotFound(backup.Response) {
@@ -491,6 +507,7 @@ func (r WindowsWebAppSlotResource) Read() sdk.ResourceFunc {
 				Name:                        id.SlotName,
 				AppServiceId:                parse.NewWebAppID(id.SubscriptionId, id.ResourceGroup, id.SiteName).ID(),
 				AuthSettings:                helpers.FlattenAuthSettings(auth),
+				AuthV2Settings:              helpers.FlattenAuthV2Settings(authV2),
 				Backup:                      helpers.FlattenBackupConfig(backup),
 				ClientAffinityEnabled:       pointer.From(props.ClientAffinityEnabled),
 				ClientCertEnabled:           pointer.From(props.ClientCertEnabled),
@@ -746,11 +763,35 @@ func (r WindowsWebAppSlotResource) Update() sdk.ResourceFunc {
 				}
 			}
 
+			updateLogs := false
+
 			if metadata.ResourceData.HasChange("auth_settings") {
 				authUpdate := helpers.ExpandAuthSettings(state.AuthSettings)
-				if _, err := client.UpdateAuthSettingsSlot(ctx, id.ResourceGroup, id.SiteName, *authUpdate, id.SlotName); err != nil {
-					return fmt.Errorf("updating Auth Settings for Windows %s: %+v", id, err)
+				if authUpdate.SiteAuthSettingsProperties == nil && metadata.ResourceData.HasChange("auth_v2_settings") {
+					authUpdate.SiteAuthSettingsProperties = &web.SiteAuthSettingsProperties{
+						Enabled:                           pointer.To(false),
+						ClientSecret:                      pointer.To(""),
+						ClientSecretSettingName:           pointer.To(""),
+						ClientSecretCertificateThumbprint: pointer.To(""),
+						GoogleClientSecret:                pointer.To(""),
+						FacebookAppSecret:                 pointer.To(""),
+						GitHubClientSecret:                pointer.To(""),
+						TwitterConsumerSecret:             pointer.To(""),
+						MicrosoftAccountClientSecret:      pointer.To(""),
+					}
+					updateLogs = true
 				}
+				if _, err := client.UpdateAuthSettingsSlot(ctx, id.ResourceGroup, id.SiteName, *authUpdate, id.SlotName); err != nil {
+					return fmt.Errorf("updating Auth Settings for Linux %s: %+v", id, err)
+				}
+			}
+
+			if metadata.ResourceData.HasChange("auth_v2_settings") {
+				authV2Update := helpers.ExpandAuthV2Settings(state.AuthV2Settings)
+				if _, err := client.UpdateAuthSettingsV2Slot(ctx, id.ResourceGroup, id.SiteName, *authV2Update, id.SlotName); err != nil {
+					return fmt.Errorf("updating AuthV2 Settings for Linux %s: %+v", id, err)
+				}
+				updateLogs = true
 			}
 
 			if metadata.ResourceData.HasChange("backup") {
@@ -770,7 +811,7 @@ func (r WindowsWebAppSlotResource) Update() sdk.ResourceFunc {
 				}
 			}
 
-			if metadata.ResourceData.HasChange("logs") {
+			if metadata.ResourceData.HasChange("logs") || updateLogs {
 				logsUpdate := helpers.ExpandLogsConfig(state.LogsConfig)
 				if logsUpdate.SiteLogsConfigProperties == nil {
 					logsUpdate = helpers.DisabledLogsConfig() // The API is update only, so we need to send an update with everything switched of when a user removes the "logs" block

--- a/internal/services/appservice/windows_web_app_slot_resource.go
+++ b/internal/services/appservice/windows_web_app_slot_resource.go
@@ -31,7 +31,7 @@ type WindowsWebAppSlotModel struct {
 	ServicePlanID                 string                                `tfschema:"service_plan_id"`
 	AppSettings                   map[string]string                     `tfschema:"app_settings"`
 	AuthSettings                  []helpers.AuthSettings                `tfschema:"auth_settings"`
-	AuthV2Settings                []helpers.AuthV2Settings              `tfschema:"auth_v2_settings"`
+	AuthV2Settings                []helpers.AuthV2Settings              `tfschema:"auth_settings_v2"`
 	Backup                        []helpers.Backup                      `tfschema:"backup"`
 	ClientAffinityEnabled         bool                                  `tfschema:"client_affinity_enabled"`
 	ClientCertEnabled             bool                                  `tfschema:"client_certificate_enabled"`
@@ -105,7 +105,7 @@ func (r WindowsWebAppSlotResource) Arguments() map[string]*pluginsdk.Schema {
 
 		"auth_settings": helpers.AuthSettingsSchema(),
 
-		"auth_v2_settings": helpers.AuthV2SettingsSchema(),
+		"auth_settings_v2": helpers.AuthV2SettingsSchema(),
 
 		"backup": helpers.BackupSchema(),
 
@@ -788,7 +788,7 @@ func (r WindowsWebAppSlotResource) Update() sdk.ResourceFunc {
 				}
 			}
 
-			if metadata.ResourceData.HasChange("auth_v2_settings") {
+			if metadata.ResourceData.HasChange("auth_settings_v2") {
 				authV2Update := helpers.ExpandAuthV2Settings(state.AuthV2Settings)
 				if _, err := client.UpdateAuthSettingsV2Slot(ctx, id.ResourceGroup, id.SiteName, *authV2Update, id.SlotName); err != nil {
 					return fmt.Errorf("updating AuthV2 Settings for Linux %s: %+v", id, err)

--- a/internal/services/appservice/windows_web_app_slot_resource_authv2_test.go
+++ b/internal/services/appservice/windows_web_app_slot_resource_authv2_test.go
@@ -1,0 +1,674 @@
+package appservice_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+)
+
+func TestAccWindowsWebAppSlot_withAuthV2AzureActiveDirectory(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_web_app_slot", "test")
+	r := WindowsWebAppSlotResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.authV2AzureActiveDirectory(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccWindowsWebAppSlot_withAuthV2Apple(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_web_app_slot", "test")
+	r := WindowsWebAppSlotResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.authV2Apple(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccWindowsWebAppSlot_withAuthV2CustomOIDC(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_web_app_slot", "test")
+	r := WindowsWebAppSlotResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.authV2CustomOIDC(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccWindowsWebAppSlot_withAuthV2Facebook(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_web_app_slot", "test")
+	r := WindowsWebAppSlotResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.authV2Facebook(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccWindowsWebAppSlot_withAuthV2Google(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_web_app_slot", "test")
+	r := WindowsWebAppSlotResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.authV2Google(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccWindowsWebAppSlot_withAuthV2Microsoft(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_web_app_slot", "test")
+	r := WindowsWebAppSlotResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.authV2Microsoft(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccWindowsWebAppSlot_withAuthV2Twitter(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_web_app_slot", "test")
+	r := WindowsWebAppSlotResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.authV2Twitter(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccWindowsWebAppSlot_withAuthV2MultipleAuths(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_web_app_slot", "test")
+	r := WindowsWebAppSlotResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.authV2Multi(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func (r WindowsWebAppSlotResource) authV2AzureActiveDirectory(data acceptance.TestData) string {
+	secretSettingName := "MICROSOFT_PROVIDER_AUTHENTICATION_SECRET"
+	secretSettingValue := "902D17F6-FD6B-4E44-BABB-58E788DCD907"
+
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_windows_web_app_slot" "test" {
+  name           = "acctestWAS-%d"
+  app_service_id = azurerm_windows_web_app.test.id
+
+  site_config {}
+
+  app_settings = {
+    "%[3]s" = "%[4]s"
+  }
+
+  auth_v2_settings {
+    auth_enabled           = true
+    unauthenticated_action = "Return401"
+    active_directory {
+      client_id                  = data.azurerm_client_config.current.client_id
+      client_secret_setting_name = "%[3]s"
+      tenant_auth_endpoint       = "https://sts.windows.net/%[5]s/v2.0"
+    }
+    login {}
+  }
+}
+`, r.baseTemplate(data), data.RandomInteger, secretSettingName, secretSettingValue, data.Client().TenantID)
+}
+
+func (r WindowsWebAppSlotResource) authV2Apple(data acceptance.TestData) string {
+	secretSettingName := "APPLE_PROVIDER_AUTHENTICATION_SECRET"
+	secretSettingValue := "902D17F6-FD6B-4E44-BABB-58E788DCD907"
+
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_windows_web_app_slot" "test" {
+  name           = "acctestWAS-%d"
+  app_service_id = azurerm_windows_web_app.test.id
+
+  site_config {}
+
+  app_settings = {
+    "%[3]s" = "%[4]s"
+  }
+
+  auth_v2_settings {
+    auth_enabled           = true
+    unauthenticated_action = "Return401"
+
+    apple {
+      client_id                  = "testAppleID"
+      client_secret_setting_name = "%[3]s"
+    }
+
+    login {}
+  }
+}
+`, r.baseTemplate(data), data.RandomInteger, secretSettingName, secretSettingValue, data.Client().TenantID)
+}
+
+func (r WindowsWebAppSlotResource) authV2CustomOIDC(data acceptance.TestData) string {
+	secretSettingName := "TESTCUSTOM_PROVIDER_AUTHENTICATION_SECRET"
+	secretSettingValue := "902D17F6-FD6B-4E44-BABB-58E788DCD907"
+
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_windows_web_app_slot" "test" {
+  name           = "acctestWAS-%d"
+  app_service_id = azurerm_windows_web_app.test.id
+
+  site_config {}
+
+  app_settings = {
+    "%[3]s" = "%[4]s"
+  }
+
+  auth_v2_settings {
+    auth_enabled           = true
+    unauthenticated_action = "Return401"
+
+    custom_oidc {
+      name                          = "testcustom"
+      client_id                     = "testCustomID"
+      openid_configuration_endpoint = "https://oidc.testcustom.contoso.com/auth"
+    }
+
+    login {}
+  }
+}
+`, r.baseTemplate(data), data.RandomInteger, secretSettingName, secretSettingValue, data.Client().TenantID)
+}
+
+func (r WindowsWebAppSlotResource) authV2Facebook(data acceptance.TestData) string {
+	secretSettingName := "FACEBOOK_PROVIDER_AUTHENTICATION_SECRET"
+	secretSettingValue := "902D17F6-FD6B-4E44-BABB-58E788DCD907"
+
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_windows_web_app_slot" "test" {
+  name           = "acctestWAS-%d"
+  app_service_id = azurerm_windows_web_app.test.id
+
+  site_config {}
+
+  app_settings = {
+    "%[3]s" = "%[4]s"
+  }
+
+  auth_v2_settings {
+    auth_enabled           = true
+    unauthenticated_action = "RedirectToLoginPage"
+
+    facebook {
+      app_id                  = "testFacebookID"
+      app_secret_setting_name = "%[3]s"
+    }
+
+    login {}
+  }
+}
+`, r.baseTemplate(data), data.RandomInteger, secretSettingName, secretSettingValue, data.Client().TenantID)
+}
+
+func (r WindowsWebAppSlotResource) authV2Github(data acceptance.TestData) string {
+	secretSettingName := "GITHUB_PROVIDER_AUTHENTICATION_SECRET"
+	secretSettingValue := "902D17F6-FD6B-4E44-BABB-58E788DCD907"
+
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_windows_web_app_slot" "test" {
+  name           = "acctestWAS-%d"
+  app_service_id = azurerm_windows_web_app.test.id
+
+  site_config {}
+
+  app_settings = {
+    "%[3]s" = "%[4]s"
+  }
+
+  auth_v2_settings {
+    auth_enabled           = true
+    unauthenticated_action = "RedirectToLoginPage"
+
+    github {
+      client_id                  = "testGithubID"
+      client_secret_setting_name = "%[3]s"
+    }
+
+    login {}
+  }
+}
+`, r.baseTemplate(data), data.RandomInteger, secretSettingName, secretSettingValue, data.Client().TenantID)
+}
+
+func (r WindowsWebAppSlotResource) authV2Google(data acceptance.TestData) string {
+	secretSettingName := "GOOGLE_PROVIDER_AUTHENTICATION_SECRET"
+	secretSettingValue := "902D17F6-FD6B-4E44-BABB-58E788DCD907"
+
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_windows_web_app_slot" "test" {
+  name           = "acctestWAS-%d"
+  app_service_id = azurerm_windows_web_app.test.id
+
+  site_config {}
+
+  app_settings = {
+    "%[3]s" = "%[4]s"
+  }
+
+  auth_v2_settings {
+    auth_enabled           = true
+    unauthenticated_action = "RedirectToLoginPage"
+
+    google {
+      client_id                  = "testGoogleID"
+      client_secret_setting_name = "%[3]s"
+    }
+
+    login {}
+  }
+}
+`, r.baseTemplate(data), data.RandomInteger, secretSettingName, secretSettingValue, data.Client().TenantID)
+}
+
+func (r WindowsWebAppSlotResource) authV2Microsoft(data acceptance.TestData) string {
+	secretSettingName := "MICROSOFT_PROVIDER_AUTHENTICATION_SECRET"
+	secretSettingValue := "902D17F6-FD6B-4E44-BABB-58E788DCD907"
+
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_windows_web_app_slot" "test" {
+  name           = "acctestWAS-%d"
+  app_service_id = azurerm_windows_web_app.test.id
+
+  site_config {}
+
+  app_settings = {
+    "%[3]s" = "%[4]s"
+  }
+
+  auth_v2_settings {
+    auth_enabled           = true
+    unauthenticated_action = "RedirectToLoginPage"
+
+    microsoft {
+      client_id                  = "testMSFTID"
+      client_secret_setting_name = "%[3]s"
+    }
+
+    login {}
+  }
+}
+`, r.baseTemplate(data), data.RandomInteger, secretSettingName, secretSettingValue, data.Client().TenantID)
+}
+
+func (r WindowsWebAppSlotResource) authV2Twitter(data acceptance.TestData) string {
+	secretSettingName := "TWITTER_PROVIDER_AUTHENTICATION_SECRET"
+	secretSettingValue := "902D17F6-FD6B-4E44-BABB-58E788DCD907"
+
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_windows_web_app_slot" "test" {
+  name           = "acctestWAS-%d"
+  app_service_id = azurerm_windows_web_app.test.id
+
+  site_config {}
+
+  app_settings = {
+    "%[3]s" = "%[4]s"
+  }
+
+  auth_v2_settings {
+    auth_enabled           = true
+    unauthenticated_action = "RedirectToLoginPage"
+
+    twitter {
+      consumer_key                 = "testTwitterKey"
+      consumer_secret_setting_name = "%[3]s"
+    }
+
+    login {}
+  }
+}
+`, r.baseTemplate(data), data.RandomInteger, secretSettingName, secretSettingValue, data.Client().TenantID)
+}
+
+func (r WindowsWebAppSlotResource) authV2Multi(data acceptance.TestData) string {
+	secretSettingValue := "902D17F6-FD6B-4E44-BABB-58E788DCD907"
+
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_windows_web_app_slot" "test" {
+  name           = "acctestWAS-%[2]d"
+  app_service_id = azurerm_windows_web_app.test.id
+
+  site_config {}
+
+  app_settings = {
+    "APPLE_PROVIDER_AUTHENTICATION_SECRET"     = "%[3]s"
+    "FACEBOOK_PROVIDER_AUTHENTICATION_SECRET"  = "%[3]s"
+    "GITHUB_PROVIDER_AUTHENTICATION_SECRET"    = "%[3]s"
+    "GOOGLE_PROVIDER_AUTHENTICATION_SECRET"    = "%[3]s"
+    "MICROSOFT_PROVIDER_AUTHENTICATION_SECRET" = "%[3]s"
+    "TWITTER_PROVIDER_AUTHENTICATION_SECRET"   = "%[3]s"
+  }
+
+  sticky_settings {
+    app_setting_names = [
+      "APPLE_PROVIDER_AUTHENTICATION_SECRET",
+      "FACEBOOK_PROVIDER_AUTHENTICATION_SECRET",
+      "GITHUB_PROVIDER_AUTHENTICATION_SECRET",
+      "GOOGLE_PROVIDER_AUTHENTICATION_SECRET",
+      "MICROSOFT_PROVIDER_AUTHENTICATION_SECRET",
+      "TWITTER_PROVIDER_AUTHENTICATION_SECRET",
+    ]
+  }
+
+  auth_v2_settings {
+    auth_enabled           = true
+    unauthenticated_action = "RedirectToLoginPage"
+
+    apple {
+      client_id                  = "testAppleID"
+      client_secret_setting_name = "APPLE_PROVIDER_AUTHENTICATION_SECRET"
+    }
+
+    facebook {
+      app_id                  = "testFacebookID"
+      app_secret_setting_name = "FACEBOOK_PROVIDER_AUTHENTICATION_SECRET"
+    }
+
+    github {
+      client_id                  = "testGithubID"
+      client_secret_setting_name = "GITHUB_PROVIDER_AUTHENTICATION_SECRET"
+    }
+
+    google {
+      client_id                  = "testGoogleID"
+      client_secret_setting_name = "GOOGLE_PROVIDER_AUTHENTICATION_SECRET"
+    }
+
+    microsoft {
+      client_id                  = "testMSFTID"
+      client_secret_setting_name = "MICROSOFT_PROVIDER_AUTHENTICATION_SECRET"
+    }
+
+    twitter {
+      consumer_key                 = "testTwitterKey"
+      consumer_secret_setting_name = "TWITTER_PROVIDER_AUTHENTICATION_SECRET"
+    }
+
+    login {}
+  }
+}
+`, r.baseTemplate(data), data.RandomInteger, secretSettingValue)
+}
+
+func (r WindowsWebAppSlotResource) completeAuthV2(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_windows_web_app_slot" "test" {
+  name           = "acctestWAS-%d"
+  app_service_id = azurerm_windows_web_app.test.id
+
+  app_settings = {
+    "foo"                                      = "bar"
+    "APPLE_PROVIDER_AUTHENTICATION_SECRET"     = "%[3]s"
+    "FACEBOOK_PROVIDER_AUTHENTICATION_SECRET"  = "%[3]s"
+    "GITHUB_PROVIDER_AUTHENTICATION_SECRET"    = "%[3]s"
+    "GOOGLE_PROVIDER_AUTHENTICATION_SECRET"    = "%[3]s"
+    "MICROSOFT_PROVIDER_AUTHENTICATION_SECRET" = "%[3]s"
+    "TWITTER_PROVIDER_AUTHENTICATION_SECRET"   = "%[3]s"
+  }
+
+  auth_v2_settings {
+    auth_enabled           = true
+    unauthenticated_action = "RedirectToLoginPage"
+
+    apple {
+      client_id                  = "testAppleID"
+      client_secret_setting_name = "APPLE_PROVIDER_AUTHENTICATION_SECRET"
+    }
+
+    facebook {
+      app_id                  = "testFacebookID"
+      app_secret_setting_name = "FACEBOOK_PROVIDER_AUTHENTICATION_SECRET"
+    }
+
+    github {
+      client_id                  = "testGithubID"
+      client_secret_setting_name = "GITHUB_PROVIDER_AUTHENTICATION_SECRET"
+    }
+
+    google {
+      client_id                  = "testGoogleID"
+      client_secret_setting_name = "GOOGLE_PROVIDER_AUTHENTICATION_SECRET"
+    }
+
+    microsoft {
+      client_id                  = "testMSFTID"
+      client_secret_setting_name = "MICROSOFT_PROVIDER_AUTHENTICATION_SECRET"
+    }
+
+    twitter {
+      consumer_key                 = "testTwitterKey"
+      consumer_secret_setting_name = "TWITTER_PROVIDER_AUTHENTICATION_SECRET"
+    }
+
+    login {}
+  }
+
+  backup {
+    name                = "acctest"
+    storage_account_url = "https://${azurerm_storage_account.test.name}.blob.core.windows.net/${azurerm_storage_container.test.name}${data.azurerm_storage_account_sas.test.sas}&sr=b"
+    schedule {
+      frequency_interval = 1
+      frequency_unit     = "Day"
+    }
+  }
+
+  logs {
+    application_logs {
+      file_system_level = "Warning"
+      azure_blob_storage {
+        level             = "Information"
+        sas_url           = "http://x.com/"
+        retention_in_days = 2
+      }
+    }
+
+    http_logs {
+      azure_blob_storage {
+        sas_url           = "https://${azurerm_storage_account.test.name}.blob.core.windows.net/${azurerm_storage_container.test.name}${data.azurerm_storage_account_sas.test.sas}&sr=b"
+        retention_in_days = 3
+      }
+    }
+  }
+
+  client_affinity_enabled            = true
+  client_certificate_enabled         = true
+  client_certificate_mode            = "Optional"
+  client_certificate_exclusion_paths = "/foo;/bar;/hello;/world"
+
+  connection_string {
+    name  = "First"
+    value = "first-connection-string"
+    type  = "Custom"
+  }
+
+  connection_string {
+    name  = "Second"
+    value = "some-postgresql-connection-string"
+    type  = "PostgreSQL"
+  }
+
+  enabled    = false
+  https_only = true
+
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.test.id]
+  }
+
+  site_config {
+    always_on        = true
+    app_command_line = "/sbin/myserver -b 0.0.0.0"
+    default_documents = [
+      "first.html",
+      "second.jsp",
+      "third.aspx",
+      "hostingstart.html",
+    ]
+    http2_enabled               = true
+    scm_use_main_ip_restriction = true
+    local_mysql_enabled         = true
+    managed_pipeline_mode       = "Integrated"
+    remote_debugging_enabled    = true
+    remote_debugging_version    = "VS2019"
+    use_32_bit_worker           = true
+    websockets_enabled          = true
+    ftps_state                  = "FtpsOnly"
+    health_check_path           = "/health"
+    worker_count                = 1
+    minimum_tls_version         = "1.1"
+    scm_minimum_tls_version     = "1.1"
+    cors {
+      allowed_origins = [
+        "http://www.contoso.com",
+        "www.contoso.com",
+      ]
+
+      support_credentials = true
+    }
+
+    container_registry_use_managed_identity       = true
+    container_registry_managed_identity_client_id = azurerm_user_assigned_identity.test.client_id
+
+    auto_swap_slot_name = "Production"
+    auto_heal_enabled   = true
+
+    auto_heal_setting {
+      trigger {
+        status_code {
+          status_code_range = "500"
+          interval          = "00:01:00"
+          count             = 10
+        }
+      }
+
+      action {
+        action_type                    = "Recycle"
+        minimum_process_execution_time = "00:05:00"
+      }
+    }
+  }
+
+  storage_account {
+    name         = "files"
+    type         = "AzureFiles"
+    account_name = azurerm_storage_account.test.name
+    share_name   = azurerm_storage_share.test.name
+    access_key   = azurerm_storage_account.test.primary_access_key
+    mount_path   = "/storage/files"
+  }
+
+  tags = {
+    Environment = "AccTest"
+    foo         = "bar"
+  }
+}
+`, r.templateWithStorageAccount(data), data.RandomInteger, data.Client().TenantID)
+}

--- a/internal/services/appservice/windows_web_app_slot_resource_authv2_test.go
+++ b/internal/services/appservice/windows_web_app_slot_resource_authv2_test.go
@@ -139,6 +139,8 @@ provider "azurerm" {
 
 %s
 
+data "azurerm_client_config" "current" {}
+
 resource "azurerm_windows_web_app_slot" "test" {
   name           = "acctestWAS-%d"
   app_service_id = azurerm_windows_web_app.test.id
@@ -149,7 +151,7 @@ resource "azurerm_windows_web_app_slot" "test" {
     "%[3]s" = "%[4]s"
   }
 
-  auth_v2_settings {
+  auth_settings_v2 {
     auth_enabled           = true
     unauthenticated_action = "Return401"
     active_directory {
@@ -184,7 +186,7 @@ resource "azurerm_windows_web_app_slot" "test" {
     "%[3]s" = "%[4]s"
   }
 
-  auth_v2_settings {
+  auth_settings_v2 {
     auth_enabled           = true
     unauthenticated_action = "Return401"
 
@@ -220,7 +222,7 @@ resource "azurerm_windows_web_app_slot" "test" {
     "%[3]s" = "%[4]s"
   }
 
-  auth_v2_settings {
+  auth_settings_v2 {
     auth_enabled           = true
     unauthenticated_action = "Return401"
 
@@ -257,7 +259,7 @@ resource "azurerm_windows_web_app_slot" "test" {
     "%[3]s" = "%[4]s"
   }
 
-  auth_v2_settings {
+  auth_settings_v2 {
     auth_enabled           = true
     unauthenticated_action = "RedirectToLoginPage"
 
@@ -293,7 +295,7 @@ resource "azurerm_windows_web_app_slot" "test" {
     "%[3]s" = "%[4]s"
   }
 
-  auth_v2_settings {
+  auth_settings_v2 {
     auth_enabled           = true
     unauthenticated_action = "RedirectToLoginPage"
 
@@ -329,7 +331,7 @@ resource "azurerm_windows_web_app_slot" "test" {
     "%[3]s" = "%[4]s"
   }
 
-  auth_v2_settings {
+  auth_settings_v2 {
     auth_enabled           = true
     unauthenticated_action = "RedirectToLoginPage"
 
@@ -365,7 +367,7 @@ resource "azurerm_windows_web_app_slot" "test" {
     "%[3]s" = "%[4]s"
   }
 
-  auth_v2_settings {
+  auth_settings_v2 {
     auth_enabled           = true
     unauthenticated_action = "RedirectToLoginPage"
 
@@ -401,7 +403,7 @@ resource "azurerm_windows_web_app_slot" "test" {
     "%[3]s" = "%[4]s"
   }
 
-  auth_v2_settings {
+  auth_settings_v2 {
     auth_enabled           = true
     unauthenticated_action = "RedirectToLoginPage"
 
@@ -441,18 +443,7 @@ resource "azurerm_windows_web_app_slot" "test" {
     "TWITTER_PROVIDER_AUTHENTICATION_SECRET"   = "%[3]s"
   }
 
-  sticky_settings {
-    app_setting_names = [
-      "APPLE_PROVIDER_AUTHENTICATION_SECRET",
-      "FACEBOOK_PROVIDER_AUTHENTICATION_SECRET",
-      "GITHUB_PROVIDER_AUTHENTICATION_SECRET",
-      "GOOGLE_PROVIDER_AUTHENTICATION_SECRET",
-      "MICROSOFT_PROVIDER_AUTHENTICATION_SECRET",
-      "TWITTER_PROVIDER_AUTHENTICATION_SECRET",
-    ]
-  }
-
-  auth_v2_settings {
+  auth_settings_v2 {
     auth_enabled           = true
     unauthenticated_action = "RedirectToLoginPage"
 
@@ -514,7 +505,7 @@ resource "azurerm_windows_web_app_slot" "test" {
     "TWITTER_PROVIDER_AUTHENTICATION_SECRET"   = "%[3]s"
   }
 
-  auth_v2_settings {
+  auth_settings_v2 {
     auth_enabled           = true
     unauthenticated_action = "RedirectToLoginPage"
 

--- a/internal/services/appservice/windows_web_app_slot_resource_authv2_test.go
+++ b/internal/services/appservice/windows_web_app_slot_resource_authv2_test.go
@@ -68,6 +68,21 @@ func TestAccWindowsWebAppSlot_withAuthV2Facebook(t *testing.T) {
 	})
 }
 
+func TestAccWindowsWebAppSlot_withAuthV2Github(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_web_app_slot", "test")
+	r := WindowsWebAppSlotResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.authV2Github(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccWindowsWebAppSlot_withAuthV2Google(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_windows_web_app_slot", "test")
 	r := WindowsWebAppSlotResource{}
@@ -226,7 +241,7 @@ resource "azurerm_windows_web_app_slot" "test" {
     auth_enabled           = true
     unauthenticated_action = "Return401"
 
-    custom_oidc {
+    custom_oidc_v2 {
       name                          = "testcustom"
       client_id                     = "testCustomID"
       openid_configuration_endpoint = "https://oidc.testcustom.contoso.com/auth"
@@ -481,185 +496,4 @@ resource "azurerm_windows_web_app_slot" "test" {
   }
 }
 `, r.baseTemplate(data), data.RandomInteger, secretSettingValue)
-}
-
-func (r WindowsWebAppSlotResource) completeAuthV2(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-%s
-
-resource "azurerm_windows_web_app_slot" "test" {
-  name           = "acctestWAS-%d"
-  app_service_id = azurerm_windows_web_app.test.id
-
-  app_settings = {
-    "foo"                                      = "bar"
-    "APPLE_PROVIDER_AUTHENTICATION_SECRET"     = "%[3]s"
-    "FACEBOOK_PROVIDER_AUTHENTICATION_SECRET"  = "%[3]s"
-    "GITHUB_PROVIDER_AUTHENTICATION_SECRET"    = "%[3]s"
-    "GOOGLE_PROVIDER_AUTHENTICATION_SECRET"    = "%[3]s"
-    "MICROSOFT_PROVIDER_AUTHENTICATION_SECRET" = "%[3]s"
-    "TWITTER_PROVIDER_AUTHENTICATION_SECRET"   = "%[3]s"
-  }
-
-  auth_settings_v2 {
-    auth_enabled           = true
-    unauthenticated_action = "RedirectToLoginPage"
-
-    apple_v2 {
-      client_id                  = "testAppleID"
-      client_secret_setting_name = "APPLE_PROVIDER_AUTHENTICATION_SECRET"
-    }
-
-    facebook_v2 {
-      app_id                  = "testFacebookID"
-      app_secret_setting_name = "FACEBOOK_PROVIDER_AUTHENTICATION_SECRET"
-    }
-
-    github_v2 {
-      client_id                  = "testGithubID"
-      client_secret_setting_name = "GITHUB_PROVIDER_AUTHENTICATION_SECRET"
-    }
-
-    google_v2 {
-      client_id                  = "testGoogleID"
-      client_secret_setting_name = "GOOGLE_PROVIDER_AUTHENTICATION_SECRET"
-    }
-
-    microsoft_v2 {
-      client_id                  = "testMSFTID"
-      client_secret_setting_name = "MICROSOFT_PROVIDER_AUTHENTICATION_SECRET"
-    }
-
-    twitter_v2 {
-      consumer_key                 = "testTwitterKey"
-      consumer_secret_setting_name = "TWITTER_PROVIDER_AUTHENTICATION_SECRET"
-    }
-
-    login {}
-  }
-
-  backup {
-    name                = "acctest"
-    storage_account_url = "https://${azurerm_storage_account.test.name}.blob.core.windows.net/${azurerm_storage_container.test.name}${data.azurerm_storage_account_sas.test.sas}&sr=b"
-    schedule {
-      frequency_interval = 1
-      frequency_unit     = "Day"
-    }
-  }
-
-  logs {
-    application_logs {
-      file_system_level = "Warning"
-      azure_blob_storage {
-        level             = "Information"
-        sas_url           = "http://x.com/"
-        retention_in_days = 2
-      }
-    }
-
-    http_logs {
-      azure_blob_storage {
-        sas_url           = "https://${azurerm_storage_account.test.name}.blob.core.windows.net/${azurerm_storage_container.test.name}${data.azurerm_storage_account_sas.test.sas}&sr=b"
-        retention_in_days = 3
-      }
-    }
-  }
-
-  client_affinity_enabled            = true
-  client_certificate_enabled         = true
-  client_certificate_mode            = "Optional"
-  client_certificate_exclusion_paths = "/foo;/bar;/hello;/world"
-
-  connection_string {
-    name  = "First"
-    value = "first-connection-string"
-    type  = "Custom"
-  }
-
-  connection_string {
-    name  = "Second"
-    value = "some-postgresql-connection-string"
-    type  = "PostgreSQL"
-  }
-
-  enabled    = false
-  https_only = true
-
-  identity {
-    type         = "UserAssigned"
-    identity_ids = [azurerm_user_assigned_identity.test.id]
-  }
-
-  site_config {
-    always_on        = true
-    app_command_line = "/sbin/myserver -b 0.0.0.0"
-    default_documents = [
-      "first.html",
-      "second.jsp",
-      "third.aspx",
-      "hostingstart.html",
-    ]
-    http2_enabled               = true
-    scm_use_main_ip_restriction = true
-    local_mysql_enabled         = true
-    managed_pipeline_mode       = "Integrated"
-    remote_debugging_enabled    = true
-    remote_debugging_version    = "VS2019"
-    use_32_bit_worker           = true
-    websockets_enabled          = true
-    ftps_state                  = "FtpsOnly"
-    health_check_path           = "/health"
-    worker_count                = 1
-    minimum_tls_version         = "1.1"
-    scm_minimum_tls_version     = "1.1"
-    cors {
-      allowed_origins = [
-        "http://www.contoso.com",
-        "www.contoso.com",
-      ]
-
-      support_credentials = true
-    }
-
-    container_registry_use_managed_identity       = true
-    container_registry_managed_identity_client_id = azurerm_user_assigned_identity.test.client_id
-
-    auto_swap_slot_name = "Production"
-    auto_heal_enabled   = true
-
-    auto_heal_setting {
-      trigger {
-        status_code {
-          status_code_range = "500"
-          interval          = "00:01:00"
-          count             = 10
-        }
-      }
-
-      action {
-        action_type                    = "Recycle"
-        minimum_process_execution_time = "00:05:00"
-      }
-    }
-  }
-
-  storage_account {
-    name         = "files"
-    type         = "AzureFiles"
-    account_name = azurerm_storage_account.test.name
-    share_name   = azurerm_storage_share.test.name
-    access_key   = azurerm_storage_account.test.primary_access_key
-    mount_path   = "/storage/files"
-  }
-
-  tags = {
-    Environment = "AccTest"
-    foo         = "bar"
-  }
-}
-`, r.templateWithStorageAccount(data), data.RandomInteger, data.Client().TenantID)
 }

--- a/internal/services/appservice/windows_web_app_slot_resource_authv2_test.go
+++ b/internal/services/appservice/windows_web_app_slot_resource_authv2_test.go
@@ -154,7 +154,7 @@ resource "azurerm_windows_web_app_slot" "test" {
   auth_settings_v2 {
     auth_enabled           = true
     unauthenticated_action = "Return401"
-    active_directory {
+    active_directory_v2 {
       client_id                  = data.azurerm_client_config.current.client_id
       client_secret_setting_name = "%[3]s"
       tenant_auth_endpoint       = "https://sts.windows.net/%[5]s/v2.0"
@@ -190,7 +190,7 @@ resource "azurerm_windows_web_app_slot" "test" {
     auth_enabled           = true
     unauthenticated_action = "Return401"
 
-    apple {
+    apple_v2 {
       client_id                  = "testAppleID"
       client_secret_setting_name = "%[3]s"
     }
@@ -263,7 +263,7 @@ resource "azurerm_windows_web_app_slot" "test" {
     auth_enabled           = true
     unauthenticated_action = "RedirectToLoginPage"
 
-    facebook {
+    facebook_v2 {
       app_id                  = "testFacebookID"
       app_secret_setting_name = "%[3]s"
     }
@@ -299,7 +299,7 @@ resource "azurerm_windows_web_app_slot" "test" {
     auth_enabled           = true
     unauthenticated_action = "RedirectToLoginPage"
 
-    github {
+    github_v2 {
       client_id                  = "testGithubID"
       client_secret_setting_name = "%[3]s"
     }
@@ -335,7 +335,7 @@ resource "azurerm_windows_web_app_slot" "test" {
     auth_enabled           = true
     unauthenticated_action = "RedirectToLoginPage"
 
-    google {
+    google_v2 {
       client_id                  = "testGoogleID"
       client_secret_setting_name = "%[3]s"
     }
@@ -371,7 +371,7 @@ resource "azurerm_windows_web_app_slot" "test" {
     auth_enabled           = true
     unauthenticated_action = "RedirectToLoginPage"
 
-    microsoft {
+    microsoft_v2 {
       client_id                  = "testMSFTID"
       client_secret_setting_name = "%[3]s"
     }
@@ -407,7 +407,7 @@ resource "azurerm_windows_web_app_slot" "test" {
     auth_enabled           = true
     unauthenticated_action = "RedirectToLoginPage"
 
-    twitter {
+    twitter_v2 {
       consumer_key                 = "testTwitterKey"
       consumer_secret_setting_name = "%[3]s"
     }
@@ -447,32 +447,32 @@ resource "azurerm_windows_web_app_slot" "test" {
     auth_enabled           = true
     unauthenticated_action = "RedirectToLoginPage"
 
-    apple {
+    apple_v2 {
       client_id                  = "testAppleID"
       client_secret_setting_name = "APPLE_PROVIDER_AUTHENTICATION_SECRET"
     }
 
-    facebook {
+    facebook_v2 {
       app_id                  = "testFacebookID"
       app_secret_setting_name = "FACEBOOK_PROVIDER_AUTHENTICATION_SECRET"
     }
 
-    github {
+    github_v2 {
       client_id                  = "testGithubID"
       client_secret_setting_name = "GITHUB_PROVIDER_AUTHENTICATION_SECRET"
     }
 
-    google {
+    google_v2 {
       client_id                  = "testGoogleID"
       client_secret_setting_name = "GOOGLE_PROVIDER_AUTHENTICATION_SECRET"
     }
 
-    microsoft {
+    microsoft_v2 {
       client_id                  = "testMSFTID"
       client_secret_setting_name = "MICROSOFT_PROVIDER_AUTHENTICATION_SECRET"
     }
 
-    twitter {
+    twitter_v2 {
       consumer_key                 = "testTwitterKey"
       consumer_secret_setting_name = "TWITTER_PROVIDER_AUTHENTICATION_SECRET"
     }
@@ -509,32 +509,32 @@ resource "azurerm_windows_web_app_slot" "test" {
     auth_enabled           = true
     unauthenticated_action = "RedirectToLoginPage"
 
-    apple {
+    apple_v2 {
       client_id                  = "testAppleID"
       client_secret_setting_name = "APPLE_PROVIDER_AUTHENTICATION_SECRET"
     }
 
-    facebook {
+    facebook_v2 {
       app_id                  = "testFacebookID"
       app_secret_setting_name = "FACEBOOK_PROVIDER_AUTHENTICATION_SECRET"
     }
 
-    github {
+    github_v2 {
       client_id                  = "testGithubID"
       client_secret_setting_name = "GITHUB_PROVIDER_AUTHENTICATION_SECRET"
     }
 
-    google {
+    google_v2 {
       client_id                  = "testGoogleID"
       client_secret_setting_name = "GOOGLE_PROVIDER_AUTHENTICATION_SECRET"
     }
 
-    microsoft {
+    microsoft_v2 {
       client_id                  = "testMSFTID"
       client_secret_setting_name = "MICROSOFT_PROVIDER_AUTHENTICATION_SECRET"
     }
 
-    twitter {
+    twitter_v2 {
       consumer_key                 = "testTwitterKey"
       consumer_secret_setting_name = "TWITTER_PROVIDER_AUTHENTICATION_SECRET"
     }

--- a/utils/float.go
+++ b/utils/float.go
@@ -1,0 +1,19 @@
+package utils
+
+// NormalizeNilableFloat normalizes a nilable float64 into a float64 value
+func NormalizeNilableFloat(input *float64) float64 {
+	if input == nil {
+		return 0
+	}
+
+	return *input
+}
+
+// NormalizeNilableFloat32 normalizes a nilable float32 into a float32 value
+func NormalizeNilableFloat32(input *float32) float32 {
+	if input == nil {
+		return 0
+	}
+
+	return *input
+}

--- a/website/docs/d/linux_web_app.html.markdown
+++ b/website/docs/d/linux_web_app.html.markdown
@@ -43,6 +43,8 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `auth_settings` - An `auth_settings` block as defined below.
 
+* `auth_settings_v2` - An `auth_settings_v2` block as defined below.
+
 * `backup` - A `backup` block as defined below.
 
 * `client_affinity_enabled` - Is Client Affinity enabled?
@@ -176,6 +178,204 @@ A `auth_settings` block exports the following:
 * `twitter` - A `twitter` block as defined below.
 
 * `unauthenticated_client_action` - The action to take when an unauthenticated client attempts to access the app.
+
+---
+
+An `auth_settings_v2` block exports the following:
+
+* `auth_enabled` - Are the AuthV2 Settings enabled.
+
+* `runtime_version` - The Runtime Version of the Authentication and Authorisation feature of this App.
+
+* `config_file_path` - The path to the App Auth settings.
+
+* `require_authentication` - Is the authentication flow used for all requests.
+
+* `unauthenticated_action` - The action to take for requests made without authentication.
+
+* `default_provider` -The Default Authentication Provider used when more than one Authentication Provider is configured and the `unauthenticated_action` is set to `RedirectToLoginPage`.
+
+* `excluded_paths` - The paths which should be excluded from the `unauthenticated_action` when it is set to `RedirectToLoginPage`.
+
+* `require_https` -Is HTTPS required on connections?
+
+* `http_route_api_prefix` - The prefix that should precede all the authentication and authorisation paths.
+
+* `forward_proxy_convention` - The convention used to determine the url of the request made.
+
+* `forward_proxy_custom_host_header_name` -The name of the custom header containing the host of the request.
+
+* `forward_proxy_custom_scheme_header_name` - The name of the custom header containing the scheme of the request.
+
+* `apple_v2` - An `apple_v2` block as defined below.
+
+* `active_directory_v2` - An `active_directory_v2` block as defined below.
+
+* `azure_static_web_app_v2` - An `azure_static_web_app_v2` block as defined below.
+
+* `custom_oidc_v2` - Zero or more `custom_oidc_v2` blocks as defined below.
+
+* `facebook_v2` - A `facebook_v2` block as defined below.
+
+* `github_v2` - A `github_v2` block as defined below.
+
+* `google_v2` - A `google_v2` block as defined below.
+
+* `microsoft_v2` - A `microsoft_v2` block as defined below.
+
+* `twitter_v2` - A `twitter_v2` block as defined below.
+
+* `login` - A `login` block as defined below.
+
+---
+
+An `apple_v2` block supports the following:
+
+* `client_id` - The OpenID Connect Client ID for the Apple web application.
+
+* `client_secret_setting_name` - The app setting name that contains the `client_secret` value used for Apple Login.
+
+* `login_scopes` - A list of Login Scopes provided by this Authentication Provider.
+
+---
+
+An `active_directory_v2` block supports the following:
+
+* `client_id` - The ID of the Client used to authenticate with Azure Active Directory.
+
+* `tenant_auth_endpoint` - The Azure Tenant Endpoint for the Authenticating Tenant. e.g. `https://login.microsoftonline.com/v2.0/{tenant-guid}/`
+
+* `client_secret_setting_name` - The App Setting name that contains the client secret of the Client.
+
+* `client_secret_certificate_thumbprint` - The thumbprint of the certificate used for signing purposes.
+
+* `jwt_allowed_groups` - The list of Allowed Groups in the JWT Claim.
+
+* `jwt_allowed_client_applications` - The list of Allowed Client Applications in the JWT Claim.
+
+* `www_authentication_disabled` - Is the www-authenticate provider omitted from the request?
+
+* `allowed_groups` -The list of allowed Group Names for the Default Authorisation Policy.
+
+* `allowed_identities` - The list of allowed Identities for the Default Authorisation Policy.
+
+* `allowed_applications` - The list of allowed Applications for the Default Authorisation Policy.
+
+* `login_parameters` - A map of key-value pairs sent to the Authorisation Endpoint when a user logs in.
+
+* `allowed_audiences` - Specifies a list of Allowed audience values to consider when validating JWTs issued by Azure Active Directory.
+
+---
+
+An `azure_static_web_app_v2` block supports the following:
+
+* `client_id` - The ID of the Client to use to authenticate with Azure Static Web App Authentication.
+
+---
+
+A `custom_oidc_v2` block supports the following:
+
+* `name` - The name of the Custom OIDC Authentication Provider.
+
+* `client_id` - The ID of the Client to use to authenticate with the Custom OIDC.
+
+* `openid_configuration_endpoint` - The app setting name that contains the `client_secret` value used for the Custom OIDC Login.
+
+* `name_claim_type` - The name of the claim that contains the users name.
+
+* `scopes` - The list of the scopes that are requested while authenticating.
+
+* `client_credential_method` - The Client Credential Method used.
+
+* `client_secret_setting_name` - The App Setting name that contains the secret for this Custom OIDC Client. This is generated from `name` above and suffixed with `_PROVIDER_AUTHENTICATION_SECRET`.
+
+* `authorisation_endpoint` - The endpoint to make the Authorisation Request as supplied by `openid_configuration_endpoint` response.
+
+* `token_endpoint` - The endpoint used to request a Token as supplied by `openid_configuration_endpoint` response.
+
+* `issuer_endpoint` - The endpoint that issued the Token as supplied by `openid_configuration_endpoint` response.
+
+* `certification_uri` - The endpoint that provides the keys necessary to validate the token as supplied by `openid_configuration_endpoint` response.
+
+---
+
+A `facebook_v2` block supports the following:
+
+* `app_id` - The App ID of the Facebook app used for login.
+
+* `app_secret_setting_name` - The app setting name that contains the `app_secret` value used for Facebook Login.
+
+* `graph_api_version` - The version of the Facebook API to be used while logging in.
+
+* `login_scopes` - The list of scopes that are requested as part of Facebook Login authentication.
+
+---
+
+A `github_v2` block supports the following:
+
+* `client_id` - The ID of the GitHub app used for login..
+
+* `client_secret_setting_name` - The app setting name that contains the `client_secret` value used for GitHub Login.
+
+* `login_scopes` - The list of OAuth 2.0 scopes that are requested as part of GitHub Login authentication.
+
+---
+
+A `google_v2` block supports the following:
+
+* `client_id` - The OpenID Connect Client ID for the Google web application.
+
+* `client_secret_setting_name` - The app setting name that contains the `client_secret` value used for Google Login.
+
+* `allowed_audiences` - The list of Allowed Audiences that are requested as part of Google Sign-In authentication.
+
+* `login_scopes` - (Optional) The list of OAuth 2.0 scopes that should be requested as part of Google Sign-In authentication.
+
+---
+
+A `microsoft_v2` block supports the following:
+
+* `client_id` - The OAuth 2.0 client ID that was created for the app used for authentication.
+
+* `client_secret_setting_name` - The app setting name containing the OAuth 2.0 client secret that was created for the app used for authentication.
+
+* `allowed_audiences` - The list of Allowed Audiences that are be requested as part of Microsoft Sign-In authentication.
+
+* `login_scopes` - The list of Login scopes that are requested as part of Microsoft Account authentication.
+
+---
+
+A `twitter_v2` block supports the following:
+
+* `consumer_key` - The OAuth 1.0a consumer key of the Twitter application used for sign-in.
+
+* `consumer_secret_setting_name` - The app setting name that contains the OAuth 1.0a consumer secret of the Twitter application used for sign-in.
+
+---
+
+A `login` block supports the following:
+
+* `logout_endpoint` - The endpoint to which logout requests are made.
+
+* `token_store_enabled` - Is the Token Store configuration Enabled.
+
+* `token_refresh_extension_time` - The number of hours after session token expiration that a session token can be used to call the token refresh API.
+
+* `token_store_path` - The directory path in the App Filesystem in which the tokens are stored.
+
+* `token_store_sas_setting_name` - The name of the app setting which contains the SAS URL of the blob storage containing the tokens.
+
+* `preserve_url_fragments_for_logins` - Are the fragments from the request preserved after the login request is made.
+
+* `allowed_external_redirect_urls` - External URLs that can be redirected to as part of logging in or logging out of the app.
+
+* `cookie_expiration_convention` - The method by which cookies expire.
+
+* `cookie_expiration_time` - The time after the request is made when the session cookie should expire.
+
+* `validate_nonce` - Is the nonce validated while completing the login flow.
+
+* `nonce_expiration_time` - The time after the request is made when the nonce should expire.
 
 ---
 

--- a/website/docs/d/windows_web_app.html.markdown
+++ b/website/docs/d/windows_web_app.html.markdown
@@ -41,6 +41,8 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `auth_settings` - A `auth_settings` block as defined below.
 
+* `auth_settings_v2` - An `auth_settings_v2` block as defined below.
+
 * `backup` - A `backup` block as defined below.
 
 * `client_affinity_enabled` - Is Client Affinity enabled?
@@ -180,6 +182,204 @@ A `auth_settings` block exports the following:
 * `twitter` - A `twitter` block as defined below.
 
 * `unauthenticated_client_action` - The action to take when an unauthenticated client attempts to access the app.
+
+---
+
+An `auth_settings_v2` block exports the following:
+
+* `auth_enabled` - Are the AuthV2 Settings enabled.
+
+* `runtime_version` - The Runtime Version of the Authentication and Authorisation feature of this App.
+
+* `config_file_path` - The path to the App Auth settings.
+
+* `require_authentication` - Is the authentication flow used for all requests.
+
+* `unauthenticated_action` - The action to take for requests made without authentication.
+
+* `default_provider` -The Default Authentication Provider used when more than one Authentication Provider is configured and the `unauthenticated_action` is set to `RedirectToLoginPage`.
+
+* `excluded_paths` - The paths which should be excluded from the `unauthenticated_action` when it is set to `RedirectToLoginPage`.
+
+* `require_https` -Is HTTPS required on connections?
+
+* `http_route_api_prefix` - The prefix that should precede all the authentication and authorisation paths.
+
+* `forward_proxy_convention` - The convention used to determine the url of the request made.
+
+* `forward_proxy_custom_host_header_name` -The name of the custom header containing the host of the request.
+
+* `forward_proxy_custom_scheme_header_name` - The name of the custom header containing the scheme of the request.
+
+* `apple_v2` - An `apple_v2` block as defined below.
+
+* `active_directory_v2` - An `active_directory_v2` block as defined below.
+
+* `azure_static_web_app_v2` - An `azure_static_web_app_v2` block as defined below.
+
+* `custom_oidc_v2` - Zero or more `custom_oidc_v2` blocks as defined below.
+
+* `facebook_v2` - A `facebook_v2` block as defined below.
+
+* `github_v2` - A `github_v2` block as defined below.
+
+* `google_v2` - A `google_v2` block as defined below.
+
+* `microsoft_v2` - A `microsoft_v2` block as defined below.
+
+* `twitter_v2` - A `twitter_v2` block as defined below.
+
+* `login` - A `login` block as defined below.
+
+---
+
+An `apple_v2` block supports the following:
+
+* `client_id` - The OpenID Connect Client ID for the Apple web application.
+
+* `client_secret_setting_name` - The app setting name that contains the `client_secret` value used for Apple Login.
+
+* `login_scopes` - A list of Login Scopes provided by this Authentication Provider.
+
+---
+
+An `active_directory_v2` block supports the following:
+
+* `client_id` - The ID of the Client used to authenticate with Azure Active Directory.
+
+* `tenant_auth_endpoint` - The Azure Tenant Endpoint for the Authenticating Tenant. e.g. `https://login.microsoftonline.com/v2.0/{tenant-guid}/`
+
+* `client_secret_setting_name` - The App Setting name that contains the client secret of the Client.
+
+* `client_secret_certificate_thumbprint` - The thumbprint of the certificate used for signing purposes.
+
+* `jwt_allowed_groups` - The list of Allowed Groups in the JWT Claim.
+
+* `jwt_allowed_client_applications` - The list of Allowed Client Applications in the JWT Claim.
+
+* `www_authentication_disabled` - Is the www-authenticate provider omitted from the request?
+
+* `allowed_groups` -The list of allowed Group Names for the Default Authorisation Policy.
+
+* `allowed_identities` - The list of allowed Identities for the Default Authorisation Policy.
+
+* `allowed_applications` - The list of allowed Applications for the Default Authorisation Policy.
+
+* `login_parameters` - A map of key-value pairs sent to the Authorisation Endpoint when a user logs in.
+
+* `allowed_audiences` - Specifies a list of Allowed audience values to consider when validating JWTs issued by Azure Active Directory.
+
+---
+
+An `azure_static_web_app_v2` block supports the following:
+
+* `client_id` - The ID of the Client to use to authenticate with Azure Static Web App Authentication.
+
+---
+
+A `custom_oidc_v2` block supports the following:
+
+* `name` - The name of the Custom OIDC Authentication Provider.
+
+* `client_id` - The ID of the Client to use to authenticate with the Custom OIDC.
+
+* `openid_configuration_endpoint` - The app setting name that contains the `client_secret` value used for the Custom OIDC Login.
+
+* `name_claim_type` - The name of the claim that contains the users name.
+
+* `scopes` - The list of the scopes that are requested while authenticating.
+
+* `client_credential_method` - The Client Credential Method used.
+
+* `client_secret_setting_name` - The App Setting name that contains the secret for this Custom OIDC Client. This is generated from `name` above and suffixed with `_PROVIDER_AUTHENTICATION_SECRET`.
+
+* `authorisation_endpoint` - The endpoint to make the Authorisation Request as supplied by `openid_configuration_endpoint` response.
+
+* `token_endpoint` - The endpoint used to request a Token as supplied by `openid_configuration_endpoint` response.
+
+* `issuer_endpoint` - The endpoint that issued the Token as supplied by `openid_configuration_endpoint` response.
+
+* `certification_uri` - The endpoint that provides the keys necessary to validate the token as supplied by `openid_configuration_endpoint` response.
+
+---
+
+A `facebook_v2` block supports the following:
+
+* `app_id` - The App ID of the Facebook app used for login.
+
+* `app_secret_setting_name` - The app setting name that contains the `app_secret` value used for Facebook Login.
+
+* `graph_api_version` - The version of the Facebook API to be used while logging in.
+
+* `login_scopes` - The list of scopes that are requested as part of Facebook Login authentication.
+
+---
+
+A `github_v2` block supports the following:
+
+* `client_id` - The ID of the GitHub app used for login..
+
+* `client_secret_setting_name` - The app setting name that contains the `client_secret` value used for GitHub Login.
+
+* `login_scopes` - The list of OAuth 2.0 scopes that are requested as part of GitHub Login authentication.
+
+---
+
+A `google_v2` block supports the following:
+
+* `client_id` - The OpenID Connect Client ID for the Google web application.
+
+* `client_secret_setting_name` - The app setting name that contains the `client_secret` value used for Google Login.
+
+* `allowed_audiences` - The list of Allowed Audiences that are requested as part of Google Sign-In authentication.
+
+* `login_scopes` - (Optional) The list of OAuth 2.0 scopes that should be requested as part of Google Sign-In authentication.
+
+---
+
+A `microsoft_v2` block supports the following:
+
+* `client_id` - The OAuth 2.0 client ID that was created for the app used for authentication.
+
+* `client_secret_setting_name` - The app setting name containing the OAuth 2.0 client secret that was created for the app used for authentication.
+
+* `allowed_audiences` - The list of Allowed Audiences that are be requested as part of Microsoft Sign-In authentication.
+
+* `login_scopes` - The list of Login scopes that are requested as part of Microsoft Account authentication.
+
+---
+
+A `twitter_v2` block supports the following:
+
+* `consumer_key` - The OAuth 1.0a consumer key of the Twitter application used for sign-in.
+
+* `consumer_secret_setting_name` - The app setting name that contains the OAuth 1.0a consumer secret of the Twitter application used for sign-in.
+
+---
+
+A `login` block supports the following:
+
+* `logout_endpoint` - The endpoint to which logout requests are made.
+
+* `token_store_enabled` - Is the Token Store configuration Enabled.
+
+* `token_refresh_extension_time` - The number of hours after session token expiration that a session token can be used to call the token refresh API.
+
+* `token_store_path` - The directory path in the App Filesystem in which the tokens are stored.
+
+* `token_store_sas_setting_name` - The name of the app setting which contains the SAS URL of the blob storage containing the tokens.
+
+* `preserve_url_fragments_for_logins` - Are the fragments from the request preserved after the login request is made.
+
+* `allowed_external_redirect_urls` - External URLs that can be redirected to as part of logging in or logging out of the app.
+
+* `cookie_expiration_convention` - The method by which cookies expire.
+
+* `cookie_expiration_time` - The time after the request is made when the session cookie should expire.
+
+* `validate_nonce` - Is the nonce validated while completing the login flow.
+
+* `nonce_expiration_time` - The time after the request is made when the nonce should expire.
 
 ---
 

--- a/website/docs/r/linux_web_app.html.markdown
+++ b/website/docs/r/linux_web_app.html.markdown
@@ -63,6 +63,8 @@ The following arguments are supported:
 
 * `auth_settings` - (Optional) A `auth_settings` block as defined below.
 
+* `auth_settings_v2` - (Optional) An `auth_settings_v2` block as defined below.
+
 * `backup` - (Optional) A `backup` block as defined below.
 
 * `client_affinity_enabled` - (Optional) Should Client Affinity be enabled?
@@ -202,6 +204,230 @@ An `auth_settings` block supports the following:
 * `twitter` - (Optional) A `twitter` block as defined below.
 
 * `unauthenticated_client_action` - (Optional) The action to take when an unauthenticated client attempts to access the app. Possible values include: `RedirectToLoginPage`, `AllowAnonymous`.
+
+---
+
+An `auth_settings_v2` block supports the following:
+
+* `auth_enabled` - (Optional) Should the AuthV2 Settings be enabled. Defaults to `false`.
+
+* `runtime_version` - (Optional) The Runtime Version of the Authentication and Authorisation feature of this App. Defaults to `~1`.
+
+* `config_file_path` - (Optional) The path to the App Auth settings. 
+
+* ~> **Note:** Relative Paths are evaluated from the Site Root directory.
+
+* `require_authentication` - (Optional) Should the authentication flow be used for all requests.
+
+* `unauthenticated_action` - (Optional) The action to take for requests made without authentication. Possible values include `RedirectToLoginPage`, `AllowAnonymous`, `Return401`, and `Return403`. Defaults to `RedirectToLoginPage`.
+
+* `default_provider` - (Optional) The Default Authentication Provider to use when more than one Authentication Provider is configured and the `unauthenticated_action` is set to `RedirectToLoginPage`.
+
+* `excluded_paths` - (Optional) The paths which should be excluded from the `unauthenticated_action` when it is set to `RedirectToLoginPage`.
+
+* `require_https` - (Optional) Should HTTPS be required on connections? Defaults to `true`.
+
+* `http_route_api_prefix` - (Optional) The prefix that should precede all the authentication and authorisation paths. Defaults to `/.auth`.
+
+* `forward_proxy_convention` - (Optional) The convention used to determine the url of the request made. Possible values include `ForwardProxyConventionNoProxy`, `ForwardProxyConventionStandard`, `ForwardProxyConventionCustom`. Defaults to `ForwardProxyConventionNoProxy`.
+
+* `forward_proxy_custom_host_header_name` - (Optional) The name of the custom header containing the host of the request.
+
+* `forward_proxy_custom_scheme_header_name` - (Optional) The name of the custom header containing the scheme of the request.
+
+* `apple_v2` - (Optional) An `apple_v2` block as defined below.
+
+* `active_directory_v2` - (Optional) An `active_directory_v2` block as defined below.
+
+* `azure_static_web_app_v2` - (Optional) An `azure_static_web_app_v2` block as defined below.
+
+* `custom_oidc_v2` - (Optional) Zero or more `custom_oidc_v2` blocks as defined below.
+
+* `facebook_v2` - (Optional) A `facebook_v2` block as defined below.
+
+* `github_v2` - (Optional) A `github_v2` block as defined below.
+
+* `google_v2` - (Optional) A `google_v2` block as defined below.
+
+* `microsoft_v2` - (Optional) A `microsoft_v2` block as defined below.
+
+* `twitter_v2` - (Optional) A `twitter_v2` block as defined below.
+
+* `login` - (Optional) A `login` block as defined below.
+
+---
+
+An `apple_v2` block supports the following:
+
+* `client_id` - (Required) The OpenID Connect Client ID for the Apple web application.
+
+* `client_secret_setting_name` - (Required) The app setting name that contains the `client_secret` value used for Apple Login.
+
+!> **NOTE:** A setting with this name must exist in `app_settings` to function correctly.
+
+* `login_scopes` - A list of Login Scopes provided by this Authentication Provider.
+
+~> **NOTE:** This is configured on the Authentication Provider side and is Read Only here.
+
+---
+
+An `active_directory_v2` block supports the following:
+
+* `client_id` - (Required) The ID of the Client to use to authenticate with Azure Active Directory.
+
+* `tenant_auth_endpoint` - (Required) The Azure Tenant Endpoint for the Authenticating Tenant. e.g. `https://login.microsoftonline.com/v2.0/{tenant-guid}/`
+
+* `client_secret_setting_name` - (Optional) The App Setting name that contains the client secret of the Client.
+
+!> **NOTE:** A setting with this name must exist in `app_settings` to function correctly.
+
+* `client_secret_certificate_thumbprint` - (Optional) The thumbprint of the certificate used for signing purposes.
+
+~> **NOTE:** One of `client_secret_setting_name` or `client_secret_certificate_thumbprint` must be specified.
+
+* `jwt_allowed_groups` - (Optional) A list of Allowed Groups in the JWT Claim.
+
+* `jwt_allowed_client_applications` - (Optional) A list of Allowed Client Applications in the JWT Claim.
+
+* `www_authentication_disabled` - (Optional) Should the www-authenticate provider should be omitted from the request? Defaults to `false`
+
+* `allowed_groups` - (Optional) The list of allowed Group Names for the Default Authorisation Policy.
+
+* `allowed_identities` - (Optional) The list of allowed Identities for the Default Authorisation Policy.
+
+* `allowed_applications` - (Optional) The list of allowed Applications for the Default Authorisation Policy.
+
+* `login_parameters` - (Optional) A map of key-value pairs to send to the Authorisation Endpoint when a user logs in.
+
+* `allowed_audiences` - (Optional) Specifies a list of Allowed audience values to consider when validating JWTs issued by Azure Active Directory.
+
+~> **NOTE:** This is configured on the Authentication Provider side and is Read Only here.
+
+---
+
+An `azure_static_web_app_v2` block supports the following:
+
+* `client_id` - (Required) The ID of the Client to use to authenticate with Azure Static Web App Authentication.
+
+---
+
+A `custom_oidc_v2` block supports the following:
+
+* `name` - (Required) The name of the Custom OIDC Authentication Provider.
+
+~> **NOTE:** An `app_setting` matching this value in upper case with the suffix of `_PROVIDER_AUTHENTICATION_SECRET` is required. e.g. `MYOIDC_PROVIDER_AUTHENTICATION_SECRET` for a value of `myoidc`.
+
+* `client_id` - (Required) The ID of the Client to use to authenticate with the Custom OIDC.
+
+* `openid_configuration_endpoint` - (Required) The app setting name that contains the `client_secret` value used for the Custom OIDC Login.
+
+* `name_claim_type` - (Optional) The name of the claim that contains the users name.
+
+* `scopes` - (Optional) The list of the scopes that should be requested while authenticating.
+
+* `client_credential_method` - The Client Credential Method used.
+
+* `client_secret_setting_name` - The App Setting name that contains the secret for this Custom OIDC Client. This is generated from `name` above and suffixed with `_PROVIDER_AUTHENTICATION_SECRET`.
+
+* `authorisation_endpoint` - The endpoint to make the Authorisation Request as supplied by `openid_configuration_endpoint` response.
+
+* `token_endpoint` - The endpoint used to request a Token as supplied by `openid_configuration_endpoint` response.
+
+* `issuer_endpoint` - The endpoint that issued the Token as supplied by `openid_configuration_endpoint` response.
+
+* `certification_uri` - The endpoint that provides the keys necessary to validate the token as supplied by `openid_configuration_endpoint` response.
+
+---
+
+A `facebook_v2` block supports the following:
+
+* `app_id` - (Required) The App ID of the Facebook app used for login.
+
+* `app_secret_setting_name` - (Required) The app setting name that contains the `app_secret` value used for Facebook Login.
+
+!> **NOTE:** A setting with this name must exist in `app_settings` to function correctly.
+
+* `graph_api_version` - (Optional) The version of the Facebook API to be used while logging in.
+
+* `login_scopes` - (Optional) The list of scopes that should be requested as part of Facebook Login authentication.
+
+---
+
+A `github_v2` block supports the following:
+
+* `client_id` - (Required) The ID of the GitHub app used for login..
+
+* `client_secret_setting_name` - (Required) The app setting name that contains the `client_secret` value used for GitHub Login.
+
+!> **NOTE:** A setting with this name must exist in `app_settings` to function correctly.
+
+* `login_scopes` - (Optional) The list of OAuth 2.0 scopes that should be requested as part of GitHub Login authentication.
+
+---
+
+A `google_v2` block supports the following:
+
+* `client_id` - (Required) The OpenID Connect Client ID for the Google web application.
+
+* `client_secret_setting_name` - (Required) The app setting name that contains the `client_secret` value used for Google Login.
+
+!> **NOTE:** A setting with this name must exist in `app_settings` to function correctly.
+
+* `allowed_audiences` - (Optional) Specifies a list of Allowed Audiences that should be requested as part of Google Sign-In authentication.
+
+* `login_scopes` - (Optional) The list of OAuth 2.0 scopes that should be requested as part of Google Sign-In authentication.
+
+---
+
+A `microsoft_v2` block supports the following:
+
+* `client_id` - (Required) The OAuth 2.0 client ID that was created for the app used for authentication.
+
+* `client_secret_setting_name` - (Required) The app setting name containing the OAuth 2.0 client secret that was created for the app used for authentication.
+
+!> **NOTE:** A setting with this name must exist in `app_settings` to function correctly.
+
+* `allowed_audiences` - (Optional) Specifies a list of Allowed Audiences that will be requested as part of Microsoft Sign-In authentication.
+
+* `login_scopes` - (Optional) The list of Login scopes that should be requested as part of Microsoft Account authentication.
+
+---
+
+A `twitter_v2` block supports the following:
+
+* `consumer_key` - (Required) The OAuth 1.0a consumer key of the Twitter application used for sign-in.
+
+* `consumer_secret_setting_name` - (Required) The app setting name that contains the OAuth 1.0a consumer secret of the Twitter application used for sign-in.
+
+!> **NOTE:** A setting with this name must exist in `app_settings` to function correctly.
+
+---
+
+A `login` block supports the following:
+
+* `logout_endpoint` - (Optional) The endpoint to which logout requests should be made.
+
+* `token_store_enabled` - (Optional) Should the Token Store configuration Enabled. Defaults to `false`
+
+* `token_refresh_extension_time` - (Optional) The number of hours after session token expiration that a session token can be used to call the token refresh API. Defaults to `72` hours.
+
+* `token_store_path` - (Optional) The directory path in the App Filesystem in which the tokens will be stored.
+
+* `token_store_sas_setting_name` - (Optional) The name of the app setting which contains the SAS URL of the blob storage containing the tokens.
+
+* `preserve_url_fragments_for_logins` - (Optional) Should the fragments from the request be preserved after the login request is made. Defaults to `false`.
+
+* `allowed_external_redirect_urls` - (Optional) External URLs that can be redirected to as part of logging in or logging out of the app. This is an advanced setting typically only needed by Windows Store application backends. 
+
+~> **Note:** URLs within the current domain are always implicitly allowed.
+
+* `cookie_expiration_convention` - (Optional) The method by which cookies expire. Possible values include: `FixedTime`, and `IdentityProviderDerived`. Defaults to `FixedTime`.
+
+* `cookie_expiration_time` - (Optional) The time after the request is made when the session cookie should expire. Defaults to `08:00:00`.
+
+* `validate_nonce` - (Optional) Should the nonce be validated while completing the login flow. Defaults to `true`.
+
+* `nonce_expiration_time` - (Optional) The time after the request is made when the nonce should expire. Defaults to `00:05:00`.
 
 ---
 

--- a/website/docs/r/linux_web_app_slot.html.markdown
+++ b/website/docs/r/linux_web_app_slot.html.markdown
@@ -64,7 +64,9 @@ The following arguments are supported:
 
 * `app_settings` - (Optional) A map of key-value pairs of App Settings.
 
-* `auth_settings` - (Optional) A `auth_settings` block as defined below.
+* `auth_settings` - (Optional) An `auth_settings` block as defined below.
+
+* `auth_settings_v2` - (Optional) An `auth_settings_v2` block as defined below.
 
 * `backup` - (Optional) A `backup` block as defined below.
 
@@ -205,6 +207,230 @@ An `auth_settings` block supports the following:
 * `twitter` - (Optional) A `twitter` block as defined below.
 
 * `unauthenticated_client_action` - (Optional) The action to take when an unauthenticated client attempts to access the app. Possible values include: `RedirectToLoginPage`, `AllowAnonymous`.
+
+---
+
+An `auth_settings_v2` block supports the following:
+
+* `auth_enabled` - (Optional) Should the AuthV2 Settings be enabled. Defaults to `false`.
+
+* `runtime_version` - (Optional) The Runtime Version of the Authentication and Authorisation feature of this App. Defaults to `~1`.
+
+* `config_file_path` - (Optional) The path to the App Auth settings.
+
+* ~> **Note:** Relative Paths are evaluated from the Site Root directory.
+
+* `require_authentication` - (Optional) Should the authentication flow be used for all requests.
+
+* `unauthenticated_action` - (Optional) The action to take for requests made without authentication. Possible values include `RedirectToLoginPage`, `AllowAnonymous`, `Return401`, and `Return403`. Defaults to `RedirectToLoginPage`.
+
+* `default_provider` - (Optional) The Default Authentication Provider to use when more than one Authentication Provider is configured and the `unauthenticated_action` is set to `RedirectToLoginPage`.
+
+* `excluded_paths` - (Optional) The paths which should be excluded from the `unauthenticated_action` when it is set to `RedirectToLoginPage`.
+
+* `require_https` - (Optional) Should HTTPS be required on connections? Defaults to `true`.
+
+* `http_route_api_prefix` - (Optional) The prefix that should precede all the authentication and authorisation paths. Defaults to `/.auth`.
+
+* `forward_proxy_convention` - (Optional) The convention used to determine the url of the request made. Possible values include `ForwardProxyConventionNoProxy`, `ForwardProxyConventionStandard`, `ForwardProxyConventionCustom`. Defaults to `ForwardProxyConventionNoProxy`.
+
+* `forward_proxy_custom_host_header_name` - (Optional) The name of the custom header containing the host of the request.
+
+* `forward_proxy_custom_scheme_header_name` - (Optional) The name of the custom header containing the scheme of the request.
+
+* `apple_v2` - (Optional) An `apple_v2` block as defined below.
+
+* `active_directory_v2` - (Optional) An `active_directory_v2` block as defined below.
+
+* `azure_static_web_app_v2` - (Optional) An `azure_static_web_app_v2` block as defined below.
+
+* `custom_oidc_v2` - (Optional) Zero or more `custom_oidc_v2` blocks as defined below.
+
+* `facebook_v2` - (Optional) A `facebook_v2` block as defined below.
+
+* `github_v2` - (Optional) A `github_v2` block as defined below.
+
+* `google_v2` - (Optional) A `google_v2` block as defined below.
+
+* `microsoft_v2` - (Optional) A `microsoft_v2` block as defined below.
+
+* `twitter_v2` - (Optional) A `twitter_v2` block as defined below.
+
+* `login` - (Optional) A `login` block as defined below.
+
+---
+
+An `apple_v2` block supports the following:
+
+* `client_id` - (Required) The OpenID Connect Client ID for the Apple web application.
+
+* `client_secret_setting_name` - (Required) The app setting name that contains the `client_secret` value used for Apple Login.
+
+!> **NOTE:** A setting with this name must exist in `app_settings` to function correctly.
+
+* `login_scopes` - A list of Login Scopes provided by this Authentication Provider.
+
+~> **NOTE:** This is configured on the Authentication Provider side and is Read Only here.
+
+---
+
+An `active_directory_v2` block supports the following:
+
+* `client_id` - (Required) The ID of the Client to use to authenticate with Azure Active Directory.
+
+* `tenant_auth_endpoint` - (Required) The Azure Tenant Endpoint for the Authenticating Tenant. e.g. `https://login.microsoftonline.com/v2.0/{tenant-guid}/`
+
+* `client_secret_setting_name` - (Optional) The App Setting name that contains the client secret of the Client.
+
+!> **NOTE:** A setting with this name must exist in `app_settings` to function correctly.
+
+* `client_secret_certificate_thumbprint` - (Optional) The thumbprint of the certificate used for signing purposes.
+
+~> **NOTE:** One of `client_secret_setting_name` or `client_secret_certificate_thumbprint` must be specified.
+
+* `jwt_allowed_groups` - (Optional) A list of Allowed Groups in the JWT Claim.
+
+* `jwt_allowed_client_applications` - (Optional) A list of Allowed Client Applications in the JWT Claim.
+
+* `www_authentication_disabled` - (Optional) Should the www-authenticate provider should be omitted from the request? Defaults to `false`
+
+* `allowed_groups` - (Optional) The list of allowed Group Names for the Default Authorisation Policy.
+
+* `allowed_identities` - (Optional) The list of allowed Identities for the Default Authorisation Policy.
+
+* `allowed_applications` - (Optional) The list of allowed Applications for the Default Authorisation Policy.
+
+* `login_parameters` - (Optional) A map of key-value pairs to send to the Authorisation Endpoint when a user logs in.
+
+* `allowed_audiences` - (Optional) Specifies a list of Allowed audience values to consider when validating JWTs issued by Azure Active Directory.
+
+~> **NOTE:** This is configured on the Authentication Provider side and is Read Only here.
+
+---
+
+An `azure_static_web_app_v2` block supports the following:
+
+* `client_id` - (Required) The ID of the Client to use to authenticate with Azure Static Web App Authentication.
+
+---
+
+A `custom_oidc_v2` block supports the following:
+
+* `name` - (Required) The name of the Custom OIDC Authentication Provider.
+
+~> **NOTE:** An `app_setting` matching this value in upper case with the suffix of `_PROVIDER_AUTHENTICATION_SECRET` is required. e.g. `MYOIDC_PROVIDER_AUTHENTICATION_SECRET` for a value of `myoidc`.
+
+* `client_id` - (Required) The ID of the Client to use to authenticate with the Custom OIDC.
+
+* `openid_configuration_endpoint` - (Required)The app setting name that contains the `client_secret` value used for the Custom OIDC Login.
+
+* `name_claim_type` - (Optional) The name of the claim that contains the users name.
+
+* `scopes` - (Optional) The list of the scopes that should be requested while authenticating.
+
+* `client_credential_method` - The Client Credential Method used.
+
+* `client_secret_setting_name` - The App Setting name that contains the secret for this Custom OIDC Client. This is generated from `name` above and suffixed with `_PROVIDER_AUTHENTICATION_SECRET`.
+
+* `authorisation_endpoint` - The endpoint to make the Authorisation Request as supplied by `openid_configuration_endpoint` response.
+
+* `token_endpoint` - The endpoint used to request a Token as supplied by `openid_configuration_endpoint` response.
+
+* `issuer_endpoint` - The endpoint that issued the Token as supplied by `openid_configuration_endpoint` response.
+
+* `certification_uri` - The endpoint that provides the keys necessary to validate the token as supplied by `openid_configuration_endpoint` response.
+
+---
+
+A `facebook_v2` block supports the following:
+
+* `app_id` - (Required) The App ID of the Facebook app used for login.
+
+* `app_secret_setting_name` - (Required) The app setting name that contains the `app_secret` value used for Facebook Login.
+
+!> **NOTE:** A setting with this name must exist in `app_settings` to function correctly.
+
+* `graph_api_version` - (Optional) The version of the Facebook API to be used while logging in.
+
+* `login_scopes` - (Optional) The list of scopes that should be requested as part of Facebook Login authentication.
+
+---
+
+A `github_v2` block supports the following:
+
+* `client_id` - (Required) The ID of the GitHub app used for login..
+
+* `client_secret_setting_name` - (Required) The app setting name that contains the `client_secret` value used for GitHub Login.
+
+!> **NOTE:** A setting with this name must exist in `app_settings` to function correctly.
+
+* `login_scopes` - (Optional) The list of OAuth 2.0 scopes that should be requested as part of GitHub Login authentication.
+
+---
+
+A `google_v2` block supports the following:
+
+* `client_id` - (Required) The OpenID Connect Client ID for the Google web application.
+
+* `client_secret_setting_name` - (Required) The app setting name that contains the `client_secret` value used for Google Login.
+
+!> **NOTE:** A setting with this name must exist in `app_settings` to function correctly.
+
+* `allowed_audiences` - (Optional) Specifies a list of Allowed Audiences that should be requested as part of Google Sign-In authentication.
+
+* `login_scopes` - (Optional) The list of OAuth 2.0 scopes that should be requested as part of Google Sign-In authentication.
+
+---
+
+A `microsoft_v2` block supports the following:
+
+* `client_id` - (Required) The OAuth 2.0 client ID that was created for the app used for authentication.
+
+* `client_secret_setting_name` - (Required) The app setting name containing the OAuth 2.0 client secret that was created for the app used for authentication.
+
+!> **NOTE:** A setting with this name must exist in `app_settings` to function correctly.
+
+* `allowed_audiences` - (Optional) Specifies a list of Allowed Audiences that will be requested as part of Microsoft Sign-In authentication.
+
+* `login_scopes` - (Optional) The list of Login scopes that should be requested as part of Microsoft Account authentication.
+
+---
+
+A `twitter_v2` block supports the following:
+
+* `consumer_key` - (Required) The OAuth 1.0a consumer key of the Twitter application used for sign-in.
+
+* `consumer_secret_setting_name` - (Required) The app setting name that contains the OAuth 1.0a consumer secret of the Twitter application used for sign-in.
+
+!> **NOTE:** A setting with this name must exist in `app_settings` to function correctly.
+
+---
+
+A `login` block supports the following:
+
+* `logout_endpoint` - (Optional) The endpoint to which logout requests should be made.
+
+* `token_store_enabled` - (Optional) Should the Token Store configuration Enabled. Defaults to `false`
+
+* `token_refresh_extension_time` - (Optional) The number of hours after session token expiration that a session token can be used to call the token refresh API. Defaults to `72` hours.
+
+* `token_store_path` - (Optional) The directory path in the App Filesystem in which the tokens will be stored.
+
+* `token_store_sas_setting_name` - (Optional) The name of the app setting which contains the SAS URL of the blob storage containing the tokens.
+
+* `preserve_url_fragments_for_logins` - (Optional) Should the fragments from the request be preserved after the login request is made. Defaults to `false`.
+
+* `allowed_external_redirect_urls` - (Optional) External URLs that can be redirected to as part of logging in or logging out of the app. This is an advanced setting typically only needed by Windows Store application backends.
+
+~> **Note:** URLs within the current domain are always implicitly allowed.
+
+* `cookie_expiration_convention` - (Optional) The method by which cookies expire. Possible values include: `FixedTime`, and `IdentityProviderDerived`. Defaults to `FixedTime`.
+
+* `cookie_expiration_time` - (Optional) The time after the request is made when the session cookie should expire. Defaults to `08:00:00`.
+
+* `validate_nonce` - (Optional) Should the nonce be validated while completing the login flow. Defaults to `true`.
+
+* `nonce_expiration_time` - (Optional) The time after the request is made when the nonce should expire. Defaults to `00:05:00`.
 
 ---
 

--- a/website/docs/r/windows_web_app.html.markdown
+++ b/website/docs/r/windows_web_app.html.markdown
@@ -60,6 +60,8 @@ The following arguments are supported:
 
 * `auth_settings` - (Optional) An `auth_settings` block as defined below.
 
+* `auth_settings_v2` - (Optional) An `auth_settings_v2` block as defined below.
+
 * `backup` - (Optional) A `backup` block as defined below.
 
 * `client_affinity_enabled` - (Optional) Should Client Affinity be enabled?
@@ -213,6 +215,230 @@ A `auth_settings` block supports the following:
 * `twitter` - (Optional) A `twitter` block as defined below.
 
 * `unauthenticated_client_action` - (Optional) The action to take when an unauthenticated client attempts to access the app. Possible values include: `RedirectToLoginPage`, `AllowAnonymous`.
+
+---
+
+An `auth_settings_v2` block supports the following:
+
+* `auth_enabled` - (Optional) Should the AuthV2 Settings be enabled. Defaults to `false`.
+
+* `runtime_version` - (Optional) The Runtime Version of the Authentication and Authorisation feature of this App. Defaults to `~1`.
+
+* `config_file_path` - (Optional) The path to the App Auth settings.
+
+* ~> **Note:** Relative Paths are evaluated from the Site Root directory.
+
+* `require_authentication` - (Optional) Should the authentication flow be used for all requests.
+
+* `unauthenticated_action` - (Optional) The action to take for requests made without authentication. Possible values include `RedirectToLoginPage`, `AllowAnonymous`, `Return401`, and `Return403`. Defaults to `RedirectToLoginPage`.
+
+* `default_provider` - (Optional) The Default Authentication Provider to use when more than one Authentication Provider is configured and the `unauthenticated_action` is set to `RedirectToLoginPage`.
+
+* `excluded_paths` - (Optional) The paths which should be excluded from the `unauthenticated_action` when it is set to `RedirectToLoginPage`.
+
+* `require_https` - (Optional) Should HTTPS be required on connections? Defaults to `true`.
+
+* `http_route_api_prefix` - (Optional) The prefix that should precede all the authentication and authorisation paths. Defaults to `/.auth`.
+
+* `forward_proxy_convention` - (Optional) The convention used to determine the url of the request made. Possible values include `ForwardProxyConventionNoProxy`, `ForwardProxyConventionStandard`, `ForwardProxyConventionCustom`. Defaults to `ForwardProxyConventionNoProxy`.
+
+* `forward_proxy_custom_host_header_name` - (Optional) The name of the custom header containing the host of the request.
+
+* `forward_proxy_custom_scheme_header_name` - (Optional) The name of the custom header containing the scheme of the request.
+
+* `apple_v2` - (Optional) An `apple_v2` block as defined below.
+
+* `active_directory_v2` - (Optional) An `active_directory_v2` block as defined below.
+
+* `azure_static_web_app_v2` - (Optional) An `azure_static_web_app_v2` block as defined below.
+
+* `custom_oidc_v2` - (Optional) Zero or more `custom_oidc_v2` blocks as defined below.
+
+* `facebook_v2` - (Optional) A `facebook_v2` block as defined below.
+
+* `github_v2` - (Optional) A `github_v2` block as defined below.
+
+* `google_v2` - (Optional) A `google_v2` block as defined below.
+
+* `microsoft_v2` - (Optional) A `microsoft_v2` block as defined below.
+
+* `twitter_v2` - (Optional) A `twitter_v2` block as defined below.
+
+* `login` - (Optional) A `login` block as defined below.
+
+---
+
+An `apple_v2` block supports the following:
+
+* `client_id` - (Required) The OpenID Connect Client ID for the Apple web application.
+
+* `client_secret_setting_name` - (Required) The app setting name that contains the `client_secret` value used for Apple Login.
+
+!> **NOTE:** A setting with this name must exist in `app_settings` to function correctly.
+
+* `login_scopes` - A list of Login Scopes provided by this Authentication Provider.
+
+~> **NOTE:** This is configured on the Authentication Provider side and is Read Only here.
+
+---
+
+An `active_directory_v2` block supports the following:
+
+* `client_id` - (Required) The ID of the Client to use to authenticate with Azure Active Directory.
+
+* `tenant_auth_endpoint` - (Required) The Azure Tenant Endpoint for the Authenticating Tenant. e.g. `https://login.microsoftonline.com/v2.0/{tenant-guid}/`
+
+* `client_secret_setting_name` - (Optional) The App Setting name that contains the client secret of the Client.
+
+!> **NOTE:** A setting with this name must exist in `app_settings` to function correctly.
+
+* `client_secret_certificate_thumbprint` - (Optional) The thumbprint of the certificate used for signing purposes.
+
+~> **NOTE:** One of `client_secret_setting_name` or `client_secret_certificate_thumbprint` must be specified.
+
+* `jwt_allowed_groups` - (Optional) A list of Allowed Groups in the JWT Claim.
+
+* `jwt_allowed_client_applications` - (Optional) A list of Allowed Client Applications in the JWT Claim.
+
+* `www_authentication_disabled` - (Optional) Should the www-authenticate provider should be omitted from the request? Defaults to `false`
+
+* `allowed_groups` - (Optional) The list of allowed Group Names for the Default Authorisation Policy.
+
+* `allowed_identities` - (Optional) The list of allowed Identities for the Default Authorisation Policy.
+
+* `allowed_applications` - (Optional) The list of allowed Applications for the Default Authorisation Policy.
+
+* `login_parameters` - (Optional) A map of key-value pairs to send to the Authorisation Endpoint when a user logs in.
+
+* `allowed_audiences` - (Optional) Specifies a list of Allowed audience values to consider when validating JWTs issued by Azure Active Directory.
+
+~> **NOTE:** This is configured on the Authentication Provider side and is Read Only here.
+
+---
+
+An `azure_static_web_app_v2` block supports the following:
+
+* `client_id` - (Required) The ID of the Client to use to authenticate with Azure Static Web App Authentication.
+
+---
+
+A `custom_oidc_v2` block supports the following:
+
+* `name` - (Required) The name of the Custom OIDC Authentication Provider.
+
+~> **NOTE:** An `app_setting` matching this value in upper case with the suffix of `_PROVIDER_AUTHENTICATION_SECRET` is required. e.g. `MYOIDC_PROVIDER_AUTHENTICATION_SECRET` for a value of `myoidc`.
+
+* `client_id` - (Required) The ID of the Client to use to authenticate with the Custom OIDC.
+
+* `openid_configuration_endpoint` - (Required) The app setting name that contains the `client_secret` value used for the Custom OIDC Login.
+
+* `name_claim_type` - (Optional) The name of the claim that contains the users name.
+
+* `scopes` - (Optional) The list of the scopes that should be requested while authenticating.
+
+* `client_credential_method` - The Client Credential Method used.
+
+* `client_secret_setting_name` - The App Setting name that contains the secret for this Custom OIDC Client. This is generated from `name` above and suffixed with `_PROVIDER_AUTHENTICATION_SECRET`.
+
+* `authorisation_endpoint` - The endpoint to make the Authorisation Request as supplied by `openid_configuration_endpoint` response.
+
+* `token_endpoint` - The endpoint used to request a Token as supplied by `openid_configuration_endpoint` response.
+
+* `issuer_endpoint` - The endpoint that issued the Token as supplied by `openid_configuration_endpoint` response.
+
+* `certification_uri` - The endpoint that provides the keys necessary to validate the token as supplied by `openid_configuration_endpoint` response.
+
+---
+
+A `facebook_v2` block supports the following:
+
+* `app_id` - (Required) The App ID of the Facebook app used for login.
+
+* `app_secret_setting_name` - (Required) The app setting name that contains the `app_secret` value used for Facebook Login.
+
+!> **NOTE:** A setting with this name must exist in `app_settings` to function correctly.
+
+* `graph_api_version` - (Optional) The version of the Facebook API to be used while logging in.
+
+* `login_scopes` - (Optional) The list of scopes that should be requested as part of Facebook Login authentication.
+
+---
+
+A `github_v2` block supports the following:
+
+* `client_id` - (Required) The ID of the GitHub app used for login..
+
+* `client_secret_setting_name` - (Required) The app setting name that contains the `client_secret` value used for GitHub Login.
+
+!> **NOTE:** A setting with this name must exist in `app_settings` to function correctly.
+
+* `login_scopes` - (Optional) The list of OAuth 2.0 scopes that should be requested as part of GitHub Login authentication.
+
+---
+
+A `google_v2` block supports the following:
+
+* `client_id` - (Required) The OpenID Connect Client ID for the Google web application.
+
+* `client_secret_setting_name` - (Required) The app setting name that contains the `client_secret` value used for Google Login.
+
+!> **NOTE:** A setting with this name must exist in `app_settings` to function correctly.
+
+* `allowed_audiences` - (Optional) Specifies a list of Allowed Audiences that should be requested as part of Google Sign-In authentication.
+
+* `login_scopes` - (Optional) The list of OAuth 2.0 scopes that should be requested as part of Google Sign-In authentication.
+
+---
+
+A `microsoft_v2` block supports the following:
+
+* `client_id` - (Required) The OAuth 2.0 client ID that was created for the app used for authentication.
+
+* `client_secret_setting_name` - (Required) The app setting name containing the OAuth 2.0 client secret that was created for the app used for authentication.
+
+!> **NOTE:** A setting with this name must exist in `app_settings` to function correctly.
+
+* `allowed_audiences` - (Optional) Specifies a list of Allowed Audiences that will be requested as part of Microsoft Sign-In authentication.
+
+* `login_scopes` - (Optional) The list of Login scopes that should be requested as part of Microsoft Account authentication.
+
+---
+
+A `twitter_v2` block supports the following:
+
+* `consumer_key` - (Required) The OAuth 1.0a consumer key of the Twitter application used for sign-in.
+
+* `consumer_secret_setting_name` - (Required) The app setting name that contains the OAuth 1.0a consumer secret of the Twitter application used for sign-in.
+
+!> **NOTE:** A setting with this name must exist in `app_settings` to function correctly.
+
+---
+
+A `login` block supports the following:
+
+* `logout_endpoint` - (Optional) The endpoint to which logout requests should be made.
+
+* `token_store_enabled` - (Optional) Should the Token Store configuration Enabled. Defaults to `false`
+
+* `token_refresh_extension_time` - (Optional) The number of hours after session token expiration that a session token can be used to call the token refresh API. Defaults to `72` hours.
+
+* `token_store_path` - (Optional) The directory path in the App Filesystem in which the tokens will be stored.
+
+* `token_store_sas_setting_name` - (Optional) The name of the app setting which contains the SAS URL of the blob storage containing the tokens.
+
+* `preserve_url_fragments_for_logins` - (Optional) Should the fragments from the request be preserved after the login request is made. Defaults to `false`.
+
+* `allowed_external_redirect_urls` - (Optional) External URLs that can be redirected to as part of logging in or logging out of the app. This is an advanced setting typically only needed by Windows Store application backends.
+
+~> **Note:** URLs within the current domain are always implicitly allowed.
+
+* `cookie_expiration_convention` - (Optional) The method by which cookies expire. Possible values include: `FixedTime`, and `IdentityProviderDerived`. Defaults to `FixedTime`.
+
+* `cookie_expiration_time` - (Optional) The time after the request is made when the session cookie should expire. Defaults to `08:00:00`.
+
+* `validate_nonce` - (Optional) Should the nonce be validated while completing the login flow. Defaults to `true`.
+
+* `nonce_expiration_time` - (Optional) The time after the request is made when the nonce should expire. Defaults to `00:05:00`.
 
 ---
 

--- a/website/docs/r/windows_web_app_slot.html.markdown
+++ b/website/docs/r/windows_web_app_slot.html.markdown
@@ -64,7 +64,9 @@ The following arguments are supported:
 
 * `app_settings` - (Optional) A map of key-value pairs of App Settings.
 
-* `auth_settings` - (Optional) A `auth_settings` block as defined below.
+* `auth_settings` - (Optional) An `auth_settings` block as defined below.
+
+* `auth_settings_v2` - (Optional) An `auth_settings_v2` block as defined below.
 
 * `backup` - (Optional) A `backup` block as defined below.
 
@@ -211,6 +213,230 @@ A `auth_settings` block supports the following:
 * `twitter` - (Optional) A `twitter` block as defined below.
 
 * `unauthenticated_client_action` - (Optional) The action to take when an unauthenticated client attempts to access the app. Possible values include: `RedirectToLoginPage`, `AllowAnonymous`.
+
+---
+
+An `auth_settings_v2` block supports the following:
+
+* `auth_enabled` - (Optional) Should the AuthV2 Settings be enabled. Defaults to `false`.
+
+* `runtime_version` - (Optional) The Runtime Version of the Authentication and Authorisation feature of this App. Defaults to `~1`.
+
+* `config_file_path` - (Optional) The path to the App Auth settings.
+
+* ~> **Note:** Relative Paths are evaluated from the Site Root directory.
+
+* `require_authentication` - (Optional) Should the authentication flow be used for all requests.
+
+* `unauthenticated_action` - (Optional) The action to take for requests made without authentication. Possible values include `RedirectToLoginPage`, `AllowAnonymous`, `Return401`, and `Return403`. Defaults to `RedirectToLoginPage`.
+
+* `default_provider` - (Optional) The Default Authentication Provider to use when more than one Authentication Provider is configured and the `unauthenticated_action` is set to `RedirectToLoginPage`.
+
+* `excluded_paths` - (Optional) The paths which should be excluded from the `unauthenticated_action` when it is set to `RedirectToLoginPage`.
+
+* `require_https` - (Optional) Should HTTPS be required on connections? Defaults to `true`.
+
+* `http_route_api_prefix` - (Optional) The prefix that should precede all the authentication and authorisation paths. Defaults to `/.auth`.
+
+* `forward_proxy_convention` - (Optional) The convention used to determine the url of the request made. Possible values include `ForwardProxyConventionNoProxy`, `ForwardProxyConventionStandard`, `ForwardProxyConventionCustom`. Defaults to `ForwardProxyConventionNoProxy`.
+
+* `forward_proxy_custom_host_header_name` - (Optional) The name of the custom header containing the host of the request.
+
+* `forward_proxy_custom_scheme_header_name` - (Optional) The name of the custom header containing the scheme of the request.
+
+* `apple_v2` - (Optional) An `apple_v2` block as defined below.
+
+* `active_directory_v2` - (Optional) An `active_directory_v2` block as defined below.
+
+* `azure_static_web_app_v2` - (Optional) An `azure_static_web_app_v2` block as defined below.
+
+* `custom_oidc_v2` - (Optional) Zero or more `custom_oidc_v2` blocks as defined below.
+
+* `facebook_v2` - (Optional) A `facebook_v2` block as defined below.
+
+* `github_v2` - (Optional) A `github_v2` block as defined below.
+
+* `google_v2` - (Optional) A `google_v2` block as defined below.
+
+* `microsoft_v2` - (Optional) A `microsoft_v2` block as defined below.
+
+* `twitter_v2` - (Optional) A `twitter_v2` block as defined below.
+
+* `login` - (Optional) A `login` block as defined below.
+
+---
+
+An `apple_v2` block supports the following:
+
+* `client_id` - (Required) The OpenID Connect Client ID for the Apple web application.
+
+* `client_secret_setting_name` - (Required) The app setting name that contains the `client_secret` value used for Apple Login.
+
+!> **NOTE:** A setting with this name must exist in `app_settings` to function correctly.
+
+* `login_scopes` - A list of Login Scopes provided by this Authentication Provider.
+
+~> **NOTE:** This is configured on the Authentication Provider side and is Read Only here.
+
+---
+
+An `active_directory_v2` block supports the following:
+
+* `client_id` - (Required) The ID of the Client to use to authenticate with Azure Active Directory.
+
+* `tenant_auth_endpoint` - (Required) The Azure Tenant Endpoint for the Authenticating Tenant. e.g. `https://login.microsoftonline.com/v2.0/{tenant-guid}/`
+
+* `client_secret_setting_name` - (Optional) The App Setting name that contains the client secret of the Client.
+
+!> **NOTE:** A setting with this name must exist in `app_settings` to function correctly.
+
+* `client_secret_certificate_thumbprint` - (Optional) The thumbprint of the certificate used for signing purposes.
+
+~> **NOTE:** One of `client_secret_setting_name` or `client_secret_certificate_thumbprint` must be specified.
+
+* `jwt_allowed_groups` - (Optional) A list of Allowed Groups in the JWT Claim.
+
+* `jwt_allowed_client_applications` - (Optional) A list of Allowed Client Applications in the JWT Claim.
+
+* `www_authentication_disabled` - (Optional) Should the www-authenticate provider should be omitted from the request? Defaults to `false`
+
+* `allowed_groups` - (Optional) The list of allowed Group Names for the Default Authorisation Policy.
+
+* `allowed_identities` - (Optional) The list of allowed Identities for the Default Authorisation Policy.
+
+* `allowed_applications` - (Optional) The list of allowed Applications for the Default Authorisation Policy.
+
+* `login_parameters` - (Optional) A map of key-value pairs to send to the Authorisation Endpoint when a user logs in.
+
+* `allowed_audiences` - (Optional) Specifies a list of Allowed audience values to consider when validating JWTs issued by Azure Active Directory.
+
+~> **NOTE:** This is configured on the Authentication Provider side and is Read Only here.
+
+---
+
+An `azure_static_web_app_v2` block supports the following:
+
+* `client_id` - (Required) The ID of the Client to use to authenticate with Azure Static Web App Authentication.
+
+---
+
+A `custom_oidc_v2` block supports the following:
+
+* `name` - (Required) The name of the Custom OIDC Authentication Provider.
+
+~> **NOTE:** An `app_setting` matching this value in upper case with the suffix of `_PROVIDER_AUTHENTICATION_SECRET` is required. e.g. `MYOIDC_PROVIDER_AUTHENTICATION_SECRET` for a value of `myoidc`.
+
+* `client_id` - (Required) The ID of the Client to use to authenticate with the Custom OIDC.
+
+* `openid_configuration_endpoint` - (Required) The app setting name that contains the `client_secret` value used for the Custom OIDC Login.
+
+* `name_claim_type` - (Optional) The name of the claim that contains the users name.
+
+* `scopes` - (Optional) The list of the scopes that should be requested while authenticating.
+
+* `client_credential_method` - The Client Credential Method used.
+
+* `client_secret_setting_name` - The App Setting name that contains the secret for this Custom OIDC Client. This is generated from `name` above and suffixed with `_PROVIDER_AUTHENTICATION_SECRET`.
+
+* `authorisation_endpoint` - The endpoint to make the Authorisation Request as supplied by `openid_configuration_endpoint` response.
+
+* `token_endpoint` - The endpoint used to request a Token as supplied by `openid_configuration_endpoint` response.
+
+* `issuer_endpoint` - The endpoint that issued the Token as supplied by `openid_configuration_endpoint` response.
+
+* `certification_uri` - The endpoint that provides the keys necessary to validate the token as supplied by `openid_configuration_endpoint` response.
+
+---
+
+A `facebook_v2` block supports the following:
+
+* `app_id` - (Required) The App ID of the Facebook app used for login.
+
+* `app_secret_setting_name` - (Required) The app setting name that contains the `app_secret` value used for Facebook Login.
+
+!> **NOTE:** A setting with this name must exist in `app_settings` to function correctly.
+
+* `graph_api_version` - (Optional) The version of the Facebook API to be used while logging in.
+
+* `login_scopes` - (Optional) The list of scopes that should be requested as part of Facebook Login authentication.
+
+---
+
+A `github_v2` block supports the following:
+
+* `client_id` - (Required) The ID of the GitHub app used for login..
+
+* `client_secret_setting_name` - (Required) The app setting name that contains the `client_secret` value used for GitHub Login.
+
+!> **NOTE:** A setting with this name must exist in `app_settings` to function correctly.
+
+* `login_scopes` - (Optional) The list of OAuth 2.0 scopes that should be requested as part of GitHub Login authentication.
+
+---
+
+A `google_v2` block supports the following:
+
+* `client_id` - (Required) The OpenID Connect Client ID for the Google web application.
+
+* `client_secret_setting_name` - (Required) The app setting name that contains the `client_secret` value used for Google Login.
+
+!> **NOTE:** A setting with this name must exist in `app_settings` to function correctly.
+
+* `allowed_audiences` - (Optional) Specifies a list of Allowed Audiences that should be requested as part of Google Sign-In authentication.
+
+* `login_scopes` - (Optional) The list of OAuth 2.0 scopes that should be requested as part of Google Sign-In authentication.
+
+---
+
+A `microsoft_v2` block supports the following:
+
+* `client_id` - (Required) The OAuth 2.0 client ID that was created for the app used for authentication.
+
+* `client_secret_setting_name` - (Required) The app setting name containing the OAuth 2.0 client secret that was created for the app used for authentication.
+
+!> **NOTE:** A setting with this name must exist in `app_settings` to function correctly.
+
+* `allowed_audiences` - (Optional) Specifies a list of Allowed Audiences that will be requested as part of Microsoft Sign-In authentication.
+
+* `login_scopes` - (Optional) The list of Login scopes that should be requested as part of Microsoft Account authentication.
+
+---
+
+A `twitter_v2` block supports the following:
+
+* `consumer_key` - (Required) The OAuth 1.0a consumer key of the Twitter application used for sign-in.
+
+* `consumer_secret_setting_name` - (Required) The app setting name that contains the OAuth 1.0a consumer secret of the Twitter application used for sign-in.
+
+!> **NOTE:** A setting with this name must exist in `app_settings` to function correctly.
+
+---
+
+A `login` block supports the following:
+
+* `logout_endpoint` - (Optional) The endpoint to which logout requests should be made.
+
+* `token_store_enabled` - (Optional) Should the Token Store configuration Enabled. Defaults to `false`
+
+* `token_refresh_extension_time` - (Optional) The number of hours after session token expiration that a session token can be used to call the token refresh API. Defaults to `72` hours.
+
+* `token_store_path` - (Optional) The directory path in the App Filesystem in which the tokens will be stored.
+
+* `token_store_sas_setting_name` - (Optional) The name of the app setting which contains the SAS URL of the blob storage containing the tokens.
+
+* `preserve_url_fragments_for_logins` - (Optional) Should the fragments from the request be preserved after the login request is made. Defaults to `false`.
+
+* `allowed_external_redirect_urls` - (Optional) External URLs that can be redirected to as part of logging in or logging out of the app. This is an advanced setting typically only needed by Windows Store application backends.
+
+* ~> **Note:** URLs within the current domain are always implicitly allowed.
+
+* `cookie_expiration_convention` - (Optional) The method by which cookies expire. Possible values include: `FixedTime`, and `IdentityProviderDerived`. Defaults to `FixedTime`.
+
+* `cookie_expiration_time` - (Optional) The time after the request is made when the session cookie should expire. Defaults to `08:00:00`.
+
+* `validate_nonce` - (Optional) Should the nonce be validated while completing the login flow. Defaults to `true`.
+
+* `nonce_expiration_time` - (Optional) The time after the request is made when the nonce should expire. Defaults to `00:05:00`.
 
 ---
 


### PR DESCRIPTION
* `azurerm_linux_web_app` - add support for AuthV2 (EasyAuthV2) `auth_settings_v2`
* `azurerm_linux_web_app_slot` - add support for AuthV2 (EasyAuthV2) `auth_settings_v2`
* `azurerm_windows_web_app` - add support for AuthV2 (EasyAuthV2) `auth_settings_v2`
* `azurerm_windows_web_app_slot` - add support for AuthV2 (EasyAuthV2) `auth_settings_v2`
* **Data Source:** `azurerm_linux_web_app` - add support for AuthV2 (EasyAuthV2) `auth_settings_v2`
* **Data Source:**`azurerm_windows_web_app` - add support for AuthV2 (EasyAuthV2) `auth_settings_v2`

Partially addresses #12928 (Function Apps to follow)