### PR TITLE
azurerm_backup_policy_vm - Add instant_restore_resource_group parameter to  documentation

### DIFF
--- a/website/docs/r/backup_policy_vm.html.markdown
+++ b/website/docs/r/backup_policy_vm.html.markdown
@@ -79,7 +79,7 @@ The following arguments are supported:
 
 * `instant_restore_retention_days` - (Optional) Specifies the instant restore retention range in days. Possible values are between `1` and `5` when `policy_type` is `V1`, and `1` to `30` when `policy_type` is `V2`.
 
-* `instant_restore_resource_group` - (Optional) Specifies the instant restore resource group as documented in the `instant_restore_resource_group` block below.
+* `instant_restore_resource_group` - (Optional) Specifies the instant restore resource group name as documented in the `instant_restore_resource_group` block below.
 
 * `retention_daily` - (Optional) Configures the policy daily retention as documented in the `retention_daily` block below. Required when backup frequency is `Daily`.
 

--- a/website/docs/r/backup_policy_vm.html.markdown
+++ b/website/docs/r/backup_policy_vm.html.markdown
@@ -79,6 +79,8 @@ The following arguments are supported:
 
 * `instant_restore_retention_days` - (Optional) Specifies the instant restore retention range in days. Possible values are between `1` and `5` when `policy_type` is `V1`, and `1` to `30` when `policy_type` is `V2`.
 
+* `instant_restore_resource_group` - (Optional) Specifies the instant restore resource group as documented in the `instant_restore_resource_group` block below.
+
 * `retention_daily` - (Optional) Configures the policy daily retention as documented in the `retention_daily` block below. Required when backup frequency is `Daily`.
 
 * `retention_weekly` - (Optional) Configures the policy weekly retention as documented in the `retention_weekly` block below. Required when backup frequency is `Weekly`.
@@ -102,6 +104,13 @@ The `backup` block supports:
 ~> **NOTE:** `hour_duration` must be multiplier of `hour_interval`
 
 * `weekdays` - (Optional) The days of the week to perform backups on. Must be one of `Sunday`, `Monday`, `Tuesday`, `Wednesday`, `Thursday`, `Friday` or `Saturday`. This is used when `frequency` is `Weekly`.
+
+---
+The `instant_restore_resource_group` block supports:
+
+* `prefix` - (Required) The prefix for the `instant_restore_resource_group` name.
+
+* `suffix` - (Optional) The suffix for the `instant_restore_resource_group` name.
 
 ---
 


### PR DESCRIPTION
Updated the documentation to include the instant_restore_resource_group parameter along with the prefix and suffix block for it per #20740