### PR TITLE
CI - increase parallelism for `containerapps` after quota increase

### DIFF
--- a/.teamcity/components/settings.kt
+++ b/.teamcity/components/settings.kt
@@ -53,8 +53,8 @@ var serviceTestConfigurationOverrides = mapOf(
         //Confidential Ledger
         "confidentialledger" to testConfiguration(locationOverride = LocationConfiguration("eastus","southcentralus","westeurope", false)),
 
-        // Container App Managed Environments are limited to 5 per location, using 3 as they can take some time to clear
-        "containerapps" to testConfiguration(parallelism = 3, locationOverride = LocationConfiguration("westeurope","eastus","canadacentral", false)),
+        // Container App Managed Environments are limited to 20 per location, using 10 as they can take some time to clear
+        "containerapps" to testConfiguration(parallelism = 10, locationOverride = LocationConfiguration("westeurope","eastus","canadacentral", false)),
 
         // The AKS API has a low rate limit
         "containers" to testConfiguration(parallelism = 5, locationOverride = LocationConfiguration("eastus","westeurope","eastus2", false), useDevTestSubscription = true),


### PR DESCRIPTION
Support request bumped to quota to 20 for us.