### PR TITLE
`azurerm_mariadb_server`: Add support for `ssl_minimal_tls_version_enforced`

### DIFF
--- a/internal/services/datafactory/data_factory_linked_service_azure_blob_storage_resource_test.go
+++ b/internal/services/datafactory/data_factory_linked_service_azure_blob_storage_resource_test.go
@@ -457,7 +457,7 @@ resource "azurerm_data_factory" "test" {
 }
 
 resource "azurerm_data_factory_linked_service_azure_blob_storage" "test" {
-  name                        = "acctestlsblob%d"
+  name                       = "acctestlsblob%d"
   data_factory_id            = azurerm_data_factory.test.id
   connection_string_insecure = "DefaultEndpointsProtocol=https;AccountName=foo;AccountKey=bar"
 }

--- a/internal/services/datashare/data_share_dataset_data_lake_gen2_data_source_test.go
+++ b/internal/services/datashare/data_share_dataset_data_lake_gen2_data_source_test.go
@@ -32,8 +32,8 @@ func (DataShareDatasetDataLakeGen2DataSource) basic(data acceptance.TestData) st
 %s
 
 data "azurerm_data_share_dataset_data_lake_gen2" "test" {
- name     = azurerm_data_share_dataset_data_lake_gen2.test.name
- share_id = azurerm_data_share_dataset_data_lake_gen2.test.share_id
+  name     = azurerm_data_share_dataset_data_lake_gen2.test.name
+  share_id = azurerm_data_share_dataset_data_lake_gen2.test.share_id
 }
 `, DataShareDataSetDataLakeGen2Resource{}.basicFile(data))
 }

--- a/internal/services/datashare/data_share_dataset_data_lake_gen2_resource_test.go
+++ b/internal/services/datashare/data_share_dataset_data_lake_gen2_resource_test.go
@@ -108,54 +108,54 @@ func (t DataShareDataSetDataLakeGen2Resource) Exists(ctx context.Context, client
 func (DataShareDataSetDataLakeGen2Resource) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
- features {}
+  features {}
 }
 
 provider "azuread" {
 }
 
 resource "azurerm_resource_group" "test" {
- name     = "acctestRG-datashare-%[1]d"
- location = "%[2]s"
+  name     = "acctestRG-datashare-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_data_share_account" "test" {
- name                = "acctest-dsa-%[1]d"
- location            = azurerm_resource_group.test.location
- resource_group_name = azurerm_resource_group.test.name
- identity {
-   type = "SystemAssigned"
- }
+  name                = "acctest-dsa-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  identity {
+    type = "SystemAssigned"
+  }
 }
 
 resource "azurerm_data_share" "test" {
- name       = "acctest_ds_%[1]d"
- account_id = azurerm_data_share_account.test.id
- kind       = "CopyBased"
+  name       = "acctest_ds_%[1]d"
+  account_id = azurerm_data_share_account.test.id
+  kind       = "CopyBased"
 }
 
 resource "azurerm_storage_account" "test" {
- name                     = "accteststr%[3]s"
- resource_group_name      = azurerm_resource_group.test.name
- location                 = azurerm_resource_group.test.location
- account_kind             = "BlobStorage"
- account_tier             = "Standard"
- account_replication_type = "LRS"
+  name                     = "accteststr%[3]s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_kind             = "BlobStorage"
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
 }
 
 resource "azurerm_storage_data_lake_gen2_filesystem" "test" {
- name               = "acctest-%[1]d"
- storage_account_id = azurerm_storage_account.test.id
+  name               = "acctest-%[1]d"
+  storage_account_id = azurerm_storage_account.test.id
 }
 
 data "azuread_service_principal" "test" {
- display_name = azurerm_data_share_account.test.name
+  display_name = azurerm_data_share_account.test.name
 }
 
 resource "azurerm_role_assignment" "test" {
- scope                = azurerm_storage_account.test.id
- role_definition_name = "Storage Blob Data Reader"
- principal_id         = data.azuread_service_principal.test.object_id
+  scope                = azurerm_storage_account.test.id
+  role_definition_name = "Storage Blob Data Reader"
+  principal_id         = data.azuread_service_principal.test.object_id
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }
@@ -165,14 +165,14 @@ func (r DataShareDataSetDataLakeGen2Resource) basicFile(data acceptance.TestData
 %s
 
 resource "azurerm_data_share_dataset_data_lake_gen2" "test" {
- name               = "acctest-dlds-%d"
- share_id           = azurerm_data_share.test.id
- storage_account_id = azurerm_storage_account.test.id
- file_system_name   = azurerm_storage_data_lake_gen2_filesystem.test.name
- file_path          = "myfile.txt"
- depends_on = [
-   azurerm_role_assignment.test,
- ]
+  name               = "acctest-dlds-%d"
+  share_id           = azurerm_data_share.test.id
+  storage_account_id = azurerm_storage_account.test.id
+  file_system_name   = azurerm_storage_data_lake_gen2_filesystem.test.name
+  file_path          = "myfile.txt"
+  depends_on = [
+    azurerm_role_assignment.test,
+  ]
 }
 `, r.template(data), data.RandomInteger)
 }
