### PR TITLE
pollers: accounting for dropped connections

### DIFF
--- a/internal/services/aadb2c/aadb2c_directory_resource.go
+++ b/internal/services/aadb2c/aadb2c_directory_resource.go
@@ -3,9 +3,9 @@ package aadb2c
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/aadb2c/2021-04-01-preview/tenants"
@@ -151,11 +151,11 @@ func (r AadB2cDirectoryResource) Create() sdk.ResourceFunc {
 
 			metadata.Logger.Infof("Import check for %s", id)
 			existing, err := client.Get(ctx, id)
-			if err != nil && existing.HttpResponse.StatusCode != http.StatusNotFound {
+			if err != nil && !response.WasNotFound(existing.HttpResponse) {
 				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
 			}
 
-			if existing.Model != nil && existing.Model.Id != nil && *existing.Model.Id != "" {
+			if !response.WasNotFound(existing.HttpResponse) {
 				return metadata.ResourceRequiresImport(r.ResourceType(), id)
 			}
 
@@ -256,7 +256,7 @@ func (r AadB2cDirectoryResource) Read() sdk.ResourceFunc {
 			metadata.Logger.Infof("Reading %s", id)
 			resp, err := client.Get(ctx, *id)
 			if err != nil {
-				if resp.HttpResponse.StatusCode == http.StatusNotFound {
+				if response.WasNotFound(resp.HttpResponse) {
 					return metadata.MarkAsGone(id)
 				}
 				return fmt.Errorf("retrieving %s: %v", id, err)

--- a/internal/services/containerapps/container_app_resource.go
+++ b/internal/services/containerapps/container_app_resource.go
@@ -337,7 +337,7 @@ func (r ContainerAppResource) Update() sdk.ResourceFunc {
 			// Delta-updates need the secrets back from the list API, or we'll end up removing them or erroring out.
 			secretsResp, err := client.ListSecrets(ctx, *id)
 			if err != nil || secretsResp.Model == nil {
-				if secretsResp.HttpResponse == nil || secretsResp.HttpResponse.StatusCode != http.StatusNoContent {
+				if !response.WasStatusCode(secretsResp.HttpResponse, http.StatusNoContent) {
 					return fmt.Errorf("retrieving secrets for update for %s: %+v", *id, err)
 				}
 			}

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
@@ -3,11 +3,11 @@ package containers_test
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"regexp"
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/agentpools"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/managedclusters"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
@@ -980,7 +980,7 @@ func (KubernetesClusterNodePoolResource) scaleNodePool(nodeCount int) acceptance
 			return fmt.Errorf("Bad: Get on agentPoolsClient: %+v", err)
 		}
 
-		if nodePool.HttpResponse.StatusCode == http.StatusNotFound {
+		if response.WasNotFound(nodePool.HttpResponse) {
 			return fmt.Errorf("Bad: Node Pool %q (Kubernetes Cluster %q / Resource Group: %q) does not exist", nodePoolName, clusterName, resourceGroup)
 		}
 

--- a/internal/services/containers/kubernetes_cluster_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_resource_test.go
@@ -3,8 +3,9 @@ package containers_test
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/lang/response"
 
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/agentpools"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/managedclusters"
@@ -222,7 +223,7 @@ func (KubernetesClusterResource) updateDefaultNodePoolAgentCount(nodeCount int) 
 			return fmt.Errorf("Bad: Get on agentPoolsClient: %+v", err)
 		}
 
-		if nodePool.HttpResponse.StatusCode == http.StatusNotFound {
+		if response.WasNotFound(nodePool.HttpResponse) {
 			return fmt.Errorf("Bad: Node Pool %q (Kubernetes Cluster %q / Resource Group: %q) does not exist", nodePoolName, clusterName, resourceGroup)
 		}
 

--- a/internal/services/eventhub/eventhub_namespace_resource.go
+++ b/internal/services/eventhub/eventhub_namespace_resource.go
@@ -684,18 +684,20 @@ func waitForEventHubNamespaceToBeDeleted(ctx context.Context, client *namespaces
 func eventHubNamespaceStateStatusCodeRefreshFunc(ctx context.Context, client *namespaces.NamespacesClient, id namespaces.NamespaceId) pluginsdk.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		res, err := client.Get(ctx, id)
+		status := "dropped connection"
 		if res.HttpResponse != nil {
-			log.Printf("Retrieving %s returned Status %d", id, res.HttpResponse.StatusCode)
+			status = strconv.Itoa(res.HttpResponse.StatusCode)
 		}
+		log.Printf("Retrieving %s returned Status %q", id, status)
 
 		if err != nil {
 			if response.WasNotFound(res.HttpResponse) {
-				return res, strconv.Itoa(res.HttpResponse.StatusCode), nil
+				return res, status, nil
 			}
 			return nil, "", fmt.Errorf("polling for the status of %s: %+v", id, err)
 		}
 
-		return res, strconv.Itoa(res.HttpResponse.StatusCode), nil
+		return res, status, nil
 	}
 }
 

--- a/internal/services/iothub/iothub_dps_resource.go
+++ b/internal/services/iothub/iothub_dps_resource.go
@@ -412,20 +412,20 @@ func iothubdpsStateStatusCodeRefreshFunc(ctx context.Context, client *iotdpsreso
 	return func() (interface{}, string, error) {
 		res, err := client.Get(ctx, id)
 
-		statusCode := -1
+		statusCode := "dropped connection"
 		if res.HttpResponse != nil {
-			statusCode = res.HttpResponse.StatusCode
+			statusCode = strconv.Itoa(res.HttpResponse.StatusCode)
 		}
-		log.Printf("Retrieving IoT Device Provisioning Service %q returned Status %d", id, statusCode)
+		log.Printf("Retrieving IoT Device Provisioning Service %q returned Status %q", id, statusCode)
 
 		if err != nil {
 			if response.WasNotFound(res.HttpResponse) {
-				return res, strconv.Itoa(statusCode), nil
+				return res, statusCode, nil
 			}
 			return nil, "", fmt.Errorf("polling for the status of the IoT Device Provisioning Service %q: %+v", id, err)
 		}
 
-		return res, strconv.Itoa(statusCode), nil
+		return res, statusCode, nil
 	}
 }
 

--- a/internal/services/netapp/netapp_account_resource.go
+++ b/internal/services/netapp/netapp_account_resource.go
@@ -290,6 +290,10 @@ func netappAccountStateRefreshFunc(ctx context.Context, client *netappaccounts.N
 			}
 		}
 
-		return res, strconv.Itoa(res.HttpResponse.StatusCode), nil
+		statusCode := "dropped connection"
+		if res.HttpResponse != nil {
+			statusCode = strconv.Itoa(res.HttpResponse.StatusCode)
+		}
+		return res, statusCode, nil
 	}
 }

--- a/internal/services/netapp/netapp_pool_resource.go
+++ b/internal/services/netapp/netapp_pool_resource.go
@@ -288,7 +288,11 @@ func netappPoolDeleteStateRefreshFunc(ctx context.Context, client *capacitypools
 			}
 		}
 
-		return res, strconv.Itoa(res.HttpResponse.StatusCode), nil
+		statusCode := "dropped connection"
+		if res.HttpResponse != nil {
+			statusCode = strconv.Itoa(res.HttpResponse.StatusCode)
+		}
+		return res, statusCode, nil
 	}
 }
 
@@ -323,6 +327,10 @@ func netappPoolStateRefreshFunc(ctx context.Context, client *capacitypools.Capac
 			}
 		}
 
