### PR TITLE
`azurerm_storage_share_{file|directory}` - Relax the directory name

### DIFF
--- a/internal/services/storage/validate/storage.go
+++ b/internal/services/storage/validate/storage.go
@@ -11,8 +11,9 @@ func StorageShareDirectoryName(v interface{}, k string) (warnings []string, erro
 	if regexp.MustCompile(`^\.+$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(`%s must not only contain dots`, k))
 	}
-	if !regexp.MustCompile(`^[^"\/:|<>*?]{1,255}$`).MatchString(value) {
-		errors = append(errors, fmt.Errorf(`%s must not contain following characters: "\/:|<>*?`, k))
+	// Note that we didn't forbid the forward slash in the non-head segment here as it seems to be allowed as the directory name for constructing directory hierarchy.
+	if !regexp.MustCompile(`^[^"/\:|<>*?]+(/[^"\:|<>*?]+)*$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(`%s must not contain following characters: "\:|<>*?`, k))
 	}
 
 	return warnings, errors

--- a/internal/services/storage/validate/storage.go
+++ b/internal/services/storage/validate/storage.go
@@ -7,9 +7,12 @@ import (
 
 func StorageShareDirectoryName(v interface{}, k string) (warnings []string, errors []error) {
 	value := v.(string)
-
-	if !regexp.MustCompile(`^[A-Za-z0-9\-_]+(/[A-Za-z0-9\-_]+)*$`).MatchString(value) {
-		errors = append(errors, fmt.Errorf("%s must contain only uppercase and lowercase alphanumeric characters, numbers, hyphens and underscores, and can be nested multiple levels", k))
+	// Per: https://learn.microsoft.com/en-us/rest/api/storageservices/naming-and-referencing-shares--directories--files--and-metadata#directory-and-file-names
+	if regexp.MustCompile(`^\.+$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(`%s must not only contain dots`, k))
+	}
+	if !regexp.MustCompile(`^[^"\/:|<>*?]{1,255}$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(`%s must not contain following characters: "\/:|<>*?`, k))
 	}
 
 	return warnings, errors


### PR DESCRIPTION
Relax the directory name for `azurerm_storage_share_file` and `azurerm_storage_share_directory`, to approximate the Azure requirement: https://learn.microsoft.com/en-us/rest/api/storageservices/naming-and-referencing-shares--directories--files--and-metadata#directory-and-file-names.

Fix #20940 

## Test

Been tested with directory name as `()`, `$$`, `conf.d` (as is in #20940), all works. Also checked that `.`, `..` (as are specified in Azure requirement) are not allowed, even `...` (.etc) will show already exist:

![image](https://user-images.githubusercontent.com/7970698/225220908-8e4ff155-9012-477c-b858-16e6a1713f0e.png)
