### PR TITLE
azurerm_servicebus_namespace returns endpoint 

### DIFF
--- a/internal/services/servicebus/servicebus_namespace_data_source.go
+++ b/internal/services/servicebus/servicebus_namespace_data_source.go
@@ -76,6 +76,11 @@ func dataSourceServiceBusNamespace() *pluginsdk.Resource {
 				Computed: true,
 			},
 
+			"endpoint": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
 			"tags": tags.SchemaDataSource(),
 		},
 	}
@@ -109,6 +114,7 @@ func dataSourceServiceBusNamespaceRead(d *pluginsdk.ResourceData, meta interface
 
 		if props := model.Properties; props != nil {
 			d.Set("zone_redundant", props.ZoneRedundant)
+			d.Set("endpoint", props.ServiceBusEndpoint)
 		}
 	}
 

--- a/internal/services/servicebus/servicebus_namespace_data_source_test.go
+++ b/internal/services/servicebus/servicebus_namespace_data_source_test.go
@@ -25,6 +25,7 @@ func TestAccDataSourceServiceBusNamespace_basic(t *testing.T) {
 				check.That(data.ResourceName).Key("default_secondary_connection_string").Exists(),
 				check.That(data.ResourceName).Key("default_primary_key").Exists(),
 				check.That(data.ResourceName).Key("default_secondary_key").Exists(),
+				check.That(data.ResourceName).Key("endpoint").Exists(),
 			),
 		},
 	})
@@ -45,6 +46,7 @@ func TestAccDataSourceServiceBusNamespace_premium(t *testing.T) {
 				check.That(data.ResourceName).Key("default_secondary_connection_string").Exists(),
 				check.That(data.ResourceName).Key("default_primary_key").Exists(),
 				check.That(data.ResourceName).Key("default_secondary_key").Exists(),
+				check.That(data.ResourceName).Key("endpoint").Exists(),
 			),
 		},
 	})

--- a/internal/services/servicebus/servicebus_namespace_resource.go
+++ b/internal/services/servicebus/servicebus_namespace_resource.go
@@ -171,6 +171,11 @@ func resourceServiceBusNamespace() *pluginsdk.Resource {
 				ForceNew: true,
 			},
 
+			"endpoint": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
 			"tags": tags.Schema(),
 		},
 
@@ -338,6 +343,8 @@ func resourceServiceBusNamespaceRead(d *pluginsdk.ResourceData, meta interface{}
 				if props.MinimumTlsVersion != nil {
 					d.Set("minimum_tls_version", *props.MinimumTlsVersion)
 				}
+
+				d.Set("endpoint", props.ServiceBusEndpoint)
 			}
 		}
 	}

--- a/internal/services/servicebus/servicebus_namespace_resource_test.go
+++ b/internal/services/servicebus/servicebus_namespace_resource_test.go
@@ -250,6 +250,22 @@ func TestAccAzureRMServiceBusNamespace_minimumTLSUpdate(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMServiceBusNamespace_endpoint(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_servicebus_namespace", "test")
+	r := ServiceBusNamespaceResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				acceptance.TestMatchResourceAttr(
+					data.ResourceName, "endpoint", regexp.MustCompile(`https://.+`)),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (t ServiceBusNamespaceResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := namespaces.ParseNamespaceID(state.ID)
 	if err != nil {

--- a/website/docs/d/servicebus_namespace.html.markdown
+++ b/website/docs/d/servicebus_namespace.html.markdown
@@ -39,6 +39,8 @@ output "location" {
 
 * `zone_redundant` - Whether or not this ServiceBus Namespace is zone redundant.
 
+* `endpoint` - The URL to access the ServiceBus Namespace.
+
 * `tags` - A mapping of tags assigned to the resource.
 
 The following attributes are exported only if there is an authorization rule named

--- a/website/docs/r/servicebus_namespace.html.markdown
+++ b/website/docs/r/servicebus_namespace.html.markdown
@@ -95,6 +95,8 @@ The following attributes are exported:
 
 * `identity` - An `identity` block as defined below, which contains the Managed Service Identity information for this ServiceBus Namespace.
 
+* `endpoint` - The URL to access the ServiceBus Namespace.
+
 ---
 
 A `identity` block exports the following:


### PR DESCRIPTION
Many times we need the "raw" endpoint for a servicebus namespace (and not the connection strings). 
This PR adds the endpoint value to both the resource (returned on create) and the data object. 
Fixes #16739.