### PR TITLE
`document` - add missing `GetRotationPolicy` in Key Vault Access Policy

### DIFF
--- a/website/docs/r/cognitive_account_customer_managed_key.html.markdown
+++ b/website/docs/r/cognitive_account_customer_managed_key.html.markdown
@@ -63,7 +63,7 @@ resource "azurerm_key_vault" "example" {
     tenant_id = data.azurerm_client_config.current.tenant_id
     object_id = data.azurerm_client_config.current.object_id
     key_permissions = [
-      "Get", "Create", "Delete", "List", "Restore", "Recover", "UnwrapKey", "WrapKey", "Purge", "Encrypt", "Decrypt", "Sign", "Verify"
+      "Get", "Create", "Delete", "List", "Restore", "Recover", "UnwrapKey", "WrapKey", "Purge", "Encrypt", "Decrypt", "Sign", "Verify", "GetRotationPolicy"
     ]
     secret_permissions = [
       "Get",

--- a/website/docs/r/databricks_workspace_customer_managed_key.html.markdown
+++ b/website/docs/r/databricks_workspace_customer_managed_key.html.markdown
@@ -82,7 +82,8 @@ resource "azurerm_key_vault_access_policy" "terraform" {
     "Update",
     "List",
     "Decrypt",
-    "Sign"
+    "Sign",
+    "GetRotationPolicy",
   ]
 }
 

--- a/website/docs/r/disk_encryption_set.html.markdown
+++ b/website/docs/r/disk_encryption_set.html.markdown
@@ -76,7 +76,7 @@ resource "azurerm_key_vault_access_policy" "example-disk" {
     "Update",
     "List",
     "Decrypt",
-    "Sign"
+    "Sign",
   ]
 }
 
@@ -95,7 +95,8 @@ resource "azurerm_key_vault_access_policy" "example-user" {
     "Update",
     "List",
     "Decrypt",
-    "Sign"
+    "Sign",
+    "GetRotationPolicy",
   ]
 }
 

--- a/website/docs/r/eventhub_namespace_customer_managed_key.html.markdown
+++ b/website/docs/r/eventhub_namespace_customer_managed_key.html.markdown
@@ -70,6 +70,7 @@ resource "azurerm_key_vault_access_policy" "example2" {
     "List",
     "Purge",
     "Recover",
+    "GetRotationPolicy",
   ]
 }
 

