### PR TITLE
New Resource: `azurerm_sentinel_data_connector_api_polling`, `azurerm_sentinel_data_connector_generic_ui`

### DIFF
--- a/internal/services/sentinel/registration.go
+++ b/internal/services/sentinel/registration.go
@@ -73,5 +73,6 @@ func (r Registration) Resources() []sdk.Resource {
 		DataConnectorThreatIntelligenceTAXIIResource{},
 		DataConnectorMicrosoftThreatIntelligenceResource{},
 		DataConnectorApiPollingResource{},
+		DataConnectorGenericUIResource{},
 	}
 }

--- a/internal/services/sentinel/registration.go
+++ b/internal/services/sentinel/registration.go
@@ -72,5 +72,6 @@ func (r Registration) Resources() []sdk.Resource {
 		LogAnalyticsWorkspaceOnboardResource{},
 		DataConnectorThreatIntelligenceTAXIIResource{},
 		DataConnectorMicrosoftThreatIntelligenceResource{},
+		DataConnectorApiPollingResource{},
 	}
 }

--- a/internal/services/sentinel/sentinel_data_connector_api_polling_resource.go
+++ b/internal/services/sentinel/sentinel_data_connector_api_polling_resource.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/workspaces"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/workspaces"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/sentinel/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/sentinel/validate"
@@ -579,7 +579,7 @@ func (r DataConnectorApiPollingResource) Update() sdk.ResourceFunc {
 			}
 
 			if _, err = client.CreateOrUpdate(ctx, id.ResourceGroup, id.WorkspaceName, id.Name, params); err != nil {
-				return fmt.Errorf("creating %s: %+v", id, err)
+				return fmt.Errorf("updating %s: %+v", id, err)
 			}
 
 			return nil

