### PR TITLE
`azurerm_storage_account` Data Source - Add 403 (previously only 401) as a valid status code for lacking permissions to list keys

### DIFF
--- a/internal/services/storage/storage_account_data_source.go
+++ b/internal/services/storage/storage_account_data_source.go
@@ -368,7 +368,7 @@ func dataSourceStorageAccountRead(d *pluginsdk.ResourceData, meta interface{}) e
 		if e, ok := err.(azautorest.DetailedError); ok {
 			if status, ok := e.StatusCode.(int); ok {
 				hasWriteLock = status == http.StatusConflict
-				doesntHavePermissions = status == http.StatusUnauthorized
+				doesntHavePermissions = (status == http.StatusUnauthorized || status == http.StatusForbidden)
 			}
 		}
 


### PR DESCRIPTION
Similar to https://github.com/hashicorp/terraform-provider-azurerm/pull/19645, but for the dta source.

Fix #20902 