### PR TITLE
`azurerm_kusto_cluster` - fixes `TestAccKustoCluster_languageExtensions`

### DIFF
--- a/internal/services/kusto/kusto_cluster_resource.go
+++ b/internal/services/kusto/kusto_cluster_resource.go
@@ -167,7 +167,7 @@ func resourceKustoCluster() *pluginsdk.Resource {
 			},
 
 			"language_extensions": {
-				Type:     pluginsdk.TypeList,
+				Type:     pluginsdk.TypeSet,
 				Optional: true,
 				Elem: &pluginsdk.Schema{
 					Type:         pluginsdk.TypeString,
@@ -377,7 +377,7 @@ func resourceKustoClusterCreateUpdate(d *pluginsdk.ResourceData, meta interface{
 	d.SetId(id.ID())
 
 	if v, ok := d.GetOk("language_extensions"); ok {
-		languageExtensions := expandKustoClusterLanguageExtensions(v.([]interface{}))
+		languageExtensions := expandKustoClusterLanguageExtensions(v.(*pluginsdk.Set).List())
 
 		currentLanguageExtensions, err := client.ListLanguageExtensions(ctx, id)
 		if err != nil {

--- a/internal/services/kusto/kusto_cluster_resource_test.go
+++ b/internal/services/kusto/kusto_cluster_resource_test.go
@@ -251,8 +251,6 @@ func TestAccKustoCluster_languageExtensions(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("language_extensions.#").HasValue("2"),
-				check.That(data.ResourceName).Key("language_extensions.0").HasValue("PYTHON"),
-				check.That(data.ResourceName).Key("language_extensions.1").HasValue("R"),
 			),
 		},
 		data.ImportStep(),

--- a/internal/services/kusto/migration/kusto_cluster_migration_v0_to_v1.go
+++ b/internal/services/kusto/migration/kusto_cluster_migration_v0_to_v1.go
@@ -148,7 +148,7 @@ func (s KustoAttachedClusterV0ToV1) Schema() map[string]*pluginsdk.Schema {
 		},
 
 		"language_extensions": {
-			Type:     pluginsdk.TypeList,
+			Type:     pluginsdk.TypeSet,
 			Optional: true,
 			Elem: &pluginsdk.Schema{
 				Type: pluginsdk.TypeString,

--- a/internal/services/kusto/migration/kusto_cluster_migration_v0_to_v1.go
+++ b/internal/services/kusto/migration/kusto_cluster_migration_v0_to_v1.go
@@ -148,7 +148,7 @@ func (s KustoAttachedClusterV0ToV1) Schema() map[string]*pluginsdk.Schema {
 		},
 
 		"language_extensions": {
-			Type:     pluginsdk.TypeSet,
+			Type:     pluginsdk.TypeList,
 			Optional: true,
 			Elem: &pluginsdk.Schema{
 				Type: pluginsdk.TypeString,


### PR DESCRIPTION
This PR resolves an issue with the `TestAccKustoCluster_languageExtensions` test, which was failing due to an update to the `language_extensions` property. This property is now treated as an unordered array, and this PR updates the test to accommodate this change.

Reraise this according to @tombuildsstuff 's comment in https://github.com/hashicorp/terraform-provider-azurerm/pull/20707