### PR TITLE
azurerm_portal_tenant_configuration - add Destroy function

### DIFF
--- a/internal/services/portal/portal_tenant_configuration_resource_test.go
+++ b/internal/services/portal/portal_tenant_configuration_resource_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -88,6 +89,22 @@ func (r PortalTenantConfigurationResource) Exists(ctx context.Context, client *c
 	}
 
 	return utils.Bool(resp.Model != nil), nil
+}
+
+func (r PortalTenantConfigurationResource) Destroy(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := parse.PortalTenantConfigurationID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.Portal.TenantConfigurationsClient.Delete(ctx)
+	if err != nil {
+		if !response.WasNotFound(resp.HttpResponse) {
+			return nil, fmt.Errorf("deleting %s: %+v", *id, err)
+		}
+	}
+
+	return utils.Bool(true), nil
 }
 
 func (r PortalTenantConfigurationResource) basic(enforcePrivateMarkdownStorage bool) string {


### PR DESCRIPTION
Seems the portal tenant configuration created by Teamcity wouldn't be deleted anymore once test case failed. So related test case is failed and the error message always indicates the resource exists. I assume we have to always destroy the old resource in test case once test case failed.

![image](https://user-images.githubusercontent.com/19754191/221494538-b2d1c91b-8261-4ae0-87ef-2d4b27122957.png)
