### PR TITLE
`data.azurerm_virtual_machine_scale_set` - ignore error when network interfaces aren't found

### DIFF
--- a/internal/services/compute/virtual_machine_scale_set_data_source.go
+++ b/internal/services/compute/virtual_machine_scale_set_data_source.go
@@ -164,6 +164,9 @@ func dataSourceVirtualMachineScaleSetRead(d *pluginsdk.ResourceData, meta interf
 		if instance.InstanceID != nil {
 			nics, err := networkInterfacesClient.ListVirtualMachineScaleSetVMNetworkInterfacesComplete(ctx, id.ResourceGroup, id.Name, *instance.InstanceID)
 			if err != nil {
+				if utils.ResponseWasNotFound(nics.Response().Response) {
+					break
+				}
 				return fmt.Errorf("listing Network Interfaces for VM Instance %q for Virtual Machine Scale Set %q (Resource Group %q): %+v", *instance.InstanceID, id.ResourceGroup, id.Name, err)
 			}
 


### PR DESCRIPTION
<img width="541" alt="image" src="https://user-images.githubusercontent.com/6515518/225154976-59773cb5-7c34-4d89-8938-27d7f148d68d.png">
