### PR TITLE
`azurerm_kubernetes_cluster` - Deprecate `network_profile.docker_bridge_cidr` since it's not longer supported by API

### DIFF
--- a/internal/services/containers/kubernetes_cluster_data_source_test.go
+++ b/internal/services/containers/kubernetes_cluster_data_source_test.go
@@ -679,7 +679,7 @@ data "azurerm_kubernetes_cluster" "test" {
   name                = azurerm_kubernetes_cluster.test.name
   resource_group_name = azurerm_kubernetes_cluster.test.resource_group_name
 }
-`, KubernetesClusterResource{}.advancedNetworkingCompleteConfig(data, "azure"))
+`, KubernetesClusterResource{}.advancedNetworkingCompleteConfig(data, "azure", true))
 }
 
 func (KubernetesClusterDataSource) advancedNetworkingAzureCalicoPolicyCompleteConfig(data acceptance.TestData) string {
@@ -723,7 +723,7 @@ data "azurerm_kubernetes_cluster" "test" {
   name                = azurerm_kubernetes_cluster.test.name
   resource_group_name = azurerm_kubernetes_cluster.test.resource_group_name
 }
-`, KubernetesClusterResource{}.advancedNetworkingCompleteConfig(data, "kubenet"))
+`, KubernetesClusterResource{}.advancedNetworkingCompleteConfig(data, "kubenet", true))
 }
 
 func (KubernetesClusterDataSource) addOnProfileOMSConfig(data acceptance.TestData) string {

--- a/internal/services/containers/kubernetes_cluster_network_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_network_resource_test.go
@@ -62,7 +62,7 @@ func TestAccKubernetesCluster_advancedNetworkingKubenetComplete(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.advancedNetworkingCompleteConfig(data, "kubenet"),
+			Config: r.advancedNetworkingCompleteConfig(data, "kubenet", true),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("network_profile.0.network_plugin").HasValue("kubenet"),
@@ -110,7 +110,23 @@ func TestAccKubernetesCluster_advancedNetworkingAzureComplete(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.advancedNetworkingCompleteConfig(data, "azure"),
+			Config: r.advancedNetworkingCompleteConfig(data, "azure", true),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("network_profile.0.network_plugin").HasValue("azure"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccKubernetesCluster_advancedNetworkingAzureWithoutDockerBridgeCidr(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
+	r := KubernetesClusterResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.advancedNetworkingCompleteConfig(data, "azure", false),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("network_profile.0.network_plugin").HasValue("azure"),
@@ -1074,7 +1090,12 @@ resource "azurerm_kubernetes_cluster" "test" {
 `, data.RandomInteger, data.Locations.Primary, ipv)
 }
 
-func (KubernetesClusterResource) advancedNetworkingCompleteConfig(data acceptance.TestData, networkPlugin string) string {
+func (KubernetesClusterResource) advancedNetworkingCompleteConfig(data acceptance.TestData, networkPlugin string, dockerCidrEnabled bool) string {
+	dockerCidr := `docker_bridge_cidr = "172.18.0.1/16"`
+	if !dockerCidrEnabled {
+		dockerCidr = ""
+	}
+
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -1127,11 +1148,11 @@ resource "azurerm_kubernetes_cluster" "test" {
   network_profile {
     network_plugin     = "%s"
     dns_service_ip     = "10.10.0.10"
-    docker_bridge_cidr = "172.18.0.1/16"
+    %s
     service_cidr       = "10.10.0.0/16"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, networkPlugin)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, networkPlugin, dockerCidr)
 }
 
 // nolint unparam

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -1273,6 +1273,7 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 			Optional:     true,
 			Computed:     true,
 			ForceNew:     true,
+			Deprecated:   "`docker_bridge_cidr` has been deprecated as the API no longer supports it and will be removed in version 4.0 of the provider.",
 			ValidateFunc: validate.CIDR,
 		}
 	}

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -817,14 +817,6 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 							ValidateFunc: validate.IPv4Address,
 						},
 
-						"docker_bridge_cidr": {
-							Type:         pluginsdk.TypeString,
-							Optional:     true,
-							Computed:     true,
-							ForceNew:     true,
-							ValidateFunc: validate.CIDR,
-						},
-
 						"ebpf_data_plane": {
 							Type:     pluginsdk.TypeString,
 							Optional: true,
@@ -1275,6 +1267,13 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 			},
 			Deprecated:    "This property has been renamed to `authorized_ip_ranges` within the `api_server_access_profile` block and will be removed in v4.0 of the provider",
 			ConflictsWith: []string{"api_server_access_profile.0.authorized_ip_ranges"},
+		}
+		resource.Schema["network_profile"].Elem.(*pluginsdk.Resource).Schema["docker_bridge_cidr"] = &pluginsdk.Schema{
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			Computed:     true,
+			ForceNew:     true,
+			ValidateFunc: validate.CIDR,
 		}
 	}
 

--- a/internal/services/containers/kubernetes_cluster_validate.go
+++ b/internal/services/containers/kubernetes_cluster_validate.go
@@ -23,7 +23,6 @@ func validateKubernetesCluster(d *pluginsdk.ResourceData, cluster *managedcluste
 			profile := rawProfiles[0].(map[string]interface{})
 
 			if networkPlugin := profile["network_plugin"].(string); networkPlugin != "" {
-				dockerBridgeCidr := profile["docker_bridge_cidr"].(string)
 				dnsServiceIP := profile["dns_service_ip"].(string)
 				serviceCidr := profile["service_cidr"].(string)
 				podCidr := profile["pod_cidr"].(string)
@@ -38,8 +37,8 @@ func validateKubernetesCluster(d *pluginsdk.ResourceData, cluster *managedcluste
 				}
 
 				// if not All empty values or All set values.
-				if !(dockerBridgeCidr == "" && dnsServiceIP == "" && !isServiceCidrSet) && !(dockerBridgeCidr != "" && dnsServiceIP != "" && isServiceCidrSet) {
-					return fmt.Errorf("`docker_bridge_cidr`, `dns_service_ip` and `service_cidr` should all be empty or all should be set")
+				if !(dnsServiceIP == "" && !isServiceCidrSet) && !(dnsServiceIP != "" && isServiceCidrSet) {
+					return fmt.Errorf("`dns_service_ip` and `service_cidr` should all be empty or both should be set")
 				}
 
 				ipVersions := profile["ip_versions"].([]interface{})

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -598,6 +598,8 @@ A `network_profile` block supports the following:
 
 * `docker_bridge_cidr` - (Optional) IP address (in CIDR notation) used as the Docker bridge IP address on nodes. Changing this forces a new resource to be created.
 
+-> **Note:** `docker_bridge_cidr` has been deprecated as the API no longer supports it and will be removed in version 4.0 of the provider.
+
 * `ebpf_data_plane` - (Optional) Specifies the eBPF data plane used for building the Kubernetes network. Possible value is `cilium`. Changing this forces a new resource to be created.
 
 ~> **Note:** When `ebpf_data_plane` is set to `cilium`, the `network_plugin` field can only be set to `azure`.


### PR DESCRIPTION
According to the [document](https://learn.microsoft.com/en-us/azure/aks/cluster-configuration#container-runtime-configuration):

>Docker is no longer supported as of September 2022.

This pr loose the original restriction: ``docker_bridge_cidr`, `dns_service_ip` and `service_cidr` should all be empty or all should be set"`, now we can just omit `docker_bridge_cidr`.

This pr should fix #18119 and [this aks module issue](https://github.com/Azure/terraform-azurerm-aks/issues/122)

---

I've also received an email said:

>We've detected that one or more of your subscription(s) are using the Docker Bridge CIDR field in the AKS API. This field is currently ignored by default and not validated, as it was made redundant during our change from Docker to containerD in Kubernetes version 1.19. Starting from April 2023 with the release of the 2023-04-01 AKS API version, the Docker Bridge CIDR field functionality will be removed. However, it will still be supported in all preexisting API versions without new updates. The April API will be fully implemented and available by 26 May 2023. 