### PR TITLE
[New Resource] - `azurerm_redis_cache_patch_schedule`

### DIFF
--- a/internal/services/redis/redis_cache_patch_schedule_resource.go
+++ b/internal/services/redis/redis_cache_patch_schedule_resource.go
@@ -1,0 +1,178 @@
+package redis
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/redis/2022-06-01/patchschedules"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/redis/2022-06-01/redis"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
+	azValidate "github.com/hashicorp/terraform-provider-azurerm/helpers/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
+)
+
+func resourceRedisPatchScheduleCache() *pluginsdk.Resource {
+	return &pluginsdk.Resource{
+		Create: resourceRedisCachePatchScheduleCreate,
+		Read:   resourceRedisCachePatchScheduleRead,
+		Update: resourceRedisCachePatchScheduleUpdate,
+		Delete: resourceRedisCachePatchScheduleDelete,
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := patchschedules.ParseRediID(id)
+			return err
+		}),
+
+		Timeouts: &pluginsdk.ResourceTimeout{
+			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
+			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
+			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
+			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*pluginsdk.Schema{
+			"redis_cache_id": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: redis.ValidateRediID,
+			},
+
+			"patch_schedule": {
+				Type:     pluginsdk.TypeList,
+				Required: true,
+				MinItems: 1,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"day_of_week": {
+							Type:             pluginsdk.TypeString,
+							Required:         true,
+							DiffSuppressFunc: suppress.CaseDifference,
+							ValidateFunc:     validation.IsDayOfTheWeek(true),
+						},
+
+						"maintenance_window": {
+							Type:         pluginsdk.TypeString,
+							Optional:     true,
+							Default:      "PT5H",
+							ValidateFunc: azValidate.ISO8601Duration,
+						},
+
+						"start_hour_utc": {
+							Type:         pluginsdk.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IntBetween(0, 23),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceRedisCachePatchScheduleCreate(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Redis.PatchSchedules
+	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := patchschedules.ParseRediID(d.Get("redis_cache_id").(string))
+	if err != nil {
+		return err
+	}
+	existing, err := client.Get(ctx, *id)
+	if err != nil {
+		if !response.WasNotFound(existing.HttpResponse) {
+			return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+		}
+	}
+
+	if !response.WasNotFound(existing.HttpResponse) {
+		return tf.ImportAsExistsError("azurerm_redis_cache_patch_schedule", id.ID())
+	}
+
+	patchSchedule := expandRedisPatchSchedule(d)
+	patchScheduleRedisId := patchschedules.NewRediID(id.SubscriptionId, id.ResourceGroupName, id.RedisName)
+	if _, err = client.CreateOrUpdate(ctx, patchScheduleRedisId, *patchSchedule); err != nil {
+		return fmt.Errorf("setting Patch Schedule for %s: %+v", id, err)
+	}
+
+	d.SetId(id.ID())
+	return resourceRedisCachePatchScheduleRead(d, meta)
+}
+
+func resourceRedisCachePatchScheduleUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Redis.PatchSchedules
+	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := patchschedules.ParseRediID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	patchSchedule := expandRedisPatchSchedule(d)
+	patchSchedulesRedisId := patchschedules.NewRediID(id.SubscriptionId, id.ResourceGroupName, id.RedisName)
+	_, err = client.CreateOrUpdate(ctx, patchSchedulesRedisId, *patchSchedule)
+	if err != nil {
+		return fmt.Errorf("setting Patch Schedule for %s: %+v", *id, err)
+	}
+
+	return resourceRedisCachePatchScheduleRead(d, meta)
+}
+
+func resourceRedisCachePatchScheduleRead(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Redis.PatchSchedules
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := patchschedules.ParseRediID(d.Id())
+	if err != nil {
+		return err
+	}
+	d.Set("redis_cache_id", id.ID())
+
+	resp, err := client.Get(ctx, *id)
+	if err != nil {
+		if response.WasNotFound(resp.HttpResponse) {
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("retrieving %s: %+v", *id, err)
+	}
+
+	patchSchedulesRedisId := patchschedules.NewRediID(id.SubscriptionId, id.ResourceGroupName, id.RedisName)
+	schedule, err := client.Get(ctx, patchSchedulesRedisId)
+	if err != nil {
+		return err
+	}
+
+	patchSchedules := flattenRedisPatchSchedules(*schedule.Model)
+	if err = d.Set("patch_schedule", patchSchedules); err != nil {
+		return fmt.Errorf("setting `patch_schedule`: %+v", err)
+	}
+
+	return nil
+}
+
+func resourceRedisCachePatchScheduleDelete(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Redis.PatchSchedules
+	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := patchschedules.ParseRediID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	if resp, err := client.Delete(ctx, *id); err != nil {
+		if !response.WasNotFound(resp.HttpResponse) {
+			return fmt.Errorf("deleting %s: %+v", *id, err)
+		}
+	}
+
+	return nil
+}

--- a/internal/services/redis/redis_cache_patch_schedule_resource_test.go
+++ b/internal/services/redis/redis_cache_patch_schedule_resource_test.go
@@ -1,0 +1,162 @@
+package redis_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-azure-sdk/resource-manager/redis/2022-06-01/patchschedules"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+type RedisCachePatchScheduleResource struct{}
+
+func TestAccRedisCachePatchSchedule_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_redis_cache_patch_schedule", "test")
+	r := RedisCachePatchScheduleResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccRedisCachePatchSchedule_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_redis_cache_patch_schedule", "test")
+	r := RedisCachePatchScheduleResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		{
+			Config: r.patchSchedule(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+	})
+}
+
+func TestAccRedisCachePatchSchedule_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_redis_cache_patch_schedule", "test")
+	r := RedisCachePatchScheduleResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.RequiresImportErrorStep(r.requiresImport),
+	})
+}
+
+func (r RedisCachePatchScheduleResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := patchschedules.ParseRediID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := clients.Redis.PatchSchedules.Get(ctx, *id)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %+v", *id, err)
+	}
+
+	return utils.Bool(resp.Model != nil), nil
+}
+
+func (r RedisCachePatchScheduleResource) basic(data acceptance.TestData) string {
+	temp := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource azurerm_redis_cache_patch_schedule test {
+  redis_cache_id = azurerm_redis_cache.test.id
+  patch_schedule {
+	day_of_week        = "Tuesday"
+	start_hour_utc     = 8
+	maintenance_window = "PT7H"
+  }
+}
+
+`, temp)
+}
+
+func (r RedisCachePatchScheduleResource) requiresImport(data acceptance.TestData) string {
+	template := r.basic(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_redis_cache_patch_schedule" "import" {
+  redis_cache_id = azurerm_redis_cache_patch_schedule.test.redis_cache_id
+  patch_schedule {
+    day_of_week        = "Tuesday"
+    start_hour_utc     = 8
+    maintenance_window = "PT7H"
+  }
+}
+`, template)
+}
+
+func (r RedisCachePatchScheduleResource) patchSchedule(data acceptance.TestData) string {
+	temp := r.template(data)
+	return fmt.Sprintf(`%s
+
+resource azurerm_redis_cache_patch_schedule test { 
+  redis_cache_id = azurerm_redis_cache.test.id
+
+  patch_schedule {
+    day_of_week        = "Tuesday"
+    start_hour_utc     =    20
+  }
+
+  patch_schedule {
+    day_of_week        = "Wednesday"
+    start_hour_utc     = 9
+  }
+}
+
+`, temp)
+}
+
+func (RedisCachePatchScheduleResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_redis_cache" "test" {
+  name                = "acctestRedis-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  capacity            = 1
+  family              = "C"
+  sku_name            = "Basic"
+  enable_non_ssl_port = false
+  minimum_tls_version = "1.2"
+
+  redis_configuration {
+  }
+
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}

