### PR TITLE
Fix AccTests for storage RP

### DIFF
--- a/internal/services/storage/storage_account_data_source_test.go
+++ b/internal/services/storage/storage_account_data_source_test.go
@@ -52,7 +52,7 @@ func TestAccDataSourceStorageAccount_withWriteLock(t *testing.T) {
 	})
 }
 
-func TestAccDataSourceStorageAccount_withEncryptionKey(t *testing.T) {
+func TestAccDataSourceStorageAccount_withEncryptionKey_Service(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_storage_account", "test")
 
 	data.DataSourceTest(t, []acceptance.TestStep{
@@ -63,6 +63,13 @@ func TestAccDataSourceStorageAccount_withEncryptionKey(t *testing.T) {
 				check.That(data.ResourceName).Key("queue_encryption_key_type").HasValue("Service"),
 			),
 		},
+	})
+}
+
+func TestAccDataSourceStorageAccount_withEncryptionKey_Account(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_storage_account", "test")
+
+	data.DataSourceTest(t, []acceptance.TestStep{
 		{
 			Config: StorageAccountDataSource{}.encryptionKeyWithDataSource(data, "Account"),
 			Check: acceptance.ComposeTestCheckFunc(

--- a/internal/services/storage/storage_account_data_source_test.go
+++ b/internal/services/storage/storage_account_data_source_test.go
@@ -80,7 +80,7 @@ func TestAccDataSourceStorageAccount_withEncryptionKey_Account(t *testing.T) {
 	})
 }
 
-func TestAccDataSourceStorageAccount_withInfrastructureEncryption(t *testing.T) {
+func TestAccDataSourceStorageAccount_withInfrastructureEncryptionEnabled(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_storage_account", "test")
 
 	data.DataSourceTest(t, []acceptance.TestStep{
@@ -90,6 +90,13 @@ func TestAccDataSourceStorageAccount_withInfrastructureEncryption(t *testing.T) 
 				check.That(data.ResourceName).Key("infrastructure_encryption_enabled").HasValue("true"),
 			),
 		},
+	})
+}
+
+func TestAccDataSourceStorageAccount_withInfrastructureEncryptionDisabled(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_storage_account", "test")
+
+	data.DataSourceTest(t, []acceptance.TestStep{
 		{
 			Config: StorageAccountDataSource{}.infrastructureEncryptionWithDataSource(data, "false"),
 			Check: acceptance.ComposeTestCheckFunc(

--- a/internal/services/storage/storage_account_resource_test.go
+++ b/internal/services/storage/storage_account_resource_test.go
@@ -246,6 +246,14 @@ func TestAccStorageAccount_isHnsEnabled(t *testing.T) {
 			),
 		},
 		data.ImportStep(),
+	})
+}
+
+func TestAccStorageAccount_isHnsDisabled(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_account", "test")
+	r := StorageAccountResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.isHnsEnabledFalse(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -253,6 +261,7 @@ func TestAccStorageAccount_isHnsEnabled(t *testing.T) {
 				check.That(data.ResourceName).Key("is_hns_enabled").HasValue("false"),
 			),
 		},
+		data.ImportStep(),
 	})
 }
 
@@ -1103,7 +1112,7 @@ func TestAccStorageAccount_defaultToOAuthAuthentication(t *testing.T) {
 	})
 }
 
