### PR TITLE
`azurerm_postgresql_flexible_server` - update `ForceNew` for `create_mode` and `version`

### DIFF
--- a/internal/services/postgres/postgresql_flexible_server_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_resource.go
@@ -305,18 +305,14 @@ func resourcePostgresqlFlexibleServer() *pluginsdk.Resource {
 						return err
 					}
 
-					if !(oldVersion < newVersion) {
-						d.ForceNew("create_mode")
-						d.ForceNew("version")
+					if oldVersion < newVersion {
+						return nil
 					}
-				} else {
-					d.ForceNew("create_mode")
-					d.ForceNew("version")
 				}
-			} else {
-				d.ForceNew("create_mode")
-				d.ForceNew("version")
 			}
+
+			d.ForceNew("create_mode")
+			d.ForceNew("version")
 
 			return nil
 		}),

--- a/internal/services/postgres/postgresql_flexible_server_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_resource.go
@@ -292,25 +292,20 @@ func resourcePostgresqlFlexibleServer() *pluginsdk.Resource {
 			createModeVal := d.Get("create_mode").(string)
 
 			if createModeVal == string(servers.CreateModeUpdate) {
-				if d.HasChange("version") {
-					oldVersionVal, newVersionVal := d.GetChange("version")
-					
-					if oldVersionVal != "" && newVersionVal != "" {
-						oldVersion, err := strconv.ParseInt(oldVersionVal.(string), 10, 32)
-						if err != nil {
-							return err
-						}
+				oldVersionVal, newVersionVal := d.GetChange("version")
 
-						newVersion, err := strconv.ParseInt(newVersionVal.(string), 10, 32)
-						if err != nil {
-							return err
-						}
+				if oldVersionVal != "" && newVersionVal != "" {
+					oldVersion, err := strconv.ParseInt(oldVersionVal.(string), 10, 32)
+					if err != nil {
+						return err
+					}
 
-						if !(oldVersion < newVersion) {
-							d.ForceNew("create_mode")
-							d.ForceNew("version")
-						}
-					} else {
+					newVersion, err := strconv.ParseInt(newVersionVal.(string), 10, 32)
+					if err != nil {
+						return err
+					}
+
+					if !(oldVersion < newVersion) {
 						d.ForceNew("create_mode")
 						d.ForceNew("version")
 					}

--- a/internal/services/postgres/postgresql_flexible_server_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_resource.go
@@ -290,10 +290,11 @@ func resourcePostgresqlFlexibleServer() *pluginsdk.Resource {
 
 		CustomizeDiff: pluginsdk.CustomizeDiffShim(func(ctx context.Context, d *pluginsdk.ResourceDiff, v interface{}) error {
 			createModeVal := d.Get("create_mode").(string)
-			oldVersionVal, newVersionVal := d.GetChange("version")
 
 			if createModeVal == string(servers.CreateModeUpdate) {
 				if d.HasChange("version") {
+					oldVersionVal, newVersionVal := d.GetChange("version")
+					
 					if oldVersionVal != "" && newVersionVal != "" {
 						oldVersion, err := strconv.ParseInt(oldVersionVal.(string), 10, 32)
 						if err != nil {

--- a/internal/services/postgres/postgresql_flexible_server_resource_test.go
+++ b/internal/services/postgres/postgresql_flexible_server_resource_test.go
@@ -366,56 +366,20 @@ resource "azurerm_resource_group" "test" {
 
 func (r PostgresqlFlexibleServerResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-postgresql-test0223"
-  location = "westeurope"
-}
+%s
 
 resource "azurerm_postgresql_flexible_server" "test" {
-  name                   = "acctest-fs-test0222"
+  name                   = "acctest-fs-%d"
   resource_group_name    = azurerm_resource_group.test.name
   location               = azurerm_resource_group.test.location
   administrator_login    = "adminTerraform"
   administrator_password = "QAZwsx123"
   storage_mb             = 32768
+  version                = "12"
   sku_name               = "GP_Standard_D2s_v3"
   zone                   = "2"
-
-  create_mode            = "Default"
-  version                = "13"
 }
-`)
-}
-
-func (r PostgresqlFlexibleServerResource) basic2(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-postgresql-test0223"
-  location = "westeurope"
-}
-
-resource "azurerm_postgresql_flexible_server" "test" {
-  name                   = "acctest-fs-test0222"
-  resource_group_name    = azurerm_resource_group.test.name
-  location               = azurerm_resource_group.test.location
-  administrator_login    = "adminTerraform"
-  administrator_password = "QAZwsx123"
-  storage_mb             = 32768
-  sku_name               = "GP_Standard_D2s_v3"
-  zone                   = "2"
-
-  create_mode            = "Update"
-  version                = "13"
-}
-`)
+`, r.template(data), data.RandomInteger)
 }
 
 func (r PostgresqlFlexibleServerResource) requiresImport(data acceptance.TestData) string {

--- a/internal/services/postgres/postgresql_flexible_server_resource_test.go
+++ b/internal/services/postgres/postgresql_flexible_server_resource_test.go
@@ -366,20 +366,56 @@ resource "azurerm_resource_group" "test" {
 
 func (r PostgresqlFlexibleServerResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-%s
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-postgresql-test0223"
+  location = "westeurope"
+}
 
 resource "azurerm_postgresql_flexible_server" "test" {
-  name                   = "acctest-fs-%d"
+  name                   = "acctest-fs-test0222"
   resource_group_name    = azurerm_resource_group.test.name
   location               = azurerm_resource_group.test.location
   administrator_login    = "adminTerraform"
   administrator_password = "QAZwsx123"
   storage_mb             = 32768
-  version                = "12"
   sku_name               = "GP_Standard_D2s_v3"
   zone                   = "2"
+
+  create_mode            = "Default"
+  version                = "13"
 }
-`, r.template(data), data.RandomInteger)
+`)
+}
+
+func (r PostgresqlFlexibleServerResource) basic2(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-postgresql-test0223"
+  location = "westeurope"
+}
+
+resource "azurerm_postgresql_flexible_server" "test" {
+  name                   = "acctest-fs-test0222"
+  resource_group_name    = azurerm_resource_group.test.name
+  location               = azurerm_resource_group.test.location
+  administrator_login    = "adminTerraform"
+  administrator_password = "QAZwsx123"
+  storage_mb             = 32768
+  sku_name               = "GP_Standard_D2s_v3"
+  zone                   = "2"
+
+  create_mode            = "Update"
+  version                = "13"
+}
+`)
 }
 
 func (r PostgresqlFlexibleServerResource) requiresImport(data acceptance.TestData) string {

--- a/website/docs/r/postgresql_flexible_server.html.markdown
+++ b/website/docs/r/postgresql_flexible_server.html.markdown
@@ -104,6 +104,8 @@ The following arguments are supported:
 
 -> **Note:** When `create_mode` is set to `Update`, it wouldn't force a new resource to be created.
 
+-> **Note:** While creating the resource, `create_mode` cannot be set to `Update`.
+
 * `delegated_subnet_id` - (Optional) The ID of the virtual network subnet to create the PostgreSQL Flexible Server. The provided subnet should not have any other resource deployed in it and this subnet will be delegated to the PostgreSQL Flexible Server, if not already delegated. Changing this forces a new PostgreSQL Flexible Server to be created.
 
 * `private_dns_zone_id` - (Optional) The ID of the private DNS zone to create the PostgreSQL Flexible Server. Changing this forces a new PostgreSQL Flexible Server to be created.

--- a/website/docs/r/postgresql_flexible_server.html.markdown
+++ b/website/docs/r/postgresql_flexible_server.html.markdown
@@ -102,8 +102,6 @@ The following arguments are supported:
 
 * `create_mode` - (Optional) The creation mode which can be used to restore or replicate existing servers. Possible values are `Default`, `PointInTimeRestore`, `Replica` and `Update`. Changing this forces a new PostgreSQL Flexible Server to be created.
 
--> **Note:** When `create_mode` is set to `Update`, it wouldn't force a new resource to be created.
-
 -> **Note:** While creating the resource, `create_mode` cannot be set to `Update`.
 
 * `delegated_subnet_id` - (Optional) The ID of the virtual network subnet to create the PostgreSQL Flexible Server. The provided subnet should not have any other resource deployed in it and this subnet will be delegated to the PostgreSQL Flexible Server, if not already delegated. Changing this forces a new PostgreSQL Flexible Server to be created.

--- a/website/docs/r/postgresql_flexible_server.html.markdown
+++ b/website/docs/r/postgresql_flexible_server.html.markdown
@@ -100,7 +100,9 @@ The following arguments are supported:
 
 * `geo_redundant_backup_enabled` - (Optional) Is Geo-Redundant backup enabled on the PostgreSQL Flexible Server. Defaults to `false`. Changing this forces a new PostgreSQL Flexible Server to be created.
 
-* `create_mode` - (Optional) The creation mode which can be used to restore or replicate existing servers. Possible values are `Default`, `PointInTimeRestore` and `Replica`. Changing this forces a new PostgreSQL Flexible Server to be created.
+* `create_mode` - (Optional) The creation mode which can be used to restore or replicate existing servers. Possible values are `Default`, `PointInTimeRestore`, `Replica` and `Update`. Changing this forces a new PostgreSQL Flexible Server to be created.
+
+-> **Note:** When `create_mode` is set to `Update`, it wouldn't force a new resource to be created.
 
 * `delegated_subnet_id` - (Optional) The ID of the virtual network subnet to create the PostgreSQL Flexible Server. The provided subnet should not have any other resource deployed in it and this subnet will be delegated to the PostgreSQL Flexible Server, if not already delegated. Changing this forces a new PostgreSQL Flexible Server to be created.
 
@@ -129,6 +131,8 @@ The following arguments are supported:
 * `tags` - (Optional) A mapping of tags which should be assigned to the PostgreSQL Flexible Server.
 
 * `version` - (Optional) The version of PostgreSQL Flexible Server to use. Possible values are `11`,`12`, `13` and `14`. Required when `create_mode` is `Default`. Changing this forces a new PostgreSQL Flexible Server to be created.
+
+-> **Note:** When `create_mode` is `Update`, upgrading version wouldn't force a new resource to be created.
 
 * `zone` - (Optional) Specifies the Availability Zone in which the PostgreSQL Flexible Server should be located.
 


### PR DESCRIPTION
Service team confirmed the version of postgresql flexible server could be in-place updated while upgrading "version" and create_mode is "Update". So I raised this PR to support it.