### PR TITLE
`azurerm_maintenance_assignment_virtual_machine` - maintenance configuration is now obtained by name rather than using the first in the list

### DIFF
--- a/internal/services/maintenance/maintenance_assignment_virtual_machine_resource.go
+++ b/internal/services/maintenance/maintenance_assignment_virtual_machine_resource.go
@@ -140,8 +140,8 @@ func resourceArmMaintenanceAssignmentVirtualMachineRead(d *pluginsdk.ResourceDat
 
 	var assignment configurationassignments.ConfigurationAssignment
 	for _, v := range *resp {
-		// Due to https://github.com/Azure/azure-rest-api-specs/issues/22894, API always returns the lowercase for Maintenance Assignment. Once this issue is fixed, we will remove `strings.ToLower()`
-		if v.Name != nil && strings.EqualFold(strings.ToLower(*v.Name), strings.ToLower(id.Name)) {
+		// Due to https://github.com/Azure/azure-rest-api-specs/issues/22894, API always returns the lowercase for Maintenance Assignment. So here it has to ignore case sensitivity. Once this issue is fixed, here will be updated to respect case sensitivity
+		if v.Name != nil && strings.EqualFold(*v.Name, id.Name) {
 			assignment = v
 		}
 	}

--- a/internal/services/maintenance/maintenance_assignment_virtual_machine_resource.go
+++ b/internal/services/maintenance/maintenance_assignment_virtual_machine_resource.go
@@ -141,7 +141,7 @@ func resourceArmMaintenanceAssignmentVirtualMachineRead(d *pluginsdk.ResourceDat
 	var assignment configurationassignments.ConfigurationAssignment
 	for _, v := range *resp {
 		// Due to https://github.com/Azure/azure-rest-api-specs/issues/22894, API always returns the lowercase for Maintenance Assignment. Once this issue is fixed, we will remove `strings.ToLower()`
-		if v.Name != nil && strings.ToLower(*v.Name) == strings.ToLower(id.Name) {
+		if v.Name != nil && strings.EqualFold(strings.ToLower(*v.Name), strings.ToLower(id.Name)) {
 			assignment = v
 		}
 	}

--- a/internal/services/maintenance/maintenance_assignment_virtual_machine_resource.go
+++ b/internal/services/maintenance/maintenance_assignment_virtual_machine_resource.go
@@ -137,7 +137,15 @@ func resourceArmMaintenanceAssignmentVirtualMachineRead(d *pluginsdk.ResourceDat
 		d.SetId("")
 		return nil
 	}
-	assignment := (*resp)[0]
+
+	var assignment configurationassignments.ConfigurationAssignment
+	for _, v := range *resp {
+		// Due to https://github.com/Azure/azure-rest-api-specs/issues/22894, API always returns the lowercase for Maintenance Assignment. Once this issue is fixed, we will remove `strings.ToLower()`
+		if v.Name != nil && strings.ToLower(*v.Name) == strings.ToLower(id.Name) {
+			assignment = v
+		}
+	}
+
 	if assignment.Id == nil || *assignment.Id == "" {
 		return fmt.Errorf("empty or nil ID of Maintenance Assignment (virtual machine ID id: %q", id.VirtualMachineIdRaw)
 	}

--- a/internal/services/maintenance/maintenance_assignment_virtual_machine_resource.go
+++ b/internal/services/maintenance/maintenance_assignment_virtual_machine_resource.go
@@ -81,8 +81,15 @@ func resourceArmMaintenanceAssignmentVirtualMachineCreate(d *pluginsdk.ResourceD
 		return err
 	}
 	if existingList != nil && len(*existingList) > 0 {
-		existing := (*existingList)[0]
-		if existing.Id != nil && *existing.Id != "" {
+		isExist := false
+		for _, existing := range *existingList {
+			// Due to https://github.com/Azure/azure-rest-api-specs/issues/22894, API always returns the lowercase for Maintenance Assignment. So here it has to ignore case sensitivity. Once this issue is fixed, here will be updated to respect case sensitivity
+			if existing.Name != nil && strings.EqualFold(*existing.Name, configurationId.MaintenanceConfigurationName) {
+				isExist = true
+			}
+		}
+
+		if isExist {
 			return tf.ImportAsExistsError("azurerm_maintenance_assignment_virtual_machine", configurationId.ID())
 		}
 	}

--- a/internal/services/maintenance/maintenance_assignment_virtual_machine_resource.go
+++ b/internal/services/maintenance/maintenance_assignment_virtual_machine_resource.go
@@ -86,6 +86,7 @@ func resourceArmMaintenanceAssignmentVirtualMachineCreate(d *pluginsdk.ResourceD
 			// Due to https://github.com/Azure/azure-rest-api-specs/issues/22894, API always returns the lowercase for Maintenance Assignment. So here it has to ignore case sensitivity. Once this issue is fixed, here will be updated to respect case sensitivity
 			if existing.Name != nil && strings.EqualFold(*existing.Name, configurationId.MaintenanceConfigurationName) {
 				isExist = true
+				break
 			}
 		}
 
@@ -150,6 +151,7 @@ func resourceArmMaintenanceAssignmentVirtualMachineRead(d *pluginsdk.ResourceDat
 		// Due to https://github.com/Azure/azure-rest-api-specs/issues/22894, API always returns the lowercase for Maintenance Assignment. So here it has to ignore case sensitivity. Once this issue is fixed, here will be updated to respect case sensitivity
 		if v.Name != nil && strings.EqualFold(*v.Name, id.Name) {
 			assignment = v
+			break
 		}
 	}
 

--- a/internal/services/maintenance/maintenance_assignment_virtual_machine_resource_test.go
+++ b/internal/services/maintenance/maintenance_assignment_virtual_machine_resource_test.go
@@ -47,6 +47,22 @@ func TestAccMaintenanceAssignmentVirtualMachine_requiresImport(t *testing.T) {
 	})
 }
 
+func TestAccMaintenanceAssignmentVirtualMachine_multipleMaintenanceAssignmentVMs(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_maintenance_assignment_virtual_machine", "test")
+	r := MaintenanceAssignmentVirtualMachineResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.multipleMaintenanceAssignmentVMs(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		// location not returned by list rest api
+		data.ImportStep("location"),
+	})
+}
+
 func (MaintenanceAssignmentVirtualMachineResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	maintenanceAssignmentVirtualMachineId, err := parse.MaintenanceAssignmentVirtualMachineID(state.ID)
 	if err != nil {
@@ -158,4 +174,29 @@ resource "azurerm_linux_virtual_machine" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary)
+}
+
+func (r MaintenanceAssignmentVirtualMachineResource) multipleMaintenanceAssignmentVMs(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_maintenance_configuration" "test2" {
+  name                = "acctest-MC2%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  scope               = "SQLDB"
+}
+
+resource "azurerm_maintenance_assignment_virtual_machine" "test" {
+  location                     = azurerm_resource_group.test.location
+  maintenance_configuration_id = azurerm_maintenance_configuration.test.id
+  virtual_machine_id           = azurerm_linux_virtual_machine.test.id
+}
+
+resource "azurerm_maintenance_assignment_virtual_machine" "test2" {
+  location                     = azurerm_resource_group.test.location
+  maintenance_configuration_id = azurerm_maintenance_configuration.test2.id
+  virtual_machine_id           = azurerm_linux_virtual_machine.test.id
+}
+`, r.template(data), data.RandomInteger)
 }

--- a/internal/services/maintenance/maintenance_assignment_virtual_machine_resource_test.go
+++ b/internal/services/maintenance/maintenance_assignment_virtual_machine_resource_test.go
@@ -47,13 +47,13 @@ func TestAccMaintenanceAssignmentVirtualMachine_requiresImport(t *testing.T) {
 	})
 }
 
-func TestAccMaintenanceAssignmentVirtualMachine_multipleMaintenanceAssignmentVMs(t *testing.T) {
+func TestAccMaintenanceAssignmentVirtualMachine_linkMultipleMaintenanceAssignmentsToOneVM(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_maintenance_assignment_virtual_machine", "test")
 	r := MaintenanceAssignmentVirtualMachineResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.multipleMaintenanceAssignmentVMs(data),
+			Config: r.linkMultipleMaintenanceAssignmentsToOneVM(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -176,7 +176,7 @@ resource "azurerm_linux_virtual_machine" "test" {
 `, data.RandomInteger, data.Locations.Primary)
 }
 
-func (r MaintenanceAssignmentVirtualMachineResource) multipleMaintenanceAssignmentVMs(data acceptance.TestData) string {
+func (r MaintenanceAssignmentVirtualMachineResource) linkMultipleMaintenanceAssignmentsToOneVM(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 


### PR DESCRIPTION
fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/20705

Currently TF always set `maintenance_configuration_id` with the first one of maintenance configuration in the list when one vm is linked by two maintenance configurations. So TF would cause diff after first apply. I assume we should check and set `maintenance_configuration_id` by the name of maintenance configuration list.

And I found seems TF only checks if the vm is linked maintenance configuration while checking if `azurerm_maintenance_assignment_virtual_machine` exists. If such, one vm cannot be linked again per current TF behavior. So I assume it's unexpected. Per my undestanding, we should check the name of maintenance configuration in the list to see if the resource exists.

![image](https://user-images.githubusercontent.com/19754191/222675176-a1b56ca5-053a-4d34-be87-df442bab0df3.png)
