### PR TITLE
r/private_endpoint: updating the resource provider name

### DIFF
--- a/internal/services/network/private_endpoint_resource.go
+++ b/internal/services/network/private_endpoint_resource.go
@@ -1132,6 +1132,12 @@ func validatePrivateEndpointSettings(d *pluginsdk.ResourceData) error {
 
 // normalize the PrivateConnectionId due to the casing change at service side
 func normalizePrivateConnectionId(privateConnectionId string) string {
+	// intentionally including the extra segment to handle Redis vs Redis Enterprise (which is within the same RP)
+	if strings.Contains(strings.ToLower(privateConnectionId), "microsoft.cache/redis/") {
+		if cacheId, err := redis.ParseRediIDInsensitively(privateConnectionId); err == nil {
+			privateConnectionId = cacheId.ID()
+		}
+	}
 	if strings.Contains(strings.ToLower(privateConnectionId), "microsoft.dbforpostgresql") {
 		if serverId, err := postgresqlServers.ParseServerIDInsensitively(privateConnectionId); err == nil {
 			privateConnectionId = serverId.ID()
@@ -1145,11 +1151,6 @@ func normalizePrivateConnectionId(privateConnectionId string) string {
 	if strings.Contains(strings.ToLower(privateConnectionId), "microsoft.dbformariadb") {
 		if serverId, err := mariadbServers.ParseServerIDInsensitively(privateConnectionId); err == nil {
 			privateConnectionId = serverId.ID()
-		}
-	}
-	if strings.Contains(strings.ToLower(privateConnectionId), "microsoft.redis") {
-		if cacheId, err := redis.ParseRediIDInsensitively(privateConnectionId); err == nil {
-			privateConnectionId = cacheId.ID()
 		}
 	}
 	if strings.Contains(strings.ToLower(privateConnectionId), "microsoft.signalrservice") {


### PR DESCRIPTION
This should be Microsoft.Cache rather than Microsoft.Redis, which differs from other RP's caught by @wiebeck here https://github.com/hashicorp/terraform-provider-azurerm/pull/20418#discussion_r1107662469