--- a/internal/services/sentinel/sentinel_data_connector_api_polling_resource.go
+++ b/internal/services/sentinel/sentinel_data_connector_api_polling_resource.go
@@ -1,0 +1,877 @@
+package sentinel
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/workspaces"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/sentinel/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/sentinel/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+	securityinsight "github.com/tombuildsstuff/kermit/sdk/securityinsights/2022-10-01-preview/securityinsights"
+)
+
+type DataConnectorApiPollModel struct {
+	Name                    string                              `tfschema:"name"`
+	LogAnalyticsWorkspaceId string                              `tfschema:"log_analytics_workspace_id"`
+	Active                  bool                                `tfschema:"active"`
+	Auth                    []DataConnectorApiPollAuthModel     `tfschema:"auth"`
+	Request                 []DataConnectorApiPollRequestModel  `tfschema:"request"`
+	Paging                  []DataConnectorApiPollPagingModel   `tfschema:"paging"`
+	Response                []DataConnectorApiPollResponseModel `tfschema:"response"`
+	UIConfig                []DataConnectorGenericUIConfigModel `tfschema:"ui"`
+}
+
+type DataConnectorApiPollAuthModel struct {
+	Type                                 string `tfschema:"type"`
+	APIKeyName                           string `tfschema:"api_key_name"`
+	APIKeyIdentifier                     string `tfschema:"api_key_identifier"`
+	IsAPIKeyInPostPayload                bool   `tfschema:"api_key_in_header_enabled"`
+	FlowName                             string `tfschema:"oauth2_flow_name"`
+	TokenEndpoint                        string `tfschema:"oauth2_token_endpoint"`
+	AuthorizationEndpoint                string `tfschema:"oauth2_authorization_endpoint"`
+	AuthorizationEndpointQueryParameters string `tfschema:"oauth2_authorization_endpoint_query_parameters"`
+	RedirectionEndpoint                  string `tfschema:"oauth2_redirection_endpoint"`
+	TokenEndpointHeaders                 string `tfschema:"oauth2_token_endpoint_headers"`
+	TokenEndpointQueryParameters         string `tfschema:"oauth2_token_endpoint_query_parameters"`
+	IsClientSecretInHeader               bool   `tfschema:"oauth2_client_secret_in_header_enabled"`
+	Scope                                string `tfschema:"oauth2_scope"`
+}
+
+type DataConnectorApiPollRequestModel struct {
+	ApiEndpoint             string `tfschema:"api_endpoint"`
+	RateLimitQPS            int32  `tfschema:"rate_limit_query_per_seconds"`
+	QueryWindowInMin        int32  `tfschema:"query_window_in_minutes"`
+	HttpMethod              string `tfschema:"http_method"`
+	QueryTimeFormat         string `tfschema:"query_time_format"`
+	RetryCount              int32  `tfschema:"retry_count"`
+	TimeOutInSeconds        int32  `tfschema:"time_out_in_seconds"`
+	Headers                 string `tfschema:"headers"`
+	QueryParameters         string `tfschema:"query_parameters"`
+	QueryParametersTemplate string `tfschema:"query_parameters_template"`
+	StartTimeAttributeName  string `tfschema:"start_time_attribute_name"`
+	EndTimeAttributeName    string `tfschema:"end_time_attribute_name"`
+}
+
+type DataConnectorApiPollPagingModel struct {
+	PagingType                             string `tfschema:"type"`
+	NextPageParaName                       string `tfschema:"next_page_parameter_name"`
+	NextPageTokenJSONPath                  string `tfschema:"next_page_token_json_path"`
+	PageCountAttributePath                 string `tfschema:"page_count_attribute_path"`
+	PageTotalCountAttributePath            string `tfschema:"page_total_count_attribute_path"`
+	PageTimeStampAttributePath             string `tfschema:"page_timestamp_attribute_path"`
+	SearchTheLatestTimeStampFromEventsList bool   `tfschema:"search_the_latest_timestamp_from_events_list_enabled"`
+	PageSizeParameterName                  string `tfschema:"page_size_parameter_name"`
+	PageSize                               int32  `tfschema:"page_size"`
+}
+
+type DataConnectorApiPollResponseModel struct {
+	EventsJSONPaths       []string `tfschema:"events_json_paths"`
+	SuccessStatusJSONPath string   `tfschema:"success_status_json_path"`
+	SuccessStatusValue    string   `tfschema:"success_status_value"`
+	GzipCompressEnabled   bool     `tfschema:"gzip_compress_enabled"`
+}
+
+type DataConnectorApiPollingResource struct{}
+
+var _ sdk.ResourceWithUpdate = DataConnectorApiPollingResource{}
+
+func (r DataConnectorApiPollingResource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"log_analytics_workspace_id": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: workspaces.ValidateWorkspaceID,
+		},
+
+		"auth": DataConnectorApiPollAuthSchema(),
+
+		"request": DataConnectorApiPollRequestSchema(),
+
+		"paging": DataConnectorApiPollPagingSchema(),
+
+		"response": DataConnectorApiPollResponseSchema(),
+
+		"ui": {
+			Type:     pluginsdk.TypeList,
+			Required: true,
+			MaxItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: DataConnectorGenericUIConfigSchema(),
+			},
+		},
+	}
+}
+
+func DataConnectorApiPollAuthSchema() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Required: true,
+		MaxItems: 1,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"type": {
+					Type:         pluginsdk.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringInSlice([]string{"Basic", "APIKey", "OAuth2"}, false),
+					// the enums comes from  https://learn.microsoft.com/en-us/azure/sentinel/create-codeless-connector?tabs=deploy-via-arm-template%2Cconnect-via-the-azure-portal
+				},
+				"api_key_name": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+				"api_key_identifier": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+				"api_key_in_header_enabled": {
+					Type:     pluginsdk.TypeBool,
+					Optional: true,
+				},
+				"oauth2_flow_name": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+				"oauth2_token_endpoint": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.IsURLWithHTTPorHTTPS,
+				},
+				"oauth2_authorization_endpoint": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.IsURLWithHTTPorHTTPS,
+				},
+				"oauth2_authorization_endpoint_query_parameters": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringIsJSON,
+				},
+				"oauth2_redirection_endpoint": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.IsURLWithHTTPorHTTPS,
+				},
+				"oauth2_token_endpoint_headers": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringIsJSON,
+				},
+				"oauth2_token_endpoint_query_parameters": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringIsJSON,
+				},
+				"oauth2_client_secret_in_header_enabled": {
+					Type:     pluginsdk.TypeBool,
+					Optional: true,
+				},
+				"oauth2_scope": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+			},
+		},
+	}
+}
+
+func DataConnectorApiPollRequestSchema() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Required: true,
+		MaxItems: 1,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"api_endpoint": {
+					Type:         pluginsdk.TypeString,
+					Required:     true,
+					ValidateFunc: validation.IsURLWithHTTPorHTTPS,
+				},
+				"http_method": {
+					Type:         pluginsdk.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringInSlice([]string{"GET", "POST"}, false),
+				},
+				"query_time_format": {
+					Type:         pluginsdk.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+				"start_time_attribute_name": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+				"end_time_attribute_name": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+				"query_window_in_minutes": {
+					Type:         pluginsdk.TypeInt,
+					Optional:     true,
+					ValidateFunc: validation.IntAtLeast(5),
+				},
+				"query_parameters": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringIsJSON,
+				},
+				"query_parameters_template": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringIsJSON,
+				},
+				"rate_limit_query_per_seconds": {
+					Type:         pluginsdk.TypeInt,
+					Optional:     true,
+					ValidateFunc: validation.IntAtLeast(1),
+				},
+				"time_out_in_seconds": {
+					Type:         pluginsdk.TypeInt,
+					Optional:     true,
+					ValidateFunc: validation.IntAtLeast(1),
+				},
+				"retry_count": {
+					Type:         pluginsdk.TypeInt,
+					Optional:     true,
+					ValidateFunc: validation.IntAtLeast(1),
+				},
+				"headers": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringIsJSON,
+				},
+			},
+		},
+	}
+}
+
+func DataConnectorApiPollPagingSchema() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"type": {
+					Type:     pluginsdk.TypeString,
+					Required: true,
+					ValidateFunc: validation.StringInSlice([]string{
+						"None",
+						"PageToken",
+						"PageCount",
+						"TimeStamp",
+					}, false),
+				},
+				"next_page_parameter_name": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+				"next_page_token_json_path": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+				"page_count_attribute_path": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+				"page_total_count_attribute_path": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+				"page_timestamp_attribute_path": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+				"search_the_latest_timestamp_from_events_list_enabled": {
+					Type:     pluginsdk.TypeBool,
+					Optional: true,
+				},
+				"page_size_parameter_name": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+				"page_size": {
+					Type:         pluginsdk.TypeInt,
+					Optional:     true,
+					ValidateFunc: validation.IntAtLeast(1),
+				},
+			},
+		},
+	}
+}
+
+func DataConnectorApiPollResponseSchema() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Required: true,
+		MaxItems: 1,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"events_json_paths": {
+					Type:     pluginsdk.TypeSet,
+					Required: true,
+					Elem: &pluginsdk.Schema{
+						Type:         pluginsdk.TypeString,
+						ValidateFunc: validation.StringIsNotEmpty,
+					},
+				},
+				"success_status_json_path": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+				"success_status_value": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+				"gzip_compress_enabled": {
+					Type:     pluginsdk.TypeBool,
+					Optional: true,
+				},
+			},
+		},
+	}
+}
+
+func (r DataConnectorApiPollingResource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"active": {
+			Type: pluginsdk.TypeBool,
+		},
+	}
+}
+
+func (r DataConnectorApiPollingResource) ModelObject() interface{} {
+	return &DataConnectorApiPollModel{}
+}
+
+func (r DataConnectorApiPollingResource) ResourceType() string {
+	return "azurerm_sentinel_data_connector_api_polling"
+}
+
+func (r DataConnectorApiPollingResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+	return validate.DataConnectorID
+}
+
+func (r DataConnectorApiPollingResource) Create() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Sentinel.DataConnectorsClient
+
+			var plan DataConnectorApiPollModel
+			if err := metadata.Decode(&plan); err != nil {
+				return fmt.Errorf("decoding %+v", err)
+			}
+
+			workspaceId, err := workspaces.ParseWorkspaceID(plan.LogAnalyticsWorkspaceId)
+			if err != nil {
+				return err
+			}
+
+			id := parse.NewDataConnectorID(workspaceId.SubscriptionId, workspaceId.ResourceGroupName, workspaceId.WorkspaceName, plan.Name)
+			existing, err := client.Get(ctx, id.ResourceGroup, id.WorkspaceName, id.Name)
+			if err != nil {
+				if !utils.ResponseWasNotFound(existing.Response) {
+					return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+				}
+			}
+			if !utils.ResponseWasNotFound(existing.Response) {
+				return metadata.ResourceRequiresImport(r.ResourceType(), id)
+			}
+
+			pollAuth, err := expandDataConnectorApiPollAuth(plan.Auth)
+			if err != nil {
+				return fmt.Errorf("expanding `auth`: %+v", err)
+			}
+
+			pollRequest, err := expandDataConnectorApiPollRequest(plan.Request)
+			if err != nil {
+				return fmt.Errorf("expanding `request`: %+v", err)
+			}
+
+			uiConfig, err := expandDataConnectorGenericUIConfigModel(plan.UIConfig)
+			if err != nil {
+				return fmt.Errorf("expanding `ui`: %+v", err)
+			}
+
+			params := securityinsight.CodelessAPIPollingDataConnector{
+				Name: &plan.Name,
+				APIPollingParameters: &securityinsight.APIPollingParameters{
+					PollingConfig: &securityinsight.CodelessConnectorPollingConfigProperties{
+						Auth:     pollAuth,
+						Request:  pollRequest,
+						Paging:   expandDataConnectorApiPollPaging(plan.Paging),
+						Response: expandDataConnectorApiPollResponse(plan.Response),
+					},
+					ConnectorUIConfig: uiConfig,
+				},
+				Kind: securityinsight.KindBasicDataConnectorKindAPIPolling,
+			}
+
+			if _, err = client.CreateOrUpdate(ctx, id.ResourceGroup, id.WorkspaceName, id.Name, params); err != nil {
+				return fmt.Errorf("creating %s: %+v", id, err)
+			}
+
+			metadata.SetID(id)
+			return nil
+		},
+	}
+}
+
+func (r DataConnectorApiPollingResource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Sentinel.DataConnectorsClient
+			id, err := parse.DataConnectorID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			existing, err := client.Get(ctx, id.ResourceGroup, id.WorkspaceName, id.Name)
+			if err != nil {
+				if utils.ResponseWasNotFound(existing.Response) {
+					return metadata.MarkAsGone(id)
+				}
+				return fmt.Errorf("retrieving %s: %+v", id, err)
+			}
+
+			dc, ok := existing.Value.(securityinsight.CodelessAPIPollingDataConnector)
+			if !ok {
+				return fmt.Errorf("%s was not an IoT Data Connector", id)
+			}
+
+			if dc.PollingConfig == nil {
+				return fmt.Errorf("retrieving %s: `polling_config` was nil", id)
+			}
+
+			model := DataConnectorApiPollModel{}
+
+			if dc.Name != nil {
+				model.Name = *dc.Name
+			}
+
+			if dc.PollingConfig.IsActive != nil {
+				model.Active = *dc.PollingConfig.IsActive
+			}
+
+			model.Auth, err = flattenDataConnectorApiPollAuth(dc.PollingConfig.Auth)
+			if err != nil {
+				return fmt.Errorf("flattening `auth`: %+v", err)
+			}
+
+			model.Request, err = flattenDataConnectorApiPollRequest(dc.PollingConfig.Request)
+			if err != nil {
+				return fmt.Errorf("flattening `request`: %+v", err)
+			}
+
+			model.Response = flattenDataConnectorApiPollResponse(dc.PollingConfig.Response)
+
+			model.Paging = flattenDataConnectorAPiPollPaging(dc.PollingConfig.Paging)
+
+			model.UIConfig, err = flattenDataConnectorGenericUIConfigModel(dc.ConnectorUIConfig)
+			if err != nil {
+				return fmt.Errorf("flattening `ui`: %+v", err)
+			}
+
+			workspaceId := workspaces.NewWorkspaceID(id.SubscriptionId, id.ResourceGroup, id.WorkspaceName)
+			model.LogAnalyticsWorkspaceId = workspaceId.ID()
+
+			return metadata.Encode(&model)
+		},
+	}
+}
+
+func (r DataConnectorApiPollingResource) Delete() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Sentinel.DataConnectorsClient
+
+			id, err := parse.DataConnectorID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			if _, err := client.Delete(ctx, id.ResourceGroup, id.WorkspaceName, id.Name); err != nil {
+				return fmt.Errorf("deleting %s: %+v", id, err)
+			}
+
+			return nil
+		},
+	}
+}
+
+func (r DataConnectorApiPollingResource) Update() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Sentinel.DataConnectorsClient
+			id, err := parse.DataConnectorID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			var plan DataConnectorApiPollModel
+			if err := metadata.Decode(&plan); err != nil {
+				return fmt.Errorf("decoding %+v", err)
+			}
+
+			_, err = client.Get(ctx, id.ResourceGroup, id.WorkspaceName, id.Name)
+			if err != nil {
+				return fmt.Errorf("reading %s: %+v", id, err)
+			}
+
+			pollAuth, err := expandDataConnectorApiPollAuth(plan.Auth)
+			if err != nil {
+				return fmt.Errorf("expanding `auth`: %+v", err)
+			}
+
+			pollRequest, err := expandDataConnectorApiPollRequest(plan.Request)
+			if err != nil {
+				return fmt.Errorf("expanding `request`: %+v", err)
+			}
+
+			uiConfig, err := expandDataConnectorGenericUIConfigModel(plan.UIConfig)
+			if err != nil {
+				return fmt.Errorf("expanding `ui`: %+v", err)
+			}
+
+			params := securityinsight.CodelessAPIPollingDataConnector{
+				Name: &plan.Name,
+				APIPollingParameters: &securityinsight.APIPollingParameters{
+					PollingConfig: &securityinsight.CodelessConnectorPollingConfigProperties{
+						Auth:     pollAuth,
+						Request:  pollRequest,
+						Paging:   expandDataConnectorApiPollPaging(plan.Paging),
+						Response: expandDataConnectorApiPollResponse(plan.Response),
+					},
+					ConnectorUIConfig: uiConfig,
+				},
+				Kind: securityinsight.KindBasicDataConnectorKindAPIPolling,
+			}
+
+			if _, err = client.CreateOrUpdate(ctx, id.ResourceGroup, id.WorkspaceName, id.Name, params); err != nil {
+				return fmt.Errorf("creating %s: %+v", id, err)
+			}
+
+			return nil
+		},
+	}
+}
+
+func expandDataConnectorApiPollAuth(input []DataConnectorApiPollAuthModel) (*securityinsight.CodelessConnectorPollingAuthProperties, error) {
+	if len(input) == 0 {
+		return nil, nil
+	}
+	item := input[0]
+	apiKeyInPostPayload := strconv.FormatBool(item.IsAPIKeyInPostPayload)
+
+	output := securityinsight.CodelessConnectorPollingAuthProperties{
+		AuthType:               &item.Type,
+		APIKeyName:             &item.APIKeyName,
+		APIKeyIdentifier:       &item.APIKeyIdentifier,
+		IsAPIKeyInPostPayload:  &apiKeyInPostPayload,
+		FlowName:               &item.FlowName,
+		TokenEndpoint:          &item.TokenEndpoint,
+		AuthorizationEndpoint:  &item.AuthorizationEndpoint,
+		RedirectionEndpoint:    &item.RedirectionEndpoint,
+		IsClientSecretInHeader: utils.Bool(item.IsClientSecretInHeader),
+		Scope:                  &item.Scope,
+	}
+
+	if item.AuthorizationEndpointQueryParameters != "" {
+		authorizationEndpointQueryParameters, err := pluginsdk.ExpandJsonFromString(item.AuthorizationEndpointQueryParameters)
+		if err != nil {
+			return nil, err
+		}
+		output.AuthorizationEndpointQueryParameters = authorizationEndpointQueryParameters
+	}
+
+	if item.TokenEndpointHeaders != "" {
+		tokenEndpointHeaders, err := pluginsdk.ExpandJsonFromString(item.TokenEndpointHeaders)
+		if err != nil {
+			return nil, err
+		}
+		output.TokenEndpointHeaders = tokenEndpointHeaders
+	}
+	if item.TokenEndpointQueryParameters != "" {
+		tokenEndpointQueryParameters, err := pluginsdk.ExpandJsonFromString(item.TokenEndpointQueryParameters)
+		if err != nil {
+			return nil, err
+		}
+		output.TokenEndpointQueryParameters = tokenEndpointQueryParameters
+	}
+
+	return &output, nil
+}
+
+func flattenDataConnectorApiPollAuth(input *securityinsight.CodelessConnectorPollingAuthProperties) ([]DataConnectorApiPollAuthModel, error) {
+	var output []DataConnectorApiPollAuthModel
+	if input == nil {
+		return output, nil
+	}
+
+	item := DataConnectorApiPollAuthModel{}
+	if input.AuthType != nil {
+		item.Type = *input.AuthType
+	}
+	if input.APIKeyName != nil {
+		item.APIKeyName = *input.APIKeyName
+	}
+	if input.APIKeyIdentifier != nil {
+		item.APIKeyIdentifier = *input.APIKeyIdentifier
+	}
+	if input.IsAPIKeyInPostPayload != nil {
+		item.IsAPIKeyInPostPayload = *input.IsAPIKeyInPostPayload == "1"
+	}
+	if input.FlowName != nil {
+		item.FlowName = *input.FlowName
+	}
+	if input.TokenEndpoint != nil {
+		item.TokenEndpoint = *input.TokenEndpoint
+	}
+	if input.AuthorizationEndpoint != nil {
+		item.AuthorizationEndpoint = *input.AuthorizationEndpoint
+	}
+	if input.AuthorizationEndpointQueryParameters != nil {
+		json, err := pluginsdk.FlattenJsonToString(input.AuthorizationEndpointQueryParameters.(map[string]interface{}))
+		if err != nil {
+			return output, err
+		}
+		item.AuthorizationEndpointQueryParameters = json
+	}
+	if input.RedirectionEndpoint != nil {
+		item.RedirectionEndpoint = *input.RedirectionEndpoint
+	}
+	if input.TokenEndpointHeaders != nil {
+		json, err := pluginsdk.FlattenJsonToString(input.TokenEndpointHeaders.(map[string]interface{}))
+		if err != nil {
+			return output, err
+		}
+		item.TokenEndpointHeaders = json
+	}
+	if input.TokenEndpointQueryParameters != nil {
+		json, err := pluginsdk.FlattenJsonToString(input.TokenEndpointQueryParameters.(map[string]interface{}))
+		if err != nil {
+			return output, err
+		}
+		item.TokenEndpointQueryParameters = json
+	}
+	if input.IsClientSecretInHeader != nil {
+		item.IsClientSecretInHeader = *input.IsClientSecretInHeader
+	}
+	if input.Scope != nil {
+		item.Scope = *input.Scope
+	}
+
+	return append(output, item), nil
+}
+
+func expandDataConnectorApiPollRequest(input []DataConnectorApiPollRequestModel) (*securityinsight.CodelessConnectorPollingRequestProperties, error) {
+	if len(input) == 0 {
+		return nil, nil
+	}
+	item := input[0]
+
+	output := securityinsight.CodelessConnectorPollingRequestProperties{
+		APIEndpoint:             &item.ApiEndpoint,
+		RateLimitQPS:            &item.RateLimitQPS,
+		QueryWindowInMin:        &item.QueryWindowInMin,
+		HTTPMethod:              &item.HttpMethod,
+		QueryTimeFormat:         &item.QueryTimeFormat,
+		RetryCount:              &item.RetryCount,
+		TimeoutInSeconds:        &item.TimeOutInSeconds,
+		StartTimeAttributeName:  &item.StartTimeAttributeName,
+		EndTimeAttributeName:    &item.EndTimeAttributeName,
+		QueryParametersTemplate: &item.QueryParametersTemplate,
+	}
+
+	if item.QueryParameters != "" {
+		queryParameters, err := pluginsdk.ExpandJsonFromString(item.QueryParameters)
+		if err != nil {
+			return nil, err
+		}
+		output.QueryParameters = queryParameters
+	}
+
+	if item.Headers != "" {
+		headers, err := pluginsdk.ExpandJsonFromString(item.Headers)
+		if err != nil {
+			return nil, err
+		}
+		output.Headers = headers
+	}
+
+	return &output, nil
+}
+
+func flattenDataConnectorApiPollRequest(input *securityinsight.CodelessConnectorPollingRequestProperties) ([]DataConnectorApiPollRequestModel, error) {
+	var output []DataConnectorApiPollRequestModel
+	if input == nil {
+		return output, nil
+	}
+
+	item := DataConnectorApiPollRequestModel{}
+	if input.APIEndpoint != nil {
+		item.ApiEndpoint = *input.APIEndpoint
+	}
+	if input.RateLimitQPS != nil {
+		item.RateLimitQPS = *input.RateLimitQPS
+	}
+	if input.QueryWindowInMin != nil {
+		item.QueryWindowInMin = *input.QueryWindowInMin
+	}
+	if input.HTTPMethod != nil {
+		item.HttpMethod = *input.HTTPMethod
+	}
+	if input.QueryTimeFormat != nil {
+		item.QueryTimeFormat = *input.QueryTimeFormat
+	}
+	if input.RetryCount != nil {
+		item.RetryCount = *input.RetryCount
+	}
+	if input.TimeoutInSeconds != nil {
+		item.TimeOutInSeconds = *input.TimeoutInSeconds
+	}
+	if input.Headers != nil {
+		json, err := pluginsdk.FlattenJsonToString(input.Headers.(map[string]interface{}))
+		if err != nil {
+			return output, err
+		}
+		item.Headers = json
+	}
+	if input.QueryParameters != nil {
+		json, err := pluginsdk.FlattenJsonToString(input.QueryParameters.(map[string]interface{}))
+		if err != nil {
+			return output, err
+		}
+		item.QueryParameters = json
+	}
+	if input.StartTimeAttributeName != nil {
+		item.StartTimeAttributeName = *input.StartTimeAttributeName
+	}
+	if input.EndTimeAttributeName != nil {
+		item.EndTimeAttributeName = *input.EndTimeAttributeName
+	}
+	if input.QueryParametersTemplate != nil {
+		item.QueryParametersTemplate = *input.QueryParametersTemplate
+	}
+	return append(output, item), nil
+}
+
+func expandDataConnectorApiPollPaging(input []DataConnectorApiPollPagingModel) *securityinsight.CodelessConnectorPollingPagingProperties {
+	if len(input) == 0 {
+		return nil
+	}
+	item := input[0]
+	searchTheLatestTimestampFromEventsListEnabledSpecified := strconv.FormatBool(item.SearchTheLatestTimeStampFromEventsList)
+	return &securityinsight.CodelessConnectorPollingPagingProperties{
+		PagingType:                             &item.PagingType,
+		NextPageParaName:                       &item.NextPageParaName,
+		NextPageTokenJSONPath:                  &item.NextPageTokenJSONPath,
+		PageCountAttributePath:                 &item.PageCountAttributePath,
+		PageTotalCountAttributePath:            &item.PageTotalCountAttributePath,
+		PageTimeStampAttributePath:             &item.PageTimeStampAttributePath,
+		SearchTheLatestTimeStampFromEventsList: &searchTheLatestTimestampFromEventsListEnabledSpecified,
+		PageSizeParaName:                       &item.PageSizeParameterName,
+		PageSize:                               &item.PageSize,
+	}
+}
+
+func flattenDataConnectorAPiPollPaging(input *securityinsight.CodelessConnectorPollingPagingProperties) []DataConnectorApiPollPagingModel {
+	var output []DataConnectorApiPollPagingModel
+	item := DataConnectorApiPollPagingModel{}
+	if input == nil {
+		return output
+	}
+	if input.PagingType != nil {
+		item.PagingType = *input.PagingType
+	}
+	if input.NextPageParaName != nil {
+		item.NextPageParaName = *input.NextPageParaName
+	}
+	if input.NextPageTokenJSONPath != nil {
+		item.NextPageTokenJSONPath = *input.NextPageTokenJSONPath
+	}
+	if input.PageCountAttributePath != nil {
+		item.PageCountAttributePath = *input.PageCountAttributePath
+	}
+	if input.PageTotalCountAttributePath != nil {
+		item.PageTotalCountAttributePath = *input.PageTotalCountAttributePath
+	}
+	if input.PageTimeStampAttributePath != nil {
+		item.PageTimeStampAttributePath = *input.PageTimeStampAttributePath
+	}
+	if input.SearchTheLatestTimeStampFromEventsList != nil {
+		item.SearchTheLatestTimeStampFromEventsList, _ = strconv.ParseBool(*input.SearchTheLatestTimeStampFromEventsList)
+	}
+	if input.PageSizeParaName != nil {
+		item.PageSizeParameterName = *input.PageSizeParaName
+	}
+	if input.PageSize != nil {
+		item.PageSize = *input.PageSize
+	}
+	return append(output, item)
+}
+
+func expandDataConnectorApiPollResponse(input []DataConnectorApiPollResponseModel) *securityinsight.CodelessConnectorPollingResponseProperties {
+	if len(input) == 0 {
+		return nil
+	}
+	item := input[0]
+	return &securityinsight.CodelessConnectorPollingResponseProperties{
+		EventsJSONPaths:       &item.EventsJSONPaths,
+		SuccessStatusJSONPath: &item.SuccessStatusJSONPath,
+		SuccessStatusValue:    &item.SuccessStatusValue,
+		IsGzipCompressed:      utils.Bool(item.GzipCompressEnabled),
+	}
+}
+
+func flattenDataConnectorApiPollResponse(input *securityinsight.CodelessConnectorPollingResponseProperties) []DataConnectorApiPollResponseModel {
+	var output []DataConnectorApiPollResponseModel
+	if input == nil {
+		return output
+	}
+	item := DataConnectorApiPollResponseModel{}
+	if input.EventsJSONPaths != nil {
+		item.EventsJSONPaths = *input.EventsJSONPaths
+	}
+	if input.SuccessStatusJSONPath != nil {
+		item.SuccessStatusJSONPath = *input.SuccessStatusJSONPath
+	}
+	if input.SuccessStatusValue != nil {
+		item.SuccessStatusValue = *input.SuccessStatusValue
+	}
+	if input.IsGzipCompressed != nil {
+		item.GzipCompressEnabled = *input.IsGzipCompressed
+	}
+	return append(output, item)
+}