--- a/website/docs/r/kusto_cluster_customer_managed_key.html.markdown
+++ b/website/docs/r/kusto_cluster_customer_managed_key.html.markdown
@@ -43,7 +43,7 @@ resource "azurerm_key_vault_access_policy" "client" {
   tenant_id    = data.azurerm_client_config.current.tenant_id
   object_id    = data.azurerm_client_config.current.object_id
 
-  key_permissions = ["Get", "List", "Create", "Delete", "Recover"]
+  key_permissions = ["Get", "List", "Create", "Delete", "Recover", "GetRotationPolicy"]
 }
 
 resource "azurerm_key_vault_key" "example" {

--- a/website/docs/r/log_analytics_cluster_customer_managed_key.html.markdown
+++ b/website/docs/r/log_analytics_cluster_customer_managed_key.html.markdown
@@ -50,6 +50,7 @@ resource "azurerm_key_vault" "example" {
     key_permissions = [
       "Create",
       "Get",
+      "GetRotationPolicy",
     ]
 
     secret_permissions = [

--- a/website/docs/r/machine_learning_workspace.html.markdown
+++ b/website/docs/r/machine_learning_workspace.html.markdown
@@ -107,6 +107,7 @@ resource "azurerm_key_vault_access_policy" "example" {
     "Get",
     "Delete",
     "Purge",
+    "GetRotationPolicy",
   ]
 }
 
@@ -241,6 +242,7 @@ resource "azurerm_key_vault_access_policy" "example-sp" {
     "Recover",
     "Delete",
     "Purge",
+    "GetRotationPolicy",
   ]
 }
 

--- a/website/docs/r/mssql_managed_instance_transparent_data_encryption.html.markdown
+++ b/website/docs/r/mssql_managed_instance_transparent_data_encryption.html.markdown
@@ -140,7 +140,7 @@ resource "azurerm_key_vault" "example" {
     object_id = data.azurerm_client_config.current.object_id
 
     key_permissions = [
-      "Get", "List", "Create", "Delete", "Update", "Recover", "Purge",
+      "Get", "List", "Create", "Delete", "Update", "Recover", "Purge", "GetRotationPolicy",
     ]
   }
   access_policy {

--- a/website/docs/r/mssql_server_transparent_data_encryption.html.markdown
+++ b/website/docs/r/mssql_server_transparent_data_encryption.html.markdown
@@ -105,7 +105,7 @@ resource "azurerm_key_vault" "example" {
     object_id = data.azurerm_client_config.current.object_id
 
     key_permissions = [
-      "Get", "List", "Create", "Delete", "Update", "Recover", "Purge",
+      "Get", "List", "Create", "Delete", "Update", "Recover", "Purge", "GetRotationPolicy",
     ]
   }
   access_policy {

--- a/website/docs/r/mysql_server_key.html.markdown
+++ b/website/docs/r/mysql_server_key.html.markdown
@@ -41,7 +41,7 @@ resource "azurerm_key_vault_access_policy" "client" {
   key_vault_id       = azurerm_key_vault.example.id
   tenant_id          = data.azurerm_client_config.current.tenant_id
   object_id          = data.azurerm_client_config.current.object_id
-  key_permissions    = ["Get", "Create", "Delete", "List", "Restore", "Recover", "UnwrapKey", "WrapKey", "Purge", "Encrypt", "Decrypt", "Sign", "Verify"]
+  key_permissions    = ["Get", "Create", "Delete", "List", "Restore", "Recover", "UnwrapKey", "WrapKey", "Purge", "Encrypt", "Decrypt", "Sign", "Verify", "GetRotationPolicy"]
   secret_permissions = ["Get"]
 }
 

--- a/website/docs/r/postgresql_server_key.html.markdown
+++ b/website/docs/r/postgresql_server_key.html.markdown
@@ -44,7 +44,7 @@ resource "azurerm_key_vault_access_policy" "client" {
   tenant_id    = data.azurerm_client_config.current.tenant_id
   object_id    = data.azurerm_client_config.current.object_id
 
-  key_permissions    = ["Get", "Create", "Delete", "List", "Restore", "Recover", "UnwrapKey", "WrapKey", "Purge", "Encrypt", "Decrypt", "Sign", "Verify"]
+  key_permissions    = ["Get", "Create", "Delete", "List", "Restore", "Recover", "UnwrapKey", "WrapKey", "Purge", "Encrypt", "Decrypt", "Sign", "Verify", "GetRotationPolicy"]
   secret_permissions = ["Get"]
 }
 

--- a/website/docs/r/storage_account_customer_managed_key.html.markdown
+++ b/website/docs/r/storage_account_customer_managed_key.html.markdown
@@ -47,7 +47,7 @@ resource "azurerm_key_vault_access_policy" "client" {
   tenant_id    = data.azurerm_client_config.current.tenant_id
   object_id    = data.azurerm_client_config.current.object_id
 
-  key_permissions    = ["Get", "Create", "Delete", "List", "Restore", "Recover", "UnwrapKey", "WrapKey", "Purge", "Encrypt", "Decrypt", "Sign", "Verify"]
+  key_permissions    = ["Get", "Create", "Delete", "List", "Restore", "Recover", "UnwrapKey", "WrapKey", "Purge", "Encrypt", "Decrypt", "Sign", "Verify", "GetRotationPolicy"]
   secret_permissions = ["Get"]
 }
 

--- a/website/docs/r/synapse_workspace.html.markdown
+++ b/website/docs/r/synapse_workspace.html.markdown
@@ -97,7 +97,7 @@ resource "azurerm_key_vault_access_policy" "deployer" {
   object_id    = data.azurerm_client_config.current.object_id
 
   key_permissions = [
-    "Create", "Get", "Delete", "Purge"
+    "Create", "Get", "Delete", "Purge", "GetRotationPolicy"
   ]
 }
 

--- a/website/docs/r/synapse_workspace_aad_admin.html.markdown
+++ b/website/docs/r/synapse_workspace_aad_admin.html.markdown
@@ -50,7 +50,7 @@ resource "azurerm_key_vault_access_policy" "deployer" {
   object_id    = data.azurerm_client_config.current.object_id
 
   key_permissions = [
-    "Create", "Get", "Delete", "Purge"
+    "Create", "Get", "Delete", "Purge", "GetRotationPolicy"
   ]
 }
 

--- a/website/docs/r/synapse_workspace_key.html.markdown
+++ b/website/docs/r/synapse_workspace_key.html.markdown
@@ -54,7 +54,7 @@ resource "azurerm_key_vault_access_policy" "deployer" {
   object_id    = data.azurerm_client_config.current.object_id
 
   key_permissions = [
-    "Create", "Get", "Delete", "Purge"
+    "Create", "Get", "Delete", "Purge", "GetRotationPolicy"
   ]
 }
 

--- a/website/docs/r/synapse_workspace_sql_aad_admin.html.markdown
+++ b/website/docs/r/synapse_workspace_sql_aad_admin.html.markdown
@@ -50,7 +50,7 @@ resource "azurerm_key_vault_access_policy" "deployer" {
   object_id    = data.azurerm_client_config.current.object_id
 
   key_permissions = [
-    "Create", "Get", "Delete", "Purge"
+    "Create", "Get", "Delete", "Purge", "GetRotationPolicy"
   ]
 }
 


### PR DESCRIPTION
Add the missing `GetRotationPolicy` in the document for the configs having `azurerm_key_vault_key`. This is found as part of #20995