### PR TITLE
`azurerm_iothub` - Fix wrong default value of `file_upload.sas_ttl` when not specified

### DIFF
--- a/internal/services/iothub/iothub_resource.go
+++ b/internal/services/iothub/iothub_resource.go
@@ -1012,10 +1012,13 @@ func expandIoTHubFileUpload(d *pluginsdk.ResourceData) (map[string]*devices.Stor
 		lockDuration := fileUploadMap["lock_duration"].(string)
 
 		storageEndpointProperties["$default"] = &devices.StorageEndpointProperties{
-			SasTTLAsIso8601:    &sasTTL,
 			AuthenticationType: authenticationType,
 			ConnectionString:   &connectionStr,
 			ContainerName:      &containerName,
+		}
+
+		if sasTTL != "" {
+			storageEndpointProperties["$default"].SasTTLAsIso8601 = &sasTTL
 		}
 
 		if identityId != "" {


### PR DESCRIPTION
`SasTTLAsIso8601` is set to a different value other than the default value `PT1H` by server when it's set to an empty string. Fixing the issue by only setting it when it has value, which will let the server set to its default value `PT1H`.

This is captured by the recent update to the test case for checking the default value #20825
------- Stdout: -------
=== RUN TestAccIotHub_fileUpload
=== PAUSE TestAccIotHub_fileUpload
=== CONT TestAccIotHub_fileUpload
testcase.go:110: Step 1/4 error: Check failed: Check 4/4 error: azurerm_iothub.test: Attribute 'file_upload.0.sas_ttl' expected "PT1H", got "PT1M"
--- FAIL: TestAccIotHub_fileUpload (301.99s)
FAIL