### PR TITLE
`azurerm_cognitive_account` - fix failed test cases

### DIFF
--- a/internal/services/cognitive/cognitive_account_customer_managed_key_resource_test.go
+++ b/internal/services/cognitive/cognitive_account_customer_managed_key_resource_test.go
@@ -207,7 +207,7 @@ resource "azurerm_key_vault" "test" {
     tenant_id = data.azurerm_client_config.current.tenant_id
     object_id = data.azurerm_client_config.current.object_id
     key_permissions = [
-      "Get", "Create", "Delete", "List", "Restore", "Recover", "UnwrapKey", "WrapKey", "Purge", "Encrypt", "Decrypt", "Sign", "Verify"
+      "Get", "Create", "Delete", "List", "Restore", "Recover", "UnwrapKey", "WrapKey", "Purge", "Encrypt", "Decrypt", "Sign", "Verify", "GetRotationPolicy"
     ]
     secret_permissions = [
       "Get",
@@ -218,7 +218,7 @@ resource "azurerm_key_vault" "test" {
     tenant_id = azurerm_user_assigned_identity.test.tenant_id
     object_id = azurerm_user_assigned_identity.test.principal_id
     key_permissions = [
-      "Get", "Create", "Delete", "List", "Restore", "Recover", "UnwrapKey", "WrapKey", "Purge", "Encrypt", "Decrypt", "Sign", "Verify"
+      "Get", "Create", "Delete", "List", "Restore", "Recover", "UnwrapKey", "WrapKey", "Purge", "Encrypt", "Decrypt", "Sign", "Verify", "GetRotationPolicy"
     ]
     secret_permissions = [
       "Get",

--- a/internal/services/cognitive/cognitive_account_resource_test.go
+++ b/internal/services/cognitive/cognitive_account_resource_test.go
@@ -1057,7 +1057,7 @@ resource "azurerm_key_vault" "test" {
     tenant_id = data.azurerm_client_config.current.tenant_id
     object_id = data.azurerm_client_config.current.object_id
     key_permissions = [
-      "Get", "Create", "Delete", "List", "Restore", "Recover", "UnwrapKey", "WrapKey", "Purge", "Encrypt", "Decrypt", "Sign", "Verify"
+      "Get", "Create", "Delete", "List", "Restore", "Recover", "UnwrapKey", "WrapKey", "Purge", "Encrypt", "Decrypt", "Sign", "Verify", "GetRotationPolicy"
     ]
     secret_permissions = [
       "Get",
@@ -1068,7 +1068,7 @@ resource "azurerm_key_vault" "test" {
     tenant_id = azurerm_user_assigned_identity.test.tenant_id
     object_id = azurerm_user_assigned_identity.test.principal_id
     key_permissions = [
-      "Get", "Create", "Delete", "List", "Restore", "Recover", "UnwrapKey", "WrapKey", "Purge", "Encrypt", "Decrypt", "Sign", "Verify"
+      "Get", "Create", "Delete", "List", "Restore", "Recover", "UnwrapKey", "WrapKey", "Purge", "Encrypt", "Decrypt", "Sign", "Verify", "GetRotationPolicy"
     ]
     secret_permissions = [
       "Get",


### PR DESCRIPTION
```
=== RUN   TestAccCognitiveAccount_customerManagedKey
=== PAUSE TestAccCognitiveAccount_customerManagedKey
=== CONT  TestAccCognitiveAccount_customerManagedKey
--- PASS: TestAccCognitiveAccount_customerManagedKey (413.11s)
PASS

=== RUN   TestAccCognitiveAccountCustomerManagedKey_basic
=== PAUSE TestAccCognitiveAccountCustomerManagedKey_basic
=== CONT  TestAccCognitiveAccountCustomerManagedKey_basic
--- PASS: TestAccCognitiveAccountCustomerManagedKey_basic (384.19s)
=== RUN   TestAccCognitiveAccountCustomerManagedKey_requiresImport
=== PAUSE TestAccCognitiveAccountCustomerManagedKey_requiresImport
=== CONT  TestAccCognitiveAccountCustomerManagedKey_requiresImport
--- PASS: TestAccCognitiveAccountCustomerManagedKey_requiresImport (399.50s)
=== RUN   TestAccCognitiveAccountCustomerManagedKey_complete
=== PAUSE TestAccCognitiveAccountCustomerManagedKey_complete
=== CONT  TestAccCognitiveAccountCustomerManagedKey_complete
--- PASS: TestAccCognitiveAccountCustomerManagedKey_complete (398.29s)
=== RUN   TestAccCognitiveAccountCustomerManagedKey_update
=== PAUSE TestAccCognitiveAccountCustomerManagedKey_update
=== CONT  TestAccCognitiveAccountCustomerManagedKey_update
--- PASS: TestAccCognitiveAccountCustomerManagedKey_update (484.49s)
PASS
```