### PR TITLE
r/kusto_iothub_data_connection: rewriting the `iothub_id` field in the Read function

### DIFF
--- a/internal/services/kusto/kusto_iothub_data_connection_resource.go
+++ b/internal/services/kusto/kusto_iothub_data_connection_resource.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	iotHubParse "github.com/hashicorp/terraform-provider-azurerm/internal/services/iothub/parse"
 	iothubValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/iothub/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/kusto/migration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/kusto/validate"
@@ -213,7 +214,11 @@ func resourceKustoIotHubDataConnectionRead(d *pluginsdk.ResourceData, meta inter
 		if dataConnection, ok := (*resp.Model).(dataconnections.IotHubDataConnection); ok {
 			d.Set("location", location.NormalizeNilable(dataConnection.Location))
 			if props := dataConnection.Properties; props != nil {
-				d.Set("iothub_id", props.IotHubResourceId)
+				iotHubId := ""
+				if parsedIoTHubId, err := iotHubParse.IotHubIDInsensitively(props.IotHubResourceId); err == nil {
+					iotHubId = parsedIoTHubId.ID()
+				}
+				d.Set("iothub_id", iotHubId)
 				d.Set("consumer_group", props.ConsumerGroup)
 				d.Set("table_name", props.TableName)
 				d.Set("mapping_rule_name", props.MappingRuleName)


### PR DESCRIPTION
The existing acctests cover the `iothub_id` field, so this normalization will workaround the API response

Fixes #20802