@@ -182,14 +182,14 @@ func (r DataShareDataSetDataLakeGen2Resource) basicFolder(data acceptance.TestDa
 %s
 
 resource "azurerm_data_share_dataset_data_lake_gen2" "test" {
- name               = "acctest-dlds-%d"
- share_id           = azurerm_data_share.test.id
- storage_account_id = azurerm_storage_account.test.id
- file_system_name   = azurerm_storage_data_lake_gen2_filesystem.test.name
- folder_path        = "test"
- depends_on = [
-   azurerm_role_assignment.test,
- ]
+  name               = "acctest-dlds-%d"
+  share_id           = azurerm_data_share.test.id
+  storage_account_id = azurerm_storage_account.test.id
+  file_system_name   = azurerm_storage_data_lake_gen2_filesystem.test.name
+  folder_path        = "test"
+  depends_on = [
+    azurerm_role_assignment.test,
+  ]
 }
 `, r.template(data), data.RandomInteger)
 }
@@ -199,13 +199,13 @@ func (r DataShareDataSetDataLakeGen2Resource) basicSystem(data acceptance.TestDa
 %s
 
 resource "azurerm_data_share_dataset_data_lake_gen2" "test" {
- name               = "acctest-dlds-%d"
- share_id           = azurerm_data_share.test.id
- storage_account_id = azurerm_storage_account.test.id
- file_system_name   = azurerm_storage_data_lake_gen2_filesystem.test.name
- depends_on = [
-   azurerm_role_assignment.test,
- ]
+  name               = "acctest-dlds-%d"
+  share_id           = azurerm_data_share.test.id
+  storage_account_id = azurerm_storage_account.test.id
+  file_system_name   = azurerm_storage_data_lake_gen2_filesystem.test.name
+  depends_on = [
+    azurerm_role_assignment.test,
+  ]
 }
 `, r.template(data), data.RandomInteger)
 }
