### PR TITLE
`azurerm_communication_service` - add `forceNew` for `data_location`

### DIFF
--- a/internal/services/communication/communication_service_resource.go
+++ b/internal/services/communication/communication_service_resource.go
@@ -58,6 +58,7 @@ func resourceArmCommunicationService() *pluginsdk.Resource {
 				Type: pluginsdk.TypeString,
 				// TODO: should this become Required and remove the default in 4.0?
 				Optional: true,
+				ForceNew: true,
 				Default:  "United States",
 				ValidateFunc: validation.StringInSlice([]string{
 					"Africa",

--- a/internal/services/communication/communication_service_resource_test.go
+++ b/internal/services/communication/communication_service_resource_test.go
@@ -78,84 +78,7 @@ func TestAccCommunicationService_update(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
-			Config: r.update(data, "Australia"),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.update(data, "Africa"),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.update(data, "Brazil"),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.update(data, "Canada"),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.update(data, "France"),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.update(data, "Germany"),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.update(data, "India"),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.update(data, "Japan"),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.update(data, "Korea"),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.update(data, "Norway"),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.update(data, "Switzerland"),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.update(data, "UAE"),
+			Config: r.update(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -223,20 +146,20 @@ resource "azurerm_communication_service" "test" {
 `, r.template(data), data.RandomInteger)
 }
 
-func (r CommunicationServiceResource) update(data acceptance.TestData, dataLocation string) string {
+func (r CommunicationServiceResource) update(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
 resource "azurerm_communication_service" "test" {
   name                = "acctest-CommunicationService-%d"
   resource_group_name = azurerm_resource_group.test.name
-  data_location       = "%s"
+  data_location       = "United States"
 
   tags = {
     env = "Test2"
   }
 }
-`, r.template(data), data.RandomInteger, dataLocation)
+`, r.template(data), data.RandomInteger)
 }
 
 func (r CommunicationServiceResource) template(data acceptance.TestData) string {

--- a/website/docs/r/communication_service.html.markdown
+++ b/website/docs/r/communication_service.html.markdown
@@ -35,7 +35,7 @@ The following arguments are supported:
 
 ---
 
-* `data_location` - (Optional) The location where the Communication service stores its data at rest. Possible values are `Africa`, `Asia Pacific`, `Australia`, `Brazil`, `Canada`, `Europe`, `France`, `Germany`, `India`, `Japan`, `Korea`, `Norway`, `Switzerland`, `UAE`, `UK` and `United States`. Defaults to `United States`.
+* `data_location` - (Optional) The location where the Communication service stores its data at rest. Possible values are `Africa`, `Asia Pacific`, `Australia`, `Brazil`, `Canada`, `Europe`, `France`, `Germany`, `India`, `Japan`, `Korea`, `Norway`, `Switzerland`, `UAE`, `UK` and `United States`. Defaults to `United States`. Changing this forces a new Communication Service to be created.
 
 * `tags` - (Optional) A mapping of tags which should be assigned to the Communication Service.
 


### PR DESCRIPTION
Recently I found the test case about communication is failed. After investigated, I found it would fail while changing data_location. Then I checked with service team. They confirmed that API doesn't support to in-place to update data_location. So we have to add forceNew for data_location.

--- PASS: TestAccCommunicationService_update (644.41s)
--- PASS: TestAccCommunicationService_basic (442.16s)
--- PASS: TestAccCommunicationService_complete (436.83s)
--- PASS: TestAccCommunicationService_requiresImport (488.58s)