### PR TITLE
`azurerm_mysql_server_key` ,  `azurerm_mysql_flexible_server` , `azurerm_postgresql_flexible_server` and `azurerm_postgresql_server_key` -  add permission to keyvault to support auto-rotation to fix acc tests failure

### DIFF
--- a/internal/services/mysql/mysql_flexible_server_resource_test.go
+++ b/internal/services/mysql/mysql_flexible_server_resource_test.go
@@ -1013,7 +1013,7 @@ resource "azurerm_key_vault_access_policy" "server" {
   tenant_id    = data.azurerm_client_config.current.tenant_id
   object_id    = azurerm_user_assigned_identity.test.principal_id
 
-  key_permissions = ["Get", "List", "WrapKey", "UnwrapKey"]
+  key_permissions = ["Get", "List", "WrapKey", "UnwrapKey", "GetRotationPolicy", "SetRotationPolicy"]
 }
 
 resource "azurerm_key_vault_access_policy" "client" {
@@ -1021,7 +1021,7 @@ resource "azurerm_key_vault_access_policy" "client" {
   tenant_id    = data.azurerm_client_config.current.tenant_id
   object_id    = data.azurerm_client_config.current.object_id
 
-  key_permissions = ["Get", "Create", "Delete", "List", "Restore", "Recover", "UnwrapKey", "WrapKey", "Purge", "Encrypt", "Decrypt", "Sign", "Verify"]
+  key_permissions = ["Get", "Create", "Delete", "List", "Restore", "Recover", "UnwrapKey", "WrapKey", "Purge", "Encrypt", "Decrypt", "Sign", "Verify", "GetRotationPolicy", "SetRotationPolicy"]
 }
 
 resource "azurerm_key_vault_key" "test" {

--- a/internal/services/mysql/mysql_server_key_resource_test.go
+++ b/internal/services/mysql/mysql_server_key_resource_test.go
@@ -111,7 +111,7 @@ resource "azurerm_key_vault_access_policy" "server" {
   key_vault_id       = azurerm_key_vault.test.id
   tenant_id          = data.azurerm_client_config.current.tenant_id
   object_id          = azurerm_mysql_server.test.identity.0.principal_id
-  key_permissions    = ["Get", "UnwrapKey", "WrapKey"]
+  key_permissions    = ["Get", "UnwrapKey", "WrapKey", "GetRotationPolicy", "SetRotationPolicy"]
   secret_permissions = ["Get"]
 }
 
@@ -119,7 +119,7 @@ resource "azurerm_key_vault_access_policy" "client" {
   key_vault_id       = azurerm_key_vault.test.id
   tenant_id          = data.azurerm_client_config.current.tenant_id
   object_id          = data.azurerm_client_config.current.object_id
-  key_permissions    = ["Get", "Create", "Delete", "List", "Restore", "Recover", "UnwrapKey", "WrapKey", "Purge", "Encrypt", "Decrypt", "Sign", "Verify"]
+  key_permissions    = ["Get", "Create", "Delete", "List", "Restore", "Recover", "UnwrapKey", "WrapKey", "Purge", "Encrypt", "Decrypt", "Sign", "Verify", "GetRotationPolicy", "SetRotationPolicy"]
   secret_permissions = ["Get"]
 }
 

--- a/internal/services/postgres/postgresql_flexible_server_resource_test.go
+++ b/internal/services/postgres/postgresql_flexible_server_resource_test.go
@@ -784,7 +784,7 @@ resource "azurerm_key_vault_access_policy" "server" {
   tenant_id    = data.azurerm_client_config.current.tenant_id
   object_id    = azurerm_user_assigned_identity.test.principal_id
 
-  key_permissions = ["Get", "List", "WrapKey", "UnwrapKey"]
+  key_permissions = ["Get", "List", "WrapKey", "UnwrapKey", "GetRotationPolicy", "SetRotationPolicy"]
 }
 
 resource "azurerm_key_vault_access_policy" "client" {
@@ -792,7 +792,7 @@ resource "azurerm_key_vault_access_policy" "client" {
   tenant_id    = data.azurerm_client_config.current.tenant_id
   object_id    = data.azurerm_client_config.current.object_id
 
-  key_permissions = ["Get", "Create", "Delete", "List", "Restore", "Recover", "UnwrapKey", "WrapKey", "Purge", "Encrypt", "Decrypt", "Sign", "Verify"]
+  key_permissions = ["Get", "Create", "Delete", "List", "Restore", "Recover", "UnwrapKey", "WrapKey", "Purge", "Encrypt", "Decrypt", "Sign", "Verify", "GetRotationPolicy", "SetRotationPolicy"]
 }
 
 resource "azurerm_key_vault_key" "test" {

--- a/internal/services/postgres/postgresql_server_key_resource_test.go
+++ b/internal/services/postgres/postgresql_server_key_resource_test.go
@@ -128,7 +128,7 @@ resource "azurerm_key_vault_access_policy" "server" {
   tenant_id    = data.azurerm_client_config.current.tenant_id
   object_id    = azurerm_postgresql_server.test.identity.0.principal_id
 
-  key_permissions    = ["Get", "UnwrapKey", "WrapKey"]
+  key_permissions    = ["Get", "UnwrapKey", "WrapKey", "GetRotationPolicy", "SetRotationPolicy"]
   secret_permissions = ["Get"]
 }
 
@@ -137,7 +137,7 @@ resource "azurerm_key_vault_access_policy" "client" {
   tenant_id    = data.azurerm_client_config.current.tenant_id
   object_id    = data.azurerm_client_config.current.object_id
 
-  key_permissions    = ["Get", "Create", "Delete", "List", "Restore", "Recover", "UnwrapKey", "WrapKey", "Purge", "Encrypt", "Decrypt", "Sign", "Verify"]
+  key_permissions    = ["Get", "Create", "Delete", "List", "Restore", "Recover", "UnwrapKey", "WrapKey", "Purge", "Encrypt", "Decrypt", "Sign", "Verify", "GetRotationPolicy", "SetRotationPolicy"]
   secret_permissions = ["Get"]
 }
 
@@ -224,7 +224,7 @@ resource "azurerm_key_vault_access_policy" "replica" {
   tenant_id    = data.azurerm_client_config.current.tenant_id
   object_id    = azurerm_postgresql_server.replica.identity.0.principal_id
 
-  key_permissions    = ["Get", "UnwrapKey", "WrapKey"]
+  key_permissions    = ["Get", "UnwrapKey", "WrapKey", "GetRotationPolicy", "SetRotationPolicy"]
   secret_permissions = ["Get"]
 }
 


### PR DESCRIPTION
After this [PR ](https://github.com/hashicorp/terraform-provider-azurerm/pull/19113)was merged, some acc tests failed with the error "current client lacks permissions to read Key Rotation Policy for Key...". So submit this PR to add permission to keyvault to support auto-rotation to fix acc tests failure.

Tests:
PASS: TestAccMySQLServerKey_basic (511.95s)
PASS: TestAccMySQLServerKey_updateKey (618.39s)
PASS: TestAccMySqlFlexibleServer_updateToCustomerManagedKey (1034.07s)
PASS: TestAccMySqlFlexibleServer_createWithCustomerManagedKey (1198.96s)
PASS: TestAccMySQLServerKey_requiresImport (568.74s)
PASS: TestAccPostgresqlFlexibleServer_createWithCustomerManagedKey (1181.62s)
PASS: TestAccPostgreSQLServerKey_basic (511.04s)
PASS: TestAccPostgreSQLServerKey_updateKey (642.74s)
PASS: TestAccPostgreSQLServerKey_requiresImport (535.14s)
PASS: TestAccPostgreSQLServerKey_replica (727.96s)