@@ -215,11 +215,11 @@ func (r DataShareDataSetDataLakeGen2Resource) requiresImport(data acceptance.Tes
 %s
 
 resource "azurerm_data_share_dataset_data_lake_gen2" "import" {
- name               = azurerm_data_share_dataset_data_lake_gen2.test.name
- share_id           = azurerm_data_share.test.id
- storage_account_id = azurerm_data_share_dataset_data_lake_gen2.test.storage_account_id
- file_system_name   = azurerm_data_share_dataset_data_lake_gen2.test.file_system_name
- file_path          = azurerm_data_share_dataset_data_lake_gen2.test.file_path
+  name               = azurerm_data_share_dataset_data_lake_gen2.test.name
+  share_id           = azurerm_data_share.test.id
+  storage_account_id = azurerm_data_share_dataset_data_lake_gen2.test.storage_account_id
+  file_system_name   = azurerm_data_share_dataset_data_lake_gen2.test.file_system_name
+  file_path          = azurerm_data_share_dataset_data_lake_gen2.test.file_path
 }
 `, r.basicFile(data))
 }

--- a/internal/services/datashare/data_share_dataset_kusto_cluster_data_source_test.go
+++ b/internal/services/datashare/data_share_dataset_kusto_cluster_data_source_test.go
@@ -31,8 +31,8 @@ func (DataShareKustoClusterDatasetDataSource) basic(data acceptance.TestData) st
 %s
 
 data "azurerm_data_share_dataset_kusto_cluster" "test" {
- name     = azurerm_data_share_dataset_kusto_cluster.test.name
- share_id = azurerm_data_share_dataset_kusto_cluster.test.share_id
+  name     = azurerm_data_share_dataset_kusto_cluster.test.name
+  share_id = azurerm_data_share_dataset_kusto_cluster.test.share_id
 }
 `, ShareKustoClusterDataSetResource{}.basic(data))
 }

--- a/internal/services/datashare/data_share_dataset_kusto_cluster_resource_test.go
+++ b/internal/services/datashare/data_share_dataset_kusto_cluster_resource_test.go
@@ -72,44 +72,44 @@ func (t ShareKustoClusterDataSetResource) Exists(ctx context.Context, clients *c
 func (ShareKustoClusterDataSetResource) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
- features {}
+  features {}
 }
 
 resource "azurerm_resource_group" "test" {
- name     = "acctestRG-datashare-%[1]d"
- location = "%[2]s"
+  name     = "acctestRG-datashare-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_data_share_account" "test" {
- name                = "acctest-DSA-%[1]d"
- location            = azurerm_resource_group.test.location
- resource_group_name = azurerm_resource_group.test.name
- identity {
-   type = "SystemAssigned"
- }
+  name                = "acctest-DSA-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  identity {
+    type = "SystemAssigned"
+  }
 }
 
 resource "azurerm_data_share" "test" {
- name       = "acctest_DS_%[1]d"
- account_id = azurerm_data_share_account.test.id
- kind       = "InPlace"
+  name       = "acctest_DS_%[1]d"
+  account_id = azurerm_data_share_account.test.id
+  kind       = "InPlace"
 }
 
 resource "azurerm_kusto_cluster" "test" {
- name                = "acctestkc%[3]s"
- location            = azurerm_resource_group.test.location
- resource_group_name = azurerm_resource_group.test.name
+  name                = "acctestkc%[3]s"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
 
- sku {
-   name     = "Dev(No SLA)_Standard_D11_v2"
-   capacity = 1
- }
+  sku {
+    name     = "Dev(No SLA)_Standard_D11_v2"
+    capacity = 1
+  }
 }
 
 resource "azurerm_role_assignment" "test" {
- scope                = azurerm_kusto_cluster.test.id
- role_definition_name = "Contributor"
- principal_id         = azurerm_data_share_account.test.identity.0.principal_id
+  scope                = azurerm_kusto_cluster.test.id
+  role_definition_name = "Contributor"
+  principal_id         = azurerm_data_share_account.test.identity.0.principal_id
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }
@@ -119,12 +119,12 @@ func (r ShareKustoClusterDataSetResource) basic(data acceptance.TestData) string
 %s
 
 resource "azurerm_data_share_dataset_kusto_cluster" "test" {
- name             = "acctest-DSKC-%d"
- share_id         = azurerm_data_share.test.id
- kusto_cluster_id = azurerm_kusto_cluster.test.id
- depends_on = [
-   azurerm_role_assignment.test,
- ]
+  name             = "acctest-DSKC-%d"
+  share_id         = azurerm_data_share.test.id
+  kusto_cluster_id = azurerm_kusto_cluster.test.id
+  depends_on = [
+    azurerm_role_assignment.test,
+  ]
 }
 `, r.template(data), data.RandomInteger)
 }
@@ -134,9 +134,9 @@ func (r ShareKustoClusterDataSetResource) requiresImport(data acceptance.TestDat
 %s
 
 resource "azurerm_data_share_dataset_kusto_cluster" "import" {
- name             = azurerm_data_share_dataset_kusto_cluster.test.name
- share_id         = azurerm_data_share.test.id
- kusto_cluster_id = azurerm_kusto_cluster.test.id
+  name             = azurerm_data_share_dataset_kusto_cluster.test.name
+  share_id         = azurerm_data_share.test.id
+  kusto_cluster_id = azurerm_kusto_cluster.test.id
 }
 `, r.basic(data))
 }