-		return res, strconv.Itoa(res.HttpResponse.StatusCode), nil
+		statusCode := "dropped connection"
+		if res.HttpResponse != nil {
+			statusCode = strconv.Itoa(res.HttpResponse.StatusCode)
+		}
+		return res, statusCode, nil
 	}
 }

--- a/internal/services/netapp/netapp_snapshot_policy_resource.go
+++ b/internal/services/netapp/netapp_snapshot_policy_resource.go
@@ -552,6 +552,10 @@ func netappSnapshotPolicyStateRefreshFunc(ctx context.Context, client *snapshotp
 			}
 		}
 
-		return res, strconv.Itoa(res.HttpResponse.StatusCode), nil
+		statusCode := "dropped connection"
+		if res.HttpResponse != nil {
+			statusCode = strconv.Itoa(res.HttpResponse.StatusCode)
+		}
+		return res, statusCode, nil
 	}
 }

--- a/internal/services/netapp/netapp_snapshot_resource.go
+++ b/internal/services/netapp/netapp_snapshot_resource.go
@@ -183,6 +183,10 @@ func netappSnapshotDeleteStateRefreshFunc(ctx context.Context, client *snapshots
 			}
 		}
 
-		return res, strconv.Itoa(res.HttpResponse.StatusCode), nil
+		statusCode := "dropped connection"
+		if res.HttpResponse != nil {
+			statusCode = strconv.Itoa(res.HttpResponse.StatusCode)
+		}
+		return res, statusCode, nil
 	}
 }

