### PR TITLE
`azurerm_virtual_desktop_host_pool` attribute `load_balancer_type` shouldn't force a new resource to be created

### DIFF
--- a/internal/services/desktopvirtualization/virtual_desktop_host_pool_resource.go
+++ b/internal/services/desktopvirtualization/virtual_desktop_host_pool_resource.go
@@ -71,7 +71,6 @@ func resourceVirtualDesktopHostPool() *pluginsdk.Resource {
 			"load_balancer_type": {
 				Type:     pluginsdk.TypeString,
 				Required: true,
-				ForceNew: true,
 				ValidateFunc: validation.StringInSlice([]string{
 					string(hostpool.LoadBalancerTypeBreadthFirst),
 					string(hostpool.LoadBalancerTypeDepthFirst),
@@ -263,7 +262,7 @@ func resourceVirtualDesktopHostPoolUpdate(d *pluginsdk.ResourceData, meta interf
 		payload.Tags = tags.Expand(d.Get("tags").(map[string]interface{}))
 	}
 
-	if d.HasChanges("custom_rdp_properties", "description", "friendly_name", "maximum_sessions_allowed", "preferred_app_group_type", "start_vm_on_connect", "validate_environment", "scheduled_agent_updates") {
+	if d.HasChanges("custom_rdp_properties", "description", "friendly_name", "load_balancer_type", "maximum_sessions_allowed", "preferred_app_group_type", "start_vm_on_connect", "validate_environment", "scheduled_agent_updates") {
 		payload.Properties = &hostpool.HostPoolPatchProperties{}
 
 		if d.HasChange("custom_rdp_properties") {
@@ -276,6 +275,11 @@ func resourceVirtualDesktopHostPoolUpdate(d *pluginsdk.ResourceData, meta interf
 
 		if d.HasChange("friendly_name") {
 			payload.Properties.FriendlyName = utils.String(d.Get("friendly_name").(string))
+		}
+
+		if d.HasChange("load_balancer_type") {
+			loadBalancerType := hostpool.LoadBalancerType(d.Get("load_balancer_type").(string))
+			payload.Properties.LoadBalancerType = &loadBalancerType
 		}
 
 		if d.HasChange("maximum_sessions_allowed") {

--- a/internal/services/desktopvirtualization/virtual_desktop_host_pool_resource_test.go
+++ b/internal/services/desktopvirtualization/virtual_desktop_host_pool_resource_test.go
@@ -245,7 +245,7 @@ resource "azurerm_virtual_desktop_host_pool" "test" {
   resource_group_name  = azurerm_resource_group.test.name
   type                 = "Pooled"
   validate_environment = true
-  load_balancer_type   = "BreadthFirst"
+  load_balancer_type   = "DepthFirst"
 }
 `, data.RandomInteger, data.Locations.Secondary, data.RandomString)
 }

--- a/website/docs/r/virtual_desktop_host_pool.html.markdown
+++ b/website/docs/r/virtual_desktop_host_pool.html.markdown
@@ -54,7 +54,7 @@ The following arguments are supported:
 
 * `type` - (Required) The type of the Virtual Desktop Host Pool. Valid options are `Personal` or `Pooled`. Changing the type forces a new resource to be created.
 
-* `load_balancer_type` - (Required) `BreadthFirst` load balancing distributes new user sessions across all available session hosts in the host pool. Possible values are `BreadthFirst`, `DepthFirst` and `Persistent`. Changing this forces a new resource to be created.
+* `load_balancer_type` - (Required) `BreadthFirst` load balancing distributes new user sessions across all available session hosts in the host pool. Possible values are `BreadthFirst`, `DepthFirst` and `Persistent`.
     `DepthFirst` load balancing distributes new user sessions to an available session host with the highest number of connections but has not reached its maximum session limit threshold.
     `Persistent` should be used if the host pool type is `Personal`
 


### PR DESCRIPTION
Noticed this when using scaling plans which can update the load balancer type setting throughout the day, running my pipelines at the wrong time risked tearing down my host pool!

