### PR TITLE
`azurerm_application_gateway` - Fix nil panic by adding a conversion check

### DIFF
--- a/internal/services/network/application_gateway_resource.go
+++ b/internal/services/network/application_gateway_resource.go
@@ -4306,7 +4306,10 @@ func expandApplicationGatewayURLPathMaps(d *pluginsdk.ResourceData, gatewayID st
 
 			rulePaths := make([]string, 0)
 			for _, rulePath := range ruleConfigMap["paths"].([]interface{}) {
-				rulePaths = append(rulePaths, rulePath.(string))
+				p, ok := rulePath.(string)
+				if ok {
+					rulePaths = append(rulePaths, p)
+				}
 			}
 
 			rule := network.ApplicationGatewayPathRule{


### PR DESCRIPTION
This pull request should fix #20712 by adding a conversion check in expand method.