### PR TITLE
Docs: Fix issue about the `key_vault_secrets_provider` in "azurerm_kubernetes_cluster" is not optional like specify in documentation

### DIFF
--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -486,7 +486,7 @@ A `key_vault_secrets_provider` block supports the following:
 
 * `secret_rotation_interval` - (Optional) The interval to poll for secret rotation. This attribute is only set when `secret_rotation` is true and defaults to `2m`.
 
--> **NOTE:** One of `secret_rotation_enabled, secret_rotation_interval` must be specified.
+-> **NOTE:** When `key_vault_secrets_provider` is set - One of `secret_rotation_enabled, secret_rotation_interval` must be specified.
 
 ---
 

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -486,6 +486,8 @@ A `key_vault_secrets_provider` block supports the following:
 
 * `secret_rotation_interval` - (Optional) The interval to poll for secret rotation. This attribute is only set when `secret_rotation` is true and defaults to `2m`.
 
+-> **NOTE:** One of `secret_rotation_enabled, secret_rotation_interval` must be specified.
+
 ---
 
 A `kubelet_config` block supports the following:

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -486,7 +486,7 @@ A `key_vault_secrets_provider` block supports the following:
 
 * `secret_rotation_interval` - (Optional) The interval to poll for secret rotation. This attribute is only set when `secret_rotation` is true and defaults to `2m`.
 
--> **NOTE:** When `key_vault_secrets_provider` is set - One of `secret_rotation_enabled, secret_rotation_interval` must be specified.
+-> **NOTE:** To enable`key_vault_secrets_provider` either `secret_rotation_enabled` or `secret_rotation_interval` must be specified.
 
 ---
 


### PR DESCRIPTION
Add note for `key_vault_secrets_provider` in tf doc to match the check in tf code about having to specify one of  `secret_rotation_enabled`, `secret_rotation_interval` when setting `key_vault_secrets_provider`.

Fix #20598 .