### PR TITLE
`azurerm_ssh_public_key` -  allow `.` for `name` validation 

### DIFF
--- a/internal/services/compute/ssh_public_key_data_source.go
+++ b/internal/services/compute/ssh_public_key_data_source.go
@@ -28,8 +28,8 @@ func dataSourceSshPublicKey() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeString,
 				Required: true,
 				ValidateFunc: validation.StringMatch(
-					regexp.MustCompile("^[-a-zA-Z0-9(_)]{1,128}$"),
-					"Public SSH Key name must be 1 - 128 characters long, can contain letters, numbers, underscores, and hyphens (but the first and last character must be a letter or number).",
+					regexp.MustCompile(`^[-a-zA-Z0-9(_).]{1,128}$`),
+					"Public SSH Key name must be 1 - 128 characters long, can contain letters, numbers, underscores, dots and hyphens (but the first and last character must be a letter or number).",
 				),
 			},
 

--- a/internal/services/compute/ssh_public_key_resource.go
+++ b/internal/services/compute/ssh_public_key_resource.go
@@ -45,8 +45,8 @@ func resourceSshPublicKey() *pluginsdk.Resource {
 				Required: true,
 				ForceNew: true,
 				ValidateFunc: validation.StringMatch(
-					regexp.MustCompile("^[-a-zA-Z0-9(_)]{1,128}$"),
-					"Public SSH Key name must be 1 - 128 characters long, can contain letters, numbers, underscores, and hyphens (but the first and last character must be a letter or number).",
+					regexp.MustCompile(`^[-a-zA-Z0-9(_).]{1,128}$`),
+					"Public SSH Key name must be 1 - 128 characters long, can contain letters, numbers, underscores, dots and hyphens (but the first and last character must be a letter or number).",
 				),
 			},
 

--- a/internal/services/compute/ssh_public_key_resource_test.go
+++ b/internal/services/compute/ssh_public_key_resource_test.go
@@ -68,7 +68,7 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_ssh_public_key" "test" {
-  name                = "test-public-key-%d"
+  name                = "tf.test-public-key-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
   public_key          = "%s"


### PR DESCRIPTION
After checking, the name of `azurerm_ssh_public_key` is allowed to contain dots. So submit this PR to fix #20920.

Test Result:
PASS: TestAccDataSourceAzureSshPublicKey_basic (197.07s)