### PR TITLE
Change the Enterprise application to Microsoft.AzureFrontDoor-Cdn for kv secrets access

### DIFF
--- a/website/docs/r/cdn_frontdoor_secret.html.markdown
+++ b/website/docs/r/cdn_frontdoor_secret.html.markdown
@@ -12,7 +12,11 @@ Manages a Front Door (standard/premium) Secret.
 
 ## Required Key Vault Permissions
 
-!>**IMPORTANT:** You must add an `Access Policy` to your `azurerm_key_vault` for the `Microsoft.Azure.Cdn` Enterprise Application Object ID.
+!>**IMPORTANT:** You must add an `Access Policy` to your `azurerm_key_vault` for the `Microsoft.AzurefrontDoor-Cdn` Enterprise Application Object ID.
+
+This can be created by running Az Powershell command like this:
+
+```New-AzADServicePrincipal -ApplicationId "205478c0-bd83-4e1b-a9d6-db63a3e1e1c8"```
 
 | Object ID                                | Key Permissions | Secret Permissions   | Certificate Permissions                       |
 |:-----------------------------------------|:---------------:|:--------------------:|:---------------------------------------------:|

--- a/website/docs/r/cdn_frontdoor_secret.html.markdown
+++ b/website/docs/r/cdn_frontdoor_secret.html.markdown
@@ -16,7 +16,7 @@ Manages a Front Door (standard/premium) Secret.
 
 This can be created by running Az Powershell command like this:
 
-```New-AzADServicePrincipal -ApplicationId "205478c0-bd83-4e1b-a9d6-db63a3e1e1c8"```
+```New-AzADServicePrincipal -ApplicationId "00000000-0000-0000-0000-000000000000"```
 
 | Object ID                                | Key Permissions | Secret Permissions   | Certificate Permissions                       |
 |:-----------------------------------------|:---------------:|:--------------------:|:---------------------------------------------:|


### PR DESCRIPTION
…Azure Frontdoor Standard/Premium

The AAD enterprise id specified in the documents didn't work for me. I've found a couple of articles that indicate the right enterprise application to add for keyvaults secrets access is:

Microsoft.AzureFrontDoor-Cdn

https://stackoverflow.com/questions/71487842/azure-front-door-and-custom-domain

https://learn.microsoft.com/en-us/answers/questions/435168/how-to-grant-access-to-microsoft-azurefrontdoor-cd

Adding Microsoft.AzureFrontDoor-Cdn works for me (as I am using Azure Front Door Standard)