### PR TITLE
`azurerm_mssql_database` - Add support through regex for ServerlessGen5 Hyperscale

### DIFF
--- a/internal/services/mssql/validate/database_sku_name.go
+++ b/internal/services/mssql/validate/database_sku_name.go
@@ -19,7 +19,7 @@ const (
 	BusinessCritical = "(BC_M_(8|10|12|14|16|18|20|24|32|64|128))"
 	Gen4             = "((GP|HS|BC)_Gen4_(1|2|3|4|5|6|7|8|9|10|16|24))"
 	Gen5             = "(GP|HS|BC)_Gen5_(2|4|6|8|10|12|14|16|18|20|24|32|40|80)"
-	ServerlessGen5   = "((GP|HS)_S_Gen5_(1|2|4|6|8|10|12|14|16|18|20|24|32|40|80))"
+	ServerlessGen5   = "(GP|HS)_S_Gen5_(1|2|4|6|8|10|12|14|16|18|20|24|32|40|80)"
 	Fsv2             = "(GP_Fsv2_(8|10|12|14|16|18|20|24|32|36|72))"
 	Dc               = "((GP|BC|HS)_DC_(2|4|6|8))"
 	EightIM          = "(HS_8IM_(24|48|80))"
@@ -30,6 +30,6 @@ func DatabaseSkuName() pluginsdk.SchemaValidateFunc {
 	pattern := "(?i)(^%s$|^%s$|^%s$|^%s$|^%s$|^%s$|^%s$|^%s$|^%s$|^%s$|^%s$|^%s$|^%s$|^%s$|^%s$)"
 	return validation.StringMatch(regexp.MustCompile(fmt.Sprintf(pattern, Free, Basic, Elastic, Standard, Premium, DataWarehouse, Stretch, BusinessCritical, Gen4, Gen5, ServerlessGen5, Fsv2, Dc, EightIM, Serverless8IM)),
 
-		`This is not a valid sku name. For example, a valid skuxxx name is 'GP_S_Gen5_1','HS_Gen4_1','BC_Gen5_2', 'ElasticPool', 'Basic', 'S0', 'P1'.`,
+		`This is not a valid sku name. For example, a valid sku name is 'GP_S_Gen5_1','HS_Gen4_1','BC_Gen5_2', 'ElasticPool', 'Basic', 'S0', 'P1'.`,
 	)
 }

--- a/internal/services/mssql/validate/database_sku_name.go
+++ b/internal/services/mssql/validate/database_sku_name.go
@@ -19,7 +19,7 @@ const (
 	BusinessCritical = "(BC_M_(8|10|12|14|16|18|20|24|32|64|128))"
 	Gen4             = "((GP|HS|BC)_Gen4_(1|2|3|4|5|6|7|8|9|10|16|24))"
 	Gen5             = "(GP|HS|BC)_Gen5_(2|4|6|8|10|12|14|16|18|20|24|32|40|80)"
-	ServerlessGen5   = "(GP_S_Gen5_(1|2|4|6|8|10|12|14|16|18|20|24|32|40))"
+	ServerlessGen5   = "((GP|HS)_S_Gen5_(1|2|4|6|8|10|12|14|16|18|20|24|32|40|80))"
 	Fsv2             = "(GP_Fsv2_(8|10|12|14|16|18|20|24|32|36|72))"
 	Dc               = "((GP|BC|HS)_DC_(2|4|6|8))"
 	EightIM          = "(HS_8IM_(24|48|80))"
@@ -30,6 +30,6 @@ func DatabaseSkuName() pluginsdk.SchemaValidateFunc {
 	pattern := "(?i)(^%s$|^%s$|^%s$|^%s$|^%s$|^%s$|^%s$|^%s$|^%s$|^%s$|^%s$|^%s$|^%s$|^%s$|^%s$)"
 	return validation.StringMatch(regexp.MustCompile(fmt.Sprintf(pattern, Free, Basic, Elastic, Standard, Premium, DataWarehouse, Stretch, BusinessCritical, Gen4, Gen5, ServerlessGen5, Fsv2, Dc, EightIM, Serverless8IM)),
 
-		`This is not a valid sku name. For example, a valid sku name is 'GP_S_Gen5_1','HS_Gen4_1','BC_Gen5_2', 'ElasticPool', 'Basic', 'S0', 'P1'.`,
+		`This is not a valid sku name. For example, a valid skuxxx name is 'GP_S_Gen5_1','HS_Gen4_1','BC_Gen5_2', 'ElasticPool', 'Basic', 'S0', 'P1'.`,
 	)
 }


### PR DESCRIPTION
Per #20547, HS is missing on ServerlessGen5. I have added it along with 80 core CPU.