### PR TITLE
Bugfix: fix missing use of `oidc_token_file_path`, CLI auth with Cloud Shell

### DIFF
--- a/.github/workflows/provider-test.yml
+++ b/.github/workflows/provider-test.yml
@@ -48,10 +48,10 @@ jobs:
 
       - name: Set OIDC Token
         run: |
-          echo "ARM_OIDC_TOKEN=$(curl -H "Accept: application/json; api-version=2.0" -H "Authorization: Bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" -H "Content-Type: application/json" -G --data-urlencode "audience=api://AzureADTokenExchange" "${ACTIONS_ID_TOKEN_REQUEST_URL}" | jq -r '.value')"  >>${GITHUB_ENV}
+          echo "ARM_OIDC_TOKEN=$(curl -H "Accept: application/json; api-version=2.0" -H "Authorization: Bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" -H "Content-Type: application/json" -G --data-urlencode "audience=api://AzureADTokenExchange" "${ACTIONS_ID_TOKEN_REQUEST_URL}" | jq -r '.value')" >>${GITHUB_ENV}
 
       - name: Set OIDC Token File Path
-        run: echo "${ARM_OIDC_TOKEN}" >"${TMPDIR}/oidc-token.jwt"
+        run: echo "${ARM_OIDC_TOKEN}" >"${RUNNER_TEMP}/oidc-token.jwt" && echo "ARM_OIDC_TOKEN_FILE_PATH=${RUNNER_TEMP}/oidc-token.jwt" >>${GITHUB_ENV}
 
       - name: Run provider tests
         run: make testacc TEST=./internal/provider TESTARGS="-run '^TestAcc'"
@@ -64,7 +64,7 @@ jobs:
           ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
 
       - name: Clean Up OIDC Token File Path
-        run: rm -f "${TMPDIR}/oidc-token.jwt"
+        run: rm -f "${RUNNER_TEMP}/oidc-token.jwt"
         if: always()
 
 # vim: set ts=2 sts=2 sw=2 et:

--- a/.github/workflows/provider-test.yml
+++ b/.github/workflows/provider-test.yml
@@ -35,6 +35,14 @@ jobs:
     needs: [secrets-check]
     if: needs.secrets-check.outputs.available == 'true'
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: ./.go-version
+
       - name: Azure CLI login
         run: az login --output none --username="${{ secrets.AZCLI_USERNAME }}" --password="${{ secrets.AZCLI_PASSWORD }}"
 
@@ -44,14 +52,6 @@ jobs:
 
       - name: Set OIDC Token File Path
         run: echo "${ARM_OIDC_TOKEN}" >"${TMPDIR}/oidc-token.jwt"
-
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Install Go
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: ./.go-version
 
       - name: Run provider tests
         run: make testacc TEST=./internal/provider TESTARGS="-run '^TestAcc'"
@@ -65,5 +65,6 @@ jobs:
 
       - name: Clean Up OIDC Token File Path
         run: rm -f "${TMPDIR}/oidc-token.jwt"
+        if: always()
 
 # vim: set ts=2 sts=2 sw=2 et:

--- a/.github/workflows/provider-test.yml
+++ b/.github/workflows/provider-test.yml
@@ -42,6 +42,9 @@ jobs:
         run: |
           echo "ARM_OIDC_TOKEN=$(curl -H "Accept: application/json; api-version=2.0" -H "Authorization: Bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" -H "Content-Type: application/json" -G --data-urlencode "audience=api://AzureADTokenExchange" "${ACTIONS_ID_TOKEN_REQUEST_URL}" | jq -r '.value')"  >>${GITHUB_ENV}
 
+      - name: Set OIDC Token File Path
+        run: echo "${ARM_OIDC_TOKEN}" >"${TMPDIR}/oidc-token.jwt"
+
       - name: Checkout
         uses: actions/checkout@v3
 
@@ -59,5 +62,8 @@ jobs:
           ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
           ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
           ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
+
+      - name: Clean Up OIDC Token File Path
+        run: rm -f "${TMPDIR}/oidc-token.jwt"
 
 # vim: set ts=2 sts=2 sw=2 et:

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -366,9 +366,13 @@ func providerConfigure(p *schema.Provider) schema.ConfigureContextFunc {
 			}
 		}
 
