### PR TITLE
Made the traffic_weight block in the ingress block of the azurerm_container_app resource optional 

### DIFF
--- a/internal/services/containerapps/container_app_resource_test.go
+++ b/internal/services/containerapps/container_app_resource_test.go
@@ -472,6 +472,99 @@ resource "azurerm_container_app" "test" {
 `, r.templatePlusExtras(data), data.RandomInteger, revisionSuffix)
 }
 
+func (r ContainerAppResource) completeWithNoIngressTrafficWeights(data acceptance.TestData, revisionSuffix string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_container_app" "test" {
+  name                         = "acctest-capp-%[2]d"
+  resource_group_name          = azurerm_resource_group.test.name
+  container_app_environment_id = azurerm_container_app_environment.test.id
+  revision_mode                = "Single"
+
+  template {
+    container {
+      name   = "acctest-cont-%[2]d"
+      image  = "jackofallops/azure-containerapps-python-acctest:v0.0.1"
+      cpu    = 0.25
+      memory = "0.5Gi"
+
+      readiness_probe {
+        transport = "HTTP"
+        port      = 5000
+      }
+
+      liveness_probe {
+        transport = "HTTP"
+        port      = 5000
+        path      = "/health"
+
+        header {
+          name  = "Cache-Control"
+          value = "no-cache"
+        }
+
+        initial_delay           = 5
+        interval_seconds        = 20
+        timeout                 = 2
+        failure_count_threshold = 1
+      }
+
+      startup_probe {
+        transport = "TCP"
+        port      = 5000
+      }
+
+      volume_mounts {
+        name = azurerm_container_app_environment_storage.test.name
+        path = "/tmp/testdata"
+      }
+    }
+
+    volume {
+      name         = azurerm_container_app_environment_storage.test.name
+      storage_type = "AzureFile"
+      storage_name = azurerm_container_app_environment_storage.test.name
+    }
+
+    min_replicas = 2
+    max_replicas = 3
+
+    revision_suffix = "%[3]s"
+  }
+
+  ingress {
+    allow_insecure_connections = true
+    external_enabled           = true
+    target_port                = 5000
+    transport                  = "http"
+  }
+
+  registry {
+    server               = azurerm_container_registry.test.login_server
+    username             = azurerm_container_registry.test.admin_username
+    password_secret_name = "registry-password"
+  }
+
+  secret {
+    name  = "registry-password"
+    value = azurerm_container_registry.test.admin_password
+  }
+
+  dapr {
+    app_id       = "acctest-cont-%[2]d"
+    app_port     = 5000
+    app_protocol = "http"
+  }
+
+  tags = {
+    foo     = "Bar"
+    accTest = "1"
+  }
+}
+`, r.templatePlusExtras(data), data.RandomInteger, revisionSuffix)
+}
+
 func (r ContainerAppResource) completeWithVnet(data acceptance.TestData, revisionSuffix string) string {
 	return fmt.Sprintf(`
 %s

--- a/internal/services/containerapps/container_app_resource_test.go
+++ b/internal/services/containerapps/container_app_resource_test.go
@@ -143,6 +143,21 @@ func TestAccContainerAppResource_complete(t *testing.T) {
 	})
 }
 
+func TestAccContainerAppResource_completeWithNoIngressTrafficWeights(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_container_app", "test")
+	r := ContainerAppResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.completeWithNoIngressTrafficWeights(data, "rev1"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccContainerAppResource_completeWithVNet(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_container_app", "test")
 	r := ContainerAppResource{}

--- a/internal/services/containerapps/helpers/container_apps.go
+++ b/internal/services/containerapps/helpers/container_apps.go
@@ -302,7 +302,7 @@ type TrafficWeight struct {
 func ContainerAppIngressTrafficWeight() *pluginsdk.Schema {
 	return &pluginsdk.Schema{
 		Type:     pluginsdk.TypeList,
-		Required: true,
+		Optional: true,
 		Elem: &pluginsdk.Resource{
 			Schema: map[string]*pluginsdk.Schema{
 				"label": {

--- a/website/docs/r/container_app.html.markdown
+++ b/website/docs/r/container_app.html.markdown
@@ -279,7 +279,7 @@ An `ingress` block supports the following:
 
 * `target_port` - (Required) The target port on the container for the Ingress traffic.
 
-* `traffic_weight` - (Required) A `traffic_weight` block as detailed below.
+* `traffic_weight` - (Optional) A `traffic_weight` block as detailed below.
 
 ~> **Note:** `traffic_weight` can only be specified when `revision_mode` is set to `Multiple`.
 


### PR DESCRIPTION
### Description
This pull request resolves #20537.

### Expected Behaviour

In `azurerm_container_app`, the `traffic_weight` block in the `ingress block` should be optional, while now you have to create at least one `traffic_weight` if the `ingress block` is not null.

### Actual Behaviour

If the container app exposes a public or private ingress, the engineer deploying the container app must specify a `traffic_weight` block in the `ingress` block in the `azurerm_container_app` resource even if this not necessary when creating the same resource using Bicep, ARM, Azure CLI, PowerShell, or Azure REST API.

### New Behaviour

The `traffic_weight` block is now optional.

### Repro steps

I made the change and successfully deployed a container app with an `ingress` block with no `traffic_weight` block in the `azurerm_container_app`.