### PR TITLE
`azurerm_mssql_managed_instance` : fix acc tests failing due to missing route settings when running tests in francecentral

### DIFF
--- a/.teamcity/components/settings.kt
+++ b/.teamcity/components/settings.kt
@@ -157,7 +157,7 @@ var serviceTestConfigurationOverrides = mapOf(
         "eventhub" to testConfiguration(useDevTestSubscription = true),
         "firewall" to testConfiguration(useDevTestSubscription = true),
         "keyvault" to testConfiguration(useDevTestSubscription = true),
-        "postgres" to testConfiguration(locationOverride = LocationConfiguration("westeurope", "centralus", "eastus", false), useDevTestSubscription = true),
+        "postgres" to testConfiguration(locationOverride = LocationConfiguration("northeurope", "centralus", "eastus", false), useDevTestSubscription = true),
         "privatedns" to testConfiguration(useDevTestSubscription = true),
         "redis" to testConfiguration(useDevTestSubscription = true)
 )

--- a/internal/services/mssql/mssql_managed_instance_resource_test.go
+++ b/internal/services/mssql/mssql_managed_instance_resource_test.go
@@ -928,6 +928,18 @@ const managedInstanceStaticRoutes = `
   }
 
   route {
+    name           = "Microsoft.Sql-managedInstances_UseOnly_mi-Storage.francecentral"
+    address_prefix = "Storage.francecentral"
+    next_hop_type  = "Internet"
+  }
+
+  route {
+    name           = "Microsoft.Sql-managedInstances_UseOnly_mi-Storage.francesouth"
+    address_prefix = "Storage.francesouth"
+    next_hop_type  = "Internet"
+  }
+
+  route {
     name           = "Microsoft.Sql-managedInstances_UseOnly_mi-EventHub.westeurope"
     address_prefix = "EventHub.westeurope"
     next_hop_type  = "Internet"


### PR DESCRIPTION
1. Fix the following tests fail as missing route settings when running tests in francecentral issue.

> TestAccMsSqlManagedInstance_multipleDnsZonePartners 
> TestAccMsSqlManagedInstance_multipleDnsZonePartners
> TestAccMsSqlManagedInstance_premium
> TestAccMsSqlManagedInstanceFailoverGroup_update

2. The following tests fail as the Zone-Redundant HA is not supported in westeurope.  Per the [doc](https://learn.microsoft.com/en-us/azure/postgresql/flexible-server/overview#azure-regions), update to northeurope rather than westeurope in teamcity setting file.

> TestAccPostgresqlFlexibleServer_failover
> TestAccFlexibleServerConfiguration_multiplePostgresqlFlexibleServerConfigurations
> TestAccPostgresqlFlexibleServer_complete
> TestAccPostgresqlFlexibleServer_completeUpdate



The tests need to run in teamcity since my test subs do not support creating instances in francecentral.