### PR TITLE
`azurerm_automation_job_schedule` - fix ID construction while re-creating job schedule

### DIFF
--- a/internal/services/automation/automation_job_schedule_resource.go
+++ b/internal/services/automation/automation_job_schedule_resource.go
@@ -136,11 +136,9 @@ func resourceAutomationJobScheduleCreate(d *pluginsdk.ResourceData, meta interfa
 				if itemProps.JobScheduleId == nil || *itemProps.JobScheduleId == "" {
 					return fmt.Errorf("job schedule Id is nil or empty listed by Automation Account %q Job Schedule List: %+v", id.AutomationAccountName, err)
 				}
-				jsId, err := jobschedule.ParseJobScheduleID(*itemProps.JobScheduleId)
-				if err != nil {
-					return fmt.Errorf("parsing job schedule Id listed by Automation Account %q Job Schedule List:%v", id.AutomationAccountName, err)
-				}
-				if _, err := client.Delete(ctx, *jsId); err != nil {
+
+				jsId := jobschedule.NewJobScheduleID(id.SubscriptionId, id.ResourceGroupName, id.AutomationAccountName, *itemProps.JobScheduleId)
+				if _, err := client.Delete(ctx, jsId); err != nil {
 					return fmt.Errorf("deleting job schedule Id listed by Automation Account %q Job Schedule List:%v", id.AutomationAccountName, err)
 				}
 			}


### PR DESCRIPTION
resolves #20719

```
TF_ACC=1 go test -v ./internal/services/automation -parallel 20 -test.run=TestAccAutomationJobSchedule_ -timeout 1440m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccAutomationJobSchedule_basic
=== PAUSE TestAccAutomationJobSchedule_basic
=== RUN   TestAccAutomationJobSchedule_complete
=== PAUSE TestAccAutomationJobSchedule_complete
=== RUN   TestAccAutomationJobSchedule_update
=== PAUSE TestAccAutomationJobSchedule_update
=== RUN   TestAccAutomationJobSchedule_requiresImport
=== PAUSE TestAccAutomationJobSchedule_requiresImport
=== CONT  TestAccAutomationJobSchedule_basic
=== CONT  TestAccAutomationJobSchedule_update
=== CONT  TestAccAutomationJobSchedule_complete
=== CONT  TestAccAutomationJobSchedule_requiresImport
--- PASS: TestAccAutomationJobSchedule_complete (120.51s)
--- PASS: TestAccAutomationJobSchedule_requiresImport (135.21s)
--- PASS: TestAccAutomationJobSchedule_basic (187.42s)
--- PASS: TestAccAutomationJobSchedule_update (273.44s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/automation    276.984s
```