### PR TITLE
internal/common: logging Requests/Responses when using `hashicorp/go-azure-sdk` as a base layer

### DIFF
--- a/internal/common/client_options.go
+++ b/internal/common/client_options.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/hashicorp/go-azure-helpers/sender"
 	"github.com/hashicorp/go-azure-sdk/sdk/auth"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
 	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
 	"github.com/hashicorp/go-azure-sdk/sdk/environments"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/meta"
@@ -62,7 +63,21 @@ type ClientOptions struct {
 func (o ClientOptions) Configure(c *resourcemanager.Client, authorizer auth.Authorizer) {
 	c.Authorizer = authorizer
 	c.UserAgent = userAgent(c.UserAgent, o.TerraformVersion, o.PartnerId, o.DisableTerraformPartnerID)
-	// TODO: configure logging
+
+	requestMiddlewares := make([]client.RequestMiddleware, 0)
+	if !o.DisableCorrelationRequestID {
+		id := o.CustomCorrelationRequestID
+		if id == "" {
+			id = correlationRequestID()
+		}
+		requestMiddlewares = append(requestMiddlewares, correlationRequestIDMiddleware(id))
+	}
+	requestMiddlewares = append(requestMiddlewares, requestLoggerMiddleware("AzureRM"))
+	c.RequestMiddlewares = &requestMiddlewares
+
+	c.ResponseMiddlewares = &[]client.ResponseMiddleware{
+		responseLoggerMiddleware("AzureRM"),
+	}
 }
 
 // ConfigureClient sets up an autorest.Client using an autorest.Authorizer

--- a/internal/common/middleware.go
+++ b/internal/common/middleware.go
@@ -1,0 +1,56 @@
+package common
+
+import (
+	"log"
+	"net/http"
+	"net/http/httputil"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+)
+
+func correlationRequestIDMiddleware(id string) client.RequestMiddleware {
+	return func(request *http.Request) (*http.Request, error) {
+		// ensure the `X-Correlation-ID` field is set
+		request.Header.Add(HeaderCorrelationRequestID, id)
+		return request, nil
+	}
+}
+
+func requestLoggerMiddleware(providerName string) client.RequestMiddleware {
+	return func(request *http.Request) (*http.Request, error) {
+		// strip the authorization header prior to printing
+		authHeaderName := "Authorization"
+		auth := request.Header.Get(authHeaderName)
+		if auth != "" {
+			request.Header.Del(authHeaderName)
+		}
+
+		// dump request to wire format
+		if dump, err := httputil.DumpRequestOut(request, true); err == nil {
+			log.Printf("[DEBUG] %s Request: \n%s\n", providerName, dump)
+		} else {
+			// fallback to basic message
+			log.Printf("[DEBUG] %s Request: %s to %s\n", providerName, request.Method, request.URL)
+		}
+
+		// add the auth header back
+		if auth != "" {
+			request.Header.Add(authHeaderName, auth)
+		}
+
+		return request, nil
+	}
+}
+
+func responseLoggerMiddleware(providerName string) client.ResponseMiddleware {
+	return func(request *http.Request, response *http.Response) (*http.Response, error) {
+		// dump response to wire format
+		if dump, err2 := httputil.DumpResponse(response, true); err2 == nil {
+			log.Printf("[DEBUG] %s Response for %s: \n%s\n", providerName, request.URL, dump)
+		} else {
+			// fallback to basic message
+			log.Printf("[DEBUG] %s Response: %s for %s\n", providerName, response.Status, request.URL)
+		}
+		return response, nil
+	}
+}


### PR DESCRIPTION
This is mostly ported directly from the `go-autorest` implementation, and whilst this does want cleaning up in time this is fine to port for now.