### PR TITLE
`azurerm_container_registry_task` - Fix updating failed due to incomplete `registry_credential`

### DIFF
--- a/internal/services/containers/container_registry_task_resource.go
+++ b/internal/services/containers/container_registry_task_resource.go
@@ -917,9 +917,10 @@ func (r ContainerRegistryTaskResource) Update() sdk.ResourceFunc {
 				}
 				existing.Identity = expandedIdentity
 			}
-			if metadata.ResourceData.HasChange("registry_credential") {
-				existing.TaskProperties.Credentials = expandRegistryTaskCredentials(model.RegistryCredential)
-			}
+
+			// Deliberately always set "registry_credential" as the custom registry's credentials are not returned by API, but are required for a PUT request.
+			existing.TaskProperties.Credentials = expandRegistryTaskCredentials(model.RegistryCredential)
+
 			if metadata.ResourceData.HasChange("agent_setting") {
 				existing.TaskProperties.AgentConfiguration = expandRegistryTaskAgentProperties(model.AgentConfig)
 			}

--- a/internal/services/containers/container_registry_task_resource_test.go
+++ b/internal/services/containers/container_registry_task_resource_test.go
@@ -389,7 +389,22 @@ func TestAccContainerRegistryTask_fileTaskStepRegistryCredential(t *testing.T) {
 			"registry_credential.0.custom.0.username",
 		),
 		{
-			Config: r.fileTaskStepRegistryCredentialIdentity(data),
+			Config: r.fileTaskStepRegistryCredentialIdentity(data, "foo"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(
+			"file_step.0.context_access_token",
+			"registry_credential.0.custom.#",
+			"registry_credential.0.custom.0.%",
+			"registry_credential.0.custom.0.identity",
+			"registry_credential.0.custom.0.login_server",
+			"registry_credential.0.custom.0.password",
+			"registry_credential.0.custom.0.username",
+		),
+		{
+			Config: r.fileTaskStepRegistryCredentialIdentity(data, "bar"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -963,7 +978,7 @@ resource "azurerm_container_registry_task" "test" {
 `, template, data.RandomInteger, data.RandomInteger, r.githubRepo.url, r.githubRepo.token, os.Getenv("ARM_CLIENT_ID"), os.Getenv("ARM_CLIENT_SECRET"))
 }
 
-func (r ContainerRegistryTaskResource) fileTaskStepRegistryCredentialIdentity(data acceptance.TestData) string {
+func (r ContainerRegistryTaskResource) fileTaskStepRegistryCredentialIdentity(data acceptance.TestData, tag string) string {
 	template := r.template(data)
 	return fmt.Sprintf(`
 %s
@@ -998,8 +1013,11 @@ resource "azurerm_container_registry_task" "test" {
       identity     = "[system]"
     }
   }
+  tags = {
+    foo = "%s"
+  }
 }
-`, template, data.RandomInteger, data.RandomInteger, r.githubRepo.url, r.githubRepo.token)
+`, template, data.RandomInteger, data.RandomInteger, r.githubRepo.url, r.githubRepo.token, tag)
 }
 
 func (r ContainerRegistryTaskResource) systemTask(data acceptance.TestData) string {


### PR DESCRIPTION
Fix #20803 

## Test

```shell
💤  TF_ACC=1 go test -v -timeout=20h ./internal/services/containers -run='TestAccContainerRegistryTask_fileTaskStepRegistryCredential'
=== RUN   TestAccContainerRegistryTask_fileTaskStepRegistryCredential
=== PAUSE TestAccContainerRegistryTask_fileTaskStepRegistryCredential
=== CONT  TestAccContainerRegistryTask_fileTaskStepRegistryCredential
--- PASS: TestAccContainerRegistryTask_fileTaskStepRegistryCredential (338.17s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/containers    338.180s
```