### PR TITLE
`app_service` - fix `cors`, `ip_restriction` and `scm_ip_restriction` processing and minor bugfixes to flatten functions.

### DIFF
--- a/internal/services/appservice/helpers/auto_heal.go
+++ b/internal/services/appservice/helpers/auto_heal.go
@@ -470,7 +470,7 @@ func expandAutoHealSettingsWindows(autoHealSettings []AutoHealSettingWindows) *w
 
 func flattenAutoHealSettingsWindows(autoHealRules *web.AutoHealRules) []AutoHealSettingWindows {
 	if autoHealRules == nil {
-		return nil
+		return []AutoHealSettingWindows{}
 	}
 
 	result := AutoHealSettingWindows{}

--- a/internal/services/appservice/helpers/common_web_app_schema.go
+++ b/internal/services/appservice/helpers/common_web_app_schema.go
@@ -1276,7 +1276,7 @@ func FlattenAppSettings(input web.StringDictionary) (map[string]string, *int, er
 
 func flattenVirtualApplications(appVirtualApplications *[]web.VirtualApplication) []VirtualApplication {
 	if appVirtualApplications == nil || onlyDefaultVirtualApplication(*appVirtualApplications) {
-		return nil
+		return []VirtualApplication{}
 	}
 
 	var virtualApplications []VirtualApplication

--- a/internal/services/appservice/helpers/function_app_schema.go
+++ b/internal/services/appservice/helpers/function_app_schema.go
@@ -1961,6 +1961,7 @@ func FlattenSiteConfigLinuxFunctionApp(functionAppSiteConfig *web.SiteConfig) (*
 		AppCommandLine:          utils.NormalizeNilableString(functionAppSiteConfig.AppCommandLine),
 		AppScaleLimit:           int(utils.NormaliseNilableInt32(functionAppSiteConfig.FunctionAppScaleLimit)),
 		ContainerRegistryMSI:    utils.NormalizeNilableString(functionAppSiteConfig.AcrUserManagedIdentityID),
+		Cors:                    FlattenCorsSettings(functionAppSiteConfig.Cors),
 		DetailedErrorLogging:    utils.NormaliseNilableBool(functionAppSiteConfig.DetailedErrorLoggingEnabled),
 		HealthCheckPath:         utils.NormalizeNilableString(functionAppSiteConfig.HealthCheckPath),
 		Http2Enabled:            utils.NormaliseNilableBool(functionAppSiteConfig.HTTP20Enabled),
@@ -2004,26 +2005,6 @@ func FlattenSiteConfigLinuxFunctionApp(functionAppSiteConfig *web.SiteConfig) (*
 		result.DefaultDocuments = *v
 	}
 
-	if functionAppSiteConfig.Cors != nil {
-		corsEmpty := false
-		corsSettings := functionAppSiteConfig.Cors
-		cors := CorsSetting{}
-		if corsSettings.SupportCredentials != nil {
-			cors.SupportCredentials = *corsSettings.SupportCredentials
-		}
-
-		if corsSettings.AllowedOrigins != nil {
-			if len(*corsSettings.AllowedOrigins) > 0 {
-				cors.AllowedOrigins = *corsSettings.AllowedOrigins
-			} else if !cors.SupportCredentials {
-				corsEmpty = true
-			}
-		}
-		if !corsEmpty {
-			result.Cors = []CorsSetting{cors}
-		}
-	}
-
 	var appStack []ApplicationStackLinuxFunctionApp
 	if functionAppSiteConfig.LinuxFxVersion != nil {
 		decoded, err := DecodeFunctionAppLinuxFxVersion(*functionAppSiteConfig.LinuxFxVersion)
@@ -2046,6 +2027,7 @@ func FlattenSiteConfigWindowsFunctionApp(functionAppSiteConfig *web.SiteConfig) 
 		AlwaysOn:                utils.NormaliseNilableBool(functionAppSiteConfig.AlwaysOn),
 		AppCommandLine:          utils.NormalizeNilableString(functionAppSiteConfig.AppCommandLine),
 		AppScaleLimit:           int(utils.NormaliseNilableInt32(functionAppSiteConfig.FunctionAppScaleLimit)),
+		Cors:                    FlattenCorsSettings(functionAppSiteConfig.Cors),
 		DetailedErrorLogging:    utils.NormaliseNilableBool(functionAppSiteConfig.DetailedErrorLoggingEnabled),
 		HealthCheckPath:         utils.NormalizeNilableString(functionAppSiteConfig.HealthCheckPath),
 		Http2Enabled:            utils.NormaliseNilableBool(functionAppSiteConfig.HTTP20Enabled),
@@ -2086,27 +2068,6 @@ func FlattenSiteConfigWindowsFunctionApp(functionAppSiteConfig *web.SiteConfig) 
 
 	if v := functionAppSiteConfig.DefaultDocuments; v != nil {
 		result.DefaultDocuments = *v
-	}
-
-	if functionAppSiteConfig.Cors != nil {
-		corsSettings := functionAppSiteConfig.Cors
-		corsEmpty := false
-		cors := CorsSetting{}
-		if corsSettings.SupportCredentials != nil {
-			cors.SupportCredentials = *corsSettings.SupportCredentials
-		}
-
-		if corsSettings.AllowedOrigins != nil {
-			if len(*corsSettings.AllowedOrigins) > 0 {
-				cors.AllowedOrigins = *corsSettings.AllowedOrigins
-			} else if !cors.SupportCredentials {
-				corsEmpty = true
-			}
-		}
-
-		if !corsEmpty {
-			result.Cors = []CorsSetting{cors}
-		}
 	}
 
 	powershellVersion := ""

--- a/internal/services/appservice/helpers/function_app_slot_schema.go
+++ b/internal/services/appservice/helpers/function_app_slot_schema.go
@@ -846,6 +846,7 @@ func FlattenSiteConfigWindowsFunctionAppSlot(functionAppSlotSiteConfig *web.Site
 		AppCommandLine:          utils.NormalizeNilableString(functionAppSlotSiteConfig.AppCommandLine),
 		AppScaleLimit:           int(utils.NormaliseNilableInt32(functionAppSlotSiteConfig.FunctionAppScaleLimit)),
 		AutoSwapSlotName:        utils.NormalizeNilableString(functionAppSlotSiteConfig.AutoSwapSlotName),
+		Cors:                    FlattenCorsSettings(functionAppSlotSiteConfig.Cors),
 		DetailedErrorLogging:    utils.NormaliseNilableBool(functionAppSlotSiteConfig.DetailedErrorLoggingEnabled),
 		HealthCheckPath:         utils.NormalizeNilableString(functionAppSlotSiteConfig.HealthCheckPath),
 		Http2Enabled:            utils.NormaliseNilableBool(functionAppSlotSiteConfig.HTTP20Enabled),
@@ -886,26 +887,6 @@ func FlattenSiteConfigWindowsFunctionAppSlot(functionAppSlotSiteConfig *web.Site
 
 	if v := functionAppSlotSiteConfig.DefaultDocuments; v != nil {
 		result.DefaultDocuments = *v
-	}
-
-	if functionAppSlotSiteConfig.Cors != nil {
-		corsEmpty := false
-		corsSettings := functionAppSlotSiteConfig.Cors
-		cors := CorsSetting{}
-		if corsSettings.SupportCredentials != nil {
-			cors.SupportCredentials = *corsSettings.SupportCredentials
-		}
-
-		if corsSettings.AllowedOrigins != nil {
-			if len(*corsSettings.AllowedOrigins) > 0 {
-				cors.AllowedOrigins = *corsSettings.AllowedOrigins
-			} else if !cors.SupportCredentials {
-				corsEmpty = true
-			}
-		}
-		if !corsEmpty {
-			result.Cors = []CorsSetting{cors}
-		}
 	}
 
 	powershellVersion := ""
@@ -1199,6 +1180,7 @@ func FlattenSiteConfigLinuxFunctionAppSlot(functionAppSlotSiteConfig *web.SiteCo
 		AppScaleLimit:           int(utils.NormaliseNilableInt32(functionAppSlotSiteConfig.FunctionAppScaleLimit)),
 		AutoSwapSlotName:        utils.NormalizeNilableString(functionAppSlotSiteConfig.AutoSwapSlotName),
 		ContainerRegistryMSI:    utils.NormalizeNilableString(functionAppSlotSiteConfig.AcrUserManagedIdentityID),
+		Cors:                    FlattenCorsSettings(functionAppSlotSiteConfig.Cors),
 		DetailedErrorLogging:    utils.NormaliseNilableBool(functionAppSlotSiteConfig.DetailedErrorLoggingEnabled),
 		HealthCheckPath:         utils.NormalizeNilableString(functionAppSlotSiteConfig.HealthCheckPath),
 		Http2Enabled:            utils.NormaliseNilableBool(functionAppSlotSiteConfig.HTTP20Enabled),
@@ -1240,26 +1222,6 @@ func FlattenSiteConfigLinuxFunctionAppSlot(functionAppSlotSiteConfig *web.SiteCo
 
 	if v := functionAppSlotSiteConfig.DefaultDocuments; v != nil {
 		result.DefaultDocuments = *v
-	}
-
-	if functionAppSlotSiteConfig.Cors != nil {
-		corsSettings := functionAppSlotSiteConfig.Cors
-		corsEmpty := false
-		cors := CorsSetting{}
-		if corsSettings.SupportCredentials != nil {
-			cors.SupportCredentials = *corsSettings.SupportCredentials
-		}
-
-		if corsSettings.AllowedOrigins != nil {
-			if len(*corsSettings.AllowedOrigins) > 0 {
-				cors.AllowedOrigins = *corsSettings.AllowedOrigins
-			} else if !cors.SupportCredentials {
-				corsEmpty = true
-			}
-		}
-		if !corsEmpty {
-			result.Cors = []CorsSetting{cors}
-		}
 	}
 
 	var appStack []ApplicationStackLinuxFunctionApp

--- a/internal/services/appservice/helpers/linux_web_app_schema.go
+++ b/internal/services/appservice/helpers/linux_web_app_schema.go
@@ -900,7 +900,7 @@ func ExpandSiteConfigLinux(siteConfig []SiteConfigLinux, existing *web.SiteConfi
 
 func FlattenSiteConfigLinux(appSiteConfig *web.SiteConfig, healthCheckCount *int) []SiteConfigLinux {
 	if appSiteConfig == nil {
-		return nil
+		return []SiteConfigLinux{}
 	}
 
 	siteConfig := SiteConfigLinux{
@@ -930,6 +930,7 @@ func FlattenSiteConfigLinux(appSiteConfig *web.SiteConfig, healthCheckCount *int
 		UseManagedIdentityACR:   pointer.From(appSiteConfig.AcrUseManagedIdentityCreds),
 		WebSockets:              pointer.From(appSiteConfig.WebSocketsEnabled),
 		VnetRouteAllEnabled:     pointer.From(appSiteConfig.VnetRouteAllEnabled),
+		Cors:                    FlattenCorsSettings(appSiteConfig.Cors),
 	}
 
 	if appSiteConfig.APIManagementConfig != nil && appSiteConfig.APIManagementConfig.ID != nil {
@@ -950,26 +951,6 @@ func FlattenSiteConfigLinux(appSiteConfig *web.SiteConfig, healthCheckCount *int
 		// Decode the string to docker values
 		linuxAppStack = decodeApplicationStackLinux(siteConfig.LinuxFxVersion)
 		siteConfig.ApplicationStack = []ApplicationStackLinux{linuxAppStack}
-	}
-
-	if appSiteConfig.Cors != nil {
-		corsEmpty := false
-		corsSettings := appSiteConfig.Cors
-		cors := CorsSetting{}
-		if corsSettings.SupportCredentials != nil {
-			cors.SupportCredentials = *corsSettings.SupportCredentials
-		}
-
-		if corsSettings.AllowedOrigins != nil {
-			if len(*corsSettings.AllowedOrigins) > 0 {
-				cors.AllowedOrigins = *corsSettings.AllowedOrigins
-			} else if !cors.SupportCredentials {
-				corsEmpty = true
-			}
-		}
-		if !corsEmpty {
-			siteConfig.Cors = []CorsSetting{cors}
-		}
 	}
 
 	return []SiteConfigLinux{siteConfig}
@@ -1047,7 +1028,7 @@ func expandAutoHealSettingsLinux(autoHealSettings []AutoHealSettingLinux) *web.A
 
 func flattenAutoHealSettingsLinux(autoHealRules *web.AutoHealRules) []AutoHealSettingLinux {
 	if autoHealRules == nil {
-		return nil
+		return []AutoHealSettingLinux{}
 	}
 
 	result := AutoHealSettingLinux{}

--- a/internal/services/appservice/helpers/shared_schema.go
+++ b/internal/services/appservice/helpers/shared_schema.go
@@ -50,7 +50,6 @@ func IpRestrictionSchema() *pluginsdk.Schema {
 	return &pluginsdk.Schema{
 		Type:       pluginsdk.TypeList,
 		Optional:   true,
-		Computed:   true,
 		ConfigMode: pluginsdk.SchemaConfigModeAttr,
 		Elem: &pluginsdk.Resource{
 			Schema: map[string]*pluginsdk.Schema{
@@ -1124,7 +1123,7 @@ func GithubAuthSettingsSchemaComputed() *pluginsdk.Schema {
 }
 
 func ExpandIpRestrictions(restrictions []IpRestriction) (*[]web.IPSecurityRestriction, error) {
-	var expanded []web.IPSecurityRestriction
+	expanded := make([]web.IPSecurityRestriction, 0)
 	if len(restrictions) == 0 {
 		return &expanded, nil
 	}

--- a/internal/services/appservice/helpers/web_app_slot_schema.go
+++ b/internal/services/appservice/helpers/web_app_slot_schema.go
@@ -727,6 +727,7 @@ func FlattenSiteConfigLinuxWebAppSlot(appSiteSlotConfig *web.SiteConfig, healthC
 		AutoHealSettings:        flattenAutoHealSettingsLinux(appSiteSlotConfig.AutoHealRules),
 		AutoSwapSlotName:        pointer.From(appSiteSlotConfig.AutoSwapSlotName),
 		ContainerRegistryMSI:    pointer.From(appSiteSlotConfig.AcrUserManagedIdentityID),
+		Cors:                    FlattenCorsSettings(appSiteSlotConfig.Cors),
 		DetailedErrorLogging:    pointer.From(appSiteSlotConfig.DetailedErrorLoggingEnabled),
 		Http2Enabled:            pointer.From(appSiteSlotConfig.HTTP20Enabled),
 		IpRestriction:           FlattenIpRestrictions(appSiteSlotConfig.IPSecurityRestrictions),
@@ -768,27 +769,6 @@ func FlattenSiteConfigLinuxWebAppSlot(appSiteSlotConfig *web.SiteConfig, healthC
 		// Decode the string to docker values
 		linuxAppStack = decodeApplicationStackLinux(siteConfig.LinuxFxVersion)
 		siteConfig.ApplicationStack = []ApplicationStackLinux{linuxAppStack}
-	}
-
-	if appSiteSlotConfig.Cors != nil {
-		corsEmpty := false
-		corsSettings := appSiteSlotConfig.Cors
-		cors := CorsSetting{}
-		if corsSettings.SupportCredentials != nil {
-			cors.SupportCredentials = *corsSettings.SupportCredentials
-		}
-
-		if corsSettings.AllowedOrigins != nil {
-			if len(*corsSettings.AllowedOrigins) > 0 {
-				cors.AllowedOrigins = *corsSettings.AllowedOrigins
-			} else if !cors.SupportCredentials {
-				corsEmpty = true
-			}
-		}
-
-		if !corsEmpty {
-			siteConfig.Cors = []CorsSetting{cors}
-		}
 	}
 
 	return []SiteConfigLinuxWebAppSlot{siteConfig}
@@ -1033,6 +1013,7 @@ func FlattenSiteConfigWindowsAppSlot(appSiteSlotConfig *web.SiteConfig, currentS
 		AutoHealSettings:         flattenAutoHealSettingsWindows(appSiteSlotConfig.AutoHealRules),
 		AutoSwapSlotName:         pointer.From(appSiteSlotConfig.AutoSwapSlotName),
 		ContainerRegistryUserMSI: pointer.From(appSiteSlotConfig.AcrUserManagedIdentityID),
+		Cors:                     FlattenCorsSettings(appSiteSlotConfig.Cors),
 		DetailedErrorLogging:     pointer.From(appSiteSlotConfig.DetailedErrorLoggingEnabled),
 		FtpsState:                string(appSiteSlotConfig.FtpsState),
 		HealthCheckPath:          pointer.From(appSiteSlotConfig.HealthCheckPath),
@@ -1111,26 +1092,6 @@ func FlattenSiteConfigWindowsAppSlot(appSiteSlotConfig *web.SiteConfig, currentS
 	winAppStack.CurrentStack = currentStack
 
 	siteConfig.ApplicationStack = []ApplicationStackWindows{winAppStack}
-
-	if appSiteSlotConfig.Cors != nil {
-		corsEmpty := false
-		corsSettings := appSiteSlotConfig.Cors
-		cors := CorsSetting{}
-		if corsSettings.SupportCredentials != nil {
-			cors.SupportCredentials = *corsSettings.SupportCredentials
-		}
-
-		if corsSettings.AllowedOrigins != nil {
-			if len(*corsSettings.AllowedOrigins) > 0 {
-				cors.AllowedOrigins = *corsSettings.AllowedOrigins
-			} else if !cors.SupportCredentials {
-				corsEmpty = true
-			}
-		}
-		if !corsEmpty {
-			siteConfig.Cors = []CorsSetting{cors}
-		}
-	}
 
 	return []SiteConfigWindowsWebAppSlot{siteConfig}
 }

--- a/internal/services/appservice/helpers/windows_web_app_schema.go
+++ b/internal/services/appservice/helpers/windows_web_app_schema.go
@@ -665,6 +665,7 @@ func FlattenSiteConfigWindows(appSiteConfig *web.SiteConfig, currentStack string
 		AutoHeal:                 pointer.From(appSiteConfig.AutoHealEnabled),
 		AutoHealSettings:         flattenAutoHealSettingsWindows(appSiteConfig.AutoHealRules),
 		ContainerRegistryUserMSI: pointer.From(appSiteConfig.AcrUserManagedIdentityID),
+		Cors:                     FlattenCorsSettings(appSiteConfig.Cors),
 		DetailedErrorLogging:     pointer.From(appSiteConfig.DetailedErrorLoggingEnabled),
 		FtpsState:                string(appSiteConfig.FtpsState),
 		HealthCheckPath:          pointer.From(appSiteConfig.HealthCheckPath),
@@ -748,26 +749,6 @@ func FlattenSiteConfigWindows(appSiteConfig *web.SiteConfig, currentStack string
 	winAppStack.CurrentStack = currentStack
 
 	siteConfig.ApplicationStack = []ApplicationStackWindows{winAppStack}
-
-	if appSiteConfig.Cors != nil {
-		corsEmpty := false
-		corsSettings := appSiteConfig.Cors
-		cors := CorsSetting{}
-		if corsSettings.SupportCredentials != nil {
-			cors.SupportCredentials = *corsSettings.SupportCredentials
-		}
-
-		if corsSettings.AllowedOrigins != nil {
-			if len(*corsSettings.AllowedOrigins) > 0 {
-				cors.AllowedOrigins = *corsSettings.AllowedOrigins
-			} else if !cors.SupportCredentials {
-				corsEmpty = true
-			}
-		}
-		if !corsEmpty {
-			siteConfig.Cors = []CorsSetting{cors}
-		}
-	}
 
 	return []SiteConfigWindows{siteConfig}, nil
 }

--- a/internal/services/appservice/linux_function_app_resource_test.go
+++ b/internal/services/appservice/linux_function_app_resource_test.go
@@ -1281,6 +1281,7 @@ func TestAccLinuxFunctionApp_msiStorageAccountElastic(t *testing.T) {
 		data.ImportStep(),
 	})
 }
+
 func TestAccLinuxFunctionApp_msiStorageAccountStandard(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_linux_function_app", "test")
 	r := LinuxFunctionAppResource{}
@@ -1362,6 +1363,54 @@ func TestAccLinuxFunctionAppASEv3_basic(t *testing.T) {
 			Config: r.withASEV3(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccLinuxFunctionApp_corsUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_function_app", "test")
+	r := LinuxFunctionAppResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data, SkuStandardPlan),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("kind").HasValue("functionapp,linux"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.withCors(data, SkuStandardPlan),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("kind").HasValue("functionapp,linux"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.withCorsSupportCredentials(data, SkuStandardPlan),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("kind").HasValue("functionapp,linux"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.withCors(data, SkuStandardPlan),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("kind").HasValue("functionapp,linux"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basic(data, SkuStandardPlan),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("kind").HasValue("functionapp,linux"),
 			),
 		},
 		data.ImportStep(),
@@ -1516,6 +1565,70 @@ resource "azurerm_linux_function_app" "test" {
   storage_account_access_key = azurerm_storage_account.test.primary_access_key
 
   site_config {}
+}
+`, r.template(data, planSku), data.RandomInteger)
+}
+
+func (r LinuxFunctionAppResource) withCors(data acceptance.TestData, planSku string) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_linux_function_app" "test" {
+  name                = "acctest-LFA-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  service_plan_id     = azurerm_service_plan.test.id
+
+  storage_account_name       = azurerm_storage_account.test.name
+  storage_account_access_key = azurerm_storage_account.test.primary_access_key
+
+  site_config {
+    cors {
+      allowed_origins = [
+        "https://www.contoso.com",
+        "www.contoso.com",
+        "custom.example.com",
+      ]
+
+      support_credentials = false
+    }
+  }
+}
+`, r.template(data, planSku), data.RandomInteger)
+}
+
+func (r LinuxFunctionAppResource) withCorsSupportCredentials(data acceptance.TestData, planSku string) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_linux_function_app" "test" {
+  name                = "acctest-LFA-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  service_plan_id     = azurerm_service_plan.test.id
+
+  storage_account_name       = azurerm_storage_account.test.name
+  storage_account_access_key = azurerm_storage_account.test.primary_access_key
+
+  site_config {
+    cors {
+      allowed_origins = [
+        "https://www.contoso.com",
+        "www.contoso.com",
+        "custom.example.com",
+      ]
+
+      support_credentials = true
+    }
+  }
 }
 `, r.template(data, planSku), data.RandomInteger)
 }

--- a/internal/services/appservice/linux_web_app_resource_test.go
+++ b/internal/services/appservice/linux_web_app_resource_test.go
@@ -369,6 +369,13 @@ func TestAccLinuxWebApp_withIPRestrictionsUpdate(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
 			Config: r.withIPRestrictions(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
@@ -383,7 +390,7 @@ func TestAccLinuxWebApp_withIPRestrictionsUpdate(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
-			Config: r.withIPRestrictions(data),
+			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -1661,6 +1668,19 @@ resource "azurerm_linux_web_app" "test" {
       action {
         action_type                    = "Recycle"
         minimum_process_execution_time = "00:05:00"
+      }
+    }
+
+    ip_restriction {
+      ip_address = "10.10.10.10/32"
+      name       = "test-restriction"
+      priority   = 123
+      action     = "Allow"
+      headers {
+        x_azure_fdid      = ["55ce4ed1-4b06-4bf1-b40e-4638452104da"]
+        x_fd_health_probe = ["1"]
+        x_forwarded_for   = ["9.9.9.9/32", "2002::1234:abcd:ffff:c0a8:101/64"]
+        x_forwarded_host  = ["example.com"]
       }
     }
 

--- a/internal/services/appservice/windows_web_app_slot_resource_test.go
+++ b/internal/services/appservice/windows_web_app_slot_resource_test.go
@@ -1943,7 +1943,9 @@ resource "azurerm_service_plan" "test2" {
 
 resource "azurerm_windows_web_app_slot" "test" {
   name           = "acctestWAS-%[2]d"
-  app_service_id = azurerm_windows_web_app.test2.id
+  app_service_id = azurerm_windows_web_app.test.id
+
+  service_plan_id = azurerm_service_plan.test2.id
 
   site_config {}
 }
@@ -1976,7 +1978,7 @@ resource "azurerm_service_plan" "test3" {
 
 resource "azurerm_windows_web_app_slot" "test" {
   name           = "acctestWAS-%[2]d"
-  app_service_id = azurerm_windows_web_app.test3.id
+  app_service_id = azurerm_windows_web_app.test.id
 
   service_plan_id = azurerm_service_plan.test3.id
 


### PR DESCRIPTION
**Breaking Changes - App Service `site_config` ** 
* `ip_restriction` blocks are no longer computed - Changes to IP restrictions outside of Terraform will now present a diff
* `scm_ip_restriction` blocks are no longer computed - Changes to SCM IP restrictions outside of Terraform will now present a diff
* `cors` blocks no longer require `allowed_origins`, however, if the property is supplied it must contain at least one item. Omitting this property will set the array empty.

---

BUG FIXES

* `azurerm_linux_function_app`  - fixed processing of `cors` block 
* `azurerm_linux_function_app_slot`  - fixed processing of `cors` block 
* `azurerm_linux_function_app`  - the `ip_restriction` block can is now successfully removed by removing from config 
* `azurerm_linux_function_app_slot`  - the `ip_restriction` block can is now successfully removed by removing from config 
* `azurerm_linux_function_app`  - the `scm_ip_restriction` block can is now successfully removed by removing from config 
* `azurerm_linux_function_app_slot`  -  the `scm_ip_restriction` block can is now successfully removed by removing from config 

* `azurerm_linux_web_app`  - fixed processing of `cors` block 
* `azurerm_linux_web_app_slot`  -fixed processing of `cors` block  
* `azurerm_linux_web_app`  - the `ip_restriction` block can is now successfully removed by removing from config 
* `azurerm_linux_web_app_slot`  - the `ip_restriction` block can is now successfully removed by removing from config 
* `azurerm_linux_web_app`  - the `scm_ip_restriction` block can is now successfully removed by removing from config 
* `azurerm_linux_web_app_slot`  - the `scm_ip_restriction` block can is now successfully removed by removing from config 

* `azurerm_windows_function_app`  - fixed processing of `cors` block 
* `azurerm_windows_function_app_slot`  - fixed processing of `cors` block 
* `azurerm_windows_function_app`  - the `ip_restriction` block can is now successfully removed by removing from config 
* `azurerm_windows_function_app_slot`  - the `ip_restriction` block can is now successfully removed by removing from config 
* `azurerm_windows_function_app`  - the `scm_ip_restriction` block can is now successfully removed by removing from config 
* `azurerm_windows_function_app_slot`  - the `scm_ip_restriction` block can is now successfully removed by removing from config 

* `azurerm_windows_web_app`  - fixed processing of `cors` block 
* `azurerm_windows_web_app_slot`  -fixed processing of `cors` block  
* `azurerm_windows_web_app`  - the `ip_restriction` block can is now successfully removed by removing from config 
* `azurerm_windows_web_app_slot`  - the `ip_restriction` block can is now successfully removed by removing from config 
* `azurerm_windows_web_app`  - the `scm_ip_restriction` block can is now successfully removed by removing from config 
* `azurerm_windows_web_app_slot`  - the `scm_ip_restriction` block can is now successfully removed by removing from config 

fixes #17173
fixes #18664
fixes #18793
fixes #19323
fixes #20148
fixes #20193
fixes #20331

Supersedes #20251
Supersedes #20327