--- a/internal/services/datashare/data_share_dataset_kusto_database_data_source_test.go
+++ b/internal/services/datashare/data_share_dataset_kusto_database_data_source_test.go
@@ -31,8 +31,8 @@ func (DataShareDatasetKustoDatabaseDataSource) basic(data acceptance.TestData) s
 %s
 
 data "azurerm_data_share_dataset_kusto_database" "test" {
- name     = azurerm_data_share_dataset_kusto_database.test.name
- share_id = azurerm_data_share_dataset_kusto_database.test.share_id
+  name     = azurerm_data_share_dataset_kusto_database.test.name
+  share_id = azurerm_data_share_dataset_kusto_database.test.share_id
 }
 `, DataShareDataSetKustoDatabaseResource{}.basic(data))
 }

--- a/internal/services/datashare/data_share_dataset_kusto_database_resource_test.go
+++ b/internal/services/datashare/data_share_dataset_kusto_database_resource_test.go
@@ -71,51 +71,51 @@ func (t DataShareDataSetKustoDatabaseResource) Exists(ctx context.Context, clien
 func (DataShareDataSetKustoDatabaseResource) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
- features {}
+  features {}
 }
 
 resource "azurerm_resource_group" "test" {
- name     = "acctestRG-datashare-%[1]d"
- location = "%[2]s"
+  name     = "acctestRG-datashare-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_data_share_account" "test" {
- name                = "acctest-DSA-%[1]d"
- location            = azurerm_resource_group.test.location
- resource_group_name = azurerm_resource_group.test.name
- identity {
-   type = "SystemAssigned"
- }
+  name                = "acctest-DSA-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  identity {
+    type = "SystemAssigned"
+  }
 }
 
 resource "azurerm_data_share" "test" {
- name       = "acctest_DS_%[1]d"
- account_id = azurerm_data_share_account.test.id
- kind       = "InPlace"
+  name       = "acctest_DS_%[1]d"
+  account_id = azurerm_data_share_account.test.id
+  kind       = "InPlace"
 }
 
 resource "azurerm_kusto_cluster" "test" {
- name                = "acctestkc%[3]s"
- location            = azurerm_resource_group.test.location
- resource_group_name = azurerm_resource_group.test.name
+  name                = "acctestkc%[3]s"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
 
- sku {
-   name     = "Dev(No SLA)_Standard_D11_v2"
-   capacity = 1
- }
+  sku {
+    name     = "Dev(No SLA)_Standard_D11_v2"
+    capacity = 1
+  }
 }
 
 resource "azurerm_kusto_database" "test" {
- name                = "acctestKD-%[1]d"
- resource_group_name = azurerm_resource_group.test.name
- location            = azurerm_resource_group.test.location
- cluster_name        = azurerm_kusto_cluster.test.name
+  name                = "acctestKD-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  cluster_name        = azurerm_kusto_cluster.test.name
 }
 
 resource "azurerm_role_assignment" "test" {
- scope                = azurerm_kusto_cluster.test.id
- role_definition_name = "Contributor"
- principal_id         = azurerm_data_share_account.test.identity.0.principal_id
+  scope                = azurerm_kusto_cluster.test.id
+  role_definition_name = "Contributor"
+  principal_id         = azurerm_data_share_account.test.identity.0.principal_id
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }
@@ -125,12 +125,12 @@ func (r DataShareDataSetKustoDatabaseResource) basic(data acceptance.TestData) s
 %s
 
 resource "azurerm_data_share_dataset_kusto_database" "test" {
- name              = "acctest-DSKD-%d"
- share_id          = azurerm_data_share.test.id
- kusto_database_id = azurerm_kusto_database.test.id
- depends_on = [
-   azurerm_role_assignment.test,
- ]
+  name              = "acctest-DSKD-%d"
+  share_id          = azurerm_data_share.test.id
+  kusto_database_id = azurerm_kusto_database.test.id
+  depends_on = [
+    azurerm_role_assignment.test,
+  ]
 }
 `, r.template(data), data.RandomInteger)
 }
