### PR TITLE
`azurerm_sentinel_log_analytics_workspace_onboarding`: support `workspace_id`, deprecate `resource_group_name` and `workspace_name`

### DIFF
--- a/internal/services/sentinel/sentinel_alert_rule_data_source_test.go
+++ b/internal/services/sentinel/sentinel_alert_rule_data_source_test.go
@@ -30,7 +30,7 @@ func (SentinelAlertRuleDataSource) basic(data acceptance.TestData) string {
 
 data "azurerm_sentinel_alert_rule" "test" {
   name                       = azurerm_sentinel_alert_rule_ms_security_incident.test.name
-  log_analytics_workspace_id = azurerm_log_analytics_solution.test.workspace_resource_id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
 }
 `, SentinelAlertRuleMsSecurityIncidentResource{}.basic(data))
 }

--- a/internal/services/sentinel/sentinel_alert_rule_fusion_resource_test.go
+++ b/internal/services/sentinel/sentinel_alert_rule_fusion_resource_test.go
@@ -126,13 +126,17 @@ func (r SentinelAlertRuleFusionResource) basic(data acceptance.TestData) string 
 
 data "azurerm_sentinel_alert_rule_template" "test" {
   display_name               = "Advanced Multistage Attack Detection"
-  log_analytics_workspace_id = azurerm_log_analytics_solution.test.workspace_resource_id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+
+  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 
 resource "azurerm_sentinel_alert_rule_fusion" "test" {
   name                       = "acctest-SentinelAlertRule-Fusion-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_solution.test.workspace_resource_id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
   alert_rule_template_guid   = data.azurerm_sentinel_alert_rule_template.test.name
+
+  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, r.template(data), data.RandomInteger)
 }
@@ -143,14 +147,18 @@ func (r SentinelAlertRuleFusionResource) disabled(data acceptance.TestData) stri
 
 data "azurerm_sentinel_alert_rule_template" "test" {
   display_name               = "Advanced Multistage Attack Detection"
-  log_analytics_workspace_id = azurerm_log_analytics_solution.test.workspace_resource_id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+
+  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 
 resource "azurerm_sentinel_alert_rule_fusion" "test" {
   name                       = "acctest-SentinelAlertRule-Fusion-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_solution.test.workspace_resource_id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
   alert_rule_template_guid   = data.azurerm_sentinel_alert_rule_template.test.name
   enabled                    = false
+
+  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, r.template(data), data.RandomInteger)
 }
@@ -161,13 +169,16 @@ func (r SentinelAlertRuleFusionResource) sourceSetting(data acceptance.TestData,
 
 data "azurerm_sentinel_alert_rule_template" "test" {
   display_name               = "Advanced Multistage Attack Detection"
-  log_analytics_workspace_id = azurerm_log_analytics_solution.test.workspace_resource_id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+
+  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 
 resource "azurerm_sentinel_alert_rule_fusion" "test" {
   name                       = "acctest-SentinelAlertRule-Fusion-%[2]d"
-  log_analytics_workspace_id = azurerm_log_analytics_solution.test.workspace_resource_id
-  alert_rule_template_guid   = data.azurerm_sentinel_alert_rule_template.test.name
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+
+  alert_rule_template_guid = data.azurerm_sentinel_alert_rule_template.test.name
   source {
     name    = "Anomalies"
     enabled = %[3]t
@@ -226,6 +237,8 @@ resource "azurerm_sentinel_alert_rule_fusion" "test" {
       enabled            = %[3]t
     }
   }
+
+  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, r.template(data), data.RandomInteger, enabled)
 }
@@ -260,17 +273,9 @@ resource "azurerm_log_analytics_workspace" "test" {
   sku                 = "PerGB2018"
 }
 
-resource "azurerm_log_analytics_solution" "test" {
-  solution_name         = "SecurityInsights"
-  location              = azurerm_resource_group.test.location
-  resource_group_name   = azurerm_resource_group.test.name
-  workspace_resource_id = azurerm_log_analytics_workspace.test.id
-  workspace_name        = azurerm_log_analytics_workspace.test.name
-
-  plan {
-    publisher = "Microsoft"
-    product   = "OMSGallery/SecurityInsights"
-  }
+resource "azurerm_sentinel_log_analytics_workspace_onboarding" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  workspace_name      = azurerm_log_analytics_workspace.test.name
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/internal/services/sentinel/sentinel_alert_rule_fusion_resource_test.go
+++ b/internal/services/sentinel/sentinel_alert_rule_fusion_resource_test.go
@@ -126,17 +126,13 @@ func (r SentinelAlertRuleFusionResource) basic(data acceptance.TestData) string 
 
 data "azurerm_sentinel_alert_rule_template" "test" {
   display_name               = "Advanced Multistage Attack Detection"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
-
-  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
+  log_analytics_workspace_id = azurerm_log_analytics_solution.test.workspace_resource_id
 }
 
 resource "azurerm_sentinel_alert_rule_fusion" "test" {
   name                       = "acctest-SentinelAlertRule-Fusion-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  log_analytics_workspace_id = azurerm_log_analytics_solution.test.workspace_resource_id
   alert_rule_template_guid   = data.azurerm_sentinel_alert_rule_template.test.name
-
-  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, r.template(data), data.RandomInteger)
 }
@@ -147,18 +143,14 @@ func (r SentinelAlertRuleFusionResource) disabled(data acceptance.TestData) stri
 
 data "azurerm_sentinel_alert_rule_template" "test" {
   display_name               = "Advanced Multistage Attack Detection"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
-
-  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
+  log_analytics_workspace_id = azurerm_log_analytics_solution.test.workspace_resource_id
 }
 
 resource "azurerm_sentinel_alert_rule_fusion" "test" {
   name                       = "acctest-SentinelAlertRule-Fusion-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  log_analytics_workspace_id = azurerm_log_analytics_solution.test.workspace_resource_id
   alert_rule_template_guid   = data.azurerm_sentinel_alert_rule_template.test.name
   enabled                    = false
-
-  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, r.template(data), data.RandomInteger)
 }
@@ -169,16 +161,13 @@ func (r SentinelAlertRuleFusionResource) sourceSetting(data acceptance.TestData,
 
 data "azurerm_sentinel_alert_rule_template" "test" {
   display_name               = "Advanced Multistage Attack Detection"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
-
-  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
+  log_analytics_workspace_id = azurerm_log_analytics_solution.test.workspace_resource_id
 }
 
 resource "azurerm_sentinel_alert_rule_fusion" "test" {
   name                       = "acctest-SentinelAlertRule-Fusion-%[2]d"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
-
-  alert_rule_template_guid = data.azurerm_sentinel_alert_rule_template.test.name
+  log_analytics_workspace_id = azurerm_log_analytics_solution.test.workspace_resource_id
+  alert_rule_template_guid   = data.azurerm_sentinel_alert_rule_template.test.name
   source {
     name    = "Anomalies"
     enabled = %[3]t
@@ -237,8 +226,6 @@ resource "azurerm_sentinel_alert_rule_fusion" "test" {
       enabled            = %[3]t
     }
   }
-
-  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, r.template(data), data.RandomInteger, enabled)
 }
@@ -273,9 +260,17 @@ resource "azurerm_log_analytics_workspace" "test" {
   sku                 = "PerGB2018"
 }
 
-resource "azurerm_sentinel_log_analytics_workspace_onboarding" "test" {
-  resource_group_name = azurerm_resource_group.test.name
-  workspace_name      = azurerm_log_analytics_workspace.test.name
+resource "azurerm_log_analytics_solution" "test" {
+  solution_name         = "SecurityInsights"
+  location              = azurerm_resource_group.test.location
+  resource_group_name   = azurerm_resource_group.test.name
+  workspace_resource_id = azurerm_log_analytics_workspace.test.id
+  workspace_name        = azurerm_log_analytics_workspace.test.name
+
+  plan {
+    publisher = "Microsoft"
+    product   = "OMSGallery/SecurityInsights"
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/internal/services/sentinel/sentinel_alert_rule_machine_learning_behavior_analytics_test.go
+++ b/internal/services/sentinel/sentinel_alert_rule_machine_learning_behavior_analytics_test.go
@@ -120,13 +120,17 @@ func (r SentinelAlertRuleMLBehaviorAnalyticsResource) basic(data acceptance.Test
 
 data "azurerm_sentinel_alert_rule_template" "test" {
   display_name               = "(Preview) Anomalous SSH Login Detection"
-  log_analytics_workspace_id = azurerm_log_analytics_solution.test.workspace_resource_id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+
+  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 
 resource "azurerm_sentinel_alert_rule_machine_learning_behavior_analytics" "test" {
   name                       = "acctest-SentinelAlertRule-MLBehaviorAnalytics-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_solution.test.workspace_resource_id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
   alert_rule_template_guid   = data.azurerm_sentinel_alert_rule_template.test.name
+
+  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, r.template(data), data.RandomInteger)
 }
@@ -137,26 +141,34 @@ func (r SentinelAlertRuleMLBehaviorAnalyticsResource) complete(data acceptance.T
 
 data "azurerm_sentinel_alert_rule_template" "test" {
   display_name               = "(Preview) Anomalous SSH Login Detection"
-  log_analytics_workspace_id = azurerm_log_analytics_solution.test.workspace_resource_id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+
+  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 
 resource "azurerm_sentinel_alert_rule_machine_learning_behavior_analytics" "test" {
   name                       = "acctest-SentinelAlertRule-MLBehaviorAnalytics-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_solution.test.workspace_resource_id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
   alert_rule_template_guid   = data.azurerm_sentinel_alert_rule_template.test.name
   enabled                    = false
+
+  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 
 data "azurerm_sentinel_alert_rule_template" "test2" {
   display_name               = "(Preview) Anomalous RDP Login Detections"
-  log_analytics_workspace_id = azurerm_log_analytics_solution.test.workspace_resource_id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+
+  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 
 resource "azurerm_sentinel_alert_rule_machine_learning_behavior_analytics" "test2" {
   name                       = "acctest-SentinelAlertRule-MLBehaviorAnalytics-2-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_solution.test.workspace_resource_id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
   alert_rule_template_guid   = data.azurerm_sentinel_alert_rule_template.test2.name
   enabled                    = false
+
+  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, r.template(data), data.RandomInteger, data.RandomInteger)
 }
@@ -191,17 +203,9 @@ resource "azurerm_log_analytics_workspace" "test" {
   sku                 = "PerGB2018"
 }
 
-resource "azurerm_log_analytics_solution" "test" {
-  solution_name         = "SecurityInsights"
-  location              = azurerm_resource_group.test.location
-  resource_group_name   = azurerm_resource_group.test.name
-  workspace_resource_id = azurerm_log_analytics_workspace.test.id
-  workspace_name        = azurerm_log_analytics_workspace.test.name
-
-  plan {
-    publisher = "Microsoft"
-    product   = "OMSGallery/SecurityInsights"
-  }
+resource "azurerm_sentinel_log_analytics_workspace_onboarding" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  workspace_name      = azurerm_log_analytics_workspace.test.name
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/internal/services/sentinel/sentinel_alert_rule_machine_learning_behavior_analytics_test.go
+++ b/internal/services/sentinel/sentinel_alert_rule_machine_learning_behavior_analytics_test.go
@@ -120,9 +120,7 @@ func (r SentinelAlertRuleMLBehaviorAnalyticsResource) basic(data acceptance.Test
 
 data "azurerm_sentinel_alert_rule_template" "test" {
   display_name               = "(Preview) Anomalous SSH Login Detection"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
-
-  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
 }
 
 resource "azurerm_sentinel_alert_rule_machine_learning_behavior_analytics" "test" {
@@ -130,7 +128,6 @@ resource "azurerm_sentinel_alert_rule_machine_learning_behavior_analytics" "test
   log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
   alert_rule_template_guid   = data.azurerm_sentinel_alert_rule_template.test.name
 
-  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, r.template(data), data.RandomInteger)
 }
@@ -141,34 +138,26 @@ func (r SentinelAlertRuleMLBehaviorAnalyticsResource) complete(data acceptance.T
 
 data "azurerm_sentinel_alert_rule_template" "test" {
   display_name               = "(Preview) Anomalous SSH Login Detection"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
-
-  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
 }
 
 resource "azurerm_sentinel_alert_rule_machine_learning_behavior_analytics" "test" {
   name                       = "acctest-SentinelAlertRule-MLBehaviorAnalytics-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
   alert_rule_template_guid   = data.azurerm_sentinel_alert_rule_template.test.name
   enabled                    = false
-
-  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 
 data "azurerm_sentinel_alert_rule_template" "test2" {
   display_name               = "(Preview) Anomalous RDP Login Detections"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
-
-  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
 }
 
 resource "azurerm_sentinel_alert_rule_machine_learning_behavior_analytics" "test2" {
   name                       = "acctest-SentinelAlertRule-MLBehaviorAnalytics-2-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
   alert_rule_template_guid   = data.azurerm_sentinel_alert_rule_template.test2.name
   enabled                    = false
-
-  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, r.template(data), data.RandomInteger, data.RandomInteger)
 }
@@ -204,8 +193,7 @@ resource "azurerm_log_analytics_workspace" "test" {
 }
 
 resource "azurerm_sentinel_log_analytics_workspace_onboarding" "test" {
-  resource_group_name = azurerm_resource_group.test.name
-  workspace_name      = azurerm_log_analytics_workspace.test.name
+  workspace_id = azurerm_log_analytics_workspace.test.id
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/internal/services/sentinel/sentinel_alert_rule_machine_learning_behavior_analytics_test.go
+++ b/internal/services/sentinel/sentinel_alert_rule_machine_learning_behavior_analytics_test.go
@@ -120,7 +120,7 @@ func (r SentinelAlertRuleMLBehaviorAnalyticsResource) basic(data acceptance.Test
 
 data "azurerm_sentinel_alert_rule_template" "test" {
   display_name               = "(Preview) Anomalous SSH Login Detection"
-  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
 }
 
 resource "azurerm_sentinel_alert_rule_machine_learning_behavior_analytics" "test" {
@@ -138,24 +138,24 @@ func (r SentinelAlertRuleMLBehaviorAnalyticsResource) complete(data acceptance.T
 
 data "azurerm_sentinel_alert_rule_template" "test" {
   display_name               = "(Preview) Anomalous SSH Login Detection"
-  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
 }
 
 resource "azurerm_sentinel_alert_rule_machine_learning_behavior_analytics" "test" {
   name                       = "acctest-SentinelAlertRule-MLBehaviorAnalytics-%d"
-  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
   alert_rule_template_guid   = data.azurerm_sentinel_alert_rule_template.test.name
   enabled                    = false
 }
 
 data "azurerm_sentinel_alert_rule_template" "test2" {
   display_name               = "(Preview) Anomalous RDP Login Detections"
-  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
 }
 
 resource "azurerm_sentinel_alert_rule_machine_learning_behavior_analytics" "test2" {
   name                       = "acctest-SentinelAlertRule-MLBehaviorAnalytics-2-%d"
-  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
   alert_rule_template_guid   = data.azurerm_sentinel_alert_rule_template.test2.name
   enabled                    = false
 }

--- a/internal/services/sentinel/sentinel_alert_rule_ms_security_incident_resource_test.go
+++ b/internal/services/sentinel/sentinel_alert_rule_ms_security_incident_resource_test.go
@@ -159,10 +159,12 @@ func (r SentinelAlertRuleMsSecurityIncidentResource) basic(data acceptance.TestD
 
 resource "azurerm_sentinel_alert_rule_ms_security_incident" "test" {
   name                       = "acctest-SentinelAlertRule-MSI-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_solution.test.workspace_resource_id
-  product_filter             = "Microsoft Cloud App Security"
-  display_name               = "some rule"
-  severity_filter            = ["High"]
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+
+  depends_on      = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
+  product_filter  = "Microsoft Cloud App Security"
+  display_name    = "some rule"
+  severity_filter = ["High"]
 }
 `, r.template(data), data.RandomInteger)
 }
@@ -173,12 +175,14 @@ func (r SentinelAlertRuleMsSecurityIncidentResource) complete(data acceptance.Te
 
 resource "azurerm_sentinel_alert_rule_ms_security_incident" "test" {
   name                       = "acctest-SentinelAlertRule-MSI-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_solution.test.workspace_resource_id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
   product_filter             = "Azure Security Center"
   display_name               = "updated rule"
   severity_filter            = ["High", "Low"]
   description                = "this is a alert rule"
   display_name_filter        = ["alert"]
+
+  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, r.template(data), data.RandomInteger)
 }
@@ -203,11 +207,13 @@ func (r SentinelAlertRuleMsSecurityIncidentResource) alertRuleTemplateGuid(data 
 
 resource "azurerm_sentinel_alert_rule_ms_security_incident" "test" {
   name                       = "acctest-SentinelAlertRule-MSI-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_solution.test.workspace_resource_id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
   product_filter             = "Microsoft Cloud App Security"
   display_name               = "some rule"
   severity_filter            = ["High"]
   alert_rule_template_guid   = "b3cfc7c0-092c-481c-a55b-34a3979758cb"
+
+  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, r.template(data), data.RandomInteger)
 }
@@ -218,12 +224,14 @@ func (r SentinelAlertRuleMsSecurityIncidentResource) displayNameExcludeFilter(da
 
 resource "azurerm_sentinel_alert_rule_ms_security_incident" "test" {
   name                        = "acctest-SentinelAlertRule-MSI-%d"
-  log_analytics_workspace_id  = azurerm_log_analytics_solution.test.workspace_resource_id
+  log_analytics_workspace_id  = azurerm_log_analytics_workspace.test.id
   product_filter              = "Microsoft Cloud App Security"
   display_name                = "some rule"
   severity_filter             = ["High"]
   display_name_filter         = ["alert1"]
   display_name_exclude_filter = ["%s"]
+
+  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, r.template(data), data.RandomInteger, displayNameExcludeFilter)
 }
@@ -247,17 +255,9 @@ resource "azurerm_log_analytics_workspace" "test" {
   reservation_capacity_in_gb_per_day = 100
 }
 
