### PR TITLE
internal/clients: exposing an error when building the auto-clients

### DIFF
--- a/internal/clients/client.go
+++ b/internal/clients/client.go
@@ -257,7 +257,9 @@ func (client *Client) Build(ctx context.Context, o *common.ClientOptions) error 
 	// Disable the Azure SDK for Go's validation since it's unhelpful for our use-case
 	validation.Disabled = true
 
-	buildAutoClients(&client.autoClient, o)
+	if err := buildAutoClients(&client.autoClient, o); err != nil {
+		return fmt.Errorf("building auto-clients: %+v", err)
+	}
 
 	client.Features = o.Features
 	client.StopContext = ctx

--- a/internal/clients/client_gen.go
+++ b/internal/clients/client_gen.go
@@ -18,8 +18,9 @@ type autoClient struct {
 	ManagedIdentity  *managedidentity_v2022_01_31_preview.Client
 }
 
-func buildAutoClients(client *autoClient, o *common.ClientOptions) {
+func buildAutoClients(client *autoClient, o *common.ClientOptions) error {
 	client.ContainerService = containers.NewClient(o)
 	client.LoadTestService = loadtestservice.NewClient(o)
 	client.ManagedIdentity = managedidentity.NewClient(o)
+	return nil
 }


### PR DESCRIPTION
This is needed since the new base layer can return an error when building clients as such we'll need to support this by hand for now, so that when the Pandora PR https://github.com/hashicorp/pandora/pull/2220 is merged, we don't have a compiler error