### PR TITLE
Various Resources: Add missing empty-id logic when resource was not found during read

### DIFF
--- a/internal/services/applicationinsights/application_insights_analytics_item_resource.go
+++ b/internal/services/applicationinsights/application_insights_analytics_item_resource.go
@@ -216,6 +216,10 @@ func resourceApplicationInsightsAnalyticsItemRead(d *pluginsdk.ResourceData, met
 
 	result, err := client.Get(ctx, resourceGroupName, appInsightsName, itemScopePath, itemID, "")
 	if err != nil {
+		if utils.ResponseWasNotFound(result.Response) {
+			d.SetId("")
+			return nil
+		}
 		return fmt.Errorf("getting Application Insights Analytics Item %s: %+v", id, err)
 	}
 

--- a/internal/services/appservice/function_app_active_slot_resource.go
+++ b/internal/services/appservice/function_app_active_slot_resource.go
@@ -127,6 +127,9 @@ func (r FunctionAppActiveSlotResource) Read() sdk.ResourceFunc {
 
 			app, err := client.Get(ctx, id.ResourceGroup, id.SiteName)
 			if err != nil {
+				if utils.ResponseWasNotFound(app.Response) {
+					return metadata.MarkAsGone(id)
+				}
 				return fmt.Errorf("reading active slot for %s: %+v", id.SiteName, err)
 			}
 

--- a/internal/services/appservice/web_app_active_slot_resource.go
+++ b/internal/services/appservice/web_app_active_slot_resource.go
@@ -127,6 +127,9 @@ func (r WebAppActiveSlotResource) Read() sdk.ResourceFunc {
 
 			app, err := client.Get(ctx, id.ResourceGroup, id.SiteName)
 			if err != nil {
+				if utils.ResponseWasNotFound(app.Response) {
+					return metadata.MarkAsGone(id)
+				}
 				return fmt.Errorf("reading active slot for %s: %+v", id.SiteName, err)
 			}
 

--- a/internal/services/automation/automation_connection_type_resource.go
+++ b/internal/services/automation/automation_connection_type_resource.go
@@ -165,6 +165,9 @@ func (m AutomationConnectionTypeResource) Read() sdk.ResourceFunc {
 			client := meta.Client.Automation.ConnectionTypeClient
 			resp, err := client.Get(ctx, *id)
 			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return meta.MarkAsGone(id)
+				}
 				return err
 			}
 

--- a/internal/services/automation/automation_software_update_configuration_resource.go
+++ b/internal/services/automation/automation_software_update_configuration_resource.go
@@ -1018,6 +1018,9 @@ func (m SoftwareUpdateConfigurationResource) Read() sdk.ResourceFunc {
 			client := meta.Client.Automation.SoftwareUpdateConfigClient
 			resp, err := client.SoftwareUpdateConfigurationsGetByName(ctx, *id, softwareupdateconfiguration.SoftwareUpdateConfigurationsGetByNameOperationOptions{})
 			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return meta.MarkAsGone(id)
+				}
 				return err
 			}
 			var output SoftwareUpdateConfigurationModel

--- a/internal/services/automation/automation_source_control_resource.go
+++ b/internal/services/automation/automation_source_control_resource.go
@@ -220,6 +220,9 @@ func (m SourceControlResource) Read() sdk.ResourceFunc {
 			client := meta.Client.Automation.SourceControlClient
 			resp, err := client.Get(ctx, *id)
 			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return meta.MarkAsGone(id)
+				}
 				return err
 			}
 

--- a/internal/services/automation/automation_watcher_resource.go
+++ b/internal/services/automation/automation_watcher_resource.go
@@ -173,6 +173,9 @@ func (m WatcherResource) Read() sdk.ResourceFunc {
 			client := meta.Client.Automation.WatcherClient
 			resp, err := client.Get(ctx, *id)
 			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return meta.MarkAsGone(id)
+				}
 				return err
 			}
 