-resource "azurerm_log_analytics_solution" "test" {
-  solution_name         = "SecurityInsights"
-  location              = azurerm_resource_group.test.location
-  resource_group_name   = azurerm_resource_group.test.name
-  workspace_resource_id = azurerm_log_analytics_workspace.test.id
-  workspace_name        = azurerm_log_analytics_workspace.test.name
-
-  plan {
-    publisher = "Microsoft"
-    product   = "OMSGallery/SecurityInsights"
-  }
+resource "azurerm_sentinel_log_analytics_workspace_onboarding" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  workspace_name      = azurerm_log_analytics_workspace.test.name
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/internal/services/sentinel/sentinel_alert_rule_ms_security_incident_resource_test.go
+++ b/internal/services/sentinel/sentinel_alert_rule_ms_security_incident_resource_test.go
@@ -160,11 +160,11 @@ func (r SentinelAlertRuleMsSecurityIncidentResource) basic(data acceptance.TestD
 resource "azurerm_sentinel_alert_rule_ms_security_incident" "test" {
   name                       = "acctest-SentinelAlertRule-MSI-%d"
   log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  product_filter             = "Microsoft Cloud App Security"
+  display_name               = "some rule"
+  severity_filter            = ["High"]
 
-  depends_on      = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
-  product_filter  = "Microsoft Cloud App Security"
-  display_name    = "some rule"
-  severity_filter = ["High"]
+  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, r.template(data), data.RandomInteger)
 }

--- a/internal/services/sentinel/sentinel_alert_rule_ms_security_incident_resource_test.go
+++ b/internal/services/sentinel/sentinel_alert_rule_ms_security_incident_resource_test.go
@@ -159,12 +159,10 @@ func (r SentinelAlertRuleMsSecurityIncidentResource) basic(data acceptance.TestD
 
 resource "azurerm_sentinel_alert_rule_ms_security_incident" "test" {
   name                       = "acctest-SentinelAlertRule-MSI-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
   product_filter             = "Microsoft Cloud App Security"
   display_name               = "some rule"
   severity_filter            = ["High"]
-
-  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, r.template(data), data.RandomInteger)
 }
@@ -175,14 +173,12 @@ func (r SentinelAlertRuleMsSecurityIncidentResource) complete(data acceptance.Te
 
 resource "azurerm_sentinel_alert_rule_ms_security_incident" "test" {
   name                       = "acctest-SentinelAlertRule-MSI-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
   product_filter             = "Azure Security Center"
   display_name               = "updated rule"
   severity_filter            = ["High", "Low"]
   description                = "this is a alert rule"
   display_name_filter        = ["alert"]
-
-  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, r.template(data), data.RandomInteger)
 }
@@ -207,13 +203,11 @@ func (r SentinelAlertRuleMsSecurityIncidentResource) alertRuleTemplateGuid(data 
 
 resource "azurerm_sentinel_alert_rule_ms_security_incident" "test" {
   name                       = "acctest-SentinelAlertRule-MSI-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
   product_filter             = "Microsoft Cloud App Security"
   display_name               = "some rule"
   severity_filter            = ["High"]
   alert_rule_template_guid   = "b3cfc7c0-092c-481c-a55b-34a3979758cb"
-
-  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, r.template(data), data.RandomInteger)
 }
@@ -224,14 +218,12 @@ func (r SentinelAlertRuleMsSecurityIncidentResource) displayNameExcludeFilter(da
 
 resource "azurerm_sentinel_alert_rule_ms_security_incident" "test" {
   name                        = "acctest-SentinelAlertRule-MSI-%d"
-  log_analytics_workspace_id  = azurerm_log_analytics_workspace.test.id
+  log_analytics_workspace_id  = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
   product_filter              = "Microsoft Cloud App Security"
   display_name                = "some rule"
   severity_filter             = ["High"]
   display_name_filter         = ["alert1"]
   display_name_exclude_filter = ["%s"]
-
-  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, r.template(data), data.RandomInteger, displayNameExcludeFilter)
 }
@@ -256,8 +248,7 @@ resource "azurerm_log_analytics_workspace" "test" {
 }
 
 resource "azurerm_sentinel_log_analytics_workspace_onboarding" "test" {
-  resource_group_name = azurerm_resource_group.test.name
-  workspace_name      = azurerm_log_analytics_workspace.test.name
+  workspace_id = azurerm_log_analytics_workspace.test.id
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/internal/services/sentinel/sentinel_alert_rule_ms_security_incident_resource_test.go
+++ b/internal/services/sentinel/sentinel_alert_rule_ms_security_incident_resource_test.go
@@ -159,7 +159,7 @@ func (r SentinelAlertRuleMsSecurityIncidentResource) basic(data acceptance.TestD
 
 resource "azurerm_sentinel_alert_rule_ms_security_incident" "test" {
   name                       = "acctest-SentinelAlertRule-MSI-%d"
-  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
   product_filter             = "Microsoft Cloud App Security"
   display_name               = "some rule"
   severity_filter            = ["High"]
@@ -173,7 +173,7 @@ func (r SentinelAlertRuleMsSecurityIncidentResource) complete(data acceptance.Te
 
 resource "azurerm_sentinel_alert_rule_ms_security_incident" "test" {
   name                       = "acctest-SentinelAlertRule-MSI-%d"
-  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
   product_filter             = "Azure Security Center"
   display_name               = "updated rule"
   severity_filter            = ["High", "Low"]
@@ -203,7 +203,7 @@ func (r SentinelAlertRuleMsSecurityIncidentResource) alertRuleTemplateGuid(data 
 
 resource "azurerm_sentinel_alert_rule_ms_security_incident" "test" {
   name                       = "acctest-SentinelAlertRule-MSI-%d"
-  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
   product_filter             = "Microsoft Cloud App Security"
   display_name               = "some rule"
   severity_filter            = ["High"]
@@ -218,7 +218,7 @@ func (r SentinelAlertRuleMsSecurityIncidentResource) displayNameExcludeFilter(da
 
 resource "azurerm_sentinel_alert_rule_ms_security_incident" "test" {
   name                        = "acctest-SentinelAlertRule-MSI-%d"
-  log_analytics_workspace_id  = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
+  log_analytics_workspace_id  = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
   product_filter              = "Microsoft Cloud App Security"
   display_name                = "some rule"
   severity_filter             = ["High"]

--- a/internal/services/sentinel/sentinel_alert_rule_nrt_resource_test.go
+++ b/internal/services/sentinel/sentinel_alert_rule_nrt_resource_test.go
@@ -152,7 +152,7 @@ func (r SentinelAlertRuleNrtResource) basic(data acceptance.TestData) string {
 
 resource "azurerm_sentinel_alert_rule_nrt" "test" {
   name                       = "acctest-SentinelAlertRule-NRT-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
   display_name               = "Some Rule"
   severity                   = "High"
   query                      = <<QUERY
@@ -161,8 +161,6 @@ AzureActivity |
   where ActivityStatus == "Succeeded" |
   make-series dcount(ResourceId) default=0 on EventSubmissionTimestamp in range(ago(7d), now(), 1d) by Caller
 QUERY
-
-  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, r.template(data), data.RandomInteger)
 }
@@ -173,7 +171,7 @@ func (r SentinelAlertRuleNrtResource) complete(data acceptance.TestData) string 
 
 resource "azurerm_sentinel_alert_rule_nrt" "test" {
   name                       = "acctest-SentinelAlertRule-NRT-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
   display_name               = "Complete Rule"
   description                = "Some Description"
   tactics                    = ["Collection", "CommandAndControl"]
@@ -227,7 +225,6 @@ resource "azurerm_sentinel_alert_rule_nrt" "test" {
     OperatingSystemType = "OSType"
   }
 
-  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, r.template(data), data.RandomInteger)
 }
@@ -238,7 +235,7 @@ func (r SentinelAlertRuleNrtResource) completeUpdate(data acceptance.TestData) s
 
 resource "azurerm_sentinel_alert_rule_nrt" "test" {
   name                       = "acctest-SentinelAlertRule-NRT-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
   display_name               = "Updated Complete Rule"
   severity                   = "High"
   query                      = "Heartbeat"
@@ -247,7 +244,6 @@ resource "azurerm_sentinel_alert_rule_nrt" "test" {
     OperatingSystemType = "OSType"
   }
 
-  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, r.template(data), data.RandomInteger)
 }
@@ -272,20 +268,16 @@ func (r SentinelAlertRuleNrtResource) alertRuleTemplateGuid(data acceptance.Test
 
 data "azurerm_sentinel_alert_rule_template" "test" {
   display_name               = "NRT Base64 encoded Windows process command-lines"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
-
-  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
 }
 
 resource "azurerm_sentinel_alert_rule_nrt" "test" {
   name                       = "acctest-SentinelAlertRule-NRT-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
   display_name               = "Some Rule"
   severity                   = "Low"
   alert_rule_template_guid   = data.azurerm_sentinel_alert_rule_template.test.name
   query                      = "Heartbeat"
-
-  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, r.template(data), data.RandomInteger)
 }
@@ -296,7 +288,7 @@ func (r SentinelAlertRuleNrtResource) eventGroupingSetting(data acceptance.TestD
 
 resource "azurerm_sentinel_alert_rule_nrt" "test" {
   name                       = "acctest-SentinelAlertRule-NRT-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
   display_name               = "Some Rule"
   severity                   = "High"
   query                      = <<QUERY
@@ -309,8 +301,6 @@ QUERY
   event_grouping {
     aggregation_method = "SingleAlert"
   }
-
-  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, r.template(data), data.RandomInteger)
 }
@@ -321,7 +311,7 @@ func (r SentinelAlertRuleNrtResource) updateEventGroupingSetting(data acceptance
 
 resource "azurerm_sentinel_alert_rule_nrt" "test" {
   name                       = "acctest-SentinelAlertRule-NRT-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
   display_name               = "Some Rule"
   severity                   = "High"
   query                      = <<QUERY
@@ -334,7 +324,6 @@ QUERY
   event_grouping {
     aggregation_method = "AlertPerResult"
   }
-  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, r.template(data), data.RandomInteger)
 }
@@ -358,8 +347,7 @@ resource "azurerm_log_analytics_workspace" "test" {
 }
 
 resource "azurerm_sentinel_log_analytics_workspace_onboarding" "test" {
-  resource_group_name = azurerm_resource_group.test.name
-  workspace_name      = azurerm_log_analytics_workspace.test.name
+  workspace_id = azurerm_log_analytics_workspace.test.id
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/internal/services/sentinel/sentinel_alert_rule_nrt_resource_test.go
+++ b/internal/services/sentinel/sentinel_alert_rule_nrt_resource_test.go
@@ -152,7 +152,7 @@ func (r SentinelAlertRuleNrtResource) basic(data acceptance.TestData) string {
 
 resource "azurerm_sentinel_alert_rule_nrt" "test" {
   name                       = "acctest-SentinelAlertRule-NRT-%d"
-  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
   display_name               = "Some Rule"
   severity                   = "High"
   query                      = <<QUERY
@@ -171,7 +171,7 @@ func (r SentinelAlertRuleNrtResource) complete(data acceptance.TestData) string 
 
 resource "azurerm_sentinel_alert_rule_nrt" "test" {
   name                       = "acctest-SentinelAlertRule-NRT-%d"
-  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
   display_name               = "Complete Rule"
   description                = "Some Description"
   tactics                    = ["Collection", "CommandAndControl"]
@@ -235,7 +235,7 @@ func (r SentinelAlertRuleNrtResource) completeUpdate(data acceptance.TestData) s
 
 resource "azurerm_sentinel_alert_rule_nrt" "test" {
   name                       = "acctest-SentinelAlertRule-NRT-%d"
-  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
   display_name               = "Updated Complete Rule"
   severity                   = "High"
   query                      = "Heartbeat"
@@ -268,12 +268,12 @@ func (r SentinelAlertRuleNrtResource) alertRuleTemplateGuid(data acceptance.Test
 
 data "azurerm_sentinel_alert_rule_template" "test" {
   display_name               = "NRT Base64 encoded Windows process command-lines"
-  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
 }
 
 resource "azurerm_sentinel_alert_rule_nrt" "test" {
   name                       = "acctest-SentinelAlertRule-NRT-%d"
-  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
   display_name               = "Some Rule"
   severity                   = "Low"
   alert_rule_template_guid   = data.azurerm_sentinel_alert_rule_template.test.name
@@ -288,7 +288,7 @@ func (r SentinelAlertRuleNrtResource) eventGroupingSetting(data acceptance.TestD
 
 resource "azurerm_sentinel_alert_rule_nrt" "test" {
   name                       = "acctest-SentinelAlertRule-NRT-%d"
-  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
   display_name               = "Some Rule"
   severity                   = "High"
   query                      = <<QUERY
@@ -311,7 +311,7 @@ func (r SentinelAlertRuleNrtResource) updateEventGroupingSetting(data acceptance
 
 resource "azurerm_sentinel_alert_rule_nrt" "test" {
   name                       = "acctest-SentinelAlertRule-NRT-%d"
-  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
   display_name               = "Some Rule"
   severity                   = "High"
   query                      = <<QUERY

--- a/internal/services/sentinel/sentinel_alert_rule_scheduled_resource_test.go
+++ b/internal/services/sentinel/sentinel_alert_rule_scheduled_resource_test.go
@@ -152,7 +152,7 @@ func (r SentinelAlertRuleScheduledResource) basic(data acceptance.TestData) stri
 
 resource "azurerm_sentinel_alert_rule_scheduled" "test" {
   name                       = "acctest-SentinelAlertRule-Sche-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
   display_name               = "Some Rule"
   severity                   = "High"
   query                      = <<QUERY
@@ -162,7 +162,6 @@ AzureActivity |
   make-series dcount(ResourceId) default=0 on EventSubmissionTimestamp in range(ago(7d), now(), 1d) by Caller
 QUERY
 
-  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, r.template(data), data.RandomInteger)
 }
@@ -173,7 +172,7 @@ func (r SentinelAlertRuleScheduledResource) complete(data acceptance.TestData) s
 
 resource "azurerm_sentinel_alert_rule_scheduled" "test" {
   name                       = "acctest-SentinelAlertRule-Sche-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
   display_name               = "Complete Rule"
   description                = "Some Description"
   tactics                    = ["Collection", "CommandAndControl"]
@@ -231,7 +230,6 @@ resource "azurerm_sentinel_alert_rule_scheduled" "test" {
     OperatingSystemType = "OSType"
   }
 
-  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, r.template(data), data.RandomInteger)
 }
@@ -242,7 +240,7 @@ func (r SentinelAlertRuleScheduledResource) completeUpdate(data acceptance.TestD
 
 resource "azurerm_sentinel_alert_rule_scheduled" "test" {
   name                       = "acctest-SentinelAlertRule-Sche-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
   display_name               = "Updated Complete Rule"
   severity                   = "High"
   query                      = "Heartbeat"
@@ -251,7 +249,6 @@ resource "azurerm_sentinel_alert_rule_scheduled" "test" {
     OperatingSystemType = "OSType"
   }
 
-  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 
 }
 `, r.template(data), data.RandomInteger)
@@ -277,14 +274,13 @@ func (r SentinelAlertRuleScheduledResource) alertRuleTemplateGuid(data acceptanc
 
 resource "azurerm_sentinel_alert_rule_scheduled" "test" {
   name                        = "acctest-SentinelAlertRule-Sche-%d"
-  log_analytics_workspace_id  = azurerm_log_analytics_workspace.test.id
+  log_analytics_workspace_id  = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
   display_name                = "Some Rule"
   severity                    = "Low"
   alert_rule_template_guid    = "09ec8fa2-b25f-4696-bfae-05a7b85d7b9e"
   alert_rule_template_version = "1.2.1"
   query                       = "Heartbeat"
 
-  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, r.template(data), data.RandomInteger)
 }
@@ -295,7 +291,7 @@ func (r SentinelAlertRuleScheduledResource) eventGroupingSetting(data acceptance
 
 resource "azurerm_sentinel_alert_rule_scheduled" "test" {
   name                       = "acctest-SentinelAlertRule-Sche-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
   display_name               = "Some Rule"
   severity                   = "Low"
   alert_rule_template_guid   = "65360bb0-8986-4ade-a89d-af3cf44d28aa"
@@ -309,8 +305,6 @@ QUERY
   event_grouping {
     aggregation_method = "SingleAlert"
   }
-
-  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, r.template(data), data.RandomInteger)
 }
@@ -321,7 +315,7 @@ func (r SentinelAlertRuleScheduledResource) updateEventGroupingSetting(data acce
 
 resource "azurerm_sentinel_alert_rule_scheduled" "test" {
   name                       = "acctest-SentinelAlertRule-Sche-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
   display_name               = "Some Rule"
   severity                   = "Low"
   alert_rule_template_guid   = "65360bb0-8986-4ade-a89d-af3cf44d28aa"
@@ -335,9 +329,6 @@ QUERY
   event_grouping {
     aggregation_method = "AlertPerResult"
   }
-
-  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
-
 }
 `, r.template(data), data.RandomInteger)
 }
@@ -374,8 +365,7 @@ resource "azurerm_log_analytics_solution" "test" {
 }
 
 resource "azurerm_sentinel_log_analytics_workspace_onboarding" "test" {
-  resource_group_name = azurerm_resource_group.test.name
-  workspace_name      = azurerm_log_analytics_workspace.test.name
+  workspace_id = azurerm_log_analytics_workspace.test.id
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/internal/services/sentinel/sentinel_alert_rule_scheduled_resource_test.go
+++ b/internal/services/sentinel/sentinel_alert_rule_scheduled_resource_test.go
@@ -152,7 +152,7 @@ func (r SentinelAlertRuleScheduledResource) basic(data acceptance.TestData) stri
 
 resource "azurerm_sentinel_alert_rule_scheduled" "test" {
   name                       = "acctest-SentinelAlertRule-Sche-%d"
-  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
   display_name               = "Some Rule"
   severity                   = "High"
   query                      = <<QUERY
@@ -172,7 +172,7 @@ func (r SentinelAlertRuleScheduledResource) complete(data acceptance.TestData) s
 
 resource "azurerm_sentinel_alert_rule_scheduled" "test" {
   name                       = "acctest-SentinelAlertRule-Sche-%d"
-  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
   display_name               = "Complete Rule"
   description                = "Some Description"
   tactics                    = ["Collection", "CommandAndControl"]
@@ -240,7 +240,7 @@ func (r SentinelAlertRuleScheduledResource) completeUpdate(data acceptance.TestD
 
 resource "azurerm_sentinel_alert_rule_scheduled" "test" {
   name                       = "acctest-SentinelAlertRule-Sche-%d"
-  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
   display_name               = "Updated Complete Rule"
   severity                   = "High"
   query                      = "Heartbeat"
@@ -274,7 +274,7 @@ func (r SentinelAlertRuleScheduledResource) alertRuleTemplateGuid(data acceptanc
 
 resource "azurerm_sentinel_alert_rule_scheduled" "test" {
   name                        = "acctest-SentinelAlertRule-Sche-%d"
-  log_analytics_workspace_id  = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
+  log_analytics_workspace_id  = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
   display_name                = "Some Rule"
   severity                    = "Low"
   alert_rule_template_guid    = "09ec8fa2-b25f-4696-bfae-05a7b85d7b9e"
@@ -291,7 +291,7 @@ func (r SentinelAlertRuleScheduledResource) eventGroupingSetting(data acceptance
 
 resource "azurerm_sentinel_alert_rule_scheduled" "test" {
   name                       = "acctest-SentinelAlertRule-Sche-%d"
-  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
   display_name               = "Some Rule"
   severity                   = "Low"
   alert_rule_template_guid   = "65360bb0-8986-4ade-a89d-af3cf44d28aa"
@@ -315,7 +315,7 @@ func (r SentinelAlertRuleScheduledResource) updateEventGroupingSetting(data acce
 
 resource "azurerm_sentinel_alert_rule_scheduled" "test" {
   name                       = "acctest-SentinelAlertRule-Sche-%d"
-  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
   display_name               = "Some Rule"
   severity                   = "Low"
   alert_rule_template_guid   = "65360bb0-8986-4ade-a89d-af3cf44d28aa"

--- a/internal/services/sentinel/sentinel_alert_rule_scheduled_resource_test.go
+++ b/internal/services/sentinel/sentinel_alert_rule_scheduled_resource_test.go
@@ -152,7 +152,7 @@ func (r SentinelAlertRuleScheduledResource) basic(data acceptance.TestData) stri
 
 resource "azurerm_sentinel_alert_rule_scheduled" "test" {
   name                       = "acctest-SentinelAlertRule-Sche-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_solution.test.workspace_resource_id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
   display_name               = "Some Rule"
   severity                   = "High"
   query                      = <<QUERY
@@ -161,6 +161,8 @@ AzureActivity |
   where ActivityStatus == "Succeeded" |
   make-series dcount(ResourceId) default=0 on EventSubmissionTimestamp in range(ago(7d), now(), 1d) by Caller
 QUERY
+
+  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, r.template(data), data.RandomInteger)
 }
@@ -171,7 +173,7 @@ func (r SentinelAlertRuleScheduledResource) complete(data acceptance.TestData) s
 
 resource "azurerm_sentinel_alert_rule_scheduled" "test" {
   name                       = "acctest-SentinelAlertRule-Sche-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_solution.test.workspace_resource_id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
   display_name               = "Complete Rule"
   description                = "Some Description"
   tactics                    = ["Collection", "CommandAndControl"]
@@ -228,6 +230,8 @@ resource "azurerm_sentinel_alert_rule_scheduled" "test" {
     OperatingSystemName = "OSName"
     OperatingSystemType = "OSType"
   }
+
+  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, r.template(data), data.RandomInteger)
 }
@@ -238,7 +242,7 @@ func (r SentinelAlertRuleScheduledResource) completeUpdate(data acceptance.TestD
 
 resource "azurerm_sentinel_alert_rule_scheduled" "test" {
   name                       = "acctest-SentinelAlertRule-Sche-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_solution.test.workspace_resource_id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
   display_name               = "Updated Complete Rule"
   severity                   = "High"
   query                      = "Heartbeat"
@@ -246,6 +250,9 @@ resource "azurerm_sentinel_alert_rule_scheduled" "test" {
     OperatingSystemName = "OSName"
     OperatingSystemType = "OSType"
   }
+
+  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
+
 }
 `, r.template(data), data.RandomInteger)
 }
@@ -270,12 +277,14 @@ func (r SentinelAlertRuleScheduledResource) alertRuleTemplateGuid(data acceptanc
 
 resource "azurerm_sentinel_alert_rule_scheduled" "test" {
   name                        = "acctest-SentinelAlertRule-Sche-%d"
-  log_analytics_workspace_id  = azurerm_log_analytics_solution.test.workspace_resource_id
+  log_analytics_workspace_id  = azurerm_log_analytics_workspace.test.id
   display_name                = "Some Rule"
   severity                    = "Low"
   alert_rule_template_guid    = "09ec8fa2-b25f-4696-bfae-05a7b85d7b9e"
   alert_rule_template_version = "1.2.1"
   query                       = "Heartbeat"
+
+  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, r.template(data), data.RandomInteger)
 }
@@ -286,7 +295,7 @@ func (r SentinelAlertRuleScheduledResource) eventGroupingSetting(data acceptance
 
 resource "azurerm_sentinel_alert_rule_scheduled" "test" {
   name                       = "acctest-SentinelAlertRule-Sche-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_solution.test.workspace_resource_id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
   display_name               = "Some Rule"
   severity                   = "Low"
   alert_rule_template_guid   = "65360bb0-8986-4ade-a89d-af3cf44d28aa"
@@ -300,6 +309,8 @@ QUERY
   event_grouping {
     aggregation_method = "SingleAlert"
   }
+
+  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, r.template(data), data.RandomInteger)
 }
@@ -310,7 +321,7 @@ func (r SentinelAlertRuleScheduledResource) updateEventGroupingSetting(data acce
 
 resource "azurerm_sentinel_alert_rule_scheduled" "test" {
   name                       = "acctest-SentinelAlertRule-Sche-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_solution.test.workspace_resource_id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
   display_name               = "Some Rule"
   severity                   = "Low"
   alert_rule_template_guid   = "65360bb0-8986-4ade-a89d-af3cf44d28aa"
@@ -324,6 +335,9 @@ QUERY
   event_grouping {
     aggregation_method = "AlertPerResult"
   }
+
+  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
+
 }
 `, r.template(data), data.RandomInteger)
 }
@@ -357,6 +371,11 @@ resource "azurerm_log_analytics_solution" "test" {
     publisher = "Microsoft"
     product   = "OMSGallery/SecurityInsights"
   }
+}
+
+resource "azurerm_sentinel_log_analytics_workspace_onboarding" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  workspace_name      = azurerm_log_analytics_workspace.test.name
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/internal/services/sentinel/sentinel_alert_rule_template_data_source_test.go
+++ b/internal/services/sentinel/sentinel_alert_rule_template_data_source_test.go
@@ -120,7 +120,7 @@ resource "azurerm_sentinel_log_analytics_workspace_onboarding" "test" {
 
 data "azurerm_sentinel_alert_rule_template" "test" {
   display_name               = "%s"
-  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, displayName)
 }

--- a/internal/services/sentinel/sentinel_alert_rule_template_data_source_test.go
+++ b/internal/services/sentinel/sentinel_alert_rule_template_data_source_test.go
@@ -114,22 +114,16 @@ resource "azurerm_log_analytics_workspace" "test" {
   sku                 = "PerGB2018"
 }
 
-resource "azurerm_log_analytics_solution" "test" {
-  solution_name         = "SecurityInsights"
-  location              = azurerm_resource_group.test.location
-  resource_group_name   = azurerm_resource_group.test.name
-  workspace_resource_id = azurerm_log_analytics_workspace.test.id
-  workspace_name        = azurerm_log_analytics_workspace.test.name
-
-  plan {
-    publisher = "Microsoft"
-    product   = "OMSGallery/SecurityInsights"
-  }
+resource "azurerm_sentinel_log_analytics_workspace_onboarding" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  workspace_name      = azurerm_log_analytics_workspace.test.name
 }
 
 data "azurerm_sentinel_alert_rule_template" "test" {
   display_name               = "%s"
-  log_analytics_workspace_id = azurerm_log_analytics_solution.test.workspace_resource_id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.id
+
+  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, displayName)
 }

--- a/internal/services/sentinel/sentinel_alert_rule_template_data_source_test.go
+++ b/internal/services/sentinel/sentinel_alert_rule_template_data_source_test.go
@@ -121,7 +121,7 @@ resource "azurerm_sentinel_log_analytics_workspace_onboarding" "test" {
 
 data "azurerm_sentinel_alert_rule_template" "test" {
   display_name               = "%s"
-  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
 
   depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }

--- a/internal/services/sentinel/sentinel_alert_rule_template_data_source_test.go
+++ b/internal/services/sentinel/sentinel_alert_rule_template_data_source_test.go
@@ -115,15 +115,12 @@ resource "azurerm_log_analytics_workspace" "test" {
 }
 
 resource "azurerm_sentinel_log_analytics_workspace_onboarding" "test" {
-  resource_group_name = azurerm_resource_group.test.name
-  workspace_name      = azurerm_log_analytics_workspace.test.name
+  workspace_id = azurerm_log_analytics_workspace.test.id
 }
 
 data "azurerm_sentinel_alert_rule_template" "test" {
   display_name               = "%s"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
-
-  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, displayName)
 }

--- a/internal/services/sentinel/sentinel_automation_rule_resource_test.go
+++ b/internal/services/sentinel/sentinel_automation_rule_resource_test.go
@@ -175,7 +175,7 @@ func (r SentinelAutomationRuleResource) basic(data acceptance.TestData) string {
 
 resource "azurerm_sentinel_automation_rule" "test" {
   name                       = "%s"
-  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
   display_name               = "acctest-SentinelAutoRule-%d"
   order                      = 1
 
@@ -197,7 +197,7 @@ data "azurerm_client_config" "current" {}
 
 resource "azurerm_sentinel_automation_rule" "test" {
   name                       = "%s"
-  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
   display_name               = "acctest-SentinelAutoRule-%d-update"
   order                      = 2
   enabled                    = false
@@ -250,7 +250,7 @@ data "azurerm_client_config" "current" {}
 
 resource "azurerm_sentinel_automation_rule" "test" {
   name                       = "%s"
-  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
   display_name               = "acctest-SentinelAutoRule-%d-update"
   order                      = 2
   enabled                    = false
@@ -318,7 +318,7 @@ data "azurerm_client_config" "current" {}
 
 resource "azurerm_sentinel_automation_rule" "test" {
   name                       = "%s"
-  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
   display_name               = "acctest-SentinelAutoRule-%d-update"
   order                      = 1
   condition_json = jsonencode([
@@ -433,7 +433,7 @@ resource "azurerm_role_assignment" "test" {
 
 resource "azurerm_sentinel_automation_rule" "test" {
   name                       = "%[3]s"
-  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
   display_name               = "acctest-SentinelAutoRule-%[2]d-update"
   order                      = 1
   triggers_on                = "Alerts"

--- a/internal/services/sentinel/sentinel_automation_rule_resource_test.go
+++ b/internal/services/sentinel/sentinel_automation_rule_resource_test.go
@@ -175,7 +175,7 @@ func (r SentinelAutomationRuleResource) basic(data acceptance.TestData) string {
 
 resource "azurerm_sentinel_automation_rule" "test" {
   name                       = "%s"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
   display_name               = "acctest-SentinelAutoRule-%d"
   order                      = 1
 
@@ -183,9 +183,6 @@ resource "azurerm_sentinel_automation_rule" "test" {
     order  = 1
     status = "Active"
   }
-
-  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
-
 }
 `, template, r.uuid, data.RandomInteger)
 }
@@ -200,7 +197,7 @@ data "azurerm_client_config" "current" {}
 
 resource "azurerm_sentinel_automation_rule" "test" {
   name                       = "%s"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
   display_name               = "acctest-SentinelAutoRule-%d-update"
   order                      = 2
   enabled                    = false
@@ -239,7 +236,6 @@ resource "azurerm_sentinel_automation_rule" "test" {
     owner_id = data.azurerm_client_config.current.object_id
   }
 
-  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, template, r.uuid, data.RandomInteger, expDate)
 }
@@ -254,7 +250,7 @@ data "azurerm_client_config" "current" {}
 
 resource "azurerm_sentinel_automation_rule" "test" {
   name                       = "%s"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
   display_name               = "acctest-SentinelAutoRule-%d-update"
   order                      = 2
   enabled                    = false
@@ -309,7 +305,6 @@ resource "azurerm_sentinel_automation_rule" "test" {
     owner_id = data.azurerm_client_config.current.object_id
   }
 
-  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, template, r.uuid, data.RandomInteger, expDate)
 }
@@ -323,7 +318,7 @@ data "azurerm_client_config" "current" {}
 
 resource "azurerm_sentinel_automation_rule" "test" {
   name                       = "%s"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
   display_name               = "acctest-SentinelAutoRule-%d-update"
   order                      = 1
   condition_json = jsonencode([
@@ -344,8 +339,6 @@ resource "azurerm_sentinel_automation_rule" "test" {
     order    = 1
     owner_id = data.azurerm_client_config.current.object_id
   }
-
-  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, template, r.uuid, data.RandomInteger)
 }
@@ -440,7 +433,7 @@ resource "azurerm_role_assignment" "test" {
 
 resource "azurerm_sentinel_automation_rule" "test" {
   name                       = "%[3]s"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
   display_name               = "acctest-SentinelAutoRule-%[2]d-update"
   order                      = 1
   triggers_on                = "Alerts"
@@ -450,7 +443,7 @@ resource "azurerm_sentinel_automation_rule" "test" {
   }
   condition_json = "[]"
 
-  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test, azurerm_logic_app_trigger_custom.test, azurerm_role_assignment.test]
+  depends_on = [azurerm_logic_app_trigger_custom.test, azurerm_role_assignment.test]
 }
 
 
@@ -495,9 +488,9 @@ resource "azurerm_log_analytics_workspace" "test" {
 }
 
 resource "azurerm_sentinel_log_analytics_workspace_onboarding" "test" {
-  resource_group_name = azurerm_resource_group.test.name
-  workspace_name      = azurerm_log_analytics_workspace.test.name
+  workspace_id = azurerm_log_analytics_workspace.test.id
 }
+
 
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/internal/services/sentinel/sentinel_automation_rule_resource_test.go
+++ b/internal/services/sentinel/sentinel_automation_rule_resource_test.go
@@ -175,7 +175,7 @@ func (r SentinelAutomationRuleResource) basic(data acceptance.TestData) string {
 
 resource "azurerm_sentinel_automation_rule" "test" {
   name                       = "%s"
-  log_analytics_workspace_id = azurerm_log_analytics_solution.sentinel.workspace_resource_id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
   display_name               = "acctest-SentinelAutoRule-%d"
   order                      = 1
 
@@ -183,6 +183,9 @@ resource "azurerm_sentinel_automation_rule" "test" {
     order  = 1
     status = "Active"
   }
+
+  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
+
 }
 `, template, r.uuid, data.RandomInteger)
 }
@@ -197,7 +200,7 @@ data "azurerm_client_config" "current" {}
 
 resource "azurerm_sentinel_automation_rule" "test" {
   name                       = "%s"
-  log_analytics_workspace_id = azurerm_log_analytics_solution.sentinel.workspace_resource_id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
   display_name               = "acctest-SentinelAutoRule-%d-update"
   order                      = 2
   enabled                    = false
@@ -235,6 +238,8 @@ resource "azurerm_sentinel_automation_rule" "test" {
     order    = 4
     owner_id = data.azurerm_client_config.current.object_id
   }
+
+  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, template, r.uuid, data.RandomInteger, expDate)
 }
@@ -249,7 +254,7 @@ data "azurerm_client_config" "current" {}
 
 resource "azurerm_sentinel_automation_rule" "test" {
   name                       = "%s"
-  log_analytics_workspace_id = azurerm_log_analytics_solution.sentinel.workspace_resource_id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
   display_name               = "acctest-SentinelAutoRule-%d-update"
   order                      = 2
   enabled                    = false
@@ -303,6 +308,8 @@ resource "azurerm_sentinel_automation_rule" "test" {
     order    = 4
     owner_id = data.azurerm_client_config.current.object_id
   }
+
+  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, template, r.uuid, data.RandomInteger, expDate)
 }
@@ -316,7 +323,7 @@ data "azurerm_client_config" "current" {}
 
 resource "azurerm_sentinel_automation_rule" "test" {
   name                       = "%s"
-  log_analytics_workspace_id = azurerm_log_analytics_solution.sentinel.workspace_resource_id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
   display_name               = "acctest-SentinelAutoRule-%d-update"
   order                      = 1
   condition_json = jsonencode([
@@ -337,6 +344,8 @@ resource "azurerm_sentinel_automation_rule" "test" {
     order    = 1
     owner_id = data.azurerm_client_config.current.object_id
   }
+
+  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, template, r.uuid, data.RandomInteger)
 }
@@ -431,7 +440,7 @@ resource "azurerm_role_assignment" "test" {
 
 resource "azurerm_sentinel_automation_rule" "test" {
   name                       = "%[3]s"
-  log_analytics_workspace_id = azurerm_log_analytics_solution.sentinel.workspace_resource_id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
   display_name               = "acctest-SentinelAutoRule-%[2]d-update"
   order                      = 1
   triggers_on                = "Alerts"
@@ -440,8 +449,11 @@ resource "azurerm_sentinel_automation_rule" "test" {
     order        = 1
   }
   condition_json = "[]"
-  depends_on     = [azurerm_logic_app_trigger_custom.test, azurerm_role_assignment.test]
+
+  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test, azurerm_logic_app_trigger_custom.test, azurerm_role_assignment.test]
 }
+
+
 
 
 `, template, data.RandomInteger, r.uuid, r.clientSecret)
@@ -482,17 +494,10 @@ resource "azurerm_log_analytics_workspace" "test" {
   sku                 = "PerGB2018"
 }
 
-resource "azurerm_log_analytics_solution" "sentinel" {
-  solution_name         = "SecurityInsights"
-  location              = azurerm_resource_group.test.location
-  resource_group_name   = azurerm_resource_group.test.name
-  workspace_resource_id = azurerm_log_analytics_workspace.test.id
-  workspace_name        = azurerm_log_analytics_workspace.test.name
-
-  plan {
-    publisher = "Microsoft"
-    product   = "OMSGallery/SecurityInsights"
-  }
+resource "azurerm_sentinel_log_analytics_workspace_onboarding" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  workspace_name      = azurerm_log_analytics_workspace.test.name
 }
+
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/internal/services/sentinel/sentinel_data_connector_azure_active_directory_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_azure_active_directory_test.go
@@ -85,7 +85,7 @@ func (r SentinelDataConnectorAzureActiveDirectoryResource) basic(data acceptance
 
 resource "azurerm_sentinel_data_connector_azure_active_directory" "test" {
   name                       = "accTestDC-%d"
-  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
 }
 `, template, data.RandomInteger)
 }
@@ -99,7 +99,7 @@ data "azurerm_client_config" "test" {}
 
 resource "azurerm_sentinel_data_connector_azure_active_directory" "test" {
   name                       = "accTestDC-%d"
-  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
   tenant_id                  = data.azurerm_client_config.test.tenant_id
 }
 `, template, data.RandomInteger)

--- a/internal/services/sentinel/sentinel_data_connector_azure_active_directory_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_azure_active_directory_test.go
@@ -86,7 +86,7 @@ func (r SentinelDataConnectorAzureActiveDirectoryResource) basic(data acceptance
 resource "azurerm_sentinel_data_connector_azure_active_directory" "test" {
   name                       = "accTestDC-%d"
   log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
-  depends_on                 = [azurerm_log_analytics_solution.test]
+  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, template, data.RandomInteger)
 }
@@ -102,7 +102,7 @@ resource "azurerm_sentinel_data_connector_azure_active_directory" "test" {
   name                       = "accTestDC-%d"
   log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
   tenant_id                  = data.azurerm_client_config.test.tenant_id
-  depends_on                 = [azurerm_log_analytics_solution.test]
+  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, template, data.RandomInteger)
 }
@@ -137,17 +137,9 @@ resource "azurerm_log_analytics_workspace" "test" {
   sku                 = "PerGB2018"
 }
 
-resource "azurerm_log_analytics_solution" "test" {
-  solution_name         = "SecurityInsights"
-  location              = azurerm_resource_group.test.location
-  resource_group_name   = azurerm_resource_group.test.name
-  workspace_resource_id = azurerm_log_analytics_workspace.test.id
-  workspace_name        = azurerm_log_analytics_workspace.test.name
-
-  plan {
-    publisher = "Microsoft"
-    product   = "OMSGallery/SecurityInsights"
-  }
+resource "azurerm_sentinel_log_analytics_workspace_onboarding" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  workspace_name      = azurerm_log_analytics_workspace.test.name
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/internal/services/sentinel/sentinel_data_connector_azure_active_directory_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_azure_active_directory_test.go
@@ -85,8 +85,7 @@ func (r SentinelDataConnectorAzureActiveDirectoryResource) basic(data acceptance
 
 resource "azurerm_sentinel_data_connector_azure_active_directory" "test" {
   name                       = "accTestDC-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
-  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
 }
 `, template, data.RandomInteger)
 }
@@ -100,9 +99,8 @@ data "azurerm_client_config" "test" {}
 
 resource "azurerm_sentinel_data_connector_azure_active_directory" "test" {
   name                       = "accTestDC-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
   tenant_id                  = data.azurerm_client_config.test.tenant_id
-  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, template, data.RandomInteger)
 }
@@ -138,8 +136,7 @@ resource "azurerm_log_analytics_workspace" "test" {
 }
 
 resource "azurerm_sentinel_log_analytics_workspace_onboarding" "test" {
-  resource_group_name = azurerm_resource_group.test.name
-  workspace_name      = azurerm_log_analytics_workspace.test.name
+  workspace_id = azurerm_log_analytics_workspace.test.id
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/internal/services/sentinel/sentinel_data_connector_azure_advanced_threat_protection_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_azure_advanced_threat_protection_test.go
@@ -86,7 +86,7 @@ func (r SentinelDataConnectorAzureAdvancedThreatProtectionResource) basic(data a
 resource "azurerm_sentinel_data_connector_azure_advanced_threat_protection" "test" {
   name                       = "accTestDC-%d"
   log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
-  depends_on                 = [azurerm_log_analytics_solution.test]
+  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, template, data.RandomInteger)
 }
@@ -102,7 +102,7 @@ resource "azurerm_sentinel_data_connector_azure_advanced_threat_protection" "tes
   name                       = "accTestDC-%d"
   log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
   tenant_id                  = data.azurerm_client_config.test.tenant_id
-  depends_on                 = [azurerm_log_analytics_solution.test]
+  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, template, data.RandomInteger)
 }
@@ -137,17 +137,9 @@ resource "azurerm_log_analytics_workspace" "test" {
   sku                 = "PerGB2018"
 }
 
-resource "azurerm_log_analytics_solution" "test" {
-  solution_name         = "SecurityInsights"
-  location              = azurerm_resource_group.test.location
-  resource_group_name   = azurerm_resource_group.test.name
-  workspace_resource_id = azurerm_log_analytics_workspace.test.id
-  workspace_name        = azurerm_log_analytics_workspace.test.name
-
-  plan {
-    publisher = "Microsoft"
-    product   = "OMSGallery/SecurityInsights"
-  }
+resource "azurerm_sentinel_log_analytics_workspace_onboarding" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  workspace_name      = azurerm_log_analytics_workspace.test.name
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/internal/services/sentinel/sentinel_data_connector_azure_advanced_threat_protection_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_azure_advanced_threat_protection_test.go
@@ -85,7 +85,7 @@ func (r SentinelDataConnectorAzureAdvancedThreatProtectionResource) basic(data a
 
 resource "azurerm_sentinel_data_connector_azure_advanced_threat_protection" "test" {
   name                       = "accTestDC-%d"
-  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
 }
 `, template, data.RandomInteger)
 }
@@ -99,7 +99,7 @@ data "azurerm_client_config" "test" {}
 
 resource "azurerm_sentinel_data_connector_azure_advanced_threat_protection" "test" {
   name                       = "accTestDC-%d"
-  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
   tenant_id                  = data.azurerm_client_config.test.tenant_id
 }
 `, template, data.RandomInteger)

--- a/internal/services/sentinel/sentinel_data_connector_azure_advanced_threat_protection_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_azure_advanced_threat_protection_test.go
@@ -85,8 +85,7 @@ func (r SentinelDataConnectorAzureAdvancedThreatProtectionResource) basic(data a
 
 resource "azurerm_sentinel_data_connector_azure_advanced_threat_protection" "test" {
   name                       = "accTestDC-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
-  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
 }
 `, template, data.RandomInteger)
 }
@@ -100,9 +99,8 @@ data "azurerm_client_config" "test" {}
 
 resource "azurerm_sentinel_data_connector_azure_advanced_threat_protection" "test" {
   name                       = "accTestDC-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
   tenant_id                  = data.azurerm_client_config.test.tenant_id
-  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, template, data.RandomInteger)
 }
@@ -138,8 +136,7 @@ resource "azurerm_log_analytics_workspace" "test" {
 }
 
 resource "azurerm_sentinel_log_analytics_workspace_onboarding" "test" {
-  resource_group_name = azurerm_resource_group.test.name
-  workspace_name      = azurerm_log_analytics_workspace.test.name
+  workspace_id = azurerm_log_analytics_workspace.test.id
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/internal/services/sentinel/sentinel_data_connector_azure_security_center_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_azure_security_center_test.go
@@ -85,7 +85,7 @@ func (r SentinelDataConnectorAzureSecurityCenterResource) basic(data acceptance.
 
 resource "azurerm_sentinel_data_connector_azure_security_center" "test" {
   name                       = "accTestDC-%d"
-  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
 }
 `, template, data.RandomInteger)
 }
@@ -99,7 +99,7 @@ data "azurerm_client_config" "test" {}
 
 resource "azurerm_sentinel_data_connector_azure_security_center" "test" {
   name                       = "accTestDC-%d"
-  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
   subscription_id            = data.azurerm_client_config.test.subscription_id
 }
 `, template, data.RandomInteger)
@@ -112,7 +112,7 @@ func (r SentinelDataConnectorAzureSecurityCenterResource) requiresImport(data ac
 
 resource "azurerm_sentinel_data_connector_azure_security_center" "import" {
   name                       = azurerm_sentinel_data_connector_azure_security_center.test.name
-  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
 }
 `, template)
 }

--- a/internal/services/sentinel/sentinel_data_connector_azure_security_center_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_azure_security_center_test.go
@@ -85,8 +85,7 @@ func (r SentinelDataConnectorAzureSecurityCenterResource) basic(data acceptance.
 
 resource "azurerm_sentinel_data_connector_azure_security_center" "test" {
   name                       = "accTestDC-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
-  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
 }
 `, template, data.RandomInteger)
 }
@@ -100,9 +99,8 @@ data "azurerm_client_config" "test" {}
 
 resource "azurerm_sentinel_data_connector_azure_security_center" "test" {
   name                       = "accTestDC-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
   subscription_id            = data.azurerm_client_config.test.subscription_id
-  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, template, data.RandomInteger)
 }
@@ -114,7 +112,7 @@ func (r SentinelDataConnectorAzureSecurityCenterResource) requiresImport(data ac
 
 resource "azurerm_sentinel_data_connector_azure_security_center" "import" {
   name                       = azurerm_sentinel_data_connector_azure_security_center.test.name
-  log_analytics_workspace_id = azurerm_sentinel_data_connector_azure_security_center.test.log_analytics_workspace_id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
 }
 `, template)
 }
@@ -138,8 +136,7 @@ resource "azurerm_log_analytics_workspace" "test" {
 }
 
 resource "azurerm_sentinel_log_analytics_workspace_onboarding" "test" {
-  resource_group_name = azurerm_resource_group.test.name
-  workspace_name      = azurerm_log_analytics_workspace.test.name
+  workspace_id = azurerm_log_analytics_workspace.test.id
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/internal/services/sentinel/sentinel_data_connector_azure_security_center_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_azure_security_center_test.go
@@ -86,7 +86,7 @@ func (r SentinelDataConnectorAzureSecurityCenterResource) basic(data acceptance.
 resource "azurerm_sentinel_data_connector_azure_security_center" "test" {
   name                       = "accTestDC-%d"
   log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
-  depends_on                 = [azurerm_log_analytics_solution.test]
+  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, template, data.RandomInteger)
 }
@@ -102,7 +102,7 @@ resource "azurerm_sentinel_data_connector_azure_security_center" "test" {
   name                       = "accTestDC-%d"
   log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
   subscription_id            = data.azurerm_client_config.test.subscription_id
-  depends_on                 = [azurerm_log_analytics_solution.test]
+  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, template, data.RandomInteger)
 }
@@ -137,17 +137,9 @@ resource "azurerm_log_analytics_workspace" "test" {
   sku                 = "PerGB2018"
 }
 
-resource "azurerm_log_analytics_solution" "test" {
-  solution_name         = "SecurityInsights"
-  location              = azurerm_resource_group.test.location
-  resource_group_name   = azurerm_resource_group.test.name
-  workspace_resource_id = azurerm_log_analytics_workspace.test.id
-  workspace_name        = azurerm_log_analytics_workspace.test.name
-
-  plan {
-    publisher = "Microsoft"
-    product   = "OMSGallery/SecurityInsights"
-  }
+resource "azurerm_sentinel_log_analytics_workspace_onboarding" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  workspace_name      = azurerm_log_analytics_workspace.test.name
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/internal/services/sentinel/sentinel_data_connector_dynamics_365_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_dynamics_365_test.go
@@ -85,7 +85,7 @@ func (r SentinelDataConnectorDynamics365Resource) basic(data acceptance.TestData
 
 resource "azurerm_sentinel_data_connector_dynamics_365" "test" {
   name                       = "accTestDC-%d"
-  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
 }
 `, template, data.RandomInteger)
 }
@@ -99,7 +99,7 @@ data "azurerm_client_config" "test" {}
 
 resource "azurerm_sentinel_data_connector_dynamics_365" "test" {
   name                       = "accTestDC-%d"
-  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
   tenant_id                  = data.azurerm_client_config.test.tenant_id
 }
 `, template, data.RandomInteger)

--- a/internal/services/sentinel/sentinel_data_connector_dynamics_365_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_dynamics_365_test.go
@@ -85,8 +85,7 @@ func (r SentinelDataConnectorDynamics365Resource) basic(data acceptance.TestData
 
 resource "azurerm_sentinel_data_connector_dynamics_365" "test" {
   name                       = "accTestDC-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
-  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
 }
 `, template, data.RandomInteger)
 }
@@ -100,9 +99,8 @@ data "azurerm_client_config" "test" {}
 
 resource "azurerm_sentinel_data_connector_dynamics_365" "test" {
   name                       = "accTestDC-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
   tenant_id                  = data.azurerm_client_config.test.tenant_id
-  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, template, data.RandomInteger)
 }
@@ -138,8 +136,7 @@ resource "azurerm_log_analytics_workspace" "test" {
 }
 
 resource "azurerm_sentinel_log_analytics_workspace_onboarding" "test" {
-  resource_group_name = azurerm_resource_group.test.name
-  workspace_name      = azurerm_log_analytics_workspace.test.name
+  workspace_id = azurerm_log_analytics_workspace.test.id
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/internal/services/sentinel/sentinel_data_connector_dynamics_365_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_dynamics_365_test.go
@@ -86,7 +86,7 @@ func (r SentinelDataConnectorDynamics365Resource) basic(data acceptance.TestData
 resource "azurerm_sentinel_data_connector_dynamics_365" "test" {
   name                       = "accTestDC-%d"
   log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
-  depends_on                 = [azurerm_log_analytics_solution.test]
+  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, template, data.RandomInteger)
 }
@@ -102,7 +102,7 @@ resource "azurerm_sentinel_data_connector_dynamics_365" "test" {
   name                       = "accTestDC-%d"
   log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
   tenant_id                  = data.azurerm_client_config.test.tenant_id
-  depends_on                 = [azurerm_log_analytics_solution.test]
+  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, template, data.RandomInteger)
 }
@@ -137,17 +137,9 @@ resource "azurerm_log_analytics_workspace" "test" {
   sku                 = "PerGB2018"
 }
 
-resource "azurerm_log_analytics_solution" "test" {
-  solution_name         = "SecurityInsights"
-  location              = azurerm_resource_group.test.location
-  resource_group_name   = azurerm_resource_group.test.name
-  workspace_resource_id = azurerm_log_analytics_workspace.test.id
-  workspace_name        = azurerm_log_analytics_workspace.test.name
-
-  plan {
-    publisher = "Microsoft"
-    product   = "OMSGallery/SecurityInsights"
-  }
+resource "azurerm_sentinel_log_analytics_workspace_onboarding" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  workspace_name      = azurerm_log_analytics_workspace.test.name
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/internal/services/sentinel/sentinel_data_connector_iot_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_iot_test.go
@@ -85,7 +85,7 @@ func (r SentinelDataConnectorIOTResource) basic(data acceptance.TestData) string
 
 resource "azurerm_sentinel_data_connector_iot" "test" {
   name                       = "accTestDC-%d"
-  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
 }
 `, template, data.RandomInteger)
 }
@@ -99,7 +99,7 @@ data "azurerm_client_config" "test" {}
 
 resource "azurerm_sentinel_data_connector_iot" "test" {
   name                       = "accTestDC-%d"
-  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
   subscription_id            = data.azurerm_client_config.test.subscription_id
 }
 `, template, data.RandomInteger)

--- a/internal/services/sentinel/sentinel_data_connector_iot_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_iot_test.go
@@ -86,7 +86,7 @@ func (r SentinelDataConnectorIOTResource) basic(data acceptance.TestData) string
 resource "azurerm_sentinel_data_connector_iot" "test" {
   name                       = "accTestDC-%d"
   log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
-  depends_on                 = [azurerm_log_analytics_solution.test]
+  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, template, data.RandomInteger)
 }
@@ -102,7 +102,7 @@ resource "azurerm_sentinel_data_connector_iot" "test" {
   name                       = "accTestDC-%d"
   log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
   subscription_id            = data.azurerm_client_config.test.subscription_id
-  depends_on                 = [azurerm_log_analytics_solution.test]
+  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, template, data.RandomInteger)
 }
@@ -137,17 +137,9 @@ resource "azurerm_log_analytics_workspace" "test" {
   sku                 = "PerGB2018"
 }
 
-resource "azurerm_log_analytics_solution" "test" {
-  solution_name         = "SecurityInsights"
-  location              = azurerm_resource_group.test.location
-  resource_group_name   = azurerm_resource_group.test.name
-  workspace_resource_id = azurerm_log_analytics_workspace.test.id
-  workspace_name        = azurerm_log_analytics_workspace.test.name
-
-  plan {
-    publisher = "Microsoft"
-    product   = "OMSGallery/SecurityInsights"
-  }
+resource "azurerm_sentinel_log_analytics_workspace_onboarding" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  workspace_name      = azurerm_log_analytics_workspace.test.name
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/internal/services/sentinel/sentinel_data_connector_iot_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_iot_test.go
@@ -85,8 +85,7 @@ func (r SentinelDataConnectorIOTResource) basic(data acceptance.TestData) string
 
 resource "azurerm_sentinel_data_connector_iot" "test" {
   name                       = "accTestDC-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
-  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
 }
 `, template, data.RandomInteger)
 }
@@ -100,9 +99,8 @@ data "azurerm_client_config" "test" {}
 
 resource "azurerm_sentinel_data_connector_iot" "test" {
   name                       = "accTestDC-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
   subscription_id            = data.azurerm_client_config.test.subscription_id
-  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, template, data.RandomInteger)
 }
@@ -138,8 +136,7 @@ resource "azurerm_log_analytics_workspace" "test" {
 }
 
 resource "azurerm_sentinel_log_analytics_workspace_onboarding" "test" {
-  resource_group_name = azurerm_resource_group.test.name
-  workspace_name      = azurerm_log_analytics_workspace.test.name
+  workspace_id = azurerm_log_analytics_workspace.test.id
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/internal/services/sentinel/sentinel_data_connector_microsoft_cloud_app_security_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_microsoft_cloud_app_security_test.go
@@ -129,7 +129,7 @@ func (r SentinelDataConnectorMicrosoftCloudAppSecurityResource) basic(data accep
 resource "azurerm_sentinel_data_connector_microsoft_cloud_app_security" "test" {
   name                       = "accTestDC-%d"
   log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
-  depends_on                 = [azurerm_log_analytics_solution.test]
+  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, template, data.RandomInteger)
 }
@@ -147,7 +147,7 @@ resource "azurerm_sentinel_data_connector_microsoft_cloud_app_security" "test" {
   tenant_id                  = data.azurerm_client_config.test.tenant_id
   alerts_enabled             = %t
   discovery_logs_enabled     = %t
-  depends_on                 = [azurerm_log_analytics_solution.test]
+  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, template, data.RandomInteger, alertsEnabled, discoveryLogsEnabled)
 }
@@ -182,17 +182,9 @@ resource "azurerm_log_analytics_workspace" "test" {
   sku                 = "PerGB2018"
 }
 
-resource "azurerm_log_analytics_solution" "test" {
-  solution_name         = "SecurityInsights"
-  location              = azurerm_resource_group.test.location
-  resource_group_name   = azurerm_resource_group.test.name
-  workspace_resource_id = azurerm_log_analytics_workspace.test.id
-  workspace_name        = azurerm_log_analytics_workspace.test.name
-
-  plan {
-    publisher = "Microsoft"
-    product   = "OMSGallery/SecurityInsights"
-  }
+resource "azurerm_sentinel_log_analytics_workspace_onboarding" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  workspace_name      = azurerm_log_analytics_workspace.test.name
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/internal/services/sentinel/sentinel_data_connector_microsoft_cloud_app_security_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_microsoft_cloud_app_security_test.go
@@ -128,8 +128,7 @@ func (r SentinelDataConnectorMicrosoftCloudAppSecurityResource) basic(data accep
 
 resource "azurerm_sentinel_data_connector_microsoft_cloud_app_security" "test" {
   name                       = "accTestDC-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
-  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
 }
 `, template, data.RandomInteger)
 }
@@ -143,11 +142,10 @@ data "azurerm_client_config" "test" {}
 
 resource "azurerm_sentinel_data_connector_microsoft_cloud_app_security" "test" {
   name                       = "accTestDC-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
   tenant_id                  = data.azurerm_client_config.test.tenant_id
   alerts_enabled             = %t
   discovery_logs_enabled     = %t
-  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, template, data.RandomInteger, alertsEnabled, discoveryLogsEnabled)
 }
@@ -183,8 +181,7 @@ resource "azurerm_log_analytics_workspace" "test" {
 }
 
 resource "azurerm_sentinel_log_analytics_workspace_onboarding" "test" {
-  resource_group_name = azurerm_resource_group.test.name
-  workspace_name      = azurerm_log_analytics_workspace.test.name
+  workspace_id = azurerm_log_analytics_workspace.test.id
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/internal/services/sentinel/sentinel_data_connector_microsoft_cloud_app_security_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_microsoft_cloud_app_security_test.go
@@ -128,7 +128,7 @@ func (r SentinelDataConnectorMicrosoftCloudAppSecurityResource) basic(data accep
 
 resource "azurerm_sentinel_data_connector_microsoft_cloud_app_security" "test" {
   name                       = "accTestDC-%d"
-  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
 }
 `, template, data.RandomInteger)
 }
@@ -142,7 +142,7 @@ data "azurerm_client_config" "test" {}
 
 resource "azurerm_sentinel_data_connector_microsoft_cloud_app_security" "test" {
   name                       = "accTestDC-%d"
-  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
   tenant_id                  = data.azurerm_client_config.test.tenant_id
   alerts_enabled             = %t
   discovery_logs_enabled     = %t

--- a/internal/services/sentinel/sentinel_data_connector_microsoft_defender_advanced_threat_protection_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_microsoft_defender_advanced_threat_protection_test.go
@@ -86,7 +86,7 @@ func (r SentinelDataConnectorMicrosoftDefenderAdvancedThreatProtectionResource) 
 resource "azurerm_sentinel_data_connector_microsoft_defender_advanced_threat_protection" "test" {
   name                       = "accTestDC-%d"
   log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
-  depends_on                 = [azurerm_log_analytics_solution.test]
+  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, template, data.RandomInteger)
 }
@@ -102,7 +102,7 @@ resource "azurerm_sentinel_data_connector_microsoft_defender_advanced_threat_pro
   name                       = "accTestDC-%d"
   log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
   tenant_id                  = data.azurerm_client_config.test.tenant_id
-  depends_on                 = [azurerm_log_analytics_solution.test]
+  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, template, data.RandomInteger)
 }
@@ -137,17 +137,9 @@ resource "azurerm_log_analytics_workspace" "test" {
   sku                 = "PerGB2018"
 }
 
-resource "azurerm_log_analytics_solution" "test" {
-  solution_name         = "SecurityInsights"
-  location              = azurerm_resource_group.test.location
-  resource_group_name   = azurerm_resource_group.test.name
-  workspace_resource_id = azurerm_log_analytics_workspace.test.id
-  workspace_name        = azurerm_log_analytics_workspace.test.name
-
-  plan {
-    publisher = "Microsoft"
-    product   = "OMSGallery/SecurityInsights"
-  }
+resource "azurerm_sentinel_log_analytics_workspace_onboarding" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  workspace_name      = azurerm_log_analytics_workspace.test.name
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/internal/services/sentinel/sentinel_data_connector_microsoft_defender_advanced_threat_protection_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_microsoft_defender_advanced_threat_protection_test.go
@@ -85,8 +85,7 @@ func (r SentinelDataConnectorMicrosoftDefenderAdvancedThreatProtectionResource) 
 
 resource "azurerm_sentinel_data_connector_microsoft_defender_advanced_threat_protection" "test" {
   name                       = "accTestDC-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
-  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
 }
 `, template, data.RandomInteger)
 }
@@ -100,9 +99,8 @@ data "azurerm_client_config" "test" {}
 
 resource "azurerm_sentinel_data_connector_microsoft_defender_advanced_threat_protection" "test" {
   name                       = "accTestDC-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
   tenant_id                  = data.azurerm_client_config.test.tenant_id
-  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, template, data.RandomInteger)
 }
@@ -138,8 +136,7 @@ resource "azurerm_log_analytics_workspace" "test" {
 }
 
 resource "azurerm_sentinel_log_analytics_workspace_onboarding" "test" {
-  resource_group_name = azurerm_resource_group.test.name
-  workspace_name      = azurerm_log_analytics_workspace.test.name
+  workspace_id = azurerm_log_analytics_workspace.test.id
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/internal/services/sentinel/sentinel_data_connector_microsoft_defender_advanced_threat_protection_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_microsoft_defender_advanced_threat_protection_test.go
@@ -85,7 +85,7 @@ func (r SentinelDataConnectorMicrosoftDefenderAdvancedThreatProtectionResource) 
 
 resource "azurerm_sentinel_data_connector_microsoft_defender_advanced_threat_protection" "test" {
   name                       = "accTestDC-%d"
-  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
 }
 `, template, data.RandomInteger)
 }
@@ -99,7 +99,7 @@ data "azurerm_client_config" "test" {}
 
 resource "azurerm_sentinel_data_connector_microsoft_defender_advanced_threat_protection" "test" {
   name                       = "accTestDC-%d"
-  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
   tenant_id                  = data.azurerm_client_config.test.tenant_id
 }
 `, template, data.RandomInteger)

--- a/internal/services/sentinel/sentinel_data_connector_microsoft_threat_intelligence_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_microsoft_threat_intelligence_test.go
@@ -51,7 +51,7 @@ func (r SentinelDataConnectorMicrosoftThreatIntelligence) basic(data acceptance.
 
 resource "azurerm_sentinel_data_connector_microsoft_threat_intelligence" "test" {
   name                                         = "acctest-DC-MTI-%d"
-  log_analytics_workspace_id                   = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
+  log_analytics_workspace_id                   = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
   microsoft_emerging_threat_feed_lookback_date = "1970-01-01T00:00:00Z"
 }
 `, r.template(data), data.RandomInteger)
@@ -65,7 +65,7 @@ data "azurerm_client_config" "test" {}
 
 resource "azurerm_sentinel_data_connector_microsoft_threat_intelligence" "test" {
   name                                         = "acctest-DC-MTI-%d"
-  log_analytics_workspace_id                   = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
+  log_analytics_workspace_id                   = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
   tenant_id                                    = data.azurerm_client_config.test.tenant_id
   microsoft_emerging_threat_feed_lookback_date = "1970-01-01T00:00:00Z"
   bing_safety_phishing_url_lookback_date       = "1970-01-01T00:00:00Z"

--- a/internal/services/sentinel/sentinel_data_connector_microsoft_threat_intelligence_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_microsoft_threat_intelligence_test.go
@@ -51,12 +51,8 @@ func (r SentinelDataConnectorMicrosoftThreatIntelligence) basic(data acceptance.
 
 resource "azurerm_sentinel_data_connector_microsoft_threat_intelligence" "test" {
   name                                         = "acctest-DC-MTI-%d"
-  log_analytics_workspace_id                   = azurerm_log_analytics_workspace.test.id
+  log_analytics_workspace_id                   = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
   microsoft_emerging_threat_feed_lookback_date = "1970-01-01T00:00:00Z"
-
-  depends_on = [
-    azurerm_sentinel_log_analytics_workspace_onboarding.test
-  ]
 }
 `, r.template(data), data.RandomInteger)
 }
@@ -69,14 +65,10 @@ data "azurerm_client_config" "test" {}
 
 resource "azurerm_sentinel_data_connector_microsoft_threat_intelligence" "test" {
   name                                         = "acctest-DC-MTI-%d"
-  log_analytics_workspace_id                   = azurerm_log_analytics_workspace.test.id
+  log_analytics_workspace_id                   = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
   tenant_id                                    = data.azurerm_client_config.test.tenant_id
   microsoft_emerging_threat_feed_lookback_date = "1970-01-01T00:00:00Z"
   bing_safety_phishing_url_lookback_date       = "1970-01-01T00:00:00Z"
-
-  depends_on = [
-    azurerm_sentinel_log_analytics_workspace_onboarding.test
-  ]
 }
 `, r.template(data), data.RandomInteger)
 }
@@ -100,8 +92,7 @@ resource "azurerm_log_analytics_workspace" "test" {
 }
 
 resource "azurerm_sentinel_log_analytics_workspace_onboarding" "test" {
-  resource_group_name = azurerm_resource_group.test.name
-  workspace_name      = azurerm_log_analytics_workspace.test.name
+  workspace_id = azurerm_log_analytics_workspace.test.id
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/internal/services/sentinel/sentinel_data_connector_microsoft_threat_protection_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_microsoft_threat_protection_test.go
@@ -86,7 +86,7 @@ func (r SentinelDataConnectorMicrosoftThreatProtectionResource) basic(data accep
 resource "azurerm_sentinel_data_connector_microsoft_threat_protection" "test" {
   name                       = "accTestDC-%d"
   log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
-  depends_on                 = [azurerm_log_analytics_solution.test]
+  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, template, data.RandomInteger)
 }
@@ -102,7 +102,7 @@ resource "azurerm_sentinel_data_connector_microsoft_threat_protection" "test" {
   name                       = "accTestDC-%d"
   log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
   tenant_id                  = data.azurerm_client_config.test.tenant_id
-  depends_on                 = [azurerm_log_analytics_solution.test]
+  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, template, data.RandomInteger)
 }
@@ -137,17 +137,9 @@ resource "azurerm_log_analytics_workspace" "test" {
   sku                 = "PerGB2018"
 }
 
-resource "azurerm_log_analytics_solution" "test" {
-  solution_name         = "SecurityInsights"
-  location              = azurerm_resource_group.test.location
-  resource_group_name   = azurerm_resource_group.test.name
-  workspace_resource_id = azurerm_log_analytics_workspace.test.id
-  workspace_name        = azurerm_log_analytics_workspace.test.name
-
-  plan {
-    publisher = "Microsoft"
-    product   = "OMSGallery/SecurityInsights"
-  }
+resource "azurerm_sentinel_log_analytics_workspace_onboarding" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  workspace_name      = azurerm_log_analytics_workspace.test.name
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/internal/services/sentinel/sentinel_data_connector_microsoft_threat_protection_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_microsoft_threat_protection_test.go
@@ -85,7 +85,7 @@ func (r SentinelDataConnectorMicrosoftThreatProtectionResource) basic(data accep
 
 resource "azurerm_sentinel_data_connector_microsoft_threat_protection" "test" {
   name                       = "accTestDC-%d"
-  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
 }
 `, template, data.RandomInteger)
 }
@@ -99,7 +99,7 @@ data "azurerm_client_config" "test" {}
 
 resource "azurerm_sentinel_data_connector_microsoft_threat_protection" "test" {
   name                       = "accTestDC-%d"
-  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
   tenant_id                  = data.azurerm_client_config.test.tenant_id
 }
 `, template, data.RandomInteger)

--- a/internal/services/sentinel/sentinel_data_connector_microsoft_threat_protection_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_microsoft_threat_protection_test.go
@@ -85,8 +85,7 @@ func (r SentinelDataConnectorMicrosoftThreatProtectionResource) basic(data accep
 
 resource "azurerm_sentinel_data_connector_microsoft_threat_protection" "test" {
   name                       = "accTestDC-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
-  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
 }
 `, template, data.RandomInteger)
 }
@@ -100,9 +99,8 @@ data "azurerm_client_config" "test" {}
 
 resource "azurerm_sentinel_data_connector_microsoft_threat_protection" "test" {
   name                       = "accTestDC-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
   tenant_id                  = data.azurerm_client_config.test.tenant_id
-  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, template, data.RandomInteger)
 }
@@ -138,8 +136,7 @@ resource "azurerm_log_analytics_workspace" "test" {
 }
 
 resource "azurerm_sentinel_log_analytics_workspace_onboarding" "test" {
-  resource_group_name = azurerm_resource_group.test.name
-  workspace_name      = azurerm_log_analytics_workspace.test.name
+  workspace_id = azurerm_log_analytics_workspace.test.id
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/internal/services/sentinel/sentinel_data_connector_office_365_project_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_office_365_project_test.go
@@ -85,7 +85,7 @@ func (r SentinelDataConnectorOffice365ProjectResource) basic(data acceptance.Tes
 
 resource "azurerm_sentinel_data_connector_office_365_project" "test" {
   name                       = "accTestDC-%d"
-  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
 }
 `, template, data.RandomInteger)
 }
@@ -99,7 +99,7 @@ data "azurerm_client_config" "test" {}
 
 resource "azurerm_sentinel_data_connector_office_365_project" "test" {
   name                       = "accTestDC-%d"
-  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
   tenant_id                  = data.azurerm_client_config.test.tenant_id
 }
 `, template, data.RandomInteger)

--- a/internal/services/sentinel/sentinel_data_connector_office_365_project_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_office_365_project_test.go
@@ -85,8 +85,7 @@ func (r SentinelDataConnectorOffice365ProjectResource) basic(data acceptance.Tes
 
 resource "azurerm_sentinel_data_connector_office_365_project" "test" {
   name                       = "accTestDC-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
-  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
 }
 `, template, data.RandomInteger)
 }
@@ -100,9 +99,8 @@ data "azurerm_client_config" "test" {}
 
 resource "azurerm_sentinel_data_connector_office_365_project" "test" {
   name                       = "accTestDC-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
   tenant_id                  = data.azurerm_client_config.test.tenant_id
-  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, template, data.RandomInteger)
 }
@@ -138,8 +136,7 @@ resource "azurerm_log_analytics_workspace" "test" {
 }
 
 resource "azurerm_sentinel_log_analytics_workspace_onboarding" "test" {
-  resource_group_name = azurerm_resource_group.test.name
-  workspace_name      = azurerm_log_analytics_workspace.test.name
+  workspace_id = azurerm_log_analytics_workspace.test.id
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/internal/services/sentinel/sentinel_data_connector_office_365_project_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_office_365_project_test.go
@@ -86,7 +86,7 @@ func (r SentinelDataConnectorOffice365ProjectResource) basic(data acceptance.Tes
 resource "azurerm_sentinel_data_connector_office_365_project" "test" {
   name                       = "accTestDC-%d"
   log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
-  depends_on                 = [azurerm_log_analytics_solution.test]
+  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, template, data.RandomInteger)
 }
@@ -102,7 +102,7 @@ resource "azurerm_sentinel_data_connector_office_365_project" "test" {
   name                       = "accTestDC-%d"
   log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
   tenant_id                  = data.azurerm_client_config.test.tenant_id
-  depends_on                 = [azurerm_log_analytics_solution.test]
+  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, template, data.RandomInteger)
 }
@@ -137,17 +137,9 @@ resource "azurerm_log_analytics_workspace" "test" {
   sku                 = "PerGB2018"
 }
 
-resource "azurerm_log_analytics_solution" "test" {
-  solution_name         = "SecurityInsights"
-  location              = azurerm_resource_group.test.location
-  resource_group_name   = azurerm_resource_group.test.name
-  workspace_resource_id = azurerm_log_analytics_workspace.test.id
-  workspace_name        = azurerm_log_analytics_workspace.test.name
-
-  plan {
-    publisher = "Microsoft"
-    product   = "OMSGallery/SecurityInsights"
-  }
+resource "azurerm_sentinel_log_analytics_workspace_onboarding" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  workspace_name      = azurerm_log_analytics_workspace.test.name
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/internal/services/sentinel/sentinel_data_connector_office_365_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_office_365_test.go
@@ -135,8 +135,7 @@ func (r SentinelDataConnectorOffice365Resource) basic(data acceptance.TestData) 
 
 resource "azurerm_sentinel_data_connector_office_365" "test" {
   name                       = "accTestDC-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
-  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
 }
 `, template, data.RandomInteger)
 }
@@ -150,12 +149,11 @@ data "azurerm_client_config" "test" {}
 
 resource "azurerm_sentinel_data_connector_office_365" "test" {
   name                       = "accTestDC-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
   tenant_id                  = data.azurerm_client_config.test.tenant_id
   exchange_enabled           = %t
   sharepoint_enabled         = %t
   teams_enabled              = %t
-  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, template, data.RandomInteger, exchangeEnabled, sharePointEnabled, teamsEnabled)
 }
@@ -191,8 +189,7 @@ resource "azurerm_log_analytics_workspace" "test" {
 }
 
 resource "azurerm_sentinel_log_analytics_workspace_onboarding" "test" {
-  resource_group_name = azurerm_resource_group.test.name
-  workspace_name      = azurerm_log_analytics_workspace.test.name
+  workspace_id = azurerm_log_analytics_workspace.test.id
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/internal/services/sentinel/sentinel_data_connector_office_365_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_office_365_test.go
@@ -135,7 +135,7 @@ func (r SentinelDataConnectorOffice365Resource) basic(data acceptance.TestData) 
 
 resource "azurerm_sentinel_data_connector_office_365" "test" {
   name                       = "accTestDC-%d"
-  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
 }
 `, template, data.RandomInteger)
 }
@@ -149,7 +149,7 @@ data "azurerm_client_config" "test" {}
 
 resource "azurerm_sentinel_data_connector_office_365" "test" {
   name                       = "accTestDC-%d"
-  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
   tenant_id                  = data.azurerm_client_config.test.tenant_id
   exchange_enabled           = %t
   sharepoint_enabled         = %t

--- a/internal/services/sentinel/sentinel_data_connector_office_365_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_office_365_test.go
@@ -136,7 +136,7 @@ func (r SentinelDataConnectorOffice365Resource) basic(data acceptance.TestData) 
 resource "azurerm_sentinel_data_connector_office_365" "test" {
   name                       = "accTestDC-%d"
   log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
-  depends_on                 = [azurerm_log_analytics_solution.test]
+  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, template, data.RandomInteger)
 }
@@ -155,7 +155,7 @@ resource "azurerm_sentinel_data_connector_office_365" "test" {
   exchange_enabled           = %t
   sharepoint_enabled         = %t
   teams_enabled              = %t
-  depends_on                 = [azurerm_log_analytics_solution.test]
+  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, template, data.RandomInteger, exchangeEnabled, sharePointEnabled, teamsEnabled)
 }
@@ -190,17 +190,9 @@ resource "azurerm_log_analytics_workspace" "test" {
   sku                 = "PerGB2018"
 }
 
-resource "azurerm_log_analytics_solution" "test" {
-  solution_name         = "SecurityInsights"
-  location              = azurerm_resource_group.test.location
-  resource_group_name   = azurerm_resource_group.test.name
-  workspace_resource_id = azurerm_log_analytics_workspace.test.id
-  workspace_name        = azurerm_log_analytics_workspace.test.name
-
-  plan {
-    publisher = "Microsoft"
-    product   = "OMSGallery/SecurityInsights"
-  }
+resource "azurerm_sentinel_log_analytics_workspace_onboarding" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  workspace_name      = azurerm_log_analytics_workspace.test.name
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/internal/services/sentinel/sentinel_data_connector_office_atp_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_office_atp_test.go
@@ -85,7 +85,7 @@ func (r SentinelDataConnectorOfficeATPResource) basic(data acceptance.TestData) 
 
 resource "azurerm_sentinel_data_connector_office_atp" "test" {
   name                       = "accTestDC-%d"
-  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
 }
 `, template, data.RandomInteger)
 }
@@ -99,7 +99,7 @@ data "azurerm_client_config" "test" {}
 
 resource "azurerm_sentinel_data_connector_office_atp" "test" {
   name                       = "accTestDC-%d"
-  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
   tenant_id                  = data.azurerm_client_config.test.tenant_id
 }
 `, template, data.RandomInteger)

--- a/internal/services/sentinel/sentinel_data_connector_office_atp_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_office_atp_test.go
@@ -86,7 +86,7 @@ func (r SentinelDataConnectorOfficeATPResource) basic(data acceptance.TestData) 
 resource "azurerm_sentinel_data_connector_office_atp" "test" {
   name                       = "accTestDC-%d"
   log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
-  depends_on                 = [azurerm_log_analytics_solution.test]
+  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, template, data.RandomInteger)
 }
@@ -102,7 +102,7 @@ resource "azurerm_sentinel_data_connector_office_atp" "test" {
   name                       = "accTestDC-%d"
   log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
   tenant_id                  = data.azurerm_client_config.test.tenant_id
-  depends_on                 = [azurerm_log_analytics_solution.test]
+  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, template, data.RandomInteger)
 }
@@ -137,17 +137,9 @@ resource "azurerm_log_analytics_workspace" "test" {
   sku                 = "PerGB2018"
 }
 
-resource "azurerm_log_analytics_solution" "test" {
-  solution_name         = "SecurityInsights"
-  location              = azurerm_resource_group.test.location
-  resource_group_name   = azurerm_resource_group.test.name
-  workspace_resource_id = azurerm_log_analytics_workspace.test.id
-  workspace_name        = azurerm_log_analytics_workspace.test.name
-
-  plan {
-    publisher = "Microsoft"
-    product   = "OMSGallery/SecurityInsights"
-  }
+resource "azurerm_sentinel_log_analytics_workspace_onboarding" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  workspace_name      = azurerm_log_analytics_workspace.test.name
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/internal/services/sentinel/sentinel_data_connector_office_atp_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_office_atp_test.go
@@ -85,8 +85,7 @@ func (r SentinelDataConnectorOfficeATPResource) basic(data acceptance.TestData) 
 
 resource "azurerm_sentinel_data_connector_office_atp" "test" {
   name                       = "accTestDC-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
-  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
 }
 `, template, data.RandomInteger)
 }
@@ -100,9 +99,8 @@ data "azurerm_client_config" "test" {}
 
 resource "azurerm_sentinel_data_connector_office_atp" "test" {
   name                       = "accTestDC-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
   tenant_id                  = data.azurerm_client_config.test.tenant_id
-  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, template, data.RandomInteger)
 }
@@ -138,8 +136,7 @@ resource "azurerm_log_analytics_workspace" "test" {
 }
 
 resource "azurerm_sentinel_log_analytics_workspace_onboarding" "test" {
-  resource_group_name = azurerm_resource_group.test.name
-  workspace_name      = azurerm_log_analytics_workspace.test.name
+  workspace_id = azurerm_log_analytics_workspace.test.id
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/internal/services/sentinel/sentinel_data_connector_office_irm_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_office_irm_test.go
@@ -85,8 +85,7 @@ func (r SentinelDataConnectorOfficeIRMResource) basic(data acceptance.TestData) 
 
 resource "azurerm_sentinel_data_connector_office_irm" "test" {
   name                       = "accTestDC-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
-  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
 }
 `, template, data.RandomInteger)
 }
@@ -100,9 +99,8 @@ data "azurerm_client_config" "test" {}
 
 resource "azurerm_sentinel_data_connector_office_irm" "test" {
   name                       = "accTestDC-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
   tenant_id                  = data.azurerm_client_config.test.tenant_id
-  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, template, data.RandomInteger)
 }
@@ -138,8 +136,7 @@ resource "azurerm_log_analytics_workspace" "test" {
 }
 
 resource "azurerm_sentinel_log_analytics_workspace_onboarding" "test" {
-  resource_group_name = azurerm_resource_group.test.name
-  workspace_name      = azurerm_log_analytics_workspace.test.name
+  workspace_id = azurerm_log_analytics_workspace.test.id
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/internal/services/sentinel/sentinel_data_connector_office_irm_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_office_irm_test.go
@@ -86,7 +86,7 @@ func (r SentinelDataConnectorOfficeIRMResource) basic(data acceptance.TestData) 
 resource "azurerm_sentinel_data_connector_office_irm" "test" {
   name                       = "accTestDC-%d"
   log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
-  depends_on                 = [azurerm_log_analytics_solution.test]
+  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, template, data.RandomInteger)
 }
@@ -102,7 +102,7 @@ resource "azurerm_sentinel_data_connector_office_irm" "test" {
   name                       = "accTestDC-%d"
   log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
   tenant_id                  = data.azurerm_client_config.test.tenant_id
-  depends_on                 = [azurerm_log_analytics_solution.test]
+  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, template, data.RandomInteger)
 }
@@ -137,17 +137,9 @@ resource "azurerm_log_analytics_workspace" "test" {
   sku                 = "PerGB2018"
 }
 
-resource "azurerm_log_analytics_solution" "test" {
-  solution_name         = "SecurityInsights"
-  location              = azurerm_resource_group.test.location
-  resource_group_name   = azurerm_resource_group.test.name
-  workspace_resource_id = azurerm_log_analytics_workspace.test.id
-  workspace_name        = azurerm_log_analytics_workspace.test.name
-
-  plan {
-    publisher = "Microsoft"
-    product   = "OMSGallery/SecurityInsights"
-  }
+resource "azurerm_sentinel_log_analytics_workspace_onboarding" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  workspace_name      = azurerm_log_analytics_workspace.test.name
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/internal/services/sentinel/sentinel_data_connector_office_irm_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_office_irm_test.go
@@ -85,7 +85,7 @@ func (r SentinelDataConnectorOfficeIRMResource) basic(data acceptance.TestData) 
 
 resource "azurerm_sentinel_data_connector_office_irm" "test" {
   name                       = "accTestDC-%d"
-  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
 }
 `, template, data.RandomInteger)
 }
@@ -99,7 +99,7 @@ data "azurerm_client_config" "test" {}
 
 resource "azurerm_sentinel_data_connector_office_irm" "test" {
   name                       = "accTestDC-%d"
-  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
   tenant_id                  = data.azurerm_client_config.test.tenant_id
 }
 `, template, data.RandomInteger)

--- a/internal/services/sentinel/sentinel_data_connector_office_power_bi_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_office_power_bi_test.go
@@ -85,8 +85,7 @@ func (r SentinelDataConnectorOfficePowerBIResource) basic(data acceptance.TestDa
 
 resource "azurerm_sentinel_data_connector_office_power_bi" "test" {
   name                       = "accTestDC-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
-  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
 }
 `, template, data.RandomInteger)
 }
@@ -100,9 +99,8 @@ data "azurerm_client_config" "test" {}
 
 resource "azurerm_sentinel_data_connector_office_power_bi" "test" {
   name                       = "accTestDC-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
   tenant_id                  = data.azurerm_client_config.test.tenant_id
-  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, template, data.RandomInteger)
 }
@@ -138,8 +136,7 @@ resource "azurerm_log_analytics_workspace" "test" {
 }
 
 resource "azurerm_sentinel_log_analytics_workspace_onboarding" "test" {
-  resource_group_name = azurerm_resource_group.test.name
-  workspace_name      = azurerm_log_analytics_workspace.test.name
+  workspace_id = azurerm_log_analytics_workspace.test.id
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/internal/services/sentinel/sentinel_data_connector_office_power_bi_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_office_power_bi_test.go
@@ -85,7 +85,7 @@ func (r SentinelDataConnectorOfficePowerBIResource) basic(data acceptance.TestDa
 
 resource "azurerm_sentinel_data_connector_office_power_bi" "test" {
   name                       = "accTestDC-%d"
-  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
 }
 `, template, data.RandomInteger)
 }
@@ -99,7 +99,7 @@ data "azurerm_client_config" "test" {}
 
 resource "azurerm_sentinel_data_connector_office_power_bi" "test" {
   name                       = "accTestDC-%d"
-  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
   tenant_id                  = data.azurerm_client_config.test.tenant_id
 }
 `, template, data.RandomInteger)

--- a/internal/services/sentinel/sentinel_data_connector_office_power_bi_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_office_power_bi_test.go
@@ -86,7 +86,7 @@ func (r SentinelDataConnectorOfficePowerBIResource) basic(data acceptance.TestDa
 resource "azurerm_sentinel_data_connector_office_power_bi" "test" {
   name                       = "accTestDC-%d"
   log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
-  depends_on                 = [azurerm_log_analytics_solution.test]
+  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, template, data.RandomInteger)
 }
@@ -102,7 +102,7 @@ resource "azurerm_sentinel_data_connector_office_power_bi" "test" {
   name                       = "accTestDC-%d"
   log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
   tenant_id                  = data.azurerm_client_config.test.tenant_id
-  depends_on                 = [azurerm_log_analytics_solution.test]
+  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, template, data.RandomInteger)
 }
@@ -137,17 +137,9 @@ resource "azurerm_log_analytics_workspace" "test" {
   sku                 = "PerGB2018"
 }
 
-resource "azurerm_log_analytics_solution" "test" {
-  solution_name         = "SecurityInsights"
-  location              = azurerm_resource_group.test.location
-  resource_group_name   = azurerm_resource_group.test.name
-  workspace_resource_id = azurerm_log_analytics_workspace.test.id
-  workspace_name        = azurerm_log_analytics_workspace.test.name
-
-  plan {
-    publisher = "Microsoft"
-    product   = "OMSGallery/SecurityInsights"
-  }
+resource "azurerm_sentinel_log_analytics_workspace_onboarding" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  workspace_name      = azurerm_log_analytics_workspace.test.name
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/internal/services/sentinel/sentinel_data_connector_threat_intelligence_taxii_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_threat_intelligence_taxii_test.go
@@ -170,7 +170,7 @@ resource "azurerm_sentinel_data_connector_threat_intelligence_taxii" "test" {
   collection_id              = "%s"
   user_name                  = "%s"
   password                   = "%s"
-  depends_on                 = [azurerm_log_analytics_solution.test]
+  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, template, data.RandomInteger, r.taxiiInfo.APIRootURL, r.taxiiInfo.CollectionID, r.taxiiInfo.UserName, r.taxiiInfo.Password)
 }
@@ -190,7 +190,7 @@ resource "azurerm_sentinel_data_connector_threat_intelligence_taxii" "test" {
   password                   = "%s"
   polling_frequency          = "OnceADay"
   lookback_date              = "1990-01-01T00:00:00Z"
-  depends_on                 = [azurerm_log_analytics_solution.test]
+  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, template, data.RandomInteger, r.taxiiInfo.APIRootURL, r.taxiiInfo.CollectionID, r.taxiiInfo.UserName, r.taxiiInfo.Password)
 }
@@ -210,7 +210,7 @@ resource "azurerm_sentinel_data_connector_threat_intelligence_taxii" "test" {
   password                   = "%s"
   polling_frequency          = "OnceADay"
   lookback_date              = "1990-01-01T00:00:00Z"
-  depends_on                 = [azurerm_log_analytics_solution.test]
+  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, template, data.RandomInteger, r.taxiiInfoAlt.APIRootURL, r.taxiiInfoAlt.CollectionID, r.taxiiInfoAlt.UserName, r.taxiiInfoAlt.Password)
 }
@@ -248,17 +248,9 @@ resource "azurerm_log_analytics_workspace" "test" {
   sku                 = "PerGB2018"
 }
 
-resource "azurerm_log_analytics_solution" "test" {
-  solution_name         = "SecurityInsights"
-  location              = azurerm_resource_group.test.location
-  resource_group_name   = azurerm_resource_group.test.name
-  workspace_resource_id = azurerm_log_analytics_workspace.test.id
-  workspace_name        = azurerm_log_analytics_workspace.test.name
-
-  plan {
-    publisher = "Microsoft"
-    product   = "OMSGallery/SecurityInsights"
-  }
+resource "azurerm_sentinel_log_analytics_workspace_onboarding" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  workspace_name      = azurerm_log_analytics_workspace.test.name
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/internal/services/sentinel/sentinel_data_connector_threat_intelligence_taxii_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_threat_intelligence_taxii_test.go
@@ -164,7 +164,7 @@ func (r DataConnectorThreatIntelligenceTAXIIResource) basic(data acceptance.Test
 
 resource "azurerm_sentinel_data_connector_threat_intelligence_taxii" "test" {
   name                       = "acctestDC-%d"
-  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
   display_name               = "test"
   api_root_url               = "%s"
   collection_id              = "%s"
@@ -181,7 +181,7 @@ func (r DataConnectorThreatIntelligenceTAXIIResource) complete(data acceptance.T
 
 resource "azurerm_sentinel_data_connector_threat_intelligence_taxii" "test" {
   name                       = "acctestDC-%d"
-  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
   display_name               = "test_update"
   api_root_url               = "%s"
   collection_id              = "%s"
@@ -200,7 +200,7 @@ func (r DataConnectorThreatIntelligenceTAXIIResource) update(data acceptance.Tes
 
 resource "azurerm_sentinel_data_connector_threat_intelligence_taxii" "test" {
   name                       = "acctestDC-%d"
-  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
   display_name               = "test_update"
   api_root_url               = "%s"
   collection_id              = "%s"

--- a/internal/services/sentinel/sentinel_data_connector_threat_intelligence_taxii_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_threat_intelligence_taxii_test.go
@@ -164,13 +164,12 @@ func (r DataConnectorThreatIntelligenceTAXIIResource) basic(data acceptance.Test
 
 resource "azurerm_sentinel_data_connector_threat_intelligence_taxii" "test" {
   name                       = "acctestDC-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
   display_name               = "test"
   api_root_url               = "%s"
   collection_id              = "%s"
   user_name                  = "%s"
   password                   = "%s"
-  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, template, data.RandomInteger, r.taxiiInfo.APIRootURL, r.taxiiInfo.CollectionID, r.taxiiInfo.UserName, r.taxiiInfo.Password)
 }
@@ -182,7 +181,7 @@ func (r DataConnectorThreatIntelligenceTAXIIResource) complete(data acceptance.T
 
 resource "azurerm_sentinel_data_connector_threat_intelligence_taxii" "test" {
   name                       = "acctestDC-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
   display_name               = "test_update"
   api_root_url               = "%s"
   collection_id              = "%s"
@@ -190,7 +189,6 @@ resource "azurerm_sentinel_data_connector_threat_intelligence_taxii" "test" {
   password                   = "%s"
   polling_frequency          = "OnceADay"
   lookback_date              = "1990-01-01T00:00:00Z"
-  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, template, data.RandomInteger, r.taxiiInfo.APIRootURL, r.taxiiInfo.CollectionID, r.taxiiInfo.UserName, r.taxiiInfo.Password)
 }
@@ -202,7 +200,7 @@ func (r DataConnectorThreatIntelligenceTAXIIResource) update(data acceptance.Tes
 
 resource "azurerm_sentinel_data_connector_threat_intelligence_taxii" "test" {
   name                       = "acctestDC-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
   display_name               = "test_update"
   api_root_url               = "%s"
   collection_id              = "%s"
@@ -210,7 +208,6 @@ resource "azurerm_sentinel_data_connector_threat_intelligence_taxii" "test" {
   password                   = "%s"
   polling_frequency          = "OnceADay"
   lookback_date              = "1990-01-01T00:00:00Z"
-  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, template, data.RandomInteger, r.taxiiInfoAlt.APIRootURL, r.taxiiInfoAlt.CollectionID, r.taxiiInfoAlt.UserName, r.taxiiInfoAlt.Password)
 }
@@ -249,8 +246,7 @@ resource "azurerm_log_analytics_workspace" "test" {
 }
 
 resource "azurerm_sentinel_log_analytics_workspace_onboarding" "test" {
-  resource_group_name = azurerm_resource_group.test.name
-  workspace_name      = azurerm_log_analytics_workspace.test.name
+  workspace_id = azurerm_log_analytics_workspace.test.id
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/internal/services/sentinel/sentinel_data_connector_threat_intelligence_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_threat_intelligence_test.go
@@ -86,7 +86,7 @@ func (r SentinelDataConnectorThreatIntelligenceResource) basic(data acceptance.T
 
 resource "azurerm_sentinel_data_connector_threat_intelligence" "test" {
   name                       = "accTestDC-%d"
-  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
 }
 `, template, data.RandomInteger)
 }
