### PR TITLE
`azurerm_kusto_cluster_customer_managed_key` - fix accTests

### DIFF
--- a/internal/services/kusto/kusto_cluster_customer_managed_key_test.go
+++ b/internal/services/kusto/kusto_cluster_customer_managed_key_test.go
@@ -357,6 +357,8 @@ resource "azurerm_key_vault_access_policy" "client" {
     "List",
     "Purge",
     "Recover",
+    "GetRotationPolicy",
+    "SetRotationPolicy",
   ]
 }
 


### PR DESCRIPTION
Add Permission to KeyVault to support auto rotation.

Fixes
- TestAccKustoClusterCustomerManagedKey_requiresImport
- TestAccKustoClusterCustomerManagedKey_basic
- TestAccKustoClusterCustomerManagedKey_updateKey
- TestAccKustoClusterCustomerManagedKey_complete