### PR TITLE
`azurerm_storage_management_policy` - Add supports for `enable_auto_tier_to_hot_from_cool`

### DIFF
--- a/internal/services/storage/storage_management_policy_resource.go
+++ b/internal/services/storage/storage_management_policy_resource.go
@@ -137,6 +137,10 @@ func resourceStorageManagementPolicy() *pluginsdk.Resource {
 													Default:      -1,
 													ValidateFunc: validation.IntBetween(0, 99999),
 												},
+												"auto_tier_to_hot_from_cool_enabled": {
+													Type:     pluginsdk.TypeBool,
+													Optional: true,
+												},
 												"tier_to_cool_after_days_since_creation_greater_than": {
 													Type:         pluginsdk.TypeInt,
 													Optional:     true,
@@ -430,6 +434,11 @@ func expandStorageManagementPolicyRule(d *pluginsdk.ResourceData, ruleIndex int)
 			sinceCreate = d.Get(fmt.Sprintf("rule.%d.actions.0.base_blob.0.tier_to_cool_after_days_since_creation_greater_than", ruleIndex))
 			sinceCreateOK = sinceCreate != -1
 
+			autoTierToHotOK := d.Get(fmt.Sprintf("rule.%d.actions.0.base_blob.0.auto_tier_to_hot_from_cool_enabled", ruleIndex)).(bool)
+			if autoTierToHotOK && !sinceAccessOK {
+				return nil, fmt.Errorf("`auto_tier_to_hot_from_cool_enabled` must be used together with `tier_to_cool_after_days_since_last_access_time_greater_than`")
+			}
+
 			var cnt int
 			if sinceModOK {
 				cnt++
@@ -454,6 +463,9 @@ func expandStorageManagementPolicyRule(d *pluginsdk.ResourceData, ruleIndex int)
 				}
 				if sinceCreateOK {
 					baseBlob.TierToCool.DaysAfterCreationGreaterThan = utils.Float(float64(sinceCreate.(int)))
+				}
+				if autoTierToHotOK {
+					baseBlob.EnableAutoTierToHotFromCool = utils.Bool(autoTierToHotOK)
 				}
 			}
 
@@ -635,6 +647,7 @@ func flattenStorageManagementPolicyRules(armRules *[]storage.ManagementPolicyRul
 						tierToCoolSinceMod               = -1
 						tierToCoolSinceAccess            = -1
 						tierToCoolSinceCreate            = -1
+						autoTierToHotOK                  = false
 						tierToArchiveSinceMod            = -1
 						tierToArchiveSinceAccess         = -1
 						tierToArchiveSinceCreate         = -1
@@ -644,6 +657,9 @@ func flattenStorageManagementPolicyRules(armRules *[]storage.ManagementPolicyRul
 						deleteSinceCreate                = -1
 					)
 
+					if v := armActionBaseBlob.EnableAutoTierToHotFromCool; v != nil {
+						autoTierToHotOK = *v
+					}
 					if props := armActionBaseBlob.TierToCool; props != nil {
 						if props.DaysAfterModificationGreaterThan != nil {
 							tierToCoolSinceMod = int(*props.DaysAfterModificationGreaterThan)
@@ -682,6 +698,7 @@ func flattenStorageManagementPolicyRules(armRules *[]storage.ManagementPolicyRul
 					}
 					action["base_blob"] = []interface{}{
 						map[string]interface{}{
+							"auto_tier_to_hot_from_cool_enabled":                             autoTierToHotOK,
 							"tier_to_cool_after_days_since_modification_greater_than":        tierToCoolSinceMod,
 							"tier_to_cool_after_days_since_last_access_time_greater_than":    tierToCoolSinceAccess,
 							"tier_to_cool_after_days_since_creation_greater_than":            tierToCoolSinceCreate,

--- a/internal/services/storage/storage_management_policy_resource_test.go
+++ b/internal/services/storage/storage_management_policy_resource_test.go
@@ -370,7 +370,14 @@ func TestAccStorageManagementPolicy_baseblobAccessTimeBased(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
-			Config: r.baseblobAccessTimeBased(data),
+			Config: r.baseblobAccessTimeBased(data, true),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.baseblobAccessTimeBased(data, false),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -1036,7 +1043,7 @@ resource "azurerm_storage_management_policy" "test" {
 `, r.templateLastAccessTimeEnabled(data))
 }
 
-func (r StorageManagementPolicyResource) baseblobAccessTimeBased(data acceptance.TestData) string {
+func (r StorageManagementPolicyResource) baseblobAccessTimeBased(data acceptance.TestData, autoTierToHotEnabled bool) string {
 	return fmt.Sprintf(`
 %s
 
@@ -1052,6 +1059,7 @@ resource "azurerm_storage_management_policy" "test" {
     }
     actions {
       base_blob {
+        auto_tier_to_hot_from_cool_enabled                             = %t
         tier_to_cool_after_days_since_last_access_time_greater_than    = 10
         tier_to_archive_after_days_since_last_access_time_greater_than = 50
         delete_after_days_since_last_access_time_greater_than          = 100
@@ -1059,7 +1067,7 @@ resource "azurerm_storage_management_policy" "test" {
     }
   }
 }
-`, r.templateLastAccessTimeEnabled(data))
+`, r.templateLastAccessTimeEnabled(data), autoTierToHotEnabled)
 }
 
 func (r StorageManagementPolicyResource) baseblobAccessTimeBasedZero(data acceptance.TestData) string {

--- a/website/docs/r/storage_management_policy.html.markdown
+++ b/website/docs/r/storage_management_policy.html.markdown
@@ -127,6 +127,10 @@ The `base_blob` block supports the following:
 
 ~> **Note:** The `tier_to_cool_after_days_since_modification_greater_than`, `tier_to_cool_after_days_since_last_access_time_greater_than` and `tier_to_cool_after_days_since_creation_greater_than` can not be set at the same time.
 
+* `auto_tier_to_hot_from_cool_enabled` - (Optional) Whether a blob should automatically be tiered from cool back to hot if it's accessed again after being tiered to cool. Defaults to `false`.
+
+~> **Note:** The `auto_tier_to_hot_from_cool_enabled` must be used together with `tier_to_cool_after_days_since_last_access_time_greater_than`.
+
 * `tier_to_archive_after_days_since_modification_greater_than` - (Optional) The age in days after last modification to tier blobs to archive storage. Supports blob currently at Hot or Cool tier. Must be between 0 and 99999. Defaults to `-1`.
 * `tier_to_archive_after_days_since_last_access_time_greater_than` - (Optional) The age in days after last access time to tier blobs to archive storage. Supports blob currently at Hot or Cool tier. Must be between `0` and`99999`. Defaults to `-1`.
 * `tier_to_archive_after_days_since_creation_greater_than` - (Optional) The age in days after creation to archive storage. Supports blob currently at Hot or Cool tier. Must be between `0` and`99999`. Defaults to `-1`.


### PR DESCRIPTION
Fix #20600

## Test

```shell
💢  TF_ACC=1 go test -v -timeout=20h ./internal/services/storage -run='TestAccStorageManagementPolicy_baseblobAccessTimeBased$'
=== RUN   TestAccStorageManagementPolicy_baseblobAccessTimeBased
=== PAUSE TestAccStorageManagementPolicy_baseblobAccessTimeBased
=== CONT  TestAccStorageManagementPolicy_baseblobAccessTimeBased
--- PASS: TestAccStorageManagementPolicy_baseblobAccessTimeBased (265.10s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/storage       265.113s
```