### PR TITLE
revert 20574 due to regression and failing tests

### DIFF
--- a/internal/services/containerapps/container_app_resource_test.go
+++ b/internal/services/containerapps/container_app_resource_test.go
@@ -143,21 +143,6 @@ func TestAccContainerAppResource_complete(t *testing.T) {
 	})
 }
 
-func TestAccContainerAppResource_completeWithNoIngressTrafficWeights(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_container_app", "test")
-	r := ContainerAppResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.completeWithNoIngressTrafficWeights(data, "rev1"),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-	})
-}
-
 func TestAccContainerAppResource_completeWithVNet(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_container_app", "test")
 	r := ContainerAppResource{}
@@ -460,99 +445,6 @@ resource "azurerm_container_app" "test" {
       latest_revision = true
       percentage      = 100
     }
-  }
-
-  registry {
-    server               = azurerm_container_registry.test.login_server
-    username             = azurerm_container_registry.test.admin_username
-    password_secret_name = "registry-password"
-  }
-
-  secret {
-    name  = "registry-password"
-    value = azurerm_container_registry.test.admin_password
-  }
-
-  dapr {
-    app_id       = "acctest-cont-%[2]d"
-    app_port     = 5000
-    app_protocol = "http"
-  }
-
-  tags = {
-    foo     = "Bar"
-    accTest = "1"
-  }
-}
-`, r.templatePlusExtras(data), data.RandomInteger, revisionSuffix)
-}
-
-func (r ContainerAppResource) completeWithNoIngressTrafficWeights(data acceptance.TestData, revisionSuffix string) string {
-	return fmt.Sprintf(`
-%s
-
-resource "azurerm_container_app" "test" {
-  name                         = "acctest-capp-%[2]d"
-  resource_group_name          = azurerm_resource_group.test.name
-  container_app_environment_id = azurerm_container_app_environment.test.id
-  revision_mode                = "Single"
-
-  template {
-    container {
-      name   = "acctest-cont-%[2]d"
-      image  = "jackofallops/azure-containerapps-python-acctest:v0.0.1"
-      cpu    = 0.25
-      memory = "0.5Gi"
-
-      readiness_probe {
-        transport = "HTTP"
-        port      = 5000
-      }
-
-      liveness_probe {
-        transport = "HTTP"
-        port      = 5000
-        path      = "/health"
-
-        header {
-          name  = "Cache-Control"
-          value = "no-cache"
-        }
-
-        initial_delay           = 5
-        interval_seconds        = 20
-        timeout                 = 2
-        failure_count_threshold = 1
-      }
-
-      startup_probe {
-        transport = "TCP"
-        port      = 5000
-      }
-
-      volume_mounts {
-        name = azurerm_container_app_environment_storage.test.name
-        path = "/tmp/testdata"
-      }
-    }
-
-    volume {
-      name         = azurerm_container_app_environment_storage.test.name
-      storage_type = "AzureFile"
-      storage_name = azurerm_container_app_environment_storage.test.name
-    }
-
-    min_replicas = 2
-    max_replicas = 3
-
-    revision_suffix = "%[3]s"
-  }
-
-  ingress {
-    allow_insecure_connections = true
-    external_enabled           = true
-    target_port                = 5000
-    transport                  = "http"
   }
 
   registry {

--- a/internal/services/containerapps/helpers/container_apps.go
+++ b/internal/services/containerapps/helpers/container_apps.go
@@ -302,7 +302,7 @@ type TrafficWeight struct {
 func ContainerAppIngressTrafficWeight() *pluginsdk.Schema {
 	return &pluginsdk.Schema{
 		Type:     pluginsdk.TypeList,
-		Optional: true,
+		Required: true,
 		Elem: &pluginsdk.Resource{
 			Schema: map[string]*pluginsdk.Schema{
 				"label": {

--- a/website/docs/r/container_app.html.markdown
+++ b/website/docs/r/container_app.html.markdown
@@ -279,7 +279,7 @@ An `ingress` block supports the following:
 
 * `target_port` - (Required) The target port on the container for the Ingress traffic.
 
-* `traffic_weight` - (Optional) A `traffic_weight` block as detailed below.
+* `traffic_weight` - (Required) A `traffic_weight` block as detailed below.
 
 ~> **Note:** `traffic_weight` can only be specified when `revision_mode` is set to `Multiple`.
 


### PR DESCRIPTION
```
=== RUN   TestAccContainerAppResource_completeWithNoIngressTrafficWeights
=== PAUSE TestAccContainerAppResource_completeWithNoIngressTrafficWeights
=== CONT  TestAccContainerAppResource_completeWithNoIngressTrafficWeights
testcase.go:110: Step 1/2 error: After applying this test step, the plan was not empty.
stdout:
Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
~ update in-place
Terraform will perform the following actions:
# azurerm_container_app.test will be updated in-place
~ resource "azurerm_container_app" "test" {
id                            = "/subscriptions/*******/resourceGroups/acctestRG-CAEnv-230302041209476946/providers/Microsoft.App/containerApps/acctest-capp-230302041209476946"
name                          = "acctest-capp-230302041209476946"
tags                          = {
"accTest" = "1"
"foo"     = "Bar"
}
# (8 unchanged attributes hidden)
~ ingress {
# (5 unchanged attributes hidden)
- traffic_weight {
- latest_revision = true -> null
- percentage      = 100 -> null
}
}
secret {
# At least one attribute in this block is (or was) sensitive,
# so its contents will not be displayed.
}
~ template {
# (3 unchanged attributes hidden)
~ container {
+ args              = []
+ command           = []
name              = "acctest-cont-230302041209476946"
# (4 unchanged attributes hidden)
# (4 unchanged blocks hidden)
}
# (1 unchanged block hidden)
}
# (2 unchanged blocks hidden)
}
Plan: 0 to add, 1 to change, 0 to destroy.
--- FAIL: TestAccContainerAppResource_completeWithNoIngressTrafficWeights (1068.26s)
FAIL
```