### PR TITLE
`api_management_custom_domain` - Updated example in docs - Refer to versionless secret id of the Key Vault certificate

### DIFF
--- a/website/docs/r/api_management_custom_domain.html.markdown
+++ b/website/docs/r/api_management_custom_domain.html.markdown
@@ -98,12 +98,12 @@ resource "azurerm_api_management_custom_domain" "example" {
 
   gateway {
     host_name    = "api.example.com"
-    key_vault_id = azurerm_key_vault_certificate.example.secret_id
+    key_vault_id = azurerm_key_vault_certificate.example.versionless_secret_id
   }
 
   developer_portal {
     host_name    = "portal.example.com"
-    key_vault_id = azurerm_key_vault_certificate.example.secret_id
+    key_vault_id = azurerm_key_vault_certificate.example.versionless_secret_id
   }
 }
 ```


### PR DESCRIPTION
Example should refer to the versionless secret id of the Key Vault certificate. When referring to the versionless id, the certificate will automatically be renewed in APIM when renewed in Key Vault.

Warning in Azure Portal if `secret_id` is used:
![image](https://user-images.githubusercontent.com/62336565/224475561-aeab0a5c-d102-4df1-937a-8d7cef8160a7.png)
