### PR TITLE
Bugfix: Azure CLI auth regression

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.1.2
 	github.com/hashicorp/go-azure-helpers v0.51.0
-	github.com/hashicorp/go-azure-sdk v0.20230217.1092053
+	github.com/hashicorp/go-azure-sdk v0.20230217.1131029
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/go-version v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -207,8 +207,8 @@ github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brv
 github.com/hashicorp/go-azure-helpers v0.12.0/go.mod h1:Zc3v4DNeX6PDdy7NljlYpnrdac1++qNW0I4U+ofGwpg=
 github.com/hashicorp/go-azure-helpers v0.51.0 h1:8KSDGkGnWH6zOT60R3KUqsi0fk1vA7AMunaOUJZMM6k=
 github.com/hashicorp/go-azure-helpers v0.51.0/go.mod h1:lsykLR4KjTUO7MiRmNWiTiX8QQtw3ILjyOvT0f5h3rw=
-github.com/hashicorp/go-azure-sdk v0.20230217.1092053 h1:044WTlqd5eoUYgL9ij7oe5H1kLTCs0D9L3rGWCMsZRY=
-github.com/hashicorp/go-azure-sdk v0.20230217.1092053/go.mod h1:aHinadEuBi04I1i+yvpPMZUxvxRxl5JgBOwlzIIxozU=
+github.com/hashicorp/go-azure-sdk v0.20230217.1131029 h1:QbSLBbv7xpterl93SM4oZX3ptN18DLNfDrPjRIMxMqc=
+github.com/hashicorp/go-azure-sdk v0.20230217.1131029/go.mod h1:aHinadEuBi04I1i+yvpPMZUxvxRxl5JgBOwlzIIxozU=
 github.com/hashicorp/go-checkpoint v0.5.0 h1:MFYpPZCnQqQTE18jFwSII6eUQrD/oxMFp3mlgcqk5mU=
 github.com/hashicorp/go-checkpoint v0.5.0/go.mod h1:7nfLNL10NsxqO4iWuW6tWW0HjZuDrwkBuEQsVcpCOgg=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=