--- a/internal/services/cdn/cdn_frontdoor_route_disable_link_to_default_domain_resource.go
+++ b/internal/services/cdn/cdn_frontdoor_route_disable_link_to_default_domain_resource.go
@@ -184,7 +184,8 @@ func resourceCdnFrontDoorRouteDisableLinkToDefaultDomainRead(d *pluginsdk.Resour
 	existing, err := routeClient.Get(routeCtx, routeId.ResourceGroup, routeId.ProfileName, routeId.AfdEndpointName, routeId.RouteName)
 	if err != nil {
 		if utils.ResponseWasNotFound(existing.Response) {
-			return fmt.Errorf("creating %s: %s was not found", id, routeId)
+			d.SetId("")
+			return nil
 		}
 
 		return fmt.Errorf("retrieving existing %s: %+v", *routeId, err)

--- a/internal/services/digitaltwins/digital_twins_time_series_database_connection_resource.go
+++ b/internal/services/digitaltwins/digital_twins_time_series_database_connection_resource.go
@@ -194,6 +194,9 @@ func (m TimeSeriesDatabaseConnectionResource) Read() sdk.ResourceFunc {
 			client := meta.Client.DigitalTwins.TimeSeriesDatabaseConnectionsClient
 			result, err := client.Get(ctx, *id)
 			if err != nil {
+				if response.WasNotFound(result.HttpResponse) {
+					return meta.MarkAsGone(id)
+				}
 				return err
 			}
 

--- a/internal/services/fluidrelay/fluid_relay_servers_resource.go
+++ b/internal/services/fluidrelay/fluid_relay_servers_resource.go
@@ -230,6 +230,9 @@ func (s Server) Read() sdk.ResourceFunc {
 
 			server, err := client.Get(ctx, *id)
 			if err != nil {
+				if response.WasNotFound(server.HttpResponse) {
+					return meta.MarkAsGone(id)
+				}
 				return fmt.Errorf("retrieving %s: %v", id, err)
 			}
 

--- a/internal/services/iothub/iothub_fallback_route_resource.go
+++ b/internal/services/iothub/iothub_fallback_route_resource.go
@@ -155,6 +155,10 @@ func resourceIotHubFallbackRouteRead(d *pluginsdk.ResourceData, meta interface{}
 
 	iothub, err := client.Get(ctx, id.ResourceGroup, id.IotHubName)
 	if err != nil {
+		if utils.ResponseWasNotFound(iothub.Response) {
+			d.SetId("")
+			return nil
+		}
 		return fmt.Errorf("loading IotHub %q (Resource Group %q): %+v", id.IotHubName, id.ResourceGroup, err)
 	}
 

--- a/internal/services/logic/logic_app_integration_account_resource.go
+++ b/internal/services/logic/logic_app_integration_account_resource.go
@@ -127,6 +127,10 @@ func resourceLogicAppIntegrationAccountRead(d *pluginsdk.ResourceData, meta inte
 
 	resp, err := client.Get(ctx, *id)
 	if err != nil {
+		if response.WasNotFound(resp.HttpResponse) {
+			d.SetId("")
+			return nil
+		}
 		return fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 	d.Set("name", id.IntegrationAccountName)

--- a/internal/services/nginx/nginx_certificate_resource.go
+++ b/internal/services/nginx/nginx_certificate_resource.go
@@ -132,6 +132,9 @@ func (m CertificateResource) Read() sdk.ResourceFunc {
 			client := meta.Client.Nginx.NginxCertificate
 			result, err := client.CertificatesGet(ctx, *id)
 			if err != nil {
+				if response.WasNotFound(result.HttpResponse) {
+					return meta.MarkAsGone(id)
+				}
 				return err
 			}
 

--- a/internal/services/nginx/nginx_configuration_resource.go
+++ b/internal/services/nginx/nginx_configuration_resource.go
@@ -227,6 +227,9 @@ func (m ConfigurationResource) Read() sdk.ResourceFunc {
 			client := meta.Client.Nginx.NginxConfiguration
 			result, err := client.ConfigurationsGet(ctx, *id)
 			if err != nil {
+				if response.WasNotFound(result.HttpResponse) {
+					return meta.MarkAsGone(id)
+				}
 				return err
 			}
 

--- a/internal/services/nginx/nginx_deployment_resource.go
+++ b/internal/services/nginx/nginx_deployment_resource.go
@@ -309,6 +309,9 @@ func (m DeploymentResource) Read() sdk.ResourceFunc {
 			client := meta.Client.Nginx.NginxDeployment
 			result, err := client.DeploymentsGet(ctx, *id)
 			if err != nil {
+				if response.WasNotFound(result.HttpResponse) {
+					return meta.MarkAsGone(id)
+				}
 				return fmt.Errorf("retrieving %s: %+v", *id, err)
 			}
 

--- a/internal/services/synapse/synapse_workspace_aad_admin_resource.go
+++ b/internal/services/synapse/synapse_workspace_aad_admin_resource.go
@@ -109,9 +109,11 @@ func resourceSynapseWorkspaceAADAdminRead(d *pluginsdk.ResourceData, meta interf
 
 	aadAdmin, err := client.Get(ctx, id.ResourceGroup, id.WorkspaceName)
 	if err != nil {
-		if !utils.ResponseWasNotFound(aadAdmin.Response) {
-			return fmt.Errorf("retrieving Synapse Workspace %q AAD Admin (Resource Group %q): %+v", id.WorkspaceName, id.ResourceGroup, err)
+		if utils.ResponseWasNotFound(aadAdmin.Response) {
+			d.SetId("")
+			return nil
 		}
+		return fmt.Errorf("retrieving %q: %+v", id, err)
 	}
 
 	workspaceID := parse.NewWorkspaceID(id.SubscriptionId, id.ResourceGroup, id.WorkspaceName)

--- a/internal/services/synapse/synapse_workspace_key_resource.go
+++ b/internal/services/synapse/synapse_workspace_key_resource.go
@@ -134,6 +134,10 @@ func resourceSynapseWorkspaceKeyRead(d *pluginsdk.ResourceData, meta interface{}
 
 	resp, err := client.Get(ctx, id.ResourceGroup, id.WorkspaceName, id.KeyName)
 	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			d.SetId("")
+			return nil
+		}
 		return fmt.Errorf("retrieving Synapse Workspace Key %q (Workspace %q): %+v", id.KeyName, id.WorkspaceName, err)
 	}
 

--- a/internal/services/synapse/synapse_workspace_sql_aad_admin_resource.go
+++ b/internal/services/synapse/synapse_workspace_sql_aad_admin_resource.go
@@ -109,9 +109,11 @@ func resourceSynapseWorkspaceSqlAADAdminRead(d *pluginsdk.ResourceData, meta int
 
 	aadAdmin, err := client.Get(ctx, id.ResourceGroup, id.WorkspaceName)
 	if err != nil {
-		if !utils.ResponseWasNotFound(aadAdmin.Response) {
-			return fmt.Errorf("retrieving Synapse Workspace %q Sql AAD Admin (Resource Group %q): %+v", id.WorkspaceName, id.ResourceGroup, err)
+		if utils.ResponseWasNotFound(aadAdmin.Response) {
+			d.SetId("")
+			return nil
 		}
+		return fmt.Errorf("retrieving %q: %+v", id, err)
 	}
 
 	workspaceID := parse.NewWorkspaceID(id.SubscriptionId, id.ResourceGroup, id.WorkspaceName)


### PR DESCRIPTION
Some resources are missing the logic of `d.SetId("")`/`metadata.MarkAsGone(id)` in `read` when resource is not found, which could cause the issue that a resource cannot be recreated when deleted outside Terraform. Adding the missing ones.