### PR TITLE
`azurerm_logic_app_standard`: fix acctest

### DIFF
--- a/internal/services/logic/integration_service_environment_resource_test.go
+++ b/internal/services/logic/integration_service_environment_resource_test.go
@@ -16,6 +16,8 @@ import (
 type IntegrationServiceEnvironmentResource struct{}
 
 func TestAccIntegrationServiceEnvironment_basic(t *testing.T) {
+	t.Skip("Skipping since Integration Service Environment is deprecated.")
+
 	data := acceptance.BuildTestData(t, "azurerm_integration_service_environment", "test")
 	r := IntegrationServiceEnvironmentResource{}
 
@@ -42,6 +44,8 @@ func TestAccIntegrationServiceEnvironment_basic(t *testing.T) {
 }
 
 func TestAccIntegrationServiceEnvironment_complete(t *testing.T) {
+	t.Skip("Skipping since Integration Service Environment is deprecated.")
+
 	data := acceptance.BuildTestData(t, "azurerm_integration_service_environment", "test")
 	r := IntegrationServiceEnvironmentResource{}
 
@@ -69,6 +73,8 @@ func TestAccIntegrationServiceEnvironment_complete(t *testing.T) {
 }
 
 func TestAccIntegrationServiceEnvironment_developer(t *testing.T) {
+	t.Skip("Skipping since Integration Service Environment is deprecated.")
+
 	data := acceptance.BuildTestData(t, "azurerm_integration_service_environment", "test")
 	r := IntegrationServiceEnvironmentResource{}
 
@@ -96,6 +102,8 @@ func TestAccIntegrationServiceEnvironment_developer(t *testing.T) {
 }
 
 func TestAccIntegrationServiceEnvironment_update(t *testing.T) {
+	t.Skip("Skipping since Integration Service Environment is deprecated.")
+
 	data := acceptance.BuildTestData(t, "azurerm_integration_service_environment", "test")
 	r := IntegrationServiceEnvironmentResource{}
 
@@ -158,6 +166,8 @@ func TestAccIntegrationServiceEnvironment_update(t *testing.T) {
 }
 
 func TestAccIntegrationServiceEnvironment_requiresImport(t *testing.T) {
+	t.Skip("Skipping since Integration Service Environment is deprecated.")
+
 	data := acceptance.BuildTestData(t, "azurerm_integration_service_environment", "test")
 	r := IntegrationServiceEnvironmentResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{

--- a/internal/services/logic/logic_app_integration_account_certificate_resource_test.go
+++ b/internal/services/logic/logic_app_integration_account_certificate_resource_test.go
@@ -136,7 +136,8 @@ resource "azurerm_key_vault_access_policy" "test1" {
     "Update",
     "List",
     "Decrypt",
-    "Sign"
+    "Sign",
+    "GetRotationPolicy"
   ]
 
   secret_permissions = [
@@ -160,7 +161,8 @@ resource "azurerm_key_vault_access_policy" "test2" {
     "Update",
     "List",
     "Decrypt",
-    "Sign"
+    "Sign",
+    "GetRotationPolicy"
   ]
 
   secret_permissions = [
@@ -288,7 +290,8 @@ resource "azurerm_key_vault_access_policy" "test3" {
     "Update",
     "List",
     "Decrypt",
-    "Sign"
+    "Sign",
+    "GetRotationPolicy"
   ]
 
   secret_permissions = [
@@ -312,7 +315,8 @@ resource "azurerm_key_vault_access_policy" "test4" {
     "Update",
     "List",
     "Decrypt",
-    "Sign"
+    "Sign",
+    "GetRotationPolicy"
   ]
 
   secret_permissions = [

--- a/internal/services/logic/logic_app_integration_account_resource_test.go
+++ b/internal/services/logic/logic_app_integration_account_resource_test.go
@@ -96,6 +96,8 @@ func TestAccLogicAppIntegrationAccount_update(t *testing.T) {
 }
 
 func TestAccLogicAppIntegrationAccount_integrationServiceEnvironment(t *testing.T) {
+	t.Skip("skip as Integration Service Environment is being deprecated")
+
 	data := acceptance.BuildTestData(t, "azurerm_logic_app_integration_account", "test")
 	r := LogicAppIntegrationAccountResource{}
 

--- a/internal/services/logic/logic_app_standard_resource_test.go
+++ b/internal/services/logic/logic_app_standard_resource_test.go
@@ -1097,6 +1097,10 @@ resource "azurerm_logic_app_standard" "test" {
   version                    = "%s"
   storage_account_name       = azurerm_storage_account.test.name
   storage_account_access_key = azurerm_storage_account.test.primary_access_key
+
+  site_config {
+    runtime_scale_monitoring_enabled = false
+  }
 }
 `, r.template(data), data.RandomInteger, version)
 }

--- a/internal/services/logic/logic_app_trigger_http_request_resource_test.go
+++ b/internal/services/logic/logic_app_trigger_http_request_resource_test.go
@@ -136,6 +136,8 @@ func TestAccLogicAppTriggerHttpRequest_disappears(t *testing.T) {
 }
 
 func TestAccLogicAppTriggerHttpRequest_workflowWithISE(t *testing.T) {
+	t.Skip("skip as Integration Service Environment is being deprecated")
+
 	data := acceptance.BuildTestData(t, "azurerm_logic_app_trigger_http_request", "test")
 	r := LogicAppTriggerHttpRequestResource{}
 

--- a/internal/services/logic/logic_app_workflow_resource_test.go
+++ b/internal/services/logic/logic_app_workflow_resource_test.go
@@ -118,6 +118,8 @@ func TestAccLogicAppWorkflow_integrationAccount(t *testing.T) {
 }
 
 func TestAccLogicAppWorkflow_integrationServiceEnvironment(t *testing.T) {
+	t.Skip("skip as Integration Service Environment is being deprecated")
+
 	data := acceptance.BuildTestData(t, "azurerm_logic_app_workflow", "test")
 	r := LogicAppWorkflowResource{}
 


### PR DESCRIPTION
adding key vault permission

and skip Integration Services Environment related tests as they have been deprecated. [REF](https://learn.microsoft.com/en-us/azure/logic-apps/ise-manage-integration-service-environment)


<img width="373" alt="Screenshot 2023-03-20 at 14 10 32" src="https://user-images.githubusercontent.com/51212351/226260742-dfc6f6d6-1747-4d73-93de-c6620b6a743c.png">
