### PR TITLE
`azurerm_postgresql_flexible_server` - support creation without enabling password authtication

### DIFF
--- a/internal/services/postgres/postgresql_flexible_server_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_resource.go
@@ -386,10 +386,8 @@ func resourcePostgresqlFlexibleServerCreate(d *pluginsdk.ResourceData, meta inte
 			if !adminPwdSet {
 				return fmt.Errorf("`administrator_password` is required when `create_mode` is `Default` and `authentication.password_auth_enabled` is set to `true`")
 			}
-		} else {
-			if adminLoginSet || adminPwdSet {
-				return fmt.Errorf("`administrator_login` and `administrator_password` cannot be set when `authentication.password_auth_enabled` is set to `false`")
-			}
+		} else if adminLoginSet || adminPwdSet {
+			return fmt.Errorf("`administrator_login` and `administrator_password` cannot be set when `authentication.password_auth_enabled` is set to `false`")
 		}
 
 		if _, ok := d.GetOk("sku_name"); !ok {
@@ -626,10 +624,8 @@ func resourcePostgresqlFlexibleServerUpdate(d *pluginsdk.ResourceData, meta inte
 		if !adminPwdSet {
 			return fmt.Errorf("`administrator_password` is required when `authentication.password_auth_enabled` is set to `true`")
 		}
-	} else {
-		if adminLoginSet || adminPwdSet {
-			return fmt.Errorf("`administrator_login` and `administrator_password` cannot be set when `authentication.password_auth_enabled` is set to `false`")
-		}
+	} else if adminLoginSet || adminPwdSet {
+		return fmt.Errorf("`administrator_login` and `administrator_password` cannot be set when `authentication.password_auth_enabled` is set to `false`")
 	}
 
 	var requireFailover bool

--- a/internal/services/postgres/postgresql_flexible_server_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_resource.go
@@ -757,6 +757,7 @@ func resourcePostgresqlFlexibleServerUpdate(d *pluginsdk.ResourceData, meta inte
 	if requireUpdateOnLogin {
 		updateMode := servers.CreateModeUpdate
 		loginParameters := servers.Server{
+			Location: location.Normalize(d.Get("location").(string)),
 			Properties: &servers.ServerProperties{
 				CreateMode:                 &updateMode,
 				AuthConfig:                 expandFlexibleServerAuthConfig(d.Get("authentication").([]interface{})),

--- a/internal/services/postgres/postgresql_flexible_server_resource_test.go
+++ b/internal/services/postgres/postgresql_flexible_server_resource_test.go
@@ -245,6 +245,7 @@ func TestAccPostgresqlFlexibleServer_authConfig(t *testing.T) {
 	r := PostgresqlFlexibleServerResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
+			// stats from pwdEnabled set to `false` to test add `admininistrator_login`
 			Config: r.authConfig(data, true, false),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
@@ -711,6 +712,14 @@ func (r PostgresqlFlexibleServerResource) authConfig(data acceptance.TestData, a
 		tenantIdBlock = "tenant_id = data.azurerm_client_config.current.tenant_id"
 	}
 
+	pwdBlock := ""
+	if pwdEnabled {
+		pwdBlock = `
+administrator_login    = "adminTerraform"
+administrator_password = "QAZwsx123"
+`
+	}
+
 	return fmt.Sprintf(`
 %s
 
@@ -718,24 +727,23 @@ data "azurerm_client_config" "current" {
 }
 
 resource "azurerm_postgresql_flexible_server" "test" {
-  name                   = "acctest-fs-%d"
-  resource_group_name    = azurerm_resource_group.test.name
-  location               = azurerm_resource_group.test.location
-  administrator_login    = "adminTerraform"
-  administrator_password = "QAZwsx123"
-  storage_mb             = 32768
-  version                = "12"
-  sku_name               = "GP_Standard_D2s_v3"
-  zone                   = "2"
+  name                = "acctest-fs-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  %[3]s
+  storage_mb = 32768
+  version    = "12"
+  sku_name   = "GP_Standard_D2s_v3"
+  zone       = "2"
 
   authentication {
-    active_directory_auth_enabled = %[3]t
-    password_auth_enabled         = %[4]t
-   %[5]s
+    active_directory_auth_enabled = %[4]t
+    password_auth_enabled         = %[5]t
+   %[6]s
   }
 
 }
-`, r.template(data), data.RandomInteger, aadEnabled, pwdEnabled, tenantIdBlock)
+`, r.template(data), data.RandomInteger, pwdBlock, aadEnabled, pwdEnabled, tenantIdBlock)
 }
 
 func (r PostgresqlFlexibleServerResource) cmkTemplate(data acceptance.TestData) string {

--- a/website/docs/r/postgresql_flexible_server.html.markdown
+++ b/website/docs/r/postgresql_flexible_server.html.markdown
@@ -88,9 +88,11 @@ The following arguments are supported:
 
 * `location` - (Required) The Azure Region where the PostgreSQL Flexible Server should exist. Changing this forces a new PostgreSQL Flexible Server to be created.
 
-* `administrator_login` - (Optional) The Administrator login for the PostgreSQL Flexible Server. Required when `create_mode` is `Default`. Changing this forces a new PostgreSQL Flexible Server to be created.
+* `administrator_login` - (Optional) The Administrator login for the PostgreSQL Flexible Server. Required when `create_mode` is `Default` and `authentication.password_auth_enabled` is `true`. 
 
-* `administrator_password` - (Optional) The Password associated with the `administrator_login` for the PostgreSQL Flexible Server. Required when `create_mode` is `Default`.
+-> **Note:** Once `administrator_login` is specified, changing this forces a new PostgreSQL Flexible Server to be created.
+
+* `administrator_password` - (Optional) The Password associated with the `administrator_login` for the PostgreSQL Flexible Server. Required when `create_mode` is `Default` and `authentication.password_auth_enabled` is `true`.
 
 * `authentication` - (Optional) An `authentication` block as defined below.
 
@@ -147,6 +149,8 @@ An `authentication` block supports the following:
 * `active_directory_auth_enabled` - (Optional) Whether or not Active Directory authentication is allowed to access the PostgreSQL Flexible Server. Defaults to `false`.
 
 * `password_auth_enabled` - (Optional) Whether or not password authentication is allowed to access the PostgreSQL Flexible Server. Defaults to `true`.
+
+-> **NOTE:** When `password_auth_enabled` is set to `false`, `administrator_login` and `administrator_password` must not be specified.
 
 * `tenant_id` - (Optional) The Tenant ID of the Azure Active Directory which is used by the Active Directory authentication. `active_directory_auth_enabled` must be set to `true`.
 


### PR DESCRIPTION
close #20561

<img width="411" alt="Screenshot 2023-02-21 at 16 03 16" src="https://user-images.githubusercontent.com/51212351/220284225-5a732771-205f-4f25-9ea3-c10b65240cc6.png">
The failed ones are because of region limit.