### PR TITLE
`azurerm_dns_txt_record` - deprecate `value` and support `values`

### DIFF
--- a/internal/services/dns/dns_txt_record_resource.go
+++ b/internal/services/dns/dns_txt_record_resource.go
@@ -229,10 +229,7 @@ func flattenAzureRmDnsTxtRecords(records *[]recordsets.TxtRecord) []map[string]i
 				}
 
 				var values []string
-				for _, v := range *recordValue {
-					values = append(values, v)
-				}
-				record["values"] = values
+				record["values"] = append(values, *recordValue...)
 			}
 
 			results = append(results, record)

--- a/internal/services/dns/dns_txt_record_resource.go
+++ b/internal/services/dns/dns_txt_record_resource.go
@@ -224,8 +224,7 @@ func flattenAzureRmDnsTxtRecords(records *[]recordsets.TxtRecord) []map[string]i
 
 			if recordValue := recordItem.Value; recordValue != nil {
 				if !features.FourPointOhBeta() {
-					value := strings.Join(*recordValue, "")
-					record["value"] = value
+					record["value"] = strings.Join(*recordValue, "")
 				}
 
 				var values []string

--- a/internal/services/dns/dns_txt_record_resource.go
+++ b/internal/services/dns/dns_txt_record_resource.go
@@ -246,7 +246,6 @@ func expandAzureRmDnsTxtRecords(d *pluginsdk.ResourceData) (*[]recordsets.TxtRec
 	recordStrings := d.Get("record").([]interface{})
 	records := make([]recordsets.TxtRecord, len(recordStrings))
 
-	var recordValuesLength int
 	for i, v := range recordStrings {
 		record := v.(map[string]interface{})
 
@@ -278,19 +277,13 @@ func expandAzureRmDnsTxtRecords(d *pluginsdk.ResourceData) (*[]recordsets.TxtRec
 			recordValues := record["values"].([]interface{})
 
 			for _, recordVal := range recordValues {
-				recordValString := recordVal.(string)
-				recordValuesLength += len(recordValString)
-				values = append(values, recordValString)
+				values = append(values, recordVal.(string))
 			}
 		}
 
 		records[i] = recordsets.TxtRecord{
 			Value: &values,
 		}
-	}
-
-	if recordValuesLength > 1024 {
-		return nil, fmt.Errorf("max length of all record values cannot exceed 1024 characters")
 	}
 
 	return &records, nil

--- a/internal/services/dns/dns_txt_record_resource.go
+++ b/internal/services/dns/dns_txt_record_resource.go
@@ -256,14 +256,14 @@ func expandAzureRmDnsTxtRecords(d *pluginsdk.ResourceData) (*[]recordsets.TxtRec
 		var values []string
 
 		if !features.FourPointOhBeta() {
-			recordValue := record["value"].(string)
-
 			if isRecordValueSet && isRecordValuesSet {
 				return nil, fmt.Errorf("`record.value` and `record.values` cannot be set together")
 			}
 
 			if isRecordValueSet {
+				recordValue := record["value"].(string)
 				segmentLen := 255
+
 				for len(recordValue) > segmentLen {
 					values = append(values, recordValue[:segmentLen])
 					recordValue = recordValue[segmentLen:]

--- a/internal/services/dns/dns_txt_record_resource_test.go
+++ b/internal/services/dns/dns_txt_record_resource_test.go
@@ -168,7 +168,7 @@ resource "azurerm_dns_txt_record" "test" {
   }
 
   record {
-    values = ["A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text"]
+    values = ["A long text....A long text....A long text....A long text....A long text....A long text....A long text....A long text...."]
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
@@ -209,7 +209,7 @@ resource "azurerm_dns_txt_record" "import" {
   }
 
   record {
-    values = ["A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text"]
+    values = ["A long text....A long text....A long text....A long text....A long text....A long text....A long text....A long text...."]
   }
 }
 `, r.basic(data))
@@ -278,7 +278,7 @@ resource "azurerm_dns_txt_record" "test" {
   }
 
   record {
-    values = ["A long text......A long text", "A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text", "A long text......A long text"]
+    values = ["A long text......A long text", "A long text....A long text....A long text....A long text....A long text....A long text....A long text....A long text....", "A long text......A long text"]
   }
 
   record {

--- a/internal/services/dns/dns_txt_record_resource_test.go
+++ b/internal/services/dns/dns_txt_record_resource_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
@@ -109,7 +110,8 @@ func (DnsTxtRecordResource) Exists(ctx context.Context, clients *clients.Client,
 }
 
 func (DnsTxtRecordResource) basic(data acceptance.TestData) string {
-	return fmt.Sprintf(`
+	if !features.FourPointOhBeta() {
+		return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
@@ -135,14 +137,46 @@ resource "azurerm_dns_txt_record" "test" {
   }
 
   record {
-    value = "A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......"
+    value = "A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+	}
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_dns_zone" "test" {
+  name                = "acctestzone%d.com"
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_dns_txt_record" "test" {
+  name                = "myarecord%d"
+  resource_group_name = azurerm_resource_group.test.name
+  zone_name           = azurerm_dns_zone.test.name
+  ttl                 = 300
+
+  record {
+    values = ["Quick brown fox"]
+  }
+
+  record {
+    values = ["A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text"]
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }
 
 func (r DnsTxtRecordResource) requiresImport(data acceptance.TestData) string {
-	return fmt.Sprintf(`
+	if !features.FourPointOhBeta() {
+		return fmt.Sprintf(`
 %s
 
 resource "azurerm_dns_txt_record" "import" {
@@ -156,14 +190,34 @@ resource "azurerm_dns_txt_record" "import" {
   }
 
   record {
-    value = "A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......"
+    value = "A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text"
+  }
+}
+`, r.basic(data))
+	}
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_dns_txt_record" "import" {
+  name                = azurerm_dns_txt_record.test.name
+  resource_group_name = azurerm_dns_txt_record.test.resource_group_name
+  zone_name           = azurerm_dns_txt_record.test.zone_name
+  ttl                 = 300
+
+  record {
+    values = ["Quick brown fox"]
+  }
+
+  record {
+    values = ["A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text"]
   }
 }
 `, r.basic(data))
 }
 
 func (DnsTxtRecordResource) updateRecords(data acceptance.TestData) string {
-	return fmt.Sprintf(`
+	if !features.FourPointOhBeta() {
+		return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
@@ -189,7 +243,7 @@ resource "azurerm_dns_txt_record" "test" {
   }
 
   record {
-    value = "A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......"
+    value = "A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text"
   }
 
   record {
@@ -197,10 +251,46 @@ resource "azurerm_dns_txt_record" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+	}
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_dns_zone" "test" {
+  name                = "acctestzone%d.com"
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_dns_txt_record" "test" {
+  name                = "myarecord%d"
+  resource_group_name = azurerm_resource_group.test.name
+  zone_name           = azurerm_dns_zone.test.name
+  ttl                 = 300
+
+  record {
+    values = ["Quick brown fox"]
+  }
+
+  record {
+    values = ["A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text"]
+  }
+
+  record {
+    values = ["A wild 3rd record appears"]
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }
 
 func (DnsTxtRecordResource) withTags(data acceptance.TestData) string {
-	return fmt.Sprintf(`
+	if !features.FourPointOhBeta() {
+		return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
@@ -235,10 +325,47 @@ resource "azurerm_dns_txt_record" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+	}
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_dns_zone" "test" {
+  name                = "acctestzone%d.com"
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_dns_txt_record" "test" {
+  name                = "myarecord%d"
+  resource_group_name = azurerm_resource_group.test.name
+  zone_name           = azurerm_dns_zone.test.name
+  ttl                 = 300
+
+  record {
+    values = ["Quick brown fox"]
+  }
+
+  record {
+    values = ["Another test txt string"]
+  }
+
+  tags = {
+    environment = "Production"
+    cost_center = "MSFT"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }
 
 func (DnsTxtRecordResource) withTagsUpdate(data acceptance.TestData) string {
-	return fmt.Sprintf(`
+	if !features.FourPointOhBeta() {
+		return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
@@ -265,6 +392,41 @@ resource "azurerm_dns_txt_record" "test" {
 
   record {
     value = "Another test txt string"
+  }
+
+  tags = {
+    environment = "staging"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+	}
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_dns_zone" "test" {
+  name                = "acctestzone%d.com"
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_dns_txt_record" "test" {
+  name                = "myarecord%d"
+  resource_group_name = azurerm_resource_group.test.name
+  zone_name           = azurerm_dns_zone.test.name
+  ttl                 = 300
+
+  record {
+    values = ["Quick brown fox"]
+  }
+
+  record {
+    values = ["Another test txt string"]
   }
 
   tags = {

--- a/internal/services/dns/dns_txt_record_resource_test.go
+++ b/internal/services/dns/dns_txt_record_resource_test.go
@@ -278,7 +278,7 @@ resource "azurerm_dns_txt_record" "test" {
   }
 
   record {
-    values = ["A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text"]
+    values = ["A long text......A long text", "A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text......A long text", "A long text......A long text"]
   }
 
   record {

--- a/website/docs/r/dns_txt_record.html.markdown
+++ b/website/docs/r/dns_txt_record.html.markdown
@@ -69,9 +69,9 @@ The `record` block supports:
 
 ~> **NOTE:** `value` is deprecated and will be removed in favour of the property `values` in version 4.0 of the AzureRM Provider.
 
-* `values` - (Optional) A list of the record values. Max length: 255 characters for each value.
+* `values` - (Optional) A list of the record values.
 
-~> **NOTE:** The max length of each value is 255 characters. The max length of all record values is 1024 characters.
+~> **NOTE:** The max length of each value is 255 characters. The combined length of all values in all records of a record set must not exceed 1024 characters.
 
 ## Attributes Reference
 

--- a/website/docs/r/dns_txt_record.html.markdown
+++ b/website/docs/r/dns_txt_record.html.markdown
@@ -65,7 +65,13 @@ The following arguments are supported:
 
 The `record` block supports:
 
-* `value` - (Required) The value of the record. Max length: 1024 characters
+* `value` - (Optional) The value of the record. Max length: 1024 characters
+
+~> **NOTE:** `value` is deprecated and will be removed in favour of the property `values` in version 4.0 of the AzureRM Provider.
+
+* `values` - (Optional) A list of the record values. Max length: 255 characters for each value.
+
+~> **NOTE:** The max length of each value is 255 characters. The max length of all record values is 1024 characters.
 
 ## Attributes Reference
 


### PR DESCRIPTION
fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/20640

Background:
Records are composed by a list of record. All values in all records must not exceed 1024 characters.
One record is composed by a list of value. Each value is limited in 255 characters.

Symptom:
When user wants to set one record with 260 characters and first value of this record is 10 characters and the second value of this record is 250 characters, but currently TF doesn't support this scenario and TF would separate this record to two values per 254 character limit. The first value of this record would be set to 254 characters and the second value of this record would be set to 6 characters. That's not what user expected. So we have to align with API behavior to support this scenario.

--- PASS: TestAccDnsTxtRecord_updateRecords (409.28s)
--- PASS: TestAccDnsTxtRecord_basic (327.92s)
--- PASS: TestAccDnsTxtRecord_requiresImport (358.97s)
--- PASS: TestAccDnsTxtRecord_withTags (415.29s)