### PR TITLE
`azurerm_batch_account` - Remove forceNew for `public_network_access_enabled`

### DIFF
--- a/internal/services/batch/batch_account_resource.go
+++ b/internal/services/batch/batch_account_resource.go
@@ -107,7 +107,6 @@ func resourceBatchAccount() *pluginsdk.Resource {
 				Type:     pluginsdk.TypeBool,
 				Optional: true,
 				Default:  true,
-				ForceNew: true,
 			},
 
 			"key_vault_reference": {

--- a/website/docs/r/batch_account.html.markdown
+++ b/website/docs/r/batch_account.html.markdown
@@ -56,7 +56,7 @@ The following arguments are supported:
 
 * `pool_allocation_mode` - (Optional) Specifies the mode to use for pool allocation. Possible values are `BatchService` or `UserSubscription`. Defaults to `BatchService`.
 
-* `public_network_access_enabled` - (Optional) Whether public network access is allowed for this server. Defaults to `true`. Changing this forces a new resource to be created.
+* `public_network_access_enabled` - (Optional) Whether public network access is allowed for this server. Defaults to `true`.
 
 ~> **NOTE:** When using `UserSubscription` mode, an Azure KeyVault reference has to be specified. See `key_vault_reference` below.
 


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/21014

Tried locally that changing this property does not need to force creating a new one.

Testing config:

```hcl
terraform {
  required_providers {
    azapi = {
      source  = "Azure/azapi"
    }
  }
}

provider "azapi" {
}

// azurerm provider
provider "azurerm" {
  features {}
}

resource "azurerm_resource_group" "test" {
  name     = "testaccRG-batch-yun"
  location = "west europe"
}

resource "azapi_resource" "name" {
  name = "testaccyun"
  type = "Microsoft.Batch/batchAccounts@2022-01-01"
  parent_id = azurerm_resource_group.test.id
  location = azurerm_resource_group.test.location
  body = jsonencode({
    properties = {
        poolAllocationMode = "BatchService"
        publicNetworkAccess = "Disabled"
    }
  })
}
```

Testing evidence with AzApi:

```

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
PS D:\TerraformTest\batch> terraform apply --auto-approve
azurerm_resource_group.test: Refreshing state... [id=/subscriptions/85b3dbca-5974-4067-9669-67a141095a76/resourceGroups/testaccRG-batch-yun]
azapi_resource.name: Refreshing state... [id=/subscriptions/85b3dbca-5974-4067-9669-67a141095a76/resourceGroups/testaccRG-batch-yun/providers/Microsoft.Batch/batchAccounts/testaccyun]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # azapi_resource.name will be updated in-place
  ~ resource "azapi_resource" "name" {
      ~ body                      = jsonencode(
          ~ {
              ~ properties = {
                  ~ publicNetworkAccess = "Disabled" -> "Enabled"
                    # (1 unchanged element hidden)
                }
            }
        )
        id                        = "/subscriptions/85b3dbca-5974-4067-9669-67a141095a76/resourceGroups/testaccRG-batch-yun/providers/Microsoft.Batch/batchAccounts/testaccyun"
        name                      = "testaccyun"
      ~ output                    = jsonencode({}) -> (known after apply)
        tags                      = {}
        # (7 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
azapi_resource.name: Modifying... [id=/subscriptions/85b3dbca-5974-4067-9669-67a141095a76/resourceGroups/testaccRG-batch-yun/providers/Microsoft.Batch/batchAccounts/testaccyun]
azapi_resource.name: Modifications complete after 7s [id=/subscriptions/85b3dbca-5974-4067-9669-67a141095a76/resourceGroups/testaccRG-batch-yun/providers/Microsoft.Batch/batchAccounts/testaccyun]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
PS D:\TerraformTest\batch> terraform apply --auto-approve
azurerm_resource_group.test: Refreshing state... [id=/subscriptions/85b3dbca-5974-4067-9669-67a141095a76/resourceGroups/testaccRG-batch-yun]
azapi_resource.name: Refreshing state... [id=/subscriptions/85b3dbca-5974-4067-9669-67a141095a76/resourceGroups/testaccRG-batch-yun/providers/Microsoft.Batch/batchAccounts/testaccyun]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # azapi_resource.name will be updated in-place
  ~ resource "azapi_resource" "name" {
      ~ body                      = jsonencode(
          ~ {
              ~ properties = {
                  ~ publicNetworkAccess = "Enabled" -> "Disabled"
                    # (1 unchanged element hidden)
                }
            }
        )
        id                        = "/subscriptions/85b3dbca-5974-4067-9669-67a141095a76/resourceGroups/testaccRG-batch-yun/providers/Microsoft.Batch/batchAccounts/testaccyun"
        name                      = "testaccyun"
      ~ output                    = jsonencode({}) -> (known after apply)
        tags                      = {}
        # (7 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
azapi_resource.name: Modifying... [id=/subscriptions/85b3dbca-5974-4067-9669-67a141095a76/resourceGroups/testaccRG-batch-yun/providers/Microsoft.Batch/batchAccounts/testaccyun]
azapi_resource.name: Modifications complete after 7s [id=/subscriptions/85b3dbca-5974-4067-9669-67a141095a76/resourceGroups/testaccRG-batch-yun/providers/Microsoft.Batch/batchAccounts/testaccyun]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```