@@ -140,9 +140,9 @@ func (r DataShareDataSetKustoDatabaseResource) requiresImport(data acceptance.Te
 %s
 
 resource "azurerm_data_share_dataset_kusto_database" "import" {
- name              = azurerm_data_share_dataset_kusto_database.test.name
- share_id          = azurerm_data_share.test.id
- kusto_database_id = azurerm_kusto_database.test.id
+  name              = azurerm_data_share_dataset_kusto_database.test.name
+  share_id          = azurerm_data_share.test.id
+  kusto_database_id = azurerm_kusto_database.test.id
 }
 `, r.basic(data))
 }

--- a/internal/services/mariadb/mariadb_server_resource_test.go
+++ b/internal/services/mariadb/mariadb_server_resource_test.go
@@ -356,15 +356,16 @@ func (r MariaDbServerResource) createReplica(data acceptance.TestData, version s
 %s
 
 resource "azurerm_mariadb_server" "replica" {
-  name                      = "acctestmariadbsvr-%d-replica"
-  location                  = azurerm_resource_group.test.location
-  resource_group_name       = azurerm_resource_group.test.name
-  sku_name                  = "B_Gen5_2"
-  version                   = "%s"
-  create_mode               = "Replica"
-  creation_source_server_id = azurerm_mariadb_server.test.id
-  ssl_enforcement_enabled   = true
-  storage_mb                = 51200
+  name                             = "acctestmariadbsvr-%d-replica"
+  location                         = azurerm_resource_group.test.location
+  resource_group_name              = azurerm_resource_group.test.name
+  sku_name                         = "B_Gen5_2"
+  version                          = "%s"
+  create_mode                      = "Replica"
+  creation_source_server_id        = azurerm_mariadb_server.test.id
+  ssl_enforcement_enabled          = true
+  ssl_minimal_tls_version_enforced = "TLS1_1"
+  storage_mb                       = 51200
 }
 `, r.basic(data, version), data.RandomInteger, version)
 }