--- a/internal/services/sentinel/sentinel_data_connector_api_polling_resource_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_api_polling_resource_test.go
@@ -30,21 +30,6 @@ func TestAccAzureRMSentinelDataConnectorApiPolling_basic(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMSentinelDataConnectorApiPolling_complete(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_sentinel_data_connector_api_polling", "test")
-	r := SentinelDataConnectorApiPollingResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.complete(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-	})
-}
-
 func TestAccAzureRMSentinelDataConnectorApiPolling_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_sentinel_data_connector_api_polling", "test")
 	r := SentinelDataConnectorApiPollingResource{}
@@ -86,7 +71,6 @@ func (r SentinelDataConnectorApiPollingResource) basic(data acceptance.TestData)
 resource "azurerm_sentinel_data_connector_api_polling" "test" {
   name                       = "accTestDC-%d"
   log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
-  active                    = true
 
   auth {
     type               = "APIKey"
@@ -148,10 +132,10 @@ resource "azurerm_sentinel_data_connector_api_polling" "test" {
 
     permission {
       resource_provider {
-        name                     = "Microsoft.OperationalInsights/workspaces"
+        name         = "Microsoft.OperationalInsights/workspaces"
         display_name = "read and write permissions are required."
         display_text = "Workspace"
-        scope                    = "Workspace"
+        scope        = "Workspace"
         required_permissions {
           read   = true
           write  = true
@@ -181,30 +165,104 @@ resource "azurerm_sentinel_data_connector_api_polling" "test" {
 `, template, data.RandomInteger)
 }
 
-func (r SentinelDataConnectorApiPollingResource) complete(data acceptance.TestData) string {
-	template := r.template(data)
-	return fmt.Sprintf(`
-%s
-
-data "azurerm_client_config" "test" {}
-
-resource "azurerm_sentinel_data_connector_azure_active_directory" "test" {
-  name                       = "accTestDC-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
-  tenant_id                  = data.azurerm_client_config.test.tenant_id
-  depends_on                 = [azurerm_log_analytics_solution.test]
-}
-`, template, data.RandomInteger)
-}
-
 func (r SentinelDataConnectorApiPollingResource) requiresImport(data acceptance.TestData) string {
 	template := r.basic(data)
 	return fmt.Sprintf(`
 %s
 
-resource "azurerm_sentinel_data_connector_azure_active_directory" "import" {
-  name                       = azurerm_sentinel_data_connector_azure_active_directory.test.name
-  log_analytics_workspace_id = azurerm_sentinel_data_connector_azure_active_directory.test.log_analytics_workspace_id
+resource "azurerm_sentinel_data_connector_api_polling" "import" {
+  name                       = azurerm_sentinel_data_connector_api_polling.test.name
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+
+  auth {
+    type               = "APIKey"
+    api_key_name       = "Authorization"
+    api_key_identifier = "Bearer"
+  }
+
+  request {
+    api_endpoint              = "https://api.slack.com/audit/v1/logs"
+    http_method               = "GET"
+    query_time_format         = "UnixTimestamp"
+    start_time_attribute_name = "oldest"
+    end_time_attribute_name   = "latest"
+    query_window_in_minutes   = 5
+    query_parameters = jsonencode({
+      "limit" = 1000
+    })
+  }
+
+  paging {
+    type                      = "PageToken"
+    next_page_parameter_name  = "cursor"
+    next_page_token_json_path = "..response_metadata.next_cursor"
+  }
+
+  response {
+    events_json_paths = ["$..entries"]
+  }
+
+  ui {
+    title                    = "Slack"
+    publisher                = "Slack"
+    description_markdown     = "The [Slack](https://slack.com) data connector provides the capability to ingest [Slack Audit Records](https://api.slack.com/admins/audit-logs) events into Microsoft Sentinel through the REST API. Refer to [API documentation](https://api.slack.com/admins/audit-logs#the_audit_event) for more information. The connector provides ability to get events which helps to examine potential security risks, analyze your team's use of collaboration, diagnose configuration problems and more. This data connector uses Microsoft Sentinel native polling capability."
+    graph_queries_table_name = "SlackAuditNativePoller_CL"
+    graph_query {
+      metric_name = "Total data received"
+      legend      = "Slack audit events"
+      base_query  = "{{graphQueriesTableName}}"
+    }
+
+    sample_query {
+      description = "All Slack audit events"
+      query       = "{{graphQueriesTableName}}\n| sort by TimeGenerated desc"
+    }
+
+    data_type {
+      name                     = "{{graphQueriesTableName}}"
+      last_data_received_query = "{{graphQueriesTableName}}\n            | summarize Time = max(TimeGenerated)\n            | where isnotempty(Time)"
+    }
+
+    connectivity_criteria {
+      type = "IsConnectedQuery"
+    }
+
+    availability {
+      enabled = true
+      preview = true
+    }
+
+    permission {
+      resource_provider {
+        name         = "Microsoft.OperationalInsights/workspaces"
+        display_name = "read and write permissions are required."
+        display_text = "Workspace"
+        scope        = "Workspace"
+        required_permissions {
+          read   = true
+          write  = true
+          delete = true
+        }
+      }
+      custom {
+        name        = "Slack API credentials"
+        description = "**SlackAPIBearerToken** is required for REST API. [See the documentation to learn more about API](https://api.slack.com/web#authentication). Check all [requirements and follow the instructions](https://api.slack.com/web#authentication) for obtaining credentials."
+      }
+    }
+
+    instruction {
+      title       = "Connect Slack to Microsoft Sentinel"
+      description = "Enable Slack audit Logs"
+      step {
+        type = "InfoMessage"
+        parameters = jsonencode({
+          "enable" = "true"
+        })
+      }
+    }
+  }
+
+  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, template)
 }

--- a/internal/services/sentinel/sentinel_data_connector_api_polling_resource_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_api_polling_resource_test.go
@@ -1,0 +1,235 @@
+package sentinel_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/sentinel/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+type SentinelDataConnectorApiPollingResource struct{}
+
+func TestAccAzureRMSentinelDataConnectorApiPolling_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_sentinel_data_connector_api_polling", "test")
+	r := SentinelDataConnectorApiPollingResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccAzureRMSentinelDataConnectorApiPolling_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_sentinel_data_connector_api_polling", "test")
+	r := SentinelDataConnectorApiPollingResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccAzureRMSentinelDataConnectorApiPolling_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_sentinel_data_connector_api_polling", "test")
+	r := SentinelDataConnectorApiPollingResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.RequiresImportErrorStep(r.requiresImport),
+	})
+}
+
+func (r SentinelDataConnectorApiPollingResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	client := clients.Sentinel.DataConnectorsClient
+
+	id, err := parse.DataConnectorID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp, err := client.Get(ctx, id.ResourceGroup, id.WorkspaceName, id.Name); err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			return utils.Bool(false), nil
+		}
+		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+
+	return utils.Bool(true), nil
+}
+
+func (r SentinelDataConnectorApiPollingResource) basic(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_sentinel_data_connector_api_polling" "test" {
+  name                       = "accTestDC-%d"
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  active                    = true
+
+  auth {
+    type               = "APIKey"
+    api_key_name       = "Authorization"
+    api_key_identifier = "Bearer"
+  }
+
+  request {
+    api_endpoint              = "https://api.slack.com/audit/v1/logs"
+    http_method               = "GET"
+    query_time_format         = "UnixTimestamp"
+    start_time_attribute_name = "oldest"
+    end_time_attribute_name   = "latest"
+    query_window_in_minutes   = 5
+    query_parameters = jsonencode({
+      "limit" = 1000
+    })
+  }
+
+  paging {
+    type                      = "PageToken"
+    next_page_parameter_name  = "cursor"
+    next_page_token_json_path = "..response_metadata.next_cursor"
+  }
+
+  response {
+    events_json_paths = ["$..entries"]
+  }
+
+  ui {
+    title                    = "Slack"
+    publisher                = "Slack"
+    description_markdown     = "The [Slack](https://slack.com) data connector provides the capability to ingest [Slack Audit Records](https://api.slack.com/admins/audit-logs) events into Microsoft Sentinel through the REST API. Refer to [API documentation](https://api.slack.com/admins/audit-logs#the_audit_event) for more information. The connector provides ability to get events which helps to examine potential security risks, analyze your team's use of collaboration, diagnose configuration problems and more. This data connector uses Microsoft Sentinel native polling capability."
+    graph_queries_table_name = "SlackAuditNativePoller_CL"
+    graph_query {
+      metric_name = "Total data received"
+      legend      = "Slack audit events"
+      base_query  = "{{graphQueriesTableName}}"
+    }
+
+    sample_query {
+      description = "All Slack audit events"
+      query       = "{{graphQueriesTableName}}\n| sort by TimeGenerated desc"
+    }
+
+    data_type {
+      name                     = "{{graphQueriesTableName}}"
+      last_data_received_query = "{{graphQueriesTableName}}\n            | summarize Time = max(TimeGenerated)\n            | where isnotempty(Time)"
+    }
+
+    connectivity_criteria {
+      type = "IsConnectedQuery"
+    }
+
+    availability {
+      enabled = true
+      preview = true
+    }
+
+    permission {
+      resource_provider {
+        name                     = "Microsoft.OperationalInsights/workspaces"
+        display_name = "read and write permissions are required."
+        display_text = "Workspace"
+        scope                    = "Workspace"
+        required_permissions {
+          read   = true
+          write  = true
+          delete = true
+        }
+      }
+      custom {
+        name        = "Slack API credentials"
+        description = "**SlackAPIBearerToken** is required for REST API. [See the documentation to learn more about API](https://api.slack.com/web#authentication). Check all [requirements and follow the instructions](https://api.slack.com/web#authentication) for obtaining credentials."
+      }
+    }
+
+    instruction {
+      title       = "Connect Slack to Microsoft Sentinel"
+      description = "Enable Slack audit Logs"
+      step {
+        type = "InfoMessage"
+        parameters = jsonencode({
+          "enable" = "true"
+        })
+      }
+    }
+  }
+
+  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
+}
+`, template, data.RandomInteger)
+}
+
+func (r SentinelDataConnectorApiPollingResource) complete(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_client_config" "test" {}
+
+resource "azurerm_sentinel_data_connector_azure_active_directory" "test" {
+  name                       = "accTestDC-%d"
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  tenant_id                  = data.azurerm_client_config.test.tenant_id
+  depends_on                 = [azurerm_log_analytics_solution.test]
+}
+`, template, data.RandomInteger)
+}
+
+func (r SentinelDataConnectorApiPollingResource) requiresImport(data acceptance.TestData) string {
+	template := r.basic(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_sentinel_data_connector_azure_active_directory" "import" {
+  name                       = azurerm_sentinel_data_connector_azure_active_directory.test.name
+  log_analytics_workspace_id = azurerm_sentinel_data_connector_azure_active_directory.test.log_analytics_workspace_id
+}
+`, template)
+}
+
+func (r SentinelDataConnectorApiPollingResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-sentinel-%d"
+  location = "%s"
+}
+
+resource "azurerm_log_analytics_workspace" "test" {
+  name                = "acctestLAW-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "PerGB2018"
+}
+
+resource "azurerm_sentinel_log_analytics_workspace_onboarding" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  workspace_name      = azurerm_log_analytics_workspace.test.name
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}

--- a/internal/services/sentinel/sentinel_data_connector_generic_ui.go
+++ b/internal/services/sentinel/sentinel_data_connector_generic_ui.go
@@ -253,6 +253,9 @@ func expandDataConnectorGenericUIAvailabilityModel(input []DataConnectorGenericU
 
 func flattenDataConnectorGenericUIAvailabilityModel(input *securityinsight.Availability) []DataConnectorGenericUIAvailabilityModel {
 	output := DataConnectorGenericUIAvailabilityModel{}
+	if input == nil {
+		return []DataConnectorGenericUIAvailabilityModel{}
+	}
 	if input.Status != nil {
 		output.Enabled = *input.Status == 1
 	}
@@ -284,6 +287,9 @@ func expandDataConnectorGenericUIPermissionsModel(input []DataConnectorGenericUI
 
 func flattenDataConnectorGenericUIPermissionsModel(input *securityinsight.Permissions) []DataConnectorGenericUIPermissionsModel {
 	output := DataConnectorGenericUIPermissionsModel{}
+	if input == nil {
+		return []DataConnectorGenericUIPermissionsModel{}
+	}
 	if input.ResourceProvider != nil {
 		output.ResourceProviders = flattenDataConnectorGenericUIPermissionsResourceProviderModel(input.ResourceProvider)
 	}

--- a/internal/services/sentinel/sentinel_data_connector_generic_ui.go
+++ b/internal/services/sentinel/sentinel_data_connector_generic_ui.go
@@ -501,8 +501,6 @@ func flattenDataConnectorGenericUIInstructionStepInstructionModel(input *[]secur
 	return output, nil
 }
 
-type DataConnectorGenericUIResource struct{}
-
 func DataConnectorGenericUIConfigSchema() map[string]*pluginsdk.Schema {
 	return map[string]*pluginsdk.Schema{
 		"title": {

--- a/internal/services/sentinel/sentinel_data_connector_generic_ui.go
+++ b/internal/services/sentinel/sentinel_data_connector_generic_ui.go
@@ -1,0 +1,763 @@
+package sentinel
+
+import (
+	"regexp"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+	securityinsight "github.com/tombuildsstuff/kermit/sdk/securityinsights/2022-10-01-preview/securityinsights"
+)
+
+type DataConnectorGenericUIConfigModel struct {
+	Title                 string                                            `tfschema:"title"`
+	Publisher             string                                            `tfschema:"publisher"`
+	DescriptionMarkdown   string                                            `tfschema:"description_markdown"`
+	CustomImage           string                                            `tfschema:"custom_image"`
+	GraphQueriesTableName string                                            `tfschema:"graph_queries_table_name"`
+	GraphQueries          []DataConnectorGenericUIGraphQueryModel           `tfschema:"graph_query"`
+	SampleQueries         []DataConnectorGenericUISampleQueryModel          `tfschema:"sample_query"`
+	DataTypes             []DataConnectorGenericUIDataTypeModel             `tfschema:"data_type"`
+	ConnectivityCriteria  []DataConnectorGenericUIConnectivityCriteriaModel `tfschema:"connectivity_criteria"`
+	Availability          []DataConnectorGenericUIAvailabilityModel         `tfschema:"availability"`
+	Permissions           []DataConnectorGenericUIPermissionsModel          `tfschema:"permission"`
+	InstructionSteps      []DataConnectorGenericUIInstructionStepModel      `tfschema:"instruction"`
+}
+
+func expandDataConnectorGenericUIConfigModel(input []DataConnectorGenericUIConfigModel) (*securityinsight.CodelessUIConnectorConfigProperties, error) {
+	if len(input) == 0 {
+		return nil, nil
+	}
+	item := input[0]
+
+	instruction, err := expandDataConnectorGenericUIInstructionStepModel(item.InstructionSteps)
+	if err != nil {
+		return nil, err
+	}
+	return &securityinsight.CodelessUIConnectorConfigProperties{
+		Title:                 &item.Title,
+		Publisher:             &item.Publisher,
+		DescriptionMarkdown:   &item.DescriptionMarkdown,
+		CustomImage:           &item.CustomImage,
+		GraphQueriesTableName: &item.GraphQueriesTableName,
+		GraphQueries:          expandDataConnectorGenericUIGraphQueryModel(item.GraphQueries),
+		SampleQueries:         expandDataConnectorGenericUISampleQueryModel(item.SampleQueries),
+		DataTypes:             expandDataConnectorGenericUIDataTypeModel(item.DataTypes),
+		ConnectivityCriteria:  expandDataConnectorGenericUIConnectivityCriteriaModel(item.ConnectivityCriteria),
+		Availability:          expandDataConnectorGenericUIAvailabilityModel(item.Availability),
+		Permissions:           expandDataConnectorGenericUIPermissionsModel(item.Permissions),
+		InstructionSteps:      instruction,
+	}, nil
+}
+
+func flattenDataConnectorGenericUIConfigModel(input *securityinsight.CodelessUIConnectorConfigProperties) ([]DataConnectorGenericUIConfigModel, error) {
+	var output []DataConnectorGenericUIConfigModel
+	if input == nil {
+		return output, nil
+	}
+
+	instruction, err := flattenDataConnectorGenericUIInstructionStepModel(input.InstructionSteps)
+	if err != nil {
+		return output, err
+	}
+
+	return append(output, DataConnectorGenericUIConfigModel{
+		Title:                 *input.Title,
+		Publisher:             *input.Publisher,
+		DescriptionMarkdown:   *input.DescriptionMarkdown,
+		CustomImage:           *input.CustomImage,
+		GraphQueriesTableName: *input.GraphQueriesTableName,
+		GraphQueries:          flattenDataConnectorGenericUIGraphQueryModel(input.GraphQueries),
+		SampleQueries:         flattenDataConnectorGenericUISampleQueryModel(input.SampleQueries),
+		DataTypes:             flattenDataConnectorGenericUIDataTypeModel(input.DataTypes),
+		ConnectivityCriteria:  flattenDataConnectorGenericUIConnectivityCriteriaModel(input.ConnectivityCriteria),
+		Availability:          flattenDataConnectorGenericUIAvailabilityModel(input.Availability),
+		Permissions:           flattenDataConnectorGenericUIPermissionsModel(input.Permissions),
+		InstructionSteps:      instruction,
+	}), nil
+}
+
+type DataConnectorGenericUIGraphQueryModel struct {
+	MetricName string `tfschema:"metric_name"`
+	Legend     string `tfschema:"legend"`
+	BaseQuery  string `tfschema:"base_query"`
+}
+
+func expandDataConnectorGenericUIGraphQueryModel(input []DataConnectorGenericUIGraphQueryModel) *[]securityinsight.CodelessUIConnectorConfigPropertiesGraphQueriesItem {
+	output := make([]securityinsight.CodelessUIConnectorConfigPropertiesGraphQueriesItem, 0)
+	for _, item := range input {
+		output = append(output, securityinsight.CodelessUIConnectorConfigPropertiesGraphQueriesItem{
+			MetricName: &item.MetricName,
+			Legend:     &item.Legend,
+			BaseQuery:  &item.BaseQuery,
+		})
+	}
+
+	return &output
+}
+
+func flattenDataConnectorGenericUIGraphQueryModel(input *[]securityinsight.CodelessUIConnectorConfigPropertiesGraphQueriesItem) []DataConnectorGenericUIGraphQueryModel {
+	output := make([]DataConnectorGenericUIGraphQueryModel, 0)
+	if input == nil {
+		return output
+	}
+
+	for _, item := range *input {
+		o := DataConnectorGenericUIGraphQueryModel{}
+		if item.MetricName != nil {
+			o.MetricName = *item.MetricName
+		}
+		if item.Legend != nil {
+			o.Legend = *item.Legend
+		}
+		if item.BaseQuery != nil {
+			o.BaseQuery = *item.BaseQuery
+		}
+		output = append(output, o)
+	}
+
+	return output
+}
+
+type DataConnectorGenericUISampleQueryModel struct {
+	Description string `tfschema:"description"`
+	Query       string `tfschema:"query"`
+}
+
+func expandDataConnectorGenericUISampleQueryModel(input []DataConnectorGenericUISampleQueryModel) *[]securityinsight.CodelessUIConnectorConfigPropertiesSampleQueriesItem {
+	output := make([]securityinsight.CodelessUIConnectorConfigPropertiesSampleQueriesItem, 0)
+	for _, item := range input {
+		output = append(output, securityinsight.CodelessUIConnectorConfigPropertiesSampleQueriesItem{
+			Description: &item.Description,
+			Query:       &item.Query,
+		})
+	}
+
+	return &output
+}
+
+func flattenDataConnectorGenericUISampleQueryModel(input *[]securityinsight.CodelessUIConnectorConfigPropertiesSampleQueriesItem) []DataConnectorGenericUISampleQueryModel {
+	output := make([]DataConnectorGenericUISampleQueryModel, 0)
+	if input == nil {
+		return output
+	}
+
+	for _, item := range *input {
+		o := DataConnectorGenericUISampleQueryModel{}
+		if item.Description != nil {
+			o.Description = *item.Description
+		}
+		if item.Query != nil {
+			o.Query = *item.Query
+		}
+		output = append(output, o)
+	}
+
+	return output
+}
+
+type DataConnectorGenericUIDataTypeModel struct {
+	Name                  string `tfschema:"name"`
+	LastDataReceivedQuery string `tfschema:"last_data_received_query"`
+}
+
+func expandDataConnectorGenericUIDataTypeModel(input []DataConnectorGenericUIDataTypeModel) *[]securityinsight.CodelessUIConnectorConfigPropertiesDataTypesItem {
+	output := make([]securityinsight.CodelessUIConnectorConfigPropertiesDataTypesItem, 0)
+	for _, item := range input {
+		output = append(output, securityinsight.CodelessUIConnectorConfigPropertiesDataTypesItem{
+			Name:                  &item.Name,
+			LastDataReceivedQuery: &item.LastDataReceivedQuery,
+		})
+	}
+
+	return &output
+}
+
+func flattenDataConnectorGenericUIDataTypeModel(input *[]securityinsight.CodelessUIConnectorConfigPropertiesDataTypesItem) []DataConnectorGenericUIDataTypeModel {
+	output := make([]DataConnectorGenericUIDataTypeModel, 0)
+	if input == nil {
+		return output
+	}
+
+	for _, item := range *input {
+		o := DataConnectorGenericUIDataTypeModel{}
+		if item.Name != nil {
+			o.Name = *item.Name
+		}
+		if item.LastDataReceivedQuery != nil {
+			o.LastDataReceivedQuery = *item.LastDataReceivedQuery
+		}
+		output = append(output, o)
+	}
+
+	return output
+}
+
+type DataConnectorGenericUIConnectivityCriteriaModel struct {
+	Type  string   `tfschema:"type"`
+	Value []string `tfschema:"value"`
+}
+
+func expandDataConnectorGenericUIConnectivityCriteriaModel(input []DataConnectorGenericUIConnectivityCriteriaModel) *[]securityinsight.CodelessUIConnectorConfigPropertiesConnectivityCriteriaItem {
+	output := make([]securityinsight.CodelessUIConnectorConfigPropertiesConnectivityCriteriaItem, 0)
+	for _, item := range input {
+		output = append(output, securityinsight.CodelessUIConnectorConfigPropertiesConnectivityCriteriaItem{
+			Type:  securityinsight.ConnectivityType(item.Type),
+			Value: &item.Value,
+		})
+	}
+
+	return &output
+}
+
+func flattenDataConnectorGenericUIConnectivityCriteriaModel(input *[]securityinsight.CodelessUIConnectorConfigPropertiesConnectivityCriteriaItem) []DataConnectorGenericUIConnectivityCriteriaModel {
+	output := make([]DataConnectorGenericUIConnectivityCriteriaModel, 0)
+	if input == nil {
+		return output
+	}
+
+	for _, item := range *input {
+		o := DataConnectorGenericUIConnectivityCriteriaModel{
+			Type: string(item.Type),
+		}
+		if item.Value != nil && len(*item.Value) > 0 {
+			o.Value = *item.Value
+		}
+		output = append(output, o)
+	}
+
+	return output
+}
+
+type DataConnectorGenericUIAvailabilityModel struct {
+	Enabled bool `tfschema:"enabled"`
+	Preview bool `tfschema:"preview"`
+}
+
+func expandDataConnectorGenericUIAvailabilityModel(input []DataConnectorGenericUIAvailabilityModel) *securityinsight.Availability {
+	if len(input) == 0 {
+		return nil
+	}
+	item := input[0]
+	var status int32 = 0
+	if item.Enabled {
+		status = 1
+	}
+	output := &securityinsight.Availability{
+		Status:    &status,
+		IsPreview: &item.Preview,
+	}
+
+	return output
+}
+
+func flattenDataConnectorGenericUIAvailabilityModel(input *securityinsight.Availability) []DataConnectorGenericUIAvailabilityModel {
+	output := DataConnectorGenericUIAvailabilityModel{}
+	if input.Status != nil {
+		output.Enabled = *input.Status == 1
+	}
+	if input.IsPreview != nil {
+		output.Preview = *input.IsPreview
+	}
+
+	return append([]DataConnectorGenericUIAvailabilityModel{}, output)
+}
+
+type DataConnectorGenericUIPermissionsModel struct {
+	ResourceProviders []DataConnectorGenericUIPermissionsResourceProviderModel `tfschema:"resource_provider"`
+	Customs           []DataConnectorGenericUIPermissionsCustomModel           `tfschema:"custom"`
+}
+
+func expandDataConnectorGenericUIPermissionsModel(input []DataConnectorGenericUIPermissionsModel) *securityinsight.Permissions {
+	if len(input) == 0 {
+		return nil
+	}
+	item := input[0]
+
+	output := &securityinsight.Permissions{
+		ResourceProvider: expandDataConnectorGenericUIPermissionsResourceProviderModel(item.ResourceProviders),
+		Customs:          expandDataConnectorGenericUIPermissionsCustomModel(item.Customs),
+	}
+
+	return output
+}
+
+func flattenDataConnectorGenericUIPermissionsModel(input *securityinsight.Permissions) []DataConnectorGenericUIPermissionsModel {
+	output := DataConnectorGenericUIPermissionsModel{}
+	if input.ResourceProvider != nil {
+		output.ResourceProviders = flattenDataConnectorGenericUIPermissionsResourceProviderModel(input.ResourceProvider)
+	}
+	if input.Customs != nil {
+		output.Customs = flattenDataConnectorGenericUIPermissionsCustomModel(input.Customs)
+	}
+
+	return append([]DataConnectorGenericUIPermissionsModel{}, output)
+}
+
+type DataConnectorGenericUIPermissionsResourceProviderModel struct {
+	Name                  string                                                     `tfschema:"name"`
+	ProviderDisplayName   string                                                     `tfschema:"display_name"`
+	PermissionDisplayText string                                                     `tfschema:"display_text"`
+	Scope                 string                                                     `tfschema:"scope"`
+	RequiredPermissions   []DataConnectorGenericUIPermissionRequiredPermissionsModel `tfschema:"required_permissions"`
+}
+
+func expandDataConnectorGenericUIPermissionsResourceProviderModel(input []DataConnectorGenericUIPermissionsResourceProviderModel) *[]securityinsight.PermissionsResourceProviderItem {
+	output := make([]securityinsight.PermissionsResourceProviderItem, 0)
+	for _, item := range input {
+		output = append(output, securityinsight.PermissionsResourceProviderItem{
+			Provider:               securityinsight.ProviderName(item.Name),
+			ProviderDisplayName:    &item.ProviderDisplayName,
+			PermissionsDisplayText: &item.PermissionDisplayText,
+			Scope:                  securityinsight.PermissionProviderScope(item.Scope),
+			RequiredPermissions:    expandDataConnectorGenericUIPermissionRequiredPermissionsModel(item.RequiredPermissions),
+		})
+	}
+
+	return &output
+}
+
+func flattenDataConnectorGenericUIPermissionsResourceProviderModel(input *[]securityinsight.PermissionsResourceProviderItem) []DataConnectorGenericUIPermissionsResourceProviderModel {
+	output := make([]DataConnectorGenericUIPermissionsResourceProviderModel, 0)
+	if input == nil {
+		return output
+	}
+
+	for _, item := range *input {
+		o := DataConnectorGenericUIPermissionsResourceProviderModel{}
+		if item.Provider != "" {
+			o.Name = string(item.Provider)
+		}
+		if item.ProviderDisplayName != nil {
+			o.ProviderDisplayName = *item.ProviderDisplayName
+		}
+		if item.PermissionsDisplayText != nil {
+			o.PermissionDisplayText = *item.PermissionsDisplayText
+		}
+		if item.Scope != "" {
+			o.Scope = string(item.Scope)
+		}
+		if item.RequiredPermissions != nil {
+			o.RequiredPermissions = flattenDataConnectorGenericUIPermissionRequiredPermissionsModel(item.RequiredPermissions)
+		}
+		output = append(output, o)
+	}
+
+	return output
+}
+
+type DataConnectorGenericUIPermissionRequiredPermissionsModel struct {
+	Action bool `tfschema:"action"`
+	Write  bool `tfschema:"write"`
+	Read   bool `tfschema:"read"`
+	Delete bool `tfschema:"delete"`
+}
+
+func expandDataConnectorGenericUIPermissionRequiredPermissionsModel(input []DataConnectorGenericUIPermissionRequiredPermissionsModel) *securityinsight.RequiredPermissions {
+	if len(input) == 0 {
+		return nil
+	}
+	item := input[0]
+
+	output := &securityinsight.RequiredPermissions{
+		Action: &item.Action,
+		Write:  &item.Write,
+		Read:   &item.Read,
+		Delete: &item.Delete,
+	}
+
+	return output
+}
+
+func flattenDataConnectorGenericUIPermissionRequiredPermissionsModel(input *securityinsight.RequiredPermissions) []DataConnectorGenericUIPermissionRequiredPermissionsModel {
+	output := DataConnectorGenericUIPermissionRequiredPermissionsModel{}
+	if input.Action != nil {
+		output.Action = *input.Action
+	}
+	if input.Write != nil {
+		output.Write = *input.Write
+	}
+	if input.Read != nil {
+		output.Read = *input.Read
+	}
+	if input.Delete != nil {
+		output.Delete = *input.Delete
+	}
+
+	return append([]DataConnectorGenericUIPermissionRequiredPermissionsModel{}, output)
+}
+
+type DataConnectorGenericUIPermissionsCustomModel struct {
+	Name        string `tfschema:"name"`
+	Description string `tfschema:"description"`
+}
+
+func expandDataConnectorGenericUIPermissionsCustomModel(input []DataConnectorGenericUIPermissionsCustomModel) *[]securityinsight.PermissionsCustomsItem {
+	output := make([]securityinsight.PermissionsCustomsItem, 0)
+	for _, v := range input {
+		output = append(output, securityinsight.PermissionsCustomsItem{
+			Name:        &v.Name,
+			Description: &v.Description,
+		})
+	}
+	return &output
+}
+
+func flattenDataConnectorGenericUIPermissionsCustomModel(input *[]securityinsight.PermissionsCustomsItem) []DataConnectorGenericUIPermissionsCustomModel {
+	output := make([]DataConnectorGenericUIPermissionsCustomModel, 0)
+	if input != nil {
+		for _, v := range *input {
+			o := DataConnectorGenericUIPermissionsCustomModel{}
+			if v.Name != nil {
+				o.Name = *v.Name
+			}
+			if v.Description != nil {
+				o.Description = *v.Description
+			}
+			output = append(output, o)
+		}
+	}
+	return output
+}
+
+type DataConnectorGenericUIInstructionStepModel struct {
+	Title        string                                                  `tfschema:"title"`
+	Description  string                                                  `tfschema:"description"`
+	Instructions []DataConnectorGenericUIInstructionStepInstructionModel `tfschema:"step"`
+}
+
+func expandDataConnectorGenericUIInstructionStepModel(input []DataConnectorGenericUIInstructionStepModel) (*[]securityinsight.CodelessUIConnectorConfigPropertiesInstructionStepsItem, error) {
+	output := make([]securityinsight.CodelessUIConnectorConfigPropertiesInstructionStepsItem, 0)
+	for _, v := range input {
+		instruction, err := expandDataConnectorGenericUIInstructionStepInstructionModel(v.Instructions)
+		if err != nil {
+			return nil, err
+		}
+		output = append(output, securityinsight.CodelessUIConnectorConfigPropertiesInstructionStepsItem{
+			Title:        &v.Title,
+			Description:  &v.Description,
+			Instructions: instruction,
+		})
+	}
+	return &output, nil
+}
+
+func flattenDataConnectorGenericUIInstructionStepModel(input *[]securityinsight.CodelessUIConnectorConfigPropertiesInstructionStepsItem) ([]DataConnectorGenericUIInstructionStepModel, error) {
+	output := make([]DataConnectorGenericUIInstructionStepModel, 0)
+	for _, v := range *input {
+		o := DataConnectorGenericUIInstructionStepModel{}
+		instruction, err := flattenDataConnectorGenericUIInstructionStepInstructionModel(v.Instructions)
+		if err != nil {
+			return nil, err
+		}
+		o.Instructions = instruction
+		if v.Title != nil {
+			o.Title = *v.Title
+		}
+		if v.Description != nil {
+			o.Description = *v.Description
+		}
+		output = append(output, o)
+	}
+	return output, nil
+}
+
+type DataConnectorGenericUIInstructionStepInstructionModel struct {
+	Type       string `tfschema:"type"`
+	Parameters string `tfschema:"parameters"`
+}
+
+func expandDataConnectorGenericUIInstructionStepInstructionModel(input []DataConnectorGenericUIInstructionStepInstructionModel) (*[]securityinsight.InstructionStepsInstructionsItem, error) {
+	output := make([]securityinsight.InstructionStepsInstructionsItem, 0)
+
+	for _, v := range input {
+		param, err := pluginsdk.ExpandJsonFromString(v.Parameters)
+		if err != nil {
+			return nil, err
+		}
+		output = append(output, securityinsight.InstructionStepsInstructionsItem{
+			Type:       securityinsight.SettingType(v.Type),
+			Parameters: &param,
+		})
+	}
+	return &output, nil
+}
+
+func flattenDataConnectorGenericUIInstructionStepInstructionModel(input *[]securityinsight.InstructionStepsInstructionsItem) ([]DataConnectorGenericUIInstructionStepInstructionModel, error) {
+	output := make([]DataConnectorGenericUIInstructionStepInstructionModel, 0)
+	if input != nil {
+		for _, v := range *input {
+			o := DataConnectorGenericUIInstructionStepInstructionModel{
+				Type: string(v.Type),
+			}
+			p, err := pluginsdk.FlattenJsonToString(v.Parameters.(map[string]interface{}))
+			if err != nil {
+				return nil, err
+			}
+			o.Parameters = p
+			output = append(output, o)
+		}
+	}
+	return output, nil
+}
+
+type DataConnectorGenericUIResource struct{}
+
+func DataConnectorGenericUIConfigSchema() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"title": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+		"publisher": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+		"description_markdown": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+		"custom_image": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ValidateFunc: validation.IsURLWithHTTPorHTTPS,
+		},
+		"graph_queries_table_name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ValidateFunc: validation.StringMatch(regexp.MustCompile(`.+_CL$`), "must end with _CL"),
+		},
+		"graph_query": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*schema.Schema{
+					"metric_name": {
+						Type:         pluginsdk.TypeString,
+						Required:     true,
+						ValidateFunc: validation.StringIsNotEmpty,
+					},
+					"legend": {
+						Type:         pluginsdk.TypeString,
+						Required:     true,
+						ValidateFunc: validation.StringIsNotEmpty,
+					},
+					"base_query": {
+						Type:         pluginsdk.TypeString,
+						Required:     true,
+						ValidateFunc: validation.StringIsNotEmpty,
+					},
+				},
+			},
+		},
+		"sample_query": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*schema.Schema{
+					"description": {
+						Type:         pluginsdk.TypeString,
+						Required:     true,
+						ValidateFunc: validation.StringIsNotEmpty,
+					},
+					"query": {
+						Type:         pluginsdk.TypeString,
+						Required:     true,
+						ValidateFunc: validation.StringIsNotEmpty,
+					},
+				},
+			},
+		},
+		"data_type": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*schema.Schema{
+					"name": {
+						Type:         pluginsdk.TypeString,
+						Required:     true,
+						ValidateFunc: validation.StringIsNotEmpty,
+					},
+					"last_data_received_query": {
+						Type:         pluginsdk.TypeString,
+						Required:     true,
+						ValidateFunc: validation.StringIsNotEmpty,
+					},
+				},
+			},
+		},
+		"connectivity_criteria": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*schema.Schema{
+					"type": {
+						Type:     pluginsdk.TypeString,
+						Required: true,
+						ValidateFunc: validation.StringInSlice([]string{
+							"IsConnectedQuery",
+						}, false),
+					},
+					"value": {
+						Type:     pluginsdk.TypeList,
+						Optional: true,
+						Elem: &pluginsdk.Schema{
+							Type:         pluginsdk.TypeString,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+					},
+				},
+			},
+		},
+		"availability": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*schema.Schema{
+					"enabled": {
+						Type:     pluginsdk.TypeBool,
+						Required: true,
+					},
+					"preview": {
+						Type:     pluginsdk.TypeBool,
+						Required: true,
+					},
+				},
+			},
+		},
+		"permission": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*schema.Schema{
+					"resource_provider": {
+						Type:     pluginsdk.TypeList,
+						Required: true,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*schema.Schema{
+								"name": {
+									Type:     pluginsdk.TypeString,
+									Required: true,
+									ValidateFunc: validation.StringInSlice([]string{
+										string(securityinsight.ProviderNameMicrosoftAuthorizationpolicyAssignments),
+										string(securityinsight.ProviderNameMicrosoftOperationalInsightssolutions),
+										string(securityinsight.ProviderNameMicrosoftOperationalInsightsworkspaces),
+										string(securityinsight.ProviderNameMicrosoftOperationalInsightsworkspacesdatasources),
+										string(securityinsight.ProviderNameMicrosoftOperationalInsightsworkspacessharedKeys),
+										string(securityinsight.ProviderNameMicrosoftaadiamdiagnosticSettings),
+									}, false),
+								},
+								"display_name": {
+									Type:         pluginsdk.TypeString,
+									Required:     true,
+									ValidateFunc: validation.StringIsNotEmpty,
+								},
+								"display_text": {
+									Type:         pluginsdk.TypeString,
+									Required:     true,
+									ValidateFunc: validation.StringIsNotEmpty,
+								},
+								"scope": {
+									Type:     pluginsdk.TypeString,
+									Required: true,
+									ValidateFunc: validation.StringInSlice(
+										[]string{
+											string(securityinsight.PermissionProviderScopeResourceGroup),
+											string(securityinsight.PermissionProviderScopeSubscription),
+											string(securityinsight.PermissionProviderScopeWorkspace),
+										}, false),
+								},
+								"required_permissions": {
+									Type:     pluginsdk.TypeList,
+									Required: true,
+									Elem: &pluginsdk.Resource{
+										Schema: map[string]*schema.Schema{
+											"action": {
+												Type:     pluginsdk.TypeBool,
+												Optional: true,
+											},
+											"write": {
+												Type:     pluginsdk.TypeBool,
+												Optional: true,
+											},
+											"read": {
+												Type:     pluginsdk.TypeBool,
+												Optional: true,
+											},
+											"delete": {
+												Type:     pluginsdk.TypeBool,
+												Optional: true,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					"custom": {
+						Type:     pluginsdk.TypeList,
+						Optional: true,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*schema.Schema{
+								"name": {
+									Type:         pluginsdk.TypeString,
+									Required:     true,
+									ValidateFunc: validation.StringIsNotEmpty,
+								},
+								"description": {
+									Type:         pluginsdk.TypeString,
+									Optional:     true,
+									ValidateFunc: validation.StringIsNotEmpty,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"instruction": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*schema.Schema{
+					"title": {
+						Type:         pluginsdk.TypeString,
+						Required:     true,
+						ValidateFunc: validation.StringIsNotEmpty,
+					},
+					"description": {
+						Type:         pluginsdk.TypeString,
+						Optional:     true,
+						ValidateFunc: validation.StringIsNotEmpty,
+					},
+					"step": {
+						Type:     pluginsdk.TypeList,
+						Optional: true,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*schema.Schema{
+								"type": {
+									Type:     pluginsdk.TypeString,
+									Required: true,
+									ValidateFunc: validation.StringInSlice([]string{
+										string(securityinsight.SettingTypeCopyableLabel),
+										string(securityinsight.SettingTypeInfoMessage),
+										string(securityinsight.SettingTypeInstructionStepsGroup),
+									}, false),
+								},
+								"parameters": {
+									Type:         pluginsdk.TypeString,
+									Optional:     true,
+									ValidateFunc: validation.StringIsJSON,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/internal/services/sentinel/sentinel_data_connector_generic_ui_resource.go
+++ b/internal/services/sentinel/sentinel_data_connector_generic_ui_resource.go
@@ -1,0 +1,275 @@
+package sentinel
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/workspaces"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/sentinel/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/sentinel/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+	securityinsight "github.com/tombuildsstuff/kermit/sdk/securityinsights/2022-10-01-preview/securityinsights"
+)
+
+type DataConnectorGenericUIResourceModel struct {
+	Name                    string `tfschema:"name"`
+	LogAnalyticsWorkspaceId string `tfschema:"log_analytics_workspace_id"`
+	// below are copied from `DataConnectorGenericUIConfigModel`
+	Title                 string                                            `tfschema:"title"`
+	Publisher             string                                            `tfschema:"publisher"`
+	DescriptionMarkdown   string                                            `tfschema:"description_markdown"`
+	CustomImage           string                                            `tfschema:"custom_image"`
+	GraphQueriesTableName string                                            `tfschema:"graph_queries_table_name"`
+	GraphQueries          []DataConnectorGenericUIGraphQueryModel           `tfschema:"graph_query"`
+	SampleQueries         []DataConnectorGenericUISampleQueryModel          `tfschema:"sample_query"`
+	DataTypes             []DataConnectorGenericUIDataTypeModel             `tfschema:"data_type"`
+	ConnectivityCriteria  []DataConnectorGenericUIConnectivityCriteriaModel `tfschema:"connectivity_criteria"`
+	Availability          []DataConnectorGenericUIAvailabilityModel         `tfschema:"availability"`
+	Permissions           []DataConnectorGenericUIPermissionsModel          `tfschema:"permission"`
+	InstructionSteps      []DataConnectorGenericUIInstructionStepModel      `tfschema:"instruction"`
+}
+
+type DataConnectorGenericUIResource struct{}
+
+var _ sdk.ResourceWithUpdate = DataConnectorGenericUIResource{}
+
+func (r DataConnectorGenericUIResource) Arguments() map[string]*schema.Schema {
+	arg := map[string]*schema.Schema{
+		"name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"log_analytics_workspace_id": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: workspaces.ValidateWorkspaceID,
+		},
+	}
+
+	for k, v := range DataConnectorGenericUIConfigSchema() {
+		arg[k] = v
+	}
+	return arg
+}
+
+func (r DataConnectorGenericUIResource) Attributes() map[string]*schema.Schema {
+	return map[string]*schema.Schema{}
+}
+
+func (r DataConnectorGenericUIResource) ModelObject() interface{} {
+	return &DataConnectorGenericUIConfigModel{}
+}
+
+func (r DataConnectorGenericUIResource) ResourceType() string {
+	return "azurerm_sentinel_data_connector_generic_ui"
+}
+
+func (r DataConnectorGenericUIResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+	return validate.DataConnectorID
+}
+
+func (r DataConnectorGenericUIResource) Create() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Sentinel.DataConnectorsClient
+
+			var plan DataConnectorGenericUIResourceModel
+			if err := metadata.Decode(&plan); err != nil {
+				return fmt.Errorf("decoding %+v", err)
+			}
+
+			workspaceId, err := workspaces.ParseWorkspaceID(plan.LogAnalyticsWorkspaceId)
+			if err != nil {
+				return err
+			}
+
+			id := parse.NewDataConnectorID(workspaceId.SubscriptionId, workspaceId.ResourceGroupName, workspaceId.WorkspaceName, plan.Name)
+			existing, err := client.Get(ctx, id.ResourceGroup, id.WorkspaceName, id.Name)
+			if err != nil {
+				if !utils.ResponseWasNotFound(existing.Response) {
+					return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+				}
+			}
+			if !utils.ResponseWasNotFound(existing.Response) {
+				return metadata.ResourceRequiresImport(r.ResourceType(), id)
+			}
+
+			uiConfig, err := expandDataConnectorGenericUIResourceModel(plan)
+			if err != nil {
+				return fmt.Errorf("expanding: %+v", err)
+			}
+
+			params := securityinsight.CodelessUIDataConnector{
+				Name: &plan.Name,
+				CodelessParameters: &securityinsight.CodelessParameters{
+					ConnectorUIConfig: uiConfig,
+				},
+				Kind: securityinsight.KindBasicDataConnectorKindGenericUI,
+			}
+
+			if _, err = client.CreateOrUpdate(ctx, id.ResourceGroup, id.WorkspaceName, id.Name, params); err != nil {
+				return fmt.Errorf("creating %s: %+v", id, err)
+			}
+
+			metadata.SetID(id)
+			return nil
+		},
+	}
+}
+
+func (r DataConnectorGenericUIResource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Sentinel.DataConnectorsClient
+			id, err := parse.DataConnectorID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			existing, err := client.Get(ctx, id.ResourceGroup, id.WorkspaceName, id.Name)
+			if err != nil {
+				if utils.ResponseWasNotFound(existing.Response) {
+					return metadata.MarkAsGone(id)
+				}
+				return fmt.Errorf("retrieving %s: %+v", id, err)
+			}
+
+			dc, ok := existing.Value.(securityinsight.CodelessUIDataConnector)
+			if !ok {
+				return fmt.Errorf("%s was not an IoT Data Connector", id)
+			}
+
+			if dc.ConnectorUIConfig == nil {
+				return fmt.Errorf("retrieving %s: `ConnectorUIConfig` was nil", id)
+			}
+
+			model, err := flattenDataConnectorGenericUIResourceModel(dc.ConnectorUIConfig)
+			if err != nil {
+				return fmt.Errorf("flattening: %+v", err)
+			}
+
+			if dc.Name != nil {
+				model.Name = *dc.Name
+			}
+
+			workspaceId := workspaces.NewWorkspaceID(id.SubscriptionId, id.ResourceGroup, id.WorkspaceName)
+			model.LogAnalyticsWorkspaceId = workspaceId.ID()
+
+			return metadata.Encode(&model)
+		},
+	}
+}
+
+func (r DataConnectorGenericUIResource) Delete() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Sentinel.DataConnectorsClient
+
+			id, err := parse.DataConnectorID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			if _, err := client.Delete(ctx, id.ResourceGroup, id.WorkspaceName, id.Name); err != nil {
+				return fmt.Errorf("deleting %s: %+v", id, err)
+			}
+
+			return nil
+		},
+	}
+}
+
+func (r DataConnectorGenericUIResource) Update() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Sentinel.DataConnectorsClient
+			id, err := parse.DataConnectorID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			var plan DataConnectorGenericUIResourceModel
+			if err := metadata.Decode(&plan); err != nil {
+				return fmt.Errorf("decoding %+v", err)
+			}
+
+			_, err = client.Get(ctx, id.ResourceGroup, id.WorkspaceName, id.Name)
+			if err != nil {
+				return fmt.Errorf("reading %s: %+v", id, err)
+			}
+
+			uiConfig, err := expandDataConnectorGenericUIResourceModel(plan)
+			if err != nil {
+				return fmt.Errorf("expanding : %+v", err)
+			}
+
+			params := securityinsight.CodelessUIDataConnector{
+				Name: &plan.Name,
+				CodelessParameters: &securityinsight.CodelessParameters{
+					ConnectorUIConfig: uiConfig,
+				},
+				Kind: securityinsight.KindBasicDataConnectorKindGenericUI,
+			}
+
+			if _, err = client.CreateOrUpdate(ctx, id.ResourceGroup, id.WorkspaceName, id.Name, params); err != nil {
+				return fmt.Errorf("updating %s: %+v", id, err)
+			}
+
+			return nil
+		},
+	}
+}
+
+func expandDataConnectorGenericUIResourceModel(input DataConnectorGenericUIResourceModel) (*securityinsight.CodelessUIConnectorConfigProperties, error) {
+	uiModel := DataConnectorGenericUIConfigModel{
+		Title:                 input.Title,
+		Publisher:             input.Publisher,
+		DescriptionMarkdown:   input.DescriptionMarkdown,
+		CustomImage:           input.CustomImage,
+		GraphQueriesTableName: input.GraphQueriesTableName,
+		GraphQueries:          input.GraphQueries,
+		SampleQueries:         input.SampleQueries,
+		DataTypes:             input.DataTypes,
+		ConnectivityCriteria:  input.ConnectivityCriteria,
+		Availability:          input.Availability,
+		Permissions:           input.Permissions,
+		InstructionSteps:      input.InstructionSteps,
+	}
+	return expandDataConnectorGenericUIConfigModel(append([]DataConnectorGenericUIConfigModel{}, uiModel))
+}
+
+func flattenDataConnectorGenericUIResourceModel(input *securityinsight.CodelessUIConnectorConfigProperties) (DataConnectorGenericUIResourceModel, error) {
+	model := DataConnectorGenericUIResourceModel{}
+	uiConfig, err := flattenDataConnectorGenericUIConfigModel(input)
+	if err != nil {
+		return model, err
+	}
+
+	model.Title = uiConfig[0].Title
+	model.Publisher = uiConfig[0].Publisher
+	model.DescriptionMarkdown = uiConfig[0].DescriptionMarkdown
+	model.CustomImage = uiConfig[0].CustomImage
+	model.GraphQueriesTableName = uiConfig[0].GraphQueriesTableName
+	model.GraphQueries = uiConfig[0].GraphQueries
+	model.SampleQueries = uiConfig[0].SampleQueries
+	model.DataTypes = uiConfig[0].DataTypes
+	model.ConnectivityCriteria = uiConfig[0].ConnectivityCriteria
+	model.Availability = uiConfig[0].Availability
+	model.Permissions = uiConfig[0].Permissions
+	model.InstructionSteps = uiConfig[0].InstructionSteps
+
+	return model, nil
+}

--- a/internal/services/sentinel/sentinel_data_connector_generic_ui_resource_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_generic_ui_resource_test.go
@@ -1,0 +1,231 @@
+package sentinel_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/sentinel/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+type SentinelDataConnectorGenericUIResource struct{}
+
+func TestAccAzureRMSentinelDataConnectorGenericUI_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_sentinel_data_connector_generic_ui", "test")
+	r := SentinelDataConnectorGenericUIResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccAzureRMSentinelDataConnectorGenericUI_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_sentinel_data_connector_generic_ui", "test")
+	r := SentinelDataConnectorGenericUIResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.RequiresImportErrorStep(r.requiresImport),
+	})
+}
+
+func (r SentinelDataConnectorGenericUIResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	client := clients.Sentinel.DataConnectorsClient
+
+	id, err := parse.DataConnectorID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp, err := client.Get(ctx, id.ResourceGroup, id.WorkspaceName, id.Name); err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			return utils.Bool(false), nil
+		}
+		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+
+	return utils.Bool(true), nil
+}
+
+func (r SentinelDataConnectorGenericUIResource) basic(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_sentinel_data_connector_generic_ui" "test" {
+  name                       = "accTestDC-%d"
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  title                      = "Slack"
+  publisher                  = "Slack"
+  description_markdown       = "The [Slack](https://slack.com) data connector provides the capability to ingest [Slack Audit Records](https://api.slack.com/admins/audit-logs) events into Microsoft Sentinel through the REST API. Refer to [API documentation](https://api.slack.com/admins/audit-logs#the_audit_event) for more information. The connector provides ability to get events which helps to examine potential security risks, analyze your team's use of collaboration, diagnose configuration problems and more. This data connector uses Microsoft Sentinel native polling capability."
+  graph_queries_table_name   = "SlackAuditNativePoller_CL"
+  graph_query {
+    metric_name = "Total data received"
+    legend      = "Slack audit events"
+    base_query  = "{{graphQueriesTableName}}"
+  }
+
+  sample_query {
+    description = "All Slack audit events"
+    query       = "{{graphQueriesTableName}}\n| sort by TimeGenerated desc"
+  }
+
+  data_type {
+    name                     = "{{graphQueriesTableName}}"
+    last_data_received_query = "{{graphQueriesTableName}}\n            | summarize Time = max(TimeGenerated)\n            | where isnotempty(Time)"
+  }
+
+  connectivity_criteria {
+    type = "IsConnectedQuery"
+  }
+
+  availability {
+    enabled = true
+    preview = true
+  }
+
+  permission {
+    resource_provider {
+      name         = "Microsoft.OperationalInsights/workspaces"
+      display_name = "read and write permissions are required."
+      display_text = "Workspace"
+      scope        = "Workspace"
+      required_permissions {
+        read   = true
+        write  = true
+        delete = true
+      }
+    }
+    custom {
+      name        = "Slack API credentials"
+      description = "**SlackAPIBearerToken** is required for REST API. [See the documentation to learn more about API](https://api.slack.com/web#authentication). Check all [requirements and follow the instructions](https://api.slack.com/web#authentication) for obtaining credentials."
+    }
+  }
+
+  instruction {
+    title       = "Connect Slack to Microsoft Sentinel"
+    description = "Enable Slack audit Logs"
+    step {
+      type = "InfoMessage"
+      parameters = jsonencode({
+        "enable" = "true"
+      })
+    }
+  }
+
+  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
+}
+`, template, data.RandomInteger)
+}
+
+func (r SentinelDataConnectorGenericUIResource) requiresImport(data acceptance.TestData) string {
+	template := r.basic(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_sentinel_data_connector_generic_ui" "import" {
+  name                       = azurerm_sentinel_data_connector_generic_ui.test.name
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  title                      = "Slack"
+  publisher                  = "Slack"
+  description_markdown       = "The [Slack](https://slack.com) data connector provides the capability to ingest [Slack Audit Records](https://api.slack.com/admins/audit-logs) events into Microsoft Sentinel through the REST API. Refer to [API documentation](https://api.slack.com/admins/audit-logs#the_audit_event) for more information. The connector provides ability to get events which helps to examine potential security risks, analyze your team's use of collaboration, diagnose configuration problems and more. This data connector uses Microsoft Sentinel native polling capability."
+  graph_queries_table_name   = "SlackAuditNativePoller_CL"
+  graph_query {
+    metric_name = "Total data received"
+    legend      = "Slack audit events"
+    base_query  = "{{graphQueriesTableName}}"
+  }
+
+  sample_query {
+    description = "All Slack audit events"
+    query       = "{{graphQueriesTableName}}\n| sort by TimeGenerated desc"
+  }
+
+  data_type {
+    name                     = "{{graphQueriesTableName}}"
+    last_data_received_query = "{{graphQueriesTableName}}\n            | summarize Time = max(TimeGenerated)\n            | where isnotempty(Time)"
+  }
+
+  connectivity_criteria {
+    type = "IsConnectedQuery"
+  }
+
+  availability {
+    enabled = true
+    preview = true
+  }
+
+  permission {
+    resource_provider {
+      name         = "Microsoft.OperationalInsights/workspaces"
+      display_name = "read and write permissions are required."
+      display_text = "Workspace"
+      scope        = "Workspace"
+      required_permissions {
+        read   = true
+        write  = true
+        delete = true
+      }
+    }
+    custom {
+      name        = "Slack API credentials"
+      description = "**SlackAPIBearerToken** is required for REST API. [See the documentation to learn more about API](https://api.slack.com/web#authentication). Check all [requirements and follow the instructions](https://api.slack.com/web#authentication) for obtaining credentials."
+    }
+  }
+
+  instruction {
+    title       = "Connect Slack to Microsoft Sentinel"
+    description = "Enable Slack audit Logs"
+    step {
+      type = "InfoMessage"
+      parameters = jsonencode({
+        "enable" = "true"
+      })
+    }
+  }
+
+  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
+}
+`, template)
+}
+
+func (r SentinelDataConnectorGenericUIResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-sentinel-%d"
+  location = "%s"
+}
+
+resource "azurerm_log_analytics_workspace" "test" {
+  name                = "acctestLAW-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "PerGB2018"
+}
+
+resource "azurerm_sentinel_log_analytics_workspace_onboarding" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  workspace_name      = azurerm_log_analytics_workspace.test.name
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}

--- a/website/docs/r/sentinel_data_connector_api_polling.html.markdown
+++ b/website/docs/r/sentinel_data_connector_api_polling.html.markdown
@@ -1,0 +1,399 @@
+---
+subcategory: "Sentinel"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_sentinel_data_connector_api_polling"
+description: |-
+  Manages a API Polling Data Connector.
+---
+
+# azurerm_sentinel_data_connector_api_polling
+
+Manages a API Polling Data Connector.
+
+## Example Usage
+
+```hcl
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "example-rg"
+  location = "east us"
+}
+
+resource "azurerm_log_analytics_workspace" "example" {
+  name                = "example-workspace"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  sku                 = "PerGB2018"
+}
+
+resource "azurerm_sentinel_log_analytics_workspace_onboarding" "example" {
+  resource_group_name = azurerm_resource_group.example.name
+  workspace_name      = azurerm_log_analytics_workspace.example.name
+}
+
+resource "azurerm_sentinel_data_connector_api_polling" "example" {
+  name                       = "example-apipolling"
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
+  enabled                    = true
+
+  auth {
+    type               = "APIKey"
+    api_key_name       = "Authorization"
+    api_key_identifier = "Bearer"
+  }
+
+  request {
+    api_endpoint              = "https://api.slack.com/audit/v1/logs"
+    http_method               = "GET"
+    query_time_format         = "UnixTimestamp"
+    start_time_attribute_name = "oldest"
+    end_time_attribute_name   = "latest"
+    query_window_in_minutes   = 5
+    query_parameters = jsonencode({
+      "limit" = 1000
+    })
+  }
+
+  paging {
+    type                      = "PageToken"
+    next_page_parameter_name  = "cursor"
+    next_page_token_json_path = "..response_metadata.next_cursor"
+  }
+
+  response {
+    events_json_paths = ["$..entries"]
+  }
+
+  ui {
+    title                    = "Slack"
+    publisher                = "Slack"
+    description_markdown     = "The [Slack](https://slack.com) data connector provides the capability to ingest [Slack Audit Records](https://api.slack.com/admins/audit-logs) events into Microsoft Sentinel through the REST API. Refer to [API documentation](https://api.slack.com/admins/audit-logs#the_audit_event) for more information. The connector provides ability to get events which helps to examine potential security risks, analyze your team's use of collaboration, diagnose configuration problems and more. This data connector uses Microsoft Sentinel native polling capability."
+    graph_queries_table_name = "SlackAuditNativePoller_CL"
+    graph_query {
+      metric_name = "Total data received"
+      legend      = "Slack audit events"
+      base_query  = "{{graphQueriesTableName}}"
+    }
+
+    sample_query {
+      description = "All Slack audit events"
+      query       = "{{graphQueriesTableName}}\n| sort by TimeGenerated desc"
+    }
+
+    data_type {
+      name                     = "{{graphQueriesTableName}}"
+      last_data_received_query = "{{graphQueriesTableName}}\n            | summarize Time = max(TimeGenerated)\n            | where isnotempty(Time)"
+    }
+
+    connectivity_criteria {
+      type = "IsConnectedQuery"
+    }
+
+    availability {
+      enabled = true
+      preview = true
+    }
+
+    permissions {
+      resource_provider {
+        name                     = "Microsoft.OperationalInsights/workspaces"
+        display_name = "read and write permissions are required."
+        display_text = "Workspace"
+        scope                    = "Workspace"
+        required_permissions {
+          read   = true
+          write  = true
+          delete = true
+        }
+      }
+      custom {
+        name        = "Slack API credentials"
+        description = "**SlackAPIBearerToken** is required for REST API. [See the documentation to learn more about API](https://api.slack.com/web#authentication). Check all [requirements and follow the instructions](https://api.slack.com/web#authentication) for obtaining credentials."
+      }
+    }
+
+    instruction {
+      title       = "Connect Slack to Microsoft Sentinel"
+      description = "Enable Slack audit Logs"
+      step {
+        type = "InfoMessage"
+        parameters = jsonencode({
+          "enable" = "true"
+        })
+      }
+    }
+  }
+
+  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name which should be used for this API Polling Data Connector. Changing this forces a new API Polling Data Connector to be created.
+
+* `log_analytics_workspace_id` - (Required) The ID of the TODO. Changing this forces a new API Polling Data Connector to be created.
+
+* `auth` - (Required) An `auth` block as defined below.
+
+* `request` - (Required) A `request` block as defined below.
+
+* `response` - (Required) A `response` block as defined below.
+
+* `ui` - (Required) A `ui` block as defined below.
+
+---
+
+* `active` - (Optional) Should the API poller be active?
+
+* `paging` - (Optional) A `paging` block as defined below.
+
+---
+
+A `auth` block supports the following:
+
+* `type` - (Required) The authentication type. Possible Values are `Basic`, `APIKey` and `OAuth2`.
+
+* `api_key_identifier` - (Optional) A prefix send in the header before the actual token.
+
+* `api_key_in_header_enabled` - (Optional) Should the key be sent in the header?
+
+* `api_key_name` - (Optional) The header name which the token is sent with.
+
+* `oauth2_authorization_endpoint` - (Optional)  The endpoint used to authorize the user, used in Oauth 2.0 flow.
+
+* `oauth2_authorization_endpoint_query_parameters` - (Optional) The json map of query parameters used in authorization request, used in Oauth 2.0 flow.
+
+* `oauth2_client_secret_in_header_enabled` - (Optional) Should the client secret be sent in header? used in Oauth 2.0 flow.
+
+* `oauth2_flow_name` - (Optional) The flow name for Oauth 2.0.
+
+* `oauth2_redirection_endpoint` - (Optional) The redirect endpoint where we will get the authorization code, used in Oauth 2.0 flow
+
+* `oauth2_scope` - (Optional) The OAuth token scope.
+
+* `oauth2_token_endpoint` - (Optional) The endpoint used to issue a token, used in Oauth 2.0 flo.
+
+* `oauth2_token_endpoint_headers` - (Optional) The json map of headers endpoint used to authorize the user, used in Oauth 2.0 flow.
+
+* `oauth2_token_endpoint_query_parameters` - (Optional) The json map of query parameters used in authorization request, used in Oauth 2.0 flow.
+
+---
+
+A `request` block supports the following:
+
+* `api_endpoint` - (Required) The endpoint used to pull data from.
+
+* `http_method` - (Required) The http method type we will use in the poll request, possible values are `GET` and `POST`.
+
+* `query_time_format` - (Required) The time format will be used the query events in a specific window.
+
+* `headers` - (Optional) The json map of headers sent in poll request.
+
+* `query_parameters` - (Optional) The json map of parameters sent in poll request.
+
+* `query_parameters_template` - (Optional) The query parameters template to use when passing query parameters in advanced scenarios. Details could be found [this document](https://learn.microsoft.com/en-us/azure/sentinel/create-codeless-connector?tabs=deploy-via-arm-template%2Cconnect-via-the-azure-portal#configure-your-connectors-polling-settings:~:text=attr_name%3E%27%3A%20%27%3Cval%3E%27...%20%7D.-,queryParametersTemplate,-String)
+
+* `query_window_in_minutes` - (Optional) The window interval we will use the pull the data. Must be greater than `5`.
+
+* `rate_limit_query_per_seconds` - (Optional) The number of calls or queries allowed in a second.
+
+* `retry_count` - (Optional) The number of request retries to try if needed.
+
+* `start_time_attribute_name` - (Optional) The start of the time window of the query events.
+
+* `end_time_attribute_name` - (Optional) The end of the time window of the query events.
+
+* `time_out_in_seconds` - (Optional) The number of seconds we will consider as a request timeout.
+
+---
+
+A `response` block supports the following:
+
+* `events_json_paths` - (Required) Specifies a list of A JSON path expression specifies a path to an element.
+
+* `gzip_compress_enabled` - (Optional) Whether the response is compressed in a gzip file?
+
+* `success_status_json_path` - (Optional) The value of success message.
+
+* `success_status_value` - (Optional) The path to the success message in the response JSON.
+
+---
+
+A `paging` block supports the following:
+
+* `type` - (Required) The paging type to use in results, Possible values are `None`, `PageToken`, `PageCount` and `TimeStamp`.
+
+* `next_page_parameter_name` - (Optional) The next page name in the request..
+
+* `next_page_token_json_path` - (Optional) The json path of the next page token header name in the response.
+
+* `page_count_attribute_path` - (Optional) The json path of the page count.
+
+* `page_size` - (Optional) The paging size.
+
+* `page_size_parameter_name` - (Optional) The name of the page size parameter..
+
+* `page_timestamp_attribute_path` - (Optional) The json path to a paging time stamp attribute.
+
+* `page_total_count_attribute_path` - (Optional) The json path to a page total count attribute.
+
+* `search_the_latest_timestamp_from_events_list_enabled` - (Optional) Whether to search for the latest time stamp in the events list.
+
+---
+
+A `ui` block supports the following:
+
+* `title` - (Required) Title displayed in the data connector page.
+
+* `graph_queries_table_name` - (Required) The name of the Log Analytics table from which data for your queries is pulled. The table name can be any string, but must end in `_CL`. For example: `TableName_CL`.
+
+* `publisher` - (Required) Publisher displayed in the data connector page.
+
+* `availability` - (Optional) An `availability` block as defined below. Defines the availability of the Data Connector.
+
+* `connectivity_criteria` - (Optional) A `connectivity_criteria` block as defined below. Defines the way the connector check connectivity.
+
+* `custom_image` - (Optional) An optional custom image to be used when displaying the connector within Azure Sentinel's connector's gallery.
+
+* `data_type` - (Optional) One or more `data_type` blocks as defined below. Defines Data types to check for last data received
+
+* `description_markdown` - (Optional) The description in markdown format of the Data Connector.
+
+* `graph_query` - (Optional) One or more `graph_query` blocks as defined below. Defines the graph query to show the current data status.
+
+* `instruction` - (Optional) One or more `instruction` blocks as defined below. Define steps to enable the connector.
+
+* `permission` - (Optional) One or more `permission` blocks as defined below. Define permission required by the Data Connector.
+
+* `sample_query` - (Optional) One or more `sample_query` blocks as defined below. Define the sample queries for the Data Connector.
+
+---
+
+A `graph_query` block supports the following:
+
+* `base_query` - (Required) The base query for the graph.
+
+* `legend` - (Required) The legend for the graph.
+
+* `metric_name` - (Required) The name of metric that the query is checking.
+
+---
+
+A `instruction` block supports the following:
+
+* `title` - (Required) The title of the instruction.
+
+* `description` - (Optional) The description of the instruction.
+
+* `step` - (Optional) One or more `step` blocks as defined below.
+
+---
+
+A `step` block supports the following:
+
+* `type` - (Required) The type of the setting. Possible values are `CopyableLabel`, `InfoMessage` and `InstructionStepsGroup`.
+
+* `parameters` - (Optional) The parameters for the setting.
+
+---
+
+A `permissions` block supports the following:
+
+* `resource_provider` - (Required) One or more `resource_provider` blocks as defined below.
+
+* `custom` - (Optional) One or more `custom` blocks as defined above.
+
+---
+
+A `resource_provider` block supports the following:
+
+* `name` - (Required) The name of the Resource Provider. Possible values are `Microsoft.Authorization/policyAssignments`, `Microsoft.OperationalInsights/solutions`, `Microsoft.OperationalInsights/workspaces`, Microsoft.OperationalInsights/workspaces/datasources`, `Microsoft.OperationalInsights/workspaces/sharedKeys` and `microsoft.aadiam/diagnosticSettings`.
+
+* `permissions_display_name` - (Required) The display name of the provider.
+
+* `permissions_display_text` - (Required) The description text of the provider.
+
+* `required_permissions` - (Required) A `required_permissions` block as defined above.
+
+* `scope` - (Required) The scope of the provider. Possible values are `PermissionProviderScopeResourceGroup`, `PermissionProviderScopeSubscription` and `PermissionProviderScopeWorkspace`.
+
+---
+
+A `required_permissions` block supports the following:
+
+* `action` - (Optional) Whether require action permission.
+
+* `delete` - (Optional) Whether require delete permission.
+
+* `read` - (Optional) Whether require read permission.
+
+* `write` - (Optional) Whether require write permission.
+
+---
+
+A `custom` block supports the following:
+
+* `name` - (Required) The name which should be used for this custom permission.
+
+* `description` - (Optional) The description of this custom permission.
+
+---
+
+A `sample_query` block supports the following:
+
+* `description` - (Required) The description of the sample query.
+
+* `query` - (Required) the sample query.
+
+---
+
+A `availability` block supports the following:
+
+* `enabled` - (Required) Should the Data Connector be enabled?
+
+* `preview` - (Required) Whether this Data Connector is in preview?
+
+---
+
+A `connectivity_criteria` block supports the following:
+
+* `type` - (Required) type of connectivity. Possible value is `IsConnectedQuery`. 
+
+* `value` - (Optional) Specifies a list of queries for checking connectivity.
+
+---
+
+A `data_type` block supports the following:
+
+* `name` - (Required) The name which should be used for this Data Type.
+
+* `last_data_received_query` - (Required) Query for indicate last data received.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported: 
+
+* `id` - The ID of the API Polling Data Connector.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the API Polling Data Connector.
+* `read` - (Defaults to 5 minutes) Used when retrieving the API Polling Data Connector.
+* `update` - (Defaults to 30 minutes) Used when updating the API Polling Data Connector.
+* `delete` - (Defaults to 30 minutes) Used when deleting the API Polling Data Connector.
+
+## Import
+
+API Polling Data Connectors can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_sentinel_data_connector_api_polling.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.OperationalInsights/workspaces/workspace1/providers/Microsoft.SecurityInsights/dataConnectors/dc1
+```

--- a/website/docs/r/sentinel_data_connector_api_polling.html.markdown
+++ b/website/docs/r/sentinel_data_connector_api_polling.html.markdown
@@ -99,10 +99,10 @@ resource "azurerm_sentinel_data_connector_api_polling" "example" {
 
     permissions {
       resource_provider {
-        name                     = "Microsoft.OperationalInsights/workspaces"
+        name         = "Microsoft.OperationalInsights/workspaces"
         display_name = "read and write permissions are required."
         display_text = "Workspace"
-        scope                    = "Workspace"
+        scope        = "Workspace"
         required_permissions {
           read   = true
           write  = true
@@ -137,7 +137,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name which should be used for this API Polling Data Connector. Changing this forces a new API Polling Data Connector to be created.
 
-* `log_analytics_workspace_id` - (Required) The ID of the TODO. Changing this forces a new API Polling Data Connector to be created.
+* `log_analytics_workspace_id` - (Required) The ID of the Log Analytics Workspace that this API Polling Data Connector resides in. Changing this forces a new API Polling Data Connector to be created.
 
 * `auth` - (Required) An `auth` block as defined below.
 
@@ -182,6 +182,10 @@ A `auth` block supports the following:
 * `oauth2_token_endpoint_headers` - (Optional) The json map of headers endpoint used to authorize the user, used in Oauth 2.0 flow.
 
 * `oauth2_token_endpoint_query_parameters` - (Optional) The json map of query parameters used in authorization request, used in Oauth 2.0 flow.
+
+-> **NOTE:** If `type` is set to `APIKey`, `api_key_identifier`, `api_key_in_header_enabled` and `api_key_name` are required.
+
+-> **NOTE:** If `type` is set to `OAuth2`, `oauth2_authorization_endpoint`, `oauth2_authorization_endpoint_query_parameters`, `oauth2_client_secret_in_header_enabled`, `oauth2_flow_name`, `oauth2_redirection_endpoint`, `oauth2_scope`, `oauth2_token_endpoint`, `oauth2_token_endpoint_headers` and `oauth2_token_endpoint_query_parameters` are required.
 
 ---
 

--- a/website/docs/r/sentinel_data_connector_generic_ui.html.markdown
+++ b/website/docs/r/sentinel_data_connector_generic_ui.html.markdown
@@ -1,0 +1,258 @@
+---
+subcategory: "Sentinel"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_sentinel_data_connector_generic_ui"
+description: |-
+  Manages a Generic UI Data Connector.
+---
+
+# azurerm_sentinel_data_connector_generic_ui
+
+Manages a Generic UI Data Connector.
+
+## Example Usage
+
+```hcl
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "example-rg"
+  location = "east us"
+}
+
+resource "azurerm_log_analytics_workspace" "example" {
+  name                = "example-workspace"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  sku                 = "PerGB2018"
+}
+
+resource "azurerm_sentinel_log_analytics_workspace_onboarding" "example" {
+  resource_group_name = azurerm_resource_group.example.name
+  workspace_name      = azurerm_log_analytics_workspace.example.name
+}
+
+resource "azurerm_sentinel_data_connector_generic_ui" "example" {
+  name                       = "example-generic-ui"
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
+
+  title                    = "Slack"
+  publisher                = "Slack"
+  description_markdown     = "The [Slack](https://slack.com) data connector provides the capability to ingest [Slack Audit Records](https://api.slack.com/admins/audit-logs) events into Microsoft Sentinel through the REST API. Refer to [API documentation](https://api.slack.com/admins/audit-logs#the_audit_event) for more information. The connector provides ability to get events which helps to examine potential security risks, analyze your team's use of collaboration, diagnose configuration problems and more. This data connector uses Microsoft Sentinel native polling capability."
+  graph_queries_table_name = "SlackAuditNativePoller_CL"
+  graph_query {
+    metric_name = "Total data received"
+    legend      = "Slack audit events"
+    base_query  = "{{graphQueriesTableName}}"
+  }
+
+  sample_query {
+    description = "All Slack audit events"
+    query       = "{{graphQueriesTableName}}\n| sort by TimeGenerated desc"
+  }
+
+  data_type {
+    name                     = "{{graphQueriesTableName}}"
+    last_data_received_query = "{{graphQueriesTableName}}\n            | summarize Time = max(TimeGenerated)\n            | where isnotempty(Time)"
+  }
+
+  connectivity_criteria {
+    type = "IsConnectedQuery"
+  }
+
+  availability {
+    enabled = true
+    preview = true
+  }
+
+  permissions {
+    resource_provider {
+      name         = "Microsoft.OperationalInsights/workspaces"
+      display_name = "read and write permissions are required."
+      display_text = "Workspace"
+      scope        = "Workspace"
+      required_permissions {
+        read   = true
+        write  = true
+        delete = true
+      }
+    }
+    custom {
+      name        = "Slack API credentials"
+      description = "**SlackAPIBearerToken** is required for REST API. [See the documentation to learn more about API](https://api.slack.com/web#authentication). Check all [requirements and follow the instructions](https://api.slack.com/web#authentication) for obtaining credentials."
+    }
+  }
+
+  instruction {
+    title       = "Connect Slack to Microsoft Sentinel"
+    description = "Enable Slack audit Logs"
+    step {
+      type = "InfoMessage"
+      parameters = jsonencode({
+        "enable" = "true"
+      })
+    }
+  }
+
+  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name which should be used for this API Polling Data Connector. Changing this forces a new API Polling Data Connector to be created.
+
+* `log_analytics_workspace_id` - (Required) The ID of the TODO. Changing this forces a new API Polling Data Connector to be created.
+
+* `title` - (Required) Title displayed in the data connector page.
+
+* `graph_queries_table_name` - (Required) The name of the Log Analytics table from which data for your queries is pulled. The table name can be any string, but must end in `_CL`. For example: `TableName_CL`.
+
+* `publisher` - (Required) Publisher displayed in the data connector page.
+
+* `availability` - (Optional) An `availability` block as defined below. Defines the availability of the Data Connector.
+
+* `connectivity_criteria` - (Optional) A `connectivity_criteria` block as defined below. Defines the way the connector check connectivity.
+
+* `custom_image` - (Optional) An optional custom image to be used when displaying the connector within Azure Sentinel's connector's gallery.
+
+* `data_type` - (Optional) One or more `data_type` blocks as defined below. Defines Data types to check for last data received
+
+* `description_markdown` - (Optional) The description in markdown format of the Data Connector.
+
+* `graph_query` - (Optional) One or more `graph_query` blocks as defined below. Defines the graph query to show the current data status.
+
+* `instruction` - (Optional) One or more `instruction` blocks as defined below. Define steps to enable the connector.
+
+* `permission` - (Optional) One or more `permission` blocks as defined below. Define permission required by the Data Connector.
+
+* `sample_query` - (Optional) One or more `sample_query` blocks as defined below. Define the sample queries for the Data Connector.
+
+---
+
+A `graph_query` block supports the following:
+
+* `base_query` - (Required) The base query for the graph.
+
+* `legend` - (Required) The legend for the graph.
+
+* `metric_name` - (Required) The name of metric that the query is checking.
+
+---
+
+A `instruction` block supports the following:
+
+* `title` - (Required) The title of the instruction.
+
+* `description` - (Optional) The description of the instruction.
+
+* `step` - (Optional) One or more `step` blocks as defined below.
+
+---
+
+A `step` block supports the following:
+
+* `type` - (Required) The type of the setting. Possible values are `CopyableLabel`, `InfoMessage` and `InstructionStepsGroup`.
+
+* `parameters` - (Optional) The parameters for the setting.
+
+---
+
+A `permissions` block supports the following:
+
+* `resource_provider` - (Required) One or more `resource_provider` blocks as defined below.
+
+* `custom` - (Optional) One or more `custom` blocks as defined above.
+
+---
+
+A `resource_provider` block supports the following:
+
+* `name` - (Required) The name of the Resource Provider. Possible values are `Microsoft.Authorization/policyAssignments`, `Microsoft.OperationalInsights/solutions`, `Microsoft.OperationalInsights/workspaces`, Microsoft.OperationalInsights/workspaces/datasources`, `Microsoft.OperationalInsights/workspaces/sharedKeys` and `microsoft.aadiam/diagnosticSettings`.
+
+* `permissions_display_name` - (Required) The display name of the provider.
+
+* `permissions_display_text` - (Required) The description text of the provider.
+
+* `required_permissions` - (Required) A `required_permissions` block as defined above.
+
+* `scope` - (Required) The scope of the provider. Possible values are `PermissionProviderScopeResourceGroup`, `PermissionProviderScopeSubscription` and `PermissionProviderScopeWorkspace`.
+
+---
+
+A `required_permissions` block supports the following:
+
+* `action` - (Optional) Whether require action permission.
+
+* `delete` - (Optional) Whether require delete permission.
+
+* `read` - (Optional) Whether require read permission.
+
+* `write` - (Optional) Whether require write permission.
+
+---
+
+A `custom` block supports the following:
+
+* `name` - (Required) The name which should be used for this custom permission.
+
+* `description` - (Optional) The description of this custom permission.
+
+---
+
+A `sample_query` block supports the following:
+
+* `description` - (Required) The description of the sample query.
+
+* `query` - (Required) the sample query.
+
+---
+
+A `availability` block supports the following:
+
+* `enabled` - (Required) Should the Data Connector be enabled?
+
+* `preview` - (Required) Whether this Data Connector is in preview?
+
+---
+
+A `connectivity_criteria` block supports the following:
+
+* `type` - (Required) type of connectivity. Possible value is `IsConnectedQuery`. 
+
+* `value` - (Optional) Specifies a list of queries for checking connectivity.
+
+---
+
+A `data_type` block supports the following:
+
+* `name` - (Required) The name which should be used for this Data Type.
+
+* `last_data_received_query` - (Required) Query for indicate last data received.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported: 
+
+* `id` - The ID of the API Polling Data Connector.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the API Polling Data Connector.
+* `read` - (Defaults to 5 minutes) Used when retrieving the API Polling Data Connector.
+* `update` - (Defaults to 30 minutes) Used when updating the API Polling Data Connector.
+* `delete` - (Defaults to 30 minutes) Used when deleting the API Polling Data Connector.
+
+## Import
+
+API Polling Data Connectors can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_sentinel_data_connector_generic_ui.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resGroup1/providers/Microsoft.OperationalInsights/workspaces/workspace1/providers/Microsoft.SecurityInsights/dataConnectors/dc1
+```


### PR DESCRIPTION
These two new resources are sharing a big part of schema so I submitted them toghter..

Test
---
```
terraform-provider-azurerm ❯ TF_ACC=1 go test -v ./internal/services/sentinel -run=TestAccAzureRMSentinelDataConnectorGenericUI  -timeout=600m                [ tengzh/vanguard/sentinel/apipolling][$⇕][🐹 v1.19.5][⏱ 34ms][12:50:25]
=== RUN   TestAccAzureRMSentinelDataConnectorGenericUI_basic
=== PAUSE TestAccAzureRMSentinelDataConnectorGenericUI_basic
=== RUN   TestAccAzureRMSentinelDataConnectorGenericUI_requiresImport
=== PAUSE TestAccAzureRMSentinelDataConnectorGenericUI_requiresImport
=== CONT  TestAccAzureRMSentinelDataConnectorGenericUI_basic
=== CONT  TestAccAzureRMSentinelDataConnectorGenericUI_requiresImport
--- PASS: TestAccAzureRMSentinelDataConnectorGenericUI_requiresImport (477.34s)
--- PASS: TestAccAzureRMSentinelDataConnectorGenericUI_basic (477.91s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/sentinel      479.120s
```

```
terraform-provider-azurerm ❯ TF_ACC=1 go test -v ./internal/services/sentinel -run=TestAccAzureRMSentinelDataConnectorApiPolling  -timeout=600m                 [ tengzh/vanguard/sentinel/apipolling][$][🐹 v1.19.5][⏱ 21s][13:11:19]
=== RUN   TestAccAzureRMSentinelDataConnectorApiPolling_basic
=== PAUSE TestAccAzureRMSentinelDataConnectorApiPolling_basic
=== RUN   TestAccAzureRMSentinelDataConnectorApiPolling_requiresImport
=== PAUSE TestAccAzureRMSentinelDataConnectorApiPolling_requiresImport
=== CONT  TestAccAzureRMSentinelDataConnectorApiPolling_basic
=== CONT  TestAccAzureRMSentinelDataConnectorApiPolling_requiresImport
--- PASS: TestAccAzureRMSentinelDataConnectorApiPolling_basic (339.04s)
--- PASS: TestAccAzureRMSentinelDataConnectorApiPolling_requiresImport (378.62s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/sentinel      379.853s
```