### PR TITLE
[Bug Fix] - `azurerm_api_management_api_diagnostic` - `sampling_percentage ` cannot set to 0

### DIFF
--- a/internal/services/apimanagement/api_management_api_diagnostic_resource.go
+++ b/internal/services/apimanagement/api_management_api_diagnostic_resource.go
@@ -189,10 +189,11 @@ func resourceApiManagementApiDiagnosticCreateUpdate(d *pluginsdk.ResourceData, m
 		},
 	}
 
-	if samplingPercentage, ok := d.GetOk("sampling_percentage"); ok {
+	samplingPercentage := d.GetRawConfig().AsValueMap()["sampling_percentage"]
+	if !samplingPercentage.IsNull() {
 		parameters.Sampling = &apimanagement.SamplingSettings{
 			SamplingType: apimanagement.SamplingTypeFixed,
-			Percentage:   utils.Float(samplingPercentage.(float64)),
+			Percentage:   utils.Float(d.Get("sampling_percentage").(float64)),
 		}
 	} else {
 		parameters.Sampling = nil


### PR DESCRIPTION
Fixes: #20672  
Fix `sampling_percentage ` cannot set to 0
```log
=== RUN   TestAccApiManagementApiDiagnostic_basic
=== PAUSE TestAccApiManagementApiDiagnostic_basic
=== RUN   TestAccApiManagementApiDiagnostic_update
=== PAUSE TestAccApiManagementApiDiagnostic_update
=== RUN   TestAccApiManagementApiDiagnostic_requiresImport
=== PAUSE TestAccApiManagementApiDiagnostic_requiresImport
=== RUN   TestAccApiManagementApiDiagnostic_complete
=== PAUSE TestAccApiManagementApiDiagnostic_complete
=== RUN   TestAccApiManagementApiDiagnostic_completeUpdate
=== PAUSE TestAccApiManagementApiDiagnostic_completeUpdate
=== RUN   TestAccApiManagementApiDiagnostic_dataMasking
=== PAUSE TestAccApiManagementApiDiagnostic_dataMasking
=== CONT  TestAccApiManagementApiDiagnostic_basic
=== CONT  TestAccApiManagementApiDiagnostic_complete
=== CONT  TestAccApiManagementApiDiagnostic_requiresImport
=== CONT  TestAccApiManagementApiDiagnostic_update
=== CONT  TestAccApiManagementApiDiagnostic_dataMasking
=== CONT  TestAccApiManagementApiDiagnostic_completeUpdate
--- PASS: TestAccApiManagementApiDiagnostic_complete (600.99s)
--- PASS: TestAccApiManagementApiDiagnostic_basic (601.57s)
--- PASS: TestAccApiManagementApiDiagnostic_requiresImport (630.25s)
--- PASS: TestAccApiManagementApiDiagnostic_completeUpdate (726.69s)
--- PASS: TestAccApiManagementApiDiagnostic_dataMasking (738.62s)
--- PASS: TestAccApiManagementApiDiagnostic_update (749.19s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/apimanagement 790.403s
```