### PR TITLE
New Resource: `azurerm_site_recovery_hyperv_replication_policy_association`

### DIFF
--- a/internal/services/recoveryservices/azuresdkhacks/client.go
+++ b/internal/services/recoveryservices/azuresdkhacks/client.go
@@ -1,0 +1,32 @@
+package azuresdkhacks
+
+import (
+	"fmt"
+
+	"github.com/Azure/go-autorest/autorest"
+)
+
+// TODO 4.0: check if it could be removed on 4.0
+// workaround for https://github.com/Azure/azure-rest-api-specs/issues/22572
+// the swagger lack definition of `certificateCreateOptions`.
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2022-10-01"
+
+func userAgent() string {
+	return fmt.Sprintf("hashicorp/go-azure-sdk/vaultcertificates/%s", defaultApiVersion)
+}
+
+type VaultCertificatesClient struct {
+	Client  autorest.Client
+	baseUri string
+}
+
+func NewVaultCertificatesClientWithBaseURI(endpoint string) VaultCertificatesClient {
+	return VaultCertificatesClient{
+		Client:  autorest.NewClientWithUserAgent(userAgent()),
+		baseUri: endpoint,
+	}
+}

--- a/internal/services/recoveryservices/azuresdkhacks/method_create_autorest.go
+++ b/internal/services/recoveryservices/azuresdkhacks/method_create_autorest.go
@@ -1,0 +1,70 @@
+package azuresdkhacks
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservices/2022-10-01/vaultcertificates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CreateOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *vaultcertificates.VaultCertificateResponse
+}
+
+// Create ...
+func (c VaultCertificatesClient) Create(ctx context.Context, id vaultcertificates.CertificateId, input CertificateRequest) (result CreateOperationResponse, err error) {
+	req, err := c.preparerForCreate(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "vaultcertificates.VaultCertificatesClient", "Create", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "vaultcertificates.VaultCertificatesClient", "Create", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForCreate(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "vaultcertificates.VaultCertificatesClient", "Create", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForCreate prepares the Create request.
+func (c VaultCertificatesClient) preparerForCreate(ctx context.Context, id vaultcertificates.CertificateId, input CertificateRequest) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPut(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForCreate handles the response to the Create request. The method always
+// closes the http.Response Body.
+func (c VaultCertificatesClient) responderForCreate(resp *http.Response) (result CreateOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+
+	return
+}

--- a/internal/services/recoveryservices/azuresdkhacks/model_certificaterequest.go
+++ b/internal/services/recoveryservices/azuresdkhacks/model_certificaterequest.go
@@ -1,0 +1,26 @@
+package azuresdkhacks
+
+import (
+	"encoding/json"
+
+	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservices/2022-10-01/vaultcertificates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CertificateRequest struct {
+	Properties    *vaultcertificates.RawCertificateData `json:"properties,omitempty"`
+	CreateOptions *CertificateCreateOptions             `json:"certificateCreateOptions,omitempty"`
+}
+
+type CertificateCreateOptions struct {
+	ValidityInHours int64 `json:"validityInHours,omitempty"`
+}
+
+func (c CertificateCreateOptions) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+
+	objectMap["validityInHours"] = c.ValidityInHours
+	return json.Marshal(objectMap)
+}

--- a/internal/services/recoveryservices/client/client.go
+++ b/internal/services/recoveryservices/client/client.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/common"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/recoveryservices/azuresdkhacks"
 )
 
 type Client struct {
@@ -26,6 +27,7 @@ type Client struct {
 	BackupOperationResultsClient              *backup.OperationResultsClient
 	VaultsClient                              *vaults.VaultsClient
 	VaultsConfigsClient                       *backupresourcevaultconfigs.BackupResourceVaultConfigsClient
+	VaultCertificatesClient                   *azuresdkhacks.VaultCertificatesClient
 	StorageConfigsClient                      *backupresourcestorageconfigsnoncrr.BackupResourceStorageConfigsNonCRRClient
 	FabricClient                              *replicationfabrics.ReplicationFabricsClient
 	ProtectionContainerClient                 *replicationprotectioncontainers.ReplicationProtectionContainersClient
@@ -45,6 +47,9 @@ func NewClient(o *common.ClientOptions) *Client {
 
 	vaultsClient := vaults.NewVaultsClientWithBaseURI(o.ResourceManagerEndpoint)
 	o.ConfigureClient(&vaultsClient.Client, o.ResourceManagerAuthorizer)
+
+	vaultCertificatesClient := azuresdkhacks.NewVaultCertificatesClientWithBaseURI(o.ResourceManagerEndpoint)
+	o.ConfigureClient(&vaultCertificatesClient.Client, o.ResourceManagerAuthorizer)
 
 	protectableItemsClient := backup.NewProtectableItemsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&protectableItemsClient.Client, o.ResourceManagerAuthorizer)
@@ -102,6 +107,7 @@ func NewClient(o *common.ClientOptions) *Client {
 		BackupOperationResultsClient:              &backupOperationResultClient,
 		VaultsClient:                              &vaultsClient,
 		VaultsConfigsClient:                       &vaultConfigsClient,
+		VaultCertificatesClient:                   &vaultCertificatesClient,
 		StorageConfigsClient:                      &storageConfigsClient,
 		FabricClient:                              &fabricClient,
 		ProtectionContainerClient:                 &protectionContainerClient,

--- a/internal/services/recoveryservices/recovery_services_vault_hyperv_host_registration_resouce.go
+++ b/internal/services/recoveryservices/recovery_services_vault_hyperv_host_registration_resouce.go
@@ -1,0 +1,427 @@
+package recoveryservices
+
+import (
+	"context"
+	"encoding/xml"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservices/2022-10-01/vaultcertificates"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservices/2022-10-01/vaults"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/recoveryservices/azuresdkhacks"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+// Registration Key is a special resource, it only support PUT, not GET/DELETE.
+// And it will be invalid with the param `certificateCreateOptions.validityInHours`
+
+const vaultResourceType string = "Vaults"
+const vaultProviderNameSpace string = "Microsoft.RecoveryServices"
+const xmlContentVersion string = "2.0"
+
+type HyperVHostRegistrationKeyModel struct {
+	Name                        string `tfschema:"name"`
+	HyperVSiteId                string `tfschema:"site_recovery_services_vault_hyperv_site_id"`
+	ValidateInHours             int64  `tfschema:"validate_in_hours"`
+	RenewOnRead                 bool   `tfschema:"renew"`
+	XmlContent                  string `tfschema:"xml_content"`
+	ResourceId                  int64  `tfschema:"resource_id"`
+	ManagementCert              string `tfschema:"management_cert"`
+	AadTenantId                 string `tfschema:"aad_tenant_id"`
+	AadAuthority                string `tfschema:"aad_authority"`
+	ServicePrincipalClientId    string `tfschema:"service_principal_client_id"`
+	AadVaultAudience            string `tfschema:"aad_vault_audience"`
+	AadManagementEndpoint       string `tfschema:"aad_management_endpoint"`
+	VaultPrivateEndpointEnabled string `tfschema:"vault_private_endpoint_enabled"`
+	ValidateToDate              string `tfschema:"validate_to"`
+}
+
+type HyperVHostRegistrationKeyResource struct{}
+
+var _ sdk.Resource = HyperVHostRegistrationKeyResource{}
+
+func (h HyperVHostRegistrationKeyResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+	return vaultcertificates.ValidateCertificateID
+}
+
+func (h HyperVHostRegistrationKeyResource) Arguments() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"site_recovery_services_vault_hyperv_site_id": {
+			Type:         schema.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: replicationfabrics.ValidateReplicationFabricID,
+		},
+
+		"validate_in_hours": {
+			Type:         schema.TypeInt,
+			ForceNew:     true,
+			Optional:     true,
+			Default:      120,
+			ValidateFunc: validation.IntAtLeast(0),
+		},
+
+		"renew": {
+			Type:     schema.TypeBool,
+			ForceNew: true,
+			Optional: true,
+			Default:  false, // defaults to `false` for import scenario.
+		},
+	}
+}
+
+func (h HyperVHostRegistrationKeyResource) Attributes() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"name": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"xml_content": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+		"resource_id": {
+			Type:     schema.TypeInt,
+			Computed: true,
+		},
+		"management_cert": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"aad_tenant_id": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"aad_authority": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"service_principal_client_id": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"aad_vault_audience": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"aad_management_endpoint": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"vault_private_endpoint_enabled": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"validate_to": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+	}
+}
+
+func (h HyperVHostRegistrationKeyResource) ModelObject() interface{} {
+	return &HyperVHostRegistrationKeyModel{}
+}
+
+func (h HyperVHostRegistrationKeyResource) ResourceType() string {
+	return "azurerm_recovery_services_vault_hyperv_host_registration_key"
+}
+
+func (h HyperVHostRegistrationKeyResource) Create() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			var metaModel HyperVHostRegistrationKeyModel
+			if err := metadata.Decode(&metaModel); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			FabricId, err := replicationfabrics.ParseReplicationFabricID(metaModel.HyperVSiteId)
+			if err != nil {
+				return fmt.Errorf("parsing: %+v", err)
+			}
+
+			date := time.Now().Format("2-01-2006")
+			name := fmt.Sprintf(`CN=CB_%s-%s-vaultcredentials`, FabricId.VaultName, date)
+
+			id := vaultcertificates.NewCertificateID(FabricId.SubscriptionId, FabricId.ResourceGroupName, FabricId.VaultName, name)
+
+			metadata.SetID(id)
+
+			return resourceRecoveryServicesVaultHyperVHostRegistrationKeyCreateInternal(ctx, id, metadata)
+		},
+	}
+}
+
+func (h HyperVHostRegistrationKeyResource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			var metaModel HyperVHostRegistrationKeyModel
+			if err := metadata.Decode(&metaModel); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			id, err := vaultcertificates.ParseCertificateID(metadata.ResourceData.Id())
+			if err != nil {
+				return fmt.Errorf("parsing: %+v", err)
+			}
+
+			if metaModel.RenewOnRead {
+				return resourceRecoveryServicesVaultHyperVHostRegistrationKeyCreateInternal(ctx, *id, metadata)
+			}
+
+			// check if the vault exists
+			vaultId := vaults.NewVaultID(id.SubscriptionId, id.ResourceGroupName, id.VaultName)
+			vaultClient := metadata.Client.RecoveryServices.VaultsClient
+			if resp, err := vaultClient.Get(ctx, vaultId); err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return metadata.MarkAsGone(id)
+				}
+				return fmt.Errorf("checking for presence of existing Recovery Services Vault %q: %+v", vaultId, err)
+			}
+
+			return metadata.Encode(&metaModel)
+		},
+	}
+}
+
+func (h HyperVHostRegistrationKeyResource) Delete() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			var metaModel HyperVHostRegistrationKeyModel
+			if err := metadata.Decode(&metaModel); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			client := metadata.Client.RecoveryServices.VaultCertificatesClient
+
+			id, err := vaultcertificates.ParseCertificateID(metadata.ResourceData.Id())
+			if err != nil {
+				return fmt.Errorf("parsing: %+v", err)
+			}
+
+			input := azuresdkhacks.CertificateRequest{
+				CreateOptions: &azuresdkhacks.CertificateCreateOptions{
+					ValidityInHours: 1,
+				},
+			}
+
+			_, err = client.Create(ctx, *id, input)
+			if err != nil {
+				return fmt.Errorf("creating: %+v", err)
+			}
+
+			return nil
+		},
+	}
+}
+
+func resourceRecoveryServicesVaultHyperVHostRegistrationKeyCreateInternal(ctx context.Context, id vaultcertificates.CertificateId, metadata sdk.ResourceMetaData) error {
+	var metaModel HyperVHostRegistrationKeyModel
+	if err := metadata.Decode(&metaModel); err != nil {
+		return fmt.Errorf("decoding: %+v", err)
+	}
+
+	client := metadata.Client.RecoveryServices.VaultCertificatesClient
+
+	// even in `import` process, the id of site(fabric) also needed, and it will create a new cert..
+	FabricId, err := replicationfabrics.ParseReplicationFabricID(metaModel.HyperVSiteId)
+	if err != nil {
+		return fmt.Errorf("parsing: %+v", err)
+	}
+
+	input := azuresdkhacks.CertificateRequest{
+		CreateOptions: &azuresdkhacks.CertificateCreateOptions{
+			ValidityInHours: metaModel.ValidateInHours,
+		},
+	}
+
+	resp, err := client.Create(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("creating: %+v", err)
+	}
+
+	if resp.Model == nil {
+		return fmt.Errorf("retrieving %s: Model was nil", id)
+	}
+
+	detail, ok := resp.Model.Properties.(vaultcertificates.ResourceCertificateAndAadDetails)
+	if !ok {
+		return fmt.Errorf("unexpected response type")
+	}
+
+	state := HyperVHostRegistrationKeyModel{
+		Name:                     id.CertificateName,
+		HyperVSiteId:             FabricId.ID(),
+		AadTenantId:              detail.AadTenantId,
+		AadAuthority:             detail.AadAuthority,
+		ServicePrincipalClientId: detail.ServicePrincipalClientId,
+		AadManagementEndpoint:    detail.AzureManagementEndpointAudience,
+		ValidateInHours:          metaModel.ValidateInHours,
+	}
+
+	if detail.ResourceId != nil {
+		state.ResourceId = *detail.ResourceId
+	}
+
+	if detail.Certificate != nil {
+		state.ManagementCert = *detail.Certificate
+	}
+
+	if detail.AadAudience != nil {
+		state.AadVaultAudience = *detail.AadAudience
+	}
+
+	if detail.ValidTo != nil {
+		state.ValidateToDate = *detail.ValidTo
+	}
+
+	vaultId := vaults.NewVaultID(id.SubscriptionId, id.ResourceGroupName, id.VaultName)
+
+	vault, err := fetchRecoveryServicesVaultDetails(ctx, metadata.Client.RecoveryServices.VaultsClient, vaultId)
+	if err != nil {
+		return fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+
+	if vault.Properties.PrivateEndpointStateForSiteRecovery != nil {
+		state.VaultPrivateEndpointEnabled = string(*vault.Properties.PrivateEndpointStateForSiteRecovery)
+	}
+
+	fabric, err := fetchRecoveryServicesFabricDetails(ctx, metadata.Client.RecoveryServices.FabricClient, *FabricId)
+	if err != nil {
+		return fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+
+	state.XmlContent, err = flattenHostRegistrationKeyXMLModel(id, vault, fabric, detail)
+	if err != nil {
+		return fmt.Errorf("flattening %s: %+v", id, err)
+	}
+
+	return metadata.Encode(&state)
+}
+
+func fetchRecoveryServicesVaultDetails(ctx context.Context, client *vaults.VaultsClient, id vaults.VaultId) (*vaults.Vault, error) {
+	resp, err := client.Get(ctx, id)
+	if err != nil {
+		if response.WasNotFound(resp.HttpResponse) {
+			return nil, fmt.Errorf("retrieving %s: %+v", id, err)
+		}
+
+		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+
+	return resp.Model, nil
+}
+
+func fetchRecoveryServicesFabricDetails(ctx context.Context, client *replicationfabrics.ReplicationFabricsClient, id replicationfabrics.ReplicationFabricId) (*replicationfabrics.Fabric, error) {
+	resp, err := client.Get(ctx, id, replicationfabrics.DefaultGetOperationOptions())
+	if err != nil {
+		if response.WasNotFound(resp.HttpResponse) {
+			return nil, fmt.Errorf("retrieving %s: %+v", id, err)
+		}
+
+		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+
+	return resp.Model, nil
+}
+
+const xmlHeader string = `<?xml version="1.0" encoding="utf-8"?>`
+
+type hyperVHostRegistrationKeyXMLModel struct {
+	XMLName                             xml.Name             `xml:"RSVaultAsrCreds"`
+	XMLNS                               string               `xml:"xmlns,attr"`
+	XMLNSI                              string               `xml:"xmlns:i,attr"`
+	VaultDetails                        vaultDetailsXMLModel `xml:"VaultDetails"`
+	ManagementCert                      string               `xml:"ManagementCert"`
+	Version                             string               `xml:"Version"`
+	AadDetails                          aadDetailsXMLModel   `xml:"AadDetails"`
+	ChannelIntegrityKey                 string               `xml:"ChannelIntegrityKey"`
+	SiteId                              string               `xml:"SiteId"`
+	SiteName                            string               `xml:"SiteName"`
+	PrivateEndpointStateForSiteRecovery string               `xml:"PrivateEndpointStateForSiteRecovery"`
+}
+
+type vaultDetailsXMLModel struct {
+	SubscriptionId    string `xml:"SubscriptionId"`
+	ResourceGroup     string `xml:"ResourceGroup"`
+	ResourceName      string `xml:"ResourceName"`
+	ResourceId        int64  `xml:"ResourceId"`
+	Location          string `xml:"Location"`
+	ResourceType      string `xml:"ResourceType"`
+	ProviderNamespace string `xml:"ProviderNamespace"`
+}
+
+type aadDetailsXMLModel struct {
+	AadAuthority             string `xml:"AadAuthority"`
+	AadTenantId              string `xml:"AadTenantId"`
+	ServicePrincipalClientId string `xml:"ServicePrincipalClientId"`
+	AadVaultAudience         string `xml:"AadVaultAudience"`
+	ArmManagementEndpoint    string `xml:"ArmManagementEndpoint"`
+}
+
+func flattenHostRegistrationKeyXMLModel(id vaultcertificates.CertificateId, vaultDetail *vaults.Vault, fabricDetails *replicationfabrics.Fabric, certDetails vaultcertificates.ResourceCertificateAndAadDetails) (string, error) {
+	if vaultDetail == nil {
+		return "", fmt.Errorf("vault was nil")
+	}
+
+	if fabricDetails == nil {
+		return "", fmt.Errorf("fabric was nil")
+	}
+
+	xmlModel := hyperVHostRegistrationKeyXMLModel{
+		XMLNSI: "http://www.w3.org/2001/XMLSchema-instance",
+		XMLNS:  "http://schemas.datacontract.org/2004/07/Microsoft.Azure.Portal.RecoveryServices.Models.Common",
+		VaultDetails: vaultDetailsXMLModel{
+			SubscriptionId:    id.SubscriptionId,
+			ResourceGroup:     id.ResourceGroupName,
+			ResourceName:      id.VaultName,
+			Location:          vaultDetail.Location,
+			ResourceType:      vaultResourceType,
+			ProviderNamespace: vaultProviderNameSpace,
+		},
+		ManagementCert: *certDetails.Certificate,
+		Version:        xmlContentVersion,
+		AadDetails: aadDetailsXMLModel{
+			AadAuthority:             certDetails.AadAuthority,
+			AadTenantId:              certDetails.AadTenantId,
+			ServicePrincipalClientId: certDetails.ServicePrincipalClientId,
+			ArmManagementEndpoint:    certDetails.AzureManagementEndpointAudience,
+		},
+		ChannelIntegrityKey: "",
+	}
+
+	if certDetails.ResourceId != nil {
+		xmlModel.VaultDetails.ResourceId = *certDetails.ResourceId
+	}
+
+	if certDetails.AadAudience != nil {
+		xmlModel.AadDetails.AadVaultAudience = *certDetails.AadAudience
+	}
+
+	if fabricDetails.Properties.InternalIdentifier != nil {
+		xmlModel.SiteId = *fabricDetails.Properties.InternalIdentifier
+	}
+
+	if fabricDetails.Name != nil {
+		xmlModel.SiteName = *fabricDetails.Name
+	}
+
+	if vaultDetail.Properties.PrivateEndpointStateForSiteRecovery != nil {
+		xmlModel.PrivateEndpointStateForSiteRecovery = string(*vaultDetail.Properties.PrivateEndpointStateForSiteRecovery)
+	}
+
+	xmlResult, err := xml.Marshal(xmlModel)
+	if err != nil {
+		return "", fmt.Errorf("marshaling: %+v", err)
+	}
+
+	return xmlHeader + string(xmlResult), nil
+}

--- a/internal/services/recoveryservices/registration.go
+++ b/internal/services/recoveryservices/registration.go
@@ -28,6 +28,7 @@ func (r Registration) Resources() []sdk.Resource {
 		SiteRecoveryReplicationRecoveryPlanResource{},
 		ReplicationPolicyHyperVResource{},
 		HyperVSiteResource{},
+		HyperVHostRegistrationKeyResource{},
 	}
 }
 

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservices/2022-10-01/vaultcertificates/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservices/2022-10-01/vaultcertificates/README.md
@@ -1,0 +1,41 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservices/2022-10-01/vaultcertificates` Documentation
+
+The `vaultcertificates` SDK allows for interaction with the Azure Resource Manager Service `recoveryservices` (API Version `2022-10-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservices/2022-10-01/vaultcertificates"
+```
+
+
+### Client Initialization
+
+```go
+client := vaultcertificates.NewVaultCertificatesClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `VaultCertificatesClient.Create`
+
+```go
+ctx := context.TODO()
+id := vaultcertificates.NewCertificateID("12345678-1234-9876-4563-123456789012", "example-resource-group", "vaultValue", "certificateValue")
+
+payload := vaultcertificates.CertificateRequest{
+	// ...
+}
+
+
+read, err := client.Create(ctx, id, payload)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservices/2022-10-01/vaultcertificates/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservices/2022-10-01/vaultcertificates/client.go
@@ -1,0 +1,18 @@
+package vaultcertificates
+
+import "github.com/Azure/go-autorest/autorest"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VaultCertificatesClient struct {
+	Client  autorest.Client
+	baseUri string
+}
+
+func NewVaultCertificatesClientWithBaseURI(endpoint string) VaultCertificatesClient {
+	return VaultCertificatesClient{
+		Client:  autorest.NewClientWithUserAgent(userAgent()),
+		baseUri: endpoint,
+	}
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservices/2022-10-01/vaultcertificates/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservices/2022-10-01/vaultcertificates/constants.go
@@ -1,0 +1,43 @@
+package vaultcertificates
+
+import "strings"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AuthType string
+
+const (
+	AuthTypeAAD                  AuthType = "AAD"
+	AuthTypeACS                  AuthType = "ACS"
+	AuthTypeAccessControlService AuthType = "AccessControlService"
+	AuthTypeAzureActiveDirectory AuthType = "AzureActiveDirectory"
+	AuthTypeInvalid              AuthType = "Invalid"
+)
+
+func PossibleValuesForAuthType() []string {
+	return []string{
+		string(AuthTypeAAD),
+		string(AuthTypeACS),
+		string(AuthTypeAccessControlService),
+		string(AuthTypeAzureActiveDirectory),
+		string(AuthTypeInvalid),
+	}
+}
+
+func parseAuthType(input string) (*AuthType, error) {
+	vals := map[string]AuthType{
+		"aad":                  AuthTypeAAD,
+		"acs":                  AuthTypeACS,
+		"accesscontrolservice": AuthTypeAccessControlService,
+		"azureactivedirectory": AuthTypeAzureActiveDirectory,
+		"invalid":              AuthTypeInvalid,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := AuthType(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservices/2022-10-01/vaultcertificates/id_certificate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservices/2022-10-01/vaultcertificates/id_certificate.go
@@ -1,0 +1,137 @@
+package vaultcertificates
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.ResourceId = CertificateId{}
+
+// CertificateId is a struct representing the Resource ID for a Certificate
+type CertificateId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	VaultName         string
+	CertificateName   string
+}
+
+// NewCertificateID returns a new CertificateId struct
+func NewCertificateID(subscriptionId string, resourceGroupName string, vaultName string, certificateName string) CertificateId {
+	return CertificateId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		VaultName:         vaultName,
+		CertificateName:   certificateName,
+	}
+}
+
+// ParseCertificateID parses 'input' into a CertificateId
+func ParseCertificateID(input string) (*CertificateId, error) {
+	parser := resourceids.NewParserFromResourceIdType(CertificateId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := CertificateId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
+		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+	}
+
+	if id.CertificateName, ok = parsed.Parsed["certificateName"]; !ok {
+		return nil, fmt.Errorf("the segment 'certificateName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ParseCertificateIDInsensitively parses 'input' case-insensitively into a CertificateId
+// note: this method should only be used for API response data and not user input
+func ParseCertificateIDInsensitively(input string) (*CertificateId, error) {
+	parser := resourceids.NewParserFromResourceIdType(CertificateId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := CertificateId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+	}
+
+	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
+		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+	}
+
+	if id.CertificateName, ok = parsed.Parsed["certificateName"]; !ok {
+		return nil, fmt.Errorf("the segment 'certificateName' was not found in the resource id %q", input)
+	}
+
+	return &id, nil
+}
+
+// ValidateCertificateID checks that 'input' can be parsed as a Certificate ID
+func ValidateCertificateID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseCertificateID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Certificate ID
+func (id CertificateId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.RecoveryServices/vaults/%s/certificates/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.VaultName, id.CertificateName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Certificate ID
+func (id CertificateId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftRecoveryServices", "Microsoft.RecoveryServices", "Microsoft.RecoveryServices"),
+		resourceids.StaticSegment("staticVaults", "vaults", "vaults"),
+		resourceids.UserSpecifiedSegment("vaultName", "vaultValue"),
+		resourceids.StaticSegment("staticCertificates", "certificates", "certificates"),
+		resourceids.UserSpecifiedSegment("certificateName", "certificateValue"),
+	}
+}
+
+// String returns a human-readable description of this Certificate ID
+func (id CertificateId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Vault Name: %q", id.VaultName),
+		fmt.Sprintf("Certificate Name: %q", id.CertificateName),
+	}
+	return fmt.Sprintf("Certificate (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservices/2022-10-01/vaultcertificates/method_create_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservices/2022-10-01/vaultcertificates/method_create_autorest.go
@@ -1,0 +1,69 @@
+package vaultcertificates
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CreateOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *VaultCertificateResponse
+}
+
+// Create ...
+func (c VaultCertificatesClient) Create(ctx context.Context, id CertificateId, input CertificateRequest) (result CreateOperationResponse, err error) {
+	req, err := c.preparerForCreate(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "vaultcertificates.VaultCertificatesClient", "Create", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "vaultcertificates.VaultCertificatesClient", "Create", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForCreate(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "vaultcertificates.VaultCertificatesClient", "Create", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForCreate prepares the Create request.
+func (c VaultCertificatesClient) preparerForCreate(ctx context.Context, id CertificateId, input CertificateRequest) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPut(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForCreate handles the response to the Create request. The method always
+// closes the http.Response Body.
+func (c VaultCertificatesClient) responderForCreate(resp *http.Response) (result CreateOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservices/2022-10-01/vaultcertificates/model_certificaterequest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservices/2022-10-01/vaultcertificates/model_certificaterequest.go
@@ -1,0 +1,8 @@
+package vaultcertificates
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CertificateRequest struct {
+	Properties *RawCertificateData `json:"properties,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservices/2022-10-01/vaultcertificates/model_rawcertificatedata.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservices/2022-10-01/vaultcertificates/model_rawcertificatedata.go
@@ -1,0 +1,9 @@
+package vaultcertificates
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RawCertificateData struct {
+	AuthType    *AuthType `json:"authType,omitempty"`
+	Certificate *string   `json:"certificate,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservices/2022-10-01/vaultcertificates/model_resourcecertificateandaaddetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservices/2022-10-01/vaultcertificates/model_resourcecertificateandaaddetails.go
@@ -1,0 +1,82 @@
+package vaultcertificates
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ResourceCertificateDetails = ResourceCertificateAndAadDetails{}
+
+type ResourceCertificateAndAadDetails struct {
+	AadAudience                     *string `json:"aadAudience,omitempty"`
+	AadAuthority                    string  `json:"aadAuthority"`
+	AadTenantId                     string  `json:"aadTenantId"`
+	AzureManagementEndpointAudience string  `json:"azureManagementEndpointAudience"`
+	ServicePrincipalClientId        string  `json:"servicePrincipalClientId"`
+	ServicePrincipalObjectId        string  `json:"servicePrincipalObjectId"`
+	ServiceResourceId               *string `json:"serviceResourceId,omitempty"`
+
+	// Fields inherited from ResourceCertificateDetails
+	Certificate  *string `json:"certificate,omitempty"`
+	FriendlyName *string `json:"friendlyName,omitempty"`
+	Issuer       *string `json:"issuer,omitempty"`
+	ResourceId   *int64  `json:"resourceId,omitempty"`
+	Subject      *string `json:"subject,omitempty"`
+	Thumbprint   *string `json:"thumbprint,omitempty"`
+	ValidFrom    *string `json:"validFrom,omitempty"`
+	ValidTo      *string `json:"validTo,omitempty"`
+}
+
+func (o *ResourceCertificateAndAadDetails) GetValidFromAsTime() (*time.Time, error) {
+	if o.ValidFrom == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.ValidFrom, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *ResourceCertificateAndAadDetails) SetValidFromAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.ValidFrom = &formatted
+}
+
+func (o *ResourceCertificateAndAadDetails) GetValidToAsTime() (*time.Time, error) {
+	if o.ValidTo == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.ValidTo, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *ResourceCertificateAndAadDetails) SetValidToAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.ValidTo = &formatted
+}
+
+var _ json.Marshaler = ResourceCertificateAndAadDetails{}
+
+func (s ResourceCertificateAndAadDetails) MarshalJSON() ([]byte, error) {
+	type wrapper ResourceCertificateAndAadDetails
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling ResourceCertificateAndAadDetails: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling ResourceCertificateAndAadDetails: %+v", err)
+	}
+	decoded["authType"] = "AzureActiveDirectory"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling ResourceCertificateAndAadDetails: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservices/2022-10-01/vaultcertificates/model_resourcecertificateandacsdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservices/2022-10-01/vaultcertificates/model_resourcecertificateandacsdetails.go
@@ -1,0 +1,78 @@
+package vaultcertificates
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ResourceCertificateDetails = ResourceCertificateAndAcsDetails{}
+
+type ResourceCertificateAndAcsDetails struct {
+	GlobalAcsHostName  string `json:"globalAcsHostName"`
+	GlobalAcsNamespace string `json:"globalAcsNamespace"`
+	GlobalAcsRPRealm   string `json:"globalAcsRPRealm"`
+
+	// Fields inherited from ResourceCertificateDetails
+	Certificate  *string `json:"certificate,omitempty"`
+	FriendlyName *string `json:"friendlyName,omitempty"`
+	Issuer       *string `json:"issuer,omitempty"`
+	ResourceId   *int64  `json:"resourceId,omitempty"`
+	Subject      *string `json:"subject,omitempty"`
+	Thumbprint   *string `json:"thumbprint,omitempty"`
+	ValidFrom    *string `json:"validFrom,omitempty"`
+	ValidTo      *string `json:"validTo,omitempty"`
+}
+
+func (o *ResourceCertificateAndAcsDetails) GetValidFromAsTime() (*time.Time, error) {
+	if o.ValidFrom == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.ValidFrom, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *ResourceCertificateAndAcsDetails) SetValidFromAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.ValidFrom = &formatted
+}
+
+func (o *ResourceCertificateAndAcsDetails) GetValidToAsTime() (*time.Time, error) {
+	if o.ValidTo == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.ValidTo, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *ResourceCertificateAndAcsDetails) SetValidToAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.ValidTo = &formatted
+}
+
+var _ json.Marshaler = ResourceCertificateAndAcsDetails{}
+
+func (s ResourceCertificateAndAcsDetails) MarshalJSON() ([]byte, error) {
+	type wrapper ResourceCertificateAndAcsDetails
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling ResourceCertificateAndAcsDetails: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling ResourceCertificateAndAcsDetails: %+v", err)
+	}
+	decoded["authType"] = "AccessControlService"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling ResourceCertificateAndAcsDetails: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservices/2022-10-01/vaultcertificates/model_resourcecertificatedetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservices/2022-10-01/vaultcertificates/model_resourcecertificatedetails.go
@@ -1,0 +1,56 @@
+package vaultcertificates
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ResourceCertificateDetails interface {
+}
+
+func unmarshalResourceCertificateDetailsImplementation(input []byte) (ResourceCertificateDetails, error) {
+	if input == nil {
+		return nil, nil
+	}
+
+	var temp map[string]interface{}
+	if err := json.Unmarshal(input, &temp); err != nil {
+		return nil, fmt.Errorf("unmarshaling ResourceCertificateDetails into map[string]interface: %+v", err)
+	}
+
+	value, ok := temp["authType"].(string)
+	if !ok {
+		return nil, nil
+	}
+
+	if strings.EqualFold(value, "AzureActiveDirectory") {
+		var out ResourceCertificateAndAadDetails
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into ResourceCertificateAndAadDetails: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "AccessControlService") {
+		var out ResourceCertificateAndAcsDetails
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into ResourceCertificateAndAcsDetails: %+v", err)
+		}
+		return out, nil
+	}
+
+	type RawResourceCertificateDetailsImpl struct {
+		Type   string                 `json:"-"`
+		Values map[string]interface{} `json:"-"`
+	}
+	out := RawResourceCertificateDetailsImpl{
+		Type:   value,
+		Values: temp,
+	}
+	return out, nil
+
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservices/2022-10-01/vaultcertificates/model_vaultcertificateresponse.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservices/2022-10-01/vaultcertificates/model_vaultcertificateresponse.go
@@ -1,0 +1,44 @@
+package vaultcertificates
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VaultCertificateResponse struct {
+	Id         *string                    `json:"id,omitempty"`
+	Name       *string                    `json:"name,omitempty"`
+	Properties ResourceCertificateDetails `json:"properties"`
+	Type       *string                    `json:"type,omitempty"`
+}
+
+var _ json.Unmarshaler = &VaultCertificateResponse{}
+
+func (s *VaultCertificateResponse) UnmarshalJSON(bytes []byte) error {
+	type alias VaultCertificateResponse
+	var decoded alias
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling into VaultCertificateResponse: %+v", err)
+	}
+
+	s.Id = decoded.Id
+	s.Name = decoded.Name
+	s.Type = decoded.Type
+
+	var temp map[string]json.RawMessage
+	if err := json.Unmarshal(bytes, &temp); err != nil {
+		return fmt.Errorf("unmarshaling VaultCertificateResponse into map[string]json.RawMessage: %+v", err)
+	}
+
+	if v, ok := temp["properties"]; ok {
+		impl, err := unmarshalResourceCertificateDetailsImplementation(v)
+		if err != nil {
+			return fmt.Errorf("unmarshaling field 'Properties' for 'VaultCertificateResponse': %+v", err)
+		}
+		s.Properties = impl
+	}
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservices/2022-10-01/vaultcertificates/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservices/2022-10-01/vaultcertificates/version.go
@@ -1,0 +1,12 @@
+package vaultcertificates
+
+import "fmt"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2022-10-01"
+
+func userAgent() string {
+	return fmt.Sprintf("hashicorp/go-azure-sdk/vaultcertificates/%s", defaultApiVersion)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -438,6 +438,7 @@ github.com/hashicorp/go-azure-sdk/resource-manager/privatedns/2018-09-01/private
 github.com/hashicorp/go-azure-sdk/resource-manager/privatedns/2018-09-01/recordsets
 github.com/hashicorp/go-azure-sdk/resource-manager/privatedns/2018-09-01/virtualnetworklinks
 github.com/hashicorp/go-azure-sdk/resource-manager/purview/2021-07-01/account
+github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservices/2022-10-01/vaultcertificates
 github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservices/2022-10-01/vaults
 github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2021-12-01/backupresourcestorageconfigsnoncrr
 github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2021-12-01/backupresourcevaultconfigs


### PR DESCRIPTION
It's a little wired resource which only expose `Create` API... 

test
---
```
terraform-provider-azurerm ❯ TF_ACC=1 go test -v ./internal/services/recoveryservices -run=TestAccRecoveryServicesVaultHyperVHostRegistrationKey_basic -timeout=600m
=== RUN   TestAccRecoveryServicesVaultHyperVHostRegistrationKey_basic
=== PAUSE TestAccRecoveryServicesVaultHyperVHostRegistrationKey_basic
=== CONT  TestAccRecoveryServicesVaultHyperVHostRegistrationKey_basic
--- PASS: TestAccRecoveryServicesVaultHyperVHostRegistrationKey_basic (421.70s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/recoveryservices      422.954s
```