@@ -100,7 +100,7 @@ data "azurerm_client_config" "test" {}
 
 resource "azurerm_sentinel_data_connector_threat_intelligence" "test" {
   name                       = "accTestDC-%d"
-  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
   tenant_id                  = data.azurerm_client_config.test.tenant_id
   lookback_date              = "1990-01-01T00:00:00Z"
 }

--- a/internal/services/sentinel/sentinel_data_connector_threat_intelligence_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_threat_intelligence_test.go
@@ -86,8 +86,7 @@ func (r SentinelDataConnectorThreatIntelligenceResource) basic(data acceptance.T
 
 resource "azurerm_sentinel_data_connector_threat_intelligence" "test" {
   name                       = "accTestDC-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
-  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
 }
 `, template, data.RandomInteger)
 }
@@ -101,9 +100,8 @@ data "azurerm_client_config" "test" {}
 
 resource "azurerm_sentinel_data_connector_threat_intelligence" "test" {
   name                       = "accTestDC-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
   tenant_id                  = data.azurerm_client_config.test.tenant_id
-  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
   lookback_date              = "1990-01-01T00:00:00Z"
 }
 `, template, data.RandomInteger)
@@ -140,8 +138,7 @@ resource "azurerm_log_analytics_workspace" "test" {
 }
 
 resource "azurerm_sentinel_log_analytics_workspace_onboarding" "test" {
-  resource_group_name = azurerm_resource_group.test.name
-  workspace_name      = azurerm_log_analytics_workspace.test.name
+  workspace_id = azurerm_log_analytics_workspace.test.id
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/internal/services/sentinel/sentinel_data_connector_threat_intelligence_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_threat_intelligence_test.go
@@ -87,7 +87,7 @@ func (r SentinelDataConnectorThreatIntelligenceResource) basic(data acceptance.T
 resource "azurerm_sentinel_data_connector_threat_intelligence" "test" {
   name                       = "accTestDC-%d"
   log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
-  depends_on                 = [azurerm_log_analytics_solution.test]
+  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, template, data.RandomInteger)
 }
@@ -103,7 +103,7 @@ resource "azurerm_sentinel_data_connector_threat_intelligence" "test" {
   name                       = "accTestDC-%d"
   log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
   tenant_id                  = data.azurerm_client_config.test.tenant_id
-  depends_on                 = [azurerm_log_analytics_solution.test]
+  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
   lookback_date              = "1990-01-01T00:00:00Z"
 }
 `, template, data.RandomInteger)
@@ -139,17 +139,9 @@ resource "azurerm_log_analytics_workspace" "test" {
   sku                 = "PerGB2018"
 }
 
-resource "azurerm_log_analytics_solution" "test" {
-  solution_name         = "SecurityInsights"
-  location              = azurerm_resource_group.test.location
-  resource_group_name   = azurerm_resource_group.test.name
-  workspace_resource_id = azurerm_log_analytics_workspace.test.id
-  workspace_name        = azurerm_log_analytics_workspace.test.name
-
-  plan {
-    publisher = "Microsoft"
-    product   = "OMSGallery/SecurityInsights"
-  }
+resource "azurerm_sentinel_log_analytics_workspace_onboarding" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  workspace_name      = azurerm_log_analytics_workspace.test.name
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/internal/services/sentinel/sentinel_log_analytics_workspace_onboard_resource.go
+++ b/internal/services/sentinel/sentinel_log_analytics_workspace_onboard_resource.go
@@ -48,7 +48,7 @@ func (r LogAnalyticsWorkspaceOnboardResource) Arguments() map[string]*pluginsdk.
 			Optional:      true,
 			Computed:      true,
 			ForceNew:      true,
-			ConflictsWith: []string{"log_analytics_workspace_id"},
+			ConflictsWith: []string{"workspace_id"},
 			ValidateFunc:  resourcegroups.ValidateName,
 		},
 
@@ -58,18 +58,17 @@ func (r LogAnalyticsWorkspaceOnboardResource) Arguments() map[string]*pluginsdk.
 			Optional:      true,
 			Computed:      true,
 			ForceNew:      true,
-			ConflictsWith: []string{"log_analytics_workspace_id"},
+			ConflictsWith: []string{"workspace_id"},
 			ValidateFunc:  validation.StringIsNotEmpty,
 		},
 
 		"workspace_id": {
-			Type:          pluginsdk.TypeString,
-			Required:      features.FourPointOhBeta(),
-			Optional:      !features.FourPointOhBeta(),
-			Computed:      !features.FourPointOhBeta(),
-			ForceNew:      true,
-			ConflictsWith: []string{"resource_group_name", "workspace_name"},
-			ValidateFunc:  workspaces.ValidateWorkspaceID,
+			Type:         pluginsdk.TypeString,
+			Required:     features.FourPointOhBeta(),
+			Optional:     !features.FourPointOhBeta(),
+			Computed:     !features.FourPointOhBeta(),
+			ForceNew:     true,
+			ValidateFunc: workspaces.ValidateWorkspaceID,
 		},
 
 		"customer_managed_key_enabled": {
@@ -83,6 +82,8 @@ func (r LogAnalyticsWorkspaceOnboardResource) Arguments() map[string]*pluginsdk.
 	if features.FourPointOhBeta() {
 		delete(out, "resource_group_name")
 		delete(out, "workspace_name")
+	} else {
+		out["workspace_id"].ConflictsWith = []string{"resource_group_name", "workspace_name"}
 	}
 
 	return out

--- a/internal/services/sentinel/sentinel_log_analytics_workspace_onboard_resource.go
+++ b/internal/services/sentinel/sentinel_log_analytics_workspace_onboard_resource.go
@@ -7,8 +7,11 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/response"
-	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourcegroups"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/workspaces"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/securityinsights/2022-11-01/sentinelonboardingstates"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
@@ -18,6 +21,7 @@ type SecurityInsightsSentinelOnboardingStateModel struct {
 	ResourceGroupName         string `tfschema:"resource_group_name"`
 	WorkspaceName             string `tfschema:"workspace_name"`
 	CustomerManagedKeyEnabled bool   `tfschema:"customer_managed_key_enabled"`
+	WorkspaceId               string `tfschema:"workspace_id"`
 }
 
 type LogAnalyticsWorkspaceOnboardResource struct{}
@@ -37,15 +41,35 @@ func (r LogAnalyticsWorkspaceOnboardResource) IDValidationFunc() pluginsdk.Schem
 }
 
 func (r LogAnalyticsWorkspaceOnboardResource) Arguments() map[string]*pluginsdk.Schema {
-	return map[string]*pluginsdk.Schema{
-
-		"resource_group_name": commonschema.ResourceGroupName(),
+	out := map[string]*pluginsdk.Schema{
+		"resource_group_name": {
+			Deprecated:    "this property has been deprecated in favour of `workspace_id`",
+			Type:          schema.TypeString,
+			Optional:      true,
+			Computed:      true,
+			ForceNew:      true,
+			ConflictsWith: []string{"log_analytics_workspace_id"},
+			ValidateFunc:  resourcegroups.ValidateName,
+		},
 
 		"workspace_name": {
-			Type:         pluginsdk.TypeString,
-			Required:     true,
-			ForceNew:     true,
-			ValidateFunc: validation.StringIsNotEmpty,
+			Deprecated:    "this property will be removed in favour of `workspace_id` in version 4.0 of the AzureRM Provider",
+			Type:          pluginsdk.TypeString,
+			Optional:      true,
+			Computed:      true,
+			ForceNew:      true,
+			ConflictsWith: []string{"log_analytics_workspace_id"},
+			ValidateFunc:  validation.StringIsNotEmpty,
+		},
+
+		"workspace_id": {
+			Type:          pluginsdk.TypeString,
+			Required:      features.FourPointOhBeta(),
+			Optional:      !features.FourPointOhBeta(),
+			Computed:      !features.FourPointOhBeta(),
+			ForceNew:      true,
+			ConflictsWith: []string{"resource_group_name", "workspace_name"},
+			ValidateFunc:  workspaces.ValidateWorkspaceID,
 		},
 
 		"customer_managed_key_enabled": {
@@ -55,6 +79,13 @@ func (r LogAnalyticsWorkspaceOnboardResource) Arguments() map[string]*pluginsdk.
 			ForceNew: true,
 		},
 	}
+
+	if features.FourPointOhBeta() {
+		delete(out, "resource_group_name")
+		delete(out, "workspace_name")
+	}
+
+	return out
 }
 
 func (r LogAnalyticsWorkspaceOnboardResource) Attributes() map[string]*pluginsdk.Schema {
@@ -71,9 +102,19 @@ func (r LogAnalyticsWorkspaceOnboardResource) Create() sdk.ResourceFunc {
 			}
 
 			client := metadata.Client.Sentinel.OnboardingStatesClient
-			subscriptionId := metadata.Client.Account.SubscriptionId
 			// the service only support `default` state
-			id := sentinelonboardingstates.NewOnboardingStateID(subscriptionId, model.ResourceGroupName, model.WorkspaceName, "default")
+			var id sentinelonboardingstates.OnboardingStateId
+			if model.WorkspaceId != "" {
+				parsedWorkspaceId, err := workspaces.ParseWorkspaceID(model.WorkspaceId)
+				if err != nil {
+					return fmt.Errorf("parsing `log_analytics_workspace_id`: %+v", err)
+				}
+				id = sentinelonboardingstates.NewOnboardingStateID(parsedWorkspaceId.SubscriptionId, parsedWorkspaceId.ResourceGroupName, parsedWorkspaceId.WorkspaceName, "default")
+			} else { // TODO: remove in 4.0
+				subscriptionId := metadata.Client.Account.SubscriptionId
+				id = sentinelonboardingstates.NewOnboardingStateID(subscriptionId, model.ResourceGroupName, model.WorkspaceName, "default")
+			}
+
 			existing, err := client.Get(ctx, id)
 			if err != nil && !response.WasNotFound(existing.HttpResponse) {
 				return fmt.Errorf("checking for existing %s: %+v", id, err)
@@ -153,9 +194,12 @@ func (r LogAnalyticsWorkspaceOnboardResource) Read() sdk.ResourceFunc {
 				return fmt.Errorf("retrieving %s: model was nil", id)
 			}
 
+			workspaceId := workspaces.NewWorkspaceID(id.SubscriptionId, id.ResourceGroupName, id.WorkspaceName).ID()
+
 			state := SecurityInsightsSentinelOnboardingStateModel{
 				ResourceGroupName: id.ResourceGroupName,
 				WorkspaceName:     id.WorkspaceName,
+				WorkspaceId:       workspaceId,
 			}
 
 			if properties := model.Properties; properties != nil {

--- a/internal/services/sentinel/sentinel_log_analytics_workspace_onboard_resource_test.go
+++ b/internal/services/sentinel/sentinel_log_analytics_workspace_onboard_resource_test.go
@@ -284,7 +284,7 @@ func (r SecurityInsightsSentinelOnboardingStateResource) requiresImport(data acc
 			%s
 
 resource "azurerm_sentinel_log_analytics_workspace_onboarding" "import" {
-  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
+  workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
 }
 `, config)
 }

