### PR TITLE
doc fix - managed service identity auth with role assignment 

### DIFF
--- a/website/docs/guides/managed_service_identity.html.markdown
+++ b/website/docs/guides/managed_service_identity.html.markdown
@@ -56,7 +56,6 @@ data "azurerm_role_definition" "contributor" {
 }
 
 resource "azurerm_role_assignment" "example" {
-  name               = azurerm_virtual_machine.example.name
   scope              = data.azurerm_subscription.current.id
   role_definition_id = "${data.azurerm_subscription.current.id}${data.azurerm_role_definition.contributor.id}"
   principal_id       = azurerm_virtual_machine.example.identity[0].principal_id


### PR DESCRIPTION
fix the error with given example config:
```
│ Error: expected "name" to be a valid UUID, got example-machine
```