### PR TITLE
`azurerm_mobile_network_sim_group` - update schema

### DIFF
--- a/internal/services/mobilenetwork/helpers.go
+++ b/internal/services/mobilenetwork/helpers.go
@@ -44,6 +44,7 @@ func resourceMobileNetworkChildWaitForDeletion(ctx context.Context, id string, g
 	return nil
 }
 
+// tracked on https://github.com/Azure/azure-rest-api-specs/issues/22634
 // some resources defined both systemAssigned and userAssigned Identity type in Swagger but only support userAssigned Identity,
 // so add a workaround to convert type here.
 func expandMobileNetworkLegacyToUserAssignedIdentity(input []identity.ModelUserAssigned) (*identity.LegacySystemAndUserAssignedMap, error) {

--- a/internal/services/mobilenetwork/mobile_network_sim_group_resource.go
+++ b/internal/services/mobilenetwork/mobile_network_sim_group_resource.go
@@ -64,7 +64,7 @@ func (r SimGroupResource) Arguments() map[string]*pluginsdk.Schema {
 			ValidateFunc: validation.IsURLWithHTTPorHTTPS,
 		},
 
-		"identity": commonschema.SystemOrUserAssignedIdentityOptional(),
+		"identity": commonschema.UserAssignedIdentityOptional(),
 
 		"location": commonschema.Location(),
 


### PR DESCRIPTION
update per https://github.com/hashicorp/terraform-provider-azurerm/pull/20339#discussion_r1106988781

test
---
```
terraform-provider-azurerm ❯ TF_ACC=1 go test -v ./internal/services/mobilenetwork -run=TestAccMobileNetworkSimGroup -timeout=600m
=== RUN   TestAccMobileNetworkSimGroupDataSource_complete
=== PAUSE TestAccMobileNetworkSimGroupDataSource_complete
=== RUN   TestAccMobileNetworkSimGroup_basic
=== PAUSE TestAccMobileNetworkSimGroup_basic
=== RUN   TestAccMobileNetworkSimGroup_withEncryptionKeyUrl
=== PAUSE TestAccMobileNetworkSimGroup_withEncryptionKeyUrl
=== RUN   TestAccMobileNetworkSimGroup_requiresImport
=== PAUSE TestAccMobileNetworkSimGroup_requiresImport
=== RUN   TestAccMobileNetworkSimGroup_complete
=== PAUSE TestAccMobileNetworkSimGroup_complete
=== RUN   TestAccMobileNetworkSimGroup_update
=== PAUSE TestAccMobileNetworkSimGroup_update
=== CONT  TestAccMobileNetworkSimGroupDataSource_complete
=== CONT  TestAccMobileNetworkSimGroup_requiresImport
=== CONT  TestAccMobileNetworkSimGroup_update
=== CONT  TestAccMobileNetworkSimGroup_complete
=== CONT  TestAccMobileNetworkSimGroup_withEncryptionKeyUrl
=== CONT  TestAccMobileNetworkSimGroup_basic
--- PASS: TestAccMobileNetworkSimGroup_basic (467.71s)
--- PASS: TestAccMobileNetworkSimGroup_requiresImport (491.87s)
--- PASS: TestAccMobileNetworkSimGroup_withEncryptionKeyUrl (760.82s)
--- PASS: TestAccMobileNetworkSimGroupDataSource_complete (781.69s)
--- PASS: TestAccMobileNetworkSimGroup_complete (782.60s)
--- PASS: TestAccMobileNetworkSimGroup_update (940.80s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/mobilenetwork 942.042s

```