--- a/internal/services/sentinel/sentinel_log_analytics_workspace_onboard_resource_test.go
+++ b/internal/services/sentinel/sentinel_log_analytics_workspace_onboard_resource_test.go
@@ -269,7 +269,7 @@ func (r SecurityInsightsSentinelOnboardingStateResource) requiresImport(data acc
 			%s
 
 resource "azurerm_sentinel_log_analytics_workspace_onboarding" "import" {
-  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_workspace_id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
 }
 `, config)
 }

--- a/internal/services/sentinel/sentinel_log_analytics_workspace_onboard_resource_test.go
+++ b/internal/services/sentinel/sentinel_log_analytics_workspace_onboard_resource_test.go
@@ -31,6 +31,20 @@ func TestAccSecurityInsightsSentinelOnboardingState_basic(t *testing.T) {
 	})
 }
 
+func TestAccSecurityInsightsSentinelOnboardingState_basicWithName(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_sentinel_log_analytics_workspace_onboarding", "test")
+	r := SecurityInsightsSentinelOnboardingStateResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basicWithName(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccSecurityInsightsSentinelOnboardingState_ToggleCmkEnabled(t *testing.T) {
 
 	if os.Getenv("ARM_RUN_TEST_LOG_ANALYTICS_CLUSTERS") == "" {
@@ -125,7 +139,8 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_sentinel_log_analytics_workspace_onboarding" "test" {
-  workspace_id = azurerm_log_analytics_workspace.test.id
+  resource_group_name = azurerm_resource_group.test.name
+  workspace_name      = azurerm_log_analytics_workspace.test.name
 }
 `, data.RandomInteger, data.Locations.Primary)
 }

