### PR TITLE
`azurerm_app_configuration` - fix failed test by adding keyvault `GetRotationPolicy` permission

### DIFF
--- a/internal/services/appconfiguration/app_configuration_resource_test.go
+++ b/internal/services/appconfiguration/app_configuration_resource_test.go
@@ -480,7 +480,7 @@ resource "azurerm_key_vault_access_policy" "client" {
   tenant_id    = data.azurerm_client_config.current.tenant_id
   object_id    = data.azurerm_client_config.current.object_id
 
-  key_permissions    = ["Get", "Create", "Delete", "List", "Restore", "Recover", "UnwrapKey", "WrapKey", "Purge", "Encrypt", "Decrypt", "Sign", "Verify"]
+  key_permissions    = ["Get", "Create", "Delete", "List", "Restore", "Recover", "UnwrapKey", "WrapKey", "Purge", "Encrypt", "Decrypt", "Sign", "Verify", "GetRotationPolicy"]
   secret_permissions = ["Get"]
 }
 
@@ -652,7 +652,7 @@ resource "azurerm_key_vault_access_policy" "client" {
   tenant_id    = data.azurerm_client_config.current.tenant_id
   object_id    = data.azurerm_client_config.current.object_id
 
-  key_permissions    = ["Get", "Create", "Delete", "List", "Restore", "Recover", "UnwrapKey", "WrapKey", "Purge", "Encrypt", "Decrypt", "Sign", "Verify"]
+  key_permissions    = ["Get", "Create", "Delete", "List", "Restore", "Recover", "UnwrapKey", "WrapKey", "Purge", "Encrypt", "Decrypt", "Sign", "Verify", "GetRotationPolicy"]
   secret_permissions = ["Get"]
 }
 
@@ -760,7 +760,7 @@ resource "azurerm_key_vault_access_policy" "client" {
   tenant_id    = data.azurerm_client_config.current.tenant_id
   object_id    = data.azurerm_client_config.current.object_id
 
-  key_permissions    = ["Get", "Create", "Delete", "List", "Restore", "Recover", "UnwrapKey", "WrapKey", "Purge", "Encrypt", "Decrypt", "Sign", "Verify"]
+  key_permissions    = ["Get", "Create", "Delete", "List", "Restore", "Recover", "UnwrapKey", "WrapKey", "Purge", "Encrypt", "Decrypt", "Sign", "Verify", "GetRotationPolicy"]
   secret_permissions = ["Get"]
 }
 

--- a/website/docs/r/app_configuration.html.markdown
+++ b/website/docs/r/app_configuration.html.markdown
@@ -81,7 +81,7 @@ resource "azurerm_key_vault_access_policy" "client" {
   tenant_id    = data.azurerm_client_config.current.tenant_id
   object_id    = data.azurerm_client_config.current.object_id
 
-  key_permissions    = ["Get", "Create", "Delete", "List", "Restore", "Recover", "UnwrapKey", "WrapKey", "Purge", "Encrypt", "Decrypt", "Sign", "Verify"]
+  key_permissions    = ["Get", "Create", "Delete", "List", "Restore", "Recover", "UnwrapKey", "WrapKey", "Purge", "Encrypt", "Decrypt", "Sign", "Verify", "GetRotationPolicy"]
   secret_permissions = ["Get"]
 }
 


### PR DESCRIPTION
`TestAccAppConfiguration_softDeletePurgeThenRecreate` will be fixed in th future.

