### PR TITLE
azurerm_client_config - export environment_name

### DIFF
--- a/internal/services/authorization/client_config_data_source.go
+++ b/internal/services/authorization/client_config_data_source.go
@@ -38,6 +38,11 @@ func dataSourceArmClientConfig() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
 			},
+
+			"environment_name": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -53,6 +58,7 @@ func dataSourceArmClientConfigRead(d *pluginsdk.ResourceData, meta interface{}) 
 	d.Set("object_id", client.Account.ObjectId)
 	d.Set("subscription_id", client.Account.SubscriptionId)
 	d.Set("tenant_id", client.Account.TenantId)
+	d.Set("environment_name", client.Account.Environment.Name)
 
 	return nil
 }

--- a/internal/services/authorization/client_config_data_source_test.go
+++ b/internal/services/authorization/client_config_data_source_test.go
@@ -16,6 +16,7 @@ func TestAccClientConfigDataSource_basic(t *testing.T) {
 	clientId := os.Getenv("ARM_CLIENT_ID")
 	tenantId := os.Getenv("ARM_TENANT_ID")
 	subscriptionId := os.Getenv("ARM_SUBSCRIPTION_ID")
+	environment := os.Getenv("ARM_ENVIRONMENT")
 	objectIdRegex := regexp.MustCompile("^[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$")
 
 	data.DataSourceTest(t, []acceptance.TestStep{
@@ -25,6 +26,7 @@ func TestAccClientConfigDataSource_basic(t *testing.T) {
 				check.That(data.ResourceName).Key("client_id").HasValue(clientId),
 				check.That(data.ResourceName).Key("tenant_id").HasValue(tenantId),
 				check.That(data.ResourceName).Key("subscription_id").HasValue(subscriptionId),
+				check.That(data.ResourceName).Key("environment_name").HasValue(environment),
 				check.That(data.ResourceName).Key("object_id").MatchesRegex(objectIdRegex),
 			),
 		},

--- a/website/docs/d/client_config.html.markdown
+++ b/website/docs/d/client_config.html.markdown
@@ -31,6 +31,7 @@ There are no arguments available for this data source.
 * `tenant_id` is set to the Azure Tenant ID.
 * `subscription_id` is set to the Azure Subscription ID.
 * `object_id` is set to the Azure Object ID.
+* `environment_name` is set to the configured Cloud Environment.
 
 ---
 


### PR DESCRIPTION
Add an attribute to azurerm_client_config with the configured cloud environment used by the provider.
Fixes #20818