### PR TITLE
bugfix: data sources should surface an error rather than using d.SetID("")

### DIFF
--- a/.github/workflows/gradually-deprecated.yaml
+++ b/.github/workflows/gradually-deprecated.yaml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version-file: ./.go-version
-      - run: ./scripts/run-gradually-deprecated.sh
+      - run: bash ./scripts/run-gradually-deprecated.sh
       - name: Add waiting-response on fail
         if: failure()
         uses: actions-ecosystem/action-add-labels@v1

--- a/internal/services/aadb2c/aadb2c_directory_data_source.go
+++ b/internal/services/aadb2c/aadb2c_directory_data_source.go
@@ -3,8 +3,9 @@ package aadb2c
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/response"
 
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/aadb2c/2021-04-01-preview/tenants"
@@ -104,11 +105,10 @@ func (r AadB2cDirectoryDataSource) Read() sdk.ResourceFunc {
 
 			id := tenants.NewB2CDirectoryID(subscriptionId, state.ResourceGroup, state.DomainName)
 
-			metadata.Logger.Infof("Reading %s", id)
 			resp, err := client.Get(ctx, id)
 			if err != nil {
-				if resp.HttpResponse.StatusCode == http.StatusNotFound {
-					return metadata.MarkAsGone(id)
+				if response.WasNotFound(resp.HttpResponse) {
+					return fmt.Errorf("%s was not found", id)
 				}
 				return fmt.Errorf("retrieving %s: %v", id, err)
 			}

--- a/internal/services/consumption/consumption_budget_resource_group_data_source.go
+++ b/internal/services/consumption/consumption_budget_resource_group_data_source.go
@@ -220,21 +220,19 @@ func resourceArmConsumptionBudgetResourceGroupDataSource() *pluginsdk.Resource {
 
 func resourceArmConsumptionBudgetResourceGroupDataSourceRead(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Consumption.BudgetsClient
-	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
 	id := budgets.NewScopedBudgetID(d.Get("resource_group_id").(string), d.Get("name").(string))
-	d.SetId(id.ID())
-
 	resp, err := client.Get(ctx, id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			d.SetId("")
-			return nil
+			return fmt.Errorf("%s was not found", id)
 		}
 		return fmt.Errorf("making read request on %s: %+v", id, err)
 	}
 
+	d.SetId(id.ID())
 	d.Set("name", id.BudgetName)
 	if model := resp.Model; model != nil {
 		if props := model.Properties; props != nil {

--- a/internal/services/databoxedge/databox_edge_device_data_source.go
+++ b/internal/services/databoxedge/databox_edge_device_data_source.go
@@ -3,7 +3,6 @@ package databoxedge
 import (
 	"context"
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/response"
@@ -138,8 +137,7 @@ func (d EdgeDeviceDataSource) Read() sdk.ResourceFunc {
 			resp, err := client.Get(ctx, id)
 			if err != nil {
 				if response.WasNotFound(resp.HttpResponse) {
-					log.Printf("[INFO] %s was not found - removing from state", id)
-					return metadata.MarkAsGone(id)
+					return fmt.Errorf("%s was not found", id)
 				}
 				return fmt.Errorf("retrieving %s: %+v", id, err)
 			}

--- a/internal/services/dataprotection/data_protection_backup_vault_data_source.go
+++ b/internal/services/dataprotection/data_protection_backup_vault_data_source.go
@@ -2,7 +2,6 @@ package dataprotection
 
 import (
 	"fmt"
-	"log"
 	"regexp"
 	"time"
 
@@ -76,9 +75,7 @@ func dataSourceDataProtectionBackupVaultRead(d *pluginsdk.ResourceData, meta int
 	resp, err := client.Get(ctx, id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			log.Printf("[INFO] DataProtection BackupVault %q does not exist - removing from state", d.Id())
-			d.SetId("")
-			return nil
+			return fmt.Errorf("%s was not found", id)
 		}
 		return fmt.Errorf("retrieving DataProtection BackupVault (%q): %+v", id, err)
 	}

--- a/internal/services/healthcare/healthcare_dicom_data_source.go
+++ b/internal/services/healthcare/healthcare_dicom_data_source.go
@@ -101,8 +101,7 @@ func dataSourceHealthcareApisDicomServiceRead(d *pluginsdk.ResourceData, meta in
 	resp, err := client.Get(ctx, id.ResourceGroup, id.WorkspaceName, id.Name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			d.SetId("")
-			return nil
+			return fmt.Errorf("%s was not found", id)
 		}
 		return fmt.Errorf("retrieving %s: %+v", id, err)
 	}

--- a/internal/services/healthcare/healthcare_fhir_data_source.go
+++ b/internal/services/healthcare/healthcare_fhir_data_source.go
@@ -151,8 +151,7 @@ func dataSourceHealthcareApisFhirServiceRead(d *pluginsdk.ResourceData, meta int
 	resp, err := client.Get(ctx, id.ResourceGroup, id.WorkspaceName, id.Name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			d.SetId("")
-			return nil
+			return fmt.Errorf("%s was not found", id)
 		}
 		return fmt.Errorf("retrieving %s: %+v", id, err)
 	}

--- a/internal/services/healthcare/healthcare_medtech_service_data_source.go
+++ b/internal/services/healthcare/healthcare_medtech_service_data_source.go
@@ -78,8 +78,7 @@ func dataSourceHealthcareIotConnectorRead(d *pluginsdk.ResourceData, meta interf
 	resp, err := client.Get(ctx, id.ResourceGroup, id.WorkspaceName, id.IotConnectorName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			d.SetId("")
-			return nil
+			return fmt.Errorf("%s was not found", id)
 		}
 		return fmt.Errorf("retrieving %s: %+v", id, err)
 	}

--- a/internal/services/hybridcompute/hybrid_compute_machine_data_source.go
+++ b/internal/services/hybridcompute/hybrid_compute_machine_data_source.go
@@ -546,7 +546,7 @@ func (r HybridComputeMachineDataSource) Read() sdk.ResourceFunc {
 			resp, err := client.Get(ctx, id, machines.GetOperationOptions{})
 			if err != nil {
 				if response.WasNotFound(resp.HttpResponse) {
-					return metadata.MarkAsGone(id)
+					return fmt.Errorf("%s was not found", id)
 				}
 
 				return fmt.Errorf("retrieving %s: %+v", id, err)

--- a/internal/services/keyvault/key_vault_certificate_data_data_source.go
+++ b/internal/services/keyvault/key_vault_certificate_data_data_source.go
@@ -109,9 +109,7 @@ func dataSourceArmKeyVaultCertificateDataRead(d *pluginsdk.ResourceData, meta in
 	cert, err := client.GetCertificate(ctx, *keyVaultBaseUri, name, version)
 	if err != nil {
 		if utils.ResponseWasNotFound(cert.Response) {
-			log.Printf("[DEBUG] Certificate %q was not found in Key Vault at URI %q - removing from state", name, *keyVaultBaseUri)
-			d.SetId("")
-			return nil
+			return fmt.Errorf("the Certificate %q was not found in Key Vault at URI %q", name, *keyVaultBaseUri)
 		}
 
 		return fmt.Errorf("reading Key Vault Certificate: %+v", err)
@@ -121,12 +119,11 @@ func dataSourceArmKeyVaultCertificateDataRead(d *pluginsdk.ResourceData, meta in
 		return fmt.Errorf("failure reading Key Vault Certificate ID for %q", name)
 	}
 
-	d.SetId(*cert.ID)
-
-	id, err := parse.ParseNestedItemID(d.Id())
+	id, err := parse.ParseNestedItemID(*cert.ID)
 	if err != nil {
 		return err
 	}
+	d.SetId(id.ID())
 
 	d.Set("name", id.Name)
 

--- a/internal/services/keyvault/key_vault_certificate_data_source.go
+++ b/internal/services/keyvault/key_vault_certificate_data_source.go
@@ -4,7 +4,6 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
-	"log"
 	"strings"
 	"time"
 
@@ -272,9 +271,7 @@ func dataSourceKeyVaultCertificateRead(d *pluginsdk.ResourceData, meta interface
 	cert, err := client.GetCertificate(ctx, *keyVaultBaseUri, name, version)
 	if err != nil {
 		if utils.ResponseWasNotFound(cert.Response) {
-			log.Printf("[DEBUG] Certificate %q was not found in Key Vault at URI %q - removing from state", name, *keyVaultBaseUri)
-			d.SetId("")
-			return nil
+			return fmt.Errorf("a Certificate named %q was not found in Key Vault at URI %q", name, *keyVaultBaseUri)
 		}
 
 		return fmt.Errorf("reading Key Vault Certificate: %+v", err)
@@ -284,12 +281,11 @@ func dataSourceKeyVaultCertificateRead(d *pluginsdk.ResourceData, meta interface
 		return fmt.Errorf("failure reading Key Vault Certificate ID for %q", name)
 	}
 
-	d.SetId(*cert.ID)
-
 	id, err := parse.ParseNestedItemID(*cert.ID)
 	if err != nil {
 		return err
 	}
+	d.SetId(id.ID())
 
 	d.Set("name", id.Name)
 

--- a/internal/services/loadbalancer/outbound_rule_data_source.go
+++ b/internal/services/loadbalancer/outbound_rule_data_source.go
@@ -2,7 +2,6 @@ package loadbalancer
 
 import (
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -95,18 +94,14 @@ func dataSourceArmLoadBalancerOutboundRuleRead(d *pluginsdk.ResourceData, meta i
 	loadBalancer, err := client.Get(ctx, loadBalancerId.ResourceGroup, loadBalancerId.Name, "")
 	if err != nil {
 		if utils.ResponseWasNotFound(loadBalancer.Response) {
-			d.SetId("")
-			log.Printf("[INFO] Load Balancer %q not found. Removing from state", loadBalancerId.Name)
-			return nil
+			return fmt.Errorf("parent %s was not found", *loadBalancerId)
 		}
-		return fmt.Errorf("failed to retrieve Load Balancer %q (resource group %q) for Outbound Rule %q: %+v", loadBalancerId.Name, loadBalancerId.ResourceGroup, name, err)
+		return fmt.Errorf("retrieving parent %s: %+v", *loadBalancerId, err)
 	}
 
 	id := parse.NewLoadBalancerOutboundRuleID(loadBalancerId.SubscriptionId, loadBalancerId.ResourceGroup, loadBalancerId.Name, name)
 	config, _, exists := FindLoadBalancerOutboundRuleByName(&loadBalancer, id.OutboundRuleName)
 	if !exists {
-		d.SetId("")
-		log.Printf("[INFO] Load Balancer Outbound Rule %q not found. Removing from state", name)
 		return fmt.Errorf("%s was not found", id)
 	}
 

--- a/internal/services/loadbalancer/rule_data_source.go
+++ b/internal/services/loadbalancer/rule_data_source.go
@@ -2,7 +2,6 @@ package loadbalancer
 
 import (
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -21,12 +20,82 @@ func dataSourceArmLoadBalancerRule() *pluginsdk.Resource {
 			Read: pluginsdk.DefaultTimeout(5 * time.Minute),
 		},
 
-		Schema: dataSourceArmLoadBalancerSchema(),
+		Schema: map[string]*pluginsdk.Schema{
+			"name": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ValidateFunc: validate.RuleName,
+			},
+
+			"loadbalancer_id": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ValidateFunc: validate.LoadBalancerID,
+			},
+
+			"frontend_ip_configuration_name": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
+			"protocol": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
+			"frontend_port": {
+				Type:     pluginsdk.TypeInt,
+				Computed: true,
+			},
+
+			"backend_port": {
+				Type:     pluginsdk.TypeInt,
+				Computed: true,
+			},
+
+			"backend_address_pool_id": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
+			"probe_id": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
+			// TODO 4.0: change this from enable_* to *_enabled
+			"enable_floating_ip": {
+				Type:     pluginsdk.TypeBool,
+				Computed: true,
+			},
+
+			// TODO 4.0: change this from enable_* to *_enabled
+			"enable_tcp_reset": {
+				Type:     pluginsdk.TypeBool,
+				Computed: true,
+			},
+
+			"disable_outbound_snat": {
+				Type:     pluginsdk.TypeBool,
+				Computed: true,
+			},
+
+			"idle_timeout_in_minutes": {
+				Type:     pluginsdk.TypeInt,
+				Computed: true,
+			},
+
+			"load_distribution": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+		},
 	}
 }
 
 func dataSourceArmLoadBalancerRuleRead(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).LoadBalancers.LoadBalancersClient
+	lbRuleClient := meta.(*clients.Client).LoadBalancers.LoadBalancingRulesClient
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -39,16 +108,10 @@ func dataSourceArmLoadBalancerRuleRead(d *pluginsdk.ResourceData, meta interface
 	loadBalancer, err := client.Get(ctx, loadBalancerId.ResourceGroup, loadBalancerId.Name, "")
 	if err != nil {
 		if utils.ResponseWasNotFound(loadBalancer.Response) {
-			d.SetId("")
-			log.Printf("[INFO] Load Balancer %q not found. Removing from state", loadBalancerId.Name)
-			return nil
+			return fmt.Errorf("parent %s was not found", *loadBalancerId)
 		}
-		return fmt.Errorf("failed to retrieve Load Balancer %q (resource group %q) for Rule %q: %+v", loadBalancerId.Name, loadBalancerId.ResourceGroup, name, err)
+		return fmt.Errorf("retrieving parent %s: %+v", *loadBalancerId, err)
 	}
-
-	lbRuleClient := meta.(*clients.Client).LoadBalancers.LoadBalancingRulesClient
-	ctx, cancel = timeouts.ForRead(meta.(*clients.Client).StopContext, d)
-	defer cancel()
 
 	id := parse.NewLoadBalancingRuleID(loadBalancerId.SubscriptionId, loadBalancerId.ResourceGroup, loadBalancerId.Name, name)
 	resp, err := lbRuleClient.Get(ctx, id.ResourceGroup, *loadBalancer.Name, name)
@@ -106,77 +169,4 @@ func dataSourceArmLoadBalancerRuleRead(d *pluginsdk.ResourceData, meta interface
 	}
 
 	return nil
-}
-
-func dataSourceArmLoadBalancerSchema() map[string]*pluginsdk.Schema {
-	return map[string]*pluginsdk.Schema{
-		"name": {
-			Type:         pluginsdk.TypeString,
-			Required:     true,
-			ValidateFunc: validate.RuleName,
-		},
-
-		"loadbalancer_id": {
-			Type:         pluginsdk.TypeString,
-			Required:     true,
-			ValidateFunc: validate.LoadBalancerID,
-		},
-
-		"frontend_ip_configuration_name": {
-			Type:     pluginsdk.TypeString,
-			Computed: true,
-		},
-
-		"protocol": {
-			Type:     pluginsdk.TypeString,
-			Computed: true,
-		},
-
-		"frontend_port": {
-			Type:     pluginsdk.TypeInt,
-			Computed: true,
-		},
-
-		"backend_port": {
-			Type:     pluginsdk.TypeInt,
-			Computed: true,
-		},
-
-		"backend_address_pool_id": {
-			Type:     pluginsdk.TypeString,
-			Computed: true,
-		},
-
-		"probe_id": {
-			Type:     pluginsdk.TypeString,
-			Computed: true,
-		},
-
-		// TODO 4.0: change this from enable_* to *_enabled
-		"enable_floating_ip": {
-			Type:     pluginsdk.TypeBool,
-			Computed: true,
-		},
-
-		// TODO 4.0: change this from enable_* to *_enabled
-		"enable_tcp_reset": {
-			Type:     pluginsdk.TypeBool,
-			Computed: true,
-		},
-
-		"disable_outbound_snat": {
-			Type:     pluginsdk.TypeBool,
-			Computed: true,
-		},
-
-		"idle_timeout_in_minutes": {
-			Type:     pluginsdk.TypeInt,
-			Computed: true,
-		},
-
-		"load_distribution": {
-			Type:     pluginsdk.TypeString,
-			Computed: true,
-		},
-	}
 }

--- a/internal/services/mobilenetwork/mobile_network_data_source.go
+++ b/internal/services/mobilenetwork/mobile_network_data_source.go
@@ -82,7 +82,7 @@ func (r MobileNetworkDataSource) Read() sdk.ResourceFunc {
 			resp, err := client.Get(ctx, id)
 			if err != nil {
 				if response.WasNotFound(resp.HttpResponse) {
-					return metadata.MarkAsGone(id)
+					return fmt.Errorf("%s was not found", id)
 				}
 
 				return fmt.Errorf("retrieving %s: %+v", id, err)

--- a/internal/services/mobilenetwork/mobile_network_sim_group_data_source.go
+++ b/internal/services/mobilenetwork/mobile_network_sim_group_data_source.go
@@ -83,7 +83,7 @@ func (r SimGroupDataSource) Read() sdk.ResourceFunc {
 			resp, err := client.Get(ctx, id)
 			if err != nil {
 				if response.WasNotFound(resp.HttpResponse) {
-					return metadata.MarkAsGone(id)
+					return fmt.Errorf("%s was not found", id)
 				}
 
 				return fmt.Errorf("retrieving %s: %+v", id, err)

--- a/internal/services/mobilenetwork/mobile_network_site_data_source.go
+++ b/internal/services/mobilenetwork/mobile_network_site_data_source.go
@@ -73,7 +73,7 @@ func (r SiteDataSource) Read() sdk.ResourceFunc {
 			}
 
 			client := metadata.Client.MobileNetwork.SiteClient
-			mobileNetworkId, err := mobilenetwork.ParseMobileNetworkID(metaModel.MobileNetworkMobileNetworkId)
+			mobileNetworkId, err := mobilenetwork.ParseMobileNetworkID(metaModel.MobileNetworkId)
 			if err != nil {
 				return err
 			}
@@ -83,7 +83,7 @@ func (r SiteDataSource) Read() sdk.ResourceFunc {
 			resp, err := client.Get(ctx, id)
 			if err != nil {
 				if response.WasNotFound(resp.HttpResponse) {
-					return metadata.MarkAsGone(id)
+					return fmt.Errorf("%s was not found", id)
 				}
 
 				return fmt.Errorf("retrieving %s: %+v", id, err)
@@ -95,9 +95,9 @@ func (r SiteDataSource) Read() sdk.ResourceFunc {
 			}
 
 			state := SiteModel{
-				Name:                         id.SiteName,
-				MobileNetworkMobileNetworkId: mobilenetwork.NewMobileNetworkID(id.SubscriptionId, id.ResourceGroupName, id.MobileNetworkName).ID(),
-				Location:                     location.Normalize(model.Location),
+				Name:            id.SiteName,
+				MobileNetworkId: mobileNetworkId.ID(),
+				Location:        location.Normalize(model.Location),
 			}
 
 			if properties := model.Properties; properties != nil {

--- a/internal/services/mobilenetwork/mobile_network_site_resource.go
+++ b/internal/services/mobilenetwork/mobile_network_site_resource.go
@@ -17,11 +17,11 @@ import (
 )
 
 type SiteModel struct {
-	Name                         string            `tfschema:"name"`
-	MobileNetworkMobileNetworkId string            `tfschema:"mobile_network_id"`
-	Location                     string            `tfschema:"location"`
-	NetworkFunctions             []string          `tfschema:"network_function_ids"`
-	Tags                         map[string]string `tfschema:"tags"`
+	Name             string            `tfschema:"name"`
+	MobileNetworkId  string            `tfschema:"mobile_network_id"`
+	Location         string            `tfschema:"location"`
+	NetworkFunctions []string          `tfschema:"network_function_ids"`
+	Tags             map[string]string `tfschema:"tags"`
 }
 
 type SiteResource struct{}
@@ -84,7 +84,7 @@ func (r SiteResource) Create() sdk.ResourceFunc {
 			}
 
 			client := metadata.Client.MobileNetwork.SiteClient
-			mobileNetworkId, err := mobilenetwork.ParseMobileNetworkID(model.MobileNetworkMobileNetworkId)
+			mobileNetworkId, err := mobilenetwork.ParseMobileNetworkID(model.MobileNetworkId)
 			if err != nil {
 				return err
 			}
@@ -182,9 +182,9 @@ func (r SiteResource) Read() sdk.ResourceFunc {
 			}
 
 			state := SiteModel{
-				Name:                         id.SiteName,
-				MobileNetworkMobileNetworkId: mobilenetwork.NewMobileNetworkID(id.SubscriptionId, id.ResourceGroupName, id.MobileNetworkName).ID(),
-				Location:                     location.Normalize(model.Location),
+				Name:            id.SiteName,
+				MobileNetworkId: mobilenetwork.NewMobileNetworkID(id.SubscriptionId, id.ResourceGroupName, id.MobileNetworkName).ID(),
+				Location:        location.Normalize(model.Location),
 			}
 
 			if properties := model.Properties; properties != nil {

--- a/internal/services/mobilenetwork/mobile_network_slice_data_source.go
+++ b/internal/services/mobilenetwork/mobile_network_slice_data_source.go
@@ -90,7 +90,7 @@ func (r SliceDataSource) Read() sdk.ResourceFunc {
 			}
 
 			client := metadata.Client.MobileNetwork.SliceClient
-			mobileNetworkId, err := mobilenetwork.ParseMobileNetworkID(metaModel.MobileNetworkMobileNetworkId)
+			mobileNetworkId, err := mobilenetwork.ParseMobileNetworkID(metaModel.MobileNetworkId)
 			if err != nil {
 				return err
 			}
@@ -100,7 +100,7 @@ func (r SliceDataSource) Read() sdk.ResourceFunc {
 			resp, err := client.Get(ctx, id)
 			if err != nil {
 				if response.WasNotFound(resp.HttpResponse) {
-					return metadata.MarkAsGone(id)
+					return fmt.Errorf("%s was not found", id)
 				}
 
 				return fmt.Errorf("retrieving %s: %+v", id, err)
@@ -113,9 +113,9 @@ func (r SliceDataSource) Read() sdk.ResourceFunc {
 			model := *resp.Model
 
 			state := SliceModel{
-				Name:                         id.SliceName,
-				MobileNetworkMobileNetworkId: mobilenetwork.NewMobileNetworkID(id.SubscriptionId, id.ResourceGroupName, id.MobileNetworkName).ID(),
-				Location:                     location.Normalize(model.Location),
+				Name:            id.SliceName,
+				MobileNetworkId: mobileNetworkId.ID(),
+				Location:        location.Normalize(model.Location),
 			}
 
 			properties := model.Properties

--- a/internal/services/mobilenetwork/mobile_network_slice_resource.go
+++ b/internal/services/mobilenetwork/mobile_network_slice_resource.go
@@ -18,12 +18,12 @@ import (
 )
 
 type SliceModel struct {
-	Name                         string            `tfschema:"name"`
-	MobileNetworkMobileNetworkId string            `tfschema:"mobile_network_id"`
-	Description                  string            `tfschema:"description"`
-	Location                     string            `tfschema:"location"`
-	Snssai                       []SnssaiModel     `tfschema:"single_network_slice_selection_assistance_information"`
-	Tags                         map[string]string `tfschema:"tags"`
+	Name            string            `tfschema:"name"`
+	MobileNetworkId string            `tfschema:"mobile_network_id"`
+	Description     string            `tfschema:"description"`
+	Location        string            `tfschema:"location"`
+	Snssai          []SnssaiModel     `tfschema:"single_network_slice_selection_assistance_information"`
+	Tags            map[string]string `tfschema:"tags"`
 }
 
 type SnssaiModel struct {
@@ -113,7 +113,7 @@ func (r SliceResource) Create() sdk.ResourceFunc {
 			}
 
 			client := metadata.Client.MobileNetwork.SliceClient
-			mobileNetworkId, err := mobilenetwork.ParseMobileNetworkID(model.MobileNetworkMobileNetworkId)
+			mobileNetworkId, err := mobilenetwork.ParseMobileNetworkID(model.MobileNetworkId)
 			if err != nil {
 				return err
 			}
@@ -231,9 +231,9 @@ func (r SliceResource) Read() sdk.ResourceFunc {
 			model := *resp.Model
 
 			state := SliceModel{
-				Name:                         id.SliceName,
-				MobileNetworkMobileNetworkId: mobilenetwork.NewMobileNetworkID(id.SubscriptionId, id.ResourceGroupName, id.MobileNetworkName).ID(),
-				Location:                     location.Normalize(model.Location),
+				Name:            id.SliceName,
+				MobileNetworkId: mobilenetwork.NewMobileNetworkID(id.SubscriptionId, id.ResourceGroupName, id.MobileNetworkName).ID(),
+				Location:        location.Normalize(model.Location),
 			}
 
 			properties := model.Properties

--- a/internal/services/monitor/monitor_data_collection_endpoint_data_source.go
+++ b/internal/services/monitor/monitor_data_collection_endpoint_data_source.go
@@ -87,8 +87,7 @@ func (d DataCollectionEndpointDataSource) Read() sdk.ResourceFunc {
 			resp, err := client.Get(ctx, id)
 			if err != nil {
 				if response.WasNotFound(resp.HttpResponse) {
-					metadata.Logger.Infof("%s was not found - removing from state!", id)
-					return metadata.MarkAsGone(id)
+					return fmt.Errorf("%s was not found", id)
 				}
 				return fmt.Errorf("retrieving %s: %+v", id, err)
 			}

--- a/internal/services/mssql/mssql_managed_instance_data_source.go
+++ b/internal/services/mssql/mssql_managed_instance_data_source.go
@@ -164,13 +164,10 @@ func (d MsSqlManagedInstanceDataSource) Read() sdk.ResourceFunc {
 			}
 
 			id := parse.NewManagedInstanceID(subscriptionId, state.ResourceGroupName, state.Name)
-
-			metadata.Logger.Infof("Reading %s", id)
-
 			resp, err := client.Get(ctx, id.ResourceGroup, id.Name, "")
 			if err != nil {
 				if utils.ResponseWasNotFound(resp.Response) {
-					return metadata.MarkAsGone(id)
+					return fmt.Errorf("%s was not found", id)
 				}
 				return fmt.Errorf("retrieving %s: %v", id, err)
 			}

--- a/internal/services/network/local_network_gateway_data_source.go
+++ b/internal/services/network/local_network_gateway_data_source.go
@@ -90,11 +90,10 @@ func dataSourceLocalNetworkGatewayRead(d *pluginsdk.ResourceData, meta interface
 	resp, err := client.Get(ctx, id.ResourceGroup, id.Name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			d.SetId("")
-			return nil
+			return fmt.Errorf("%s was not found", id)
 		}
 
-		return fmt.Errorf("reading the state of %s: %+v", id, err)
+		return fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
 	d.SetId(id.ID())

--- a/internal/services/network/vpn_gateway_data_source.go
+++ b/internal/services/network/vpn_gateway_data_source.go
@@ -2,7 +2,6 @@ package network
 
 import (
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
@@ -158,9 +157,7 @@ func dataSourceVPNGatewayRead(d *pluginsdk.ResourceData, meta interface{}) error
 	resp, err := client.Get(ctx, id.ResourceGroup, id.Name)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
-			log.Printf("[DEBUG] VPN Gateway %q was not found in Resource Group %q - removing from state", id.Name, id.ResourceGroup)
-			d.SetId("")
-			return nil
+			return fmt.Errorf("%s was not found", id)
 		}
 
 		return fmt.Errorf("Error retrieving VPN Gateway %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)

--- a/internal/services/policy/assignment_data_source.go
+++ b/internal/services/policy/assignment_data_source.go
@@ -154,7 +154,7 @@ func (AssignmentDataSource) Read() sdk.ResourceFunc {
 			resp, err := client.Get(ctx, id.Scope, id.Name)
 			if err != nil {
 				if utils.ResponseWasNotFound(resp.Response) {
-					return metadata.MarkAsGone(id)
+					return fmt.Errorf("%s was not found", id)
 				}
 				return fmt.Errorf("retrieving %s: %+v", id, err)
 			}

--- a/internal/services/recoveryservices/site_recovery_replication_recovery_plan_data_source.go
+++ b/internal/services/recoveryservices/site_recovery_replication_recovery_plan_data_source.go
@@ -47,13 +47,12 @@ func (r SiteRecoveryReplicationRecoveryPlanDataSource) Read() sdk.ResourceFunc {
 			}
 
 			id := replicationrecoveryplans.NewReplicationRecoveryPlanID(subscriptionId, vaultId.ResourceGroupName, vaultId.VaultName, metaModel.Name)
-
 			resp, err := client.Get(ctx, id)
 			if err != nil {
 				if response.WasNotFound(resp.HttpResponse) {
-					return metadata.MarkAsGone(id)
+					return fmt.Errorf("%s was not found", id)
 				}
-				return fmt.Errorf("making Read request on site recovery replication plan %s : %+v", id.String(), err)
+				return fmt.Errorf("retrieving %s: %+v", id, err)
 			}
 
 			model := resp.Model

--- a/internal/services/redisenterprise/redis_enterprise_database_data_source.go
+++ b/internal/services/redisenterprise/redis_enterprise_database_data_source.go
@@ -90,8 +90,7 @@ func dataSourceRedisEnterpriseDatabaseRead(d *pluginsdk.ResourceData, meta inter
 	resp, err := client.Get(ctx, id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			d.SetId("")
-			return nil
+			return fmt.Errorf("%s was not found", id)
 		}
 		return fmt.Errorf("retrieving %s: %+v", id, err)
 	}

--- a/internal/services/servicebus/servicebus_namespace_disaster_recovery_config_data_source.go
+++ b/internal/services/servicebus/servicebus_namespace_disaster_recovery_config_data_source.go
@@ -113,8 +113,7 @@ func dataSourceServiceBusNamespaceDisasterRecoveryConfigRead(d *pluginsdk.Resour
 	resp, err := client.Get(ctx, id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			d.SetId("")
-			return nil
+			return fmt.Errorf("%s was not found", id)
 		}
 		return fmt.Errorf("retrieving %s: %+v", id, err)
 	}

--- a/internal/services/signalr/web_pubsub_data_source.go
+++ b/internal/services/signalr/web_pubsub_data_source.go
@@ -2,7 +2,6 @@ package signalr
 
 import (
 	"fmt"
-	"log"
 	"strings"
 	"time"
 
@@ -131,9 +130,7 @@ func dataSourceWebPubsubRead(d *pluginsdk.ResourceData, meta interface{}) error 
 	resp, err := client.Get(ctx, id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
-			log.Printf("[INFO] Web Pubsub %s does not exist - removing from state", d.Id())
-			d.SetId("")
-			return nil
+			return fmt.Errorf("%s was not found", id)
 		}
 		return fmt.Errorf("retrieving %q: %+v", id, err)
 	}

--- a/internal/services/storage/storage_blob_data_source.go
+++ b/internal/services/storage/storage_blob_data_source.go
@@ -97,9 +97,7 @@ func dataSourceStorageBlobRead(d *pluginsdk.ResourceData, meta interface{}) erro
 	props, err := blobsClient.GetProperties(ctx, accountName, containerName, name, input)
 	if err != nil {
 		if utils.ResponseWasNotFound(props.Response) {
-			log.Printf("[INFO] Blob %q was not found in Container %q / Account %q - assuming removed & removing from state...", name, containerName, accountName)
-			d.SetId("")
-			return nil
+			return fmt.Errorf("the Blob %q was not found in Container %q / Account %q", name, containerName, accountName)
 		}
 
 		return fmt.Errorf("retrieving properties for Blob %q (Container %q / Account %q): %s", name, containerName, accountName, err)

--- a/internal/services/storage/storage_table_entity_data_source.go
+++ b/internal/services/storage/storage_table_entity_data_source.go
@@ -2,7 +2,6 @@ package storage
 
 import (
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -72,9 +71,7 @@ func dataSourceStorageTableEntityRead(d *pluginsdk.ResourceData, meta interface{
 		return fmt.Errorf("retrieving Account %q for Table %q: %s", storageAccountName, tableName, err)
 	}
 	if account == nil {
-		log.Printf("[WARN] Unable to determine Resource Group for Storage Table %q (Account %s) - assuming removed & removing from state", tableName, storageAccountName)
-		d.SetId("")
-		return nil
+		return fmt.Errorf("the parent Storage Account %s was not found", storageAccountName)
 	}
 
 	client, err := storageClient.TableEntityClient(ctx, *account)

--- a/internal/services/web/app_service_environment_v3_data_source.go
+++ b/internal/services/web/app_service_environment_v3_data_source.go
@@ -187,7 +187,7 @@ func (r AppServiceEnvironmentV3DataSource) Read() sdk.ResourceFunc {
 			existing, err := client.Get(ctx, id.ResourceGroup, id.HostingEnvironmentName)
 			if err != nil {
 				if utils.ResponseWasNotFound(existing.Response) {
-					return metadata.MarkAsGone(id)
+					return fmt.Errorf("%s was not found", id)
 				}
 				return fmt.Errorf("retrieving %s: %+v", id, err)
 			}

--- a/scripts/run-gradually-deprecated.sh
+++ b/scripts/run-gradually-deprecated.sh
@@ -149,6 +149,7 @@ function runDeprecatedFunctions {
 
 function main {
   # testing
+  echo "in main"
   exit 1
 
   if [ "$GITHUB_ACTIONS_STAGE" == "UNIT_TESTS" ];
@@ -163,4 +164,5 @@ function main {
   checkForUnclearErrorMessages
 }
 
+echo "in file"
 main

--- a/scripts/run-gradually-deprecated.sh
+++ b/scripts/run-gradually-deprecated.sh
@@ -133,7 +133,7 @@ function runDeprecatedFunctions {
     echo "$result"
     exit 1
   fi
-  result=$(grep -Ril "markasgone" ./internal/services/**/*.go | grep data_source)
+  result=$(grep -Ril "markasgone" ./internal/services/**/*data_source*.go)
   if [ "$result" != "" ];
   then
     echo "Data Sources should return an error when a resource cannot be found rather than"

--- a/scripts/run-gradually-deprecated.sh
+++ b/scripts/run-gradually-deprecated.sh
@@ -72,30 +72,36 @@ function runGraduallyDeprecatedFunctions {
       }
     fi
 
-    # check for d.Get inside Delete
-    deleteFuncName=$(grep -o "Delete: .*," "$f" -m1 | grep -o " .*Delete"| tr -d " ")
-    if [ "$deleteFuncName" != "" ];
+    # avoid false positives
+    isThisScript=$(echo "$f" | grep "run-gradually-deprecated")
+    if [ "$isThisScript" == "" ];
     then
-      deleteMethod=$(cat -n $f | sed -n -e "/func $deleteFuncName.*$/,/[[:digit:]]*\treturn nil/{ /func $deleteFuncName$/d; /[[:digit:]]*\treturn nil/d; p; }")
-      foundGet=$(echo "$deleteMethod" | grep "d\.Get(.*)" -m1)
-      if [ "$foundGet" != "" ];
+      # check for d.Get inside Delete
+      deleteFuncName=$(grep -o "Delete: .*," "$f" -m1 | grep -o " .*Delete"| tr -d " ")
+      if [ "$deleteFuncName" != "" ];
       then
-        echo "$f $foundGet"
-        echo "Please do not use 'd.Get' within the Delete function as this does not work as expected in Delete"
-        exit 1
-      fi
-    else
-      # check for Get in typed resource
-      deleteFuncName=" Delete() sdk.ResourceFunc "
-      deleteMethod=$(cat -n $f | sed -n -e "/$deleteFuncName.*$/,/[[:digit:]]*\t\t\treturn nil/{ /$deleteFuncName.*$/d; /[[:digit:]]*\t\t\treturn nil/d; p; }")
-      foundGet=$(echo "$deleteMethod" | grep "metadata.ResourceData.Get" -m1)
-      if [ "$foundGet" != "" ];
-      then
-        echo "$f $foundGet"
-        echo "Please do not use 'metadata.ResourceData.Get' within the Delete function as this does not work as expected in Delete"
-        exit 1
-      fi
+        deleteMethod=$(cat -n $f | sed -n -e "/func $deleteFuncName.*$/,/[[:digit:]]*\treturn nil/{ /func $deleteFuncName$/d; /[[:digit:]]*\treturn nil/d; p; }")
+        foundGet=$(echo "$deleteMethod" | grep "d\.Get(.*)" -m1)
+        if [ "$foundGet" != "" ];
+        then
+          echo "$f $foundGet"
+          echo "Please do not use 'd.Get' within the Delete function as this does not work as expected in Delete"
+          exit 1
+        fi
+      else
+        # check for Get in typed resource
+        deleteFuncName=" Delete() sdk.ResourceFunc "
+        deleteMethod=$(cat -n $f | sed -n -e "/$deleteFuncName.*$/,/[[:digit:]]*\t\t\treturn nil/{ /$deleteFuncName.*$/d; /[[:digit:]]*\t\t\treturn nil/d; p; }")
+        foundGet=$(echo "$deleteMethod" | grep "metadata.ResourceData.Get" -m1)
+        if [ "$foundGet" != "" ];
+        then
+            echo "$f $foundGet"
+            echo "Please do not use 'metadata.ResourceData.Get' within the Delete function as this does not work as expected in Delete"
+            exit 1
+          fi
+        fi
     fi
+
   done
 }
 
@@ -115,7 +121,7 @@ function checkForUnclearErrorMessages {
 
 function runDeprecatedFunctions {
   echo "==> Checking for use of deprecated functions..."
-  result=$(grep -Ril "d.setid(\"\")" ./internal/services/**/data_source_*.go)
+  result=$(grep -Ril "d.setid(\"\")" ./internal/services/**/*.go) | grep data_source
   if [ "$result" != "" ];
   then
     echo "Data Sources should return an error when a resource cannot be found rather than"

--- a/scripts/run-gradually-deprecated.sh
+++ b/scripts/run-gradually-deprecated.sh
@@ -121,7 +121,7 @@ function checkForUnclearErrorMessages {
 
 function runDeprecatedFunctions {
   echo "==> Checking for use of deprecated functions..."
-  result=$(grep -Ril "d.setid(\"\")" ./internal/services/**/*.go | grep data_source)
+  result=$(grep -Ril "d.setid(\"\")" ./internal/services/**/*data_source*.go)
   if [ "$result" != "" ];
   then
     echo "Data Sources should return an error when a resource cannot be found rather than"

--- a/scripts/run-gradually-deprecated.sh
+++ b/scripts/run-gradually-deprecated.sh
@@ -121,7 +121,7 @@ function checkForUnclearErrorMessages {
 
 function runDeprecatedFunctions {
   echo "==> Checking for use of deprecated functions..."
-  result=$(grep -Ril "d.setid(\"\")" ./internal/services/**/*.go) | grep data_source
+  result=$(grep -Ril "d.setid(\"\")" ./internal/services/**/*.go | grep data_source)
   if [ "$result" != "" ];
   then
     echo "Data Sources should return an error when a resource cannot be found rather than"
@@ -130,6 +130,19 @@ function runDeprecatedFunctions {
     echo "Please remove the references to 'd.SetId("") from the Data Sources listed below"
     echo "and raise an error instead:"
     echo ""
+    echo "$result"
+    exit 1
+  fi
+  result=$(grep -Ril "markasgone" ./internal/services/**/*.go | grep data_source)
+  if [ "$result" != "" ];
+  then
+    echo "Data Sources should return an error when a resource cannot be found rather than"
+    echo "marking the resource as gone."
+    echo ""
+    echo "Please remove the references to 'metadata.MarkAsGone' from the Data Sources listed below"
+    echo "and raise an error instead:"
+    echo ""
+    echo "$result"
     exit 1
   fi
 }

--- a/scripts/run-gradually-deprecated.sh
+++ b/scripts/run-gradually-deprecated.sh
@@ -148,6 +148,9 @@ function runDeprecatedFunctions {
 }
 
 function main {
+  # testing
+  exit 1
+
   if [ "$GITHUB_ACTIONS_STAGE" == "UNIT_TESTS" ];
   then
     echo "Skipping - the Gradually Deprecated check is separate in Github Actions"


### PR DESCRIPTION
Since we're looking up a particular resource by it's details, if it's not found we should return an error, unfortunately these data sources haven't been doing that due to the broken script - so this commit fixes both the data sources and the script to validate that Data Sources don't use `d.SetID("")`

Changelog:

```
BUG FIXES

* Data Source: `azurerm_aadb2c_directory` - fixing a bug where the Data Source didn't return an error when the AAD B2C was not found
* Data Source: `azurerm_app_service_environment_v3` - fixing a bug where the Data Source didn't return an error when the App Service Environment was not found
* Data Source: `azurerm_consumption_budget_resource_group` - using the correct timeout value
* Data Source: `azurerm_consumption_budget_resource_group` - fixing a bug where the Data Source didn't return an error when the Consumption Budget Resource Group was not found
* Data Source: `azurerm_data_protection_backup_vault` - fixing a bug where the Data Source didn't return an error when the Data Protection Backup Vault was not found
* Data Source: `azurerm_databox_edge_device` - fixing a bug where the Data Source didn't return an error when the DataBox Edge Device was not found
* Data Source: `azurerm_healthcare_dicom` - fixing a bug where the Data Source didn't return an error when the HealthCare DICOM was not found
* Data Source: `azurerm_healthcare_fhir` - fixing a bug where the Data Source didn't return an error when the HealthCare FHIR was not found
* Data Source: `azurerm_healthcare_medtech_service` - fixing a bug where the Data Source didn't return an error when the HealthCare MedTech Service was not found
* Data Source: `azurerm_hybrid_compute_machine` - fixing a bug where the Data Source didn't return an error when the Hybrid Compute Machine was not found
* Data Source: `azurerm_key_vault_certificate_data` - fixing a bug where the Data Source didn't return an error when the KeyVault Certificate was not found
* Data Source: `azurerm_key_vault_certificate` - fixing a bug where the Data Source didn't return an error when the KeyVault Certificate was not found
* Data Source: `azurerm_lb_outbound_rule` - fixing a bug where the Data Source didn't return an error when the Load Balancer Outbound Rule was not found
* Data Source: `azurerm_lb_rule` - fixing a bug where the Data Source didn't return an error when the Load Balancer Rule was not found
* Data Source: `azurerm_local_network_gateway` - fixing a bug where the Data Source didn't return an error when the Local Network Gateway was not found
* Data Source: `azurerm_mobile_network` - fixing a bug where the Data Source didn't return an error when the Mobile Network was not found
* Data Source: `azurerm_mobile_network_sim_group` - fixing a bug where the Data Source didn't return an error when the Mobile Network Sim Group was not found
* Data Source: `azurerm_mobile_network_site` - fixing a bug where the Data Source didn't return an error when the Mobile Network Site was not found
* Data Source: `azurerm_mobile_network_slice` - fixing a bug where the Data Source didn't return an error when the Mobile Network Slice was not found
* Data Source: `azurerm_monitor_data_collection_endpoint` - fixing a bug where the Data Source didn't return an error when the Monitor Data Collection Endpoint was not found
* Data Source: `azurerm_mssql_managed_instance` - fixing a bug where the Data Source didn't return an error when the MSSQL Managed Instance was not found
* Data Source: `azurerm_policy_assignment` - fixing a bug where the Data Source didn't return an error when the Policy Assignment was not found
* Data Source: `azurerm_redis_enterprise_database` - fixing a bug where the Data Source didn't return an error when the Redis Enterprise Database was not found
* Data Source: `azurerm_servicebus_namespace_disaster_recovery_config` - fixing a bug where the Data Source didn't return an error when the ServiceBus Namespace Disaster Recovery Config was not found
* Data Source: `azurerm_site_recovery_replication_recovery_plan` - fixing a bug where the Data Source didn't return an error when the Site Recovery Replication Recovery Plan was not found
* Data Source: `azurerm_storage_blob` - fixing a bug where the Data Source didn't return an error when the Blob was not found
* Data Source: `azurerm_storage_table_entity` - fixing a bug where the Data Source didn't return an error when the Table Entity was not found
* Data Source: `azurerm_vpn_gateway` - fixing a bug where the Data Source didn't return an error when the VPN Gateway was not found
* Data Source: `azurerm_web_pubsub` - fixing a bug where the Data Source didn't return an error when the Web PubSub was not found
```