+		oidcToken, err := getOidcToken(d)
+		if err != nil {
+			return nil, diag.FromErr(err)
+		}
+
 		var (
 			env *environments.Environment
-			err error
 
 			envName      = d.Get("environment").(string)
 			metadataHost = d.Get("metadata_host").(string)
@@ -399,7 +403,7 @@ func providerConfigure(p *schema.Provider) schema.ConfigureContextFunc {
 			ClientCertificatePassword: d.Get("client_certificate_password").(string),
 			ClientSecret:              d.Get("client_secret").(string),
 
-			OIDCAssertionToken:          d.Get("oidc_token").(string),
+			OIDCAssertionToken:          *oidcToken,
 			GitHubOIDCTokenRequestURL:   d.Get("oidc_request_url").(string),
 			GitHubOIDCTokenRequestToken: d.Get("oidc_request_token").(string),
 
@@ -482,6 +486,28 @@ func decodeCertificate(clientCertificate string) ([]byte, error) {
 		pfx = out[:n]
 	}
 	return pfx, nil
+}
+
+func getOidcToken(d *schema.ResourceData) (*string, error) {
+	idToken := strings.TrimSpace(d.Get("oidc_token").(string))
+
+	if path := d.Get("oidc_token_file_path").(string); path != "" {
+		fileTokenRaw, err := os.ReadFile(path)
+
+		if err != nil {
+			return nil, fmt.Errorf("reading OIDC Token from file %q: %v", path, err)
+		}
+
+		fileToken := strings.TrimSpace(string(fileTokenRaw))
+
+		if idToken != "" && idToken != fileToken {
+			return nil, fmt.Errorf("mismatch between supplied OIDC token and supplied OIDC token file contents - please either remove one or ensure they match")
+		}
+
+		idToken = string(fileToken)
+	}
+
+	return &idToken, nil
 }
 
 const resourceProviderRegistrationErrorFmt = `Error ensuring Resource Providers are registered.

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -504,7 +504,7 @@ func getOidcToken(d *schema.ResourceData) (*string, error) {
 			return nil, fmt.Errorf("mismatch between supplied OIDC token and supplied OIDC token file contents - please either remove one or ensure they match")
 		}
 
-		idToken = string(fileToken)
+		idToken = fileToken
 	}
 
 	return &idToken, nil

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -271,8 +271,8 @@ func TestAccProvider_genericOidcAuth(t *testing.T) {
 	if os.Getenv("TF_ACC") == "" {
 		t.Skip("TF_ACC not set")
 	}
-	if os.Getenv("ARM_OIDC_TOKEN") == "" {
-		t.Skip("ARM_OIDC_TOKEN not set")
+	if os.Getenv("ARM_OIDC_TOKEN") == "" && os.Getenv("ARM_OIDC_TOKEN_FILE_PATH") == "" {
+		t.Skip("ARM_OIDC_TOKEN or ARM_OIDC_TOKEN_FILE_PATH not set")
 	}
 
 	logging.SetOutput(t)
@@ -289,12 +289,17 @@ func TestAccProvider_genericOidcAuth(t *testing.T) {
 			t.Fatalf("configuring environment %q: %v", envName, err)
 		}
 
+		oidcToken, err := getOidcToken(d)
+		if err != nil {
+			return nil, diag.FromErr(err)
+		}
+
 		authConfig := &auth.Credentials{
 			Environment:                   *env,
 			TenantID:                      d.Get("tenant_id").(string),
 			ClientID:                      d.Get("client_id").(string),
 			EnableAuthenticationUsingOIDC: true,
-			OIDCAssertionToken:            d.Get("oidc_token").(string),
+			OIDCAssertionToken:            *oidcToken,
 		}
 
 		return buildClient(ctx, provider, d, authConfig)


### PR DESCRIPTION
- **provider:** fix an issue with authentication using `oidc_token_file_path`
- **provider:** fix an issue with Azure CLI authentication when running in Azure Cloud Shell

Closes: https://github.com/hashicorp/terraform-provider-azurerm/issues/20674
Closes: https://github.com/hashicorp/terraform-provider-azurerm/issues/20794