### PR TITLE
`express_route_circuit_peering_resource` - Support `advertised_communities`

### DIFF
--- a/internal/services/network/express_route_circuit_peering_resource_test.go
+++ b/internal/services/network/express_route_circuit_peering_resource_test.go
@@ -286,6 +286,7 @@ resource "azurerm_express_route_circuit_peering" "test" {
 
   microsoft_peering_config {
     advertised_public_prefixes = ["123.1.0.0/24"]
+    advertised_communities     = ["regionalCommunity"]
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
@@ -340,6 +341,7 @@ resource "azurerm_express_route_circuit_peering" "test" {
 
     microsoft_peering {
       advertised_public_prefixes = ["2002:db01::/126"]
+      advertised_communities     = ["regionalCommunity"]
     }
   }
 }

--- a/website/docs/r/express_route_circuit_peering.html.markdown
+++ b/website/docs/r/express_route_circuit_peering.html.markdown
@@ -150,6 +150,8 @@ A `microsoft_peering_config` block contains:
 
 * `routing_registry_name` - (Optional) The Routing Registry against which the AS number and prefixes are registered. For example: `ARIN`, `RIPE`, `AFRINIC` etc. Defaults to `NONE`.
 
+* `advertised_communities` - (Optional) The communities of Bgp Peering specified for microsoft peering.
+
 ---
 
 A `ipv6` block contains:
@@ -175,6 +177,8 @@ A `microsoft_peering` block contains:
 * `customer_asn` - (Optional) The CustomerASN of the peering. Defaults to `0`.
 
 * `routing_registry_name` - (Optional) The Routing Registry against which the AS number and prefixes are registered. For example: `ARIN`, `RIPE`, `AFRINIC` etc. Defaults to `NONE`.
+
+* `advertised_communities` - (Optional) The communities of Bgp Peering specified for microsoft peering.
 
 ## Attributes Reference
 


### PR DESCRIPTION
1. Support `advertised_communities`
2. Fix potential bug: Update may remove the connections created on this peering.

```log
=== RUN   TestAccExpressRouteCircuit
=== RUN   TestAccExpressRouteCircuit/MicrosoftPeering
=== RUN   TestAccExpressRouteCircuit/MicrosoftPeering/microsoftPeering
=== RUN   TestAccExpressRouteCircuit/MicrosoftPeering/microsoftPeeringIpv6
--- PASS: TestAccExpressRouteCircuit (1310.67s)
    --- PASS: TestAccExpressRouteCircuit/MicrosoftPeering (1310.67s)
        --- PASS: TestAccExpressRouteCircuit/MicrosoftPeering/microsoftPeering (592.86s)
        --- PASS: TestAccExpressRouteCircuit/MicrosoftPeering/microsoftPeeringIpv6 (717.82s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/network       5651.990s
```