### PR TITLE
azurerm_monitor_action_group - Add optional location parameter and default to Global #20151

### DIFF
--- a/internal/services/monitor/monitor_action_group_resource.go
+++ b/internal/services/monitor/monitor_action_group_resource.go
@@ -589,6 +589,7 @@ func resourceMonitorActionGroupRead(d *pluginsdk.ResourceData, meta interface{})
 
 	d.Set("name", id.Name)
 	d.Set("resource_group_name", id.ResourceGroup)
+	d.Set("location", location.NormalizeNilable(resp.Location))
 
 	if group := resp.ActionGroup; group != nil {
 		d.Set("short_name", group.GroupShortName)

--- a/internal/services/monitor/monitor_action_group_resource.go
+++ b/internal/services/monitor/monitor_action_group_resource.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func resourceMonitorActionGroup() *pluginsdk.Resource {

--- a/internal/services/monitor/monitor_action_group_resource.go
+++ b/internal/services/monitor/monitor_action_group_resource.go
@@ -58,6 +58,13 @@ func resourceMonitorActionGroup() *pluginsdk.Resource {
 
 			"resource_group_name": commonschema.ResourceGroupName(),
 
+			"location": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				Default:  "Global",
+				ForceNew: true,
+			},
+
 			"short_name": {
 				Type:         pluginsdk.TypeString,
 				Required:     true,
@@ -476,6 +483,7 @@ func resourceMonitorActionGroupCreateUpdate(d *pluginsdk.ResourceData, meta inte
 	client := meta.(*clients.Client).Monitor.ActionGroupsClient
 	tenantId := meta.(*clients.Client).Account.TenantId
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
+	location := d.Get("location").(string)
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -523,7 +531,7 @@ func resourceMonitorActionGroupCreateUpdate(d *pluginsdk.ResourceData, meta inte
 	expandedTags := tags.Expand(t)
 
 	parameters := insights.ActionGroupResource{
-		Location: utils.String(azure.NormalizeLocation("Global")),
+		Location: utils.String(location),
 		ActionGroup: &insights.ActionGroup{
 			GroupShortName:             utils.String(shortName),
 			Enabled:                    utils.Bool(enabled),

--- a/internal/services/monitor/monitor_action_group_resource.go
+++ b/internal/services/monitor/monitor_action_group_resource.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2021-11-01/eventhubs"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -22,7 +23,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func resourceMonitorActionGroup() *pluginsdk.Resource {
@@ -60,11 +60,11 @@ func resourceMonitorActionGroup() *pluginsdk.Resource {
 			"resource_group_name": commonschema.ResourceGroupName(),
 
 			"location": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				ForceNew:         true,
-				Default:          "global",
-				ValidateFunc:     validation.Any(
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Default:  "global",
+				ValidateFunc: validation.Any(
 					location.EnhancedValidate,
 					validation.StringInSlice([]string{
 						"global",

--- a/internal/services/monitor/monitor_action_group_resource.go
+++ b/internal/services/monitor/monitor_action_group_resource.go
@@ -59,10 +59,18 @@ func resourceMonitorActionGroup() *pluginsdk.Resource {
 			"resource_group_name": commonschema.ResourceGroupName(),
 
 			"location": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				Default:  "Global",
-				ForceNew: true,
+				Type:             schema.TypeString,
+				Optional:         true,
+				ForceNew:         true,
+				Default:          "global",
+				ValidateFunc:     validation.Any(
+					location.EnhancedValidate,
+					validation.StringInSlice([]string{
+						"global",
+					}, false),
+				),
+				StateFunc:        location.StateFunc,
+				DiffSuppressFunc: location.DiffSuppressFunc,
 			},
 
 			"short_name": {
@@ -483,7 +491,7 @@ func resourceMonitorActionGroupCreateUpdate(d *pluginsdk.ResourceData, meta inte
 	client := meta.(*clients.Client).Monitor.ActionGroupsClient
 	tenantId := meta.(*clients.Client).Account.TenantId
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
-	location := d.Get("location").(string)
+	location := location.Normalize(d.Get("location").(string))
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 

--- a/internal/services/monitor/monitor_action_group_resource_test.go
+++ b/internal/services/monitor/monitor_action_group_resource_test.go
@@ -1195,7 +1195,7 @@ resource "azurerm_monitor_action_group" "test" {
   resource_group_name = azurerm_resource_group.test.name
   short_name          = "acctestag"
   enabled             = false
-  location	          = "swedencentral"
+  location            = "swedencentral"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/internal/services/monitor/monitor_action_group_resource_test.go
+++ b/internal/services/monitor/monitor_action_group_resource_test.go
@@ -325,7 +325,7 @@ func TestAccMonitorActionGroup_locationBasic(t *testing.T) {
 			Config: r.locationBasic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("enabled").HasValue("global"),
+				check.That(data.ResourceName).Key("location").HasValue("global"),
 			),
 		},
 		data.ImportStep(),

--- a/internal/services/monitor/monitor_action_group_resource_test.go
+++ b/internal/services/monitor/monitor_action_group_resource_test.go
@@ -1179,7 +1179,7 @@ func (t MonitorActionGroupResource) Exists(ctx context.Context, clients *clients
 	return utils.Bool(resp.ID != nil), nil
 }
 
-func (MonitorActionGroupResource) locationBasic(data acceptance.TestData) string {
+func (MonitorActionGroupResource) location(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -1195,7 +1195,7 @@ resource "azurerm_monitor_action_group" "test" {
   resource_group_name = azurerm_resource_group.test.name
   short_name          = "acctestag"
   enabled             = false
-  location	          = "global"
+  location	          = "swedencentral"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/internal/services/monitor/monitor_action_group_resource_test.go
+++ b/internal/services/monitor/monitor_action_group_resource_test.go
@@ -300,32 +300,15 @@ func TestAccMonitorActionGroup_disabledUpdate(t *testing.T) {
 	})
 }
 
-func TestAccMonitorActionGroup_locationBasic(t *testing.T) {
+func TestAccMonitorActionGroup_location(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_monitor_action_group", "test")
 	r := MonitorActionGroupResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.locationBasic(data),
+			Config: r.location(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("location").HasValue("global"),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.basic(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("location").HasValue("global"),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.locationBasic(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("location").HasValue("global"),
 			),
 		},
 		data.ImportStep(),

--- a/internal/services/monitor/monitor_action_group_resource_test.go
+++ b/internal/services/monitor/monitor_action_group_resource_test.go
@@ -1212,7 +1212,7 @@ resource "azurerm_monitor_action_group" "test" {
   resource_group_name = azurerm_resource_group.test.name
   short_name          = "acctestag"
   enabled             = false
-  location	      = "global"
+  location	          = "global"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/internal/services/monitor/monitor_action_group_resource_test.go
+++ b/internal/services/monitor/monitor_action_group_resource_test.go
@@ -300,6 +300,38 @@ func TestAccMonitorActionGroup_disabledUpdate(t *testing.T) {
 	})
 }
 
+func TestAccMonitorActionGroup_locationBasic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_monitor_action_group", "test")
+	r := MonitorActionGroupResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.locationBasic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("location").HasValue("global"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("location").HasValue("global"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.locationBasic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("enabled").HasValue("global"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccMonitorActionGroup_singleReceiverUpdate(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_monitor_action_group", "test")
 	r := MonitorActionGroupResource{}
@@ -1162,4 +1194,25 @@ func (t MonitorActionGroupResource) Exists(ctx context.Context, clients *clients
 	}
 
 	return utils.Bool(resp.ID != nil), nil
+}
+
+func (MonitorActionGroupResource) locationBasic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_monitor_action_group" "test" {
+  name                = "acctestActionGroup-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  short_name          = "acctestag"
+  enabled             = false
+  location	      = "global"
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/website/docs/r/monitor_action_group.html.markdown
+++ b/website/docs/r/monitor_action_group.html.markdown
@@ -122,7 +122,6 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the Action Group. Changing this forces a new resource to be created. 
 * `resource_group_name` - (Required) The name of the resource group in which to create the Action Group instance. Changing this forces a new resource to be created.
-* `location` - (Optional) The Azure Region where the Action Group should exist. Changing this forces a new Action Group to be created. Defaults to `global`.
 * `short_name` - (Required) The short name of the action group. This will be used in SMS messages.
 * `enabled` - (Optional) Whether this action group is enabled. If an action group is not enabled, then none of its receivers will receive communications. Defaults to `true`.
 * `arm_role_receiver` - (Optional) One or more `arm_role_receiver` blocks as defined below.
@@ -132,6 +131,7 @@ The following arguments are supported:
 * `email_receiver` - (Optional) One or more `email_receiver` blocks as defined below.
 * `event_hub_receiver` - (Optional) One or more `event_hub_receiver` blocks as defined below.
 * `itsm_receiver` - (Optional) One or more `itsm_receiver` blocks as defined below.
+* `location` - (Optional) The Azure Region where the Action Group should exist. Changing this forces a new Action Group to be created. Defaults to `global`.
 * `logic_app_receiver` - (Optional) One or more `logic_app_receiver` blocks as defined below.
 * `sms_receiver` - (Optional) One or more `sms_receiver` blocks as defined below.
 * `voice_receiver` - (Optional) One or more `voice_receiver` blocks as defined below.

--- a/website/docs/r/monitor_action_group.html.markdown
+++ b/website/docs/r/monitor_action_group.html.markdown
@@ -122,6 +122,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the Action Group. Changing this forces a new resource to be created. 
 * `resource_group_name` - (Required) The name of the resource group in which to create the Action Group instance. Changing this forces a new resource to be created.
+* `location` - (Optional) The Azure Region where the Action Group should exist. Changing this forces a new Action Group to be created. Defaults to `Global`.
 * `short_name` - (Required) The short name of the action group. This will be used in SMS messages.
 * `enabled` - (Optional) Whether this action group is enabled. If an action group is not enabled, then none of its receivers will receive communications. Defaults to `true`.
 * `arm_role_receiver` - (Optional) One or more `arm_role_receiver` blocks as defined below.

--- a/website/docs/r/monitor_action_group.html.markdown
+++ b/website/docs/r/monitor_action_group.html.markdown
@@ -122,7 +122,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the Action Group. Changing this forces a new resource to be created. 
 * `resource_group_name` - (Required) The name of the resource group in which to create the Action Group instance. Changing this forces a new resource to be created.
-* `location` - (Optional) The Azure Region where the Action Group should exist. Changing this forces a new Action Group to be created. Defaults to `Global`.
+* `location` - (Optional) The Azure Region where the Action Group should exist. Changing this forces a new Action Group to be created. Defaults to `global`.
 * `short_name` - (Required) The short name of the action group. This will be used in SMS messages.
 * `enabled` - (Optional) Whether this action group is enabled. If an action group is not enabled, then none of its receivers will receive communications. Defaults to `true`.
 * `arm_role_receiver` - (Optional) One or more `arm_role_receiver` blocks as defined below.


### PR DESCRIPTION
- Add location parameter to this issue: https://github.com/hashicorp/terraform-provider-azurerm/issues/20151 #20151
  - Location defaults to **global** to avoid breaking current configs for users
  - Location forces new one to be created when changing locations
  - Updated document to reflect the new parameter   
