### PR TITLE
azurerm_nginx_configuration - fix package_data, protected_file validation logic

### DIFF
--- a/internal/services/nginx/nginx_configuration_resource.go
+++ b/internal/services/nginx/nginx_configuration_resource.go
@@ -102,8 +102,9 @@ func (m ConfigurationResource) Arguments() map[string]*pluginsdk.Schema {
 		},
 
 		"config_file": {
-			Type:     pluginsdk.TypeSet,
-			Required: true,
+			Type:         pluginsdk.TypeSet,
+			Optional:     true,
+			AtLeastOneOf: []string{"config_file", "package_data"},
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*pluginsdk.Schema{
 					"content": {
@@ -122,8 +123,9 @@ func (m ConfigurationResource) Arguments() map[string]*pluginsdk.Schema {
 		},
 
 		"protected_file": {
-			Type:     pluginsdk.TypeSet,
-			Optional: true,
+			Type:         pluginsdk.TypeSet,
+			Optional:     true,
+			RequiredWith: []string{"config_file"},
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*pluginsdk.Schema{
 					"content": {
@@ -143,9 +145,11 @@ func (m ConfigurationResource) Arguments() map[string]*pluginsdk.Schema {
 		},
 
 		"package_data": {
-			Type:         pluginsdk.TypeString,
-			Optional:     true,
-			ValidateFunc: validation.StringIsNotEmpty,
+			Type:          pluginsdk.TypeString,
+			Optional:      true,
+			ValidateFunc:  validation.StringIsNotEmpty,
+			AtLeastOneOf:  []string{"config_file", "package_data"},
+			ConflictsWith: []string{"protected_file", "config_file"},
 		},
 
 		"root_file": {

--- a/website/docs/r/nginx_configuration.html.markdown
+++ b/website/docs/r/nginx_configuration.html.markdown
@@ -57,17 +57,19 @@ EOT
 
 The following arguments are supported:
 
-* `config_file` - (Required) One or more `config_file` blocks as defined below.
-
 * `nginx_deployment_id` - (Required) The ID of the Nginx Deployment. Changing this forces a new Nginx Configuration to be created.
 
 * `root_file` - (Required) Specify the root file path of this Nginx Configuration.
 
 ---
 
+-> **NOTE:** Either `package_data` or `config_file` must be specified - but not both.
+
 * `package_data` - (Optional) Specify the package data for this configuration.
 
-* `protected_file` - (Optional) One or more `config_file` (Protected File) blocks with sensitive information as defined below.
+* `config_file` - (Optional) One or more `config_file` blocks as defined below.
+
+* `protected_file` - (Optional) One or more `protected_file` (Protected File) blocks with sensitive information as defined below. If specified `config_file` must also be specified.
 
 ---
 
@@ -79,7 +81,7 @@ A `config_file` block supports the following:
 
 ---
 
-A `config_file` (Protected File) block supports the following:
+A `protected_file` (Protected File) block supports the following:
 
 * `content` - (Required) Specifies the base-64 encoded contents of this config file (Sensitive).
 


### PR DESCRIPTION
The validation was always requiring a `config_file`, which is not accurate. Updates the schemas to make:

- `config_file` and `package_data` mutually exclusive
- `protected_file` requires `config_file`

Also updates docs to match.

fixes #20487 