### PR TITLE
locks: making the NewMutexKV method private

### DIFF
--- a/internal/locks/lock.go
+++ b/internal/locks/lock.go
@@ -1,7 +1,7 @@
 package locks
 
 // armMutexKV is the instance of MutexKV for ARM resources
-var armMutexKV = NewMutexKV()
+var armMutexKV = newMutexKV()
 
 func ByID(id string) {
 	armMutexKV.Lock(id)

--- a/internal/locks/mutexkv.go
+++ b/internal/locks/mutexkv.go
@@ -40,8 +40,8 @@ func (m *mutexKV) get(key string) *sync.Mutex {
 	return mutex
 }
 
-// Returns a properly initialized mutexKV
-func NewMutexKV() *mutexKV {
+// newMutexKV returns a properly initialized mutexKV
+func newMutexKV() *mutexKV {
 	return &mutexKV{
 		store: make(map[string]*sync.Mutex),
 	}


### PR DESCRIPTION
This shouldn't be used outside of this package