### PR TITLE
temp: duplicating a data source to validate the linter passes

### DIFF
--- a/internal/services/portal/registration.go
+++ b/internal/services/portal/registration.go
@@ -29,7 +29,8 @@ func (r Registration) WebsiteCategories() []string {
 // SupportedDataSources returns the supported Data Sources supported by this Service
 func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
 	return map[string]*pluginsdk.Resource{
-		"azurerm_portal_dashboard": dataSourcePortalDashboard(),
+		"azurerm_portal_dashboard":       dataSourcePortalDashboard(),
+		"azurerm_portal_dashboard_other": dataSourcePortalDashboard(),
 	}
 }
 


### PR DESCRIPTION
This'll want closing, but exists just to check that `unit-test` and `gradually-deprecated` pass