### PR TITLE
`azurerm_automation_schedule` - import `time/tzdata` to embed timezone information

### DIFF
--- a/internal/services/automation/automation_schedule_resource.go
+++ b/internal/services/automation/automation_schedule_resource.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	// import time/tzdata to embed timezone information in the program
+	// add this to resolve https://github.com/hashicorp/terraform-provider-azurerm/issues/20690
 	_ "time/tzdata"
 
 	"github.com/hashicorp/go-azure-helpers/lang/response"

--- a/internal/services/automation/automation_schedule_resource.go
+++ b/internal/services/automation/automation_schedule_resource.go
@@ -6,6 +6,8 @@ import (
 	"log"
 	"strings"
 	"time"
+	// import time/tzdata to embed timezone information in the program
+	_ "time/tzdata"
 
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"

--- a/internal/services/automation/automation_schedule_resource.go
+++ b/internal/services/automation/automation_schedule_resource.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"strings"
 	"time"
+
 	// import time/tzdata to embed timezone information in the program
 	_ "time/tzdata"
 


### PR DESCRIPTION
 whilst some platform/system does not provide full timezone information in the tzdata database, `time.LoadLocation()` will raise an error. this PR will cause the binary file size increase about <10kb by embeding the zip data of timezone into the built binary file.

reference https://github.com/golang/go/issues/38017 

resolves #20690.