### PR TITLE
`azurerm_iothub_endpoint_*` `azurerm_iothub_route` - set Id to nil when resource is not found

### DIFF
--- a/internal/services/iothub/iothub_endpoint_servicebus_queue_resource.go
+++ b/internal/services/iothub/iothub_endpoint_servicebus_queue_resource.go
@@ -244,6 +244,10 @@ func resourceIotHubEndpointServiceBusQueueRead(d *pluginsdk.ResourceData, meta i
 
 	iothub, err := client.Get(ctx, id.ResourceGroup, id.IotHubName)
 	if err != nil {
+		if utils.ResponseWasNotFound(iothub.Response) {
+			d.SetId("")
+			return nil
+		}
 		return fmt.Errorf("loading IotHub %q (Resource Group %q): %+v", id.IotHubName, id.ResourceGroup, err)
 	}
 
@@ -253,13 +257,17 @@ func resourceIotHubEndpointServiceBusQueueRead(d *pluginsdk.ResourceData, meta i
 	d.Set("iothub_id", iotHubId.ID())
 
 	if iothub.Properties == nil || iothub.Properties.Routing == nil || iothub.Properties.Routing.Endpoints == nil {
+		d.SetId("")
 		return nil
 	}
+
+	exist := false
 
 	if endpoints := iothub.Properties.Routing.Endpoints.ServiceBusQueues; endpoints != nil {
 		for _, endpoint := range *endpoints {
 			if existingEndpointName := endpoint.Name; existingEndpointName != nil {
 				if strings.EqualFold(*existingEndpointName, id.EndpointName) {
+					exist = true
 					d.Set("resource_group_name", endpoint.ResourceGroup)
 
 					authenticationType := string(devices.AuthenticationTypeKeyBased)
@@ -294,6 +302,10 @@ func resourceIotHubEndpointServiceBusQueueRead(d *pluginsdk.ResourceData, meta i
 				}
 			}
 		}
+	}
+
+	if !exist {
+		d.SetId("")
 	}
 
 	return nil

--- a/internal/services/iothub/iothub_endpoint_storage_container_resource.go
+++ b/internal/services/iothub/iothub_endpoint_storage_container_resource.go
@@ -284,6 +284,10 @@ func resourceIotHubEndpointStorageContainerRead(d *pluginsdk.ResourceData, meta 
 
 	iothub, err := client.Get(ctx, id.ResourceGroup, id.IotHubName)
 	if err != nil {
+		if utils.ResponseWasNotFound(iothub.Response) {
+			d.SetId("")
+			return nil
+		}
 		return fmt.Errorf("loading IotHub %q (Resource Group %q): %+v", id.IotHubName, id.ResourceGroup, err)
 	}
 
@@ -293,13 +297,17 @@ func resourceIotHubEndpointStorageContainerRead(d *pluginsdk.ResourceData, meta 
 	d.Set("iothub_id", iotHubId.ID())
 
 	if iothub.Properties == nil || iothub.Properties.Routing == nil || iothub.Properties.Routing.Endpoints == nil {
+		d.SetId("")
 		return nil
 	}
+
+	exist := false
 
 	if endpoints := iothub.Properties.Routing.Endpoints.StorageContainers; endpoints != nil {
 		for _, endpoint := range *endpoints {
 			if existingEndpointName := endpoint.Name; existingEndpointName != nil {
 				if strings.EqualFold(*existingEndpointName, id.EndpointName) {
+					exist = true
 					d.Set("container_name", endpoint.ContainerName)
 					d.Set("file_name_format", endpoint.FileNameFormat)
 					d.Set("batch_frequency_in_seconds", endpoint.BatchFrequencyInSeconds)
@@ -333,6 +341,10 @@ func resourceIotHubEndpointStorageContainerRead(d *pluginsdk.ResourceData, meta 
 				}
 			}
 		}
+	}
+
+	if !exist {
+		d.SetId("")
 	}
 
 	return nil

--- a/internal/services/iothub/iothub_route_resource.go
+++ b/internal/services/iothub/iothub_route_resource.go
@@ -197,6 +197,10 @@ func resourceIotHubRouteRead(d *pluginsdk.ResourceData, meta interface{}) error 
 
 	iothub, err := client.Get(ctx, id.ResourceGroup, id.IotHubName)
 	if err != nil {
+		if utils.ResponseWasNotFound(iothub.Response) {
+			d.SetId("")
+			return nil
+		}
 		return fmt.Errorf("loading IotHub %q (Resource Group %q): %+v", id.IotHubName, id.ResourceGroup, err)
 	}
 
@@ -205,13 +209,17 @@ func resourceIotHubRouteRead(d *pluginsdk.ResourceData, meta interface{}) error 
 	d.Set("resource_group_name", id.ResourceGroup)
 
 	if iothub.Properties == nil || iothub.Properties.Routing == nil {
+		d.SetId("")
 		return nil
 	}
+
+	exist := false
 
 	if routes := iothub.Properties.Routing.Routes; routes != nil {
 		for _, route := range *routes {
 			if route.Name != nil {
 				if strings.EqualFold(*route.Name, id.Name) {
+					exist = true
 					d.Set("source", route.Source)
 					d.Set("condition", route.Condition)
 					d.Set("enabled", route.IsEnabled)
@@ -219,6 +227,10 @@ func resourceIotHubRouteRead(d *pluginsdk.ResourceData, meta interface{}) error 
 				}
 			}
 		}
+	}
+
+	if !exist {
+		d.SetId("")
 	}
 
 	return nil


### PR DESCRIPTION
These are extracted resources from `azurerm_iothub` and use certain properties from an IoT Hub. When removed outside of Terraform, the read fails directly instead of recreating the resource. Adding the logic to set the ID to empty string when IoTHub or the endpoint/route itself are removed so that they could be recreated in Terraform