--- a/internal/services/sentinel/sentinel_log_analytics_workspace_onboard_resource_test.go
+++ b/internal/services/sentinel/sentinel_log_analytics_workspace_onboard_resource_test.go
@@ -101,8 +101,31 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_sentinel_log_analytics_workspace_onboarding" "test" {
+  workspace_id = azurerm_log_analytics_workspace.test.id
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func (r SecurityInsightsSentinelOnboardingStateResource) basicWithName(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_log_analytics_workspace" "test" {
+  name                = "acctestLAW-%[1]d"
+  location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
-  workspace_name      = azurerm_log_analytics_workspace.test.name
+  sku                 = "PerGB2018"
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctest-rg-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_sentinel_log_analytics_workspace_onboarding" "test" {
+  workspace_id = azurerm_log_analytics_workspace.test.id
 }
 `, data.RandomInteger, data.Locations.Primary)
 }
@@ -232,13 +255,11 @@ resource "azurerm_log_analytics_linked_service" "test" {
 }
 
 resource "azurerm_sentinel_log_analytics_workspace_onboarding" "test" {
-  resource_group_name          = azurerm_resource_group.test.name
-  workspace_name               = azurerm_log_analytics_workspace.test.name
+  workspace_id                 = azurerm_log_analytics_workspace.test.id
   customer_managed_key_enabled = true
 
   depends_on = [azurerm_log_analytics_linked_service.test]
 }
-
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }
 
@@ -248,8 +269,7 @@ func (r SecurityInsightsSentinelOnboardingStateResource) requiresImport(data acc
 			%s
 
 resource "azurerm_sentinel_log_analytics_workspace_onboarding" "import" {
-  resource_group_name = azurerm_resource_group.test.name
-  workspace_name      = azurerm_log_analytics_workspace.test.name
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_workspace_id
 }
 `, config)
 }

