### PR TITLE
r/automation_account: deprecating `key_source`

### DIFF
--- a/internal/services/automation/automation_account_resource.go
+++ b/internal/services/automation/automation_account_resource.go
@@ -5,11 +5,13 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/automation/2021-06-22/automationaccount"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
@@ -17,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/automation/validate"
 	keyVaultParse "github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/parse"
 	keyVaultValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/validate"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
@@ -65,7 +66,6 @@ func resourceAutomationAccount() *pluginsdk.Resource {
 			"encryption": {
 				Type:     pluginsdk.TypeList,
 				Optional: true,
-				Computed: true,
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*schema.Schema{
 						"user_assigned_identity_id": {
@@ -75,11 +75,14 @@ func resourceAutomationAccount() *pluginsdk.Resource {
 						},
 
 						"key_source": {
-							Type:     pluginsdk.TypeString,
-							Optional: true,
-							Computed: true,
+							Type:       pluginsdk.TypeString,
+							Optional:   true,
+							Deprecated: "This field is now ignored and will be removed in the next major version of the Azure Provider, the `encryption` block can be omitted to disable encryption",
 							ValidateFunc: validation.StringInSlice(
-								automationaccount.PossibleValuesForEncryptionKeySourceType(),
+								[]string{
+									string(automationaccount.EncryptionKeySourceTypeMicrosoftPointAutomation),
+									string(automationaccount.EncryptionKeySourceTypeMicrosoftPointKeyvault),
+								},
 								false,
 							),
 						},
@@ -99,7 +102,7 @@ func resourceAutomationAccount() *pluginsdk.Resource {
 				Default:  true,
 			},
 
-			"tags": tags.Schema(),
+			"tags": commonschema.Tags(),
 
 			"dsc_server_endpoint": {
 				Type:     pluginsdk.TypeString,
@@ -172,26 +175,27 @@ func resourceAutomationAccountCreate(d *pluginsdk.ResourceData, meta interface{}
 	if err != nil {
 		return fmt.Errorf("expanding `identity`: %+v", err)
 	}
+
+	enc, err := expandEncryption(d.Get("encryption").([]interface{}))
+	if err != nil {
+		return fmt.Errorf("expanding `encryption`: %v", err)
+	}
+
 	parameters := automationaccount.AutomationAccountCreateOrUpdateParameters{
+		Location: utils.String(location.Normalize(d.Get("location").(string))),
 		Properties: &automationaccount.AutomationAccountCreateOrUpdateProperties{
+			Encryption: enc,
 			Sku: &automationaccount.Sku{
 				Name: automationaccount.SkuNameEnum(d.Get("sku_name").(string)),
 			},
 			PublicNetworkAccess: utils.Bool(d.Get("public_network_access_enabled").(bool)),
 		},
-		Location: utils.String(location.Normalize(d.Get("location").(string))),
 	}
 
 	if localAuth := d.Get("local_authentication_enabled").(bool); !localAuth {
 		parameters.Properties.DisableLocalAuth = utils.Bool(true)
 	}
-	if encryption := d.Get("encryption").([]interface{}); len(encryption) > 0 {
-		enc, err := expandEncryption(encryption[0].(map[string]interface{}))
-		if err != nil {
-			return fmt.Errorf("expanding `encryption`: %v", err)
-		}
-		parameters.Properties.Encryption = enc
-	}
+
 	// for create account do not set identity property (even TypeNone is not allowed), or api will response error
 	if identityVal.Type != identity.TypeNone {
 		parameters.Identity = identityVal
@@ -217,35 +221,35 @@ func resourceAutomationAccountUpdate(d *pluginsdk.ResourceData, meta interface{}
 	if err != nil {
 		return err
 	}
+
 	identity, err := identity.ExpandSystemAndUserAssignedMap(d.Get("identity").([]interface{}))
 	if err != nil {
 		return fmt.Errorf("expanding `identity`: %+v", err)
 	}
+
+	enc, err := expandEncryption(d.Get("encryption").([]interface{}))
+	if err != nil {
+		return fmt.Errorf("expanding `encryption`: %v", err)
+	}
+
 	parameters := automationaccount.AutomationAccountUpdateParameters{
+		Location: utils.String(location.Normalize(d.Get("location").(string))),
+		Identity: identity,
 		Properties: &automationaccount.AutomationAccountUpdateProperties{
 			Sku: &automationaccount.Sku{
 				Name: automationaccount.SkuNameEnum(d.Get("sku_name").(string)),
 			},
 			PublicNetworkAccess: utils.Bool(d.Get("public_network_access_enabled").(bool)),
+			Encryption:          enc,
 		},
-		Location: utils.String(location.Normalize(d.Get("location").(string))),
-		Identity: identity,
 	}
 
 	if localAuth := d.Get("local_authentication_enabled").(bool); !localAuth {
 		parameters.Properties.DisableLocalAuth = utils.Bool(true)
 	}
 
-	if encryption := d.Get("encryption").([]interface{}); len(encryption) > 0 {
-		enc, err := expandEncryption(encryption[0].(map[string]interface{}))
-		if err != nil {
-			return fmt.Errorf("expanding `encryption`: %v", err)
-		}
-		parameters.Properties.Encryption = enc
-	}
-
-	if tagsVal := expandStringInterfaceMap(d.Get("tags").(map[string]interface{})); tagsVal != nil {
-		parameters.Tags = &tagsVal
+	if tagsVal := tags.Expand(d.Get("tags").(map[string]interface{})); tagsVal != nil {
+		parameters.Tags = tagsVal
 	}
 
 	if _, err := client.Update(ctx, *id, parameters); err != nil {
@@ -365,9 +369,17 @@ func resourceAutomationAccountDelete(d *pluginsdk.ResourceData, meta interface{}
 	return nil
 }
 
-func expandEncryption(encMap map[string]interface{}) (*automationaccount.EncryptionProperties, error) {
+func expandEncryption(input []interface{}) (*automationaccount.EncryptionProperties, error) {
+	if len(input) == 0 {
+		return &automationaccount.EncryptionProperties{
+			KeySource: pointer.To(automationaccount.EncryptionKeySourceTypeMicrosoftPointAutomation),
+		}, nil
+	}
+
+	v := input[0].(map[string]interface{})
+
 	var id interface{}
-	id, ok := encMap["user_assigned_identity_id"].(string)
+	id, ok := v["user_assigned_identity_id"].(string)
 	if !ok {
 		return nil, fmt.Errorf("read encryption user identity id error")
 	}
@@ -375,11 +387,9 @@ func expandEncryption(encMap map[string]interface{}) (*automationaccount.Encrypt
 		Identity: &automationaccount.EncryptionPropertiesIdentity{
 			UserAssignedIdentity: &id,
 		},
+		KeySource: pointer.To(automationaccount.EncryptionKeySourceTypeMicrosoftPointKeyvault),
 	}
-	if val, ok := encMap["key_source"].(string); ok && val != "" {
-		prop.KeySource = (*automationaccount.EncryptionKeySourceType)(&val)
-	}
-	if keyIdStr := encMap["key_vault_key_id"].(string); keyIdStr != "" {
+	if keyIdStr := v["key_vault_key_id"].(string); keyIdStr != "" {
 		keyId, err := keyVaultParse.ParseOptionallyVersionedNestedItemID(keyIdStr)
 		if err != nil {
 			return nil, err
@@ -393,22 +403,37 @@ func expandEncryption(encMap map[string]interface{}) (*automationaccount.Encrypt
 	return prop, nil
 }
 
-func flattenEncryption(encryption *automationaccount.EncryptionProperties) (res []interface{}) {
-	if encryption == nil {
-		return
+func flattenEncryption(encryption *automationaccount.EncryptionProperties) []interface{} {
+	if encryption == nil || encryption.KeySource == nil || *encryption.KeySource != automationaccount.EncryptionKeySourceTypeMicrosoftPointKeyvault {
+		return []interface{}{}
 	}
-	item := map[string]interface{}{}
-	if encryption.KeySource != nil {
-		item["key_source"] = (string)(*encryption.KeySource)
-	}
-	if encryption.Identity != nil && encryption.Identity.UserAssignedIdentity != nil {
-		item["user_assigned_identity_id"] = (*encryption.Identity.UserAssignedIdentity).(string)
-	}
+
+	keyVaultKeyId := ""
+	userAssignedIdentityId := ""
+
 	if keyProp := encryption.KeyVaultProperties; keyProp != nil {
-		keyVaultKeyId, err := keyVaultParse.NewNestedItemID(*keyProp.KeyvaultUri, "keys", *keyProp.KeyName, *keyProp.KeyVersion)
+		keyId, err := keyVaultParse.NewNestedItemID(*keyProp.KeyvaultUri, "keys", *keyProp.KeyName, *keyProp.KeyVersion)
 		if err == nil {
-			item["key_vault_key_id"] = keyVaultKeyId.ID()
+			keyVaultKeyId = keyId.ID()
 		}
 	}
-	return []interface{}{item}
+
+	if encryption.Identity != nil && encryption.Identity.UserAssignedIdentity != nil {
+		userAssignedIdentityIdRaw := (*encryption.Identity.UserAssignedIdentity).(string)
+		if userAssignedIdentityIdRaw != "" {
+			uaiId, err := commonids.ParseUserAssignedIdentityIDInsensitively(userAssignedIdentityIdRaw)
+			if err == nil {
+				userAssignedIdentityId = uaiId.ID()
+			}
+		}
+	}
+	return []interface{}{
+		map[string]interface{}{
+			"key_vault_key_id":          keyVaultKeyId,
+			"user_assigned_identity_id": userAssignedIdentityId,
+
+			// TODO: remove this field in 4.x
+			"key_source": "",
+		},
+	}
 }

--- a/internal/services/automation/automation_account_resource_test.go
+++ b/internal/services/automation/automation_account_resource_test.go
@@ -81,7 +81,6 @@ func TestAccAutomationAccount_encryption(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("sku_name").HasValue("Basic"),
 				check.That(data.ResourceName).Key("local_authentication_enabled").HasValue("false"),
-				check.That(data.ResourceName).Key("encryption.0.key_source").HasValue("Microsoft.Keyvault"),
 			),
 		},
 		data.ImportStep(),
@@ -386,7 +385,6 @@ resource "azurerm_automation_account" "test" {
   local_authentication_enabled = false
 
   encryption {
-    key_source                = "Microsoft.Keyvault"
     user_assigned_identity_id = azurerm_user_assigned_identity.test.id
     key_vault_key_id          = azurerm_key_vault_key.test.id
   }

--- a/website/docs/r/automation_account.html.markdown
+++ b/website/docs/r/automation_account.html.markdown
@@ -36,15 +36,25 @@ The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the Automation Account. Changing this forces a new resource to be created.
 
-* `public_network_access_enabled` - (Optional) Whether public network access is allowed for the container registry. Defaults to `true`.
-
 * `resource_group_name` - (Required) The name of the resource group in which the Automation Account is created. Changing this forces a new resource to be created.
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 
 * `sku_name` - (Required) The SKU of the account. Possible values are `Basic` and `Free`.
 
+---
+
 * `local_authentication_enabled` - (Optional) Whether requests using non-AAD authentication are blocked. Defaults to `true`.
+
+* `public_network_access_enabled` - (Optional) Whether public network access is allowed for the container registry. Defaults to `true`.
+
+---
+
+An `encryption` block supports the following:
+
+* `key_vault_key_id` - (Required) The ID of the Key Vault Key which should be used to Encrypt the data in this Automation Account.
+
+* `user_assigned_identity_id` - (Optional) The User Assigned Managed Identity ID to be used for accessing the Customer Managed Key for encryption.
 
 ---
 
@@ -63,16 +73,6 @@ An `identity` block supports the following:
 * `identity_ids` - (Optional) The ID of the User Assigned Identity which should be assigned to this Automation Account.
 
 -> **Note:** `identity_ids` is required when `type` is set to `UserAssigned` or `SystemAssigned, UserAssigned`.
-
----
-
-An `encryption` block supports the following:
-
-* `user_assigned_identity_id` - (Optional) The User Assigned Managed Identity ID to be used for accessing the Customer Managed Key for encryption.
-
-* `key_source` - (Optional) The source of the encryption key. Possible values are `Microsoft.Automation` and `Microsoft.Keyvault`.
-
-* `key_vault_key_id` - (Required) The ID of the Key Vault Key which should be used to Encrypt the data in this Automation Account.
 
 ---
 


### PR DESCRIPTION
This field shouldn't be exposed, since it can be inferred from the presence of the `encryption` block - other resources doing this were removed in 3.0 - so whilst there's now a unit test to check for this schema design, this lone instance should be fixed to be compatible.

Supersedes #20433
Fixes: https://github.com/hashicorp/terraform-provider-azurerm/issues/20421