### PR TITLE
azurerm_mariadb_server - add support for "ssl_minimal_tls_version_enforced" 

### DIFF
--- a/internal/services/mariadb/mariadb_server_resource.go
+++ b/internal/services/mariadb/mariadb_server_resource.go
@@ -221,7 +221,6 @@ func resourceMariaDbServerCreate(d *pluginsdk.ResourceData, meta interface{}) er
 	}
 
 	tlsMin := servers.MinimalTlsVersionEnum(d.Get("ssl_minimal_tls_version_enforced").(string))
-
 	if ssl == servers.SslEnforcementEnumDisabled && tlsMin != servers.MinimalTlsVersionEnumTLSEnforcementDisabled {
 		return fmt.Errorf("`ssl_minimal_tls_version_enforced` must be set to `TLSEnforcementDisabled` if `ssl_enforcement_enabled` is set to `false`")
 	}
@@ -249,6 +248,7 @@ func resourceMariaDbServerCreate(d *pluginsdk.ResourceData, meta interface{}) er
 			AdministratorLogin:         admin,
 			AdministratorLoginPassword: pass,
 			PublicNetworkAccess:        &publicAccess,
+			MinimalTlsVersion:          &tlsMin,
 			SslEnforcement:             &ssl,
 			StorageProfile:             storage,
 			Version:                    &version,
@@ -264,7 +264,6 @@ func resourceMariaDbServerCreate(d *pluginsdk.ResourceData, meta interface{}) er
 			SourceServerId:      source,
 			RestorePointInTime:  v.(string),
 			PublicNetworkAccess: &publicAccess,
-			MinimalTlsVersion:   &tlsMin,
 			SslEnforcement:      &ssl,
 			StorageProfile:      storage,
 			Version:             &version,
@@ -328,12 +327,19 @@ func resourceMariaDbServerUpdate(d *pluginsdk.ResourceData, meta interface{}) er
 		ssl = servers.SslEnforcementEnumDisabled
 	}
 
+	tlsMin := servers.MinimalTlsVersionEnum(d.Get("ssl_minimal_tls_version_enforced").(string))
+
+	if ssl == servers.SslEnforcementEnumDisabled && tlsMin != servers.MinimalTlsVersionEnumTLSEnforcementDisabled {
+		return fmt.Errorf("`ssl_minimal_tls_version_enforced` must be set to `TLSEnforcementDisabled` if `ssl_enforcement_enabled` is set to `false`")
+	}
+
 	storageProfile := expandMariaDbStorageProfile(d)
 	serverVersion := servers.ServerVersion(d.Get("version").(string))
 	properties := servers.ServerUpdateParameters{
 		Properties: &servers.ServerUpdateParametersProperties{
 			AdministratorLoginPassword: utils.String(d.Get("administrator_login_password").(string)),
 			PublicNetworkAccess:        &publicAccess,
+			MinimalTlsVersion:          &tlsMin,
 			SslEnforcement:             &ssl,
 			StorageProfile:             storageProfile,
 			Version:                    &serverVersion,

--- a/internal/services/mariadb/mariadb_server_resource_test.go
+++ b/internal/services/mariadb/mariadb_server_resource_test.go
@@ -296,7 +296,7 @@ resource "azurerm_mariadb_server" "test" {
   backup_retention_days        		= 7
   geo_redundant_backup_enabled 		= false
   ssl_enforcement_enabled      		= true
-  ssl_minimal_tls_version_enforced  = "TLS1_2"
+  ssl_minimal_tls_version_enforced      = "TLS1_2"
   storage_mb                   		= 51200
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, version)

--- a/internal/services/mariadb/mariadb_server_resource_test.go
+++ b/internal/services/mariadb/mariadb_server_resource_test.go
@@ -290,13 +290,14 @@ resource "azurerm_mariadb_server" "test" {
   sku_name            = "B_Gen5_2"
   version             = "%s"
 
-  administrator_login          = "acctestun"
-  administrator_login_password = "H@Sh1CoR3!"
-  auto_grow_enabled            = true
-  backup_retention_days        = 7
-  geo_redundant_backup_enabled = false
-  ssl_enforcement_enabled      = true
-  storage_mb                   = 51200
+  administrator_login          		= "acctestun"
+  administrator_login_password 		= "H@Sh1CoR3!"
+  auto_grow_enabled            		= true
+  backup_retention_days        		= 7
+  geo_redundant_backup_enabled 		= false
+  ssl_enforcement_enabled      		= true
+  ssl_minimal_tls_version_enforced  = "TLS1_2"
+  storage_mb                   		= 51200
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, version)
 }

--- a/website/docs/r/mariadb_server.html.markdown
+++ b/website/docs/r/mariadb_server.html.markdown
@@ -34,11 +34,12 @@ resource "azurerm_mariadb_server" "example" {
   storage_mb = 5120
   version    = "10.2"
 
-  auto_grow_enabled             = true
-  backup_retention_days         = 7
-  geo_redundant_backup_enabled  = false
-  public_network_access_enabled = false
-  ssl_enforcement_enabled       = true
+  auto_grow_enabled                = true
+  backup_retention_days            = 7
+  geo_redundant_backup_enabled     = false
+  public_network_access_enabled    = false
+  ssl_enforcement_enabled          = true
+  ssl_minimal_tls_version_enforced = "TLS1_2"
 }
 ```
 
@@ -75,6 +76,10 @@ The following arguments are supported:
 * `restore_point_in_time` - (Optional) When `create_mode` is `PointInTimeRestore`, specifies the point in time to restore from `creation_source_server_id`. It should be provided in [RFC3339](https://www.rfc-editor.org/rfc/rfc3339) format, e.g. `2013-11-08T22:00:40Z`.
 
 * `ssl_enforcement_enabled` - (Required) Specifies if SSL should be enforced on connections. Possible values are `true` and `false`.
+
+-> **NOTE:** `ssl_minimal_tls_version_enforced` must be set to `TLSEnforcementDisabled` when `ssl_enforcement_enabled` is set to `false`.
+
+* `ssl_minimal_tls_version_enforced` - (Optional) The minimum TLS version to support on the sever. Possible values are `TLSEnforcementDisabled`, `TLS1_0`, `TLS1_1`, and `TLS1_2`. Defaults to `TLS1_2`.
 
 * `storage_mb` - (Optional) Max storage allowed for a server. Possible values are between `5120` MB (5GB) and `1024000`MB (1TB) for the Basic SKU and between `5120` MB (5GB) and `4096000` MB (4TB) for General Purpose/Memory Optimized SKUs. For more information see the [product documentation](https://docs.microsoft.com/rest/api/mariadb/servers/create#storageprofile).
 


### PR DESCRIPTION
Updated resource to utilize parameter "ssl_minimal_tls_version_enforced", added to test, and updated doc

#18679