--- a/internal/services/sentinel/sentinel_watchlist_item_resource_test.go
+++ b/internal/services/sentinel/sentinel_watchlist_item_resource_test.go
@@ -152,24 +152,18 @@ resource "azurerm_log_analytics_workspace" "test" {
   sku                 = "PerGB2018"
 }
 
-resource "azurerm_log_analytics_solution" "sentinel" {
-  solution_name         = "SecurityInsights"
-  location              = azurerm_resource_group.test.location
-  resource_group_name   = azurerm_resource_group.test.name
-  workspace_resource_id = azurerm_log_analytics_workspace.test.id
-  workspace_name        = azurerm_log_analytics_workspace.test.name
-
-  plan {
-    publisher = "Microsoft"
-    product   = "OMSGallery/SecurityInsights"
-  }
+resource "azurerm_sentinel_log_analytics_workspace_onboarding" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  workspace_name      = azurerm_log_analytics_workspace.test.name
 }
 
 resource "azurerm_sentinel_watchlist" "test" {
   name                       = "accTestWL-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_solution.sentinel.workspace_resource_id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
   display_name               = "test"
   item_search_key            = "k1"
+
+  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }

--- a/internal/services/sentinel/sentinel_watchlist_item_resource_test.go
+++ b/internal/services/sentinel/sentinel_watchlist_item_resource_test.go
@@ -153,8 +153,7 @@ resource "azurerm_log_analytics_workspace" "test" {
 }
 
 resource "azurerm_sentinel_log_analytics_workspace_onboarding" "test" {
-  resource_group_name = azurerm_resource_group.test.name
-  workspace_name      = azurerm_log_analytics_workspace.test.name
+  workspace_id = azurerm_log_analytics_workspace.test.id
 }
 
 resource "azurerm_sentinel_watchlist" "test" {
@@ -163,7 +162,6 @@ resource "azurerm_sentinel_watchlist" "test" {
   display_name               = "test"
   item_search_key            = "k1"
 
-  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }

--- a/internal/services/sentinel/sentinel_watchlist_item_resource_test.go
+++ b/internal/services/sentinel/sentinel_watchlist_item_resource_test.go
@@ -158,10 +158,9 @@ resource "azurerm_sentinel_log_analytics_workspace_onboarding" "test" {
 
 resource "azurerm_sentinel_watchlist" "test" {
   name                       = "accTestWL-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
   display_name               = "test"
   item_search_key            = "k1"
-
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }

--- a/internal/services/sentinel/sentinel_watchlist_resource_test.go
+++ b/internal/services/sentinel/sentinel_watchlist_resource_test.go
@@ -85,9 +85,11 @@ func (r WatchlistResource) basic(data acceptance.TestData) string {
 
 resource "azurerm_sentinel_watchlist" "test" {
   name                       = "accTestWL-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_solution.sentinel.workspace_resource_id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
   display_name               = "test"
   item_search_key            = "Key"
+
+  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, template, data.RandomInteger)
 }
@@ -99,12 +101,14 @@ func (r WatchlistResource) complete(data acceptance.TestData) string {
 
 resource "azurerm_sentinel_watchlist" "test" {
   name                       = "accTestWL-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_solution.sentinel.workspace_resource_id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
   display_name               = "test"
   description                = "description"
   labels                     = ["label1", "laebl2"]
   default_duration           = "P2DT3H"
   item_search_key            = "Key"
+
+  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, template, data.RandomInteger)
 }
@@ -141,17 +145,10 @@ resource "azurerm_log_analytics_workspace" "test" {
   sku                 = "PerGB2018"
 }
 
-resource "azurerm_log_analytics_solution" "sentinel" {
-  solution_name         = "SecurityInsights"
-  location              = azurerm_resource_group.test.location
-  resource_group_name   = azurerm_resource_group.test.name
-  workspace_resource_id = azurerm_log_analytics_workspace.test.id
-  workspace_name        = azurerm_log_analytics_workspace.test.name
-
-  plan {
-    publisher = "Microsoft"
-    product   = "OMSGallery/SecurityInsights"
-  }
+resource "azurerm_sentinel_log_analytics_workspace_onboarding" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  workspace_name      = azurerm_log_analytics_workspace.test.name
 }
+
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/internal/services/sentinel/sentinel_watchlist_resource_test.go
+++ b/internal/services/sentinel/sentinel_watchlist_resource_test.go
@@ -85,7 +85,7 @@ func (r WatchlistResource) basic(data acceptance.TestData) string {
 
 resource "azurerm_sentinel_watchlist" "test" {
   name                       = "accTestWL-%d"
-  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
   display_name               = "test"
   item_search_key            = "Key"
 }
@@ -99,7 +99,7 @@ func (r WatchlistResource) complete(data acceptance.TestData) string {
 
 resource "azurerm_sentinel_watchlist" "test" {
   name                       = "accTestWL-%d"
-  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
   display_name               = "test"
   description                = "description"
   labels                     = ["label1", "laebl2"]

--- a/internal/services/sentinel/sentinel_watchlist_resource_test.go
+++ b/internal/services/sentinel/sentinel_watchlist_resource_test.go
@@ -85,11 +85,9 @@ func (r WatchlistResource) basic(data acceptance.TestData) string {
 
 resource "azurerm_sentinel_watchlist" "test" {
   name                       = "accTestWL-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
   display_name               = "test"
   item_search_key            = "Key"
-
-  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, template, data.RandomInteger)
 }
@@ -101,14 +99,12 @@ func (r WatchlistResource) complete(data acceptance.TestData) string {
 
 resource "azurerm_sentinel_watchlist" "test" {
   name                       = "accTestWL-%d"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.log_analytics_space_id
   display_name               = "test"
   description                = "description"
   labels                     = ["label1", "laebl2"]
   default_duration           = "P2DT3H"
   item_search_key            = "Key"
-
-  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.test]
 }
 `, template, data.RandomInteger)
 }
@@ -146,9 +142,9 @@ resource "azurerm_log_analytics_workspace" "test" {
 }
 
 resource "azurerm_sentinel_log_analytics_workspace_onboarding" "test" {
-  resource_group_name = azurerm_resource_group.test.name
-  workspace_name      = azurerm_log_analytics_workspace.test.name
+  workspace_id = azurerm_log_analytics_workspace.test.id
 }
+
 
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/website/docs/r/azurerm_sentinel_alert_rule_machine_learning_behavior_analytics.html.markdown
+++ b/website/docs/r/azurerm_sentinel_alert_rule_machine_learning_behavior_analytics.html.markdown
@@ -26,16 +26,13 @@ resource "azurerm_log_analytics_workspace" "example" {
 }
 
 resource "azurerm_sentinel_log_analytics_workspace_onboarding" "example" {
-  resource_group_name = azurerm_resource_group.example.name
-  workspace_name      = azurerm_log_analytics_workspace.example.name
+  workspace_id = azurerm_log_analytics_workspace.example.id
 }
 
 resource "azurerm_sentinel_alert_rule_machine_learning_behavior_analytics" "example" {
   name                       = "example-ml-alert-rule"
   log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
   alert_rule_template_guid   = "737a2ce1-70a3-4968-9e90-3e6aca836abf"
-
-  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.example]
 }
 
 

--- a/website/docs/r/azurerm_sentinel_alert_rule_machine_learning_behavior_analytics.html.markdown
+++ b/website/docs/r/azurerm_sentinel_alert_rule_machine_learning_behavior_analytics.html.markdown
@@ -25,23 +25,17 @@ resource "azurerm_log_analytics_workspace" "example" {
   sku                 = "PerGB2018"
 }
 
-resource "azurerm_log_analytics_solution" "example" {
-  solution_name         = "SecurityInsights"
-  location              = azurerm_resource_group.example.location
-  resource_group_name   = azurerm_resource_group.example.name
-  workspace_resource_id = azurerm_log_analytics_workspace.example.id
-  workspace_name        = azurerm_log_analytics_workspace.example.name
-
-  plan {
-    publisher = "Microsoft"
-    product   = "OMSGallery/SecurityInsights"
-  }
+resource "azurerm_sentinel_log_analytics_workspace_onboarding" "example" {
+  resource_group_name = azurerm_resource_group.example.name
+  workspace_name      = azurerm_log_analytics_workspace.example.name
 }
 
 resource "azurerm_sentinel_alert_rule_machine_learning_behavior_analytics" "example" {
   name                       = "example-ml-alert-rule"
-  log_analytics_workspace_id = azurerm_log_analytics_solution.example.workspace_resource_id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
   alert_rule_template_guid   = "737a2ce1-70a3-4968-9e90-3e6aca836abf"
+
+  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.example]
 }
 
 

--- a/website/docs/r/sentinel_alert_rule_fusion.html.markdown
+++ b/website/docs/r/sentinel_alert_rule_fusion.html.markdown
@@ -25,23 +25,17 @@ resource "azurerm_log_analytics_workspace" "example" {
   sku                 = "PerGB2018"
 }
 
-resource "azurerm_log_analytics_solution" "example" {
-  solution_name         = "SecurityInsights"
-  location              = azurerm_resource_group.example.location
-  resource_group_name   = azurerm_resource_group.example.name
-  workspace_resource_id = azurerm_log_analytics_workspace.example.id
-  workspace_name        = azurerm_log_analytics_workspace.example.name
-
-  plan {
-    publisher = "Microsoft"
-    product   = "OMSGallery/SecurityInsights"
-  }
+resource "azurerm_sentinel_log_analytics_workspace_onboarding" "example" {
+  resource_group_name = azurerm_resource_group.example.name
+  workspace_name      = azurerm_log_analytics_workspace.example.name
 }
 
 resource "azurerm_sentinel_alert_rule_fusion" "example" {
   name                       = "example-fusion-alert-rule"
-  log_analytics_workspace_id = azurerm_log_analytics_solution.example.workspace_resource_id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
   alert_rule_template_guid   = "f71aba3d-28fb-450b-b192-4e76a83015c8"
+
+  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.example]
 }
 ```
 

--- a/website/docs/r/sentinel_alert_rule_fusion.html.markdown
+++ b/website/docs/r/sentinel_alert_rule_fusion.html.markdown
@@ -25,17 +25,23 @@ resource "azurerm_log_analytics_workspace" "example" {
   sku                 = "PerGB2018"
 }
 
-resource "azurerm_sentinel_log_analytics_workspace_onboarding" "example" {
-  resource_group_name = azurerm_resource_group.example.name
-  workspace_name      = azurerm_log_analytics_workspace.example.name
+resource "azurerm_log_analytics_solution" "example" {
+  solution_name         = "SecurityInsights"
+  location              = azurerm_resource_group.example.location
+  resource_group_name   = azurerm_resource_group.example.name
+  workspace_resource_id = azurerm_log_analytics_workspace.example.id
+  workspace_name        = azurerm_log_analytics_workspace.example.name
+
+  plan {
+    publisher = "Microsoft"
+    product   = "OMSGallery/SecurityInsights"
+  }
 }
 
 resource "azurerm_sentinel_alert_rule_fusion" "example" {
   name                       = "example-fusion-alert-rule"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
+  log_analytics_workspace_id = azurerm_log_analytics_solution.example.workspace_resource_id
   alert_rule_template_guid   = "f71aba3d-28fb-450b-b192-4e76a83015c8"
-
-  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.example]
 }
 ```
 

--- a/website/docs/r/sentinel_alert_rule_ms_security_incident.html.markdown
+++ b/website/docs/r/sentinel_alert_rule_ms_security_incident.html.markdown
@@ -30,18 +30,15 @@ resource "azurerm_log_analytics_workspace" "example" {
 }
 
 resource "azurerm_sentinel_log_analytics_workspace_onboarding" "example" {
-  resource_group_name = azurerm_resource_group.example.name
-  workspace_name      = azurerm_log_analytics_workspace.example.name
+  workspace_id = azurerm_log_analytics_workspace.example.id
 }
 
 resource "azurerm_sentinel_alert_rule_ms_security_incident" "example" {
   name                       = "example-ms-security-incident-alert-rule"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.example.workspace_id
   product_filter             = "Microsoft Cloud App Security"
   display_name               = "example rule"
   severity_filter            = ["High"]
-
-  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.example]
 }
 ```
 

--- a/website/docs/r/sentinel_alert_rule_ms_security_incident.html.markdown
+++ b/website/docs/r/sentinel_alert_rule_ms_security_incident.html.markdown
@@ -29,25 +29,19 @@ resource "azurerm_log_analytics_workspace" "example" {
   sku                 = "PerGB2018"
 }
 
-resource "azurerm_log_analytics_solution" "example" {
-  solution_name         = "SecurityInsights"
-  location              = azurerm_resource_group.example.location
-  resource_group_name   = azurerm_resource_group.example.name
-  workspace_resource_id = azurerm_log_analytics_workspace.example.id
-  workspace_name        = azurerm_log_analytics_workspace.example.name
-
-  plan {
-    publisher = "Microsoft"
-    product   = "OMSGallery/SecurityInsights"
-  }
+resource "azurerm_sentinel_log_analytics_workspace_onboarding" "example" {
+  resource_group_name = azurerm_resource_group.example.name
+  workspace_name      = azurerm_log_analytics_workspace.example.name
 }
 
 resource "azurerm_sentinel_alert_rule_ms_security_incident" "example" {
   name                       = "example-ms-security-incident-alert-rule"
-  log_analytics_workspace_id = azurerm_log_analytics_solution.example.workspace_resource_id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
   product_filter             = "Microsoft Cloud App Security"
   display_name               = "example rule"
   severity_filter            = ["High"]
+
+  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.example]
 }
 ```
 

--- a/website/docs/r/sentinel_alert_rule_nrt.html.markdown
+++ b/website/docs/r/sentinel_alert_rule_nrt.html.markdown
@@ -29,22 +29,14 @@ resource "azurerm_log_analytics_workspace" "example" {
   sku                 = "pergb2018"
 }
 
-resource "azurerm_log_analytics_solution" "example" {
-  solution_name         = "SecurityInsights"
-  location              = azurerm_resource_group.example.location
-  resource_group_name   = azurerm_resource_group.example.name
-  workspace_resource_id = azurerm_log_analytics_workspace.example.id
-  workspace_name        = azurerm_log_analytics_workspace.example.name
-
-  plan {
-    publisher = "Microsoft"
-    product   = "OMSGallery/SecurityInsights"
-  }
+resource "azurerm_sentinel_log_analytics_workspace_onboarding" "example" {
+  resource_group_name = azurerm_resource_group.example.name
+  workspace_name      = azurerm_log_analytics_workspace.example.name
 }
 
 resource "azurerm_sentinel_alert_rule_nrt" "example" {
   name                       = "example"
-  log_analytics_workspace_id = azurerm_log_analytics_solution.example.workspace_resource_id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
   display_name               = "example"
   severity                   = "High"
   query                      = <<QUERY
@@ -53,6 +45,8 @@ AzureActivity |
   where ActivityStatus == "Succeeded" |
   make-series dcount(ResourceId) default=0 on EventSubmissionTimestamp in range(ago(7d), now(), 1d) by Caller
 QUERY
+
+  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.example]
 }
 ```
 

--- a/website/docs/r/sentinel_alert_rule_nrt.html.markdown
+++ b/website/docs/r/sentinel_alert_rule_nrt.html.markdown
@@ -30,13 +30,12 @@ resource "azurerm_log_analytics_workspace" "example" {
 }
 
 resource "azurerm_sentinel_log_analytics_workspace_onboarding" "example" {
-  resource_group_name = azurerm_resource_group.example.name
-  workspace_name      = azurerm_log_analytics_workspace.example.name
+  workspace_id = azurerm_log_analytics_workspace.example.id
 }
 
 resource "azurerm_sentinel_alert_rule_nrt" "example" {
   name                       = "example"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.example.workspace_id
   display_name               = "example"
   severity                   = "High"
   query                      = <<QUERY
@@ -45,8 +44,6 @@ AzureActivity |
   where ActivityStatus == "Succeeded" |
   make-series dcount(ResourceId) default=0 on EventSubmissionTimestamp in range(ago(7d), now(), 1d) by Caller
 QUERY
-
-  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.example]
 }
 ```
 

--- a/website/docs/r/sentinel_alert_rule_scheduled.html.markdown
+++ b/website/docs/r/sentinel_alert_rule_scheduled.html.markdown
@@ -29,22 +29,14 @@ resource "azurerm_log_analytics_workspace" "example" {
   sku                 = "PerGB2018"
 }
 
-resource "azurerm_log_analytics_solution" "example" {
-  solution_name         = "SecurityInsights"
-  location              = azurerm_resource_group.example.location
-  resource_group_name   = azurerm_resource_group.example.name
-  workspace_resource_id = azurerm_log_analytics_workspace.example.id
-  workspace_name        = azurerm_log_analytics_workspace.example.name
-
-  plan {
-    publisher = "Microsoft"
-    product   = "OMSGallery/SecurityInsights"
-  }
+resource "azurerm_sentinel_log_analytics_workspace_onboarding" "example" {
+  resource_group_name = azurerm_resource_group.example.name
+  workspace_name      = azurerm_log_analytics_workspace.example.name
 }
 
 resource "azurerm_sentinel_alert_rule_scheduled" "example" {
   name                       = "example"
-  log_analytics_workspace_id = azurerm_log_analytics_solution.example.workspace_resource_id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
   display_name               = "example"
   severity                   = "High"
   query                      = <<QUERY
@@ -53,6 +45,8 @@ AzureActivity |
   where ActivityStatus == "Succeeded" |
   make-series dcount(ResourceId) default=0 on EventSubmissionTimestamp in range(ago(7d), now(), 1d) by Caller
 QUERY
+
+  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.example]
 }
 ```
 

--- a/website/docs/r/sentinel_alert_rule_scheduled.html.markdown
+++ b/website/docs/r/sentinel_alert_rule_scheduled.html.markdown
@@ -30,13 +30,12 @@ resource "azurerm_log_analytics_workspace" "example" {
 }
 
 resource "azurerm_sentinel_log_analytics_workspace_onboarding" "example" {
-  resource_group_name = azurerm_resource_group.example.name
-  workspace_name      = azurerm_log_analytics_workspace.example.name
+  workspace_id = azurerm_log_analytics_workspace.example.id
 }
 
 resource "azurerm_sentinel_alert_rule_scheduled" "example" {
   name                       = "example"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.example.workspace_id
   display_name               = "example"
   severity                   = "High"
   query                      = <<QUERY
@@ -45,8 +44,6 @@ AzureActivity |
   where ActivityStatus == "Succeeded" |
   make-series dcount(ResourceId) default=0 on EventSubmissionTimestamp in range(ago(7d), now(), 1d) by Caller
 QUERY
-
-  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.example]
 }
 ```
 

--- a/website/docs/r/sentinel_automation_rule.html.markdown
+++ b/website/docs/r/sentinel_automation_rule.html.markdown
@@ -29,28 +29,22 @@ resource "azurerm_log_analytics_workspace" "example" {
   sku                 = "PerGB2018"
 }
 
-resource "azurerm_log_analytics_solution" "sentinel" {
-  solution_name         = "SecurityInsights"
-  location              = azurerm_resource_group.example.location
-  resource_group_name   = azurerm_resource_group.example.name
-  workspace_resource_id = azurerm_log_analytics_workspace.example.id
-  workspace_name        = azurerm_log_analytics_workspace.example.name
-
-  plan {
-    publisher = "Microsoft"
-    product   = "OMSGallery/SecurityInsights"
-  }
+resource "azurerm_sentinel_log_analytics_workspace_onboarding" "example" {
+  resource_group_name = azurerm_resource_group.example.name
+  workspace_name      = azurerm_log_analytics_workspace.example.name
 }
 
 resource "azurerm_sentinel_automation_rule" "example" {
   name                       = "56094f72-ac3f-40e7-a0c0-47bd95f70336"
-  log_analytics_workspace_id = azurerm_log_analytics_solution.sentinel.workspace_resource_id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
   display_name               = "automation_rule1"
   order                      = 1
   action_incident {
     order  = 1
     status = "Active"
   }
+
+  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.example]
 }
 ```
 

--- a/website/docs/r/sentinel_automation_rule.html.markdown
+++ b/website/docs/r/sentinel_automation_rule.html.markdown
@@ -30,21 +30,18 @@ resource "azurerm_log_analytics_workspace" "example" {
 }
 
 resource "azurerm_sentinel_log_analytics_workspace_onboarding" "example" {
-  resource_group_name = azurerm_resource_group.example.name
-  workspace_name      = azurerm_log_analytics_workspace.example.name
+  workspace_id = azurerm_log_analytics_workspace.example.id
 }
 
 resource "azurerm_sentinel_automation_rule" "example" {
   name                       = "56094f72-ac3f-40e7-a0c0-47bd95f70336"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.example.workspace_id
   display_name               = "automation_rule1"
   order                      = 1
   action_incident {
     order  = 1
     status = "Active"
   }
-
-  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.example]
 }
 ```
 

--- a/website/docs/r/sentinel_data_connector_aws_cloud_trail.html.markdown
+++ b/website/docs/r/sentinel_data_connector_aws_cloud_trail.html.markdown
@@ -25,23 +25,17 @@ resource "azurerm_log_analytics_workspace" "example" {
   sku                 = "PerGB2018"
 }
 
-resource "azurerm_log_analytics_solution" "example" {
-  solution_name         = "SecurityInsights"
-  location              = azurerm_resource_group.example.location
-  resource_group_name   = azurerm_resource_group.example.name
-  workspace_resource_id = azurerm_log_analytics_workspace.example.id
-  workspace_name        = azurerm_log_analytics_workspace.example.name
-
-  plan {
-    publisher = "Microsoft"
-    product   = "OMSGallery/SecurityInsights"
-  }
+resource "azurerm_sentinel_log_analytics_workspace_onboarding" "example" {
+  resource_group_name = azurerm_resource_group.example.name
+  workspace_name      = azurerm_log_analytics_workspace.example.name
 }
 
 resource "azurerm_sentinel_data_connector_aws_cloud_trail" "example" {
   name                       = "example"
-  log_analytics_workspace_id = azurerm_log_analytics_solution.example.workspace_resource_id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
   aws_role_arn               = "arn:aws:iam::000000000000:role/role1"
+
+  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.example]
 }
 ```
 

--- a/website/docs/r/sentinel_data_connector_aws_cloud_trail.html.markdown
+++ b/website/docs/r/sentinel_data_connector_aws_cloud_trail.html.markdown
@@ -26,16 +26,13 @@ resource "azurerm_log_analytics_workspace" "example" {
 }
 
 resource "azurerm_sentinel_log_analytics_workspace_onboarding" "example" {
-  resource_group_name = azurerm_resource_group.example.name
-  workspace_name      = azurerm_log_analytics_workspace.example.name
+  workspace_id = azurerm_log_analytics_workspace.example.id
 }
 
 resource "azurerm_sentinel_data_connector_aws_cloud_trail" "example" {
   name                       = "example"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.example.workspace_id
   aws_role_arn               = "arn:aws:iam::000000000000:role/role1"
-
-  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.example]
 }
 ```
 

--- a/website/docs/r/sentinel_data_connector_aws_s3.html.markdown
+++ b/website/docs/r/sentinel_data_connector_aws_s3.html.markdown
@@ -25,26 +25,19 @@ resource "azurerm_log_analytics_workspace" "example" {
   sku                 = "PerGB2018"
 }
 
-resource "azurerm_log_analytics_solution" "example" {
-  solution_name         = "SecurityInsights"
-  location              = azurerm_resource_group.example.location
-  resource_group_name   = azurerm_resource_group.example.name
-  workspace_resource_id = azurerm_log_analytics_workspace.example.id
-  workspace_name        = azurerm_log_analytics_workspace.example.name
-
-  plan {
-    publisher = "Microsoft"
-    product   = "OMSGallery/SecurityInsights"
-  }
+resource "azurerm_sentinel_log_analytics_workspace_onboarding" "example" {
+  resource_group_name = azurerm_resource_group.example.name
+  workspace_name      = azurerm_log_analytics_workspace.example.name
 }
 
 resource "azurerm_sentinel_data_connector_aws_s3" "example" {
   name                       = "example"
-  log_analytics_workspace_id = azurerm_log_analytics_solution.example.workspace_resource_id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
   aws_role_arn               = "arn:aws:iam::000000000000:role/role1"
   destination_table          = "AWSGuardDuty"
   sqs_urls                   = ["https://sqs.us-east-1.amazonaws.com/000000000000/example"]
-  depends_on                 = [azurerm_log_analytics_solution.example]
+
+  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.example]
 }
 ```
 

--- a/website/docs/r/sentinel_data_connector_aws_s3.html.markdown
+++ b/website/docs/r/sentinel_data_connector_aws_s3.html.markdown
@@ -26,18 +26,15 @@ resource "azurerm_log_analytics_workspace" "example" {
 }
 
 resource "azurerm_sentinel_log_analytics_workspace_onboarding" "example" {
-  resource_group_name = azurerm_resource_group.example.name
-  workspace_name      = azurerm_log_analytics_workspace.example.name
+  workspace_id = azurerm_log_analytics_workspace.example.id
 }
 
 resource "azurerm_sentinel_data_connector_aws_s3" "example" {
   name                       = "example"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.example.workspace_id
   aws_role_arn               = "arn:aws:iam::000000000000:role/role1"
   destination_table          = "AWSGuardDuty"
   sqs_urls                   = ["https://sqs.us-east-1.amazonaws.com/000000000000/example"]
-
-  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.example]
 }
 ```
 

--- a/website/docs/r/sentinel_data_connector_azure_active_directory.html.markdown
+++ b/website/docs/r/sentinel_data_connector_azure_active_directory.html.markdown
@@ -25,22 +25,17 @@ resource "azurerm_log_analytics_workspace" "example" {
   sku                 = "PerGB2018"
 }
 
-resource "azurerm_log_analytics_solution" "example" {
-  solution_name         = "SecurityInsights"
-  location              = azurerm_resource_group.example.location
-  resource_group_name   = azurerm_resource_group.example.name
-  workspace_resource_id = azurerm_log_analytics_workspace.example.id
-  workspace_name        = azurerm_log_analytics_workspace.example.name
-
-  plan {
-    publisher = "Microsoft"
-    product   = "OMSGallery/SecurityInsights"
-  }
+resource "azurerm_sentinel_log_analytics_workspace_onboarding" "example" {
+  resource_group_name = azurerm_resource_group.example.name
+  workspace_name      = azurerm_log_analytics_workspace.example.name
 }
+
 
 resource "azurerm_sentinel_data_connector_azure_active_directory" "example" {
   name                       = "example"
-  log_analytics_workspace_id = azurerm_log_analytics_solution.example.workspace_resource_id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
+
+  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.example]
 }
 ```
 

