### PR TITLE
`azurerm_maintenance_assignment_virtual_machine` - fixing potential nil panic by adding a nil check

### DIFF
--- a/internal/services/maintenance/maintenance_assignment_virtual_machine_resource.go
+++ b/internal/services/maintenance/maintenance_assignment_virtual_machine_resource.go
@@ -191,5 +191,8 @@ func getMaintenanceAssignmentVirtualMachine(ctx context.Context, client *configu
 		}
 	}
 
-	return resp.Model.Value, nil
+	if resp.Model != nil {
+		result = resp.Model.Value
+	}
+	return
 }


### PR DESCRIPTION
This pull request fixed a potential nil panic by adding a nil check on reading response from sdk. It should solved #20780.