### PR TITLE
azurerm_app_service_connection: fix failing acc tests

### DIFF
--- a/internal/services/serviceconnector/service_connector_app_service_resource_test.go
+++ b/internal/services/serviceconnector/service_connector_app_service_resource_test.go
@@ -132,6 +132,13 @@ resource "azurerm_linux_web_app" "test" {
   service_plan_id     = azurerm_service_plan.test.id
 
   site_config {}
+
+  lifecycle {
+    ignore_changes = [
+      app_settings["AZURE_STORAGEBLOB_RESOURCEENDPOINT"],
+      identity,
+    ]
+  }
 }
 
 resource "azurerm_app_service_connection" "test" {
@@ -358,6 +365,13 @@ resource "azurerm_linux_web_app" "test" {
   resource_group_name = azurerm_resource_group.test.name
   service_plan_id     = azurerm_service_plan.test.id
   site_config {}
+
+  lifecycle {
+    ignore_changes = [
+      app_settings,
+      identity,
+    ]
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }

--- a/website/docs/r/app_service_connection.html.markdown
+++ b/website/docs/r/app_service_connection.html.markdown
@@ -66,13 +66,6 @@ resource "azurerm_linux_web_app" "example" {
   resource_group_name = azurerm_resource_group.example.name
   service_plan_id     = azurerm_service_plan.example.id
   site_config {}
-
-  lifecycle {
-    ignore_changes = [
-      app_setting,
-      identity,
-    ]
-  }
 }
 
 resource "azurerm_app_service_connection" "example" {
@@ -95,7 +88,7 @@ The following arguments are supported:
 
 * `target_resource_id` - (Required) The ID of the target resource. Changing this forces a new resource to be created. Possible values are `Postgres`, `PostgresFlexible`, `Mysql`, `Sql`, `Redis`, `RedisEnterprise`, `CosmosCassandra`, `CosmosGremlin`, `CosmosMongo`, `CosmosSql`, `CosmosTable`, `StorageBlob`, `StorageQueue`, `StorageFile`, `StorageTable`, `AppConfig`, `EventHub`, `ServiceBus`, `SignalR`, `WebPubSub`, `ConfluentKafka`.
 
-* `authentication` - (Required) The authentication info. Service connection will change the `identity` field of the linked app service, to avoid triggering Terraform alert on update in-place, please include a `lifecycle` block to ignore the change on identity as the example given above, or set `identity -> type` as `systemAssigned`.  An `authentication` block as defined below.
+* `authentication` - (Required) The authentication info.  An `authentication` block as defined below.
 
 ---
 

--- a/website/docs/r/app_service_connection.html.markdown
+++ b/website/docs/r/app_service_connection.html.markdown
@@ -66,7 +66,7 @@ resource "azurerm_linux_web_app" "example" {
   resource_group_name = azurerm_resource_group.example.name
   service_plan_id     = azurerm_service_plan.example.id
   site_config {}
-  
+
   lifecycle {
     ignore_changes = [
       app_setting,

--- a/website/docs/r/app_service_connection.html.markdown
+++ b/website/docs/r/app_service_connection.html.markdown
@@ -95,7 +95,7 @@ The following arguments are supported:
 
 * `target_resource_id` - (Required) The ID of the target resource. Changing this forces a new resource to be created. Possible values are `Postgres`, `PostgresFlexible`, `Mysql`, `Sql`, `Redis`, `RedisEnterprise`, `CosmosCassandra`, `CosmosGremlin`, `CosmosMongo`, `CosmosSql`, `CosmosTable`, `StorageBlob`, `StorageQueue`, `StorageFile`, `StorageTable`, `AppConfig`, `EventHub`, `ServiceBus`, `SignalR`, `WebPubSub`, `ConfluentKafka`.
 
-* `authentication` - (Required) The authentication info. Service connection will change the `identity` field of the linked app service, to avoid triggering Terraform alert on update in-place, please include a `lifecycle` block to ignore the change on identity as the example given above.  An `authentication` block as defined below.
+* `authentication` - (Required) The authentication info. Service connection will change the `identity` field of the linked app service, to avoid triggering Terraform alert on update in-place, please include a `lifecycle` block to ignore the change on identity as the example given above, or set `identity -> type` as `systemAssigned`.  An `authentication` block as defined below.
 
 ---
 

--- a/website/docs/r/app_service_connection.html.markdown
+++ b/website/docs/r/app_service_connection.html.markdown
@@ -66,6 +66,13 @@ resource "azurerm_linux_web_app" "example" {
   resource_group_name = azurerm_resource_group.example.name
   service_plan_id     = azurerm_service_plan.example.id
   site_config {}
+  
+  lifecycle {
+    ignore_changes = [
+      app_setting,
+      identity,
+    ]
+  }
 }
 
 resource "azurerm_app_service_connection" "example" {
@@ -88,7 +95,7 @@ The following arguments are supported:
 
 * `target_resource_id` - (Required) The ID of the target resource. Changing this forces a new resource to be created. Possible values are `Postgres`, `PostgresFlexible`, `Mysql`, `Sql`, `Redis`, `RedisEnterprise`, `CosmosCassandra`, `CosmosGremlin`, `CosmosMongo`, `CosmosSql`, `CosmosTable`, `StorageBlob`, `StorageQueue`, `StorageFile`, `StorageTable`, `AppConfig`, `EventHub`, `ServiceBus`, `SignalR`, `WebPubSub`, `ConfluentKafka`.
 
-* `authentication` - (Required) The authentication info. An `authentication` block as defined below.
+* `authentication` - (Required) The authentication info. Service connection will change the `identity` field of the linked app service, to avoid triggering Terraform alert on update in-place, please include a `lifecycle` block to ignore the change on identity as the example given above.  An `authentication` block as defined below.
 
 ---
 

--- a/website/docs/r/app_service_connection.html.markdown
+++ b/website/docs/r/app_service_connection.html.markdown
@@ -88,7 +88,9 @@ The following arguments are supported:
 
 * `target_resource_id` - (Required) The ID of the target resource. Changing this forces a new resource to be created. Possible values are `Postgres`, `PostgresFlexible`, `Mysql`, `Sql`, `Redis`, `RedisEnterprise`, `CosmosCassandra`, `CosmosGremlin`, `CosmosMongo`, `CosmosSql`, `CosmosTable`, `StorageBlob`, `StorageQueue`, `StorageFile`, `StorageTable`, `AppConfig`, `EventHub`, `ServiceBus`, `SignalR`, `WebPubSub`, `ConfluentKafka`.
 
-* `authentication` - (Required) The authentication info.  An `authentication` block as defined below.
+* `authentication` - (Required) The authentication info. An `authentication` block as defined below.
+
+-> **Note:** If a Managed Identity is used, this will need to be configured on the App Service.
 
 ---
 


### PR DESCRIPTION
* The failure was caused by an upstream service, the related fields are now ignored.
* All related tests passed.