### PR TITLE
bugfix: explicitly send the blob endpoint from the environment

### DIFF
--- a/internal/services/machinelearning/machine_learning_datastore_blobstorage_resource.go
+++ b/internal/services/machinelearning/machine_learning_datastore_blobstorage_resource.go
@@ -157,8 +157,14 @@ func (r MachineLearningDataStoreBlobStorage) Create() sdk.ResourceFunc {
 				Type: utils.ToPtr(string(datastore.DatastoreTypeAzureBlob)),
 			}
 
+			storageDomainSuffix, ok := metadata.Client.Account.Environment.Storage.DomainSuffix()
+			if !ok {
+				return fmt.Errorf("could not determine Storage domain suffix for environment %q", metadata.Client.Account.Environment.Name)
+			}
+
 			props := &datastore.AzureBlobDatastore{
 				AccountName:                   utils.String(containerId.StorageAccountName),
+				Endpoint:                      storageDomainSuffix,
 				ContainerName:                 utils.String(containerId.ContainerName),
 				Description:                   utils.String(model.Description),
 				ServiceDataAccessAuthIdentity: utils.ToPtr(datastore.ServiceDataAccessAuthIdentity(model.ServiceDataAuthIdentity)),


### PR DESCRIPTION
Else the API defaults to core.windows.net which is wrong for non-public clouds.

Closes: #20943