### PR TITLE
`azurerm_key_vault_certificate` - Support update of certificates based on `certificate_policy`

### DIFF
--- a/internal/services/keyvault/key_vault_certificate_resource.go
+++ b/internal/services/keyvault/key_vault_certificate_resource.go
@@ -652,7 +652,7 @@ func keyVaultCertificateCreationRefreshFunc(ctx context.Context, client *keyvaul
 		// If another process starts a new certificate creation right after our
 		// operation was completed we might not observe the completed state. Also as
 		// soon someone started a new create operation there is no way to determine
-		// what happend to the previous operation. Because of that we return an error
+		// what happened to the previous operation. Because of that we return an error
 		// if there is a new operation (not the same request ID) running.
 		if *operation.RequestID != requestID {
 			return nil, "", fmt.Errorf("could not observe outcome of certificate creation because another process started a new creation")

--- a/internal/services/keyvault/key_vault_certificate_resource.go
+++ b/internal/services/keyvault/key_vault_certificate_resource.go
@@ -92,7 +92,6 @@ func resourceKeyVaultCertificate() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeList,
 				Optional: true,
 				Computed: true,
-				ForceNew: true,
 				AtLeastOneOf: []string{
 					"certificate_policy",
 					"certificate",
@@ -109,7 +108,6 @@ func resourceKeyVaultCertificate() *pluginsdk.Resource {
 									"name": {
 										Type:     pluginsdk.TypeString,
 										Required: true,
-										ForceNew: true,
 									},
 								},
 							},
@@ -124,7 +122,6 @@ func resourceKeyVaultCertificate() *pluginsdk.Resource {
 										Type:     pluginsdk.TypeString,
 										Optional: true,
 										Computed: true,
-										ForceNew: true,
 										ValidateFunc: validation.StringInSlice([]string{
 											string(keyvault.JSONWebKeyCurveNameP256),
 											string(keyvault.JSONWebKeyCurveNameP256K),
@@ -135,13 +132,11 @@ func resourceKeyVaultCertificate() *pluginsdk.Resource {
 									"exportable": {
 										Type:     pluginsdk.TypeBool,
 										Required: true,
-										ForceNew: true,
 									},
 									"key_size": {
 										Type:     pluginsdk.TypeInt,
 										Optional: true,
 										Computed: true,
-										ForceNew: true,
 										ValidateFunc: validation.IntInSlice([]int{
 											256,
 											384,
@@ -154,7 +149,6 @@ func resourceKeyVaultCertificate() *pluginsdk.Resource {
 									"key_type": {
 										Type:     pluginsdk.TypeString,
 										Required: true,
-										ForceNew: true,
 										ValidateFunc: validation.StringInSlice([]string{
 											string(keyvault.JSONWebKeyTypeEC),
 											string(keyvault.JSONWebKeyTypeECHSM),
@@ -166,7 +160,6 @@ func resourceKeyVaultCertificate() *pluginsdk.Resource {
 									"reuse_key": {
 										Type:     pluginsdk.TypeBool,
 										Required: true,
-										ForceNew: true,
 									},
 								},
 							},
@@ -185,7 +178,6 @@ func resourceKeyVaultCertificate() *pluginsdk.Resource {
 												"action_type": {
 													Type:     pluginsdk.TypeString,
 													Required: true,
-													ForceNew: true,
 													ValidateFunc: validation.StringInSlice([]string{
 														string(keyvault.CertificatePolicyActionAutoRenew),
 														string(keyvault.CertificatePolicyActionEmailContacts),
@@ -204,12 +196,10 @@ func resourceKeyVaultCertificate() *pluginsdk.Resource {
 												"days_before_expiry": {
 													Type:     pluginsdk.TypeInt,
 													Optional: true,
-													ForceNew: true,
 												},
 												"lifetime_percentage": {
 													Type:     pluginsdk.TypeInt,
 													Optional: true,
-													ForceNew: true,
 												},
 											},
 										},
@@ -226,7 +216,6 @@ func resourceKeyVaultCertificate() *pluginsdk.Resource {
 									"content_type": {
 										Type:     pluginsdk.TypeString,
 										Required: true,
-										ForceNew: true,
 									},
 								},
 							},
@@ -243,7 +232,6 @@ func resourceKeyVaultCertificate() *pluginsdk.Resource {
 										Type:     pluginsdk.TypeList,
 										Optional: true,
 										Computed: true,
-										ForceNew: true,
 										Elem: &pluginsdk.Schema{
 											Type:         pluginsdk.TypeString,
 											ValidateFunc: validation.StringIsNotEmpty,
@@ -252,7 +240,6 @@ func resourceKeyVaultCertificate() *pluginsdk.Resource {
 									"key_usage": {
 										Type:     pluginsdk.TypeSet,
 										Required: true,
-										ForceNew: true,
 										Elem: &pluginsdk.Schema{
 											Type: pluginsdk.TypeString,
 											ValidateFunc: validation.StringInSlice([]string{
@@ -271,12 +258,10 @@ func resourceKeyVaultCertificate() *pluginsdk.Resource {
 									"subject": {
 										Type:     pluginsdk.TypeString,
 										Required: true,
-										ForceNew: true,
 									},
 									"subject_alternative_names": {
 										Type:     pluginsdk.TypeList,
 										Optional: true,
-										ForceNew: true,
 										Computed: true,
 										MaxItems: 1,
 										Elem: &pluginsdk.Resource{
@@ -284,7 +269,6 @@ func resourceKeyVaultCertificate() *pluginsdk.Resource {
 												"emails": {
 													Type:     pluginsdk.TypeSet,
 													Optional: true,
-													ForceNew: true,
 													Elem: &pluginsdk.Schema{
 														Type: pluginsdk.TypeString,
 													},
@@ -298,7 +282,6 @@ func resourceKeyVaultCertificate() *pluginsdk.Resource {
 												"dns_names": {
 													Type:     pluginsdk.TypeSet,
 													Optional: true,
-													ForceNew: true,
 													Elem: &pluginsdk.Schema{
 														Type: pluginsdk.TypeString,
 													},
@@ -312,7 +295,6 @@ func resourceKeyVaultCertificate() *pluginsdk.Resource {
 												"upns": {
 													Type:     pluginsdk.TypeSet,
 													Optional: true,
-													ForceNew: true,
 													Elem: &pluginsdk.Schema{
 														Type: pluginsdk.TypeString,
 													},
@@ -329,7 +311,6 @@ func resourceKeyVaultCertificate() *pluginsdk.Resource {
 									"validity_in_months": {
 										Type:     pluginsdk.TypeInt,
 										Required: true,
-										ForceNew: true,
 									},
 								},
 							},
@@ -427,6 +408,66 @@ func resourceKeyVaultCertificate() *pluginsdk.Resource {
 	}
 }
 
+func createCertificate(d *pluginsdk.ResourceData, meta interface{}) (keyvault.CertificateBundle, error) {
+	keyVaultsClient := meta.(*clients.Client).KeyVault
+	client := meta.(*clients.Client).KeyVault.ManagementClient
+	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	name := d.Get("name").(string)
+	keyVaultId, err := parse.VaultID(d.Get("key_vault_id").(string))
+	if err != nil {
+		return keyvault.CertificateBundle{}, err
+	}
+
+	keyVaultBaseUrl, err := keyVaultsClient.BaseUriForKeyVault(ctx, *keyVaultId)
+	if err != nil {
+		return keyvault.CertificateBundle{}, fmt.Errorf("looking up Base URI for Certificate %q in %s: %+v", name, *keyVaultId, err)
+	}
+
+	t := d.Get("tags").(map[string]interface{})
+
+	policy, err := expandKeyVaultCertificatePolicy(d)
+	if err != nil {
+		return keyvault.CertificateBundle{}, fmt.Errorf("expanding certificate policy: %s", err)
+	}
+
+	parameters := keyvault.CertificateCreateParameters{
+		CertificatePolicy: policy,
+		Tags:              tags.Expand(t),
+	}
+
+	operation, err := client.CreateCertificate(ctx, *keyVaultBaseUrl, name, parameters)
+	if err != nil {
+		return keyvault.CertificateBundle{}, err
+	}
+
+	if operation.RequestID == nil {
+		return keyvault.CertificateBundle{}, fmt.Errorf("request_id missing in certificate create operation")
+	}
+
+	log.Printf("[DEBUG] Waiting for Key Vault Certificate %q in Vault %q to be provisioned", name, *keyVaultBaseUrl)
+	stateConf := &pluginsdk.StateChangeConf{
+		Pending:    []string{"Provisioning"},
+		Target:     []string{"Ready"},
+		Refresh:    keyVaultCertificateCreationRefreshFunc(ctx, client, *keyVaultBaseUrl, name, *operation.RequestID),
+		MinTimeout: 15 * time.Second,
+		Timeout:    d.Timeout(pluginsdk.TimeoutCreate),
+	}
+	// It has been observed that at least one certificate issuer responds to a request with manual processing by issuer staff. SLA's may differ among issuers.
+	// The total create timeout duration is divided by a modified poll interval of 30s to calculate the number of times to allow not found instead of the default 20.
+	// Using math.Floor, the calculation will err on the lower side of the creation timeout, so as to return before the overall create timeout occurs.
+	if policy != nil && policy.IssuerParameters != nil && policy.IssuerParameters.Name != nil && *policy.IssuerParameters.Name != "Self" {
+		stateConf.PollInterval = 30 * time.Second
+		stateConf.NotFoundChecks = int(math.Floor(float64(stateConf.Timeout) / float64(stateConf.PollInterval)))
+	}
+
+	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+		return keyvault.CertificateBundle{}, fmt.Errorf("waiting for Certificate %q in Vault %q to become available: %s", name, *keyVaultBaseUrl, err)
+	}
+	return client.GetCertificate(ctx, *keyVaultBaseUrl, name, "")
+}
+
 func resourceKeyVaultCertificateCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	keyVaultsClient := meta.(*clients.Client).KeyVault
 	client := meta.(*clients.Client).KeyVault.ManagementClient
@@ -461,6 +502,7 @@ func resourceKeyVaultCertificateCreate(d *pluginsdk.ResourceData, meta interface
 		return fmt.Errorf("expanding certificate policy: %s", err)
 	}
 
+	var newCert keyvault.CertificateBundle
 	if v, ok := d.GetOk("certificate"); ok {
 		// Import
 		certificate := expandKeyVaultCertificate(v)
@@ -470,9 +512,14 @@ func resourceKeyVaultCertificateCreate(d *pluginsdk.ResourceData, meta interface
 			CertificatePolicy:        policy,
 			Tags:                     tags.Expand(t),
 		}
-		if resp, err := client.ImportCertificate(ctx, *keyVaultBaseUrl, name, importParameters); err != nil {
-			if meta.(*clients.Client).Features.KeyVault.RecoverSoftDeletedCerts && utils.ResponseWasConflict(resp.Response) {
+		newCert, err = client.ImportCertificate(ctx, *keyVaultBaseUrl, name, importParameters)
+		if err != nil {
+			if meta.(*clients.Client).Features.KeyVault.RecoverSoftDeletedCerts && utils.ResponseWasConflict(newCert.Response) {
 				if err = recoverDeletedCertificate(ctx, d, meta, *keyVaultBaseUrl, name); err != nil {
+					return err
+				}
+				newCert, err = client.ImportCertificate(ctx, *keyVaultBaseUrl, name, importParameters)
+				if err != nil {
 					return err
 				}
 			} else {
@@ -481,50 +528,24 @@ func resourceKeyVaultCertificateCreate(d *pluginsdk.ResourceData, meta interface
 		}
 	} else {
 		// Generate new
-		parameters := keyvault.CertificateCreateParameters{
-			CertificatePolicy: policy,
-			Tags:              tags.Expand(t),
-		}
-		if resp, err := client.CreateCertificate(ctx, *keyVaultBaseUrl, name, parameters); err != nil {
-			if meta.(*clients.Client).Features.KeyVault.RecoverSoftDeletedCerts && utils.ResponseWasConflict(resp.Response) {
+		newCert, err = createCertificate(d, meta)
+		if err != nil {
+			if meta.(*clients.Client).Features.KeyVault.RecoverSoftDeletedCerts && utils.ResponseWasConflict(newCert.Response) {
 				if err = recoverDeletedCertificate(ctx, d, meta, *keyVaultBaseUrl, name); err != nil {
+					return err
+				}
+				// after we recovered the existing certificate we still have to apply our changes
+				newCert, err = createCertificate(d, meta)
+				if err != nil {
 					return err
 				}
 			} else {
 				return err
 			}
 		}
-
-		log.Printf("[DEBUG] Waiting for Key Vault Certificate %q in Vault %q to be provisioned", name, *keyVaultBaseUrl)
-		stateConf := &pluginsdk.StateChangeConf{
-			Pending:    []string{"Provisioning"},
-			Target:     []string{"Ready"},
-			Refresh:    keyVaultCertificateCreationRefreshFunc(ctx, client, *keyVaultBaseUrl, name),
-			MinTimeout: 15 * time.Second,
-			Timeout:    d.Timeout(pluginsdk.TimeoutCreate),
-		}
-		// It has been observed that at least one certificate issuer responds to a request with manual processing by issuer staff. SLA's may differ among issuers.
-		// The total create timeout duration is divided by a modified poll interval of 30s to calculate the number of times to allow not found instead of the default 20.
-		// Using math.Floor, the calculation will err on the lower side of the creation timeout, so as to return before the overall create timeout occurs.
-		if policy != nil && policy.IssuerParameters != nil && policy.IssuerParameters.Name != nil && *policy.IssuerParameters.Name != "Self" {
-			stateConf.PollInterval = 30 * time.Second
-			stateConf.NotFoundChecks = int(math.Floor(float64(stateConf.Timeout) / float64(stateConf.PollInterval)))
-		}
-
-		if _, err := stateConf.WaitForStateContext(ctx); err != nil {
-			return fmt.Errorf("waiting for Certificate %q in Vault %q to become available: %s", name, *keyVaultBaseUrl, err)
-		}
 	}
 
-	resp, err := client.GetCertificate(ctx, *keyVaultBaseUrl, name, "")
-	if err != nil {
-		return err
-	}
-	if resp.ID == nil {
-		return fmt.Errorf("cannot read KeyVault Certificate '%s' (in key vault '%s')", name, *keyVaultBaseUrl)
-	}
-
-	certificateId, err := parse.ParseNestedItemID(*resp.ID)
+	certificateId, err := parse.ParseNestedItemID(*newCert.ID)
 	if err != nil {
 		return err
 	}
@@ -593,6 +614,17 @@ func resourceKeyVaultCertificateUpdate(d *schema.ResourceData, meta interface{})
 			}
 		}
 	}
+	if d.HasChange("certificate_policy") {
+		newCert, err := createCertificate(d, meta)
+		if err != nil {
+			return err
+		}
+		certificateId, err := parse.ParseNestedItemID(*newCert.ID)
+		if err != nil {
+			return err
+		}
+		d.SetId(certificateId.ID())
+	}
 
 	if d.HasChange("tags") {
 		patch := keyvault.CertificateUpdateParameters{}
@@ -607,25 +639,38 @@ func resourceKeyVaultCertificateUpdate(d *schema.ResourceData, meta interface{})
 	return resourceKeyVaultCertificateRead(d, meta)
 }
 
-func keyVaultCertificateCreationRefreshFunc(ctx context.Context, client *keyvault.BaseClient, keyVaultBaseUrl string, name string) pluginsdk.StateRefreshFunc {
+func keyVaultCertificateCreationRefreshFunc(ctx context.Context, client *keyvault.BaseClient, keyVaultBaseUrl string, name string, requestID string) pluginsdk.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		res, err := client.GetCertificate(ctx, keyVaultBaseUrl, name, "")
+		operation, err := client.GetCertificateOperation(ctx, keyVaultBaseUrl, name)
 		if err != nil {
-			return nil, "", fmt.Errorf("issuing read request in keyVaultCertificateCreationRefreshFunc for Certificate %q in Vault %q: %s", name, keyVaultBaseUrl, err)
+			return nil, "", fmt.Errorf("failed to read CertificateOperation in keyVaultCertificateCreationRefreshFunc for Certificate %q in Vault %q: %s", name, keyVaultBaseUrl, err)
+		}
+		if operation.RequestID == nil {
+			return nil, "", fmt.Errorf("missing request_id in certificate operation")
 		}
 
-		if res.Policy != nil &&
-			res.Policy.IssuerParameters != nil &&
-			res.Policy.IssuerParameters.Name != nil &&
-			strings.EqualFold(*(res.Policy.IssuerParameters.Name), "unknown") {
-			return res, "Ready", nil
+		// If another process starts a new certificate creation right after our
+		// operation was completed we might not observe the completed state. Also as
+		// soon someone started a new create operation there is no way to determine
+		// what happend to the previous operation. Because of that we return an error
+		// if there is a new operation (not the same request ID) running.
+		if *operation.RequestID != requestID {
+			return nil, "", fmt.Errorf("could not observe outcome of certificate creation because another process started a new creation")
 		}
 
-		if res.Sid == nil || *res.Sid == "" {
-			return nil, "Provisioning", nil
+		if operation.Status == nil {
+			return nil, "", fmt.Errorf("missing status in certificate operation")
 		}
 
-		return res, "Ready", nil
+		if *operation.Status == "inProgress" {
+			return operation, "Provisioning", nil
+		}
+
+		if *operation.Status == "completed" {
+			return operation, "Ready", nil
+		}
+
+		return nil, "", fmt.Errorf("certifcate creation faild in state '%s'", *operation.Status)
 	}
 }
 

--- a/internal/services/keyvault/key_vault_certificate_resource.go
+++ b/internal/services/keyvault/key_vault_certificate_resource.go
@@ -666,7 +666,7 @@ func keyVaultCertificateCreationRefreshFunc(ctx context.Context, client *keyvaul
 			return operation, "Provisioning", nil
 		}
 
-		if *operation.Status == "completed" {
+		if strings.EqualFold(*operation.Status, "completed") {
 			return operation, "Ready", nil
 		}
 

--- a/internal/services/keyvault/key_vault_certificate_resource.go
+++ b/internal/services/keyvault/key_vault_certificate_resource.go
@@ -415,7 +415,7 @@ func createCertificate(d *pluginsdk.ResourceData, meta interface{}) (keyvault.Ce
 	defer cancel()
 
 	name := d.Get("name").(string)
-	keyVaultId, err := parse.VaultID(d.Get("key_vault_id").(string))
+	keyVaultId, err := commonids.ParseKeyVaultID(d.Get("key_vault_id").(string))
 	if err != nil {
 		return keyvault.CertificateBundle{}, err
 	}
@@ -662,7 +662,7 @@ func keyVaultCertificateCreationRefreshFunc(ctx context.Context, client *keyvaul
 			return nil, "", fmt.Errorf("missing status in certificate operation")
 		}
 
-		if *operation.Status == "inProgress" {
+		if strings.EqualFold(*operation.Status, "inProgress") {
 			return operation, "Provisioning", nil
 		}
 

--- a/internal/services/keyvault/key_vault_certificate_resource_test.go
+++ b/internal/services/keyvault/key_vault_certificate_resource_test.go
@@ -209,6 +209,26 @@ func TestAccKeyVaultCertificate_updateTags(t *testing.T) {
 	})
 }
 
+func TestAccKeyVaultCertificate_updateCertificate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_key_vault_certificate", "test")
+	r := KeyVaultCertificateResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basicGenerateCertificate(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("certificate_policy.0.key_properties.0.key_size").HasValue("2048"),
+			),
+		},
+		{
+			Config: r.updateCertificate(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("certificate_policy.0.key_properties.0.key_size").HasValue("4096"),
+			),
+		},
+	})
+}
+
 func TestAccKeyVaultCertificate_basicGenerateEllipticCurve(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_key_vault_certificate", "test")
 	r := KeyVaultCertificateResource{}
@@ -627,6 +647,118 @@ resource "azurerm_key_vault_certificate" "test" {
         "keyAgreement",
         "keyEncipherment",
         "keyCertSign",
+      ]
+
+      subject            = "CN=hello-world"
+      validity_in_months = 12
+    }
+  }
+}
+`, r.template(data), data.RandomString)
+}
+
+func (r KeyVaultCertificateResource) basicGenerateCertificate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_key_vault_certificate" "test" {
+  name         = "acctestcert%s"
+  key_vault_id = azurerm_key_vault.test.id
+
+  certificate_policy {
+    issuer_parameters {
+      name = "Self"
+    }
+
+    key_properties {
+      exportable = true
+      key_size   = 2048
+      key_type   = "RSA"
+      reuse_key  = true
+    }
+
+    lifetime_action {
+      action {
+        action_type = "AutoRenew"
+      }
+
+      trigger {
+        days_before_expiry = 30
+      }
+    }
+
+    secret_properties {
+      content_type = "application/x-pkcs12"
+    }
+
+    x509_certificate_properties {
+      key_usage = [
+        "cRLSign",
+        "dataEncipherment",
+        "digitalSignature",
+        "keyAgreement",
+        "keyCertSign",
+        "keyEncipherment",
+      ]
+
+      subject            = "CN=hello-world"
+      validity_in_months = 12
+    }
+  }
+}
+`, r.template(data), data.RandomString)
+}
+
+func (r KeyVaultCertificateResource) updateCertificate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_key_vault_certificate" "test" {
+  name         = "acctestcert%s"
+  key_vault_id = azurerm_key_vault.test.id
+
+  certificate_policy {
+    issuer_parameters {
+      name = "Self"
+    }
+
+    key_properties {
+      exportable = true
+      key_size   = 4096
+      key_type   = "RSA"
+      reuse_key  = true
+    }
+
+    lifetime_action {
+      action {
+        action_type = "AutoRenew"
+      }
+
+      trigger {
+        days_before_expiry = 30
+      }
+    }
+
+    secret_properties {
+      content_type = "application/x-pkcs12"
+    }
+
+    x509_certificate_properties {
+      key_usage = [
+        "cRLSign",
+        "dataEncipherment",
+        "digitalSignature",
+        "keyAgreement",
+        "keyCertSign",
+        "keyEncipherment",
       ]
 
       subject            = "CN=hello-world"


### PR DESCRIPTION
This PR adds support for updating certificates created using a `certificate_policy`.
For this I factored out the create and wait logic into a separate `createCertificate` function which is then used in the actual create and update functions of the certificate resource. If a certificate already exists the CreateCertificate function from the SDK creates a new version of that certificate.

Should fix: 
* fix #17358 
* fix #13012 
* fix #12456 
* fix #10658 

Further this PR fixes the problem when a certificate gets recovered the actual requested settings were not applied which meant you ended up with the old certificate (the one you deleted)

There still remains the problem that values which contain or depend on the certificate version (`id`, `version`, `secret_id`, `certificate_data`, `certificate_data_bas64` and `thumbprint`) are not recomputed in the same run as the certificates change. To make it clear, this was already a problem before this change. If you imported a new version of a certificate using the field `certificate.contents`  some fields are never updated .
I tried to fix this using a `CustomizeDiffFunc` (see https://github.com/dvob/terraform-provider-azurerm/commit/ef3cb69de40e908f7e6ee642ddeb9ba27e339a4d). The problem with that was that the `*schema.ResourceDiff` always reported changes for the `certificate_policy` and hence the values got recomputed every time.
Further it was not possible to mark `id` as recomputed. This is probably due to the special treatment of the `id` field.
Probably the `id` should not contain the version. I'm not sure if this could be changed, because this would be a breaking change. On the other hand at the moment it probably also doesn't really behave as a user would expect it.