### PR TITLE
`azurerm_role_definition` - Add conversion check to avoid nil panic

### DIFF
--- a/internal/services/authorization/role_definition_resource.go
+++ b/internal/services/authorization/role_definition_resource.go
@@ -466,7 +466,9 @@ func expandRoleDefinitionAssignableScopes(d *pluginsdk.ResourceData) []string {
 		scopes = append(scopes, assignedScope)
 	} else {
 		for _, scope := range assignableScopes {
-			scopes = append(scopes, scope.(string))
+			if s, ok := scope.(string); ok {
+				scopes = append(scopes, s)
+			}
 		}
 	}
 


### PR DESCRIPTION
This pr added a conversion check to avoid potential nil panic, it should fix #20467.