@@ -374,16 +375,17 @@ func (r MariaDbServerResource) createPointInTimeRestore(data acceptance.TestData
 %s
 
 resource "azurerm_mariadb_server" "restore" {
-  name                      = "acctestmariadbsvr-%d-restore"
-  location                  = azurerm_resource_group.test.location
-  resource_group_name       = azurerm_resource_group.test.name
-  sku_name                  = "B_Gen5_2"
-  version                   = "%s"
-  create_mode               = "PointInTimeRestore"
-  creation_source_server_id = azurerm_mariadb_server.test.id
-  restore_point_in_time     = "%s"
-  ssl_enforcement_enabled   = true
-  storage_mb                = 51200
+  name                             = "acctestmariadbsvr-%d-restore"
+  location                         = azurerm_resource_group.test.location
+  resource_group_name              = azurerm_resource_group.test.name
+  sku_name                         = "B_Gen5_2"
+  version                          = "%s"
+  create_mode                      = "PointInTimeRestore"
+  creation_source_server_id        = azurerm_mariadb_server.test.id
+  restore_point_in_time            = "%s"
+  ssl_enforcement_enabled          = true
+  ssl_minimal_tls_version_enforced = "TLS1_1"
+  storage_mb                       = 51200
 }
 `, r.basic(data, version), data.RandomInteger, version, restoreTime)
 }

--- a/internal/services/mariadb/mariadb_server_resource_test.go
+++ b/internal/services/mariadb/mariadb_server_resource_test.go
@@ -230,10 +230,11 @@ resource "azurerm_mariadb_server" "test" {
   sku_name            = "B_Gen5_2"
   version             = "%s"
 
-  administrator_login          = "acctestun"
-  administrator_login_password = "H@Sh1CoR3!"
-  ssl_enforcement_enabled      = true
-  storage_mb                   = 51200
+  administrator_login              = "acctestun"
+  administrator_login_password     = "H@Sh1CoR3!"
+  ssl_enforcement_enabled          = true
+  ssl_minimal_tls_version_enforced = "TLS1_1"
+  storage_mb                       = 51200
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, version)
 }

--- a/website/docs/r/mariadb_server.html.markdown
+++ b/website/docs/r/mariadb_server.html.markdown
@@ -34,11 +34,12 @@ resource "azurerm_mariadb_server" "example" {
   storage_mb = 5120
   version    = "10.2"
 
-  auto_grow_enabled             = true
-  backup_retention_days         = 7
-  geo_redundant_backup_enabled  = false
-  public_network_access_enabled = false
-  ssl_enforcement_enabled       = true
+  auto_grow_enabled                 = true
+  backup_retention_days             = 7
+  geo_redundant_backup_enabled      = false
+  public_network_access_enabled     = false
+  ssl_enforcement_enabled           = true
+  ssl_minimal_tls_version_enforced  = "TLS1_2"
 }
 ```
 
@@ -75,6 +76,8 @@ The following arguments are supported:
 * `restore_point_in_time` - (Optional) When `create_mode` is `PointInTimeRestore`, specifies the point in time to restore from `creation_source_server_id`. It should be provided in [RFC3339](https://www.rfc-editor.org/rfc/rfc3339) format, e.g. `2013-11-08T22:00:40Z`.
 
 * `ssl_enforcement_enabled` - (Required) Specifies if SSL should be enforced on connections. Possible values are `true` and `false`.
+
+* `ssl_minimal_tls_version_enforced` - (Optional) The minimum TLS version to support on the sever. Possible values are `TLSEnforcementDisabled`, `TLS1_0`, `TLS1_1`, and `TLS1_2`. Defaults to `TLS1_2`.
 
 * `storage_mb` - (Optional) Max storage allowed for a server. Possible values are between `5120` MB (5GB) and `1024000`MB (1TB) for the Basic SKU and between `5120` MB (5GB) and `4096000` MB (4TB) for General Purpose/Memory Optimized SKUs. For more information see the [product documentation](https://docs.microsoft.com/rest/api/mariadb/servers/create#storageprofile).
 

--- a/website/docs/r/mariadb_server.html.markdown
+++ b/website/docs/r/mariadb_server.html.markdown
@@ -34,12 +34,12 @@ resource "azurerm_mariadb_server" "example" {
   storage_mb = 5120
   version    = "10.2"
 
-  auto_grow_enabled                 = true
-  backup_retention_days             = 7
-  geo_redundant_backup_enabled      = false
-  public_network_access_enabled     = false
-  ssl_enforcement_enabled           = true
-  ssl_minimal_tls_version_enforced  = "TLS1_2"
+  auto_grow_enabled                = true
+  backup_retention_days            = 7
+  geo_redundant_backup_enabled     = false
+  public_network_access_enabled    = false
+  ssl_enforcement_enabled          = true
+  ssl_minimal_tls_version_enforced = "TLS1_2"
 }
 ```
 


### PR DESCRIPTION
```
$ TF_ACC=1 go test -v ./internal/services/mariadb -timeout=1000m -run='TestAccMariaDbServer_basicTenTwo'

=== RUN   TestAccMariaDbServer_basicTenTwo
=== PAUSE TestAccMariaDbServer_basicTenTwo
=== CONT  TestAccMariaDbServer_basicTenTwo
--- PASS: TestAccMariaDbServer_basicTenTwo (296.33s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/mariadb	297.574s
```

Fixes #7899