-func TestAccStorageAccount_encryptionKeyType(t *testing.T) {
+func TestAccStorageAccount_encryptionKeyType_Account(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_storage_account", "test")
 	r := StorageAccountResource{}
 
@@ -1115,6 +1124,14 @@ func TestAccStorageAccount_encryptionKeyType(t *testing.T) {
 			),
 		},
 		data.ImportStep(),
+	})
+}
+
+func TestAccStorageAccount_encryptionKeyType_Service(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_account", "test")
+	r := StorageAccountResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.encryptionKeyType(data, "Service"),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -3969,6 +3986,7 @@ resource "azurerm_storage_account" "test" {
     user_assigned_identity_id = azurerm_user_assigned_identity.test.id
   }
 
+  infrastructure_encryption_enabled = true
   table_encryption_key_type = "Account"
   queue_encryption_key_type = "Account"
 

--- a/internal/services/storage/storage_management_policy_data_source.go
+++ b/internal/services/storage/storage_management_policy_data_source.go
@@ -94,29 +94,45 @@ func dataSourceStorageManagementPolicy() *pluginsdk.Resource {
 													Type:     pluginsdk.TypeInt,
 													Computed: true,
 												},
-												"tier_to_archive_after_days_since_modification_greater_than": {
-													Type:     pluginsdk.TypeInt,
-													Computed: true,
-												},
-												"delete_after_days_since_modification_greater_than": {
-													Type:     pluginsdk.TypeInt,
-													Computed: true,
-												},
-												"tier_to_archive_after_days_since_last_access_time_greater_than": {
-													Type:     pluginsdk.TypeInt,
-													Computed: true,
-												},
-												"tier_to_archive_after_days_since_last_tier_change_greater_than": {
-													Type:     pluginsdk.TypeInt,
-													Computed: true,
-												},
-												"delete_after_days_since_last_access_time_greater_than": {
-													Type:     pluginsdk.TypeInt,
-													Computed: true,
-												},
 												"tier_to_cool_after_days_since_last_access_time_greater_than": {
 													Type:     pluginsdk.TypeInt,
 													Computed: true,
+												},
+												"auto_tier_to_hot_from_cool_enabled": {
+													Type:     pluginsdk.TypeBool,
+													Optional: true,
+												},
+												"tier_to_cool_after_days_since_creation_greater_than": {
+													Type:     pluginsdk.TypeInt,
+													Optional: true,
+												},
+												"tier_to_archive_after_days_since_modification_greater_than": {
+													Type:     pluginsdk.TypeInt,
+													Optional: true,
+												},
+												"tier_to_archive_after_days_since_last_access_time_greater_than": {
+													Type:     pluginsdk.TypeInt,
+													Optional: true,
+												},
+												"tier_to_archive_after_days_since_last_tier_change_greater_than": {
+													Type:     pluginsdk.TypeInt,
+													Optional: true,
+												},
+												"tier_to_archive_after_days_since_creation_greater_than": {
+													Type:     pluginsdk.TypeInt,
+													Optional: true,
+												},
+												"delete_after_days_since_modification_greater_than": {
+													Type:     pluginsdk.TypeInt,
+													Optional: true,
+												},
+												"delete_after_days_since_last_access_time_greater_than": {
+													Type:     pluginsdk.TypeInt,
+													Optional: true,
+												},
+												"delete_after_days_since_creation_greater_than": {
+													Type:     pluginsdk.TypeInt,
+													Optional: true,
 												},
 											},
 										},

--- a/website/docs/d/storage_management_policy.html.markdown
+++ b/website/docs/d/storage_management_policy.html.markdown
@@ -65,11 +65,15 @@ The following arguments are supported:
 
 * `tier_to_cool_after_days_since_modification_greater_than` - The age in days after last modification to tier blobs to cool storage. Supports blob currently at Hot tier.
 * `tier_to_cool_after_days_since_last_access_time_greater_than` - The age in days after last access time to tier blobs to cool storage. Supports blob currently at Hot tier.
-* `tier_to_archive_after_days_since_modification_greater_than` - The age in days after last modification to tier blobs to archive storage. Supports blob currently at Hot or Cool tier.
-* `tier_to_archive_after_days_since_last_access_time_greater_than` - The age in days after last access time to tier blobs to archive storage. Supports blob currently at Hot or Cool tier.
-* `tier_to_archive_after_days_since_last_tier_change_greater_than` - The age in days after last tier change to the blobs to skip to be archived.
+* `tier_to_cool_after_days_since_creation_greater_than` - Optional The age in days after creation to cool storage. Supports blob currently at Hot tier.
+* `auto_tier_to_hot_from_cool_enabled` - Whether a blob should automatically be tiered from cool back to hot if it's accessed again after being tiered to cool.
+* `tier_to_archive_after_days_since_modification_greater_than` - The age in days after last modification to tier blobs to archive storage.
+* `tier_to_archive_after_days_since_last_access_time_greater_than` - The age in days after last access time to tier blobs to archive storage.
+* `tier_to_archive_after_days_since_creation_greater_than` - The age in days after creation to archive storage.
+* `tier_to_archive_after_days_since_last_tier_change_greater_than` - The age in days after last tier change to the blobs to skip to be archved.
 * `delete_after_days_since_modification_greater_than` - The age in days after last modification to delete the blob.
 * `delete_after_days_since_last_access_time_greater_than` - The age in days after last access time to delete the blob.
+* `delete_after_days_since_creation_greater_than` - The age in days after creation to delete the blob.
 
 ---
 


### PR DESCRIPTION
This PR fixes several test failures for storage RP, including two types:

- Splitting test cases which will force new a storage account in one step. This causes issuse because of storage will cache the data plane DNS cache for about 1min, a recreated storage account will look for an out-of-date DNS record for a newly created storage account, when accessing its data plane endpoints. This results into errors like:
  
  >  Status=404 Code="ResourceNotFound" Message="The specified resource does not exist"
- Align the schema of resource and data source of `azurerm_storage_management_policy` since the data source reuse the flatten function of resource