### PR TITLE
github action: updating the golint gha to run only on the internal folder

### DIFF
--- a/.github/workflows/golint.yaml
+++ b/.github/workflows/golint.yaml
@@ -27,4 +27,4 @@ jobs:
       - uses: golangci/golangci-lint-action@v3
         with:
           version: 'v1.51.1'
-          args: -v
+          args: -v ./internal/...


### PR DESCRIPTION
This is intentionally skipping the `helpers` and `utils` folders, since both will be removed and should contain no new logic at this point - this also avoids running this against the vendor folder