### PR TITLE
`azurerm_iothub` - update computed props in `file_upload` to default

### DIFF
--- a/internal/services/iothub/iothub_resource.go
+++ b/internal/services/iothub/iothub_resource.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	eventhubValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/eventhub/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/iothub/migration"
@@ -215,20 +216,38 @@ func resourceIotHub() *pluginsdk.Resource {
 						"sas_ttl": {
 							Type:         pluginsdk.TypeString,
 							Optional:     true,
-							Computed:     true,
+							Computed:     !features.FourPointOhBeta(),
 							ValidateFunc: validate.ISO8601Duration,
+							Default: func() interface{} {
+								if !features.FourPointOhBeta() {
+									return nil
+								}
+								return "PT1H"
+							}(),
 						},
 						"default_ttl": {
 							Type:         pluginsdk.TypeString,
 							Optional:     true,
-							Computed:     true,
+							Computed:     !features.FourPointOhBeta(),
 							ValidateFunc: validate.ISO8601Duration,
+							Default: func() interface{} {
+								if !features.FourPointOhBeta() {
+									return nil
+								}
+								return "PT1H"
+							}(),
 						},
 						"lock_duration": {
 							Type:         pluginsdk.TypeString,
 							Optional:     true,
-							Computed:     true,
+							Computed:     !features.FourPointOhBeta(),
 							ValidateFunc: validate.ISO8601Duration,
+							Default: func() interface{} {
+								if !features.FourPointOhBeta() {
+									return nil
+								}
+								return "PT1M"
+							}(),
 						},
 					},
 				},

--- a/internal/services/iothub/iothub_resource_test.go
+++ b/internal/services/iothub/iothub_resource_test.go
@@ -158,6 +158,9 @@ func TestAccIotHub_fileUpload(t *testing.T) {
 			Config: r.fileUploadBasic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("file_upload.0.default_ttl").HasValue("PT1H"),
+				check.That(data.ResourceName).Key("file_upload.0.lock_duration").HasValue("PT1M"),
+				check.That(data.ResourceName).Key("file_upload.0.sas_ttl").HasValue("PT1H"),
 			),
 		},
 		data.ImportStep(),


### PR DESCRIPTION
Updating acc test to check default value as well
Document already has the default values available:
https://github.com/hashicorp/terraform-provider-azurerm/blob/f5f5f2ee4b0971fe70d2550510e4103fae64c817/website/docs/r/iothub.html.markdown?plain=1#L297-L303
Azure document for reference: https://learn.microsoft.com/azure/iot-hub/iot-hub-devguide-file-upload#file-upload-settings