### PR TITLE
`azurerm_storage_account` - Tolerate timeout when accessing blob data plane endpoint (for retrieving static web site props)

### DIFF
--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -2225,7 +2225,13 @@ func resourceStorageAccountRead(d *pluginsdk.ResourceData, meta interface{}) err
 
 		staticWebsiteProps, err := accountsClient.GetServiceProperties(ctx, id.Name)
 		if err != nil {
-			return fmt.Errorf("reading static website for AzureRM Storage Account %q: %+v", id.Name, err)
+			// TODO 4.0 - Remove following if check.
+			// In most cases, the error that has no response returned indicates context deadline exceeded, which in most cases happens during DNS resolving.
+			// This happens when using private endpoint and private dns zone, where users didn't add the A record for the blob endpoint.
+			// We tolerate this error for now.
+			if staticWebsiteProps.Response.Response != nil {
+				return fmt.Errorf("reading static website for AzureRM Storage Account %q: %+v", id.Name, err)
+			}
 		}
 		staticWebsite := flattenStaticWebsiteProperties(staticWebsiteProps)
 		if err := d.Set("static_website", staticWebsite); err != nil {


### PR DESCRIPTION
This PR reverts part of the change in #19062, to tolerate timeout when accessing blob data plane endpoint (for retrieving static web site props). This fixes #20257.