### PR TITLE
`azurerm_network_manager` - add env variable to switch test

### DIFF
--- a/internal/services/network/network_manager_resource_test.go
+++ b/internal/services/network/network_manager_resource_test.go
@@ -3,6 +3,8 @@ package network_test
 import (
 	"context"
 	"fmt"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
@@ -13,7 +15,9 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
-type ManagerResource struct{}
+type ManagerResource struct {
+	DoNotRunNetworkManagerTests string
+}
 
 func TestAccNetworkManager(t *testing.T) {
 	// NOTE: this is a combined test rather than separate split out tests due to
@@ -82,6 +86,14 @@ func TestAccNetworkManager(t *testing.T) {
 		},
 	}
 
+	r := ManagerResource{os.Getenv("ARM_TEST_DO_DOT_RUN_NETWORK_MANAGER_TESTS")}
+	if r.DoNotRunNetworkManagerTests == "" {
+		t.Skipf("`ARM_TEST_DO_DOT_RUN_NETWORK_MANAGER_TESTS` must be set for acceptance tests")
+	}
+
+	if strings.EqualFold(r.DoNotRunNetworkManagerTests, "true") {
+		t.Skipf("`azurerm_network_manager` currently is not testable due to service requirements")
+	}
 	for group, m := range testCases {
 		m := m
 		t.Run(group, func(t *testing.T) {


### PR DESCRIPTION
Add env variable `ARM_TEST_DO_DOT_RUN_NETWORK_MANAGER_TESTS` to control whether to run Network Manager related acc tests. Default is NOT run.

```
TF_ACC=1 go test -v ./internal/services/network -parallel 20 -test.run=TestAccNetworkManager -timeout 1440m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccNetworkManager
    network_manager_resource_test.go:91: `ARM_TEST_DO_NOT_RUN_NETWORK_MANAGER_TESTS` must be set for acceptance tests
--- SKIP: TestAccNetworkManager (0.00s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/network 
```

```
ARM_TEST_DO_DOT_RUN_NETWORK_MANAGER_TESTS=true TF_ACC=1 go test -v ./internal/services/network -parallel 50 -test.run=TestAccNetworkManager -timeout 1440m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccNetworkManager
    network_manager_resource_test.go:95: `azurerm_network_manager` currently is not testable due to service requirements
--- SKIP: TestAccNetworkManager (0.00s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/network       0.021s

```