### PR TITLE
`azurerm_kusto_cluster` - fixes `TestAccKustoCluster_languageExtensions`

### DIFF
--- a/internal/services/kusto/kusto_cluster_resource.go
+++ b/internal/services/kusto/kusto_cluster_resource.go
@@ -271,6 +271,9 @@ func languageExtensionDiffSuppress(_, _, _ string, d *schema.ResourceData) bool 
 		if oldValue != nil && newValue != nil {
 			oldList := oldValue.([]interface{})
 			newList := newValue.([]interface{})
+			if len(oldList) != len(newList) {
+				return false
+			}
 			diff := make(map[string]int, len(oldList))
 			for _, _o := range oldList {
 				oldItem := _o.(string)

--- a/internal/services/kusto/kusto_cluster_resource_test.go
+++ b/internal/services/kusto/kusto_cluster_resource_test.go
@@ -252,8 +252,8 @@ func TestAccKustoCluster_languageExtensions(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("language_extensions.#").HasValue("2"),
-				check.That(data.ResourceName).Key("language_extensions.0").HasValue("PYTHON"),
-				check.That(data.ResourceName).Key("language_extensions.1").HasValue("R"),
+				check.That(data.ResourceName).Key("language_extensions.0").Exists(),
+				check.That(data.ResourceName).Key("language_extensions.1").Exists(),
 			),
 		},
 		data.ImportStep(),


### PR DESCRIPTION
This PR resolves an issue with the `TestAccKustoCluster_languageExtensions` test, which was failing due to an update to the `language_extensions` property. This property is now treated as an unordered array, and this PR updates the test to accommodate this change.