### PR TITLE
`azurerm_signalr_service` - add `public_network_access_enabled`, `local_auth_enabled`, `aad_auth_enabled`, `tls_client_cert_enabled`, `serverless_connection_timeout_in_seconds` that were introduced in latest 2023-02-01 api

### DIFF
--- a/internal/services/signalr/signalr_service_data_source.go
+++ b/internal/services/signalr/signalr_service_data_source.go
@@ -2,6 +2,7 @@ package signalr
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/response"
@@ -51,6 +52,31 @@ func dataSourceArmSignalRService() *pluginsdk.Resource {
 			},
 
 			"server_port": {
+				Type:     pluginsdk.TypeInt,
+				Computed: true,
+			},
+
+			"local_auth_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Computed: true,
+			},
+
+			"aad_auth_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Computed: true,
+			},
+
+			"public_network_access_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Computed: true,
+			},
+
+			"tls_client_cert_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Computed: true,
+			},
+
+			"serverless_connection_timeout_in_seconds": {
 				Type:     pluginsdk.TypeInt,
 				Computed: true,
 			},
@@ -117,6 +143,34 @@ func dataSourceArmSignalRServiceRead(d *pluginsdk.ResourceData, meta interface{}
 			d.Set("ip_address", props.ExternalIP)
 			d.Set("public_port", props.PublicPort)
 			d.Set("server_port", props.ServerPort)
+
+			aadAuthEnabled := true
+			if props.DisableAadAuth != nil {
+				aadAuthEnabled = !(*props.DisableAadAuth)
+			}
+			d.Set("aad_auth_enabled", aadAuthEnabled)
+
+			localAuthEnabled := true
+			if props.DisableLocalAuth != nil {
+				localAuthEnabled = !(*props.DisableLocalAuth)
+			}
+			d.Set("local_auth_enabled", localAuthEnabled)
+
+			publicNetworkAccessEnabled := true
+			if props.PublicNetworkAccess != nil {
+				publicNetworkAccessEnabled = strings.EqualFold(*props.PublicNetworkAccess, "Enabled")
+			}
+			d.Set("public_network_access_enabled", publicNetworkAccessEnabled)
+
+			tlsClientCertEnabled := false
+			if props.Tls != nil && props.Tls.ClientCertEnabled != nil {
+				tlsClientCertEnabled = *props.Tls.ClientCertEnabled
+			}
+			d.Set("tls_client_cert_enabled", tlsClientCertEnabled)
+
+			if props.Serverless != nil && props.Serverless.ConnectionTimeoutInSeconds != nil {
+				d.Set("serverless_connection_timeout_in_seconds", int(*props.Serverless.ConnectionTimeoutInSeconds))
+			}
 		}
 
 		if err := tags.FlattenAndSet(d, model.Tags); err != nil {

--- a/internal/services/signalr/signalr_service_resource.go
+++ b/internal/services/signalr/signalr_service_resource.go
@@ -286,7 +286,7 @@ func resourceArmSignalRServiceUpdate(d *pluginsdk.ResourceData, meta interface{}
 
 	resourceType := signalr.SignalRResource{}
 
-	if d.HasChanges("cors", "features", "upstream_endpoint", "connectivity_logs_enabled", "messaging_logs_enabled", "service_mode", "live_trace_enabled", "live_trace") {
+	if d.HasChanges("cors", "features", "upstream_endpoint", "connectivity_logs_enabled", "messaging_logs_enabled", "service_mode", "live_trace_enabled", "live_trace", "public_network_access_enabled", "local_auth_enabled", "aad_auth_enabled", "tls_client_cert_enabled", "serverless_connection_timeout_in_seconds") {
 		resourceType.Properties = &signalr.SignalRProperties{}
 
 		if d.HasChange("cors") {
@@ -300,26 +300,18 @@ func resourceArmSignalRServiceUpdate(d *pluginsdk.ResourceData, meta interface{}
 
 		if d.HasChange("public_network_access_enabled") {
 			publicNetworkAcc := "Enabled"
-			if _, ok := d.GetOk("public_network_access_enabled"); ok && !d.Get("public_network_access_enabled").(bool) {
+			if !d.Get("public_network_access_enabled").(bool) {
 				publicNetworkAcc = "Disabled"
 			}
 			resourceType.Properties.PublicNetworkAccess = utils.String(publicNetworkAcc)
 		}
 
 		if d.HasChange("local_auth_enabled") {
-			localAuthEnabled := true
-			if v, ok := d.GetOk("local_auth_enabled"); ok {
-				localAuthEnabled = v.(bool)
-			}
-			resourceType.Properties.DisableAadAuth = utils.Bool(!localAuthEnabled)
+			resourceType.Properties.DisableLocalAuth = utils.Bool(!d.Get("local_auth_enabled").(bool))
 		}
 
 		if d.HasChange("aad_auth_enabled") {
-			aadAuthEnabled := true
-			if v, ok := d.GetOk("aad_auth_enabled"); ok {
-				aadAuthEnabled = v.(bool)
-			}
-			resourceType.Properties.DisableAadAuth = utils.Bool(!aadAuthEnabled)
+			resourceType.Properties.DisableAadAuth = utils.Bool(!d.Get("aad_auth_enabled").(bool))
 		}
 
 		if d.HasChange("tls_client_cert_enabled") {
@@ -330,7 +322,7 @@ func resourceArmSignalRServiceUpdate(d *pluginsdk.ResourceData, meta interface{}
 
 		if d.HasChange("serverless_connection_timeout_in_seconds") {
 			resourceType.Properties.Serverless = &signalr.ServerlessSettings{
-				ConnectionTimeoutInSeconds: utils.Int64(d.Get("serverless_connection_timeout_in_seconds").(int64)),
+				ConnectionTimeoutInSeconds: utils.Int64(int64(d.Get("serverless_connection_timeout_in_seconds").(int))),
 			}
 		}
 

--- a/internal/services/signalr/signalr_service_resource_test.go
+++ b/internal/services/signalr/signalr_service_resource_test.go
@@ -41,6 +41,50 @@ func TestAccSignalRService_basic(t *testing.T) {
 	})
 }
 
+func TestAccSignalRService_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_signalr_service", "test")
+	r := SignalRServiceResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccSignalRService_identity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_signalr_service", "test")
+	r := SignalRServiceResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.systemAssignedIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.userAssignedIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.systemAssignedIdentity(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccSignalRService_premium(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_signalr_service", "test")
 	r := SignalRServiceResource{}
@@ -489,6 +533,111 @@ resource "azurerm_signalr_service" "test" {
   sku {
     name     = "Free_F1"
     capacity = 1
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (r SignalRServiceResource) complete(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_signalr_service" "test" {
+  name                = "acctestSignalR-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  sku {
+    name     = "Free_F1"
+    capacity = 1
+  }
+
+  public_network_access_enabled            = false
+  local_auth_enabled                       = false
+  aad_auth_enabled                         = false
+  tls_client_cert_enabled                  = false
+  serverless_connection_timeout_in_seconds = 5
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (r SignalRServiceResource) userAssignedIdentity(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_user_assigned_identity" "test" {
+  name                = "acctest-uai-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_signalr_service" "test" {
+  name                = "acctestSignalR-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  sku {
+    name     = "Free_F1"
+    capacity = 1
+  }
+
+  public_network_access_enabled            = true
+  local_auth_enabled                       = true
+  aad_auth_enabled                         = true
+  tls_client_cert_enabled                  = true
+  serverless_connection_timeout_in_seconds = 10
+
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.test.id]
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}
+
+func (r SignalRServiceResource) systemAssignedIdentity(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_signalr_service" "test" {
+  name                = "acctestSignalR-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  sku {
+    name     = "Free_F1"
+    capacity = 1
+  }
+
+  public_network_access_enabled            = false
+  local_auth_enabled                       = false
+  aad_auth_enabled                         = false
+  tls_client_cert_enabled                  = false
+  serverless_connection_timeout_in_seconds = 5
+
+  identity {
+    type = "SystemAssigned"
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)

--- a/internal/services/signalr/signalr_service_resource_test.go
+++ b/internal/services/signalr/signalr_service_resource_test.go
@@ -581,7 +581,7 @@ resource "azurerm_signalr_service" "test" {
     capacity = 1
   }
 
-  public_network_access_enabled            = false
+  public_network_access_enabled            = true
   local_auth_enabled                       = false
   aad_auth_enabled                         = false
   tls_client_cert_enabled                  = false
@@ -620,7 +620,7 @@ resource "azurerm_signalr_service" "test" {
   public_network_access_enabled            = true
   local_auth_enabled                       = true
   aad_auth_enabled                         = true
-  tls_client_cert_enabled                  = true
+  tls_client_cert_enabled                  = false
   serverless_connection_timeout_in_seconds = 10
 
   identity {
@@ -652,7 +652,7 @@ resource "azurerm_signalr_service" "test" {
     capacity = 1
   }
 
-  public_network_access_enabled            = false
+  public_network_access_enabled            = true
   local_auth_enabled                       = false
   aad_auth_enabled                         = false
   tls_client_cert_enabled                  = false

--- a/internal/services/signalr/signalr_service_resource_test.go
+++ b/internal/services/signalr/signalr_service_resource_test.go
@@ -56,6 +56,28 @@ func TestAccSignalRService_complete(t *testing.T) {
 	})
 }
 
+func TestAccSignalRService_propertyUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_signalr_service", "test")
+	r := SignalRServiceResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccSignalRService_identity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_signalr_service", "test")
 	r := SignalRServiceResource{}

--- a/website/docs/d/signalr_service.html.markdown
+++ b/website/docs/d/signalr_service.html.markdown
@@ -51,15 +51,15 @@ The following attributes are exported:
 
 * `secondary_connection_string` - The secondary connection string of the SignalR service.
 
-* `public_network_access_enabled` - Is public network access enabled?
+* `public_network_access_enabled` - Is public network access enabled for this SignalR service?
 
-* `local_auth_enabled` - Is local auth enabled?
+* `local_auth_enabled` - Is local auth enable for this SignalR serviced?
 
-* `aad_auth_enabled` - Is aad auth enabled?
+* `aad_auth_enabled` - Is aad auth enabled for this SignalR service?
 
-* `tls_client_cert_enabled` - Is tls client cert enabled
+* `tls_client_cert_enabled` - Is tls client cert enabled for this SignalR service?
 
-* `serverless_connection_timeout_in_seconds` - The serverless connection timeout.
+* `serverless_connection_timeout_in_seconds` - The serverless connection timeout of this SignalR service.
 
 * `identity` - An `identity` block as documented below.
 
@@ -67,7 +67,7 @@ The following attributes are exported:
 
 The `identity` block exports the following:
 
-* `type` - The type of identity used for the web pubsub.
+* `type` - The type of identity used for the signalR service.
 
 * `user_assigned_identity_id` - The ID of the User Assigned Identity. This value will be empty when using system assigned identity.
 

--- a/website/docs/d/signalr_service.html.markdown
+++ b/website/docs/d/signalr_service.html.markdown
@@ -51,6 +51,32 @@ The following attributes are exported:
 
 * `secondary_connection_string` - The secondary connection string of the SignalR service.
 
+* `public_network_access_enabled` - Is public network access enabled?
+
+* `local_auth_enabled` - Is local auth enabled?
+
+* `aad_auth_enabled` - Is aad auth enabled?
+
+* `tls_client_cert_enabled` - Is tls client cert enabled
+
+* `serverless_connection_timeout_in_seconds` - The serverless connection timeout.
+
+* `identity` - An `identity` block as documented below.
+
+---
+
+The `identity` block exports the following:
+
+* `type` - The type of identity used for the web pubsub.
+
+* `user_assigned_identity_id` - The ID of the User Assigned Identity. This value will be empty when using system assigned identity.
+
+* `principal_id` - The principal id of the system assigned identity.
+
+* `tenant_id` - The tenant id of the system assigned identity.
+
+---
+
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:

--- a/website/docs/r/signalr_service.html.markdown
+++ b/website/docs/r/signalr_service.html.markdown
@@ -3,7 +3,7 @@ subcategory: "Messaging"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_signalr_service"
 description: |-
-  Manages an Azure SignalR service.
+Manages an Azure SignalR service.
 ---
 
 # azurerm_signalr_service
@@ -129,9 +129,9 @@ A `sku` block supports the following:
 
 An `identity` block supports the following:
 
-* `type` - (Required) Specifies the type of Managed Service Identity that should be configured on this Web PubSub. Possible values are `SystemAssigned`, `UserAssigned`.
+* `type` - (Required) Specifies the type of Managed Service Identity that should be configured on this signalR. Possible values are `SystemAssigned`, `UserAssigned`.
 
-* `identity_ids` - (Optional) Specifies a list of User Assigned Managed Identity IDs to be assigned to this Web PubSub.
+* `identity_ids` - (Optional) Specifies a list of User Assigned Managed Identity IDs to be assigned to this signalR.
 
 ~> **NOTE:** This is required when `type` is set to `UserAssigned`
 

--- a/website/docs/r/signalr_service.html.markdown
+++ b/website/docs/r/signalr_service.html.markdown
@@ -3,7 +3,7 @@ subcategory: "Messaging"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_signalr_service"
 description: |-
-Manages an Azure SignalR service.
+  Manages an Azure SignalR service.
 ---
 
 # azurerm_signalr_service
@@ -71,11 +71,15 @@ The following arguments are supported:
 
 * `public_network_access_enabled` - (Optional) Whether to enable public network access? Defaults to `true`.
 
+~> **Note:** `public_network_access_enabled` cannot be set to `false` in `Free` sku tier.
+
 * `local_auth_enabled` - (Optional) Whether to enable local auth? Defaults to `true`.
 
 * `aad_auth_enabled` - (Optional) Whether to enable AAD auth? Defaults to `true`.
 
 * `tls_client_cert_enabled` - (Optional) Whether to request client certificate during TLS handshake? Defaults to `false`.
+
+~> **Note:** `tls_client_cert_enabled` cannot be set to `true` in `Free` sku tier.
 
 * `serverless_connection_timeout_in_seconds` - (Optional) Specifies the client connection timeout. Defaults to `30`.
 

--- a/website/docs/r/signalr_service.html.markdown
+++ b/website/docs/r/signalr_service.html.markdown
@@ -32,6 +32,8 @@ resource "azurerm_signalr_service" "example" {
     allowed_origins = ["http://www.example.com"]
   }
 
+  public_network_access_enabled = false
+
   connectivity_logs_enabled = true
   messaging_logs_enabled    = true
   service_mode              = "Default"
@@ -64,6 +66,18 @@ The following arguments are supported:
 * `messaging_logs_enabled` - (Optional) Specifies if Messaging Logs are enabled or not. Defaults to `false`.
 
 * `live_trace_enabled` - (Optional) Specifies if Live Trace is enabled or not. Defaults to `false`.
+
+* `identity` - (Optional) An `identity` block as defined below.
+
+* `public_network_access_enabled` - (Optional) Whether to enable public network access? Defaults to `true`.
+
+* `local_auth_enabled` - (Optional) Whether to enable local auth? Defaults to `true`.
+
+* `aad_auth_enabled` - (Optional) Whether to enable AAD auth? Defaults to `true`.
+
+* `tls_client_cert_enabled` - (Optional) Whether to request client certificate during TLS handshake? Defaults to `false`.
+
+* `serverless_connection_timeout_in_seconds` - (Optional) Specifies the client connection timeout. Defaults to `30`.
 
 * `service_mode` - (Optional) Specifies the service mode. Possible values are `Classic`, `Default` and `Serverless`. Defaults to `Default`.
 
@@ -110,6 +124,16 @@ A `sku` block supports the following:
 * `name` - (Required) Specifies which tier to use. Valid values are `Free_F1`, `Standard_S1` and `Premium_P1`.
 
 * `capacity` - (Required) Specifies the number of units associated with this SignalR service. Valid values are `1`, `2`, `5`, `10`, `20`, `50` and `100`.
+
+---
+
+An `identity` block supports the following:
+
+* `type` - (Required) Specifies the type of Managed Service Identity that should be configured on this Web PubSub. Possible values are `SystemAssigned`, `UserAssigned`.
+
+* `identity_ids` - (Optional) Specifies a list of User Assigned Managed Identity IDs to be assigned to this Web PubSub.
+
+~> **NOTE:** This is required when `type` is set to `UserAssigned`
 
 ## Attributes Reference
 


### PR DESCRIPTION
properties added:
```
1. public_network_access_enabled
2. local_auth_enabled
3. aad_auth_enabled
4. tls_client_cert_enabled
5. serverless_connection_timeout_in_seconds
```