### PR TITLE
`azurerm_kubernetes_cluster` - Support for BYO `ingress_application_gateway_identity`

### DIFF
--- a/internal/services/containers/kubernetes_addons.go
+++ b/internal/services/containers/kubernetes_addons.go
@@ -388,18 +388,19 @@ func expandKubernetesAddOns(d *pluginsdk.ResourceData, input map[string]interfac
 			Config:  &config,
 		}
 
-		identityRaw := value["ingress_application_gateway_identity"].([]interface{})
-		if len(identityRaw) > 0 && identityRaw[0] != nil {
+		ingressApplicationGatewayIdentity := value["ingress_application_gateway_identity"].([]interface{})
+		if len(ingressApplicationGatewayIdentity) > 0 && ingressApplicationGatewayIdentity[0] != nil {
+			gatewayIdentity := ingressApplicationGatewayIdentity[0].(map[string]interface{})
 			identity := managedclusters.UserAssignedIdentity{}
 
-			if clientID, ok := value["client_id"]; ok && clientID != "" {
+			if clientID, ok := gatewayIdentity["client_id"]; ok && clientID != "" {
 				identity.ClientId = utils.String(clientID.(string))
 			}
 
-			if objectID, ok := value["object_id"]; ok && objectID != "" {
+			if objectID, ok := gatewayIdentity["object_id"]; ok && objectID != "" {
 				identity.ObjectId = utils.String(objectID.(string))
 			}
-			if resourceID, ok := value["user_assigned_identity_id"]; ok && resourceID != "" {
+			if resourceID, ok := gatewayIdentity["user_assigned_identity_id"]; ok && resourceID != "" {
 				identity.ResourceId = utils.String(resourceID.(string))
 			}
 		}

--- a/internal/services/containers/kubernetes_addons.go
+++ b/internal/services/containers/kubernetes_addons.go
@@ -387,6 +387,23 @@ func expandKubernetesAddOns(d *pluginsdk.ResourceData, input map[string]interfac
 			Enabled: true,
 			Config:  &config,
 		}
+
+		identityRaw := value["ingress_application_gateway_identity"].([]interface{})
+		if len(identityRaw) > 0 && identityRaw[0] != nil {
+			identity := managedclusters.UserAssignedIdentity{}
+
+			if clientID, ok := value["client_id"]; ok && clientID != "" {
+				identity.ClientId = utils.String(clientID.(string))
+			}
+
+			if objectID, ok := value["object_id"]; ok && objectID != "" {
+				identity.ObjectId = utils.String(objectID.(string))
+			}
+			if resourceID, ok := value["user_assigned_identity_id"]; ok && resourceID != "" {
+				identity.ResourceId = utils.String(resourceID.(string))
+			}
+		}
+
 	} else if len(ingressApplicationGateway) == 0 && d.HasChange("ingress_application_gateway") {
 		addonProfiles[ingressApplicationGatewayKey] = disabled
 	}

--- a/internal/services/containers/kubernetes_addons.go
+++ b/internal/services/containers/kubernetes_addons.go
@@ -195,29 +195,33 @@ func schemaKubernetesAddOns() map[string]*pluginsdk.Schema {
 						},
 						ValidateFunc: subnetValidate.SubnetID,
 					},
-					"effective_gateway_id": {
-						Type:     pluginsdk.TypeString,
-						Computed: true,
-					},
 					"ingress_application_gateway_identity": {
 						Type:     pluginsdk.TypeList,
+						Optional: true,
 						Computed: true,
 						Elem: &pluginsdk.Resource{
 							Schema: map[string]*pluginsdk.Schema{
 								"client_id": {
 									Type:     pluginsdk.TypeString,
+									Optional: true,
 									Computed: true,
 								},
 								"object_id": {
 									Type:     pluginsdk.TypeString,
+									Optional: true,
 									Computed: true,
 								},
 								"user_assigned_identity_id": {
 									Type:     pluginsdk.TypeString,
+									Optional: true,
 									Computed: true,
 								},
 							},
 						},
+					},
+					"effective_gateway_id": {
+						Type:     pluginsdk.TypeString,
+						Computed: true,
 					},
 				},
 			},

--- a/internal/services/containers/kubernetes_addons.go
+++ b/internal/services/containers/kubernetes_addons.go
@@ -387,7 +387,7 @@ func expandKubernetesAddOns(d *pluginsdk.ResourceData, input map[string]interfac
 			config["subnetId"] = subnetId.(string)
 		}
 
-		addonProfiles[ingressApplicationGatewayKey] = managedclusters.ManagedClusterAddonProfile{
+		ingressApplicationGatewayProfile := managedclusters.ManagedClusterAddonProfile{
 			Enabled: true,
 			Config:  &config,
 		}
@@ -407,7 +407,11 @@ func expandKubernetesAddOns(d *pluginsdk.ResourceData, input map[string]interfac
 			if resourceID, ok := gatewayIdentity["user_assigned_identity_id"]; ok && resourceID != "" {
 				identity.ResourceId = utils.String(resourceID.(string))
 			}
+
+			ingressApplicationGatewayProfile.Identity = &identity
 		}
+
+		addonProfiles[ingressApplicationGatewayKey] = ingressApplicationGatewayProfile
 
 	} else if len(ingressApplicationGateway) == 0 && d.HasChange("ingress_application_gateway") {
 		addonProfiles[ingressApplicationGatewayKey] = disabled

--- a/internal/services/containers/kubernetes_cluster_addons_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_addons_resource_test.go
@@ -168,6 +168,21 @@ func TestAccKubernetesCluster_addonProfileIngressApplicationGateway_appGatewayId
 	})
 }
 