--- a/internal/services/redis/redis_cache_resource.go
+++ b/internal/services/redis/redis_cache_resource.go
@@ -229,6 +229,7 @@ func resourceRedisCache() *pluginsdk.Resource {
 			"patch_schedule": {
 				Type:     pluginsdk.TypeList,
 				Optional: true,
+				Computed: true,
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
 						"day_of_week": {

--- a/internal/services/redis/registration.go
+++ b/internal/services/redis/registration.go
@@ -35,8 +35,9 @@ func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
 // SupportedResources returns the supported Resources supported by this Service
 func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 	return map[string]*pluginsdk.Resource{
-		"azurerm_redis_cache":         resourceRedisCache(),
-		"azurerm_redis_firewall_rule": resourceRedisFirewallRule(),
-		"azurerm_redis_linked_server": resourceRedisLinkedServer(),
+		"azurerm_redis_cache":                resourceRedisCache(),
+		"azurerm_redis_cache_patch_schedule": resourceRedisPatchScheduleCache(),
+		"azurerm_redis_firewall_rule":        resourceRedisFirewallRule(),
+		"azurerm_redis_linked_server":        resourceRedisLinkedServer(),
 	}
 }

--- a/website/docs/r/redis_cache.html.markdown
+++ b/website/docs/r/redis_cache.html.markdown
@@ -11,6 +11,8 @@ description: |-
 
 Manages a Redis Cache.
 
+~> **NOTE:** It's possible to define Redis Patch Schedule both within [the `azurerm_redis_cache` resource](redis_cache.html) via the `patch_schedule` block and by using [the `azurerm_redis_cache_patch_schedule` resource](redis_cache_patch_schedule.html). However it's not possible to use both methods to manage Patch Schedule within a Redis, since there'll be conflicts.
+
 ## Example Usage
 
 This example provisions a Standard Redis Cache. Other examples of the `azurerm_redis_cache` resource can be found in [the `./examples/redis-cache` directory within the GitHub Repository](https://github.com/hashicorp/terraform-provider-azurerm/tree/main/examples/redis-cache)

--- a/website/docs/r/redis_cache_patch_schedule.html.markdown
+++ b/website/docs/r/redis_cache_patch_schedule.html.markdown
@@ -11,6 +11,8 @@ description: |-
 
 Manages a Redis Cache Patch Schedule.
 
+~> **NOTE:** It's possible to define Redis Patch Schedule both within [the `azurerm_redis_cache` resource](redis_cache.html) via the `patch_schedule` block and by using [the `azurerm_redis_cache_patch_schedule` resource](redis_cache_patch_schedule.html). However it's not possible to use both methods to manage Patch Schedule within a Redis, since there'll be conflicts.
+
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/redis_cache_patch_schedule.html.markdown
+++ b/website/docs/r/redis_cache_patch_schedule.html.markdown
@@ -1,0 +1,86 @@
+---
+subcategory: "Redis"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_redis_cache_patch_schedule"
+description: |-
+  Manages a Redis Cache Patch Schedule
+
+---
+
+# azurerm_redis_cache_patch_schedule
+
+Manages a Redis Cache Patch Schedule.
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_redis_cache" "example" {
+  name                = "example-cache"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  capacity            = 2
+  family              = "C"
+  sku_name            = "Standard"
+  enable_non_ssl_port = false
+  minimum_tls_version = "1.2"
+
+  redis_configuration {
+  }
+}
+
+resource azurerm_redis_cache_patch_schedule example {
+  redis_cache_id = azurerm_redis_cache.example.id
+  patch_schedule {
+    day_of_week    = "Tuesday"
+    start_hour_utc = 20
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `redis_cache_id` - (Required) The ID of the Redis Cache. Changing this forces a new resource to be created.
+
+* `patch_schedule` - (Required) A list of `patch_schedule` blocks as defined below.
+
+---
+
+A `patch_schedule` block supports the following:
+
+* `day_of_week` - (Required) the Weekday name - possible values include `Monday`, `Tuesday`, `Wednesday` etc.
+
+* `start_hour_utc` - (Optional) the Start Hour for maintenance in UTC - possible values range from `0 - 23`.
+
+~> **Note:** The Patch Window lasts for `5` hours from the `start_hour_utc`.
+
+* `maintenance_window` - (Optional) The ISO 8601 timespan which specifies the amount of time the Redis Cache can be updated. Defaults to `PT5H`.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the Redis Cache.
+
+## Timeouts
+
+ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Redis Cache Patch Schedule.
+* `update` - (Defaults to 30 minutes) Used when updating the Redis Cache Patch Schedule.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Redis Cache Patch Schedule.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Redis Cache Patch Schedule.
+
+## Import
+
+Redis Cache Patch Schedule can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_redis_cache_patch_schedule.patch1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Cache/redis/cache1
+```


### PR DESCRIPTION
New resource `azurerm_redis_cache_patch_schedule`
```log
=== RUN   TestAccRedisCachePatchSchedule_basic
=== PAUSE TestAccRedisCachePatchSchedule_basic
=== RUN   TestAccRedisCachePatchSchedule_update
=== PAUSE TestAccRedisCachePatchSchedule_update
=== RUN   TestAccRedisCachePatchSchedule_requiresImport
=== PAUSE TestAccRedisCachePatchSchedule_requiresImport
=== CONT  TestAccRedisCachePatchSchedule_basic
=== CONT  TestAccRedisCachePatchSchedule_requiresImport
=== CONT  TestAccRedisCachePatchSchedule_update
--- PASS: TestAccRedisCachePatchSchedule_basic (2000.39s)
--- PASS: TestAccRedisCachePatchSchedule_requiresImport (2106.93s)
--- PASS: TestAccRedisCachePatchSchedule_update (2125.93s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/redis 2166.898s
```