### PR TITLE
`azurerm_healthcare_service` - extend range of the cosmosdb_throughput to a maximum of `100000`

### DIFF
--- a/internal/services/healthcare/healthcare_service_resource.go
+++ b/internal/services/healthcare/healthcare_service_resource.go
@@ -67,7 +67,7 @@ func resourceHealthcareService() *pluginsdk.Resource {
 				Type:         pluginsdk.TypeInt,
 				Optional:     true,
 				Default:      1000,
-				ValidateFunc: validation.IntBetween(1, 10000),
+				ValidateFunc: validation.IntBetween(1, 100000),
 			},
 
 			"cosmosdb_key_vault_key_versionless_id": {

--- a/website/docs/r/healthcare_service.html.markdown
+++ b/website/docs/r/healthcare_service.html.markdown
@@ -58,7 +58,7 @@ The following arguments are supported:
 
 * `access_policy_object_ids` - (Optional) A set of Azure object IDs that are allowed to access the Service. If not configured, the default value is the object id of the service principal or user that is running Terraform.
 * `authentication_configuration` - (Optional) An `authentication_configuration` block as defined below.
-* `cosmosdb_throughput` - (Optional) The provisioned throughput for the backing database. Range of `400`-`10000`. Defaults to `400`.
+* `cosmosdb_throughput` - (Optional) The provisioned throughput for the backing database. Range of `400`-`100000`. Defaults to `1000`.
 * `cosmosdb_key_vault_key_versionless_id` - (Optional) A versionless Key Vault Key ID for CMK encryption of the backing database. Changing this forces a new resource to be created.
 
 ~> **Please Note** In order to use a `Custom Key` from Key Vault for encryption you must grant Azure Cosmos DB Service access to your key vault. For instructions on how to configure your Key Vault correctly please refer to the [product documentation](https://docs.microsoft.com/azure/cosmos-db/how-to-setup-cmk#add-an-access-policy-to-your-azure-key-vault-instance)


### PR DESCRIPTION
Azure API for FHIR supports a higher RU/s rate than it's currently allowed by the property validation. See [MS docs](https://learn.microsoft.com/en-us/azure/healthcare-apis/azure-api-for-fhir/configure-database#update-throughput)
This prevents resource users to configure higher throughput via terraform. 
I updated the upper limit according to the MS documentation - 100,000 RU/s.

I also updated the default value to 1000 in the docs, as it's configured in the resource itself.