### PR TITLE
Add Standard sku_tier to Kubernetes

### DIFF
--- a/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
@@ -1677,7 +1677,7 @@ resource "azurerm_kubernetes_cluster" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   dns_prefix          = "acctestaks%d"
-  sku_tier            = "Paid"
+  sku_tier            = "Standard"
   default_node_pool {
     name           = "default"
     node_count     = 1

--- a/internal/services/containers/kubernetes_cluster_other_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_other_resource_test.go
@@ -1372,7 +1372,7 @@ resource "azurerm_kubernetes_cluster" "test" {
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   dns_prefix          = "acctestaks%d"
-  sku_tier            = "Paid"
+  sku_tier            = "Standard"
 
   default_node_pool {
     name       = "default"

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -1111,6 +1111,7 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 				ValidateFunc: validation.StringInSlice([]string{
 					string(managedclusters.ManagedClusterSKUTierFree),
 					string(managedclusters.ManagedClusterSKUTierPaid),
+					string(managedclusters.ManagedClusterSKUTierStandard),
 				}, false),
 			},
 

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/managedclusters/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/managedclusters/constants.go
@@ -530,21 +530,24 @@ func parseManagedClusterSKUName(input string) (*ManagedClusterSKUName, error) {
 type ManagedClusterSKUTier string
 
 const (
-	ManagedClusterSKUTierFree ManagedClusterSKUTier = "Free"
-	ManagedClusterSKUTierPaid ManagedClusterSKUTier = "Paid"
+	ManagedClusterSKUTierFree     ManagedClusterSKUTier = "Free"
+	ManagedClusterSKUTierPaid     ManagedClusterSKUTier = "Paid"
+	ManagedClusterSKUTierStandard ManagedClusterSKUTier = "Standard"
 )
 
 func PossibleValuesForManagedClusterSKUTier() []string {
 	return []string{
 		string(ManagedClusterSKUTierFree),
 		string(ManagedClusterSKUTierPaid),
+		string(ManagedClusterSKUTierStandard),
 	}
 }
 
 func parseManagedClusterSKUTier(input string) (*ManagedClusterSKUTier, error) {
 	vals := map[string]ManagedClusterSKUTier{
-		"free": ManagedClusterSKUTierFree,
-		"paid": ManagedClusterSKUTierPaid,
+		"free":     ManagedClusterSKUTierFree,
+		"paid":     ManagedClusterSKUTierPaid,
+		"standard": ManagedClusterSKUTierStandard,
 	}
 	if v, ok := vals[strings.ToLower(input)]; ok {
 		return &v, nil

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -235,7 +235,7 @@ resource "azurerm_kubernetes_cluster" "example" {
 
 !> **Note:** A migration scenario from `service_principal` to `identity` is supported. When upgrading `service_principal` to `identity`, your cluster's control plane and addon pods will switch to use managed identity, but the kubelets will keep using your configured `service_principal` until you upgrade your Node Pool.
 
-* `sku_tier` - (Optional) The SKU Tier that should be used for this Kubernetes Cluster. Possible values are `Free` and `Paid` (which includes the Uptime SLA). Defaults to `Free`.
+* `sku_tier` - (Optional) The SKU Tier that should be used for this Kubernetes Cluster. Possible values are `Free`, `Standard` and `Paid` (which is Deprecated and will be removed 2023-07-01). Standard and Paid includes the Uptime SLA. Defaults to `Free`.
 
 * `storage_profile` - (Optional) A `storage_profile` block as defined below.
 


### PR DESCRIPTION
#20455 Add support for Standard sku_tier to Kubernetes.

Azure is changing their naming standard for their SKU tiers. This commit enables the Standard tier which will become the default replacement for the Paid tier in July.

The Standard tier has been GA since 2023-01-01

https://learn.microsoft.com/en-us/azure/aks/free-standard-pricing-tiers#uptime-sla