--- a/internal/services/netapp/netapp_volume_resource.go
+++ b/internal/services/netapp/netapp_volume_resource.go
@@ -838,7 +838,11 @@ func netappVolumeStateRefreshFunc(ctx context.Context, client *volumes.VolumesCl
 			}
 		}
 
-		return res, strconv.Itoa(res.HttpResponse.StatusCode), nil
+		statusCode := "dropped connection"
+		if res.HttpResponse != nil {
+			statusCode = strconv.Itoa(res.HttpResponse.StatusCode)
+		}
+		return res, statusCode, nil
 	}
 }
 
@@ -875,17 +879,18 @@ func netappVolumeReplicationStateRefreshFunc(ctx context.Context, client *volume
 	return func() (interface{}, string, error) {
 		res, err := client.VolumesReplicationStatus(ctx, id)
 		if err != nil {
-			if httpResponse := res.HttpResponse; httpResponse != nil {
-				if httpResponse.StatusCode == 400 && (strings.Contains(strings.ToLower(err.Error()), "deleting") || strings.Contains(strings.ToLower(err.Error()), "volume replication missing or deleted")) {
-					// This error can be ignored until a bug is fixed on RP side that it is returning 400 while the replication is in "Deleting" process
-					// TODO: remove this workaround when above bug is fixed
-				} else if !response.WasNotFound(httpResponse) {
-					return nil, "", fmt.Errorf("retrieving replication status from %s: %s", id, err)
-				}
+			if response.WasBadRequest(res.HttpResponse) && (strings.Contains(strings.ToLower(err.Error()), "deleting") || strings.Contains(strings.ToLower(err.Error()), "volume replication missing or deleted")) {
+				// This error can be ignored until a bug is fixed on RP side that it is returning 400 while the replication is in "Deleting" process
+				// TODO: remove this workaround when above bug is fixed
+			} else if !response.WasNotFound(res.HttpResponse) {
+				return nil, "", fmt.Errorf("retrieving replication status from %s: %s", id, err)
 			}
 		}
-
-		return res, strconv.Itoa(res.HttpResponse.StatusCode), nil
+		statusCode := "dropped connection"
+		if res.HttpResponse != nil {
+			statusCode = strconv.Itoa(res.HttpResponse.StatusCode)
+		}
+		return res, statusCode, nil
 	}
 }
 

--- a/internal/services/notificationhub/notification_hub_namespace_resource.go
+++ b/internal/services/notificationhub/notification_hub_namespace_resource.go
@@ -224,14 +224,19 @@ func resourceNotificationHubNamespaceDelete(d *pluginsdk.ResourceData, meta inte
 func notificationHubNamespaceStateRefreshFunc(ctx context.Context, client *namespaces.NamespacesClient, id namespaces.NamespaceId) pluginsdk.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		resp, err := client.Get(ctx, id)
+		statusCode := "dropped connection"
+		if resp.HttpResponse != nil {
+			statusCode = strconv.Itoa(resp.HttpResponse.StatusCode)
+		}
+
 		if err != nil {
 			if response.WasNotFound(resp.HttpResponse) {
-				return nil, "404", nil
+				return nil, statusCode, nil
 			}
 
 			return nil, "", fmt.Errorf("retrieving %s: %+v", id, err)
 		}
 
-		return resp, strconv.Itoa(resp.HttpResponse.StatusCode), nil
+		return resp, statusCode, nil
 	}
 }

