### PR TITLE
`azurerm_automation_account`: fix AccTest of adding `GetRotationPolicy` for keyvault

### DIFF
--- a/internal/services/automation/automation_account_resource_test.go
+++ b/internal/services/automation/automation_account_resource_test.go
@@ -323,6 +323,7 @@ resource "azurerm_key_vault" "test" {
       "List",
       "Delete",
       "Purge",
+      "GetRotationPolicy",
     ]
 
     secret_permissions = [
@@ -341,6 +342,7 @@ resource "azurerm_key_vault" "test" {
       "Recover",
       "WrapKey",
       "UnwrapKey",
+      "GetRotationPolicy",
     ]
 
     secret_permissions = []


### PR DESCRIPTION
keyvualt update permission cause acc test failed.

```
Error: current client lacks permissions to read Key Rotation Policy for Key "acckvkey-230315011742356455" ("Vault: (Name \"vault230315011742356455\" / Resource Group \"acctestRG-auto-230315011742356455\")", Vault url: "https://vault230315011742356455.vault.azure.net/"), 

please update this as described here: https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_key#example-usage : keyvault.BaseClient#GetKeyRotationPolicy: Failure responding to request:

 StatusCode=403 -- Original Error: autorest/azure: Service returned an error. Status=403 Code="Forbidden" Message="The user, group or application 'appid=*******;oid=3aa04c8c-5a75-4e5e-9117-1b7cf6f33e21;numgroups=9;iss=https://sts.windows.net/*******/' does not have keys getrotationpolicy permission on key vault 'vault230315011742356455;location=westeurope'. For help resolving this issue, please see https://go.microsoft.com/fwlink/?linkid=2125287" InnerError={"code":"ForbiddenByPolicy"}
```