### PR TITLE
Fix resource azurerm_cdn_frontdoor_origin with Private Link Service example

### DIFF
--- a/website/docs/r/cdn_frontdoor_origin.html.markdown
+++ b/website/docs/r/cdn_frontdoor_origin.html.markdown
@@ -127,13 +127,13 @@ resource "azurerm_cdn_frontdoor_profile" "example" {
 }
 
 resource "azurerm_cdn_frontdoor_origin" example {
-  name                          = "origin-example"
-  cdn_frontdoor_origin_group_id = azurerm_cdn_frontdoor_origin_group.example.id
-  enabled                       = true
-  host_name                     = "example.com"
-  origin_host_header            = "example.com"
-  priority                      = 1
-  weight                        = 1000
+  name                           = "origin-example"
+  cdn_frontdoor_origin_group_id  = azurerm_cdn_frontdoor_origin_group.example.id
+  enabled                        = true
+  host_name                      = "example.com"
+  origin_host_header             = "example.com"
+  priority                       = 1
+  weight                         = 1000
   certificate_name_check_enabled = false
 
   private_link {

--- a/website/docs/r/cdn_frontdoor_origin.html.markdown
+++ b/website/docs/r/cdn_frontdoor_origin.html.markdown
@@ -126,6 +126,23 @@ resource "azurerm_cdn_frontdoor_profile" "example" {
   sku_name            = "Premium_AzureFrontDoor"
 }
 
+resource "azurerm_cdn_frontdoor_origin" example {
+  name                          = "origin-example"
+  cdn_frontdoor_origin_group_id = azurerm_cdn_frontdoor_origin_group.example.id
+  enabled                       = true
+  host_name                     = "example.com"
+  origin_host_header            = "example.com"
+  priority                      = 1
+  weight                        = 1000
+  certificate_name_check_enabled = false
+
+  private_link {
+    request_message        = "Request access for Private Link Origin CDN Frontdoor"
+    location               = azurerm_resource_group.example.location
+    private_link_target_id = azurerm_private_link_service.example.id
+  }
+}
+
 resource "azurerm_cdn_frontdoor_origin_group" "example" {
   name                     = "group-example"
   cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.example.id


### PR DESCRIPTION
The `azurerm_cdn_frontdoor_origin` example using the private link service was missing the resource `azurerm_cdn_frontdoor_origin` itself in the example.

This PR should complete the example.
