### PR TITLE
Docs: Update attributes reference for `azurerm_subscription` resource

### DIFF
--- a/website/docs/r/subscription.html.markdown
+++ b/website/docs/r/subscription.html.markdown
@@ -96,7 +96,8 @@ The following arguments are supported:
 In addition to the Arguments listed above - the following Attributes are exported:
 
 * `id` - The Resource ID of the Alias.
-
+* `subscription_id` - The subscription GUID.
+* `subscription_name` - The subscription name.
 * `tenant_id` - The ID of the Tenant to which the subscription belongs.
 
 ## Timeouts


### PR DESCRIPTION
Update attributes reference for `azurerm_subscription`.

Add the following attributes to documentation:
- `subscription_id`
- `subscription_name`

Attributes are filed out here: https://github.com/hashicorp/terraform-provider-azurerm/blob/7c3b64ea04b26023b25188225d194a78c2b76fc2/internal/services/subscription/subscription_resource.go#L344-L345
