### PR TITLE
r/kubernetes_cluster: parsing the `log_analytics_workspace_id` response insensitively to fix #20478

### DIFF
--- a/internal/services/containers/kubernetes_addons.go
+++ b/internal/services/containers/kubernetes_addons.go
@@ -311,7 +311,7 @@ func expandKubernetesAddOns(d *pluginsdk.ResourceData, input map[string]interfac
 		config := make(map[string]string)
 
 		if workspaceID, ok := value["log_analytics_workspace_id"]; ok && workspaceID != "" {
-			lawid, err := workspaces.ParseWorkspaceID(workspaceID.(string))
+			lawid, err := workspaces.ParseWorkspaceIDInsensitively(workspaceID.(string))
 			if err != nil {
 				return nil, fmt.Errorf("parsing Log Analytics Workspace ID: %+v", err)
 			}


### PR DESCRIPTION
Resource IDs returned from the Azure API should be parsed case-insensitively within Read functions - fixes #20478 