--- a/website/docs/r/sentinel_data_connector_azure_active_directory.html.markdown
+++ b/website/docs/r/sentinel_data_connector_azure_active_directory.html.markdown
@@ -26,16 +26,13 @@ resource "azurerm_log_analytics_workspace" "example" {
 }
 
 resource "azurerm_sentinel_log_analytics_workspace_onboarding" "example" {
-  resource_group_name = azurerm_resource_group.example.name
-  workspace_name      = azurerm_log_analytics_workspace.example.name
+  workspace_id = azurerm_log_analytics_workspace.example.id
 }
 
 
 resource "azurerm_sentinel_data_connector_azure_active_directory" "example" {
   name                       = "example"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
-
-  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.example]
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.example.workspace_id
 }
 ```
 

--- a/website/docs/r/sentinel_data_connector_azure_advanced_threat_protection.html.markdown
+++ b/website/docs/r/sentinel_data_connector_azure_advanced_threat_protection.html.markdown
@@ -28,16 +28,12 @@ resource "azurerm_log_analytics_workspace" "example" {
 }
 
 resource "azurerm_sentinel_log_analytics_workspace_onboarding" "example" {
-  resource_group_name = azurerm_resource_group.example.name
-  workspace_name      = azurerm_log_analytics_workspace.example.name
+  workspace_id = azurerm_log_analytics_workspace.example.id
 }
-
 
 resource "azurerm_sentinel_data_connector_azure_advanced_threat_protection" "example" {
   name                       = "example"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
-
-  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.example]
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.example.workspace_id
 }
 ```
 

--- a/website/docs/r/sentinel_data_connector_azure_advanced_threat_protection.html.markdown
+++ b/website/docs/r/sentinel_data_connector_azure_advanced_threat_protection.html.markdown
@@ -27,22 +27,17 @@ resource "azurerm_log_analytics_workspace" "example" {
   sku                 = "PerGB2018"
 }
 
-resource "azurerm_log_analytics_solution" "example" {
-  solution_name         = "SecurityInsights"
-  location              = azurerm_resource_group.example.location
-  resource_group_name   = azurerm_resource_group.example.name
-  workspace_resource_id = azurerm_log_analytics_workspace.example.id
-  workspace_name        = azurerm_log_analytics_workspace.example.name
-
-  plan {
-    publisher = "Microsoft"
-    product   = "OMSGallery/SecurityInsights"
-  }
+resource "azurerm_sentinel_log_analytics_workspace_onboarding" "example" {
+  resource_group_name = azurerm_resource_group.example.name
+  workspace_name      = azurerm_log_analytics_workspace.example.name
 }
+
 
 resource "azurerm_sentinel_data_connector_azure_advanced_threat_protection" "example" {
   name                       = "example"
-  log_analytics_workspace_id = azurerm_log_analytics_solution.example.workspace_resource_id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
+
+  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.example]
 }
 ```
 

--- a/website/docs/r/sentinel_data_connector_azure_security_center.html.markdown
+++ b/website/docs/r/sentinel_data_connector_azure_security_center.html.markdown
@@ -25,22 +25,17 @@ resource "azurerm_log_analytics_workspace" "example" {
   sku                 = "PerGB2018"
 }
 
-resource "azurerm_log_analytics_solution" "example" {
-  solution_name         = "SecurityInsights"
-  location              = azurerm_resource_group.example.location
-  resource_group_name   = azurerm_resource_group.example.name
-  workspace_resource_id = azurerm_log_analytics_workspace.example.id
-  workspace_name        = azurerm_log_analytics_workspace.example.name
-
-  plan {
-    publisher = "Microsoft"
-    product   = "OMSGallery/SecurityInsights"
-  }
+resource "azurerm_sentinel_log_analytics_workspace_onboarding" "example" {
+  resource_group_name = azurerm_resource_group.example.name
+  workspace_name      = azurerm_log_analytics_workspace.example.name
 }
+
 
 resource "azurerm_sentinel_data_connector_azure_security_center" "example" {
   name                       = "example"
-  log_analytics_workspace_id = azurerm_log_analytics_solution.example.workspace_resource_id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
+
+  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.example]
 }
 ```
 

--- a/website/docs/r/sentinel_data_connector_azure_security_center.html.markdown
+++ b/website/docs/r/sentinel_data_connector_azure_security_center.html.markdown
@@ -26,16 +26,12 @@ resource "azurerm_log_analytics_workspace" "example" {
 }
 
 resource "azurerm_sentinel_log_analytics_workspace_onboarding" "example" {
-  resource_group_name = azurerm_resource_group.example.name
-  workspace_name      = azurerm_log_analytics_workspace.example.name
+  workspace_id = azurerm_log_analytics_workspace.example.id
 }
-
 
 resource "azurerm_sentinel_data_connector_azure_security_center" "example" {
   name                       = "example"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
-
-  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.example]
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.example.workspace_id
 }
 ```
 

--- a/website/docs/r/sentinel_data_connector_dynamics_365.html.markdown
+++ b/website/docs/r/sentinel_data_connector_dynamics_365.html.markdown
@@ -25,22 +25,17 @@ resource "azurerm_log_analytics_workspace" "example" {
   sku                 = "PerGB2018"
 }
 
-resource "azurerm_log_analytics_solution" "example" {
-  solution_name         = "SecurityInsights"
-  location              = azurerm_resource_group.example.location
-  resource_group_name   = azurerm_resource_group.example.name
-  workspace_resource_id = azurerm_log_analytics_workspace.example.id
-  workspace_name        = azurerm_log_analytics_workspace.example.name
-
-  plan {
-    publisher = "Microsoft"
-    product   = "OMSGallery/SecurityInsights"
-  }
+resource "azurerm_sentinel_log_analytics_workspace_onboarding" "example" {
+  resource_group_name = azurerm_resource_group.example.name
+  workspace_name      = azurerm_log_analytics_workspace.example.name
 }
+
 
 resource "azurerm_sentinel_data_connector_dynamics_365" "example" {
   name                       = "example"
-  log_analytics_workspace_id = azurerm_log_analytics_solution.example.workspace_resource_id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
+
+  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.example]
 }
 ```
 

--- a/website/docs/r/sentinel_data_connector_dynamics_365.html.markdown
+++ b/website/docs/r/sentinel_data_connector_dynamics_365.html.markdown
@@ -26,16 +26,12 @@ resource "azurerm_log_analytics_workspace" "example" {
 }
 
 resource "azurerm_sentinel_log_analytics_workspace_onboarding" "example" {
-  resource_group_name = azurerm_resource_group.example.name
-  workspace_name      = azurerm_log_analytics_workspace.example.name
+  workspace_id = azurerm_log_analytics_workspace.example.id
 }
-
 
 resource "azurerm_sentinel_data_connector_dynamics_365" "example" {
   name                       = "example"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
-
-  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.example]
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.example.workspace_id
 }
 ```
 

--- a/website/docs/r/sentinel_data_connector_iot.html.markdown
+++ b/website/docs/r/sentinel_data_connector_iot.html.markdown
@@ -25,22 +25,15 @@ resource "azurerm_log_analytics_workspace" "example" {
   sku                 = "PerGB2018"
 }
 
-resource "azurerm_log_analytics_solution" "example" {
-  solution_name         = "SecurityInsights"
-  location              = azurerm_resource_group.example.location
-  resource_group_name   = azurerm_resource_group.example.name
-  workspace_resource_id = azurerm_log_analytics_workspace.example.id
-  workspace_name        = azurerm_log_analytics_workspace.example.name
-
-  plan {
-    publisher = "Microsoft"
-    product   = "OMSGallery/SecurityInsights"
-  }
+resource "azurerm_sentinel_log_analytics_workspace_onboarding" "example" {
+  resource_group_name = azurerm_resource_group.example.name
+  workspace_name      = azurerm_log_analytics_workspace.example.name
 }
 
 resource "azurerm_sentinel_data_connector_iot" "example" {
   name                       = "example"
-  log_analytics_workspace_id = azurerm_log_analytics_solution.example.workspace_resource_id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
+  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.example]
 }
 ```
 

--- a/website/docs/r/sentinel_data_connector_iot.html.markdown
+++ b/website/docs/r/sentinel_data_connector_iot.html.markdown
@@ -26,14 +26,12 @@ resource "azurerm_log_analytics_workspace" "example" {
 }
 
 resource "azurerm_sentinel_log_analytics_workspace_onboarding" "example" {
-  resource_group_name = azurerm_resource_group.example.name
-  workspace_name      = azurerm_log_analytics_workspace.example.name
+  workspace_id = azurerm_log_analytics_workspace.example.id
 }
 
 resource "azurerm_sentinel_data_connector_iot" "example" {
   name                       = "example"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
-  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.example]
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.example.workspace_id
 }
 ```
 

--- a/website/docs/r/sentinel_data_connector_microsoft_cloud_app_security.html.markdown
+++ b/website/docs/r/sentinel_data_connector_microsoft_cloud_app_security.html.markdown
@@ -27,22 +27,16 @@ resource "azurerm_log_analytics_workspace" "example" {
   sku                 = "PerGB2018"
 }
 
-resource "azurerm_log_analytics_solution" "example" {
-  solution_name         = "SecurityInsights"
-  location              = azurerm_resource_group.example.location
-  resource_group_name   = azurerm_resource_group.example.name
-  workspace_resource_id = azurerm_log_analytics_workspace.example.id
-  workspace_name        = azurerm_log_analytics_workspace.example.name
-
-  plan {
-    publisher = "Microsoft"
-    product   = "OMSGallery/SecurityInsights"
-  }
+resource "azurerm_sentinel_log_analytics_workspace_onboarding" "example" {
+  resource_group_name = azurerm_resource_group.example.name
+  workspace_name      = azurerm_log_analytics_workspace.example.name
 }
+
 
 resource "azurerm_sentinel_data_connector_microsoft_cloud_app_security" "example" {
   name                       = "example"
-  log_analytics_workspace_id = azurerm_log_analytics_solution.example.workspace_resource_id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
+  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.example]
 }
 ```
 

--- a/website/docs/r/sentinel_data_connector_microsoft_cloud_app_security.html.markdown
+++ b/website/docs/r/sentinel_data_connector_microsoft_cloud_app_security.html.markdown
@@ -28,15 +28,12 @@ resource "azurerm_log_analytics_workspace" "example" {
 }
 
 resource "azurerm_sentinel_log_analytics_workspace_onboarding" "example" {
-  resource_group_name = azurerm_resource_group.example.name
-  workspace_name      = azurerm_log_analytics_workspace.example.name
+  workspace_id = azurerm_log_analytics_workspace.example.id
 }
-
 
 resource "azurerm_sentinel_data_connector_microsoft_cloud_app_security" "example" {
   name                       = "example"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
-  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.example]
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.example.workspace_id
 }
 ```
 

--- a/website/docs/r/sentinel_data_connector_microsoft_defender_advanced_threat_protection.html.markdown
+++ b/website/docs/r/sentinel_data_connector_microsoft_defender_advanced_threat_protection.html.markdown
@@ -26,15 +26,12 @@ resource "azurerm_log_analytics_workspace" "example" {
 }
 
 resource "azurerm_sentinel_log_analytics_workspace_onboarding" "example" {
-  resource_group_name = azurerm_resource_group.example.name
-  workspace_name      = azurerm_log_analytics_workspace.example.name
+  workspace_id = azurerm_log_analytics_workspace.example.id
 }
 
 resource "azurerm_sentinel_data_connector_microsoft_defender_advanced_threat_protection" "example" {
   name                       = "example"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
-
-  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.example]
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.example.workspace_id
 }
 ```
 

--- a/website/docs/r/sentinel_data_connector_microsoft_defender_advanced_threat_protection.html.markdown
+++ b/website/docs/r/sentinel_data_connector_microsoft_defender_advanced_threat_protection.html.markdown
@@ -25,22 +25,16 @@ resource "azurerm_log_analytics_workspace" "example" {
   sku                 = "PerGB2018"
 }
 
