### PR TITLE
`data.azurerm_service_plan` - now decode into DataSourceModel

### DIFF
--- a/internal/services/appservice/service_plan_data_source.go
+++ b/internal/services/appservice/service_plan_data_source.go
@@ -115,7 +115,7 @@ func (r ServicePlanDataSource) Read() sdk.ResourceFunc {
 			client := metadata.Client.AppService.ServicePlanClient
 			subscriptionId := metadata.Client.Account.SubscriptionId
 
-			var servicePlan ServicePlanModel
+			var servicePlan ServicePlanDataSourceModel
 			if err := metadata.Decode(&servicePlan); err != nil {
 				return err
 			}


### PR DESCRIPTION
Just saw this minor bug where we're decoding into the Resource Model instead of the DataSource Model