### PR TITLE
data plane: fixing a regression where endpoint was used rather than domainSuffix

### DIFF
--- a/internal/services/logic/logic_app_standard_resource.go
+++ b/internal/services/logic/logic_app_standard_resource.go
@@ -236,9 +236,10 @@ func resourceLogicAppStandardCreate(d *pluginsdk.ResourceData, meta interface{})
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	storageEndpointSuffix, ok := meta.(*clients.Client).Account.Environment.Storage.Endpoint()
+	env := meta.(*clients.Client).Account.Environment
+	storageAccountDomainSuffix, ok := env.Storage.DomainSuffix()
 	if !ok {
-		return fmt.Errorf("could not determine storage endpoint suffix for environment %q", meta.(*clients.Client).Account.Environment.Name)
+		return fmt.Errorf("could not determine the domain suffix for storage accounts in environment %q: %+v", env.Name, env.Storage)
 	}
 
 	log.Printf("[INFO] preparing arguments for AzureRM Logic App Standard creation.")
@@ -286,7 +287,7 @@ func resourceLogicAppStandardCreate(d *pluginsdk.ResourceData, meta interface{})
 	VirtualNetworkSubnetID := d.Get("virtual_network_subnet_id").(string)
 	t := d.Get("tags").(map[string]interface{})
 
-	basicAppSettings, err := getBasicLogicAppSettings(d, *storageEndpointSuffix)
+	basicAppSettings, err := getBasicLogicAppSettings(d, *storageAccountDomainSuffix)
 	if err != nil {
 		return err
 	}
@@ -356,9 +357,10 @@ func resourceLogicAppStandardUpdate(d *pluginsdk.ResourceData, meta interface{})
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	storageEndpointSuffix, ok := meta.(*clients.Client).Account.Environment.Storage.Endpoint()
+	env := meta.(*clients.Client).Account.Environment
+	storageAccountDomainSuffix, ok := env.Storage.DomainSuffix()
 	if !ok {
-		return fmt.Errorf("could not determine storage endpoint suffix for environment %q", meta.(*clients.Client).Account.Environment.Name)
+		return fmt.Errorf("could not determine the domain suffix for storage accounts in environment %q: %+v", env.Name, env.Storage)
 	}
 
 	id, err := parse.LogicAppStandardID(d.Id())
@@ -375,7 +377,7 @@ func resourceLogicAppStandardUpdate(d *pluginsdk.ResourceData, meta interface{})
 	httpsOnly := d.Get("https_only").(bool)
 	t := d.Get("tags").(map[string]interface{})
 
-	basicAppSettings, err := getBasicLogicAppSettings(d, *storageEndpointSuffix)
+	basicAppSettings, err := getBasicLogicAppSettings(d, *storageAccountDomainSuffix)
 	if err != nil {
 		return err
 	}
@@ -393,7 +395,7 @@ func resourceLogicAppStandardUpdate(d *pluginsdk.ResourceData, meta interface{})
 	siteConfig.AppSettings = &basicAppSettings
 
 	// WEBSITE_VNET_ROUTE_ALL is superseded by a setting in site_config that defaults to false from 2021-02-01
-	appSettings, err := expandLogicAppStandardSettings(d, *storageEndpointSuffix)
+	appSettings, err := expandLogicAppStandardSettings(d, *storageAccountDomainSuffix)
 	if err != nil {
 		return fmt.Errorf("expanding `app_settings`: %+v", err)
 	}

