### PR TITLE
New Resources: Support create key for managed hardware security modules

### DIFF
--- a/internal/clients/builder.go
+++ b/internal/clients/builder.go
@@ -113,6 +113,11 @@ func Build(ctx context.Context, builder ClientBuilder) (*Client, error) {
 		return nil, fmt.Errorf("building account: %+v", err)
 	}
 
+	managedHSMAuth, err := auth.NewAuthorizerFromCredentials(ctx, *builder.AuthConfig, builder.AuthConfig.Environment.ManagedHSM)
+	if err != nil {
+		return nil, fmt.Errorf("unable to build authorizer for Managed HSM API: %+v", err)
+	}
+
 	client := Client{
 		Account: account,
 	}
@@ -121,6 +126,7 @@ func Build(ctx context.Context, builder ClientBuilder) (*Client, error) {
 		Authorizers: &common.Authorizers{
 			BatchManagement: batchManagementAuth,
 			KeyVault:        keyVaultAuth,
+			ManagedHSM:      managedHSMAuth,
 			ResourceManager: resourceManagerAuth,
 			Storage:         storageAuth,
 			Synapse:         synapseAuth,
@@ -137,6 +143,7 @@ func Build(ctx context.Context, builder ClientBuilder) (*Client, error) {
 
 		BatchManagementAuthorizer: authWrapper.AutorestAuthorizer(batchManagementAuth),
 		KeyVaultAuthorizer:        authWrapper.AutorestAuthorizer(keyVaultAuth).BearerAuthorizerCallback(),
+		ManagedHSMAuthorizer:      authWrapper.AutorestAuthorizer(managedHSMAuth).BearerAuthorizerCallback(),
 		ResourceManagerAuthorizer: authWrapper.AutorestAuthorizer(resourceManagerAuth),
 		StorageAuthorizer:         authWrapper.AutorestAuthorizer(storageAuth),
 		SynapseAuthorizer:         authWrapper.AutorestAuthorizer(synapseAuth),

--- a/internal/common/client_options.go
+++ b/internal/common/client_options.go
@@ -20,6 +20,7 @@ import (
 type Authorizers struct {
 	BatchManagement auth.Authorizer
 	KeyVault        auth.Authorizer
+	ManagedHSM      auth.Authorizer
 	ResourceManager auth.Authorizer
 	Storage         auth.Authorizer
 	Synapse         auth.Authorizer
@@ -54,6 +55,7 @@ type ClientOptions struct {
 	// Legacy authorizers for go-autorest
 	BatchManagementAuthorizer autorest.Authorizer
 	KeyVaultAuthorizer        autorest.Authorizer
+	ManagedHSMAuthorizer      autorest.Authorizer
 	ResourceManagerAuthorizer autorest.Authorizer
 	StorageAuthorizer         autorest.Authorizer
 	SynapseAuthorizer         autorest.Authorizer

--- a/internal/services/keyvault/client/client.go
+++ b/internal/services/keyvault/client/client.go
@@ -9,7 +9,9 @@ import (
 type Client struct {
 	ManagedHsmClient *keyvault.ManagedHsmsClient
 	ManagementClient *keyvaultmgmt.BaseClient
+	MHSMSDClient     *keyvaultmgmt.HSMSecurityDomainClient
 	VaultsClient     *keyvault.VaultsClient
+	MHSMRoleClient   *keyvaultmgmt.RoleDefinitionsClient
 	options          *common.ClientOptions
 }
 
@@ -20,13 +22,21 @@ func NewClient(o *common.ClientOptions) *Client {
 	managementClient := keyvaultmgmt.New()
 	o.ConfigureClient(&managementClient.Client, o.KeyVaultAuthorizer)
 
+	sdClient := keyvaultmgmt.NewHSMSecurityDomainClient()
+	o.ConfigureClient(&sdClient.Client, o.ManagedHSMAuthorizer)
+
+	mhsmRoleDefineClient := keyvaultmgmt.NewRoleDefinitionsClient()
+	o.ConfigureClient(&mhsmRoleDefineClient.Client, o.ManagedHSMAuthorizer)
+
 	vaultsClient := keyvault.NewVaultsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&vaultsClient.Client, o.ResourceManagerAuthorizer)
 
 	return &Client{
 		ManagedHsmClient: &managedHsmClient,
 		ManagementClient: &managementClient,
+		MHSMSDClient:     &sdClient,
 		VaultsClient:     &vaultsClient,
+		MHSMRoleClient:   &mhsmRoleDefineClient,
 		options:          o,
 	}
 }

--- a/internal/services/keyvault/client/client.go
+++ b/internal/services/keyvault/client/client.go
@@ -7,12 +7,14 @@ import (
 )
 
 type Client struct {
-	ManagedHsmClient *keyvault.ManagedHsmsClient
-	ManagementClient *keyvaultmgmt.BaseClient
-	MHSMSDClient     *keyvaultmgmt.HSMSecurityDomainClient
-	VaultsClient     *keyvault.VaultsClient
-	MHSMRoleClient   *keyvaultmgmt.RoleDefinitionsClient
-	options          *common.ClientOptions
+	VaultsClient         *keyvault.VaultsClient
+	ManagedHsmClient     *keyvault.ManagedHsmsClient
+	ManagementClient     *keyvaultmgmt.BaseClient
+	ManagementHSMClient  *keyvaultmgmt.BaseClient
+	MHSMSDClient         *keyvaultmgmt.HSMSecurityDomainClient
+	MHSMRoleClient       *keyvaultmgmt.RoleDefinitionsClient
+	options              *common.ClientOptions
+	MHSMRoleAssignClient *keyvaultmgmt.RoleAssignmentsClient
 }
 
 func NewClient(o *common.ClientOptions) *Client {
@@ -22,27 +24,35 @@ func NewClient(o *common.ClientOptions) *Client {
 	managementClient := keyvaultmgmt.New()
 	o.ConfigureClient(&managementClient.Client, o.KeyVaultAuthorizer)
 
+	managementHSMClient := keyvaultmgmt.New()
+	o.ConfigureClient(&managementHSMClient.Client, o.ManagedHSMAuthorizer)
+
 	sdClient := keyvaultmgmt.NewHSMSecurityDomainClient()
 	o.ConfigureClient(&sdClient.Client, o.ManagedHSMAuthorizer)
 
 	mhsmRoleDefineClient := keyvaultmgmt.NewRoleDefinitionsClient()
 	o.ConfigureClient(&mhsmRoleDefineClient.Client, o.ManagedHSMAuthorizer)
 
+	roleAssignClient := keyvaultmgmt.NewRoleAssignmentsClient()
+	o.ConfigureClient(&roleAssignClient.Client, o.ManagedHSMAuthorizer)
+
 	vaultsClient := keyvault.NewVaultsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&vaultsClient.Client, o.ResourceManagerAuthorizer)
 
 	return &Client{
-		ManagedHsmClient: &managedHsmClient,
-		ManagementClient: &managementClient,
-		MHSMSDClient:     &sdClient,
-		VaultsClient:     &vaultsClient,
-		MHSMRoleClient:   &mhsmRoleDefineClient,
-		options:          o,
+		ManagedHsmClient:     &managedHsmClient,
+		ManagementClient:     &managementClient,
+		ManagementHSMClient:  &managementHSMClient,
+		MHSMSDClient:         &sdClient,
+		VaultsClient:         &vaultsClient,
+		MHSMRoleClient:       &mhsmRoleDefineClient,
+		MHSMRoleAssignClient: &roleAssignClient,
+		options:              o,
 	}
 }
 
-func (client Client) KeyVaultClientForSubscription(subscriptionId string) *keyvault.VaultsClient {
-	vaultsClient := keyvault.NewVaultsClientWithBaseURI(client.options.ResourceManagerEndpoint, subscriptionId)
-	client.options.ConfigureClient(&vaultsClient.Client, client.options.ResourceManagerAuthorizer)
+func (c *Client) KeyVaultClientForSubscription(subscriptionId string) *keyvault.VaultsClient {
+	vaultsClient := keyvault.NewVaultsClientWithBaseURI(c.options.ResourceManagerEndpoint, subscriptionId)
+	c.options.ConfigureClient(&vaultsClient.Client, c.options.ResourceManagerAuthorizer)
 	return &vaultsClient
 }

--- a/internal/services/keyvault/client/helpers.go
+++ b/internal/services/keyvault/client/helpers.go
@@ -7,16 +7,57 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2021-10-01/keyvault" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/parse"
 	resourcesClient "github.com/hashicorp/terraform-provider-azurerm/internal/services/resource/client"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
-var (
-	keyVaultsCache = map[string]keyVaultDetails{}
-	keysmith       = &sync.RWMutex{}
-	lock           = map[string]*sync.RWMutex{}
-)
+type vaultCahcher interface {
+	GetVault(vault parse.Vaulter) *keyVaultDetails
+	GetVaultByKey(key string) *keyVaultDetails
+	AddVault(vault parse.Vaulter, dataPlaneURI string)
+	Delete(vault parse.Vaulter)
+}
+
+type vaultCache struct {
+	cache map[string]keyVaultDetails
+	lock  sync.RWMutex
+}
+
+func (v *vaultCache) GetVault(vault parse.Vaulter) (res *keyVaultDetails) {
+	return v.GetVaultByKey(vault.GetCacheKey())
+}
+
+func (v *vaultCache) GetVaultByKey(key string) (res *keyVaultDetails) {
+	v.lock.RLock()
+	if val, ok := v.cache[key]; ok {
+		res = &val
+	}
+	v.lock.RUnlock()
+	return
+}
+
+func (v *vaultCache) AddVault(vault parse.Vaulter, dataPlaneURI string) {
+	v.lock.Lock()
+	v.cache[vault.GetCacheKey()] = keyVaultDetails{
+		keyVaultId:       vault.ID(),
+		dataPlaneBaseUri: dataPlaneURI,
+		resourceGroup:    vault.GetResourceGroup(),
+	}
+	v.lock.Unlock()
+}
+
+func (v *vaultCache) Delete(vault parse.Vaulter) {
+	v.lock.Lock()
+	delete(v.cache, vault.GetCacheKey())
+	v.lock.Unlock()
+}
+
+var vaultCacheIns vaultCahcher = &vaultCache{
+	cache: map[string]keyVaultDetails{},
+}
 
 type keyVaultDetails struct {
 	keyVaultId       string
@@ -24,105 +65,126 @@ type keyVaultDetails struct {
 	resourceGroup    string
 }
 
-func (c *Client) AddToCache(keyVaultId parse.VaultId, dataPlaneUri string) {
-	cacheKey := c.cacheKeyForKeyVault(keyVaultId.Name)
-	keysmith.Lock()
-	keyVaultsCache[cacheKey] = keyVaultDetails{
-		keyVaultId:       keyVaultId.ID(),
-		dataPlaneBaseUri: dataPlaneUri,
-		resourceGroup:    keyVaultId.ResourceGroup,
-	}
-	keysmith.Unlock()
+func (c *Client) AddToCache(keyVaultId parse.Vaulter, dataPlaneUri string) {
+	vaultCacheIns.AddVault(keyVaultId, dataPlaneUri)
 }
 
-func (c *Client) BaseUriForKeyVault(ctx context.Context, keyVaultId parse.VaultId) (*string, error) {
-	cacheKey := c.cacheKeyForKeyVault(keyVaultId.Name)
-	keysmith.Lock()
-	if lock[cacheKey] == nil {
-		lock[cacheKey] = &sync.RWMutex{}
+func (c *Client) BaseUriForKeyVault(ctx context.Context, keyVaultId parse.Vaulter) (*string, error) {
+	if cached := vaultCacheIns.GetVault(keyVaultId); cached != nil {
+		return &cached.dataPlaneBaseUri, nil
 	}
-	keysmith.Unlock()
-	lock[cacheKey].Lock()
-	defer lock[cacheKey].Unlock()
+	var (
+		baseURI       *string
+		subscription  = keyVaultId.GetSubscriptionID()
+		resourceGroup = keyVaultId.GetResourceGroup()
+		name          = keyVaultId.GetName()
+		err           error
+	)
 
-	if v, ok := keyVaultsCache[cacheKey]; ok {
-		return &v.dataPlaneBaseUri, nil
-	}
-
-	vaultsClient := c.VaultsClient
-
-	if keyVaultId.SubscriptionId != c.VaultsClient.SubscriptionID {
-		vaultsClient = c.KeyVaultClientForSubscription(keyVaultId.SubscriptionId)
-	}
-
-	resp, err := vaultsClient.Get(ctx, keyVaultId.ResourceGroup, keyVaultId.Name)
-	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
-			return nil, fmt.Errorf("%s was not found", keyVaultId)
+	switch vault := keyVaultId.(type) {
+	case parse.VaultId, *parse.VaultId:
+		if subscription != c.VaultsClient.SubscriptionID {
+			c.VaultsClient = c.KeyVaultClientForSubscription(subscription)
 		}
-		return nil, fmt.Errorf("retrieving %s: %+v", keyVaultId, err)
+
+		resp, err := c.VaultsClient.Get(ctx, resourceGroup, vault.GetName())
+		if err != nil {
+			if utils.ResponseWasNotFound(resp.Response) {
+				return nil, fmt.Errorf("%s was not found", keyVaultId)
+			}
+			return nil, fmt.Errorf("retrieving %s: %+v", keyVaultId, err)
+		}
+
+		if resp.Properties == nil || resp.Properties.VaultURI == nil {
+			return nil, fmt.Errorf("`properties` was nil for %s", keyVaultId)
+		}
+
+		baseURI = resp.Properties.VaultURI
+	case parse.ManagedHSMId, *parse.ManagedHSMId:
+		resp, err := c.ManagedHsmClient.Get(ctx, resourceGroup, name)
+		if err != nil {
+			if utils.ResponseWasNotFound(resp.Response) {
+				return nil, fmt.Errorf("%s was not found", keyVaultId)
+			}
+			return nil, fmt.Errorf("retrieving %s: %+v", keyVaultId, err)
+		}
+
+		if resp.Properties == nil || resp.Properties.HsmURI == nil {
+			return nil, fmt.Errorf("`properties` was nil for %s", keyVaultId)
+		}
+
+		baseURI = resp.Properties.HsmURI
+	default:
+		err = fmt.Errorf("not support key vault type: %q", keyVaultId)
 	}
-
-	if resp.Properties == nil || resp.Properties.VaultURI == nil {
-		return nil, fmt.Errorf("`properties` was nil for %s", keyVaultId)
+	if baseURI != nil {
+		vaultCacheIns.AddVault(keyVaultId, *baseURI)
 	}
-
-	c.AddToCache(keyVaultId, *resp.Properties.VaultURI)
-
-	return resp.Properties.VaultURI, nil
+	return baseURI, err
 }
 
-func (c *Client) Exists(ctx context.Context, keyVaultId parse.VaultId) (bool, error) {
-	cacheKey := c.cacheKeyForKeyVault(keyVaultId.Name)
-	keysmith.Lock()
-	if lock[cacheKey] == nil {
-		lock[cacheKey] = &sync.RWMutex{}
-	}
-	keysmith.Unlock()
-	lock[cacheKey].Lock()
-	defer lock[cacheKey].Unlock()
-
-	if _, ok := keyVaultsCache[cacheKey]; ok {
+func (c *Client) Exists(ctx context.Context, keyVaultId parse.Vaulter) (bool, error) {
+	if cached := vaultCacheIns.GetVault(keyVaultId); cached != nil {
 		return true, nil
 	}
 
-	resp, err := c.VaultsClient.Get(ctx, keyVaultId.ResourceGroup, keyVaultId.Name)
-	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
-			return false, nil
-		}
-		return false, fmt.Errorf("retrieving %s: %+v", keyVaultId, err)
+	uri, err := c.GetVaultURI(ctx, keyVaultId)
+	if err != nil || uri == "" {
+		return false, err
 	}
 
-	if resp.Properties == nil || resp.Properties.VaultURI == nil {
-		return false, fmt.Errorf("`properties` was nil for %s", keyVaultId)
-	}
-
-	c.AddToCache(keyVaultId, *resp.Properties.VaultURI)
+	c.AddToCache(keyVaultId, uri)
 
 	return true, nil
 }
 
-func (c *Client) KeyVaultIDFromBaseUrl(ctx context.Context, resourcesClient *resourcesClient.Client, keyVaultBaseUrl string) (*string, error) {
-	keyVaultName, err := c.parseNameFromBaseUrl(keyVaultBaseUrl)
+// GetVault try to get KeyVault or HSM instance of vaulter
+func (c *Client) GetVault(ctx context.Context, vaulter parse.Vaulter) (
+	vault *keyvault.Vault,
+	hsm *keyvault.ManagedHsm,
+	err error) {
+
+	switch vaulter.Type() {
+	case parse.VaultTypeDefault:
+		vaultIns, err := c.VaultsClient.Get(ctx, vaulter.GetResourceGroup(), vaulter.GetName())
+		return &vaultIns, nil, err
+	case parse.VaultTypeMHSM:
+		hsmIns, err := c.ManagedHsmClient.Get(ctx, vaulter.GetResourceGroup(), vaulter.GetName())
+		return nil, &hsmIns, err
+	}
+	return nil, nil, fmt.Errorf("not supported type: %s", vaulter.Type())
+}
+
+// GetVaultURI Get uri of key vault or uri of hsm
+func (c *Client) GetVaultURI(ctx context.Context, vaulter parse.Vaulter) (uri string, err error) {
+	vault, hsm, err := c.GetVault(ctx, vaulter)
+	if vault != nil && vault.Properties != nil && vault.Properties.VaultURI != nil {
+		uri = *vault.Properties.VaultURI
+	} else if hsm != nil && hsm.Properties != nil && hsm.Properties.HsmURI != nil {
+		uri = *hsm.Properties.HsmURI
+	}
+	return uri, err
+}
+
+func (c *Client) KeyVaultIDFromBaseUrl(ctx context.Context,
+	resourcesClient *resourcesClient.Client,
+	keyVaultBaseUrl string) (
+	*string, error) {
+
+	keyVaultName, vaultType, err := c.parseNameFromBaseUrl(keyVaultBaseUrl)
 	if err != nil {
 		return nil, err
 	}
 
-	cacheKey := c.cacheKeyForKeyVault(*keyVaultName)
-	keysmith.Lock()
-	if lock[cacheKey] == nil {
-		lock[cacheKey] = &sync.RWMutex{}
-	}
-	keysmith.Unlock()
-	lock[cacheKey].Lock()
-	defer lock[cacheKey].Unlock()
-
-	if v, ok := keyVaultsCache[cacheKey]; ok {
-		return &v.keyVaultId, nil
+	if cached := vaultCacheIns.GetVaultByKey(parse.MakeCacheKey(vaultType, pointer.From(keyVaultName))); cached != nil {
+		return &cached.keyVaultId, nil
 	}
 
 	filter := fmt.Sprintf("resourceType eq 'Microsoft.KeyVault/vaults' and name eq '%s'", *keyVaultName)
+	isMHSMVault := vaultType == parse.VaultTypeMHSM
+	if isMHSMVault {
+		filter = fmt.Sprintf("resourceType eq 'Microsoft.KeyVault/managedHSMs' and name eq '%s'", *keyVaultName)
+	}
 	result, err := resourcesClient.ResourcesClient.List(ctx, filter, "", utils.Int32(5))
 	if err != nil {
 		return nil, fmt.Errorf("listing resources matching %q: %+v", filter, err)
@@ -134,23 +196,20 @@ func (c *Client) KeyVaultIDFromBaseUrl(ctx context.Context, resourcesClient *res
 				continue
 			}
 
-			id, err := parse.VaultID(*v.ID)
+			id, err := parse.NewVaulterFromString(*v.ID)
 			if err != nil {
 				return nil, fmt.Errorf("parsing %q: %+v", *v.ID, err)
 			}
-			if !strings.EqualFold(id.Name, *keyVaultName) {
+			if !strings.EqualFold(id.GetName(), *keyVaultName) {
 				continue
 			}
 
-			props, err := c.VaultsClient.Get(ctx, id.ResourceGroup, id.Name)
+			vaultURI, err := c.GetVaultURI(ctx, id)
 			if err != nil {
-				return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
-			}
-			if props.Properties == nil || props.Properties.VaultURI == nil {
-				return nil, fmt.Errorf("retrieving %s: `properties.VaultUri` was nil", *id)
+				return nil, err
 			}
 
-			c.AddToCache(*id, *props.Properties.VaultURI)
+			c.AddToCache(id, vaultURI)
 			return utils.String(id.ID()), nil
 		}
 
@@ -164,25 +223,13 @@ func (c *Client) KeyVaultIDFromBaseUrl(ctx context.Context, resourcesClient *res
 }
 
 func (c *Client) Purge(keyVaultId parse.VaultId) {
-	cacheKey := c.cacheKeyForKeyVault(keyVaultId.Name)
-	keysmith.Lock()
-	if lock[cacheKey] == nil {
-		lock[cacheKey] = &sync.RWMutex{}
-	}
-	keysmith.Unlock()
-	lock[cacheKey].Lock()
-	delete(keyVaultsCache, cacheKey)
-	lock[cacheKey].Unlock()
+	vaultCacheIns.Delete(keyVaultId)
 }
 
-func (c *Client) cacheKeyForKeyVault(name string) string {
-	return strings.ToLower(name)
-}
-
-func (c *Client) parseNameFromBaseUrl(input string) (*string, error) {
+func (c *Client) parseNameFromBaseUrl(input string) (*string, parse.VaultType, error) {
 	uri, err := url.Parse(input)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
 	// https://the-keyvault.vault.azure.net
@@ -192,8 +239,8 @@ func (c *Client) parseNameFromBaseUrl(input string) (*string, error) {
 	// https://the-keyvault.vault.azure.cn
 
 	segments := strings.Split(uri.Host, ".")
-	if len(segments) < 3 || segments[1] != "vault" {
-		return nil, fmt.Errorf("expected a URI in the format `the-keyvault-name.vault.**` but got %q", uri.Host)
+	if len(segments) < 3 || !parse.IsValidValtType(segments[1]) {
+		return nil, "", fmt.Errorf("expected a URI in the format `the-keyvault-name.vault.**` or `the-keyvault-name.managedhsm.**` but got %q", uri.Host)
 	}
-	return &segments[0], nil
+	return &segments[0], parse.VaultType(segments[1]), nil
 }

--- a/internal/services/keyvault/key_vault_managed_hardware_security_module_resource.go
+++ b/internal/services/keyvault/key_vault_managed_hardware_security_module_resource.go
@@ -238,11 +238,11 @@ func resourceArmKeyVaultManagedHardwareSecurityModuleCreate(d *pluginsdk.Resourc
 	}
 
 	// security domain download to activate this module
-	if certs := d.Get("activate_config").([]interface{}); certs != nil && len(certs) > 0 && (certs)[0] != nil {
+	if certs := d.Get("activate_config").([]interface{}); len(certs) > 0 && (certs)[0] != nil {
 		// get hsm uri
 		hsmRes, err := future.Result(*client)
 		if hsmRes.Properties == nil || hsmRes.Properties.HsmURI == nil {
-			log.Printf("get emtpy HSM URI when activating it, skip it now: %+v", err)
+			log.Printf("get empty HSM URI when activating it, skip it now: %+v", err)
 		} else {
 			encData, err := securityDomainDownload(ctx,
 				meta.(*clients.Client).KeyVault,
@@ -498,7 +498,7 @@ func securityDomainDownload(ctx context.Context, cli *client.Client, vaultBaseUR
 	}
 
 	err = waitHSMPendingStatus(ctx, vaultBaseURL, sdClient, false)
-	return encData.Value, nil
+	return encData.Value, err
 }
 
 // if isUpload is false, then check the download pending

--- a/internal/services/keyvault/key_vault_managed_hardware_security_module_resource.go
+++ b/internal/services/keyvault/key_vault_managed_hardware_security_module_resource.go
@@ -435,7 +435,7 @@ func securityDomainDownload(ctx context.Context, cli *client.Client, vaultBaseUR
 		keyID, _ := parse.ParseNestedItemID(certID)
 		certRes, err := keyClient.GetCertificate(ctx, keyID.KeyVaultBaseUrl, keyID.Name, keyID.Version)
 		if err != nil {
-			return "", fmt.Errorf("retriving key %s: %v", certID, err)
+			return "", fmt.Errorf("retreiving key %s: %v", certID, err)
 		}
 		if certRes.Cer == nil {
 			return "", fmt.Errorf("got nil key for %s", certID)
@@ -444,8 +444,6 @@ func securityDomainDownload(ctx context.Context, cli *client.Client, vaultBaseUR
 			Kty:    pointer.FromString("RSA"),
 			KeyOps: &[]string{""},
 			Alg:    pointer.FromString("RSA-OAEP-256"),
-		}
-		if *cert.Alg == "" {
 		}
 		if certRes.Policy != nil && certRes.Policy.KeyProperties != nil {
 			cert.Kty = pointer.FromString(string(certRes.Policy.KeyProperties.KeyType))

--- a/internal/services/keyvault/key_vault_managed_hardware_security_module_resource.go
+++ b/internal/services/keyvault/key_vault_managed_hardware_security_module_resource.go
@@ -1,18 +1,27 @@
 package keyvault
 
 import (
+	"context"
+	"crypto/sha1"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
+	"io"
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2021-10-01/keyvault" // nolint: staticcheck
 	"github.com/gofrs/uuid"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/client"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
@@ -20,6 +29,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
+	kv73 "github.com/tombuildsstuff/kermit/sdk/keyvault/7.4/keyvault"
 )
 
 func resourceKeyVaultManagedHardwareSecurityModule() *pluginsdk.Resource {
@@ -27,6 +37,7 @@ func resourceKeyVaultManagedHardwareSecurityModule() *pluginsdk.Resource {
 		Create: resourceArmKeyVaultManagedHardwareSecurityModuleCreate,
 		Read:   resourceArmKeyVaultManagedHardwareSecurityModuleRead,
 		Delete: resourceArmKeyVaultManagedHardwareSecurityModuleDelete,
+		Update: resourceArmKeyVaultManagedHardwareSecurityModuleUpdate,
 
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
 			_, err := parse.ManagedHSMID(id)
@@ -36,6 +47,7 @@ func resourceKeyVaultManagedHardwareSecurityModule() *pluginsdk.Resource {
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(60 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
+			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(60 * time.Minute),
 		},
 
@@ -131,6 +143,30 @@ func resourceKeyVaultManagedHardwareSecurityModule() *pluginsdk.Resource {
 				},
 			},
 
+			"security_domain_certificate": {
+				Type:     pluginsdk.TypeSet,
+				MinItems: 3,
+				MaxItems: 10,
+				Optional: true,
+				Elem: &pluginsdk.Schema{
+					Type:         pluginsdk.TypeString,
+					ValidateFunc: validate.NestedItemId,
+				},
+			},
+
+			"security_domain_quorum": {
+				Type:         pluginsdk.TypeInt,
+				Optional:     true,
+				RequiredWith: []string{"security_domain_certificate"},
+				ValidateFunc: validation.IntBetween(2, 10),
+			},
+
+			"security_domain_enc_data": {
+				Type:      pluginsdk.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+
 			// https://github.com/Azure/azure-rest-api-specs/issues/13365
 			"tags": tags.ForceNewSchema(),
 		},
@@ -181,6 +217,7 @@ func resourceArmKeyVaultManagedHardwareSecurityModuleCreate(d *pluginsdk.Resourc
 		hsm.Properties.PublicNetworkAccess = keyvault.PublicNetworkAccessDisabled
 	}
 
+	client.Client.RetryAttempts = 1 // retry if failed
 	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.Name, hsm)
 	if err != nil {
 		return fmt.Errorf("creating %s: %+v", id, err)
@@ -190,8 +227,66 @@ func resourceArmKeyVaultManagedHardwareSecurityModuleCreate(d *pluginsdk.Resourc
 		return fmt.Errorf("waiting on creation for %s: %+v", id, err)
 	}
 
+	// security domain download to activate this module
+	if certs := utils.ExpandStringSlice(d.Get("security_domain_certificate").(*pluginsdk.Set).List()); certs != nil && len(*certs) > 0 {
+		// get hsm uri
+		hsmRes, err := future.Result(*client)
+		if err != nil {
+			return fmt.Errorf("get hsm result: %v", err)
+		}
+		if hsmRes.Properties == nil || hsmRes.Properties.HsmURI == nil {
+			return fmt.Errorf("get nil hsmURI for %s", id)
+		}
+
+		encData, err := securityDomainDownload(ctx,
+			meta.(*clients.Client).KeyVault,
+			*hsmRes.Properties.HsmURI,
+			*certs,
+			d.Get("security_domain_quorum").(int),
+		)
+		if err == nil {
+			d.Set("security_domain_enc_data", encData)
+		} else {
+			log.Printf("security domain download: %v", err)
+		}
+	}
+
 	d.SetId(id.ID())
 	return resourceArmKeyVaultManagedHardwareSecurityModuleRead(d, meta)
+}
+
+// update to re-activate the security module
+func resourceArmKeyVaultManagedHardwareSecurityModuleUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+	cli := meta.(*clients.Client).KeyVault.ManagedHsmClient
+	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.ManagedHSMID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	resp, err := cli.Get(ctx, id.ResourceGroup, id.Name)
+	if err != nil || resp.Properties == nil || resp.Properties.HsmURI == nil {
+		return fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+
+	if d.HasChange("security_domain_certificate") {
+		if certs := utils.ExpandStringSlice(d.Get("security_domain_certificate").(*pluginsdk.Set).List()); len(*certs) > 0 {
+			// get hsm uri
+			encData, err := securityDomainDownload(ctx,
+				meta.(*clients.Client).KeyVault,
+				*resp.Properties.HsmURI,
+				*certs,
+				d.Get("security_domain_quorum").(int),
+			)
+			if err != nil {
+				return fmt.Errorf("security domain download: %v", err)
+			}
+			d.Set("security_domain_enc_data", encData)
+		}
+	}
+	return nil
 }
 
 func resourceArmKeyVaultManagedHardwareSecurityModuleRead(d *pluginsdk.ResourceData, meta interface{}) error {
@@ -327,4 +422,85 @@ func flattenMHSMNetworkAcls(acl *keyvault.MHSMNetworkRuleSet) []interface{} {
 		res["default_action"] = string(acl.DefaultAction)
 	}
 	return []interface{}{res}
+}
+
+func securityDomainDownload(ctx context.Context, cli *client.Client, vaultBaseURL string, certIDs []string, qourum int) (encDataStr string, err error) {
+	sdClient := cli.MHSMSDClient
+	keyClient := cli.ManagementClient
+
+	var param kv73.CertificateInfoObject
+	param.Required = utils.Int32(int32(qourum))
+	var certs []kv73.SecurityDomainJSONWebKey
+	for _, certID := range certIDs {
+		keyID, _ := parse.ParseNestedItemID(certID)
+		certRes, err := keyClient.GetCertificate(ctx, keyID.KeyVaultBaseUrl, keyID.Name, keyID.Version)
+		if err != nil {
+			return "", fmt.Errorf("retriving key %s: %v", certID, err)
+		}
+		if certRes.Cer == nil {
+			return "", fmt.Errorf("got nil key for %s", certID)
+		}
+		cert := kv73.SecurityDomainJSONWebKey{
+			Kty:    pointer.FromString("RSA"),
+			KeyOps: &[]string{""},
+			Alg:    pointer.FromString("RSA-OAEP-256"),
+		}
+		if *cert.Alg == "" {
+		}
+		if certRes.Policy != nil && certRes.Policy.KeyProperties != nil {
+			cert.Kty = pointer.FromString(string(certRes.Policy.KeyProperties.KeyType))
+		}
+		x5c := ""
+		if contents := certRes.Cer; contents != nil {
+			x5c = base64.StdEncoding.EncodeToString(*contents)
+		}
+		cert.X5c = &[]string{x5c}
+
+		sum1 := sha1.Sum([]byte(x5c))
+		x5tDst := make([]byte, base64.StdEncoding.EncodedLen(len(sum1)))
+		base64.URLEncoding.Encode(x5tDst, sum1[:])
+		cert.X5t = pointer.FromString(string(x5tDst))
+
+		sum256 := sha256.Sum256([]byte(x5c))
+		s256Dst := make([]byte, base64.StdEncoding.EncodedLen(len(sum256)))
+		base64.URLEncoding.Encode(s256Dst, sum256[:])
+		cert.X5tS256 = pointer.FromString(string(s256Dst))
+		certs = append(certs, cert)
+	}
+	param.Certificates = &certs
+
+	future, err := sdClient.Download(ctx, vaultBaseURL, param)
+	if err != nil {
+		return "", fmt.Errorf("downloading for %s: %v", vaultBaseURL, err)
+	}
+
+	originResponse := future.Response()
+	data, err := io.ReadAll(originResponse.Body)
+	if err != nil {
+		return "", err
+	}
+	var encData struct {
+		Value string `json:"value"`
+	}
+
+	err = json.Unmarshal(data, &encData)
+	if err != nil {
+		return "", fmt.Errorf("unmarshal EncData: %v", err)
+	}
+	// wait download code has bug will never return
+	// limit ctx to wait 5 second(value from azcli)
+	ctx, cancel := context.WithTimeout(ctx, time.Second*5)
+	defer cancel()
+	if err := future.WaitForCompletionRef(ctx, sdClient.Client); err != nil {
+		if !response.WasStatusCode(future.Response(), http.StatusOK) {
+			log.Printf("waiting for download of %s: %v. ignore", vaultBaseURL, err)
+		}
+	}
+	result, err := future.Result(*sdClient)
+	if result.Value != nil {
+		encData.Value = pointer.ToString(result.Value)
+	}
+	encDataStr = encData.Value
+
+	return encDataStr, nil
 }

--- a/internal/services/keyvault/key_vault_managed_hardware_security_module_resource_test.go
+++ b/internal/services/keyvault/key_vault_managed_hardware_security_module_resource_test.go
@@ -301,15 +301,15 @@ resource "azurerm_key_vault_role_assignment" "test" {
   principal_id       = "${data.azurerm_client_config.current.object_id}"
 }
 
-resource "azurerm_key_vault_key" "%s" {
-  name         = "mhsm-key-%s"
+resource "azurerm_key_vault_key" "%[2]s" {
+  name         = "mhsm-key-%[3]s"
   key_vault_id = azurerm_key_vault_managed_hardware_security_module.test.id
-  key_type     = "EC"
+  key_type     = "EC-HSM"
   key_size     = 2048
 
   key_opts = [
-    "sign",
     "verify",
+    "sign",
   ]
 }
 `, template, r.testKeyResourceName(), data.RandomString)

--- a/internal/services/keyvault/key_vault_managed_hardware_security_module_resource_test.go
+++ b/internal/services/keyvault/key_vault_managed_hardware_security_module_resource_test.go
@@ -177,6 +177,7 @@ resource "azurerm_key_vault" "test" {
       "Purge",
       "Recover",
       "Update",
+      "GetRotationPolicy",
     ]
 
     secret_permissions = [

--- a/internal/services/keyvault/key_vault_managed_hardware_security_module_resource_test.go
+++ b/internal/services/keyvault/key_vault_managed_hardware_security_module_resource_test.go
@@ -26,6 +26,7 @@ func TestAccKeyVaultManagedHardwareSecurityModule(t *testing.T) {
 			"basic":    testAccKeyVaultManagedHardwareSecurityModule_basic,
 			"update":   testAccKeyVaultManagedHardwareSecurityModule_requiresImport,
 			"complete": testAccKeyVaultManagedHardwareSecurityModule_complete,
+			"download": testAccKeyVaultManagedHardwareSecurityModule_download,
 		},
 	})
 }
@@ -42,6 +43,28 @@ func testAccKeyVaultManagedHardwareSecurityModule_basic(t *testing.T) {
 			),
 		},
 		data.ImportStep(),
+	})
+}
+
+func testAccKeyVaultManagedHardwareSecurityModule_download(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_key_vault_managed_hardware_security_module", "test")
+	r := KeyVaultManagedHardwareSecurityModuleResource{}
+
+	data.ResourceSequentialTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.download(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("security_domain_certificate", "security_domain_enc_data", "security_domain_quorum"),
 	})
 }
 
@@ -124,6 +147,126 @@ resource "azurerm_key_vault_managed_hardware_security_module" "import" {
   admin_object_ids    = azurerm_key_vault_managed_hardware_security_module.test.admin_object_ids
 }
 `, template)
+}
+
+func (r KeyVaultManagedHardwareSecurityModuleResource) download(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_key_vault" "test" {
+  name                       = "acc%[2]d"
+  location                   = azurerm_resource_group.test.location
+  resource_group_name        = azurerm_resource_group.test.name
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "standard"
+  soft_delete_retention_days = 7
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azurerm_client_config.current.object_id
+
+    key_permissions = [
+      "Create",
+      "Delete",
+      "Get",
+      "Purge",
+      "Recover",
+      "Update",
+    ]
+
+    secret_permissions = [
+      "Delete",
+      "Get",
+      "Set",
+    ]
+
+    certificate_permissions = [
+      "Create",
+      "Delete",
+      "DeleteIssuers",
+      "Get",
+      "Purge",
+      "Update"
+    ]
+  }
+
+  tags = {
+    environment = "Production"
+  }
+}
+
+resource "azurerm_key_vault_certificate" "cert" {
+  count        = 3
+  name         = "acchsmcert${count.index}"
+  key_vault_id = azurerm_key_vault.test.id
+
+  certificate_policy {
+    issuer_parameters {
+      name = "Self"
+    }
+
+    key_properties {
+      exportable = true
+      key_size   = 2048
+      key_type   = "RSA"
+      reuse_key  = true
+    }
+
+    lifetime_action {
+      action {
+        action_type = "AutoRenew"
+      }
+
+      trigger {
+        days_before_expiry = 30
+      }
+    }
+
+    secret_properties {
+      content_type = "application/x-pkcs12"
+    }
+
+    x509_certificate_properties {
+      extended_key_usage = []
+
+      key_usage = [
+        "cRLSign",
+        "dataEncipherment",
+        "digitalSignature",
+        "keyAgreement",
+        "keyCertSign",
+        "keyEncipherment",
+      ]
+
+      subject            = "CN=hello-world"
+      validity_in_months = 12
+    }
+  }
+}
+
+resource "azurerm_key_vault_managed_hardware_security_module" "test" {
+  name                     = "kvHsm%[2]d"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  sku_name                 = "Standard_B1"
+  tenant_id                = data.azurerm_client_config.current.tenant_id
+  admin_object_ids         = [data.azurerm_client_config.current.object_id]
+  purge_protection_enabled = false
+
+  security_domain_certificate = [
+    azurerm_key_vault_certificate.cert[0].id,
+    azurerm_key_vault_certificate.cert[1].id,
+    azurerm_key_vault_certificate.cert[2].id,
+  ]
+
+  security_domain_quorum = 2
+}
+`, template, data.RandomInteger)
 }
 
 func (r KeyVaultManagedHardwareSecurityModuleResource) complete(data acceptance.TestData) string {

--- a/internal/services/keyvault/key_vault_role_assignment_resource.go
+++ b/internal/services/keyvault/key_vault_role_assignment_resource.go
@@ -1,0 +1,188 @@
+package keyvault
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+	"github.com/tombuildsstuff/kermit/sdk/keyvault/7.4/keyvault"
+)
+
+type KeyVaultRoleAssignmentModel struct {
+	VaultBaseUrl     string `tfschema:"vault_base_url"`
+	Name             string `tfschema:"name"`
+	Scope            string `tfschema:"scope"`
+	RoleDefinitionId string `tfschema:"role_definition_id"`
+	PrincipalId      string `tfschema:"principal_id"`
+	ResourceId       string `tfschema:"resource_id"`
+}
+
+func (k KeyVaultRoleAssignmentModel) ID() string {
+	return fmt.Sprintf("%s%s/%s", k.VaultBaseUrl, k.Scope, k.Name)
+}
+
+type KeyVaultRoleAssignmentResource struct{}
+
+var _ sdk.Resource = (*KeyVaultRoleAssignmentResource)(nil)
+
+func (m KeyVaultRoleAssignmentResource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"vault_base_url": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"scope": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		// https://learn.microsoft.com/en-us/azure/key-vault/managed-hsm/built-in-roles
+		"role_definition_id": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"principal_id": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+	}
+}
+
+func (m KeyVaultRoleAssignmentResource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"resource_id": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+	}
+}
+
+func (m KeyVaultRoleAssignmentResource) ModelObject() interface{} {
+	return &KeyVaultRoleAssignmentModel{}
+}
+
+func (m KeyVaultRoleAssignmentResource) ResourceType() string {
+	return "azurerm_key_vault_role_assignment"
+}
+
+func (m KeyVaultRoleAssignmentResource) Create() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, meta sdk.ResourceMetaData) (err error) {
+			client := meta.Client.KeyVault.MHSMRoleAssignClient
+
+			var model KeyVaultRoleAssignmentModel
+			if err := meta.Decode(&model); err != nil {
+				return err
+			}
+
+			id, err := parse.NewMHSMNestedItemID(model.VaultBaseUrl, model.Scope, parse.RoleAssignmentType, model.Name)
+			if err != nil {
+				return err
+			}
+			existing, err := client.Get(ctx, model.VaultBaseUrl, model.Scope, model.Name)
+			if !utils.ResponseWasNotFound(existing.Response) {
+				if err != nil {
+					return fmt.Errorf("retreiving %s: %v", model.ID(), err)
+				}
+				return meta.ResourceRequiresImport(m.ResourceType(), id)
+			}
+
+			var param keyvault.RoleAssignmentCreateParameters
+			param.Properties = &keyvault.RoleAssignmentProperties{}
+			prop := param.Properties
+			prop.PrincipalID = pointer.FromString(model.PrincipalId)
+			prop.RoleDefinitionID = pointer.FromString(model.RoleDefinitionId)
+
+			_, err = client.Create(ctx, model.VaultBaseUrl, model.Scope, model.Name, param)
+			if err != nil {
+				return fmt.Errorf("creating %s: %v", model.ID(), err)
+			}
+
+			meta.SetID(id)
+			return nil
+		},
+	}
+}
+
+func (m KeyVaultRoleAssignmentResource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, meta sdk.ResourceMetaData) error {
+			client := meta.Client.KeyVault.MHSMRoleAssignClient
+
+			id, err := parse.MHSMNestedItemID(meta.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			result, err := client.Get(ctx, id.VaultBaseUrl, id.Scope, id.Name)
+			if err != nil {
+				if utils.ResponseWasNotFound(result.Response) {
+					return meta.MarkAsGone(id)
+				}
+				return err
+			}
+
+			var model KeyVaultRoleAssignmentModel
+			if err := meta.Decode(&model); err != nil {
+				return err
+			}
+
+			prop := result.Properties
+			model.Scope = string(prop.Scope)
+			model.RoleDefinitionId = pointer.ToString(prop.RoleDefinitionID)
+			model.PrincipalId = pointer.ToString(prop.PrincipalID)
+			model.ResourceId = pointer.ToString(result.ID)
+
+			return meta.Encode(&model)
+		},
+	}
+}
+
+func (m KeyVaultRoleAssignmentResource) Delete() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 10 * time.Minute,
+		Func: func(ctx context.Context, meta sdk.ResourceMetaData) error {
+			id, err := parse.MHSMNestedItemID(meta.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			meta.Logger.Infof("deleting %s", id)
+
+			if _, err := meta.Client.KeyVault.MHSMRoleAssignClient.Delete(ctx, id.VaultBaseUrl, id.Scope, id.Name); err != nil {
+				return fmt.Errorf("deleting %s: %v", id.ID(), err)
+			}
+			return nil
+		},
+	}
+}
+
+func (m KeyVaultRoleAssignmentResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+	return validate.MHSMNestedItemId
+}

--- a/internal/services/keyvault/key_vault_role_assignment_resource_test.go
+++ b/internal/services/keyvault/key_vault_role_assignment_resource_test.go
@@ -1,0 +1,118 @@
+package keyvault_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+type KeyVaultRoleAssignmentResource struct{}
+
+func (a KeyVaultRoleAssignmentResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := parse.MHSMNestedItemID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.KeyVault.MHSMRoleAssignClient.Get(ctx, id.VaultBaseUrl, id.Scope, id.Name)
+	if err != nil {
+		return nil, fmt.Errorf("retrieving Type %s: %+v", id, err)
+	}
+	return utils.Bool(resp.Properties != nil), nil
+}
+
+func (a KeyVaultRoleAssignmentResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-auto-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_key_vault_managed_hardware_security_module" "test" {
+  name                     = "kvHSM-%[1]d"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = "%[2]s"
+  sku_name                 = "Standard_B1"
+  tenant_id                = data.azurerm_client_config.current.tenant_id
+  admin_object_ids         = [data.azurerm_client_config.current.object_id]
+  purge_protection_enabled = false
+}
+
+data "azurerm_key_vault_role_definition" "user" {
+  vault_base_url     = azurerm_key_vault_managed_hardware_security_module.test.hsm_uri
+  role_definition_id = "21dbd100-6940-42c2-9190-5d6cb909625b"
+  scope              = "/"
+  principal_id       = data.azurerm_client_config.current.object_id
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func (a KeyVaultRoleAssignmentResource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+
+%s
+
+resource "azurerm_key_vault_role_assignment" "test" {
+  vault_base_url     = azurerm_key_vault_managed_hardware_security_module.test.hsm_uri
+  scope              = "${data.azurerm_key_vault_role_definition.user.scope}"
+  role_definition_id = "${data.azurerm_key_vault_role_definition.user.id}"
+  principal_id       = "${data.azurerm_client_config.current.object_id}"
+}
+`, a.template(data))
+}
+
+func (a KeyVaultRoleAssignmentResource) update(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+
+
+
+
+%s
+
+resource "azurerm_key_vault_role_assignment" "test" {
+
+  vault_base_url     = "example"
+  name               = "acctest-%[2]d"
+  scope              = "example"
+  role_definition_id = "example"
+  principal_id       = "example"
+}
+`, a.template(data), data.RandomInteger)
+}
+
+// TODO we cannot test it right now, because we cannot activate mnagedhsm keyvault from terraform
+func TestAccKeyVaultRoleAssignment_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, keyvault.KeyVaultRoleAssignmentResource{}.ResourceType(), "test")
+	r := KeyVaultRoleAssignmentResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("is_global").HasValue("false"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.update(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("is_global").HasValue("false"),
+			),
+		},
+		data.ImportStep(),
+	})
+}

--- a/internal/services/keyvault/key_vault_role_definition_data_resource.go
+++ b/internal/services/keyvault/key_vault_role_definition_data_resource.go
@@ -65,7 +65,6 @@ func (k KeyvaultRoleDefinitionDataResource) Arguments() map[string]*pluginsdk.Sc
 		"vault_base_url": {
 			Type:         pluginsdk.TypeString,
 			Required:     true,
-			ForceNew:     true,
 			ValidateFunc: validation.IsURLWithHTTPorHTTPS,
 		},
 
@@ -73,7 +72,6 @@ func (k KeyvaultRoleDefinitionDataResource) Arguments() map[string]*pluginsdk.Sc
 			Type:     pluginsdk.TypeString,
 			Default:  "/",
 			Optional: true,
-			ForceNew: true,
 			ValidateFunc: validation.StringInSlice([]string{
 				"/",
 			}, false),

--- a/internal/services/keyvault/key_vault_role_definition_data_resource.go
+++ b/internal/services/keyvault/key_vault_role_definition_data_resource.go
@@ -1,0 +1,210 @@
+package keyvault
+
+import (
+	"context"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+	"github.com/tombuildsstuff/kermit/sdk/keyvault/7.4/keyvault"
+)
+
+type KeyVaultRoleDefinitionDataSourceModel struct {
+	Name             string       `tfschema:"name"`
+	RoleName         string       `tfschema:"role_name"`
+	Scope            string       `tfschema:"scope"`
+	VaultBaseUrl     string       `tfschema:"vault_base_url"`
+	Description      string       `tfschema:"description"`
+	AssignableScopes []string     `tfschema:"assignable_scopes"`
+	Permission       []Permission `tfschema:"permission"`
+	RoleType         string       `tfschema:"role_type"`
+	ResourceId       string       `tfschema:"resource_id"`
+}
+
+func (k *KeyVaultRoleDefinitionDataSourceModel) ToSDKPermissions() *[]keyvault.Permission {
+	var res []keyvault.Permission
+	for _, p := range k.Permission {
+		ins := keyvault.Permission{}
+		if p.Actions != nil {
+			ins.Actions = pointer.FromSliceOfStrings(p.Actions)
+		}
+		if p.NotActions != nil {
+			ins.NotActions = pointer.FromSliceOfStrings(p.NotActions)
+		}
+		ins.DataActions, ins.NotDataActions = p.toSDKDataAction()
+		res = append(res, ins)
+	}
+	return &res
+}
+
+func (k *KeyVaultRoleDefinitionDataSourceModel) LoadSDKPermission(perms *[]keyvault.Permission) {
+	if perms != nil {
+		k.Permission = []Permission{}
+		for _, p := range *perms {
+			k.Permission = append(k.Permission, (&Permission{}).loadSDKDataAction(p))
+		}
+	}
+}
+
+type KeyvaultRoleDefinitionDataResource struct{}
+
+var _ sdk.DataSource = (*KeyvaultRoleDefinitionDataResource)(nil)
+
+func (k KeyvaultRoleDefinitionDataResource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ValidateFunc: validation.IsUUID,
+		},
+
+		"vault_base_url": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.IsURLWithHTTPorHTTPS,
+		},
+
+		"scope": {
+			Type:     pluginsdk.TypeString,
+			Default:  "/",
+			Optional: true,
+			ForceNew: true,
+			ValidateFunc: validation.StringInSlice([]string{
+				"/",
+			}, false),
+		},
+	}
+}
+
+func (k KeyvaultRoleDefinitionDataResource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"role_type": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"role_name": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"resource_id": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"description": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"assignable_scopes": {
+			Type:     pluginsdk.TypeList,
+			Computed: true,
+			Elem: &pluginsdk.Schema{
+				Type: pluginsdk.TypeString,
+			},
+		},
+
+		//lintignore:XS003
+		"permission": {
+			Type:     pluginsdk.TypeList,
+			Computed: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"actions": {
+						Type:     pluginsdk.TypeList,
+						Computed: true,
+						Elem: &pluginsdk.Schema{
+							Type: pluginsdk.TypeString,
+						},
+					},
+
+					"not_actions": {
+						Type:     pluginsdk.TypeList,
+						Computed: true,
+						Elem: &pluginsdk.Schema{
+							Type: pluginsdk.TypeString,
+						},
+					},
+
+					"data_actions": {
+						Type:     pluginsdk.TypeSet,
+						Computed: true,
+						Elem: &pluginsdk.Schema{
+							Type: pluginsdk.TypeString,
+						},
+						Set: pluginsdk.HashString,
+					},
+
+					"not_data_actions": {
+						Type:     pluginsdk.TypeSet,
+						Computed: true,
+						Elem: &pluginsdk.Schema{
+							Type: pluginsdk.TypeString,
+						},
+						Set: pluginsdk.HashString,
+					},
+				},
+			},
+		},
+	}
+}
+
+func (k KeyvaultRoleDefinitionDataResource) ModelObject() interface{} {
+	return &KeyVaultRoleDefinitionDataSourceModel{}
+}
+
+func (k KeyvaultRoleDefinitionDataResource) ResourceType() string {
+	return "azurerm_key_vault_role_definition"
+}
+
+func (k KeyvaultRoleDefinitionDataResource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, meta sdk.ResourceMetaData) error {
+			var model KeyVaultRoleDefinitionDataSourceModel
+			if err := meta.Decode(&model); err != nil {
+				return err
+			}
+
+			id, err := parse.NewMHSMNestedItemID(model.VaultBaseUrl, model.Scope, parse.RoleDefinitionType, model.Name)
+			if err != nil {
+				return err
+			}
+
+			client := meta.Client.KeyVault.MHSMRoleClient
+			result, err := client.Get(ctx, model.VaultBaseUrl, model.Scope, model.Name)
+			if err != nil {
+				if utils.ResponseWasNotFound(result.Response) {
+					return meta.MarkAsGone(id)
+				}
+				return err
+			}
+
+			model.ResourceId = pointer.From(result.ID)
+
+			if prop := result.RoleDefinitionProperties; prop != nil {
+				model.Description = pointer.ToString(prop.Description)
+				model.RoleType = string(prop.RoleType)
+				model.RoleName = pointer.From(prop.RoleName)
+
+				if prop.AssignableScopes != nil {
+					for _, r := range *prop.AssignableScopes {
+						model.AssignableScopes = append(model.AssignableScopes, string(r))
+					}
+				}
+
+				model.LoadSDKPermission(prop.Permissions)
+			}
+
+			meta.SetID(id)
+			return meta.Encode(&model)
+		},
+	}
+}

--- a/internal/services/keyvault/key_vault_role_definition_resource.go
+++ b/internal/services/keyvault/key_vault_role_definition_resource.go
@@ -185,6 +185,8 @@ func (k KeyVaultRoleDefinitionResource) Arguments() map[string]*pluginsdk.Schema
 			},
 		},
 
+		// the server changes the value to `/` when pass a `/keys`: https://github.com/Azure/azure-rest-api-specs/issues/23045
+		// so limit the value to `/` for current version
 		"assignable_scopes": {
 			Type:     pluginsdk.TypeList,
 			Optional: true,

--- a/internal/services/keyvault/key_vault_role_definition_resource.go
+++ b/internal/services/keyvault/key_vault_role_definition_resource.go
@@ -1,0 +1,362 @@
+package keyvault
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+	"github.com/tombuildsstuff/kermit/sdk/keyvault/7.4/keyvault"
+)
+
+type Permission struct {
+	Actions        []string `tfschema:"actions"`
+	NotActions     []string `tfschema:"not_actions"`
+	DataActions    []string `tfschema:"data_actions"`
+	NotDataActions []string `tfschema:"not_data_actions"`
+}
+
+func (p *Permission) toSDKDataAction() (pda, pnda *[]keyvault.DataAction) {
+	var da, nda = make([]keyvault.DataAction, 0), make([]keyvault.DataAction, 0)
+	for _, d := range p.DataActions {
+		da = append(da, keyvault.DataAction(d))
+	}
+	for _, nd := range p.NotDataActions {
+		nda = append(nda, keyvault.DataAction(nd))
+	}
+	pda, pnda = &da, &nda
+	return
+}
+
+func (p *Permission) loadSDKDataAction(perm keyvault.Permission) Permission {
+	p.Actions = pointer.ToSliceOfStrings(perm.Actions)
+	p.NotActions = pointer.ToSliceOfStrings(perm.NotActions)
+	if perm.DataActions != nil {
+		for _, a := range *perm.DataActions {
+			p.DataActions = append(p.DataActions, string(a))
+		}
+	}
+	if perm.NotDataActions != nil {
+		for _, a := range *perm.NotDataActions {
+			p.NotDataActions = append(p.NotDataActions, string(a))
+		}
+	}
+	return *p
+}
+
+type KeyVaultRoleDefinitionModel struct {
+	Name             string       `tfschema:"name"`
+	RoleName         string       `tfschema:"role_name"`
+	Scope            string       `tfschema:"scope"`
+	VaultBaseUrl     string       `tfschema:"vault_base_url"`
+	Description      string       `tfschema:"description"`
+	AssignableScopes []string     `tfschema:"assignable_scopes"`
+	Permission       []Permission `tfschema:"permission"`
+	RoleType         string       `tfschema:"role_type"`
+	ResourceId       string       `tfschema:"resource_id"`
+}
+
+func (k *KeyVaultRoleDefinitionModel) id() string {
+	return fmt.Sprintf("%s/%s/%s", strings.TrimRight(k.VaultBaseUrl, "/"), k.Scope, k.Name)
+}
+
+func (k *KeyVaultRoleDefinitionModel) ToSDKPermissions() *[]keyvault.Permission {
+	var res []keyvault.Permission
+	for _, p := range k.Permission {
+		ins := keyvault.Permission{}
+		if p.Actions != nil {
+			ins.Actions = pointer.FromSliceOfStrings(p.Actions)
+		}
+		if p.NotActions != nil {
+			ins.NotActions = pointer.FromSliceOfStrings(p.NotActions)
+		}
+		ins.DataActions, ins.NotDataActions = p.toSDKDataAction()
+		res = append(res, ins)
+	}
+	return &res
+}
+
+func (k *KeyVaultRoleDefinitionModel) LoadSDKPermission(perms *[]keyvault.Permission) {
+	if perms != nil {
+		k.Permission = []Permission{}
+		for _, p := range *perms {
+			k.Permission = append(k.Permission, (&Permission{}).loadSDKDataAction(p))
+		}
+	}
+}
+
+type KeyVaultRoleDefinitionResource struct{}
+
+var _ sdk.ResourceWithUpdate = (*KeyVaultRoleDefinitionResource)(nil)
+
+func (k KeyVaultRoleDefinitionResource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.IsUUID,
+		},
+
+		"role_name": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"vault_base_url": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.IsURLWithHTTPorHTTPS,
+		},
+
+		"scope": {
+			Type:     pluginsdk.TypeString,
+			Default:  "/",
+			Optional: true,
+			ForceNew: true,
+			ValidateFunc: validation.StringInSlice([]string{
+				"/",
+			}, false),
+		},
+
+		//lintignore:XS003
+		"permission": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"actions": {
+						Type:     pluginsdk.TypeList,
+						Optional: true,
+						Elem: &pluginsdk.Schema{
+							Type:         pluginsdk.TypeString,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+					},
+
+					"not_actions": {
+						Type:     pluginsdk.TypeList,
+						Optional: true,
+						Elem: &pluginsdk.Schema{
+							Type:         pluginsdk.TypeString,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+					},
+
+					"data_actions": {
+						Type:     pluginsdk.TypeSet,
+						Optional: true,
+						Elem: &pluginsdk.Schema{
+							Type: pluginsdk.TypeString,
+							ValidateFunc: validation.StringInSlice(func() (res []string) {
+								for _, v := range keyvault.PossibleDataActionValues() {
+									res = append(res, string(v))
+								}
+								return
+							}(), false),
+						},
+						Set: pluginsdk.HashString,
+					},
+
+					"not_data_actions": {
+						Type:     pluginsdk.TypeSet,
+						Optional: true,
+						Elem: &pluginsdk.Schema{
+							Type: pluginsdk.TypeString,
+							ValidateFunc: validation.StringInSlice(func() (res []string) {
+								for _, v := range keyvault.PossibleDataActionValues() {
+									res = append(res, string(v))
+								}
+								return
+							}(), false),
+						},
+						Set: pluginsdk.HashString,
+					},
+				},
+			},
+		},
+
+		"assignable_scopes": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			Elem: &pluginsdk.Schema{
+				Type: pluginsdk.TypeString,
+				ValidateFunc: validation.StringInSlice([]string{
+					string(keyvault.RoleScopeGlobal),
+					// string(keyvault.RoleScopeKeys),
+				}, false),
+			},
+		},
+
+		"description": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+	}
+}
+
+func (k KeyVaultRoleDefinitionResource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"role_type": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"resource_id": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+	}
+}
+
+func (k KeyVaultRoleDefinitionResource) ModelObject() interface{} {
+	return &KeyVaultRoleDefinitionModel{}
+}
+
+func (k KeyVaultRoleDefinitionResource) ResourceType() string {
+	return "azurerm_key_vault_role_definition"
+}
+
+func (k KeyVaultRoleDefinitionResource) createOrUpdateFunc(isUpdate bool) sdk.ResourceRunFunc {
+	return func(ctx context.Context, meta sdk.ResourceMetaData) (err error) {
+		client := meta.Client.KeyVault.MHSMRoleClient
+
+		var model KeyVaultRoleDefinitionModel
+		if err = meta.Decode(&model); err != nil {
+			return err
+		}
+
+		id, err := parse.NewMHSMNestedItemID(model.VaultBaseUrl, model.Scope, parse.RoleDefinitionType, model.Name)
+		if err != nil {
+			return err
+		}
+
+		existing, err := client.Get(ctx, id.VaultBaseUrl, id.Scope, id.Name)
+		if !utils.ResponseWasNotFound(existing.Response) {
+			if err != nil {
+				return fmt.Errorf("retreiving role definition by name %s: %v", model.Name, err)
+			}
+			if !isUpdate {
+				return meta.ResourceRequiresImport(k.ResourceType(), id)
+			}
+		} else if isUpdate {
+			return fmt.Errorf("not found resource to update: %s", id)
+		}
+
+		var param keyvault.RoleDefinitionCreateParameters
+		param.Properties = &keyvault.RoleDefinitionProperties{}
+		prop := param.Properties
+		prop.RoleName = utils.String(model.RoleName)
+		prop.Description = utils.String(model.Description)
+		prop.RoleType = keyvault.RoleTypeCustomRole
+		prop.Permissions = model.ToSDKPermissions()
+
+		var scopes []keyvault.RoleScope
+		for _, role := range model.AssignableScopes {
+			scopes = append(scopes, keyvault.RoleScope(role))
+		}
+		if len(scopes) > 0 {
+			prop.AssignableScopes = &scopes
+		}
+
+		_, err = client.CreateOrUpdate(ctx, model.VaultBaseUrl, model.Scope, model.Name, param)
+		if err != nil {
+			return fmt.Errorf("creating %s: %v", model.id(), err)
+		}
+
+		meta.SetID(id)
+		return nil
+	}
+}
+
+func (k KeyVaultRoleDefinitionResource) Create() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func:    k.createOrUpdateFunc(false),
+	}
+}
+
+func (k KeyVaultRoleDefinitionResource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, meta sdk.ResourceMetaData) error {
+			// import has no model data but only id
+			id, err := parse.MHSMNestedItemID(meta.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			var model KeyVaultRoleDefinitionModel
+			if err = meta.Decode(&model); err != nil {
+				return err
+			}
+
+			client := meta.Client.KeyVault.MHSMRoleClient
+			result, err := client.Get(ctx, id.VaultBaseUrl, id.Scope, id.Name)
+			if utils.ResponseWasNotFound(result.Response) {
+				return meta.MarkAsGone(id)
+			}
+			if err != nil {
+				return err
+			}
+			model.ResourceId = pointer.From(result.ID)
+
+			if prop := result.RoleDefinitionProperties; prop != nil {
+				model.Description = pointer.ToString(prop.Description)
+				model.RoleType = string(prop.RoleType)
+				model.RoleName = pointer.From(prop.RoleName)
+
+				if prop.AssignableScopes != nil {
+					model.AssignableScopes = nil
+					for _, r := range *prop.AssignableScopes {
+						model.AssignableScopes = append(model.AssignableScopes, string(r))
+					}
+				}
+
+				model.LoadSDKPermission(prop.Permissions)
+			}
+
+			meta.SetID(id)
+			return meta.Encode(&model)
+		},
+	}
+}
+
+func (k KeyVaultRoleDefinitionResource) Update() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: time.Minute * 10,
+		Func:    k.createOrUpdateFunc(true),
+	}
+}
+
+func (k KeyVaultRoleDefinitionResource) Delete() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 10 * time.Minute,
+		Func: func(ctx context.Context, meta sdk.ResourceMetaData) error {
+			id, err := parse.MHSMNestedItemID(meta.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+			meta.Logger.Infof("deleting %s", id.ID())
+
+			if _, err = meta.Client.KeyVault.MHSMRoleClient.Delete(ctx, id.VaultBaseUrl, id.Scope, id.Name); err != nil {
+				return fmt.Errorf("deleting %+v: %v", id, err)
+			}
+			return nil
+		},
+	}
+}
+
+func (k KeyVaultRoleDefinitionResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+	return validate.MHSMNestedItemId
+}

--- a/internal/services/keyvault/key_vault_role_definition_resource_test.go
+++ b/internal/services/keyvault/key_vault_role_definition_resource_test.go
@@ -1,0 +1,120 @@
+package keyvault_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+)
+
+type KeyVaultRoleDefinitionResource struct{}
+
+func (a KeyVaultRoleDefinitionResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	baseURL := state.Attributes["vault_base_url"]
+	id, err := parse.MHSMNestedItemID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.KeyVault.MHSMRoleClient.Get(ctx, baseURL, "/", id.Name)
+	if err != nil {
+		return nil, fmt.Errorf("retrieving Type %s: %+v", id, err)
+	}
+	return utils.Bool(resp.RoleDefinitionProperties != nil), nil
+}
+
+func (a KeyVaultRoleDefinitionResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-auto-%[1]d"
+  location = "%[2]s"
+}
+
+data "azurerm_client_config" "current" {
+}
+
+resource "azurerm_key_vault_managed_hardware_security_module" "test" {
+  name                     = "kvHsm%[1]d"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  sku_name                 = "Standard_B1"
+  tenant_id                = data.azurerm_client_config.current.tenant_id
+  admin_object_ids         = [data.azurerm_client_config.current.object_id]
+  purge_protection_enabled = false
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func (a KeyVaultRoleDefinitionResource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+
+
+%s
+
+resource "azurerm_key_vault_role_definition" "test" {
+  name              = "acctest-%[2]d"
+  scope             = "/"
+  vault_base_url    = azurerm_key_vault_managed_hardware_security_module.test.hsm_uri
+  description       = "desc foo"
+  assignable_scopes = ["/keys"]
+  permission {
+    actions = ["Microsoft.KeyVault/managedHsm/keys/read/action"]
+  }
+}
+`, a.template(data), data.RandomInteger, data.Locations.Primary)
+}
+
+func (a KeyVaultRoleDefinitionResource) update(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+
+
+%s
+
+resource "azurerm_key_vault_role_definition" "test" {
+  name              = "acctest-%[2]d"
+  scope             = "/"
+  vault_base_url    = azurerm_key_vault_managed_hardware_security_module.test.hsm_uri
+  description       = "desc foo"
+  assignable_scopes = ["/keys"]
+  permission {
+    actions     = ["Microsoft.KeyVault/managedHsm/keys/read/action"]
+    not_actions = ["Microsoft.KeyVault/managedHsm/keys/delete/action"]
+  }
+}
+`, a.template(data), data.RandomInteger)
+}
+
+// We cannot run this Test for now, because we cannot activate mhsm keyvault by terraform now.
+func TestAccKeyVaultRoleDefinition_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, keyvault.KeyVaultRoleDefinitionResource{}.ResourceType(), "test")
+	r := KeyVaultRoleDefinitionResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("is_global").HasValue("false"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.update(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("is_global").HasValue("false"),
+			),
+		},
+		data.ImportStep(),
+	})
+}

--- a/internal/services/keyvault/parse/managed_hsm_key.go
+++ b/internal/services/keyvault/parse/managed_hsm_key.go
@@ -1,0 +1,81 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+type ManagedHSMKeyId struct {
+	SubscriptionId string
+	ResourceGroup  string
+	ManagedHSMName string
+	KeyName        string
+	VersionName    string
+}
+
+func NewManagedHSMKeyID(subscriptionId, resourceGroup, managedHSMName, keyName, versionName string) ManagedHSMKeyId {
+	return ManagedHSMKeyId{
+		SubscriptionId: subscriptionId,
+		ResourceGroup:  resourceGroup,
+		ManagedHSMName: managedHSMName,
+		KeyName:        keyName,
+		VersionName:    versionName,
+	}
+}
+
+func (id ManagedHSMKeyId) String() string {
+	segments := []string{
+		fmt.Sprintf("Version Name %q", id.VersionName),
+		fmt.Sprintf("Key Name %q", id.KeyName),
+		fmt.Sprintf("Managed H S M Name %q", id.ManagedHSMName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+	}
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Managed H S M Key", segmentsStr)
+}
+
+func (id ManagedHSMKeyId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.KeyVault/managedHSMs/%s/keys/%s/versions/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.ManagedHSMName, id.KeyName, id.VersionName)
+}
+
+// ManagedHSMKeyID parses a ManagedHSMKey ID into an ManagedHSMKeyId struct
+func ManagedHSMKeyID(input string) (*ManagedHSMKeyId, error) {
+	id, err := resourceids.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := ManagedHSMKeyId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	if resourceId.ManagedHSMName, err = id.PopSegment("managedHSMs"); err != nil {
+		return nil, err
+	}
+	if resourceId.KeyName, err = id.PopSegment("keys"); err != nil {
+		return nil, err
+	}
+	if resourceId.VersionName, err = id.PopSegment("versions"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/internal/services/keyvault/parse/managed_hsm_key_test.go
+++ b/internal/services/keyvault/parse/managed_hsm_key_test.go
@@ -1,0 +1,144 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.Id = ManagedHSMKeyId{}
+
+func TestManagedHSMKeyIDFormatter(t *testing.T) {
+	actual := NewManagedHSMKeyID("12345678-1234-9876-4563-123456789012", "resGroup1", "hsm1", "key1", "version1").ID()
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/managedHSMs/hsm1/keys/key1/versions/version1"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestManagedHSMKeyID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *ManagedHSMKeyId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing ManagedHSMName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/",
+			Error: true,
+		},
+
+		{
+			// missing value for ManagedHSMName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/managedHSMs/",
+			Error: true,
+		},
+
+		{
+			// missing KeyName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/managedHSMs/hsm1/",
+			Error: true,
+		},
+
+		{
+			// missing value for KeyName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/managedHSMs/hsm1/keys/",
+			Error: true,
+		},
+
+		{
+			// missing VersionName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/managedHSMs/hsm1/keys/key1/",
+			Error: true,
+		},
+
+		{
+			// missing value for VersionName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/managedHSMs/hsm1/keys/key1/versions/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/managedHSMs/hsm1/keys/key1/versions/version1",
+			Expected: &ManagedHSMKeyId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:  "resGroup1",
+				ManagedHSMName: "hsm1",
+				KeyName:        "key1",
+				VersionName:    "version1",
+			},
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.KEYVAULT/MANAGEDHSMS/HSM1/KEYS/KEY1/VERSIONS/VERSION1",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := ManagedHSMKeyID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.ManagedHSMName != v.Expected.ManagedHSMName {
+			t.Fatalf("Expected %q but got %q for ManagedHSMName", v.Expected.ManagedHSMName, actual.ManagedHSMName)
+		}
+		if actual.KeyName != v.Expected.KeyName {
+			t.Fatalf("Expected %q but got %q for KeyName", v.Expected.KeyName, actual.KeyName)
+		}
+		if actual.VersionName != v.Expected.VersionName {
+			t.Fatalf("Expected %q but got %q for VersionName", v.Expected.VersionName, actual.VersionName)
+		}
+	}
+}

--- a/internal/services/keyvault/parse/mhsm_nested_item.go
+++ b/internal/services/keyvault/parse/mhsm_nested_item.go
@@ -1,0 +1,97 @@
+package parse
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.Id = MHSMNestedItemId{}
+
+type MHSMResourceType string
+
+const (
+	MHSMKeys           MHSMResourceType = ""
+	RoleDefinitionType MHSMResourceType = "RoleDefinition"
+	RoleAssignmentType MHSMResourceType = "RoleAssignment"
+	MSHMDownload       MHSMResourceType = "Download"
+)
+
+type MHSMNestedItemId struct {
+	VaultBaseUrl string
+	Scope        string
+	Type         MHSMResourceType
+	Name         string
+}
+
+func NewMHSMNestedItemID(hsmBaseUrl, scope string, typ MHSMResourceType, name string) (*MHSMNestedItemId, error) {
+	keyVaultUrl, err := url.Parse(hsmBaseUrl)
+	if err != nil || hsmBaseUrl == "" {
+		return nil, fmt.Errorf("parsing managedHSM nested itemID %q: %+v", hsmBaseUrl, err)
+	}
+	// (@jackofallops) - Log Analytics service adds the port number to the API returns, so we strip it here
+	if hostParts := strings.Split(keyVaultUrl.Host, ":"); len(hostParts) > 1 {
+		keyVaultUrl.Host = hostParts[0]
+	}
+
+	return &MHSMNestedItemId{
+		VaultBaseUrl: keyVaultUrl.String(),
+		Scope:        scope,
+		Type:         typ,
+		Name:         name,
+	}, nil
+}
+
+func (n MHSMNestedItemId) ID() string {
+	// example: https://tharvey-keyvault.managedhsm.azure.net///uuid-idshifds-fks
+	segments := []string{
+		strings.TrimSuffix(n.VaultBaseUrl, "/"),
+		n.Scope,
+		string(n.Type),
+		n.Name,
+	}
+	return strings.TrimSuffix(strings.Join(segments, "/"), "/")
+}
+
+func (n MHSMNestedItemId) String() string {
+	return n.ID()
+}
+
+func MHSMNestedItemID(input string) (*MHSMNestedItemId, error) {
+	return parseMHSMNestedItemId(input)
+}
+
+func parseMHSMNestedItemId(id string) (*MHSMNestedItemId, error) {
+	idURL, err := url.ParseRequestURI(id)
+	if err != nil {
+		return nil, fmt.Errorf("Cannot parse Azure KeyVault Child Id: %s", err)
+	}
+
+	path := idURL.Path
+
+	path = strings.TrimPrefix(path, "/")
+	path = strings.TrimSuffix(path, "/")
+
+	nameSep := strings.LastIndex(path, "/")
+	if nameSep <= 0 {
+		return nil, fmt.Errorf("no name speparate exist in %s", id)
+	}
+	scope, name := path[:nameSep], path[nameSep+1:]
+
+	typeSep := strings.LastIndex(scope, "/")
+	if typeSep <= 0 {
+		return nil, fmt.Errorf("no type speparate exist in %s", id)
+	}
+	scope, typ := scope[:typeSep], scope[typeSep+1:]
+
+	childId := MHSMNestedItemId{
+		VaultBaseUrl: fmt.Sprintf("%s://%s/", idURL.Scheme, idURL.Host),
+		Scope:        scope,
+		Type:         MHSMResourceType(typ),
+		Name:         name,
+	}
+
+	return &childId, nil
+}

--- a/internal/services/keyvault/parse/mhsm_nested_item_test.go
+++ b/internal/services/keyvault/parse/mhsm_nested_item_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestNewMHSMNestedItemID(t *testing.T) {
-	mhsmType := MHSMKeys
+	mhsmType := RoleDefinitionType
 	cases := []struct {
 		Scenario        string
 		keyVaultBaseUrl string
@@ -26,7 +26,7 @@ func TestNewMHSMNestedItemID(t *testing.T) {
 			keyVaultBaseUrl: "https://test.managedhsm.azure.net",
 			Scope:           "/",
 			Name:            "test",
-			Expected:        "https://test.managedhsm.azure.net///test",
+			Expected:        fmt.Sprintf("https://test.managedhsm.azure.net///%s/test", mhsmType),
 			ExpectError:     false,
 		},
 		{
@@ -34,7 +34,7 @@ func TestNewMHSMNestedItemID(t *testing.T) {
 			keyVaultBaseUrl: "https://test.managedhsm.azure.net:443",
 			Scope:           "/keys",
 			Name:            "test",
-			Expected:        "https://test.managedhsm.azure.net//keys/test",
+			Expected:        fmt.Sprintf("https://test.managedhsm.azure.net//keys/%s/test", mhsmType),
 			ExpectError:     false,
 		},
 	}

--- a/internal/services/keyvault/parse/mhsm_nested_item_test.go
+++ b/internal/services/keyvault/parse/mhsm_nested_item_test.go
@@ -1,0 +1,153 @@
+package parse
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestNewMHSMNestedItemID(t *testing.T) {
+	mhsmType := MHSMKeys
+	cases := []struct {
+		Scenario        string
+		keyVaultBaseUrl string
+		Expected        string
+		Scope           string
+		Name            string
+		ExpectError     bool
+	}{
+		{
+			Scenario:        "empty values",
+			keyVaultBaseUrl: "",
+			Expected:        "",
+			ExpectError:     true,
+		},
+		{
+			Scenario:        "valid, no port",
+			keyVaultBaseUrl: "https://test.managedhsm.azure.net",
+			Scope:           "/",
+			Name:            "test",
+			Expected:        "https://test.managedhsm.azure.net///test",
+			ExpectError:     false,
+		},
+		{
+			Scenario:        "valid, with port",
+			keyVaultBaseUrl: "https://test.managedhsm.azure.net:443",
+			Scope:           "/keys",
+			Name:            "test",
+			Expected:        "https://test.managedhsm.azure.net//keys/test",
+			ExpectError:     false,
+		},
+	}
+	for idx, tc := range cases {
+		id, err := NewMHSMNestedItemID(tc.keyVaultBaseUrl, tc.Scope, mhsmType, tc.Name)
+		if err != nil {
+			if !tc.ExpectError {
+				t.Fatalf("Got error for New Resource ID '%s': %+v", tc.keyVaultBaseUrl, err)
+				return
+			}
+			continue
+		}
+		if id.ID() != tc.Expected {
+			t.Fatalf("Expected %d id for %q to be %q, got %q", idx, tc.keyVaultBaseUrl, tc.Expected, id)
+		}
+	}
+}
+
+func TestParseMHSMNestedItemID(t *testing.T) {
+	typ := RoleDefinitionType
+	cases := []struct {
+		Input       string
+		Expected    MHSMNestedItemId
+		ExpectError bool
+	}{
+		{
+			Input:       "",
+			ExpectError: true,
+		},
+		{
+			Input:       fmt.Sprintf("https://my-keyvault.managedhsm.azure.net///%s/test", typ),
+			ExpectError: true,
+			Expected: MHSMNestedItemId{
+				Name:         "test",
+				VaultBaseUrl: "https://my-keyvault.managedhsm.azure.net/",
+				Scope:        "/",
+			},
+		},
+		{
+			Input:       fmt.Sprintf("https://my-keyvault.managedhsm.azure.net///%s/bird", typ),
+			ExpectError: true,
+			Expected: MHSMNestedItemId{
+				Name:         "bird",
+				VaultBaseUrl: "https://my-keyvault.managedhsm.azure.net/",
+				Scope:        "/",
+			},
+		},
+		{
+			Input:       fmt.Sprintf("https://my-keyvault.managedhsm.azure.net///%s/bird", typ),
+			ExpectError: false,
+			Expected: MHSMNestedItemId{
+				Name:         "bird",
+				VaultBaseUrl: "https://my-keyvault.managedhsm.azure.net/",
+				Scope:        "/",
+			},
+		},
+		{
+			Input:       fmt.Sprintf("https://my-keyvault.managedhsm.azure.net//keys/%s/world", typ),
+			ExpectError: false,
+			Expected: MHSMNestedItemId{
+				Name:         "world",
+				VaultBaseUrl: "https://my-keyvault.managedhsm.azure.net/",
+				Scope:        "/keys",
+			},
+		},
+		{
+			Input:       fmt.Sprintf("https://my-keyvault.managedhsm.azure.net//keys/%s/fdf067c93bbb4b22bff4d8b7a9a56217", typ),
+			ExpectError: true,
+			Expected: MHSMNestedItemId{
+				Name:         "fdf067c93bbb4b22bff4d8b7a9a56217",
+				VaultBaseUrl: "https://my-keyvault.managedhsm.azure.net/",
+				Scope:        "/keys",
+			},
+		},
+		{
+			Input:       "https://kvhsm23030816100222.managedhsm.azure.net///RoleDefinition/862d4d5e-bf01-11ed-a49d-00155d61ee9e",
+			ExpectError: true,
+			Expected: MHSMNestedItemId{
+				Name:         "862d4d5e-bf01-11ed-a49d-00155d61ee9e",
+				VaultBaseUrl: "https://kvhsm23030816100222.managedhsm.azure.net/",
+				Scope:        "/",
+			},
+		},
+	}
+
+	for idx, tc := range cases {
+		secretId, err := MHSMNestedItemID(tc.Input)
+		if err != nil {
+			if tc.ExpectError {
+				continue
+			}
+
+			t.Fatalf("Got error for ID '%s': %+v", tc.Input, err)
+		}
+
+		if secretId == nil {
+			t.Fatalf("Expected a SecretID to be parsed for ID '%s', got nil.", tc.Input)
+		}
+
+		if tc.Expected.VaultBaseUrl != secretId.VaultBaseUrl {
+			t.Fatalf("Expected %d 'KeyVaultBaseUrl' to be '%s', got '%s' for ID '%s'", idx, tc.Expected.VaultBaseUrl, secretId.VaultBaseUrl, tc.Input)
+		}
+
+		if tc.Expected.Name != secretId.Name {
+			t.Fatalf("Expected 'Name' to be '%s', got '%s' for ID '%s'", tc.Expected.Name, secretId.Name, tc.Input)
+		}
+
+		if tc.Expected.Scope != secretId.Scope {
+			t.Fatalf("Expected 'Scope' to be '%s', got '%s' for ID '%s'", tc.Expected.Scope, secretId.Scope, tc.Input)
+		}
+
+		if tc.Input != secretId.ID() {
+			t.Fatalf("Expected 'ID()' to be '%s', got '%s'", tc.Input, secretId.ID())
+		}
+	}
+}

--- a/internal/services/keyvault/parse/nested_item_test.go
+++ b/internal/services/keyvault/parse/nested_item_test.go
@@ -30,6 +30,12 @@ func TestNewNestedItemID(t *testing.T) {
 			Expected:        "https://test.vault.azure.net/keys/test/testVersionString",
 			ExpectError:     false,
 		},
+		{
+			Scenario:        "mhsm valid, with port",
+			keyVaultBaseUrl: "https://test.managedhsm.azure.net:443",
+			Expected:        "https://test.managedhsm.azure.net/keys/test/testVersionString",
+			ExpectError:     false,
+		},
 	}
 	for _, tc := range cases {
 		id, err := NewNestedItemID(tc.keyVaultBaseUrl, childType, childName, childVersion)
@@ -88,6 +94,15 @@ func TestParseNestedItemID(t *testing.T) {
 			Expected: NestedItemId{
 				Name:            "castle",
 				KeyVaultBaseUrl: "https://my-keyvault.vault.azure.net/",
+				Version:         "1492",
+			},
+		},
+		{
+			Input:       "https://my-keyvault.managedhsm.azure.net/keys/castle/1492",
+			ExpectError: false,
+			Expected: NestedItemId{
+				Name:            "castle",
+				KeyVaultBaseUrl: "https://my-keyvault.managedhsm.azure.net/",
 				Version:         "1492",
 			},
 		},
@@ -176,6 +191,15 @@ func TestParseOptionallyVersionedNestedItemID(t *testing.T) {
 			Expected: NestedItemId{
 				Name:            "castle",
 				KeyVaultBaseUrl: "https://my-keyvault.vault.azure.net/",
+				Version:         "1492",
+			},
+		},
+		{
+			Input:       "https://my-keyvault.managedhsm.azure.net/keys/castle/1492",
+			ExpectError: false,
+			Expected: NestedItemId{
+				Name:            "castle",
+				KeyVaultBaseUrl: "https://my-keyvault.managedhsm.azure.net/",
 				Version:         "1492",
 			},
 		},

--- a/internal/services/keyvault/parse/vault_interface.go
+++ b/internal/services/keyvault/parse/vault_interface.go
@@ -1,0 +1,87 @@
+package parse
+
+import "fmt"
+
+type VaultType string
+
+const (
+	VaultTypeDefault VaultType = "vault"
+	VaultTypeMHSM    VaultType = "managedhsm"
+)
+
+func IsValidValtType(s string) bool {
+	return s == string(VaultTypeDefault) || s == string(VaultTypeMHSM)
+}
+
+type Vaulter interface {
+	ID() string
+	GetSubscriptionID() string
+	GetResourceGroup() string
+	GetName() string
+	GetCacheKey() string
+	Type() VaultType
+}
+
+var (
+	_ Vaulter = VaultId{}
+	_ Vaulter = ManagedHSMId{}
+)
+
+func IsMHSMVaulter(v Vaulter) bool {
+	_, ok := v.(*ManagedHSMId)
+	return ok
+}
+
+func NewVaulterFromString(input string) (Vaulter, error) {
+	var e1, e2 error
+	if vid, e1 := VaultID(input); e1 == nil {
+		return vid, nil
+	}
+	if mid, e2 := ManagedHSMID(input); e2 == nil {
+		return mid, nil
+	}
+	return nil, fmt.Errorf("parse vautler err: %+v or +%v", e1, e2)
+}
+
+func (id VaultId) GetSubscriptionID() string {
+	return id.SubscriptionId
+}
+
+func (id VaultId) GetResourceGroup() string {
+	return id.ResourceGroup
+}
+
+func (id VaultId) GetName() string {
+	return id.Name
+}
+func (id VaultId) Type() VaultType {
+	return VaultTypeDefault
+}
+
+func (id VaultId) GetCacheKey() string {
+	return MakeCacheKey(id.Type(), id.GetName())
+}
+
+func (id ManagedHSMId) GetSubscriptionID() string {
+	return id.SubscriptionId
+}
+
+func (id ManagedHSMId) GetResourceGroup() string {
+	return id.ResourceGroup
+}
+
+func (id ManagedHSMId) GetName() string {
+	return id.Name
+}
+
+func (id ManagedHSMId) Type() VaultType {
+	return VaultTypeMHSM
+}
+
+func (id ManagedHSMId) GetCacheKey() string {
+	return MakeCacheKey(id.Type(), id.GetName())
+}
+
+func MakeCacheKey(typ VaultType, name string) string {
+	return fmt.Sprintf("%s:%s", typ, name)
+}

--- a/internal/services/keyvault/parse/vaulter_key_interface.go
+++ b/internal/services/keyvault/parse/vaulter_key_interface.go
@@ -1,0 +1,25 @@
+package parse
+
+// interface to unify key of keyvalt and key of hsm behavior
+
+type VaultKeyID interface {
+	ID() string
+	String() string
+}
+
+func NewVaultKeyID(vaulter Vaulter, keyName, version string) VaultKeyID {
+	switch vaulter.Type() {
+	case VaultTypeMHSM:
+		return NewManagedHSMKeyID(vaulter.GetSubscriptionID(), vaulter.GetResourceGroup(), vaulter.GetName(), keyName, version)
+	default:
+		return NewKeyID(vaulter.GetSubscriptionID(), vaulter.GetResourceGroup(), vaulter.GetName(), keyName, version)
+	}
+}
+func NewVaultKeyVersionlessID(vaulter Vaulter, keyName string) VaultKeyID {
+	switch vaulter.Type() {
+	case VaultTypeMHSM:
+		return NewManagedHSMKeyID(vaulter.GetSubscriptionID(), vaulter.GetResourceGroup(), vaulter.GetName(), keyName, "")
+	default:
+		return NewKeyVersionlessID(vaulter.GetSubscriptionID(), vaulter.GetResourceGroup(), vaulter.GetName(), keyName)
+	}
+}

--- a/internal/services/keyvault/registration.go
+++ b/internal/services/keyvault/registration.go
@@ -60,11 +60,13 @@ func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 func (r Registration) DataSources() []sdk.DataSource {
 	return []sdk.DataSource{
 		EncryptedValueDataSource{},
+		KeyvaultRoleDefinitionDataResource{},
 	}
 }
 
 func (r Registration) Resources() []sdk.Resource {
 	return []sdk.Resource{
 		KeyVaultCertificateContactsResource{},
+		KeyVaultRoleDefinitionResource{},
 	}
 }

--- a/internal/services/keyvault/registration.go
+++ b/internal/services/keyvault/registration.go
@@ -68,5 +68,6 @@ func (r Registration) Resources() []sdk.Resource {
 	return []sdk.Resource{
 		KeyVaultCertificateContactsResource{},
 		KeyVaultRoleDefinitionResource{},
+		KeyVaultRoleAssignmentResource{},
 	}
 }

--- a/internal/services/keyvault/resourceids.go
+++ b/internal/services/keyvault/resourceids.go
@@ -2,6 +2,8 @@ package keyvault
 
 //go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=Vault -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/vaults/vault1 -rewrite=true
 //go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=ManagedHSM -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/managedHSMs/hsm1
+//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=ManagedHSMKey -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/managedHSMs/hsm1/keys/key1/versions/version1
+//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=ManagedHSMKeyVersionless -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/managedHSMs/hsm1/keys/key1
 
 // KeyVault Access Policies are Terraform specific, but can be either an Object ID or an Application ID
 //go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=AccessPolicyApplication -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/vaults/vault1/objectId/object1/applicationId/application1

--- a/internal/services/keyvault/validate/managed_hsm_key_id.go
+++ b/internal/services/keyvault/validate/managed_hsm_key_id.go
@@ -1,0 +1,23 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/parse"
+)
+
+func ManagedHSMKeyID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := parse.ManagedHSMKeyID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}

--- a/internal/services/keyvault/validate/managed_hsm_key_id_test.go
+++ b/internal/services/keyvault/validate/managed_hsm_key_id_test.go
@@ -1,0 +1,100 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import "testing"
+
+func TestManagedHSMKeyID(t *testing.T) {
+	cases := []struct {
+		Input string
+		Valid bool
+	}{
+
+		{
+			// empty
+			Input: "",
+			Valid: false,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Valid: false,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Valid: false,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Valid: false,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Valid: false,
+		},
+
+		{
+			// missing ManagedHSMName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/",
+			Valid: false,
+		},
+
+		{
+			// missing value for ManagedHSMName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/managedHSMs/",
+			Valid: false,
+		},
+
+		{
+			// missing KeyName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/managedHSMs/hsm1/",
+			Valid: false,
+		},
+
+		{
+			// missing value for KeyName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/managedHSMs/hsm1/keys/",
+			Valid: false,
+		},
+
+		{
+			// missing VersionName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/managedHSMs/hsm1/keys/key1/",
+			Valid: false,
+		},
+
+		{
+			// missing value for VersionName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/managedHSMs/hsm1/keys/key1/versions/",
+			Valid: false,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.KeyVault/managedHSMs/hsm1/keys/key1/versions/version1",
+			Valid: true,
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.KEYVAULT/MANAGEDHSMS/HSM1/KEYS/KEY1/VERSIONS/VERSION1",
+			Valid: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Logf("[DEBUG] Testing Value %s", tc.Input)
+		_, errors := ManagedHSMKeyID(tc.Input, "test")
+		valid := len(errors) == 0
+
+		if tc.Valid != valid {
+			t.Fatalf("Expected %t but got %t", tc.Valid, valid)
+		}
+	}
+}

--- a/internal/services/keyvault/validate/mhsm_nested_item_id.go
+++ b/internal/services/keyvault/validate/mhsm_nested_item_id.go
@@ -1,0 +1,27 @@
+package validate
+
+import (
+	"fmt"
+
+	keyVaultParse "github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+func MHSMNestedItemId(i interface{}, k string) (warnings []string, errors []error) {
+	if warnings, errors = validation.StringIsNotEmpty(i, k); len(errors) > 0 {
+		return warnings, errors
+	}
+
+	v, ok := i.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("Expected %s to be a string!", k))
+		return warnings, errors
+	}
+
+	if _, err := keyVaultParse.MHSMNestedItemID(v); err != nil {
+		errors = append(errors, fmt.Errorf("parsing %q: %s", v, err))
+		return warnings, errors
+	}
+
+	return warnings, errors
+}

--- a/internal/services/keyvault/validate/mhsm_nested_item_id_test.go
+++ b/internal/services/keyvault/validate/mhsm_nested_item_id_test.go
@@ -1,0 +1,55 @@
+package validate
+
+import (
+	"testing"
+)
+
+func TestMHSMNestedItemId(t *testing.T) {
+	cases := []struct {
+		Input       string
+		ExpectError bool
+	}{
+		{
+			Input:       "",
+			ExpectError: true,
+		},
+		{
+			Input:       "https://my-keyvault.managedhsm.azure.net///test",
+			ExpectError: false,
+		},
+		{
+			Input:       "https://my-keyvault.managedhsm.azure.net//keys/test",
+			ExpectError: false,
+		},
+
+		{
+			Input:       "https://my-keyvault.managedhsm.azure.net/certificates/hello/world",
+			ExpectError: true,
+		},
+		{
+			Input:       "https://my-keyvault.managedhsm.azure.net/keys/castle/1492",
+			ExpectError: false,
+		},
+		{
+			Input:       "https://my-keyvault.managedhsm.azure.net/secrets/bird/fdf067c93bbb4b22bff4d8b7a9a56217/XXX",
+			ExpectError: true,
+		},
+	}
+
+	for _, tc := range cases {
+		warnings, err := MHSMNestedItemId(tc.Input, "example")
+		if err != nil {
+			if !tc.ExpectError {
+				t.Fatalf("Got error for input %q: %+v", tc.Input, err)
+			}
+
+			return
+		}
+
+		if tc.ExpectError && len(warnings) == 0 {
+			t.Fatalf("Got no errors for input %q but expected some", tc.Input)
+		} else if !tc.ExpectError && len(warnings) > 0 {
+			t.Fatalf("Got %d errors for input %q when didn't expect any", len(warnings), tc.Input)
+		}
+	}
+}

--- a/website/docs/d/key_vault_role_definition.html.markdown
+++ b/website/docs/d/key_vault_role_definition.html.markdown
@@ -1,0 +1,71 @@
+---
+subcategory: "Key Vault"
+layout: "azurerm"
+page_title: "Azure Resource Manager: Data Source: azurerm_key_vault_role_definition"
+description: |-
+  Gets information about an existing KeyVault Role Definition.
+---
+
+# Data Source: azurerm_key_vault_role_definition
+
+Use this data source to access information about an existing KeyVault Role Definition.
+
+## Example Usage
+
+```hcl
+data "azurerm_key_vault_role_definition" "example" {
+  vault_base_url     = azurerm_key_vault_managed_hardware_security_module.test.hsm_uri
+  name = "21dbd100-6940-42c2-9190-5d6cb909625b"
+  scope              = "/"
+}
+
+output "id" {
+  value = data.azurerm_key_vault_role_definition.example.id
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name in UUID notation of this KeyVault Role Definition.
+
+* `vault_base_url` - (Required) Specify the base URL of the Managed HSM resource.
+
+* `scope` - (Optional) Specify the scope to retrieve the role definition. Defaults to `/`.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported: 
+
+* `id` - The ID of the KeyVault Role Definition.
+
+* `assignable_scopes` - A list of assignable role scope. Possible values are `/` and `/keys`.
+
+* `description` - A text description of this role definition.
+
+* `permission` - A `permission` block as defined below.
+
+* `resource_id` - The ID of the role definition resource without base url.
+
+* `role_name` - The role name of the role definition.
+
+* `role_type` - The type of the role definition. Possible values are `AKVBuiltInRole` and `CustomRole`.
+
+---
+
+A `permission` block exports the following:
+
+* `actions` - (Optional) A list of action permission granted.
+
+* `not_actions` - (Optional) A list of action permission excluded (but not denied).
+
+* `data_actions` - (Optional) A list of data action permission granted. Possible values are `Microsoft.KeyVault/managedHsm/keys/read/action`, `Microsoft.KeyVault/managedHsm/keys/write/action`, `Microsoft.KeyVault/managedHsm/keys/deletedKeys/read/action`, `Microsoft.KeyVault/managedHsm/keys/deletedKeys/recover/action`, `Microsoft.KeyVault/managedHsm/keys/backup/action`, `Microsoft.KeyVault/managedHsm/keys/restore/action`, `Microsoft.KeyVault/managedHsm/roleAssignments/delete/action`, `Microsoft.KeyVault/managedHsm/roleAssignments/read/action`, `Microsoft.KeyVault/managedHsm/roleAssignments/write/action`, `Microsoft.KeyVault/managedHsm/roleDefinitions/read/action`, `Microsoft.KeyVault/managedHsm/roleDefinitions/write/action`, `Microsoft.KeyVault/managedHsm/roleDefinitions/delete/action`, `Microsoft.KeyVault/managedHsm/keys/encrypt/action`, `Microsoft.KeyVault/managedHsm/keys/decrypt/action`, `Microsoft.KeyVault/managedHsm/keys/wrap/action`, `Microsoft.KeyVault/managedHsm/keys/unwrap/action`, `Microsoft.KeyVault/managedHsm/keys/sign/action`, `Microsoft.KeyVault/managedHsm/keys/verify/action`, `Microsoft.KeyVault/managedHsm/keys/create`, `Microsoft.KeyVault/managedHsm/keys/delete`, `Microsoft.KeyVault/managedHsm/keys/export/action`, `Microsoft.KeyVault/managedHsm/keys/release/action`, `Microsoft.KeyVault/managedHsm/keys/import/action`, `Microsoft.KeyVault/managedHsm/keys/deletedKeys/delete`, `Microsoft.KeyVault/managedHsm/securitydomain/download/action`, `Microsoft.KeyVault/managedHsm/securitydomain/download/read`, `Microsoft.KeyVault/managedHsm/securitydomain/upload/action`, `Microsoft.KeyVault/managedHsm/securitydomain/upload/read`, `Microsoft.KeyVault/managedHsm/securitydomain/transferkey/read`, `Microsoft.KeyVault/managedHsm/backup/start/action`, `Microsoft.KeyVault/managedHsm/restore/start/action`, `Microsoft.KeyVault/managedHsm/backup/status/action`, `Microsoft.KeyVault/managedHsm/restore/status/action` and `Microsoft.KeyVault/managedHsm/rng/action`.
+
+* `not_data_actions` - (Optional) A list of data action permission granted. Possible values are `Microsoft.KeyVault/managedHsm/keys/read/action`, `Microsoft.KeyVault/managedHsm/keys/write/action`, `Microsoft.KeyVault/managedHsm/keys/deletedKeys/read/action`, `Microsoft.KeyVault/managedHsm/keys/deletedKeys/recover/action`, `Microsoft.KeyVault/managedHsm/keys/backup/action`, `Microsoft.KeyVault/managedHsm/keys/restore/action`, `Microsoft.KeyVault/managedHsm/roleAssignments/delete/action`, `Microsoft.KeyVault/managedHsm/roleAssignments/read/action`, `Microsoft.KeyVault/managedHsm/roleAssignments/write/action`, `Microsoft.KeyVault/managedHsm/roleDefinitions/read/action`, `Microsoft.KeyVault/managedHsm/roleDefinitions/write/action`, `Microsoft.KeyVault/managedHsm/roleDefinitions/delete/action`, `Microsoft.KeyVault/managedHsm/keys/encrypt/action`, `Microsoft.KeyVault/managedHsm/keys/decrypt/action`, `Microsoft.KeyVault/managedHsm/keys/wrap/action`, `Microsoft.KeyVault/managedHsm/keys/unwrap/action`, `Microsoft.KeyVault/managedHsm/keys/sign/action`, `Microsoft.KeyVault/managedHsm/keys/verify/action`, `Microsoft.KeyVault/managedHsm/keys/create`, `Microsoft.KeyVault/managedHsm/keys/delete`, `Microsoft.KeyVault/managedHsm/keys/export/action`, `Microsoft.KeyVault/managedHsm/keys/release/action`, `Microsoft.KeyVault/managedHsm/keys/import/action`, `Microsoft.KeyVault/managedHsm/keys/deletedKeys/delete`, `Microsoft.KeyVault/managedHsm/securitydomain/download/action`, `Microsoft.KeyVault/managedHsm/securitydomain/download/read`, `Microsoft.KeyVault/managedHsm/securitydomain/upload/action`, `Microsoft.KeyVault/managedHsm/securitydomain/upload/read`, `Microsoft.KeyVault/managedHsm/securitydomain/transferkey/read`, `Microsoft.KeyVault/managedHsm/backup/start/action`, `Microsoft.KeyVault/managedHsm/restore/start/action`, `Microsoft.KeyVault/managedHsm/backup/status/action`, `Microsoft.KeyVault/managedHsm/restore/status/action` and `Microsoft.KeyVault/managedHsm/rng/action`.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the KeyVault.

--- a/website/docs/d/key_vault_role_definition.html.markdown
+++ b/website/docs/d/key_vault_role_definition.html.markdown
@@ -14,9 +14,9 @@ Use this data source to access information about an existing KeyVault Role Defin
 
 ```hcl
 data "azurerm_key_vault_role_definition" "example" {
-  vault_base_url     = azurerm_key_vault_managed_hardware_security_module.test.hsm_uri
-  name = "21dbd100-6940-42c2-9190-5d6cb909625b"
-  scope              = "/"
+  vault_base_url = azurerm_key_vault_managed_hardware_security_module.test.hsm_uri
+  name           = "21dbd100-6940-42c2-9190-5d6cb909625b"
+  scope          = "/"
 }
 
 output "id" {

--- a/website/docs/r/key_vault_key.html.markdown
+++ b/website/docs/r/key_vault_key.html.markdown
@@ -3,13 +3,13 @@ subcategory: "Key Vault"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_key_vault_key"
 description: |-
-  Manages a Key Vault Key.
+  Manages a Key Vault Key or a Managed HSM Key.
 
 ---
 
 # azurerm_key_vault_key
 
-Manages a Key Vault Key.
+Manages a Key Vault Key or a Managed HSM Key.
 
 ## Example Usage
 
@@ -97,7 +97,7 @@ The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the Key Vault Key. Changing this forces a new resource to be created.
 
-* `key_vault_id` - (Required) The ID of the Key Vault where the Key should be created. Changing this forces a new resource to be created.
+* `key_vault_id` - (Required) The ID of the Key Vault, or the Managed HSM, where the Key should be created. Changing this forces a new resource to be created.
 
 * `key_type` - (Required) Specifies the Key Type to use for this Key Vault Key. Possible values are `EC` (Elliptic Curve), `EC-HSM`, `RSA` and `RSA-HSM`. Changing this forces a new resource to be created.
 
@@ -138,7 +138,7 @@ An `automatic` block supports the following:
 The following attributes are exported:
 
 * `id` - The Key Vault Key ID.
-* `resource_id` - The (Versioned) ID for this Key Vault Key. This property points to a specific version of a Key Vault Key, as such using this won't auto-rotate values if used in other Azure Services.
+* `resource_id` - The (Versioned) ID for this Key Vault/Manage HSM Key. This property points to a specific version of a Key Vault Key, as such using this won't auto-rotate values if used in other Azure Services.
 * `resource_versionless_id` - The Versionless ID of the Key Vault Key. This property allows other Azure Services (that support it) to auto-rotate their value when the Key Vault Key is updated.
 * `version` - The current version of the Key Vault Key.
 * `versionless_id` - The Base ID of the Key Vault Key.

--- a/website/docs/r/key_vault_managed_hardware_security_module.html.markdown
+++ b/website/docs/r/key_vault_managed_hardware_security_module.html.markdown
@@ -12,6 +12,8 @@ Manages a Key Vault Managed Hardware Security Module.
 
 ~> **Note:** the Azure Provider includes a Feature Toggle which will purge a Key Vault Managed Hardware Security Module resource on destroy, rather than the default soft-delete. See [`purge_soft_deleted_hardware_security_modules_on_destroy`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/features-block#purge_soft_deleted_hardware_security_modules_on_destroy) for more information.
 
+~> **Note:** To create a key for the Manage HSM, you can use the `[azurerm_key_vault_key](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_key)`.
+
 ## Example Usage
 
 ```hcl

--- a/website/docs/r/key_vault_managed_hardware_security_module.html.markdown
+++ b/website/docs/r/key_vault_managed_hardware_security_module.html.markdown
@@ -70,6 +70,10 @@ The following arguments are supported:
 
 * `network_acls` - (Optional) A `network_acls` block as defined below.
 
+* `security_domain_certificate` - (Optional) A list of KeyVault certificates resource ID(minimum of three and up to a maximum of 10) to activate this Managed HSM. More information see [activate-your-managed-hsm](https://learn.microsoft.com/en-us/azure/key-vault/managed-hsm/quick-create-cli#activate-your-managed-hsm)
+
+* `security_domain_quorum` - (Optional) Specifies the minimum number of shares required to decrypt the security domain for recovery. This is required the `security_domain_certificate` is provided. The value must between 2 and 10 (inclusive).
+
 * `tags` - (Optional) A mapping of tags to assign to the resource. Changing this forces a new resource to be created.
 
 ---
@@ -87,6 +91,8 @@ The following attributes are exported:
 * `id` - The Key Vault Secret Managed Hardware Security Module ID.
 
 * `hsm_uri` - The URI of the Key Vault Managed Hardware Security Module, used for performing operations on keys.
+
+* `security_domain_enc_data` - The sensitive data will be used for disaster recovery or for creating another Managed HSM that shares same security domain so the two can share keys.
 
 ## Timeouts
 

--- a/website/docs/r/key_vault_managed_hardware_security_module.html.markdown
+++ b/website/docs/r/key_vault_managed_hardware_security_module.html.markdown
@@ -70,9 +70,7 @@ The following arguments are supported:
 
 * `network_acls` - (Optional) A `network_acls` block as defined below.
 
-* `security_domain_certificate` - (Optional) A list of KeyVault certificates resource ID(minimum of three and up to a maximum of 10) to activate this Managed HSM. More information see [activate-your-managed-hsm](https://learn.microsoft.com/en-us/azure/key-vault/managed-hsm/quick-create-cli#activate-your-managed-hsm)
-
-* `security_domain_quorum` - (Optional) Specifies the minimum number of shares required to decrypt the security domain for recovery. This is required the `security_domain_certificate` is provided. The value must between 2 and 10 (inclusive).
+* `activate_config` - (Optional) A `activate_config` block used to activate this Managed HSM as defined below.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource. Changing this forces a new resource to be created.
 
@@ -83,6 +81,14 @@ A `network_acls` block supports the following:
 * `bypass` - (Required) Specifies which traffic can bypass the network rules. Possible values are `AzureServices` and `None`.
 
 * `default_action` - (Required) The Default Action to use. Possible values are `Allow` and `Deny`.
+
+---
+
+A `activate_config` block supports the following:
+
+* `security_domain_certificate` - (Required) A list of KeyVault certificates resource ID(minimum of three and up to a maximum of 10) to activate this Managed HSM. More information see [activate-your-managed-hsm](https://learn.microsoft.com/en-us/azure/key-vault/managed-hsm/quick-create-cli#activate-your-managed-hsm)
+
+* `security_domain_quorum` - (Required) Specifies the minimum number of shares required to decrypt the security domain for recovery. This is required the `security_domain_certificate` is provided. The value must between 2 and 10 (inclusive).
 
 ## Attributes Reference
 

--- a/website/docs/r/key_vault_role_assignment.html.markdown
+++ b/website/docs/r/key_vault_role_assignment.html.markdown
@@ -1,0 +1,67 @@
+---
+subcategory: "Key Vault"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_key_vault_role_assignment"
+description: |-
+  Manages a KeyVault Role Assignment.
+---
+
+# azurerm_key_vault_role_assignment
+
+Manages a KeyVault Role Assignment.
+
+## Example Usage
+
+```hcl
+data "azurerm_key_vault_role_definition" "user" {
+  vault_base_url = azurerm_key_vault_managed_hardware_security_module.test.hsm_uri
+  name           = "21dbd100-6940-42c2-9190-5d6cb909625b"
+  scope          = "/"
+}
+
+resource "azurerm_key_vault_role_assignment" "example" {
+  name               = "a9dbe818-56e7-5878-c0ce-a1477692c1d6"
+  vault_base_url     = azurerm_key_vault_managed_hardware_security_module.example.hsm_uri
+  scope              = "${data.azurerm_key_vault_role_definition.user.scope}"
+  role_definition_id = "${data.azurerm_key_vault_role_definition.user.resource_id}"
+  principal_id       = "${data.azurerm_client_config.current.object_id}"
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name in GUID notation which should be used for this KeyVault Role Assignment. Changing this forces a new KeyVault to be created.
+
+* `principal_id` - (Required) The principal ID to be assigned to this role. It can point to a user, service principal, or security group. Changing this forces a new KeyVault to be created.
+
+* `role_definition_id` - (Required) The resource ID of the role definition to assign. Changing this forces a new KeyVault to be created.
+
+* `scope` - (Required) Specifies the scope to create the role assignment. Changing this forces a new KeyVault to be created.
+
+* `vault_base_url` - (Required) The HSM URI of a Managed Hardware Security Module resource. Changing this forces a new KeyVault to be created.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported: 
+
+* `id` - The ID of the KeyVault Role Assignment with Vault Base URL.
+
+* `resource_id` - The resource id of created assignment resource.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the KeyVault.
+* `read` - (Defaults to 5 minutes) Used when retrieving the KeyVault.
+* `delete` - (Defaults to 10 minutes) Used when deleting the KeyVault.
+
+## Import
+
+KeyVaults can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_key_vault_role_assignment.example https://0000.managedhsm.azure.net///RoleAssignment/00000000-0000-0000-0000-000000000000
+```

--- a/website/docs/r/key_vault_role_definition.html.markdown
+++ b/website/docs/r/key_vault_role_definition.html.markdown
@@ -1,0 +1,106 @@
+---
+subcategory: "Key Vault"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_key_vault_role_definition"
+description: |-
+  Manages a KeyVault Role Definition.
+---
+
+# azurerm_key_vault_role_definition
+
+Manages a KeyVault Role Definition. This resource works together with [Managed hardware security module resource](./key_vault_managed_hardware_security_module).
+
+## Example Usage
+
+```hcl
+resource "azurerm_key_vault_managed_hardware_security_module" "example" {
+  name                     = "example"
+  resource_group_name      = azurerm_resource_group.example.name
+  location                 = azurerm_resource_group.example.location
+  sku_name                 = "Standard_B1"
+  tenant_id                = data.azurerm_client_config.current.tenant_id
+  admin_object_ids         = [data.azurerm_client_config.current.object_id]
+  purge_protection_enabled = false
+
+  active_config {
+    security_domain_certificate = [
+      azurerm_key_vault_certificate.cert[0].id,
+      azurerm_key_vault_certificate.cert[1].id,
+      azurerm_key_vault_certificate.cert[2].id,
+    ]
+    security_domain_quorum = 2
+  }
+}
+
+resource "azurerm_key_vault_role_definition" "example" {
+  name = "7d206142-bf01-11ed-80bc-00155d61ee9e"
+  scope             = "/"
+  vault_base_url    = azurerm_key_vault_managed_hardware_security_module.example.hsm_uri
+  description       = "desc foo"
+  assignable_scopes = ["/"]
+  permission {
+    data_actions     = [
+      "Microsoft.KeyVault/managedHsm/keys/read/action",
+    ]
+  }
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name which should be used for this KeyVault Role Definition. Changing this forces a new KeyVault Role Definition to be created.
+
+* `vault_base_url` - (Required) The base URL of the managed hardware security module resource. Changing this forces a new KeyVault Role Definition to be created.
+
+---
+
+* `assignable_scopes` - (Optional) Specifies a list of scopes allowed to assign. Possible value is `/`.
+
+* `description` - (Optional) Specifies a text description about this KeyVault Role Definition.
+
+* `permission` - (Optional) One or more `permission` blocks as defined below.
+
+* `role_name` - (Optional) Specify a name for this KeyVault Role Definition.
+
+* `scope` - (Optional) Specify the scope of this role definition. Possible value is `/`. Defaults to `/`. Changing this forces a new KeyVault to be created.
+
+---
+
+A `permission` block supports the following, more details about permission see [permitted-operations](https://learn.microsoft.com/en-us/azure/key-vault/managed-hsm/built-in-roles#permitted-operations):
+
+* `actions` - (Optional) Specifies a list of action permission to granted.
+
+* `not_actions` - (Optional) Specifies a list of action permission excluded (but not denied).
+
+* `data_actions` - (Optional) Specifies a list of data action permission to grant. Possible values are `Microsoft.KeyVault/managedHsm/keys/read/action`, `Microsoft.KeyVault/managedHsm/keys/write/action`, `Microsoft.KeyVault/managedHsm/keys/deletedKeys/read/action`, `Microsoft.KeyVault/managedHsm/keys/deletedKeys/recover/action`, `Microsoft.KeyVault/managedHsm/keys/backup/action`, `Microsoft.KeyVault/managedHsm/keys/restore/action`, `Microsoft.KeyVault/managedHsm/roleAssignments/delete/action`, `Microsoft.KeyVault/managedHsm/roleAssignments/read/action`, `Microsoft.KeyVault/managedHsm/roleAssignments/write/action`, `Microsoft.KeyVault/managedHsm/roleDefinitions/read/action`, `Microsoft.KeyVault/managedHsm/roleDefinitions/write/action`, `Microsoft.KeyVault/managedHsm/roleDefinitions/delete/action`, `Microsoft.KeyVault/managedHsm/keys/encrypt/action`, `Microsoft.KeyVault/managedHsm/keys/decrypt/action`, `Microsoft.KeyVault/managedHsm/keys/wrap/action`, `Microsoft.KeyVault/managedHsm/keys/unwrap/action`, `Microsoft.KeyVault/managedHsm/keys/sign/action`, `Microsoft.KeyVault/managedHsm/keys/verify/action`, `Microsoft.KeyVault/managedHsm/keys/create`, `Microsoft.KeyVault/managedHsm/keys/delete`, `Microsoft.KeyVault/managedHsm/keys/export/action`, `Microsoft.KeyVault/managedHsm/keys/release/action`, `Microsoft.KeyVault/managedHsm/keys/import/action`, `Microsoft.KeyVault/managedHsm/keys/deletedKeys/delete`, `Microsoft.KeyVault/managedHsm/securitydomain/download/action`, `Microsoft.KeyVault/managedHsm/securitydomain/download/read`, `Microsoft.KeyVault/managedHsm/securitydomain/upload/action`, `Microsoft.KeyVault/managedHsm/securitydomain/upload/read`, `Microsoft.KeyVault/managedHsm/securitydomain/transferkey/read`, `Microsoft.KeyVault/managedHsm/backup/start/action`, `Microsoft.KeyVault/managedHsm/restore/start/action`, `Microsoft.KeyVault/managedHsm/backup/status/action`, `Microsoft.KeyVault/managedHsm/restore/status/action` and `Microsoft.KeyVault/managedHsm/rng/action`.
+
+* `not_data_actions` - (Optional) Specifies a list of data action permission not to grant. Possible values are `Microsoft.KeyVault/managedHsm/keys/read/action`, `Microsoft.KeyVault/managedHsm/keys/write/action`, `Microsoft.KeyVault/managedHsm/keys/deletedKeys/read/action`, `Microsoft.KeyVault/managedHsm/keys/deletedKeys/recover/action`, `Microsoft.KeyVault/managedHsm/keys/backup/action`, `Microsoft.KeyVault/managedHsm/keys/restore/action`, `Microsoft.KeyVault/managedHsm/roleAssignments/delete/action`, `Microsoft.KeyVault/managedHsm/roleAssignments/read/action`, `Microsoft.KeyVault/managedHsm/roleAssignments/write/action`, `Microsoft.KeyVault/managedHsm/roleDefinitions/read/action`, `Microsoft.KeyVault/managedHsm/roleDefinitions/write/action`, `Microsoft.KeyVault/managedHsm/roleDefinitions/delete/action`, `Microsoft.KeyVault/managedHsm/keys/encrypt/action`, `Microsoft.KeyVault/managedHsm/keys/decrypt/action`, `Microsoft.KeyVault/managedHsm/keys/wrap/action`, `Microsoft.KeyVault/managedHsm/keys/unwrap/action`, `Microsoft.KeyVault/managedHsm/keys/sign/action`, `Microsoft.KeyVault/managedHsm/keys/verify/action`, `Microsoft.KeyVault/managedHsm/keys/create`, `Microsoft.KeyVault/managedHsm/keys/delete`, `Microsoft.KeyVault/managedHsm/keys/export/action`, `Microsoft.KeyVault/managedHsm/keys/release/action`, `Microsoft.KeyVault/managedHsm/keys/import/action`, `Microsoft.KeyVault/managedHsm/keys/deletedKeys/delete`, `Microsoft.KeyVault/managedHsm/securitydomain/download/action`, `Microsoft.KeyVault/managedHsm/securitydomain/download/read`, `Microsoft.KeyVault/managedHsm/securitydomain/upload/action`, `Microsoft.KeyVault/managedHsm/securitydomain/upload/read`, `Microsoft.KeyVault/managedHsm/securitydomain/transferkey/read`, `Microsoft.KeyVault/managedHsm/backup/start/action`, `Microsoft.KeyVault/managedHsm/restore/start/action`, `Microsoft.KeyVault/managedHsm/backup/status/action`, `Microsoft.KeyVault/managedHsm/restore/status/action` and `Microsoft.KeyVault/managedHsm/rng/action`.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported: 
+
+* `id` - The ID of the KeyVault Role Definition.
+
+* `resource_id` - The ID of the role definition resource without Key Vault base URL.
+
+* `role_type` - The type of the role definition. Possible values are `AKVBuiltInRole` and `CustomRole`.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the KeyVault.
+* `read` - (Defaults to 5 minutes) Used when retrieving the KeyVault.
+* `update` - (Defaults to 10 minutes) Used when updating the KeyVault.
+* `delete` - (Defaults to 10 minutes) Used when deleting the KeyVault.
+
+## Import
+
+KeyVaults can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_key_vault_role_definition.example https://0000.managedhsm.azure.net///RoleDefinition/00000000-0000-0000-0000-000000000000
+```

--- a/website/docs/r/key_vault_role_definition.html.markdown
+++ b/website/docs/r/key_vault_role_definition.html.markdown
@@ -33,13 +33,13 @@ resource "azurerm_key_vault_managed_hardware_security_module" "example" {
 }
 
 resource "azurerm_key_vault_role_definition" "example" {
-  name = "7d206142-bf01-11ed-80bc-00155d61ee9e"
+  name              = "7d206142-bf01-11ed-80bc-00155d61ee9e"
   scope             = "/"
   vault_base_url    = azurerm_key_vault_managed_hardware_security_module.example.hsm_uri
   description       = "desc foo"
   assignable_scopes = ["/"]
   permission {
-    data_actions     = [
+    data_actions = [
       "Microsoft.KeyVault/managedHsm/keys/read/action",
     ]
   }


### PR DESCRIPTION
> Draft as dependent on #20855 

To support creating keys for Manged HSM, we have to activate the HSM first which is supported in #20855 . and then this PR can create keys. resolves #13654.

And we need local RBAC for HSM as described here [managed-hsm/role-management](https://learn.microsoft.com/en-us/azure/key-vault/managed-hsm/role-management). this PR introcued two terraform resources to support role management: `azurerm_key_vault_role_definition` and `azurerm_key_vault_role_assignment`. this also resolves #20112.

The PR reuse the existing `azurerm_key_vaule_key` resource to create keys for Managed HSM with a bunch of changes to make keyvaultkey CURD methods support Managed HSM.