### PR TITLE
`azurerm_batch_account` - add permission to CMK

### DIFF
--- a/internal/services/batch/batch_account_data_source_test.go
+++ b/internal/services/batch/batch_account_data_source_test.go
@@ -284,7 +284,9 @@ resource "azurerm_key_vault" "test" {
       "Create",
       "Delete",
       "WrapKey",
-      "UnwrapKey"
+      "UnwrapKey",
+      "GetRotationPolicy",
+      "SetRotationPolicy",
     ]
   }
 

--- a/internal/services/batch/batch_account_resource_test.go
+++ b/internal/services/batch/batch_account_resource_test.go
@@ -614,7 +614,9 @@ resource "azurerm_key_vault" "test" {
       "Create",
       "Delete",
       "WrapKey",
-      "UnwrapKey"
+      "UnwrapKey",
+      "GetRotationPolicy",
+      "SetRotationPolicy",
     ]
   }
 


### PR DESCRIPTION
- Add permission to `customer_managed_key`
- Fixes TestAccBatchAccountDataSource_cmk
- Fixes TestAccBatchAccount_cmk

Testing evidence:

GOROOT=C:\Users\yunliu1\go\go1.19.3 #gosetup
GOPATH=C:\Users\yunliu1\go #gosetup
C:\Users\yunliu1\go\go1.19.3\bin\go.exe test -c -o C:\Users\yunliu1\AppData\Local\Temp\GoLand\___TestAccBatchAccount_cmk_in_github_com_hashicorp_terraform_provider_azurerm_internal_services_batch.test.exe github.com/hashicorp/terraform-provider-azurerm/internal/services/batch #gosetup
C:\Users\yunliu1\go\go1.19.3\bin\go.exe tool test2json -t C:\Users\yunliu1\AppData\Local\Temp\GoLand\___TestAccBatchAccount_cmk_in_github_com_hashicorp_terraform_provider_azurerm_internal_services_batch.test.exe -test.v -test.paniconexit0 -test.run ^\QTestAccBatchAccount_cmk\E$ #gosetup
=== RUN   TestAccBatchAccount_cmk
=== PAUSE TestAccBatchAccount_cmk
=== CONT  TestAccBatchAccount_cmk
--- PASS: TestAccBatchAccount_cmk (397.16s)
PASS


Process finished with the exit code 0

GOROOT=C:\Users\yunliu1\go\go1.19.3 #gosetup
GOPATH=C:\Users\yunliu1\go #gosetup
C:\Users\yunliu1\go\go1.19.3\bin\go.exe test -c -o C:\Users\yunliu1\AppData\Local\Temp\GoLand\___TestAccBatchAccountDataSource_cmk_in_github_com_hashicorp_terraform_provider_azurerm_internal_services_batch.test.exe github.com/hashicorp/terraform-provider-azurerm/internal/services/batch #gosetup
C:\Users\yunliu1\go\go1.19.3\bin\go.exe tool test2json -t C:\Users\yunliu1\AppData\Local\Temp\GoLand\___TestAccBatchAccountDataSource_cmk_in_github_com_hashicorp_terraform_provider_azurerm_internal_services_batch.test.exe -test.v -test.paniconexit0 -test.run ^\QTestAccBatchAccountDataSource_cmk\E$ #gosetup
=== RUN   TestAccBatchAccountDataSource_cmk
=== PAUSE TestAccBatchAccountDataSource_cmk
=== CONT  TestAccBatchAccountDataSource_cmk
--- PASS: TestAccBatchAccountDataSource_cmk (395.40s)
PASS


Process finished with the exit code 0