### PR TITLE
`azurerm_network_manager_scope_connection`, `azurerm_network_manager_subscription_connection`, `azurerm_network_manager_management_group_connection` - add resource delete check

### DIFF
--- a/internal/services/network/network_manager_management_group_connection_resource.go
+++ b/internal/services/network/network_manager_management_group_connection_resource.go
@@ -234,6 +234,34 @@ func (r ManagerManagementGroupConnectionResource) Delete() sdk.ResourceFunc {
 				return fmt.Errorf("deleting %s: %+v", id, err)
 			}
 
+			deadline, ok := ctx.Deadline()
+			if !ok {
+				return fmt.Errorf("context had no deadline")
+			}
+
+			// confirm the connection is fully deleted
+			stateChangeConf := &pluginsdk.StateChangeConf{
+				Pending: []string{"Exists"},
+				Target:  []string{"NotFound"},
+				Refresh: func() (result interface{}, state string, err error) {
+					resp, err := client.Get(ctx, id.ManagementGroupName, id.NetworkManagerConnectionName)
+					if err != nil {
+						if utils.ResponseWasNotFound(resp.Response) {
+							return "NotFound", "NotFound", nil
+						}
+						return "Error", "Error", err
+					}
+					return resp, "Exists", nil
+				},
+				PollInterval:              3 * time.Second,
+				ContinuousTargetOccurence: 3,
+				Timeout:                   time.Until(deadline),
+			}
+
+			if _, err = stateChangeConf.WaitForStateContext(ctx); err != nil {
+				return fmt.Errorf("waiting for %s to be deleted: %+v", id, err)
+			}
+
 			return nil
 		},
 	}

--- a/internal/services/network/network_manager_scope_connection_resource.go
+++ b/internal/services/network/network_manager_scope_connection_resource.go
@@ -253,6 +253,33 @@ func (r ManagerScopeConnectionResource) Delete() sdk.ResourceFunc {
 				return fmt.Errorf("deleting %s: %+v", id, err)
 			}
 
+			deadline, ok := ctx.Deadline()
+			if !ok {
+				return fmt.Errorf("context had no deadline")
+			}
+
+			// confirm the connection is fully deleted
+			stateChangeConf := &pluginsdk.StateChangeConf{
+				Pending: []string{"Exists"},
+				Target:  []string{"NotFound"},
+				Refresh: func() (result interface{}, state string, err error) {
+					resp, err := client.Get(ctx, id.ResourceGroup, id.NetworkManagerName, id.ScopeConnectionName)
+					if err != nil {
+						if utils.ResponseWasNotFound(resp.Response) {
+							return "NotFound", "NotFound", nil
+						}
+						return "Error", "Error", err
+					}
+					return resp, "Exists", nil
+				},
+				MinTimeout:                3 * time.Second,
+				ContinuousTargetOccurence: 3,
+				Timeout:                   time.Until(deadline),
+			}
+
+			if _, err = stateChangeConf.WaitForStateContext(ctx); err != nil {
+				return fmt.Errorf("waiting for %s to be deleted: %+v", id, err)
+			}
 			return nil
 		},
 	}

--- a/internal/services/network/network_manager_subscription_connection_resource.go
+++ b/internal/services/network/network_manager_subscription_connection_resource.go
@@ -232,6 +232,34 @@ func (r ManagerSubscriptionConnectionResource) Delete() sdk.ResourceFunc {
 				return fmt.Errorf("deleting %s: %+v", id, err)
 			}
 
+			deadline, ok := ctx.Deadline()
+			if !ok {
+				return fmt.Errorf("context had no deadline")
+			}
+
+			// confirm the connection is fully deleted
+			stateChangeConf := &pluginsdk.StateChangeConf{
+				Pending: []string{"Exists"},
+				Target:  []string{"NotFound"},
+				Refresh: func() (result interface{}, state string, err error) {
+					resp, err := client.Get(ctx, id.NetworkManagerConnectionName)
+					if err != nil {
+						if utils.ResponseWasNotFound(resp.Response) {
+							return "NotFound", "NotFound", nil
+						}
+						return "Error", "Error", err
+					}
+					return resp, "Exists", nil
+				},
+				MinTimeout:                3 * time.Second,
+				ContinuousTargetOccurence: 3,
+				Timeout:                   time.Until(deadline),
+			}
+
+			if _, err = stateChangeConf.WaitForStateContext(ctx); err != nil {
+				return fmt.Errorf("waiting for %s to be deleted: %+v", id, err)
+			}
+
 			return nil
 		},
 	}


### PR DESCRIPTION
Add `stateChangeConf.WaitForStateContext(ctx)` to make sure the connection is deleted.

