### PR TITLE
Linux and windows virtual machine admin password validations

### DIFF
--- a/internal/services/compute/linux_virtual_machine_resource.go
+++ b/internal/services/compute/linux_virtual_machine_resource.go
@@ -98,6 +98,7 @@ func resourceLinuxVirtualMachine() *pluginsdk.Resource {
 				ForceNew:         true,
 				Sensitive:        true,
 				DiffSuppressFunc: adminPasswordDiffSuppressFunc,
+				ValidateFunc:     computeValidate.LinuxAdminPassword,
 			},
 
 			"admin_ssh_key": SSHKeysSchema(true),

--- a/internal/services/compute/validate/linux_admin_password.go
+++ b/internal/services/compute/validate/linux_admin_password.go
@@ -1,0 +1,51 @@
+package validate
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// LinuxAdminPassword validates that admin_password meets the Azure API requirements for Linux Virtual Machines.
+func LinuxAdminPassword(i interface{}, k string) (warnings []string, errors []error) {
+	// adminPassword must be a string.
+	v, ok := i.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string but it wasn't", k))
+		return
+	}
+
+	// adminPassword must not be empty.
+	if strings.TrimSpace(v) == "" {
+		errors = append(errors, fmt.Errorf("%q must not be empty", k))
+		return
+	}
+
+	// adminPassword Min-length is 6 characters and Max-length is 72 characters.
+	if len(v) < 6 || len(v) > 72 {
+		errors = append(errors, fmt.Errorf("%q most be between %d and %d characters, got %d", k, 6, 72, len(v)))
+	}
+
+	// adminPassword cannot match the following disallowed names.
+	disallowedNames := []string{"abc@123", "P@$$w0rd", "P@ssw0rd", "P@ssword123", "Pa$$word", "pass@word1", "Password!", "Password1", "Password22", "iloveyou!"}
+	for _, value := range disallowedNames {
+		if value == v {
+			errors = append(errors, fmt.Errorf("%q specified is not allowed, got %q, cannot match: %q", k, v, strings.Join(disallowedNames, ", ")))
+		}
+	}
+
+	// adminPassword has to fulfill 3 out of these 4 conditions: Has lower characters, Has upper characters, Has a digit, Has a special character (Regex match [\W_])
+	conditions := 0
+	tests := []string{"[a-z]", "[A-Z]", "[0-9]", "[^\\d\\w]"}
+	for _, test := range tests {
+		t, _ := regexp.MatchString(test, v)
+		if t {
+			conditions++
+		}
+	}
+	if conditions < 3 {
+		errors = append(errors, fmt.Errorf("%q has to fulfill 3 out of these 4 conditions: Has lower characters, Has upper characters, Has a digit, Has a special character other than \"_\", fullfiled only %d conditions", k, conditions))
+	}
+
+	return
+}

--- a/internal/services/compute/validate/linux_admin_password.go
+++ b/internal/services/compute/validate/linux_admin_password.go
@@ -47,5 +47,5 @@ func LinuxAdminPassword(i interface{}, k string) (warnings []string, errors []er
 		errors = append(errors, fmt.Errorf("%q has to fulfill 3 out of these 4 conditions: Has lower characters, Has upper characters, Has a digit, Has a special character other than \"_\", fullfiled only %d conditions", k, conditions))
 	}
 
-	return
+	return warnings, errors
 }

--- a/internal/services/compute/validate/linux_admin_password_test.go
+++ b/internal/services/compute/validate/linux_admin_password_test.go
@@ -1,0 +1,66 @@
+package validate
+
+import "testing"
+
+func TestLinuxAdminPassword(t *testing.T) {
+	testData := []struct {
+		input    string
+		expected bool
+	}{
+		{
+			// bad: empty
+			input:    "",
+			expected: false,
+		},
+		{
+			// bad: all lower characters
+			input:    "juanjo",
+			expected: false,
+		},
+		{
+			// bad: only some caps
+			input:    "JuanJo",
+			expected: false,
+		},
+		{
+			// bad: can't use reserved words
+			input:    "P@$$w0rd",
+			expected: false,
+		},
+		{
+			// bad: can't be longer than 72 characters
+			input:    "abcdefghijklmnopqrstuvwxyzabcdefghiJklmno9q.stuvwxyzabcdefghijkjlmnopqrst",
+			expected: false,
+		},
+		{
+			// 72 characters its fine
+			input:    "abcdefghijklmnopqrstuvwxyzabcD.9ghijklmnopqrstuvwxyzabcdefghijkjlmnopqrs",
+			expected: true,
+		},
+		{
+			// bad: can't be less than 6 characters
+			input:    "A9.de",
+			expected: false,
+		},
+		{
+			// bad: "_" doesnt count as special character
+			input:    "A9BC_7",
+			expected: false,
+		},
+		{
+			// "/" count as special character
+			input:    "A9BC/7",
+			expected: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q..", v.input)
+
+		_, errors := LinuxAdminPassword(v.input, "admin_password")
+		actual := len(errors) == 0
+		if v.expected != actual {
+			t.Fatalf("Expected %t but got %t", v.expected, actual)
+		}
+	}
+}

--- a/internal/services/compute/validate/windows_admin_password.go
+++ b/internal/services/compute/validate/windows_admin_password.go
@@ -47,5 +47,5 @@ func WindowsAdminPassword(i interface{}, k string) (warnings []string, errors []
 		errors = append(errors, fmt.Errorf("%q has to fulfill 3 out of these 4 conditions: Has lower characters, Has upper characters, Has a digit, Has a special character other than \"_\", fullfiled only %d conditions", k, conditions))
 	}
 
-	return
+	return warnings, errors
 }

