### PR TITLE
`azurerm_express_route_connection` - Support `inbound_route_map_id`, `outbound_route_map_id`, `enabled_private_link_fast_path`

### DIFF
--- a/internal/services/network/express_route_connection_resource.go
+++ b/internal/services/network/express_route_connection_resource.go
@@ -68,7 +68,7 @@ func resourceExpressRouteConnection() *pluginsdk.Resource {
 				Optional: true,
 			},
 
-			"enabled_express_route_gateway_bypass": {
+			"express_route_gateway_bypass_enabled": {
 				Type:     pluginsdk.TypeBool,
 				Optional: true,
 				Default:  false,
@@ -179,7 +179,7 @@ func resourceExpressRouteConnectionCreate(d *pluginsdk.ResourceData, meta interf
 			EnableInternetSecurity:    utils.Bool(d.Get("enable_internet_security").(bool)),
 			RoutingConfiguration:      expandExpressRouteConnectionRouting(d.Get("routing").([]interface{})),
 			RoutingWeight:             utils.Int32(int32(d.Get("routing_weight").(int))),
-			ExpressRouteGatewayBypass: utils.Bool(d.Get("enabled_express_route_gateway_bypass").(bool)),
+			ExpressRouteGatewayBypass: utils.Bool(d.Get("express_route_gateway_bypass_enabled").(bool)),
 		},
 	}
 
@@ -229,7 +229,7 @@ func resourceExpressRouteConnectionRead(d *pluginsdk.ResourceData, meta interfac
 		d.Set("enable_internet_security", props.EnableInternetSecurity)
 
 		if props.ExpressRouteGatewayBypass != nil {
-			d.Set("enabled_express_route_gateway_bypass", props.ExpressRouteGatewayBypass)
+			d.Set("express_route_gateway_bypass_enabled", props.ExpressRouteGatewayBypass)
 		}
 
 		circuitPeeringID := ""
@@ -273,7 +273,7 @@ func resourceExpressRouteConnectionUpdate(d *pluginsdk.ResourceData, meta interf
 			EnableInternetSecurity:    utils.Bool(d.Get("enable_internet_security").(bool)),
 			RoutingConfiguration:      expandExpressRouteConnectionRouting(d.Get("routing").([]interface{})),
 			RoutingWeight:             utils.Int32(int32(d.Get("routing_weight").(int))),
-			ExpressRouteGatewayBypass: utils.Bool(d.Get("enabled_express_route_gateway_bypass").(bool)),
+			ExpressRouteGatewayBypass: utils.Bool(d.Get("express_route_gateway_bypass_enabled").(bool)),
 		},
 	}
 

--- a/internal/services/network/express_route_connection_resource.go
+++ b/internal/services/network/express_route_connection_resource.go
@@ -68,6 +68,12 @@ func resourceExpressRouteConnection() *pluginsdk.Resource {
 				Optional: true,
 			},
 
+			"enabled_express_route_gateway_bypass": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
 			"routing": {
 				Type:     pluginsdk.TypeList,
 				Optional: true,
@@ -75,6 +81,18 @@ func resourceExpressRouteConnection() *pluginsdk.Resource {
 				MaxItems: 1,
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
+						"inbound_route_map_id": {
+							Type:         pluginsdk.TypeString,
+							Optional:     true,
+							ValidateFunc: validate.RouteMapID,
+						},
+
+						"outbound_route_map_id": {
+							Type:         pluginsdk.TypeString,
+							Optional:     true,
+							ValidateFunc: validate.RouteMapID,
+						},
+
 						"associated_route_table_id": {
 							Type:         pluginsdk.TypeString,
 							Optional:     true,
@@ -158,9 +176,10 @@ func resourceExpressRouteConnectionCreate(d *pluginsdk.ResourceData, meta interf
 			ExpressRouteCircuitPeering: &network.ExpressRouteCircuitPeeringID{
 				ID: utils.String(d.Get("express_route_circuit_peering_id").(string)),
 			},
-			EnableInternetSecurity: utils.Bool(d.Get("enable_internet_security").(bool)),
-			RoutingConfiguration:   expandExpressRouteConnectionRouting(d.Get("routing").([]interface{})),
-			RoutingWeight:          utils.Int32(int32(d.Get("routing_weight").(int))),
+			EnableInternetSecurity:    utils.Bool(d.Get("enable_internet_security").(bool)),
+			RoutingConfiguration:      expandExpressRouteConnectionRouting(d.Get("routing").([]interface{})),
+			RoutingWeight:             utils.Int32(int32(d.Get("routing_weight").(int))),
+			ExpressRouteGatewayBypass: utils.Bool(d.Get("enabled_express_route_gateway_bypass").(bool)),
 		},
 	}
 
@@ -209,6 +228,10 @@ func resourceExpressRouteConnectionRead(d *pluginsdk.ResourceData, meta interfac
 		d.Set("authorization_key", props.AuthorizationKey)
 		d.Set("enable_internet_security", props.EnableInternetSecurity)
 
+		if props.ExpressRouteGatewayBypass != nil {
+			d.Set("enabled_express_route_gateway_bypass", props.ExpressRouteGatewayBypass)
+		}
+
 		circuitPeeringID := ""
 		if v := props.ExpressRouteCircuitPeering; v != nil {
 			circuitPeeringID = *v.ID
@@ -247,9 +270,10 @@ func resourceExpressRouteConnectionUpdate(d *pluginsdk.ResourceData, meta interf
 			ExpressRouteCircuitPeering: &network.ExpressRouteCircuitPeeringID{
 				ID: utils.String(d.Get("express_route_circuit_peering_id").(string)),
 			},
-			EnableInternetSecurity: utils.Bool(d.Get("enable_internet_security").(bool)),
-			RoutingConfiguration:   expandExpressRouteConnectionRouting(d.Get("routing").([]interface{})),
-			RoutingWeight:          utils.Int32(int32(d.Get("routing_weight").(int))),
+			EnableInternetSecurity:    utils.Bool(d.Get("enable_internet_security").(bool)),
+			RoutingConfiguration:      expandExpressRouteConnectionRouting(d.Get("routing").([]interface{})),
+			RoutingWeight:             utils.Int32(int32(d.Get("routing_weight").(int))),
+			ExpressRouteGatewayBypass: utils.Bool(d.Get("enabled_express_route_gateway_bypass").(bool)),
 		},
 	}
 
@@ -305,6 +329,18 @@ func expandExpressRouteConnectionRouting(input []interface{}) *network.RoutingCo
 		}
 	}
 
+	if inboundRouteMapId := v["inbound_route_map_id"].(string); inboundRouteMapId != "" {
+		result.InboundRouteMap = &network.SubResource{
+			ID: utils.String(inboundRouteMapId),
+		}
+	}
+
+	if outboundRouteMapId := v["outbound_route_map_id"].(string); outboundRouteMapId != "" {
+		result.OutboundRouteMap = &network.SubResource{
+			ID: utils.String(outboundRouteMapId),
+		}
+	}
+
 	if propagatedRouteTable := v["propagated_route_table"].([]interface{}); len(propagatedRouteTable) != 0 {
 		result.PropagatedRouteTables = expandExpressRouteConnectionPropagatedRouteTable(propagatedRouteTable)
 	}
@@ -346,12 +382,20 @@ func flattenExpressRouteConnectionRouting(input *network.RoutingConfiguration) (
 		return nil, err
 	}
 
-	return []interface{}{
-		map[string]interface{}{
-			"associated_route_table_id": routeTableId.ID(),
-			"propagated_route_table":    flattenExpressRouteConnectionPropagatedRouteTable(input.PropagatedRouteTables),
-		},
-	}, nil
+	result := map[string]interface{}{
+		"associated_route_table_id": routeTableId.ID(),
+		"propagated_route_table":    flattenExpressRouteConnectionPropagatedRouteTable(input.PropagatedRouteTables),
+	}
+
+	if input.InboundRouteMap != nil && input.InboundRouteMap.ID != nil {
+		result["inbound_route_map_id"] = input.InboundRouteMap.ID
+	}
+
+	if input.OutboundRouteMap != nil && input.OutboundRouteMap.ID != nil {
+		result["outbound_route_map_id"] = input.OutboundRouteMap.ID
+	}
+
+	return []interface{}{result}, nil
 }
 
 func flattenExpressRouteConnectionPropagatedRouteTable(input *network.PropagatedRouteTable) []interface{} {

--- a/internal/services/network/express_route_connection_resource_test.go
+++ b/internal/services/network/express_route_connection_resource_test.go
@@ -86,14 +86,7 @@ func testAccExpressRouteConnection_update(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
-			Config: r.complete(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.basic(data),
+			Config: r.update(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -166,6 +159,81 @@ resource "azurerm_express_route_connection" "test" {
       route_table_ids = [azurerm_virtual_hub.test.default_route_table_id]
     }
   }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r ExpressRouteConnectionResource) update(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_route_map" "routemap1" {
+  name           = "routemapfirst"
+  virtual_hub_id = azurerm_virtual_hub.test.id
+
+  rule {
+    name                 = "rule1"
+    next_step_if_matched = "Continue"
+
+    action {
+      type = "Add"
+
+      parameter {
+        as_path = ["22334"]
+      }
+    }
+
+    match_criterion {
+      match_condition = "Contains"
+      route_prefix    = ["10.0.0.0/8"]
+    }
+  }
+}
+
+resource "azurerm_route_map" "routemap2" {
+  name           = "routemapsecond"
+  virtual_hub_id = azurerm_virtual_hub.test.id
+
+  rule {
+    name                 = "rule1"
+    next_step_if_matched = "Continue"
+
+    action {
+      type = "Add"
+
+      parameter {
+        as_path = ["22334"]
+      }
+    }
+
+    match_criterion {
+      match_condition = "Contains"
+      route_prefix    = ["10.0.0.0/8"]
+    }
+  }
+}
+
+resource "azurerm_express_route_connection" "test" {
+  name                                 = "acctest-ExpressRouteConnection-%d"
+  express_route_gateway_id             = azurerm_express_route_gateway.test.id
+  express_route_circuit_peering_id     = azurerm_express_route_circuit_peering.test.id
+  routing_weight                       = 2
+  authorization_key                    = "90f8db47-e25b-4b65-a68b-7743ced2a16b"
+  enable_internet_security             = true
+  enabled_express_route_gateway_bypass = true
+
+  routing {
+    associated_route_table_id = azurerm_virtual_hub.test.default_route_table_id
+
+    propagated_route_table {
+      labels          = ["label1"]
+      route_table_ids = [azurerm_virtual_hub.test.default_route_table_id]
+    }
+
+    inbound_route_map_id  = azurerm_route_map.routemap1.id
+    outbound_route_map_id = azurerm_route_map.routemap2.id
+  }
+  depends_on = [azurerm_route_map.routemap1, azurerm_route_map.routemap2]
 }
 `, r.template(data), data.RandomInteger)
 }

--- a/internal/services/network/express_route_connection_resource_test.go
+++ b/internal/services/network/express_route_connection_resource_test.go
@@ -220,7 +220,7 @@ resource "azurerm_express_route_connection" "test" {
   routing_weight                       = 2
   authorization_key                    = "90f8db47-e25b-4b65-a68b-7743ced2a16b"
   enable_internet_security             = true
-  enabled_express_route_gateway_bypass = true
+  express_route_gateway_bypass_enabled = true
 
   routing {
     associated_route_table_id = azurerm_virtual_hub.test.default_route_table_id

--- a/website/docs/r/express_route_connection.html.markdown
+++ b/website/docs/r/express_route_connection.html.markdown
@@ -95,8 +95,8 @@ The following arguments are supported:
 * `authorization_key` - (Optional) The authorization key to establish the Express Route Connection.
 
 * `enable_internet_security` - (Optional) Is Internet security enabled for this Express Route Connection?
-  
-* `enabled_express_route_gateway_bypass` - (Optional) Indicates whether FastPath enabled for Virtual Wan Firewall Hub. Defaults to `false`.
+
+* `express_route_gateway_bypass_enabled` - (Optional) Specified whether Fast Path is enabled for Virtual Wan Firewall Hub. Defaults to `false`.
 
 * `routing` - (Optional) A `routing` block as defined below.
 
@@ -108,9 +108,9 @@ A `routing` block supports the following:
 
 * `associated_route_table_id` - (Optional) The ID of the Virtual Hub Route Table associated with this Express Route Connection.
 
-* `inbound_route_map_id` - (Optional) The ID of the RouteMap associated with this Express Route Connection for inbound learned routes.
-
-* `outbound_route_map_id` - (Optional) The ID of the RouteMap associated with this Express Route Connection for outbound advertised routes.
+* `inbound_route_map_id` - (Optional) The ID of the Route Map associated with this Express Route Connection for inbound routes.
+ 
+* `outbound_route_map_id` - (Optional) The ID of the Route Map associated with this Express Route Connection for outbound routes.
 
 * `propagated_route_table` - (Optional) A `propagated_route_table` block as defined below.
 

--- a/website/docs/r/express_route_connection.html.markdown
+++ b/website/docs/r/express_route_connection.html.markdown
@@ -95,6 +95,8 @@ The following arguments are supported:
 * `authorization_key` - (Optional) The authorization key to establish the Express Route Connection.
 
 * `enable_internet_security` - (Optional) Is Internet security enabled for this Express Route Connection?
+  
+* `enabled_express_route_gateway_bypass` - (Optional) Indicates whether FastPath enabled for Virtual Wan Firewall Hub. Defaults to `false`.
 
 * `routing` - (Optional) A `routing` block as defined below.
 
@@ -105,6 +107,10 @@ The following arguments are supported:
 A `routing` block supports the following:
 
 * `associated_route_table_id` - (Optional) The ID of the Virtual Hub Route Table associated with this Express Route Connection.
+
+* `inbound_route_map_id` - (Optional) The ID of the RouteMap associated with this Express Route Connection for inbound learned routes.
+
+* `outbound_route_map_id` - (Optional) The ID of the RouteMap associated with this Express Route Connection for outbound advertised routes.
 
 * `propagated_route_table` - (Optional) A `propagated_route_table` block as defined below.
 


### PR DESCRIPTION
Support `inbound_route_map_id`, `outbound_route_map_id`, `enabled_private_link_fast_path`

```log
=== RUN   TestAccExpressRouteConnection_basic
--- PASS: TestAccExpressRouteConnection_basic (5665.34s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/network       5705.892s


PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/network       6358.210s

=== RUN   TestAccExpressRouteConnection
=== RUN   TestAccExpressRouteConnection/Resource
=== RUN   TestAccExpressRouteConnection/Resource/requiresImport
--- PASS: TestAccExpressRouteConnection (5550.84s)
    --- PASS: TestAccExpressRouteConnection/Resource (5550.84s)
        --- PASS: TestAccExpressRouteConnection/Resource/requiresImport (5550.84s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/network       5603.748s

=== RUN   TestAccExpressRouteConnection
=== RUN   TestAccExpressRouteConnection/Resource
=== RUN   TestAccExpressRouteConnection/Resource/complete
--- PASS: TestAccExpressRouteConnection (5472.03s)
    --- PASS: TestAccExpressRouteConnection/Resource (5472.03s)
        --- PASS: TestAccExpressRouteConnection/Resource/complete (5472.03s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/network       5532.557s

=== RUN   TestAccExpressRouteConnection
=== RUN   TestAccExpressRouteConnection/Resource
=== RUN   TestAccExpressRouteConnection/Resource/update
--- PASS: TestAccExpressRouteConnection (6486.12s)
    --- PASS: TestAccExpressRouteConnection/Resource (6486.12s)
        --- PASS: TestAccExpressRouteConnection/Resource/update (6486.12s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/network       6533.837s
```