### PR TITLE
data source `azurerm_key_vault_secrets`, `azurerm_key_vault_certificates` - expose certificates block

### DIFF
--- a/internal/services/keyvault/key_vault_certificates_data_source_test.go
+++ b/internal/services/keyvault/key_vault_certificates_data_source_test.go
@@ -19,6 +19,7 @@ func TestAccDataSourceKeyVaultCertificates_basic(t *testing.T) {
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("names.#").HasValue("31"),
+				check.That(data.ResourceName).Key("certificates.#").HasValue("31"),
 			),
 		},
 	})

--- a/internal/services/keyvault/key_vault_secrets_data_source_test.go
+++ b/internal/services/keyvault/key_vault_secrets_data_source_test.go
@@ -19,6 +19,7 @@ func TestAccDataSourceKeyVaultSecrets_basic(t *testing.T) {
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("names.#").HasValue("31"),
+				check.That(data.ResourceName).Key("secrets.#").HasValue("31"),
 			),
 		},
 	})

--- a/website/docs/d/key_vault_certificates.html.markdown
+++ b/website/docs/d/key_vault_certificates.html.markdown
@@ -42,6 +42,16 @@ In addition to the arguments above, the following attributes are exported:
 * `names` - List containing names of certificates that exist in this Key Vault.
 
 * `key_vault_id` - The Key Vault ID.
+ 
+* `certificates` - One or more `certificates` blocks as defined below.
+
+---
+
+A `certificates` block supports following:
+
+* `name` - The name of secret.
+
+* `enabled` - Whether this secret is enabled.
 
 ## Timeouts
 

--- a/website/docs/d/key_vault_secrets.html.markdown
+++ b/website/docs/d/key_vault_secrets.html.markdown
@@ -39,6 +39,18 @@ In addition to the Argument listed above - the following Attributes are exported
 
 * `names` - List containing names of secrets that exist in this Key Vault.
 
+* `secrets` - One or more `secrets` blocks as defined below.
+
+---
+
+A `secrets` block supports following:
+
+* `name` - The name of secret.
+
+* `enabled` - Whether this secret is enabled.
+
+* `id` - The ID of this secret.
+
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:


### PR DESCRIPTION
resolves #20459, resolves #20136

```
--- PASS: TestAccDataSourceKeyVaultSecrets_basic (730.94s)
--- PASS: TestAccDataSourceKeyVaultCertificates_basic (567.44s)
PASS
```