```
--- PASS: TestAccAppConfiguration_free (87.65s)
--- PASS: TestAccAppConfiguration_purgeProtectionAndSoftDeleteEnabled (98.78s)
--- PASS: TestAccAppConfiguration_requiresImport (100.39s)
--- PASS: TestAccAppConfiguration_purgeProtectionEnabled (100.79s)
--- PASS: TestAccAppConfiguration_identity (100.79s)
--- PASS: TestAccAppConfiguration_standard (108.88s)
--- PASS: TestAccAppConfiguration_softDeleteRecoveryDisabled (112.67s)
--- PASS: TestAccAppConfiguration_identityUserAssigned (112.75s)
=== CONT  TestAccAppConfiguration_softDeletePurgeThenRecreate
    testcase.go:110: Step 4/5 error: Error running apply: exit status 1
        
        Error: creating Configuration Store (Subscription: "85b3dbca-5974-4067-9669-67a141095a76"
        Resource Group Name: "acctestRG-appconfig-230313134200746763"
        Configuration Store Name: "testaccappconf230313134200746763"): polling after Create: Code="NameUnavailable" Message="The specified name is already in use." AdditionalInfo=[{"info":{"activityId":"b09a1ba8-64ef-4c8c-b6ef-7d48ea55d509"},"type":"ActivityId"}]
        
          with azurerm_app_configuration.test,
          on terraform_plugin_test.tf line 26, in resource "azurerm_app_configuration" "test":
          26: resource "azurerm_app_configuration" "test" {
        
--- PASS: TestAccAppConfigurationKey_basicNoLabel_afterLabel (128.91s)
--- PASS: TestAccAppConfigurationKeyDataSource_basicNoLabel (131.75s)
--- PASS: TestAccAppConfigurationFeature_basicWithSlash (135.89s)
--- PASS: TestAccAppConfigurationKeysDataSource_label (137.67s)
--- PASS: TestAccAppConfigurationKey_basicNoLabel (138.55s)
--- PASS: TestAccAppConfigurationKey_slash (138.92s)
--- PASS: TestAccAppConfiguration_purgeProtectionViaUpdate (141.07s)
--- PASS: TestAccAppConfigurationFeature_basicNoFilters (143.19s)
--- PASS: TestAccAppConfigurationKey_requiresImport (143.62s)
--- PASS: TestAccAppConfigurationFeature_requiresImport (145.20s)
--- PASS: TestAccAppConfigurationKeysDataSource_key (146.03s)
--- PASS: TestAccAppConfigurationKeyDataSource_basic (146.82s)
--- PASS: TestAccAppConfigurationKey_basic (146.92s)
--- PASS: TestAccAppConfigurationKeysDataSource_allkeys (148.61s)
--- PASS: TestAccAppConfigurationFeature_basic (149.09s)
--- PASS: TestAccAppConfigurationFeature_basicNoLabel (149.69s)
--- PASS: TestAccAppConfiguration_purgeProtectionAttemptToDisable (153.67s)
--- PASS: TestAccAppConfigurationFeature_enabledUpdate (160.82s)
--- PASS: TestAccAppConfiguration_softDeleteRecovery (161.03s)
--- PASS: TestAccAppConfigurationKey_lockUpdate (165.50s)
--- PASS: TestAccAppConfigurationFeature_lockUpdate (165.71s)
--- PASS: TestAccAppConfigurationFeature_noLabelUpdate (173.81s)
--- PASS: TestAccAppConfiguration_identityUpdated (227.41s)
--- PASS: TestAccAppConfigurationKeyDataSource_basicVault (293.35s)
--- PASS: TestAccAppConfigurationKey_basicVault (299.96s)
--- PASS: TestAccAppConfiguration_complete (327.78s)
--- PASS: TestAccAppConfiguration_encryption (334.99s)
--- PASS: TestAccAppConfiguration_encryptionUpdated (363.25s)
--- PASS: TestAccAppConfigurationKey_KVToVault (364.05s)
--- PASS: TestAccAppConfigurationDataSource_basic (368.68s)
--- PASS: TestAccAppConfiguration_update (409.81s)
--- FAIL: TestAccAppConfiguration_softDeletePurgeThenRecreate (677.07s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-azurerm/internal/services/appconfiguration      679.283s
FAIL
make: *** [acctests] Error 1

```