### PR TITLE
`azurerm_key_vault_managed_hardware_security_module` - support for `activate_config`

### DIFF
--- a/internal/clients/builder.go
+++ b/internal/clients/builder.go
@@ -106,6 +106,11 @@ func Build(ctx context.Context, builder ClientBuilder) (*Client, error) {
 		return nil, fmt.Errorf("building account: %+v", err)
 	}
 
+	managedHSMAuth, err := auth.NewAuthorizerFromCredentials(ctx, *builder.AuthConfig, builder.AuthConfig.Environment.ManagedHSM)
+	if err != nil {
+		return nil, fmt.Errorf("unable to build authorizer for Managed HSM API: %+v", err)
+	}
+
 	client := Client{
 		Account: account,
 	}
@@ -114,6 +119,7 @@ func Build(ctx context.Context, builder ClientBuilder) (*Client, error) {
 		Authorizers: &common.Authorizers{
 			BatchManagement: batchManagementAuth,
 			KeyVault:        keyVaultAuth,
+			ManagedHSM:      managedHSMAuth,
 			ResourceManager: resourceManagerAuth,
 			Storage:         storageAuth,
 			Synapse:         synapseAuth,
@@ -130,6 +136,7 @@ func Build(ctx context.Context, builder ClientBuilder) (*Client, error) {
 
 		BatchManagementAuthorizer: authWrapper.AutorestAuthorizer(batchManagementAuth),
 		KeyVaultAuthorizer:        authWrapper.AutorestAuthorizer(keyVaultAuth).BearerAuthorizerCallback(),
+		ManagedHSMAuthorizer:      authWrapper.AutorestAuthorizer(managedHSMAuth).BearerAuthorizerCallback(),
 		ResourceManagerAuthorizer: authWrapper.AutorestAuthorizer(resourceManagerAuth),
 		StorageAuthorizer:         authWrapper.AutorestAuthorizer(storageAuth),
 		SynapseAuthorizer:         authWrapper.AutorestAuthorizer(synapseAuth),

--- a/internal/common/client_options.go
+++ b/internal/common/client_options.go
@@ -20,6 +20,7 @@ import (
 type Authorizers struct {
 	BatchManagement auth.Authorizer
 	KeyVault        auth.Authorizer
+	ManagedHSM      auth.Authorizer
 	ResourceManager auth.Authorizer
 	Storage         auth.Authorizer
 	Synapse         auth.Authorizer
@@ -55,6 +56,7 @@ type ClientOptions struct {
 	AttestationAuthorizer     autorest.Authorizer
 	BatchManagementAuthorizer autorest.Authorizer
 	KeyVaultAuthorizer        autorest.Authorizer
+	ManagedHSMAuthorizer      autorest.Authorizer
 	ResourceManagerAuthorizer autorest.Authorizer
 	StorageAuthorizer         autorest.Authorizer
 	SynapseAuthorizer         autorest.Authorizer

--- a/internal/services/keyvault/client/client.go
+++ b/internal/services/keyvault/client/client.go
@@ -11,6 +11,9 @@ type Client struct {
 	ManagedHsmClient *managedhsms.ManagedHsmsClient
 	ManagementClient *dataplane.BaseClient
 	VaultsClient     *vaults.VaultsClient
+
+	MHSMSDClient   *dataplane.HSMSecurityDomainClient
+	MHSMRoleClient *dataplane.RoleDefinitionsClient
 }
 
 func NewClient(o *common.ClientOptions) *Client {
@@ -21,11 +24,20 @@ func NewClient(o *common.ClientOptions) *Client {
 	o.ConfigureClient(&managementClient.Client, o.KeyVaultAuthorizer)
 
 	vaultsClient := vaults.NewVaultsClientWithBaseURI(o.ResourceManagerEndpoint)
+
+	sdClient := dataplane.NewHSMSecurityDomainClient()
+	o.ConfigureClient(&sdClient.Client, o.ManagedHSMAuthorizer)
+
+	mhsmRoleDefineClient := dataplane.NewRoleDefinitionsClient()
+	o.ConfigureClient(&mhsmRoleDefineClient.Client, o.ManagedHSMAuthorizer)
+
 	o.ConfigureClient(&vaultsClient.Client, o.ResourceManagerAuthorizer)
 
 	return &Client{
 		ManagedHsmClient: &managedHsmClient,
 		ManagementClient: &managementClient,
 		VaultsClient:     &vaultsClient,
+		MHSMSDClient:     &sdClient,
+		MHSMRoleClient:   &mhsmRoleDefineClient,
 	}
 }

--- a/internal/services/keyvault/key_vault_managed_hardware_security_module_resource.go
+++ b/internal/services/keyvault/key_vault_managed_hardware_security_module_resource.go
@@ -110,7 +110,7 @@ func resourceKeyVaultManagedHardwareSecurityModule() *pluginsdk.Resource {
 			"public_network_access_enabled": {
 				Type:     pluginsdk.TypeBool,
 				Optional: true,
-				//Computed: true,
+				// Computed: true,
 				Default:  true,
 				ForceNew: true,
 			},
@@ -148,7 +148,7 @@ func resourceKeyVaultManagedHardwareSecurityModule() *pluginsdk.Resource {
 				MaxItems: 1,
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*schema.Schema{
-						"certificate_ids": {
+						"activation_key_vault_certificate_ids": {
 							Type:     pluginsdk.TypeSet,
 							MinItems: 3,
 							MaxItems: 10,
@@ -230,7 +230,7 @@ func resourceArmKeyVaultManagedHardwareSecurityModuleCreate(d *pluginsdk.Resourc
 	// security domain download to activate this module
 	if certs := d.Get("activate_config").([]interface{}); len(certs) > 0 && (certs)[0] != nil {
 		// get hsm uri
-		resp, err := hsmClient.Get(ctx, id)
+		resp, _ := hsmClient.Get(ctx, id)
 		hsmUri := ""
 		if resp.Model != nil && resp.Model.Properties != nil && resp.Model.Properties.HsmUri != nil {
 			hsmUri = *resp.Model.Properties.HsmUri
@@ -272,7 +272,6 @@ func resourceArmKeyVaultManagedHardwareSecurityModuleUpdate(d *pluginsdk.Resourc
 
 	// if it has activate_config but with no enc data in stat, try to activate it
 	if certs := d.Get("activate_config").([]interface{}); len(certs) > 0 && certs[0] != nil &&
-		//d.Get("security_domain_encrypted_data").(string) == "" {
 		d.HasChange("activate_config") {
 		// get hsm uri
 		encData, err := securityDomainDownload(ctx,
@@ -436,7 +435,7 @@ func securityDomainDownload(ctx context.Context, cli *client.Client, vaultBaseUR
 
 	var param kv74.CertificateInfoObject
 	var qourum = config["security_domain_quorum"].(int)
-	certIDs := config["certificate_ids"].(*pluginsdk.Set).List()
+	certIDs := config["activation_key_vault_certificate_ids"].(*pluginsdk.Set).List()
 
 	param.Required = utils.Int32(int32(qourum))
 	var certs []kv74.SecurityDomainJSONWebKey

--- a/internal/services/keyvault/key_vault_managed_hardware_security_module_resource.go
+++ b/internal/services/keyvault/key_vault_managed_hardware_security_module_resource.go
@@ -224,21 +224,8 @@ func resourceArmKeyVaultManagedHardwareSecurityModuleCreate(d *pluginsdk.Resourc
 	}
 
 	if err := hsmClient.CreateOrUpdateThenPoll(ctx, id, hsm); err != nil {
-		//=======
-		//	// do NOT retry if failed, for it takes too long to create and will not success. let it fail
-		//	// but `hsmClient` is a shared variable such change may cause data-race, but it should be fine for a hsmClient tool
-		//	retry := hsmClient.Client.RetryAttempts
-		//	hsmClient.Client.RetryAttempts = 1
-		//	future, err := hsmClient.CreateOrUpdate(ctx, id.ResourceGroup, id.Name, hsm)
-		//	if err != nil {
-		//>>>>>>> b215a3b91d (activate mhsm in create/update with certificate)
 		return fmt.Errorf("creating %s: %+v", id, err)
 	}
-	//hsmClient.Client.RetryAttempts = retry
-	//
-	//if err = future.WaitForCompletionRef(ctx, hsmClient.Client); err != nil {
-	//	return fmt.Errorf("waiting on creation for %s: %+v", id, err)
-	//}
 
 	// security domain download to activate this module
 	if certs := d.Get("activate_config").([]interface{}); len(certs) > 0 && (certs)[0] != nil {

--- a/internal/services/keyvault/key_vault_managed_hardware_security_module_resource_test.go
+++ b/internal/services/keyvault/key_vault_managed_hardware_security_module_resource_test.go
@@ -166,8 +166,8 @@ func (r KeyVaultManagedHardwareSecurityModuleResource) download(data acceptance.
 	activateConfig := ""
 	if certCount > 0 {
 		activateConfig = `activate_config {
-		certificate_ids 	   = [for cert in azurerm_key_vault_certificate.cert : cert.id]
-		security_domain_quorum = 2
+		activation_key_vault_certificate_ids = [for cert in azurerm_key_vault_certificate.cert : cert.id]
+		security_domain_quorum 				 = 2
 	}`
 	}
 

--- a/internal/services/keyvault/key_vault_managed_hardware_security_module_resource_test.go
+++ b/internal/services/keyvault/key_vault_managed_hardware_security_module_resource_test.go
@@ -19,14 +19,12 @@ func TestAccKeyVaultManagedHardwareSecurityModule(t *testing.T) {
 	// NOTE: this is a combined test rather than separate split out tests due to
 	// Azure only being able provision against one instance at a time
 	acceptance.RunTestsInSequence(t, map[string]map[string]func(t *testing.T){
-		//"data_source": {
-		//	"basic": testAccDataSourceKeyVaultManagedHardwareSecurityModule_basic,
-		//},
 		"resource": {
-			//"basic":    testAccKeyVaultManagedHardwareSecurityModule_basic,
-			//"update":   testAccKeyVaultManagedHardwareSecurityModule_requiresImport,
-			//"complete": testAccKeyVaultManagedHardwareSecurityModule_complete,
-			"download": testAccKeyVaultManagedHardwareSecurityModule_download,
+			"data_source": testAccDataSourceKeyVaultManagedHardwareSecurityModule_basic,
+			"basic":       testAccKeyVaultManagedHardwareSecurityModule_basic,
+			"update":      testAccKeyVaultManagedHardwareSecurityModule_requiresImport,
+			"complete":    testAccKeyVaultManagedHardwareSecurityModule_complete,
+			"download":    testAccKeyVaultManagedHardwareSecurityModule_download,
 		},
 	})
 }

--- a/internal/services/keyvault/parse/nested_item_test.go
+++ b/internal/services/keyvault/parse/nested_item_test.go
@@ -30,6 +30,12 @@ func TestNewNestedItemID(t *testing.T) {
 			Expected:        "https://test.vault.azure.net/keys/test/testVersionString",
 			ExpectError:     false,
 		},
+		{
+			Scenario:        "mhsm valid, with port",
+			keyVaultBaseUrl: "https://test.managedhsm.azure.net:443",
+			Expected:        "https://test.managedhsm.azure.net/keys/test/testVersionString",
+			ExpectError:     false,
+		},
 	}
 	for _, tc := range cases {
 		id, err := NewNestedItemID(tc.keyVaultBaseUrl, childType, childName, childVersion)
@@ -88,6 +94,15 @@ func TestParseNestedItemID(t *testing.T) {
 			Expected: NestedItemId{
 				Name:            "castle",
 				KeyVaultBaseUrl: "https://my-keyvault.vault.azure.net/",
+				Version:         "1492",
+			},
+		},
+		{
+			Input:       "https://my-keyvault.managedhsm.azure.net/keys/castle/1492",
+			ExpectError: false,
+			Expected: NestedItemId{
+				Name:            "castle",
+				KeyVaultBaseUrl: "https://my-keyvault.managedhsm.azure.net/",
 				Version:         "1492",
 			},
 		},
@@ -176,6 +191,15 @@ func TestParseOptionallyVersionedNestedItemID(t *testing.T) {
 			Expected: NestedItemId{
 				Name:            "castle",
 				KeyVaultBaseUrl: "https://my-keyvault.vault.azure.net/",
+				Version:         "1492",
+			},
+		},
+		{
+			Input:       "https://my-keyvault.managedhsm.azure.net/keys/castle/1492",
+			ExpectError: false,
+			Expected: NestedItemId{
+				Name:            "castle",
+				KeyVaultBaseUrl: "https://my-keyvault.managedhsm.azure.net/",
 				Version:         "1492",
 			},
 		},

--- a/website/docs/r/key_vault_managed_hardware_security_module.html.markdown
+++ b/website/docs/r/key_vault_managed_hardware_security_module.html.markdown
@@ -86,7 +86,7 @@ A `network_acls` block supports the following:
 
 A `activate_config` block supports the following:
 
-* `certificate_ids` - (Required) A list of Key Vault Certificate IDs which should be used to activate this Managed HSM. More information on [activating the Managed HSM can be found in the Microsoft documentation](https://learn.microsoft.com/en-us/azure/key-vault/managed-hsm/quick-create-cli#activate-your-managed-hsm).
+* `activation_key_vault_certificate_ids` - (Required) A list of Key Vault Certificate IDs which should be used to activate this Managed HSM. More information on [activating the Managed HSM can be found in the Microsoft documentation](https://learn.microsoft.com/en-us/azure/key-vault/managed-hsm/quick-create-cli#activate-your-managed-hsm).
 
 * `security_domain_quorum` - (Required) Specifies the minimum number of shares required to decrypt the security domain for recovery. The value must between 2 and 10 (inclusive).
 

--- a/website/docs/r/key_vault_managed_hardware_security_module.html.markdown
+++ b/website/docs/r/key_vault_managed_hardware_security_module.html.markdown
@@ -86,9 +86,9 @@ A `network_acls` block supports the following:
 
 A `activate_config` block supports the following:
 
-* `security_domain_certificate` - (Required) A list of KeyVault certificates resource ID(minimum of three and up to a maximum of 10) to activate this Managed HSM. More information see [activate-your-managed-hsm](https://learn.microsoft.com/en-us/azure/key-vault/managed-hsm/quick-create-cli#activate-your-managed-hsm)
+* `certificate_ids` - (Required) A list of Key Vault Certificate IDs which should be used to activate this Managed HSM. More information on [activating the Managed HSM can be found in the Microsoft documentation](https://learn.microsoft.com/en-us/azure/key-vault/managed-hsm/quick-create-cli#activate-your-managed-hsm).
 
-* `security_domain_quorum` - (Required) Specifies the minimum number of shares required to decrypt the security domain for recovery. This is required the `security_domain_certificate` is provided. The value must between 2 and 10 (inclusive).
+* `security_domain_quorum` - (Required) Specifies the minimum number of shares required to decrypt the security domain for recovery. The value must between 2 and 10 (inclusive).
 
 ## Attributes Reference
 
@@ -98,7 +98,7 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `hsm_uri` - The URI of the Key Vault Managed Hardware Security Module, used for performing operations on keys.
 
-* `security_domain_enc_data` - The sensitive data will be used for disaster recovery or for creating another Managed HSM that shares same security domain so the two can share keys.
+* `security_domain_encrypted_data` - The sensitive data will be used for disaster recovery or for creating another Managed HSM that shares same security domain so the two can share keys.
 
 ## Timeouts
 

--- a/website/docs/r/key_vault_managed_hardware_security_module.html.markdown
+++ b/website/docs/r/key_vault_managed_hardware_security_module.html.markdown
@@ -70,6 +70,8 @@ The following arguments are supported:
 
 * `network_acls` - (Optional) A `network_acls` block as defined below.
 
+* `activate_config` - (Optional) A `activate_config` block used to activate this Managed HSM as defined below.
+
 * `tags` - (Optional) A mapping of tags to assign to the resource. Changing this forces a new resource to be created.
 
 ---
@@ -80,6 +82,14 @@ A `network_acls` block supports the following:
 
 * `default_action` - (Required) The Default Action to use. Possible values are `Allow` and `Deny`.
 
+---
+
+A `activate_config` block supports the following:
+
+* `security_domain_certificate` - (Required) A list of KeyVault certificates resource ID(minimum of three and up to a maximum of 10) to activate this Managed HSM. More information see [activate-your-managed-hsm](https://learn.microsoft.com/en-us/azure/key-vault/managed-hsm/quick-create-cli#activate-your-managed-hsm)
+
+* `security_domain_quorum` - (Required) Specifies the minimum number of shares required to decrypt the security domain for recovery. This is required the `security_domain_certificate` is provided. The value must between 2 and 10 (inclusive).
+
 ## Attributes Reference
 
 In addition to the Arguments listed above - the following Attributes are exported:
@@ -87,6 +97,8 @@ In addition to the Arguments listed above - the following Attributes are exporte
 * `id` - The Key Vault Secret Managed Hardware Security Module ID.
 
 * `hsm_uri` - The URI of the Key Vault Managed Hardware Security Module, used for performing operations on keys.
+
+* `security_domain_enc_data` - The sensitive data will be used for disaster recovery or for creating another Managed HSM that shares same security domain so the two can share keys.
 
 ## Timeouts
 


### PR DESCRIPTION
Draft for download pending SDK issue

the managed HSM has to be activated before using it. This PR add this function by using the certificates generated from keyvault reosurce.

this function is needed for creating keys under managed HSM.

reference doc: https://learn.microsoft.com/en-us/azure/key-vault/managed-hsm/quick-create-cli#activate-your-managed-hsm

docs of az cli: https://learn.microsoft.com/en-us/cli/azure/keyvault/security-domain?view=azure-cli-latest

```
=== RUN   TestAccKeyVaultManagedHardwareSecurityModule/resource/download
        --- PASS: TestAccKeyVaultManagedHardwareSecurityModule/resource/download (1839.39s)
```

(related pr #20150)