### PR TITLE
`azurerm_monitor_diagnostic_setting` - remove explicitly disable `log` in Update

### DIFF
--- a/internal/services/monitor/monitor_diagnostic_setting_resource.go
+++ b/internal/services/monitor/monitor_diagnostic_setting_resource.go
@@ -97,7 +97,7 @@ func resourceMonitorDiagnosticSetting() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
 				ForceNew: false,
-				Default:  "AzureDiagnostics",
+				Computed: true,
 				ValidateFunc: validation.StringInSlice([]string{
 					"Dedicated",
 					"AzureDiagnostics", // Not documented in azure API, but some resource has skew. See: https://github.com/Azure/azure-rest-api-specs/issues/9281
@@ -411,52 +411,6 @@ func resourceMonitorDiagnosticSettingUpdate(d *pluginsdk.ResourceData, meta inte
 
 	if !hasEnabledMetrics && !hasEnabledLogs {
 		return fmt.Errorf("at least one type of Log or Metric must be enabled")
-	}
-
-	if d.HasChange("enabled_log") {
-		oldEnabledLogs, newEnabledLogs := d.GetChange("enabled_log")
-
-		for _, oldLog := range oldEnabledLogs.(*pluginsdk.Set).List() {
-			logRemoved := true
-			oldLogMap := oldLog.(map[string]interface{})
-
-			for _, newLog := range newEnabledLogs.(*pluginsdk.Set).List() {
-				newLogMap := newLog.(map[string]interface{})
-
-				// check if an enabled_log has been removed from config and if so, set to disabled
-				if (oldLogMap["category"].(string) != "" && strings.EqualFold(oldLogMap["category"].(string), newLogMap["category"].(string))) || (oldLogMap["category_group"].(string) != "" && strings.EqualFold(oldLogMap["category_group"].(string), newLogMap["category_group"].(string))) {
-					logRemoved = false
-					break
-				}
-			}
-
-			if logRemoved {
-
-				disabledLog := diagnosticsettings.LogSettings{
-					Category:      utils.String(oldLogMap["category"].(string)),
-					CategoryGroup: utils.String(oldLogMap["category_group"].(string)),
-					Enabled:       false,
-				}
-
-				retentionPolicy := diagnosticsettings.RetentionPolicy{}
-				if v, ok := oldLogMap["retention_policy"].([]interface{}); ok {
-					if len(v) > 0 {
-
-						policyMap := v[0].(map[string]interface{})
-						if days, ok := policyMap["days"].(int); ok {
-							retentionPolicy.Days = int64(days)
-						}
-
-						if enabled, ok := policyMap["enabled"].(bool); ok {
-							retentionPolicy.Enabled = enabled
-						}
-					}
-				}
-				disabledLog.RetentionPolicy = &retentionPolicy
-
-				logs = append(logs, disabledLog)
-			}
-		}
 	}
 
 	parameters := diagnosticsettings.DiagnosticSettingsResource{

--- a/internal/services/monitor/monitor_diagnostic_setting_resource_test.go
+++ b/internal/services/monitor/monitor_diagnostic_setting_resource_test.go
@@ -189,6 +189,14 @@ func TestAccMonitorDiagnosticSetting_enabledLogs(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
+			Config: r.enabledLogsCategoryGroup(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("enabled_log.#").HasValue("1"),
+			),
+		},
+		data.ImportStep(),
+		{
 			Config: r.enabledLogsUpdated(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
@@ -884,7 +892,6 @@ resource "azurerm_monitor_diagnostic_setting" "test" {
   target_resource_id             = azurerm_key_vault.test.id
   eventhub_authorization_rule_id = azurerm_eventhub_namespace_authorization_rule.test.id
   eventhub_name                  = azurerm_eventhub.test.name
-  log_analytics_destination_type = "AzureDiagnostics"
 
   enabled_log {
     category = "AuditEvent"
@@ -897,6 +904,80 @@ resource "azurerm_monitor_diagnostic_setting" "test" {
 
   enabled_log {
     category = "AzurePolicyEvaluationDetails"
+
+    retention_policy {
+      days    = 0
+      enabled = false
+    }
+  }
+
+  metric {
+    category = "AllMetrics"
+    enabled  = true
+
+    retention_policy {
+      enabled = false
+      days    = 7
+    }
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomIntOfLength(17))
+}
+
+func (MonitorDiagnosticSettingResource) enabledLogsCategoryGroup(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_client_config" "current" {
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_eventhub_namespace" "test" {
+  name                = "acctest-EHN-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "Basic"
+}
+
+resource "azurerm_eventhub" "test" {
+  name                = "acctest-EH-%[1]d"
+  namespace_name      = azurerm_eventhub_namespace.test.name
+  resource_group_name = azurerm_resource_group.test.name
+  partition_count     = 2
+  message_retention   = 1
+}
+
+resource "azurerm_eventhub_namespace_authorization_rule" "test" {
+  name                = "example"
+  namespace_name      = azurerm_eventhub_namespace.test.name
+  resource_group_name = azurerm_resource_group.test.name
+  listen              = true
+  send                = true
+  manage              = true
+}
+
+resource "azurerm_key_vault" "test" {
+  name                = "acctest%[3]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  tenant_id           = data.azurerm_client_config.current.tenant_id
+  sku_name            = "standard"
+}
+
+resource "azurerm_monitor_diagnostic_setting" "test" {
+  name                           = "acctest-DS-%[1]d"
+  target_resource_id             = azurerm_key_vault.test.id
+  eventhub_authorization_rule_id = azurerm_eventhub_namespace_authorization_rule.test.id
+  eventhub_name                  = azurerm_eventhub.test.name
+
+  enabled_log {
+    category_group = "allLogs"
 
     retention_policy {
       days    = 0
@@ -968,7 +1049,6 @@ resource "azurerm_monitor_diagnostic_setting" "test" {
   target_resource_id             = azurerm_key_vault.test.id
   eventhub_authorization_rule_id = azurerm_eventhub_namespace_authorization_rule.test.id
   eventhub_name                  = azurerm_eventhub.test.name
-  log_analytics_destination_type = "AzureDiagnostics"
 
   enabled_log {
     category = "AuditEvent"


### PR DESCRIPTION
resolves https://github.com/hashicorp/terraform-provider-azurerm/issues/20554
A diagnostic setting must use either `category_group`  or `category` in `log`(also `enabled_log`) block. The service API cannot accept diable a log with `category_group` and enable log with `category` at the same time, see https://github.com/Azure/azure-rest-api-specs/issues/22719

By test, we don't need to explicitly disable the logs in update. Some changes are to pass the acc test, relaetd to https://github.com/hashicorp/terraform-provider-azurerm/pull/20203

```
TF_ACC=1 go test -v ./internal/services/monitor -parallel 20 -test.run=TestAccMonitorDiagnosticSetting_enabledLogs -timeout 1440m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccMonitorDiagnosticSetting_enabledLogs
=== PAUSE TestAccMonitorDiagnosticSetting_enabledLogs
=== CONT  TestAccMonitorDiagnosticSetting_enabledLogs
--- PASS: TestAccMonitorDiagnosticSetting_enabledLogs (507.91s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/monitor       509.859s

```