-resource "azurerm_log_analytics_solution" "example" {
-  solution_name         = "SecurityInsights"
-  location              = azurerm_resource_group.example.location
-  resource_group_name   = azurerm_resource_group.example.name
-  workspace_resource_id = azurerm_log_analytics_workspace.example.id
-  workspace_name        = azurerm_log_analytics_workspace.example.name
-
-  plan {
-    publisher = "Microsoft"
-    product   = "OMSGallery/SecurityInsights"
-  }
+resource "azurerm_sentinel_log_analytics_workspace_onboarding" "example" {
+  resource_group_name = azurerm_resource_group.example.name
+  workspace_name      = azurerm_log_analytics_workspace.example.name
 }
 
 resource "azurerm_sentinel_data_connector_microsoft_defender_advanced_threat_protection" "example" {
   name                       = "example"
-  log_analytics_workspace_id = azurerm_log_analytics_solution.example.workspace_resource_id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
+
+  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.example]
 }
 ```
 

--- a/website/docs/r/sentinel_data_connector_microsoft_threat_intelligence.html.markdown
+++ b/website/docs/r/sentinel_data_connector_microsoft_threat_intelligence.html.markdown
@@ -30,19 +30,14 @@ resource "azurerm_log_analytics_workspace" "example" {
 }
 
 resource "azurerm_sentinel_log_analytics_workspace_onboarding" "example" {
-  resource_group_name = azurerm_resource_group.example.name
-  workspace_name      = azurerm_log_analytics_workspace.example.name
+  workspace_id = azurerm_log_analytics_workspace.example.id
 }
 
 resource "azurerm_sentinel_data_connector_microsoft_threat_intelligence" "example" {
   name                                         = "example-dc-msti"
-  log_analytics_workspace_id                   = azurerm_log_analytics_workspace.example.id
+  log_analytics_workspace_id                   = azurerm_sentinel_log_analytics_workspace_onboarding.example.workspace_id
   bing_safety_phishing_url_lookback_date       = "1970-01-01T00:00:00Z"
   microsoft_emerging_threat_feed_lookback_date = "1970-01-01T00:00:00Z"
-
-  depends_on = [
-    azurerm_sentinel_log_analytics_workspace_onboarding.test
-  ]
 }
 ```
 

--- a/website/docs/r/sentinel_data_connector_microsoft_threat_protection.html.markdown
+++ b/website/docs/r/sentinel_data_connector_microsoft_threat_protection.html.markdown
@@ -26,16 +26,12 @@ resource "azurerm_log_analytics_workspace" "example" {
 }
 
 resource "azurerm_sentinel_log_analytics_workspace_onboarding" "example" {
-  resource_group_name = azurerm_resource_group.example.name
-  workspace_name      = azurerm_log_analytics_workspace.example.name
+  workspace_id = azurerm_log_analytics_workspace.example.id
 }
-
 
 resource "azurerm_sentinel_data_connector_microsoft_threat_protection" "example" {
   name                       = "example"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
-
-  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.example]
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.example.workspace_id
 }
 ```
 

--- a/website/docs/r/sentinel_data_connector_microsoft_threat_protection.html.markdown
+++ b/website/docs/r/sentinel_data_connector_microsoft_threat_protection.html.markdown
@@ -25,22 +25,17 @@ resource "azurerm_log_analytics_workspace" "example" {
   sku                 = "PerGB2018"
 }
 
-resource "azurerm_log_analytics_solution" "example" {
-  solution_name         = "SecurityInsights"
-  location              = azurerm_resource_group.example.location
-  resource_group_name   = azurerm_resource_group.example.name
-  workspace_resource_id = azurerm_log_analytics_workspace.example.id
-  workspace_name        = azurerm_log_analytics_workspace.example.name
-
-  plan {
-    publisher = "Microsoft"
-    product   = "OMSGallery/SecurityInsights"
-  }
+resource "azurerm_sentinel_log_analytics_workspace_onboarding" "example" {
+  resource_group_name = azurerm_resource_group.example.name
+  workspace_name      = azurerm_log_analytics_workspace.example.name
 }
+
 
 resource "azurerm_sentinel_data_connector_microsoft_threat_protection" "example" {
   name                       = "example"
-  log_analytics_workspace_id = azurerm_log_analytics_solution.example.workspace_resource_id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
+
+  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.example]
 }
 ```
 

--- a/website/docs/r/sentinel_data_connector_office_365.html.markdown
+++ b/website/docs/r/sentinel_data_connector_office_365.html.markdown
@@ -26,14 +26,12 @@ resource "azurerm_log_analytics_workspace" "example" {
 }
 
 resource "azurerm_sentinel_log_analytics_workspace_onboarding" "example" {
-  resource_group_name = azurerm_resource_group.example.name
-  workspace_name      = azurerm_log_analytics_workspace.example.name
+  workspace_id = azurerm_log_analytics_workspace.example.id
 }
 
 resource "azurerm_sentinel_data_connector_office_365" "example" {
   name                       = "example"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
-  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.example]
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.example.workspace_id
 }
 ```
 

--- a/website/docs/r/sentinel_data_connector_office_365.html.markdown
+++ b/website/docs/r/sentinel_data_connector_office_365.html.markdown
@@ -25,22 +25,15 @@ resource "azurerm_log_analytics_workspace" "example" {
   sku                 = "PerGB2018"
 }
 
-resource "azurerm_log_analytics_solution" "example" {
-  solution_name         = "SecurityInsights"
-  location              = azurerm_resource_group.example.location
-  resource_group_name   = azurerm_resource_group.example.name
-  workspace_resource_id = azurerm_log_analytics_workspace.example.id
-  workspace_name        = azurerm_log_analytics_workspace.example.name
-
-  plan {
-    publisher = "Microsoft"
-    product   = "OMSGallery/SecurityInsights"
-  }
+resource "azurerm_sentinel_log_analytics_workspace_onboarding" "example" {
+  resource_group_name = azurerm_resource_group.example.name
+  workspace_name      = azurerm_log_analytics_workspace.example.name
 }
 
 resource "azurerm_sentinel_data_connector_office_365" "example" {
   name                       = "example"
-  log_analytics_workspace_id = azurerm_log_analytics_solution.example.workspace_resource_id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
+  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.example]
 }
 ```
 

--- a/website/docs/r/sentinel_data_connector_office_365_project.html.markdown
+++ b/website/docs/r/sentinel_data_connector_office_365_project.html.markdown
@@ -25,22 +25,16 @@ resource "azurerm_log_analytics_workspace" "example" {
   sku                 = "PerGB2018"
 }
 
-resource "azurerm_log_analytics_solution" "example" {
-  solution_name         = "SecurityInsights"
-  location              = azurerm_resource_group.example.location
-  resource_group_name   = azurerm_resource_group.example.name
-  workspace_resource_id = azurerm_log_analytics_workspace.example.id
-  workspace_name        = azurerm_log_analytics_workspace.example.name
-
-  plan {
-    publisher = "Microsoft"
-    product   = "OMSGallery/SecurityInsights"
-  }
+resource "azurerm_sentinel_log_analytics_workspace_onboarding" "example" {
+  resource_group_name = azurerm_resource_group.example.name
+  workspace_name      = azurerm_log_analytics_workspace.example.name
 }
+
 
 resource "azurerm_sentinel_data_connector_office_365_project" "example" {
   name                       = "example"
-  log_analytics_workspace_id = azurerm_log_analytics_solution.example.workspace_resource_id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
+  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.example]
 }
 ```
 

--- a/website/docs/r/sentinel_data_connector_office_365_project.html.markdown
+++ b/website/docs/r/sentinel_data_connector_office_365_project.html.markdown
@@ -26,15 +26,12 @@ resource "azurerm_log_analytics_workspace" "example" {
 }
 
 resource "azurerm_sentinel_log_analytics_workspace_onboarding" "example" {
-  resource_group_name = azurerm_resource_group.example.name
-  workspace_name      = azurerm_log_analytics_workspace.example.name
+  workspace_id = azurerm_log_analytics_workspace.example.id
 }
-
 
 resource "azurerm_sentinel_data_connector_office_365_project" "example" {
   name                       = "example"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
-  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.example]
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.example.workspace_id
 }
 ```
 

--- a/website/docs/r/sentinel_data_connector_office_atp.html.markdown
+++ b/website/docs/r/sentinel_data_connector_office_atp.html.markdown
@@ -25,22 +25,15 @@ resource "azurerm_log_analytics_workspace" "example" {
   sku                 = "PerGB2018"
 }
 
-resource "azurerm_log_analytics_solution" "example" {
-  solution_name         = "SecurityInsights"
-  location              = azurerm_resource_group.example.location
-  resource_group_name   = azurerm_resource_group.example.name
-  workspace_resource_id = azurerm_log_analytics_workspace.example.id
-  workspace_name        = azurerm_log_analytics_workspace.example.name
-
-  plan {
-    publisher = "Microsoft"
-    product   = "OMSGallery/SecurityInsights"
-  }
+resource "azurerm_sentinel_log_analytics_workspace_onboarding" "example" {
+  resource_group_name = azurerm_resource_group.example.name
+  workspace_name      = azurerm_log_analytics_workspace.example.name
 }
 
 resource "azurerm_sentinel_data_connector_office_atp" "example" {
   name                       = "example"
-  log_analytics_workspace_id = azurerm_log_analytics_solution.example.workspace_resource_id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
+  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.example]
 }
 ```
 

--- a/website/docs/r/sentinel_data_connector_office_atp.html.markdown
+++ b/website/docs/r/sentinel_data_connector_office_atp.html.markdown
@@ -26,14 +26,12 @@ resource "azurerm_log_analytics_workspace" "example" {
 }
 
 resource "azurerm_sentinel_log_analytics_workspace_onboarding" "example" {
-  resource_group_name = azurerm_resource_group.example.name
-  workspace_name      = azurerm_log_analytics_workspace.example.name
+  workspace_id = azurerm_log_analytics_workspace.example.id
 }
 
 resource "azurerm_sentinel_data_connector_office_atp" "example" {
   name                       = "example"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
-  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.example]
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.example.workspace_id
 }
 ```
 

--- a/website/docs/r/sentinel_data_connector_office_irm.html.markdown
+++ b/website/docs/r/sentinel_data_connector_office_irm.html.markdown
@@ -25,22 +25,15 @@ resource "azurerm_log_analytics_workspace" "example" {
   sku                 = "PerGB2018"
 }
 
-resource "azurerm_log_analytics_solution" "example" {
-  solution_name         = "SecurityInsights"
-  location              = azurerm_resource_group.example.location
-  resource_group_name   = azurerm_resource_group.example.name
-  workspace_resource_id = azurerm_log_analytics_workspace.example.id
-  workspace_name        = azurerm_log_analytics_workspace.example.name
-
-  plan {
-    publisher = "Microsoft"
-    product   = "OMSGallery/SecurityInsights"
-  }
+resource "azurerm_sentinel_log_analytics_workspace_onboarding" "example" {
+  resource_group_name = azurerm_resource_group.example.name
+  workspace_name      = azurerm_log_analytics_workspace.example.name
 }
 
 resource "azurerm_sentinel_data_connector_office_irm" "example" {
   name                       = "example"
-  log_analytics_workspace_id = azurerm_log_analytics_solution.example.workspace_resource_id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
+  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.example]
 }
 ```
 

--- a/website/docs/r/sentinel_data_connector_office_irm.html.markdown
+++ b/website/docs/r/sentinel_data_connector_office_irm.html.markdown
@@ -26,14 +26,12 @@ resource "azurerm_log_analytics_workspace" "example" {
 }
 
 resource "azurerm_sentinel_log_analytics_workspace_onboarding" "example" {
-  resource_group_name = azurerm_resource_group.example.name
-  workspace_name      = azurerm_log_analytics_workspace.example.name
+  workspace_id = azurerm_log_analytics_workspace.example.id
 }
 
 resource "azurerm_sentinel_data_connector_office_irm" "example" {
   name                       = "example"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
-  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.example]
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.example.workspace_id
 }
 ```
 

--- a/website/docs/r/sentinel_data_connector_office_power_bi.html.markdown
+++ b/website/docs/r/sentinel_data_connector_office_power_bi.html.markdown
@@ -26,14 +26,12 @@ resource "azurerm_log_analytics_workspace" "example" {
 }
 
 resource "azurerm_sentinel_log_analytics_workspace_onboarding" "example" {
-  resource_group_name = azurerm_resource_group.example.name
-  workspace_name      = azurerm_log_analytics_workspace.example.name
+  workspace_id = azurerm_log_analytics_workspace.example.id
 }
 
 resource "azurerm_sentinel_data_connector_office_power_bi" "example" {
   name                       = "example"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
-  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.example]
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.example.workspace_id
 }
 ```
 

--- a/website/docs/r/sentinel_data_connector_office_power_bi.html.markdown
+++ b/website/docs/r/sentinel_data_connector_office_power_bi.html.markdown
@@ -25,22 +25,15 @@ resource "azurerm_log_analytics_workspace" "example" {
   sku                 = "PerGB2018"
 }
 
-resource "azurerm_log_analytics_solution" "example" {
-  solution_name         = "SecurityInsights"
-  location              = azurerm_resource_group.example.location
-  resource_group_name   = azurerm_resource_group.example.name
-  workspace_resource_id = azurerm_log_analytics_workspace.example.id
-  workspace_name        = azurerm_log_analytics_workspace.example.name
-
-  plan {
-    publisher = "Microsoft"
-    product   = "OMSGallery/SecurityInsights"
-  }
+resource "azurerm_sentinel_log_analytics_workspace_onboarding" "example" {
+  resource_group_name = azurerm_resource_group.example.name
+  workspace_name      = azurerm_log_analytics_workspace.example.name
 }
 
 resource "azurerm_sentinel_data_connector_office_power_bi" "example" {
   name                       = "example"
-  log_analytics_workspace_id = azurerm_log_analytics_solution.example.workspace_resource_id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
+  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.example]
 }
 ```
 

--- a/website/docs/r/sentinel_data_connector_threat_intelligence.html.markdown
+++ b/website/docs/r/sentinel_data_connector_threat_intelligence.html.markdown
@@ -25,22 +25,15 @@ resource "azurerm_log_analytics_workspace" "example" {
   sku                 = "PerGB2018"
 }
 
-resource "azurerm_log_analytics_solution" "example" {
-  solution_name         = "SecurityInsights"
-  location              = azurerm_resource_group.example.location
-  resource_group_name   = azurerm_resource_group.example.name
-  workspace_resource_id = azurerm_log_analytics_workspace.example.id
-  workspace_name        = azurerm_log_analytics_workspace.example.name
-
-  plan {
-    publisher = "Microsoft"
-    product   = "OMSGallery/SecurityInsights"
-  }
+resource "azurerm_sentinel_log_analytics_workspace_onboarding" "example" {
+  resource_group_name = azurerm_resource_group.example.name
+  workspace_name      = azurerm_log_analytics_workspace.example.name
 }
 
 resource "azurerm_sentinel_data_connector_threat_intelligence" "example" {
   name                       = "example"
-  log_analytics_workspace_id = azurerm_log_analytics_solution.example.workspace_resource_id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
+  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.example]
 }
 ```
 

--- a/website/docs/r/sentinel_data_connector_threat_intelligence.html.markdown
+++ b/website/docs/r/sentinel_data_connector_threat_intelligence.html.markdown
@@ -26,14 +26,12 @@ resource "azurerm_log_analytics_workspace" "example" {
 }
 
 resource "azurerm_sentinel_log_analytics_workspace_onboarding" "example" {
-  resource_group_name = azurerm_resource_group.example.name
-  workspace_name      = azurerm_log_analytics_workspace.example.name
+  workspace_id = azurerm_log_analytics_workspace.example.id
 }
 
 resource "azurerm_sentinel_data_connector_threat_intelligence" "example" {
   name                       = "example"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
-  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.example]
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.example.workspace_id
 }
 ```
 

--- a/website/docs/r/sentinel_data_connector_threat_intelligence_taxii.html.markdown
+++ b/website/docs/r/sentinel_data_connector_threat_intelligence_taxii.html.markdown
@@ -25,26 +25,18 @@ resource "azurerm_log_analytics_workspace" "example" {
   sku                 = "PerGB2018"
 }
 
-resource "azurerm_log_analytics_solution" "example" {
-  solution_name         = "SecurityInsights"
-  location              = azurerm_resource_group.example.location
-  resource_group_name   = azurerm_resource_group.example.name
-  workspace_resource_id = azurerm_log_analytics_workspace.example.id
-  workspace_name        = azurerm_log_analytics_workspace.example.name
-
-  plan {
-    publisher = "Microsoft"
-    product   = "OMSGallery/SecurityInsights"
-  }
+resource "azurerm_sentinel_log_analytics_workspace_onboarding" "example" {
+  resource_group_name = azurerm_resource_group.example.name
+  workspace_name      = azurerm_log_analytics_workspace.example.name
 }
 
 resource "azurerm_sentinel_data_connector_threat_intelligence_taxii" "example" {
   name                       = "example"
-  log_analytics_workspace_id = azurerm_log_analytics_solution.example.workspace_resource_id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
   display_name               = "example"
   api_root_url               = "https://foo/taxii2/api2/"
   collection_id              = "someid"
-  depends_on                 = [azurerm_log_analytics_solution.test]
+  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.example]
 }
 ```
 

--- a/website/docs/r/sentinel_data_connector_threat_intelligence_taxii.html.markdown
+++ b/website/docs/r/sentinel_data_connector_threat_intelligence_taxii.html.markdown
@@ -26,17 +26,15 @@ resource "azurerm_log_analytics_workspace" "example" {
 }
 
 resource "azurerm_sentinel_log_analytics_workspace_onboarding" "example" {
-  resource_group_name = azurerm_resource_group.example.name
-  workspace_name      = azurerm_log_analytics_workspace.example.name
+  workspace_id = azurerm_log_analytics_workspace.example.id
 }
 
 resource "azurerm_sentinel_data_connector_threat_intelligence_taxii" "example" {
   name                       = "example"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.example.workspace_id
   display_name               = "example"
   api_root_url               = "https://foo/taxii2/api2/"
   collection_id              = "someid"
-  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.example]
 }
 ```
 

--- a/website/docs/r/sentinel_watchlist.html.markdown
+++ b/website/docs/r/sentinel_watchlist.html.markdown
@@ -28,15 +28,13 @@ resource "azurerm_log_analytics_workspace" "example" {
   sku                 = "PerGB2018"
 }
 resource "azurerm_sentinel_log_analytics_workspace_onboarding" "example" {
-  resource_group_name = azurerm_resource_group.example.name
-  workspace_name      = azurerm_log_analytics_workspace.example.name
+  workspace_id = azurerm_log_analytics_workspace.example.id
 }
 resource "azurerm_sentinel_watchlist" "example" {
   name                       = "example-watchlist"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.example.workspace_id
   display_name               = "example-wl"
   item_search_key            = "Key"
-  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.example]
 }
 ```
 

--- a/website/docs/r/sentinel_watchlist.html.markdown
+++ b/website/docs/r/sentinel_watchlist.html.markdown
@@ -27,22 +27,16 @@ resource "azurerm_log_analytics_workspace" "example" {
   resource_group_name = azurerm_resource_group.example.name
   sku                 = "PerGB2018"
 }
-resource "azurerm_log_analytics_solution" "example" {
-  solution_name         = "SecurityInsights"
-  location              = azurerm_resource_group.example.location
-  resource_group_name   = azurerm_resource_group.example.name
-  workspace_resource_id = azurerm_log_analytics_workspace.example.id
-  workspace_name        = azurerm_log_analytics_workspace.example.name
-  plan {
-    publisher = "Microsoft"
-    product   = "OMSGallery/SecurityInsights"
-  }
+resource "azurerm_sentinel_log_analytics_workspace_onboarding" "example" {
+  resource_group_name = azurerm_resource_group.example.name
+  workspace_name      = azurerm_log_analytics_workspace.example.name
 }
 resource "azurerm_sentinel_watchlist" "example" {
   name                       = "example-watchlist"
-  log_analytics_workspace_id = azurerm_log_analytics_solution.example.workspace_resource_id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
   display_name               = "example-wl"
   item_search_key            = "Key"
+  depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.example]
 }
 ```
 

--- a/website/docs/r/sentinel_watchlist_item.html.markdown
+++ b/website/docs/r/sentinel_watchlist_item.html.markdown
@@ -29,23 +29,18 @@ resource "azurerm_log_analytics_workspace" "example" {
   sku                 = "PerGB2018"
 }
 
-resource "azurerm_log_analytics_solution" "example" {
-  solution_name         = "SecurityInsights"
-  location              = azurerm_resource_group.example.location
-  resource_group_name   = azurerm_resource_group.example.name
-  workspace_resource_id = azurerm_log_analytics_workspace.example.id
-  workspace_name        = azurerm_log_analytics_workspace.example.name
-  plan {
-    publisher = "Microsoft"
-    product   = "OMSGallery/SecurityInsights"
-  }
+resource "azurerm_sentinel_log_analytics_workspace_onboarding" "example" {
+  resource_group_name = azurerm_resource_group.example.name
+  workspace_name      = azurerm_log_analytics_workspace.example.name
 }
 
 resource "azurerm_sentinel_watchlist" "example" {
   name                       = "example-watchlist"
-  log_analytics_workspace_id = azurerm_log_analytics_solution.example.workspace_resource_id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
   display_name               = "example-wl"
   item_search_key            = "Key"
+
+  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.example]
 }
 
 resource "azurerm_sentinel_watchlist_item" "example" {

--- a/website/docs/r/sentinel_watchlist_item.html.markdown
+++ b/website/docs/r/sentinel_watchlist_item.html.markdown
@@ -30,17 +30,14 @@ resource "azurerm_log_analytics_workspace" "example" {
 }
 
 resource "azurerm_sentinel_log_analytics_workspace_onboarding" "example" {
-  resource_group_name = azurerm_resource_group.example.name
-  workspace_name      = azurerm_log_analytics_workspace.example.name
+  workspace_id = azurerm_log_analytics_workspace.example.id
 }
 
 resource "azurerm_sentinel_watchlist" "example" {
   name                       = "example-watchlist"
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
+  log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.example.workspace_id
   display_name               = "example-wl"
   item_search_key            = "Key"
-
-  depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.example]
 }
 
 resource "azurerm_sentinel_watchlist_item" "example" {


### PR DESCRIPTION
<img width="553" alt="Screenshot 2023-02-27 at 14 42 12" src="https://user-images.githubusercontent.com/51212351/221492736-6ac21239-6102-449a-9439-fb4c8eabdb03.png">
the failed ones are because of `InvalidLicense`

Acctests may fail with is not onboarded 
```
Error: checking for presence of existing Data Connector: (Name "accTestDC-230224022526508153" / Workspace Name "acctestLAW-230224022526508153" / Resource Group "acctestRG-sentinel-230224022526508153"): securityinsight.DataConnectorsClient#Get: Failure responding to request: StatusCode=400 -- Original Error: autorest/azure: Service returned an error. Status=400 Code="BadRequest" Message="{\"error\":{\"code\":\"BadRequest\",\"message\":\"Workspace 'acctestLAW-230224022526508153' is not onboarded to Microsoft Sentinel.\"}}"
```
change from `azurerm_log_analytics_solution` to `azurerm_sentinel_log_analytics_workspace_onboarding`. 

`azurerm_sentinel_alert_rule_fusion` is excluded, the service is installing `Advanced Multistage Attack Detection` by default in `onboarding` API, the only one fusion rule. It's also installed by default by Portal.  May update its test case in another PR