### PR TITLE
`azurerm_security_center_subscription_pricing` - support new enum value `CosmosDbs` for `resource_type`

### DIFF
--- a/internal/services/securitycenter/security_center_subscription_pricing_resource.go
+++ b/internal/services/securitycenter/security_center_subscription_pricing_resource.go
@@ -67,6 +67,7 @@ func resourceSecurityCenterSubscriptionPricing() *pluginsdk.Resource {
 					"Dns",
 					"OpenSourceRelationalDatabases",
 					"Containers",
+					"CosmosDbs",
 					"CloudPosture",
 				}, false),
 			},

--- a/internal/services/securitycenter/security_center_subscription_pricing_resource_test.go
+++ b/internal/services/securitycenter/security_center_subscription_pricing_resource_test.go
@@ -72,6 +72,23 @@ func TestAccSecurityCenterSubscriptionPricing_update(t *testing.T) {
 	})
 }
 
+func TestAccSecurityCenterSubscriptionPricing_cosmosDbs(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_security_center_subscription_pricing", "test")
+	r := SecurityCenterSubscriptionPricingResource{}
+
+	// lintignore:AT001
+	data.ResourceSequentialTestSkipCheckDestroyed(t, []acceptance.TestStep{
+		{
+			Config: r.tier("Standard", "CosmosDbs"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("tier").HasValue("Standard"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccSecurityCenterSubscriptionPricing_storageAccountSubplan(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_security_center_subscription_pricing", "test")
 	r := SecurityCenterSubscriptionPricingResource{}

--- a/website/docs/r/security_center_subscription_pricing.html.markdown
+++ b/website/docs/r/security_center_subscription_pricing.html.markdown
@@ -26,7 +26,7 @@ resource "azurerm_security_center_subscription_pricing" "example" {
 The following arguments are supported:
 
 * `tier` - (Required) The pricing tier to use. Possible values are `Free` and `Standard`.
-* `resource_type` - (Optional) The resource type this setting affects. Possible values are `AppServices`, `ContainerRegistry`, `KeyVaults`, `KubernetesService`, `SqlServers`, `SqlServerVirtualMachines`, `StorageAccounts`, `VirtualMachines`, `Arm`, `Dns`, `OpenSourceRelationalDatabases`, `Containers` and `CloudPosture`. Defaults to `VirtualMachines`
+* `resource_type` - (Optional) The resource type this setting affects. Possible values are `AppServices`, `ContainerRegistry`, `KeyVaults`, `KubernetesService`, `SqlServers`, `SqlServerVirtualMachines`, `StorageAccounts`, `VirtualMachines`, `Arm`, `Dns`, `OpenSourceRelationalDatabases`, `Containers`, `CosmosDbs` and `CloudPosture`. Defaults to `VirtualMachines`
 * `subplan` - (Optional) Resource type pricing subplan. Contact your MSFT representative for possible values.
 
 ~> **NOTE:** Changing the pricing tier to `Standard` affects all resources of the given type in the subscription and could be quite costly.


### PR DESCRIPTION
There is a new enum value [`CosmosDbs`](https://github.com/Azure/azure-policy/blob/f10ba3633a8072cf25f212eb363fedd1c84427d4/built-in-policies/policyDefinitions/Security%20Center/MDC_Microsoft_Defender_Azure_Cosmos_DB_Deploy.json#L63) for `resource_type`. So I submitted this PR to support it.

![image](https://user-images.githubusercontent.com/19754191/222622178-eb1b0082-de58-452a-8234-4a542334524f.png)
