### PR TITLE
`data.azurerm_redis_cache` : fix issue about schedules could not be found when no `patch_schedule` is specified in creation

### DIFF
--- a/internal/services/redis/redis_cache_data_source.go
+++ b/internal/services/redis/redis_cache_data_source.go
@@ -245,7 +245,9 @@ func dataSourceRedisCacheRead(d *pluginsdk.ResourceData, meta interface{}) error
 	patchScheduleRedisId := patchschedules.NewRediID(id.SubscriptionId, id.ResourceGroupName, id.RedisName)
 	schedule, err := patchSchedulesClient.Get(ctx, patchScheduleRedisId)
 	if err != nil {
-		return fmt.Errorf("obtaining patch schedules for %s: %+v", id, err)
+		if !response.WasNotFound(schedule.HttpResponse) {
+			return fmt.Errorf("obtaining patch schedules for %s: %+v", id, err)
+		}
 	}
 	var patchSchedule []interface{}
 	if model := schedule.Model; model != nil {


### PR DESCRIPTION
Since `patch_schedule` is an optional property, "patchSchedulesClient.Get " could not find the schedule when `patch_schedule` is not specified in creation. Submitted this PR to fix [issue #20489](https://github.com/hashicorp/terraform-provider-azurerm/issues/20489) by only setting `patch_schedule`  if the schedule exists.