--- a/internal/services/notificationhub/notification_hub_resource.go
+++ b/internal/services/notificationhub/notification_hub_resource.go
@@ -209,15 +209,20 @@ func resourceNotificationHubCreateUpdate(d *pluginsdk.ResourceData, meta interfa
 func notificationHubStateRefreshFunc(ctx context.Context, client *notificationhubs.NotificationHubsClient, id notificationhubs.NotificationHubId) pluginsdk.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		res, err := client.Get(ctx, id)
+		statusCode := "dropped connection"
+		if res.HttpResponse != nil {
+			statusCode = strconv.Itoa(res.HttpResponse.StatusCode)
+		}
+
 		if err != nil {
 			if response.WasNotFound(res.HttpResponse) {
-				return nil, "404", nil
+				return nil, statusCode, nil
 			}
 
 			return nil, "", fmt.Errorf("retrieving %s: %+v", id, err)
 		}
 
-		return res, strconv.Itoa(res.HttpResponse.StatusCode), nil
+		return res, statusCode, nil
 	}
 }
 

--- a/internal/services/sentinel/sentinel_log_analytics_workspace_onboard_resource.go
+++ b/internal/services/sentinel/sentinel_log_analytics_workspace_onboard_resource.go
@@ -103,16 +103,19 @@ func (r LogAnalyticsWorkspaceOnboardResource) Create() sdk.ResourceFunc {
 				Target:  []string{"200"},
 				Refresh: func() (interface{}, string, error) {
 					resp, err := client.Get(ctx, id)
+					statusCode := "dropped connection"
+					if resp.HttpResponse != nil {
+						statusCode = strconv.Itoa(resp.HttpResponse.StatusCode)
+					}
+
 					if err != nil {
 						if response.WasNotFound(resp.HttpResponse) {
-							return resp, "404", nil
+							return resp, statusCode, nil
 						}
 						return resp, "", err
 					}
-					if resp.HttpResponse != nil {
-						return resp, strconv.Itoa(resp.HttpResponse.StatusCode), nil
-					}
-					return resp, "", fmt.Errorf("http response is nil")
+
+					return resp, statusCode, nil
 				},
 				Timeout: time.Until(deadline),
 				Delay:   15 * time.Second,

--- a/internal/services/servicefabricmanaged/service_fabric_managed_cluster_resource_test.go
+++ b/internal/services/servicefabricmanaged/service_fabric_managed_cluster_resource_test.go
@@ -126,20 +126,19 @@ func TestAccServiceFabricManagedCluster_authentication(t *testing.T) {
 }
 
 func (r ClusterResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
-	resourceID, err := managedcluster.ParseManagedClusterID(state.ID)
+	id, err := managedcluster.ParseManagedClusterID(state.ID)
 	if err != nil {
 		return nil, fmt.Errorf("while parsing resource ID: %+v", err)
 	}
 
-	client := clients.ServiceFabricManaged.ManagedClusterClient
-	resp, err := client.Get(ctx, *resourceID)
+	resp, err := clients.ServiceFabricManaged.ManagedClusterClient.Get(ctx, *id)
 	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
 			return utils.Bool(false), nil
 		}
-		return nil, fmt.Errorf("while checking for cluster's %q existence: %+v", resourceID.String(), err)
+		return nil, fmt.Errorf("while checking for cluster's %q existence: %+v", id.String(), err)
 	}
-	return utils.Bool(resp.HttpResponse.StatusCode == 200), nil
+	return utils.Bool(resp.Model != nil), nil
 }
 
 func (r ClusterResource) basic(data acceptance.TestData, nodeTypeData string) string {


### PR DESCRIPTION
It's possible that the connection can be dropped whilst polling, if this is the case then a nil *http.HttpResponse will be returned (since there's no response) - as such we need to use the `response.WasNotFound` (and similar) methods when checking the HTTP Status Code which take dropped connections into account