--- a/internal/services/compute/validate/windows_admin_password.go
+++ b/internal/services/compute/validate/windows_admin_password.go
@@ -21,7 +21,7 @@ func WindowsAdminPassword(i interface{}, k string) (warnings []string, errors []
 		return
 	}
 
-	// adminPassword Min-length is 6 characters and Max-length is 72 characters.
+	// adminPassword Min-length is 8 characters and Max-length is 123 characters.
 	if len(v) < 8 || len(v) > 123 {
 		errors = append(errors, fmt.Errorf("%q most be between %d and %d characters, got %d", k, 8, 123, len(v)))
 	}

--- a/internal/services/compute/validate/windows_admin_password.go
+++ b/internal/services/compute/validate/windows_admin_password.go
@@ -1,0 +1,51 @@
+package validate
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// WindowsAdminPassword validates that admin_password meets the Azure API requirements for Windows Virtual Machines.
+func WindowsAdminPassword(i interface{}, k string) (warnings []string, errors []error) {
+	// adminPassword must be a string.
+	v, ok := i.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string but it wasn't", k))
+		return
+	}
+
+	// adminPassword must not be empty.
+	if strings.TrimSpace(v) == "" {
+		errors = append(errors, fmt.Errorf("%q must not be empty", k))
+		return
+	}
+
+	// adminPassword Min-length is 6 characters and Max-length is 72 characters.
+	if len(v) < 8 || len(v) > 123 {
+		errors = append(errors, fmt.Errorf("%q most be between %d and %d characters, got %d", k, 8, 123, len(v)))
+	}
+
+	// adminPassword cannot match the following disallowed names.
+	disallowedNames := []string{"abc@123", "P@$$w0rd", "P@ssw0rd", "P@ssword123", "Pa$$word", "pass@word1", "Password!", "Password1", "Password22", "iloveyou!"}
+	for _, value := range disallowedNames {
+		if value == v {
+			errors = append(errors, fmt.Errorf("%q specified is not allowed, got %q, cannot match: %q", k, v, strings.Join(disallowedNames, ", ")))
+		}
+	}
+
+	// adminPassword has to fulfill 3 out of these 4 conditions: Has lower characters, Has upper characters, Has a digit, Has a special character (Regex match [\W_])
+	conditions := 0
+	tests := []string{"[a-z]", "[A-Z]", "[0-9]", "[^\\d\\w]"}
+	for _, test := range tests {
+		t, _ := regexp.MatchString(test, v)
+		if t {
+			conditions++
+		}
+	}
+	if conditions < 3 {
+		errors = append(errors, fmt.Errorf("%q has to fulfill 3 out of these 4 conditions: Has lower characters, Has upper characters, Has a digit, Has a special character other than \"_\", fullfiled only %d conditions", k, conditions))
+	}
+
+	return
+}

--- a/internal/services/compute/validate/windows_admin_password_test.go
+++ b/internal/services/compute/validate/windows_admin_password_test.go
@@ -1,0 +1,71 @@
+package validate
+
+import "testing"
+
+func TestWindowsAdminPassword(t *testing.T) {
+	testData := []struct {
+		input    string
+		expected bool
+	}{
+		{
+			// bad: empty
+			input:    "",
+			expected: false,
+		},
+		{
+			// bad: all lower characters
+			input:    "juanjose",
+			expected: false,
+		},
+		{
+			// bad: only some caps
+			input:    "JuanJose",
+			expected: false,
+		},
+		{
+			// bad: can't use reserved words
+			input:    "P@$$w0rd",
+			expected: false,
+		},
+		{
+			// bad: can't be longer than 123 characters
+			input:    "abcdefghijklmnopqrstuvwxyzabcdefghiJklmno9q.stuvwxyzabcdefghijkjlmnopqrstabcdefghijklmnopqrstuvwxyzabcdefghiJklmno9q.stuvwxyzabcdefg",
+			expected: false,
+		},
+		{
+			// 72 characters its fine
+			input:    "abcdefghijklmnopqrstuvwxyzabcD.9ghijklmnopqrstuvwxyzabcdefghijkjlmnopqrs",
+			expected: true,
+		},
+		{
+			// bad: can't be less than 8 characters
+			input:    "A9.de",
+			expected: false,
+		},
+		{
+			// bad: "_" doesnt count as special character
+			input:    "A9BC_7AB",
+			expected: false,
+		},
+		{
+			// "/" counts as special character
+			input:    "A9BC/7AB",
+			expected: true,
+		},
+		{
+			// " " counts as special character
+			input:    "A9BC 7AB",
+			expected: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q..", v.input)
+
+		_, errors := WindowsAdminPassword(v.input, "admin_password")
+		actual := len(errors) == 0
+		if v.expected != actual {
+			t.Fatalf("Expected %t but got %t", v.expected, actual)
+		}
+	}
+}

--- a/internal/services/compute/windows_virtual_machine_resource.go
+++ b/internal/services/compute/windows_virtual_machine_resource.go
@@ -71,6 +71,7 @@ func resourceWindowsVirtualMachine() *pluginsdk.Resource {
 				ForceNew:         true,
 				Sensitive:        true,
 				DiffSuppressFunc: adminPasswordDiffSuppressFunc,
+				ValidateFunc:     computeValidate.WindowsAdminPassword,
 			},
 
 			"admin_username": {


### PR DESCRIPTION
Related to #20400 

Adding validations for `azurerm_linux_virtual_machine` and `azurerm_windows_virtual_machine` `admin_password` to fulfil Azure API requirements in https://learn.microsoft.com/en-us/rest/api/compute/virtual-machines/create-or-update?tabs=HTTP#osprofile