--- a/internal/services/synapse/synapse_role_assignment_resource.go
+++ b/internal/services/synapse/synapse_role_assignment_resource.go
@@ -96,10 +96,10 @@ func resourceSynapseRoleAssignmentCreate(d *pluginsdk.ResourceData, meta interfa
 	synapseClient := meta.(*clients.Client).Synapse
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-	environment := meta.(*clients.Client).Account.Environment
-	synapseDomainSuffix, ok := environment.Synapse.DomainSuffix()
+	env := meta.(*clients.Client).Account.Environment
+	synapseDomainSuffix, ok := env.Synapse.DomainSuffix()
 	if !ok {
-		return fmt.Errorf("could not determine Synapse domain suffix for environment %q", environment.Name)
+		return fmt.Errorf("could not determine the domain suffix for synapse in environment %q: %+v", env.Name, env.Storage)
 	}
 
 	synapseScope := ""
@@ -180,10 +180,11 @@ func resourceSynapseRoleAssignmentRead(d *pluginsdk.ResourceData, meta interface
 	synapseClient := meta.(*clients.Client).Synapse
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-	environment := meta.(*clients.Client).Account.Environment
-	synapseEndpointSuffix, ok := environment.Synapse.Endpoint()
+
+	env := meta.(*clients.Client).Account.Environment
+	synapseDomainSuffix, ok := env.Synapse.DomainSuffix()
 	if !ok {
-		return fmt.Errorf("could not determine synapse endpoint suffix for environment %q", environment.Name)
+		return fmt.Errorf("could not determine the domain suffix for synapse in environment %q: %+v", env.Name, env.Storage)
 	}
 
 	id, err := parse.RoleAssignmentID(d.Id())
@@ -196,11 +197,11 @@ func resourceSynapseRoleAssignmentRead(d *pluginsdk.ResourceData, meta interface
 		return err
 	}
 
-	client, err := synapseClient.RoleAssignmentsClient(workspaceName, *synapseEndpointSuffix)
+	client, err := synapseClient.RoleAssignmentsClient(workspaceName, *synapseDomainSuffix)
 	if err != nil {
 		return err
 	}
-	roleDefinitionsClient, err := synapseClient.RoleDefinitionsClient(workspaceName, *synapseEndpointSuffix)
+	roleDefinitionsClient, err := synapseClient.RoleDefinitionsClient(workspaceName, *synapseDomainSuffix)
 	if err != nil {
 		return err
 	}
@@ -246,10 +247,10 @@ func resourceSynapseRoleAssignmentDelete(d *pluginsdk.ResourceData, meta interfa
 	synapseClient := meta.(*clients.Client).Synapse
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
-	environment := meta.(*clients.Client).Account.Environment
-	synapseDomainSuffix, ok := environment.Synapse.DomainSuffix()
+	env := meta.(*clients.Client).Account.Environment
+	synapseDomainSuffix, ok := env.Synapse.DomainSuffix()
 	if !ok {
-		return fmt.Errorf("could not determine Synapse domain suffix for environment %q", environment.Name)
+		return fmt.Errorf("could not determine the domain suffix for synapse in environment %q: %+v", env.Name, env.Storage)
 	}
 
 	id, err := parse.RoleAssignmentID(d.Id())

--- a/internal/services/synapse/synapse_role_assignment_resource_test.go
+++ b/internal/services/synapse/synapse_role_assignment_resource_test.go
@@ -71,9 +71,10 @@ func (r SynapseRoleAssignmentResource) Exists(ctx context.Context, client *clien
 		return nil, err
 	}
 
-	suffix, ok := client.Account.Environment.Synapse.DomainSuffix()
+	env := client.Account.Environment
+	suffix, ok := env.Synapse.DomainSuffix()
 	if !ok {
-		return nil, fmt.Errorf("could not determine Synapse domain suffix for environment %q", client.Account.Environment.Name)
+		return nil, fmt.Errorf("could not determine the domain suffix for synapse in environment %q: %+v", env.Name, env.Storage)
 	}
 
 	roleAssignmentsClient, err := client.Synapse.RoleAssignmentsClient(workspaceName, *suffix)


### PR DESCRIPTION
This fixes both `azurerm_logic_app_standard` and `azurerm_synapse_role_assignment` to use the `domainSuffix` rather than the `endpoint` value as the domain suffix

Fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/20531