### PR TITLE
Docs: clarify cache_duration as the minimum cache duration

### DIFF
--- a/website/docs/r/frontdoor.html.markdown
+++ b/website/docs/r/frontdoor.html.markdown
@@ -221,7 +221,7 @@ The `forwarding_configuration` block supports the following:
 
 * `cache_query_parameters` - (Optional) Specify query parameters (array). Works only in combination with `cache_query_parameter_strip_directive` set to `StripAllExcept` or `StripOnly`.
 
-* `cache_duration` - (Optional) Specify the caching duration (in ISO8601 notation e.g. `P1DT2H` for 1 day and 2 hours). Needs to be greater than 0 and smaller than 365 days. `cache_duration` works only in combination with `cache_enabled` set to `true`.
+* `cache_duration` - (Optional) Specify the minimum caching duration (in ISO8601 notation e.g. `P1DT2H` for 1 day and 2 hours). Needs to be greater than 0 and smaller than 365 days. `cache_duration` works only in combination with `cache_enabled` set to `true`.
 
 * `custom_forwarding_path` - (Optional) Path to use when constructing the request to forward to the backend. This functions as a URL Rewrite. Default behaviour preserves the URL path.
 


### PR DESCRIPTION
Clarify the `cache_duration` value is the _minimum_ duration an entry will be cached.

From Front Door Designer routing rules reflecting `cache_duration = "PT1M"`:
![image](https://user-images.githubusercontent.com/10604101/226391924-ae6a0489-ed6d-489d-bf59-5c1738120638.png)