--- a/internal/clients/builder.go
+++ b/internal/clients/builder.go
@@ -130,8 +130,8 @@ func Build(ctx context.Context, builder ClientBuilder) (*Client, error) {
 		Environment: builder.AuthConfig.Environment,
 		Features:    builder.Features,
 
-		SubscriptionId:   builder.SubscriptionID,
-		TenantId:         builder.AuthConfig.TenantID,
+		SubscriptionId:   account.SubscriptionId,
+		TenantId:         account.TenantId,
 		PartnerId:        builder.PartnerID,
 		TerraformVersion: builder.TerraformVersion,
 

--- a/vendor/github.com/hashicorp/go-azure-sdk/sdk/auth/autorest/auth.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/sdk/auth/autorest/auth.go
@@ -34,23 +34,24 @@ func (c *Authorizer) WithAuthorization() autorest.PrepareDecorator {
 
 				req, err = autorest.Prepare(req, autorest.WithHeader("Authorization", fmt.Sprintf("Bearer %s", token.AccessToken)))
 				if err != nil {
-					return req, err
+					return nil, fmt.Errorf("preparing request: %+v", err)
 				}
 
 				auxTokens, err := c.AuxiliaryTokens(ctx, req)
 				if err != nil {
-					return req, err
+					return nil, fmt.Errorf("preparing auxiliary tokens for request: %+v", err)
 				}
-
-				auxTokenList := make([]string, 0)
-				for _, a := range auxTokens {
-					if a != nil && a.AccessToken != "" {
-						auxTokenList = append(auxTokenList, fmt.Sprintf("%s %s", a.TokenType, a.AccessToken))
+				if len(auxTokens) > 0 {
+					auxTokenList := make([]string, 0)
+					for _, a := range auxTokens {
+						if a != nil && a.AccessToken != "" {
+							auxTokenList = append(auxTokenList, fmt.Sprintf("%s %s", a.TokenType, a.AccessToken))
+						}
 					}
-				}
 
-				if len(auxTokenList) > 0 {
-					return autorest.Prepare(req, autorest.WithHeader("x-ms-authorization-auxiliary", strings.Join(auxTokenList, ", ")))
+					if len(auxTokenList) > 0 {
+						return autorest.Prepare(req, autorest.WithHeader("x-ms-authorization-auxiliary", strings.Join(auxTokenList, ", ")))
+					}
 				}
 
 				return req, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/sdk/auth/azure_cli_authorizer.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/sdk/auth/azure_cli_authorizer.go
@@ -45,6 +45,9 @@ type AzureCliAuthorizer struct {
 	// TenantID is the specified tenant ID, or the auto-detected tenant ID if none was specified
 	TenantID string
 
+	// DefaultSubscriptionID is the default subscription, when detected
+	DefaultSubscriptionID string
+
 	conf *azureCliConfig
 }
 
@@ -141,6 +144,9 @@ type azureCliConfig struct {
 
 	// AuxiliaryTenantIDs is an optional list of tenant IDs for which to obtain additional tokens
 	AuxiliaryTenantIDs []string
+
+	// DefaultSubscriptionID is the optional default subscription ID
+	DefaultSubscriptionID string
 }
 
 // newAzureCliConfig validates the supplied tenant ID and returns a new azureCliConfig.
@@ -153,7 +159,7 @@ func newAzureCliConfig(api environments.Api, tenantId string, auxiliaryTenantIds
 		return nil, err
 	}
 
-	// check tenant id
+	// check tenant ID
 	tenantId, err = azurecli.CheckTenantID(tenantId)
 	if err != nil {
 		return nil, err
@@ -162,10 +168,17 @@ func newAzureCliConfig(api environments.Api, tenantId string, auxiliaryTenantIds
 		return nil, errors.New("invalid tenantId or unable to determine tenantId")
 	}
 
+	// get the default subscription ID
+	subscriptionId, err := azurecli.GetDefaultSubscriptionID()
+	if err != nil {
+		return nil, err
+	}
+
 	return &azureCliConfig{
-		Api:                api,
-		TenantID:           tenantId,
-		AuxiliaryTenantIDs: auxiliaryTenantIds,
+		Api:                   api,
+		TenantID:              tenantId,
+		AuxiliaryTenantIDs:    auxiliaryTenantIds,
+		DefaultSubscriptionID: subscriptionId,
 	}, nil
 }
 
@@ -173,8 +186,9 @@ func newAzureCliConfig(api environments.Api, tenantId string, auxiliaryTenantIds
 func (c *azureCliConfig) TokenSource(ctx context.Context) (Authorizer, error) {
 	// Cache access tokens internally to avoid unnecessary `az` invocations
 	return NewCachedAuthorizer(&AzureCliAuthorizer{
-		TenantID: c.TenantID,
-		conf:     c,
+		TenantID:              c.TenantID,
+		DefaultSubscriptionID: c.DefaultSubscriptionID,
+		conf:                  c,
 	})
 }
 

--- a/vendor/github.com/hashicorp/go-azure-sdk/sdk/internal/azurecli/azcli.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/sdk/internal/azurecli/azcli.go
@@ -59,6 +59,19 @@ func CheckAzVersion(minVersion string, nextMajorVersion *string) error {
 	return nil
 }
 
+// GetDefaultSubscriptionID tries to determine the default subscription
+func GetDefaultSubscriptionID() (string, error) {
+	var account struct {
+		SubscriptionID string `json:"id"`
+	}
+	err := JSONUnmarshalAzCmd(&account, "account", "show")
+	if err != nil {
+		return "", fmt.Errorf("obtaining subscription ID: %s", err)
+	}
+
+	return account.SubscriptionID, nil
+}
+
 // CheckTenantID validates the supplied tenant ID, and tries to determine the default tenant if a valid one is not supplied.
 func CheckTenantID(tenantId string) (string, error) {
 	validTenantId, err := regexp.MatchString("^[a-zA-Z0-9._-]+$", tenantId)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -159,7 +159,7 @@ github.com/hashicorp/go-azure-helpers/resourcemanager/zones
 github.com/hashicorp/go-azure-helpers/resourceproviders
 github.com/hashicorp/go-azure-helpers/sender
 github.com/hashicorp/go-azure-helpers/storage
-# github.com/hashicorp/go-azure-sdk v0.20230217.1092053
+# github.com/hashicorp/go-azure-sdk v0.20230217.1131029
 ## explicit; go 1.19
 github.com/hashicorp/go-azure-sdk/resource-manager/aad/2021-05-01/domainservices
 github.com/hashicorp/go-azure-sdk/resource-manager/aadb2c/2021-04-01-preview


### PR DESCRIPTION
Source the tenant ID and subscription ID from Azure CLI to ensure the provider can operate when these are not specified.

Depends on: https://github.com/hashicorp/go-azure-sdk/pull/319
Fixes: #20514