### PR TITLE
`azurerm_recovery_services_vault` - new property `classic_vmware_replicate_enabled`

### DIFF
--- a/internal/services/recoveryservices/client/client.go
+++ b/internal/services/recoveryservices/client/client.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationvaultsetting"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/common"
 )
 
@@ -25,6 +26,7 @@ type Client struct {
 	BackupOperationStatusesClient             *backup.OperationStatusesClient
 	VaultsClient                              *vaults.VaultsClient
 	VaultsConfigsClient                       *backupresourcevaultconfigs.BackupResourceVaultConfigsClient
+	VaultsSettingsClient                      *replicationvaultsetting.ReplicationVaultSettingClient
 	StorageConfigsClient                      *backupresourcestorageconfigsnoncrr.BackupResourceStorageConfigsNonCRRClient
 	FabricClient                              *replicationfabrics.ReplicationFabricsClient
 	ProtectionContainerClient                 *replicationprotectioncontainers.ReplicationProtectionContainersClient
@@ -38,6 +40,9 @@ type Client struct {
 func NewClient(o *common.ClientOptions) *Client {
 	vaultConfigsClient := backupresourcevaultconfigs.NewBackupResourceVaultConfigsClientWithBaseURI(o.ResourceManagerEndpoint)
 	o.ConfigureClient(&vaultConfigsClient.Client, o.ResourceManagerAuthorizer)
+
+	vaultSettingsClient := replicationvaultsetting.NewReplicationVaultSettingClientWithBaseURI(o.ResourceManagerEndpoint)
+	o.ConfigureClient(&vaultSettingsClient.Client, o.ResourceManagerAuthorizer)
 
 	storageConfigsClient := backupresourcestorageconfigsnoncrr.NewBackupResourceStorageConfigsNonCRRClientWithBaseURI(o.ResourceManagerEndpoint)
 	o.ConfigureClient(&storageConfigsClient.Client, o.ResourceManagerAuthorizer)
@@ -97,6 +102,7 @@ func NewClient(o *common.ClientOptions) *Client {
 		BackupOperationStatusesClient:             &backupOperationStatusesClient,
 		VaultsClient:                              &vaultsClient,
 		VaultsConfigsClient:                       &vaultConfigsClient,
+		VaultsSettingsClient:                      &vaultSettingsClient,
 		StorageConfigsClient:                      &storageConfigsClient,
 		FabricClient:                              &fabricClient,
 		ProtectionContainerClient:                 &protectionContainerClient,

--- a/internal/services/recoveryservices/recovery_services_vault_resource.go
+++ b/internal/services/recoveryservices/recovery_services_vault_resource.go
@@ -142,10 +142,10 @@ func resourceRecoveryServicesVault() *pluginsdk.Resource {
 				Default:  true,
 			},
 
-			"classic_vmware_replicate_enabled": {
+			"classic_vmware_replication_enabled": {
 				Type:     pluginsdk.TypeBool,
 				Optional: true,
-				Default:  false,
+				Computed: true,
 				ForceNew: true,
 			},
 		},
@@ -333,7 +333,7 @@ func resourceRecoveryServicesVaultCreate(d *pluginsdk.ResourceData, meta interfa
 		return fmt.Errorf("waiting for on update for Recovery Service %s: %+v", id.String(), err)
 	}
 
-	if d.Get("classic_vmware_replicate_enabled").(bool) {
+	if d.Get("classic_vmware_replication_enabled").(bool) {
 		settingsId := replicationvaultsetting.NewReplicationVaultSettingID(id.SubscriptionId, id.ResourceGroupName, id.VaultName, "default")
 		settingsInput := replicationvaultsetting.VaultSettingCreationInput{
 			Properties: replicationvaultsetting.VaultSettingCreationInputProperties{
@@ -662,7 +662,7 @@ func resourceRecoveryServicesVaultRead(d *pluginsdk.ResourceData, meta interface
 	}
 	if vaultSetting.Model != nil && vaultSetting.Model.Properties != nil && vaultSetting.Model.Properties.VMwareToAzureProviderType != nil {
 		providerType := vaultSetting.Model.Properties.VMwareToAzureProviderType
-		d.Set("classic_vmware_replicate_enabled", strings.EqualFold(*providerType, "vmware"))
+		d.Set("classic_vmware_replication_enabled", strings.EqualFold(*providerType, "vmware"))
 	}
 
 	return tags.FlattenAndSet(d, model.Tags)

--- a/internal/services/recoveryservices/recovery_services_vault_resource_test.go
+++ b/internal/services/recoveryservices/recovery_services_vault_resource_test.go
@@ -488,6 +488,22 @@ func TestAccRecoveryServicesVault_TogglePublicNetworkAccessEnabled(t *testing.T)
 	})
 }
 
+func TestAccRecoveryServicesVault_basicWithClassicVmwareReplicateEnabled(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_recovery_services_vault", "test")
+	r := RecoveryServicesVaultResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basicWithClassicVmwareReplicateEnabled(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("classic_vmware_replicate_enabled").HasValue("true"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (RecoveryServicesVaultResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
@@ -550,7 +566,7 @@ resource "azurerm_recovery_services_vault" "test" {
   resource_group_name = azurerm_resource_group.test.name
   sku                 = "Standard"
 
-  cross_region_restore_enabled = %v
+  cross_region_restore_enabled = %t
 
   soft_delete_enabled = false
 }
@@ -1269,4 +1285,26 @@ resource "azurerm_recovery_services_vault" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString, sku)
+}
+
+func (RecoveryServicesVaultResource) basicWithClassicVmwareReplicateEnabled(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-recovery-%d"
+  location = "%s"
+}
+
+resource "azurerm_recovery_services_vault" "test" {
+  name                             = "acctest-Vault-%d"
+  location                         = azurerm_resource_group.test.location
+  resource_group_name              = azurerm_resource_group.test.name
+  sku                              = "Standard"
+  classic_vmware_replicate_enabled = true
+  soft_delete_enabled              = false
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/internal/services/recoveryservices/recovery_services_vault_resource_test.go
+++ b/internal/services/recoveryservices/recovery_services_vault_resource_test.go
@@ -497,7 +497,7 @@ func TestAccRecoveryServicesVault_basicWithClassicVmwareReplicateEnabled(t *test
 			Config: r.basicWithClassicVmwareReplicateEnabled(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("classic_vmware_replicate_enabled").HasValue("true"),
+				check.That(data.ResourceName).Key("classic_vmware_replication_enabled").HasValue("true"),
 			),
 		},
 		data.ImportStep(),
@@ -1303,7 +1303,7 @@ resource "azurerm_recovery_services_vault" "test" {
   location                         = azurerm_resource_group.test.location
   resource_group_name              = azurerm_resource_group.test.name
   sku                              = "Standard"
-  classic_vmware_replicate_enabled = true
+  classic_vmware_replication_enabled = true
   soft_delete_enabled              = false
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)

--- a/internal/services/recoveryservices/recovery_services_vault_resource_test.go
+++ b/internal/services/recoveryservices/recovery_services_vault_resource_test.go
@@ -1299,12 +1299,12 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_recovery_services_vault" "test" {
-  name                             = "acctest-Vault-%d"
-  location                         = azurerm_resource_group.test.location
-  resource_group_name              = azurerm_resource_group.test.name
-  sku                              = "Standard"
+  name                               = "acctest-Vault-%d"
+  location                           = azurerm_resource_group.test.location
+  resource_group_name                = azurerm_resource_group.test.name
+  sku                                = "Standard"
   classic_vmware_replication_enabled = true
-  soft_delete_enabled              = false
+  soft_delete_enabled                = false
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationvaultsetting/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationvaultsetting/README.md
@@ -1,0 +1,70 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationvaultsetting` Documentation
+
+The `replicationvaultsetting` SDK allows for interaction with the Azure Resource Manager Service `recoveryservicessiterecovery` (API Version `2022-10-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationvaultsetting"
+```
+
+
+### Client Initialization
+
+```go
+client := replicationvaultsetting.NewReplicationVaultSettingClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `ReplicationVaultSettingClient.Create`
+
+```go
+ctx := context.TODO()
+id := replicationvaultsetting.NewReplicationVaultSettingID("12345678-1234-9876-4563-123456789012", "example-resource-group", "vaultValue", "replicationVaultSettingValue")
+
+payload := replicationvaultsetting.VaultSettingCreationInput{
+	// ...
+}
+
+
+if err := client.CreateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `ReplicationVaultSettingClient.Get`
+
+```go
+ctx := context.TODO()
+id := replicationvaultsetting.NewReplicationVaultSettingID("12345678-1234-9876-4563-123456789012", "example-resource-group", "vaultValue", "replicationVaultSettingValue")
+
+read, err := client.Get(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `ReplicationVaultSettingClient.List`
+
+```go
+ctx := context.TODO()
+id := replicationvaultsetting.NewVaultID("12345678-1234-9876-4563-123456789012", "example-resource-group", "vaultValue")
+
+// alternatively `client.List(ctx, id)` can be used to do batched pagination
+items, err := client.ListComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationvaultsetting/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationvaultsetting/client.go
@@ -1,0 +1,18 @@
+package replicationvaultsetting
+
+import "github.com/Azure/go-autorest/autorest"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ReplicationVaultSettingClient struct {
+	Client  autorest.Client
+	baseUri string
+}
+
+func NewReplicationVaultSettingClientWithBaseURI(endpoint string) ReplicationVaultSettingClient {
+	return ReplicationVaultSettingClient{
+		Client:  autorest.NewClientWithUserAgent(userAgent()),
+		baseUri: endpoint,
+	}
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationvaultsetting/id_replicationvaultsetting.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationvaultsetting/id_replicationvaultsetting.go
@@ -1,0 +1,137 @@
+package replicationvaultsetting
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = ReplicationVaultSettingId{}
+
+// ReplicationVaultSettingId is a struct representing the Resource ID for a Replication Vault Setting
+type ReplicationVaultSettingId struct {
+	SubscriptionId              string
+	ResourceGroupName           string
+	VaultName                   string
+	ReplicationVaultSettingName string
+}
+
+// NewReplicationVaultSettingID returns a new ReplicationVaultSettingId struct
+func NewReplicationVaultSettingID(subscriptionId string, resourceGroupName string, vaultName string, replicationVaultSettingName string) ReplicationVaultSettingId {
+	return ReplicationVaultSettingId{
+		SubscriptionId:              subscriptionId,
+		ResourceGroupName:           resourceGroupName,
+		VaultName:                   vaultName,
+		ReplicationVaultSettingName: replicationVaultSettingName,
+	}
+}
+
+// ParseReplicationVaultSettingID parses 'input' into a ReplicationVaultSettingId
+func ParseReplicationVaultSettingID(input string) (*ReplicationVaultSettingId, error) {
+	parser := resourceids.NewParserFromResourceIdType(ReplicationVaultSettingId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := ReplicationVaultSettingId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
+		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+	}
+
+	if id.ReplicationVaultSettingName, ok = parsed.Parsed["replicationVaultSettingName"]; !ok {
+		return nil, fmt.Errorf("the segment 'replicationVaultSettingName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ParseReplicationVaultSettingIDInsensitively parses 'input' case-insensitively into a ReplicationVaultSettingId
+// note: this method should only be used for API response data and not user input
+func ParseReplicationVaultSettingIDInsensitively(input string) (*ReplicationVaultSettingId, error) {
+	parser := resourceids.NewParserFromResourceIdType(ReplicationVaultSettingId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := ReplicationVaultSettingId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
+		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+	}
+
+	if id.ReplicationVaultSettingName, ok = parsed.Parsed["replicationVaultSettingName"]; !ok {
+		return nil, fmt.Errorf("the segment 'replicationVaultSettingName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ValidateReplicationVaultSettingID checks that 'input' can be parsed as a Replication Vault Setting ID
+func ValidateReplicationVaultSettingID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseReplicationVaultSettingID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Replication Vault Setting ID
+func (id ReplicationVaultSettingId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.RecoveryServices/vaults/%s/replicationVaultSettings/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.VaultName, id.ReplicationVaultSettingName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Replication Vault Setting ID
+func (id ReplicationVaultSettingId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftRecoveryServices", "Microsoft.RecoveryServices", "Microsoft.RecoveryServices"),
+		resourceids.StaticSegment("staticVaults", "vaults", "vaults"),
+		resourceids.UserSpecifiedSegment("vaultName", "vaultValue"),
+		resourceids.StaticSegment("staticReplicationVaultSettings", "replicationVaultSettings", "replicationVaultSettings"),
+		resourceids.UserSpecifiedSegment("replicationVaultSettingName", "replicationVaultSettingValue"),
+	}
+}
+
+// String returns a human-readable description of this Replication Vault Setting ID
+func (id ReplicationVaultSettingId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Vault Name: %q", id.VaultName),
+		fmt.Sprintf("Replication Vault Setting Name: %q", id.ReplicationVaultSettingName),
+	}
+	return fmt.Sprintf("Replication Vault Setting (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationvaultsetting/id_vault.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationvaultsetting/id_vault.go
@@ -1,0 +1,124 @@
+package replicationvaultsetting
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = VaultId{}
+
+// VaultId is a struct representing the Resource ID for a Vault
+type VaultId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	VaultName         string
+}
+
+// NewVaultID returns a new VaultId struct
+func NewVaultID(subscriptionId string, resourceGroupName string, vaultName string) VaultId {
+	return VaultId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		VaultName:         vaultName,
+	}
+}
+
+// ParseVaultID parses 'input' into a VaultId
+func ParseVaultID(input string) (*VaultId, error) {
+	parser := resourceids.NewParserFromResourceIdType(VaultId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := VaultId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
+		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ParseVaultIDInsensitively parses 'input' case-insensitively into a VaultId
+// note: this method should only be used for API response data and not user input
+func ParseVaultIDInsensitively(input string) (*VaultId, error) {
+	parser := resourceids.NewParserFromResourceIdType(VaultId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := VaultId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
+		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ValidateVaultID checks that 'input' can be parsed as a Vault ID
+func ValidateVaultID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseVaultID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Vault ID
+func (id VaultId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.RecoveryServices/vaults/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.VaultName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Vault ID
+func (id VaultId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftRecoveryServices", "Microsoft.RecoveryServices", "Microsoft.RecoveryServices"),
+		resourceids.StaticSegment("staticVaults", "vaults", "vaults"),
+		resourceids.UserSpecifiedSegment("vaultName", "vaultValue"),
+	}
+}
+
+// String returns a human-readable description of this Vault ID
+func (id VaultId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Vault Name: %q", id.VaultName),
+	}
+	return fmt.Sprintf("Vault (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationvaultsetting/method_create_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationvaultsetting/method_create_autorest.go
@@ -1,0 +1,79 @@
+package replicationvaultsetting
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CreateOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// Create ...
+func (c ReplicationVaultSettingClient) Create(ctx context.Context, id ReplicationVaultSettingId, input VaultSettingCreationInput) (result CreateOperationResponse, err error) {
+	req, err := c.preparerForCreate(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationvaultsetting.ReplicationVaultSettingClient", "Create", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForCreate(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationvaultsetting.ReplicationVaultSettingClient", "Create", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// CreateThenPoll performs Create then polls until it's completed
+func (c ReplicationVaultSettingClient) CreateThenPoll(ctx context.Context, id ReplicationVaultSettingId, input VaultSettingCreationInput) error {
+	result, err := c.Create(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing Create: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after Create: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForCreate prepares the Create request.
+func (c ReplicationVaultSettingClient) preparerForCreate(ctx context.Context, id ReplicationVaultSettingId, input VaultSettingCreationInput) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPut(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForCreate sends the Create request. The method will close the
+// http.Response Body if it receives an error.
+func (c ReplicationVaultSettingClient) senderForCreate(ctx context.Context, req *http.Request) (future CreateOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationvaultsetting/method_get_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationvaultsetting/method_get_autorest.go
@@ -1,0 +1,68 @@
+package replicationvaultsetting
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *VaultSetting
+}
+
+// Get ...
+func (c ReplicationVaultSettingClient) Get(ctx context.Context, id ReplicationVaultSettingId) (result GetOperationResponse, err error) {
+	req, err := c.preparerForGet(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationvaultsetting.ReplicationVaultSettingClient", "Get", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationvaultsetting.ReplicationVaultSettingClient", "Get", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForGet(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationvaultsetting.ReplicationVaultSettingClient", "Get", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForGet prepares the Get request.
+func (c ReplicationVaultSettingClient) preparerForGet(ctx context.Context, id ReplicationVaultSettingId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForGet handles the response to the Get request. The method always
+// closes the http.Response Body.
+func (c ReplicationVaultSettingClient) responderForGet(resp *http.Response) (result GetOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationvaultsetting/method_list_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationvaultsetting/method_list_autorest.go
@@ -1,0 +1,186 @@
+package replicationvaultsetting
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *[]VaultSetting
+
+	nextLink     *string
+	nextPageFunc func(ctx context.Context, nextLink string) (ListOperationResponse, error)
+}
+
+type ListCompleteResult struct {
+	Items []VaultSetting
+}
+
+func (r ListOperationResponse) HasMore() bool {
+	return r.nextLink != nil
+}
+
+func (r ListOperationResponse) LoadMore(ctx context.Context) (resp ListOperationResponse, err error) {
+	if !r.HasMore() {
+		err = fmt.Errorf("no more pages returned")
+		return
+	}
+	return r.nextPageFunc(ctx, *r.nextLink)
+}
+
+// List ...
+func (c ReplicationVaultSettingClient) List(ctx context.Context, id VaultId) (resp ListOperationResponse, err error) {
+	req, err := c.preparerForList(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationvaultsetting.ReplicationVaultSettingClient", "List", nil, "Failure preparing request")
+		return
+	}
+
+	resp.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationvaultsetting.ReplicationVaultSettingClient", "List", resp.HttpResponse, "Failure sending request")
+		return
+	}
+
+	resp, err = c.responderForList(resp.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "replicationvaultsetting.ReplicationVaultSettingClient", "List", resp.HttpResponse, "Failure responding to request")
+		return
+	}
+	return
+}
+
+// preparerForList prepares the List request.
+func (c ReplicationVaultSettingClient) preparerForList(ctx context.Context, id VaultId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/replicationVaultSettings", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// preparerForListWithNextLink prepares the List request with the given nextLink token.
+func (c ReplicationVaultSettingClient) preparerForListWithNextLink(ctx context.Context, nextLink string) (*http.Request, error) {
+	uri, err := url.Parse(nextLink)
+	if err != nil {
+		return nil, fmt.Errorf("parsing nextLink %q: %+v", nextLink, err)
+	}
+	queryParameters := map[string]interface{}{}
+	for k, v := range uri.Query() {
+		if len(v) == 0 {
+			continue
+		}
+		val := v[0]
+		val = autorest.Encode("query", val)
+		queryParameters[k] = val
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(uri.Path),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForList handles the response to the List request. The method always
+// closes the http.Response Body.
+func (c ReplicationVaultSettingClient) responderForList(resp *http.Response) (result ListOperationResponse, err error) {
+	type page struct {
+		Values   []VaultSetting `json:"value"`
+		NextLink *string        `json:"nextLink"`
+	}
+	var respObj page
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&respObj),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	result.Model = &respObj.Values
+	result.nextLink = respObj.NextLink
+	if respObj.NextLink != nil {
+		result.nextPageFunc = func(ctx context.Context, nextLink string) (result ListOperationResponse, err error) {
+			req, err := c.preparerForListWithNextLink(ctx, nextLink)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "replicationvaultsetting.ReplicationVaultSettingClient", "List", nil, "Failure preparing request")
+				return
+			}
+
+			result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "replicationvaultsetting.ReplicationVaultSettingClient", "List", result.HttpResponse, "Failure sending request")
+				return
+			}
+
+			result, err = c.responderForList(result.HttpResponse)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "replicationvaultsetting.ReplicationVaultSettingClient", "List", result.HttpResponse, "Failure responding to request")
+				return
+			}
+
+			return
+		}
+	}
+	return
+}
+
+// ListComplete retrieves all of the results into a single object
+func (c ReplicationVaultSettingClient) ListComplete(ctx context.Context, id VaultId) (ListCompleteResult, error) {
+	return c.ListCompleteMatchingPredicate(ctx, id, VaultSettingOperationPredicate{})
+}
+
+// ListCompleteMatchingPredicate retrieves all of the results and then applied the predicate
+func (c ReplicationVaultSettingClient) ListCompleteMatchingPredicate(ctx context.Context, id VaultId, predicate VaultSettingOperationPredicate) (resp ListCompleteResult, err error) {
+	items := make([]VaultSetting, 0)
+
+	page, err := c.List(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading the initial page: %+v", err)
+		return
+	}
+	if page.Model != nil {
+		for _, v := range *page.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	for page.HasMore() {
+		page, err = page.LoadMore(ctx)
+		if err != nil {
+			err = fmt.Errorf("loading the next page: %+v", err)
+			return
+		}
+
+		if page.Model != nil {
+			for _, v := range *page.Model {
+				if predicate.Matches(v) {
+					items = append(items, v)
+				}
+			}
+		}
+	}
+
+	out := ListCompleteResult{
+		Items: items,
+	}
+	return out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationvaultsetting/model_vaultsetting.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationvaultsetting/model_vaultsetting.go
@@ -1,0 +1,12 @@
+package replicationvaultsetting
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VaultSetting struct {
+	Id         *string                 `json:"id,omitempty"`
+	Location   *string                 `json:"location,omitempty"`
+	Name       *string                 `json:"name,omitempty"`
+	Properties *VaultSettingProperties `json:"properties,omitempty"`
+	Type       *string                 `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationvaultsetting/model_vaultsettingcreationinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationvaultsetting/model_vaultsettingcreationinput.go
@@ -1,0 +1,8 @@
+package replicationvaultsetting
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VaultSettingCreationInput struct {
+	Properties VaultSettingCreationInputProperties `json:"properties"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationvaultsetting/model_vaultsettingcreationinputproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationvaultsetting/model_vaultsettingcreationinputproperties.go
@@ -1,0 +1,9 @@
+package replicationvaultsetting
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VaultSettingCreationInputProperties struct {
+	MigrationSolutionId       *string `json:"migrationSolutionId,omitempty"`
+	VMwareToAzureProviderType *string `json:"vmwareToAzureProviderType,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationvaultsetting/model_vaultsettingproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationvaultsetting/model_vaultsettingproperties.go
@@ -1,0 +1,9 @@
+package replicationvaultsetting
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VaultSettingProperties struct {
+	MigrationSolutionId       *string `json:"migrationSolutionId,omitempty"`
+	VMwareToAzureProviderType *string `json:"vmwareToAzureProviderType,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationvaultsetting/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationvaultsetting/predicates.go
@@ -1,0 +1,29 @@
+package replicationvaultsetting
+
+type VaultSettingOperationPredicate struct {
+	Id       *string
+	Location *string
+	Name     *string
+	Type     *string
+}
+
+func (p VaultSettingOperationPredicate) Matches(input VaultSetting) bool {
+
+	if p.Id != nil && (input.Id == nil && *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Location != nil && (input.Location == nil && *p.Location != *input.Location) {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil && *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil && *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationvaultsetting/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationvaultsetting/version.go
@@ -1,0 +1,12 @@
+package replicationvaultsetting
+
+import "fmt"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2022-10-01"
+
+func userAgent() string {
+	return fmt.Sprintf("hashicorp/go-azure-sdk/replicationvaultsetting/%s", defaultApiVersion)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -443,6 +443,7 @@ github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/
 github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings
 github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers
 github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans
+github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationvaultsetting
 github.com/hashicorp/go-azure-sdk/resource-manager/redis/2021-06-01
 github.com/hashicorp/go-azure-sdk/resource-manager/redis/2021-06-01/firewallrules
 github.com/hashicorp/go-azure-sdk/resource-manager/redis/2021-06-01/patchschedules

--- a/website/docs/r/recovery_services_vault.html.markdown
+++ b/website/docs/r/recovery_services_vault.html.markdown
@@ -60,6 +60,8 @@ The following arguments are supported:
 
 !> **Note:** Once Encryption with your own key has been Enabled it's not possible to Disable it.
 
+* `classic_vmware_replicate_enabled` - (Optional) Whether to enable Classic experience for VMWare replication. If it set to `false` it will protect VMware machines using the new stateless ASR replication appliance. Defaults to `false`. Changing this forces a new resource to be created.
+
 ---
 
 An `identity` block supports the following:

--- a/website/docs/r/recovery_services_vault.html.markdown
+++ b/website/docs/r/recovery_services_vault.html.markdown
@@ -60,7 +60,7 @@ The following arguments are supported:
 
 !> **Note:** Once Encryption with your own key has been Enabled it's not possible to Disable it.
 
-* `classic_vmware_replication_enabled` - (Optional) Whether to enable Classic experience for VMWare replication. If it set to `false` it will protect VMware machines using the new stateless ASR replication appliance. Changing this forces a new resource to be created.
+* `classic_vmware_replication_enabled` - (Optional) Whether to enable the Classic experience for VMware replication. If set to `false` VMware machines will be protected using the new stateless ASR replication appliance. Changing this forces a new resource to be created.
 
 ---
 

--- a/website/docs/r/recovery_services_vault.html.markdown
+++ b/website/docs/r/recovery_services_vault.html.markdown
@@ -60,7 +60,7 @@ The following arguments are supported:
 
 !> **Note:** Once Encryption with your own key has been Enabled it's not possible to Disable it.
 
-* `classic_vmware_replicate_enabled` - (Optional) Whether to enable Classic experience for VMWare replication. If it set to `false` it will protect VMware machines using the new stateless ASR replication appliance. Defaults to `false`. Changing this forces a new resource to be created.
+* `classic_vmware_replication_enabled` - (Optional) Whether to enable Classic experience for VMWare replication. If it set to `false` it will protect VMware machines using the new stateless ASR replication appliance. Changing this forces a new resource to be created.
 
 ---
 


### PR DESCRIPTION
test
---
```
terraform-provider-azurerm ❯ TF_ACC=1 go test -v ./internal/services/recoveryservices -run=TestAccRecoveryServicesVault -timeout=600m -parallel 20            [ tengzh/recovery/vmware/vault_update][$⇕][🐹 v1.19.5][⏱ 10ms][16:05:43]
=== RUN   TestAccRecoveryServicesVault_basic
=== PAUSE TestAccRecoveryServicesVault_basic
=== RUN   TestAccRecoveryServicesVault_ToggleCrossRegionRestore
=== PAUSE TestAccRecoveryServicesVault_ToggleCrossRegionRestore
=== RUN   TestAccRecoveryServicesVault_basicWithCrossRegionRestoreAndWrongStorageType
=== PAUSE TestAccRecoveryServicesVault_basicWithCrossRegionRestoreAndWrongStorageType
=== RUN   TestAccRecoveryServicesVault_zrs
=== PAUSE TestAccRecoveryServicesVault_zrs
=== RUN   TestAccRecoveryServicesVault_complete
=== PAUSE TestAccRecoveryServicesVault_complete
=== RUN   TestAccRecoveryServicesVault_update
=== PAUSE TestAccRecoveryServicesVault_update
=== RUN   TestAccRecoveryServicesVault_requiresImport
=== PAUSE TestAccRecoveryServicesVault_requiresImport
=== RUN   TestAccRecoveryServicesVault_SystemAssignedIdentity
=== PAUSE TestAccRecoveryServicesVault_SystemAssignedIdentity
=== RUN   TestAccRecoveryServicesVault_UserAssignedIdentity
=== PAUSE TestAccRecoveryServicesVault_UserAssignedIdentity
=== RUN   TestAccRecoveryServicesVault_immutability
=== PAUSE TestAccRecoveryServicesVault_immutability
=== RUN   TestAccRecoveryServicesVault_softDelete
=== PAUSE TestAccRecoveryServicesVault_softDelete
=== RUN   TestAccRecoveryServicesVault_storageModeType
=== PAUSE TestAccRecoveryServicesVault_storageModeType
=== RUN   TestAccRecoveryServicesVault_crossRegionRestore
=== PAUSE TestAccRecoveryServicesVault_crossRegionRestore
=== RUN   TestAccRecoveryServicesVault_sku
=== PAUSE TestAccRecoveryServicesVault_sku
=== RUN   TestAccRecoveryServicesVault_updateSkuWithExistingEncryption
=== PAUSE TestAccRecoveryServicesVault_updateSkuWithExistingEncryption
=== RUN   TestAccRecoveryServicesVault_encryptionWithKeyVaultKey
=== PAUSE TestAccRecoveryServicesVault_encryptionWithKeyVaultKey
=== RUN   TestAccRecoveryServicesVault_turnOnEncryptionWithKeyVaultKey
=== PAUSE TestAccRecoveryServicesVault_turnOnEncryptionWithKeyVaultKey
=== RUN   TestAccRecoveryServicesVault_turnOffEncryptionWithKeyVaultKeyShouldHaveClearlyErrorMessage
=== PAUSE TestAccRecoveryServicesVault_turnOffEncryptionWithKeyVaultKeyShouldHaveClearlyErrorMessage
=== RUN   TestAccRecoveryServicesVault_changeInfrastructureEncryptionEnabledShouldHaveClearlyErrorMessage
=== PAUSE TestAccRecoveryServicesVault_changeInfrastructureEncryptionEnabledShouldHaveClearlyErrorMessage
=== RUN   TestAccRecoveryServicesVault_encryptionWithInfrastructureEncryption
=== PAUSE TestAccRecoveryServicesVault_encryptionWithInfrastructureEncryption
=== RUN   TestAccRecoveryServicesVault_switchEncryptionKeyVaultKey
=== PAUSE TestAccRecoveryServicesVault_switchEncryptionKeyVaultKey
=== RUN   TestAccRecoveryServicesVault_encryptionWithUserAssignedIdentity
=== PAUSE TestAccRecoveryServicesVault_encryptionWithUserAssignedIdentity
=== RUN   TestAccRecoveryServicesVault_TogglePublicNetworkAccessEnabled
=== PAUSE TestAccRecoveryServicesVault_TogglePublicNetworkAccessEnabled
=== RUN   TestAccRecoveryServicesVault_basicWithClassicVmwareReplicateEnabled
=== PAUSE TestAccRecoveryServicesVault_basicWithClassicVmwareReplicateEnabled
=== CONT  TestAccRecoveryServicesVault_basic
=== CONT  TestAccRecoveryServicesVault_crossRegionRestore
=== CONT  TestAccRecoveryServicesVault_changeInfrastructureEncryptionEnabledShouldHaveClearlyErrorMessage
=== CONT  TestAccRecoveryServicesVault_encryptionWithKeyVaultKey
=== CONT  TestAccRecoveryServicesVault_updateSkuWithExistingEncryption
=== CONT  TestAccRecoveryServicesVault_storageModeType
=== CONT  TestAccRecoveryServicesVault_requiresImport
=== CONT  TestAccRecoveryServicesVault_zrs
=== CONT  TestAccRecoveryServicesVault_immutability
=== CONT  TestAccRecoveryServicesVault_ToggleCrossRegionRestore
=== CONT  TestAccRecoveryServicesVault_basicWithClassicVmwareReplicateEnabled
=== CONT  TestAccRecoveryServicesVault_TogglePublicNetworkAccessEnabled
=== CONT  TestAccRecoveryServicesVault_encryptionWithUserAssignedIdentity
=== CONT  TestAccRecoveryServicesVault_switchEncryptionKeyVaultKey
=== CONT  TestAccRecoveryServicesVault_basicWithCrossRegionRestoreAndWrongStorageType
=== CONT  TestAccRecoveryServicesVault_encryptionWithInfrastructureEncryption
=== CONT  TestAccRecoveryServicesVault_complete
=== CONT  TestAccRecoveryServicesVault_update
=== CONT  TestAccRecoveryServicesVault_UserAssignedIdentity
=== CONT  TestAccRecoveryServicesVault_softDelete
--- PASS: TestAccRecoveryServicesVault_basicWithCrossRegionRestoreAndWrongStorageType (196.46s)
=== CONT  TestAccRecoveryServicesVault_SystemAssignedIdentity
--- PASS: TestAccRecoveryServicesVault_zrs (415.18s)
=== CONT  TestAccRecoveryServicesVault_turnOffEncryptionWithKeyVaultKeyShouldHaveClearlyErrorMessage
--- PASS: TestAccRecoveryServicesVault_basic (417.14s)
=== CONT  TestAccRecoveryServicesVault_turnOnEncryptionWithKeyVaultKey
--- PASS: TestAccRecoveryServicesVault_basicWithClassicVmwareReplicateEnabled (423.75s)
=== CONT  TestAccRecoveryServicesVault_sku
--- PASS: TestAccRecoveryServicesVault_complete (424.74s)
--- PASS: TestAccRecoveryServicesVault_UserAssignedIdentity (426.30s)
--- PASS: TestAccRecoveryServicesVault_requiresImport (439.65s)
--- PASS: TestAccRecoveryServicesVault_crossRegionRestore (596.33s)
--- PASS: TestAccRecoveryServicesVault_SystemAssignedIdentity (403.77s)
--- PASS: TestAccRecoveryServicesVault_storageModeType (628.92s)
--- PASS: TestAccRecoveryServicesVault_encryptionWithInfrastructureEncryption (690.57s)
--- PASS: TestAccRecoveryServicesVault_encryptionWithKeyVaultKey (713.42s)
--- PASS: TestAccRecoveryServicesVault_immutability (756.27s)
--- PASS: TestAccRecoveryServicesVault_encryptionWithUserAssignedIdentity (771.18s)
--- PASS: TestAccRecoveryServicesVault_update (773.64s)
--- PASS: TestAccRecoveryServicesVault_changeInfrastructureEncryptionEnabledShouldHaveClearlyErrorMessage (795.37s)
--- PASS: TestAccRecoveryServicesVault_updateSkuWithExistingEncryption (809.09s)
--- PASS: TestAccRecoveryServicesVault_ToggleCrossRegionRestore (866.35s)
--- PASS: TestAccRecoveryServicesVault_switchEncryptionKeyVaultKey (947.61s)
--- PASS: TestAccRecoveryServicesVault_TogglePublicNetworkAccessEnabled (1078.45s)
--- PASS: TestAccRecoveryServicesVault_softDelete (1207.75s)
--- PASS: TestAccRecoveryServicesVault_turnOnEncryptionWithKeyVaultKey (863.69s)
--- PASS: TestAccRecoveryServicesVault_turnOffEncryptionWithKeyVaultKeyShouldHaveClearlyErrorMessage (883.62s)
--- PASS: TestAccRecoveryServicesVault_sku (1172.84s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/recoveryservices      1597.923s

```