+func TestAccKubernetesCluster_addonProfileIngressApplicationGateway_byoManagedIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
+	r := KubernetesClusterResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.addonProfileIngressApplicationGatewayBYOManagedIdentityConfig(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccKubernetesCluster_addonProfileIngressApplicationGateway_subnetCIDR(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
 	r := KubernetesClusterResource{}
@@ -783,6 +798,154 @@ resource "azurerm_kubernetes_cluster" "test" {
 
   identity {
     type = "SystemAssigned"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
+func (KubernetesClusterResource) addonProfileIngressApplicationGatewayBYOManagedIdentityConfig(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-aks-%d"
+  location = "%s"
+}
+
+resource "azurerm_user_assigned_identity" "aks_identity_test" {
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  name                = "test_identity"
+}
+
+resource "azurerm_user_assigned_identity" "agw_identity_test" {
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  name                = "test_agw_identity"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvirtnet%d"
+  address_space       = ["172.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctestsubnet%d"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["172.0.2.0/24"]
+}
+
+resource "azurerm_public_ip" "test" {
+  name                = "acctestpublicip%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  sku                 = "Standard"
+  allocation_method   = "Static"
+}
+
+resource "azurerm_application_gateway" "test" {
+  name                = "acctestappgw%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  sku {
+    name     = "Standard_v2"
+    tier     = "Standard_v2"
+    capacity = 2
+  }
+
+  gateway_ip_configuration {
+    name      = "gwipcfg"
+    subnet_id = azurerm_subnet.test.id
+  }
+
+  frontend_port {
+    name = "frontendport"
+    port = 80
+  }
+
+  frontend_ip_configuration {
+    name                 = "frontendipcfg"
+    public_ip_address_id = azurerm_public_ip.test.id
+  }
+
+  backend_address_pool {
+    name = "backendaddresspool"
+  }
+
+  backend_http_settings {
+    name                  = "backendhttpsettings"
+    cookie_based_affinity = "Disabled"
+    port                  = 80
+    protocol              = "Http"
+    request_timeout       = 60
+  }
+
+  http_listener {
+    name                           = "httplistener"
+    frontend_ip_configuration_name = "frontendipcfg"
+    frontend_port_name             = "frontendport"
+    protocol                       = "Http"
+  }
+
+  request_routing_rule {
+    name                       = "requestroutingrule"
+    rule_type                  = "Basic"
+    http_listener_name         = "httplistener"
+    backend_address_pool_name  = "backendaddresspool"
+    backend_http_settings_name = "backendhttpsettings"
+    priority                   = 1
+  }
+
+	identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.agw_identity_test.id]
+  }
+}
+
+resource "azurerm_kubernetes_cluster" "test" {
+  name                = "acctestaks%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%d"
+
+  linux_profile {
+    admin_username = "acctestuser%d"
+
+    ssh_key {
+      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqaZoyiz1qbdOQ8xEf6uEu1cCwYowo5FHtsBhqLoDnnp7KUTEBN+L2NxRIfQ781rxV6Iq5jSav6b2Q8z5KiseOlvKA/RF2wqU0UPYqQviQhLmW6THTpmrv/YkUCuzxDpsH7DUDhZcwySLKVVe0Qm3+5N2Ta6UYH3lsDf9R9wTP2K/+vAnflKebuypNlmocIvakFWoZda18FOmsOoIVXQ8HWFNCuw9ZCunMSN62QGamCe3dL5cXlkgHYv7ekJE15IA9aOJcM7e90oeTqo+7HTcWfdu0qQqPWY5ujyMw/llas8tsXY85LFqRnr3gJ02bAscjc477+X+j/gkpFoN1QEmt terraform@demo.tld"
+    }
+  }
+
+  default_node_pool {
+    name       = "default"
+    node_count = 1
+    vm_size    = "Standard_DS2_v2"
+  }
+
+  ingress_application_gateway {
+    gateway_id = azurerm_application_gateway.test.id
+
+		ingress_application_gateway_identity {
+			client_id = azurerm_user_assigned_identity.agw_identity_test.client_id
+			object_id = azurerm_user_assigned_identity.agw_identity_test.object_id
+			user_assigned_identity_id = azurerm_user_assigned_identity.agw_identity_test.id
+		}
+		
+  }
+
+  identity {
+    type = "UserAssigned"
+		identity_ids = [azurerm_user_assigned_identity.agw_identity_test.id]
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)

--- a/internal/services/containers/kubernetes_cluster_addons_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_addons_resource_test.go
@@ -937,7 +937,7 @@ resource "azurerm_kubernetes_cluster" "test" {
 
 		ingress_application_gateway_identity {
 			client_id = azurerm_user_assigned_identity.agw_identity_test.client_id
-			object_id = azurerm_user_assigned_identity.agw_identity_test.object_id
+			object_id = azurerm_user_assigned_identity.agw_identity_test.principal_id
 			user_assigned_identity_id = azurerm_user_assigned_identity.agw_identity_test.id
 		}
 		


### PR DESCRIPTION
Fixes #21008

---

Doesn't work yet, seems like the identity is not sticking based on the API requests. Upstream [issue](https://github.com/Azure/AKS/issues/3555) filed for now.