### PR TITLE
`azurerm_kubernetes_cluster` - add missing property to `oms_agent` schema

### DIFF
--- a/internal/services/containers/kubernetes_cluster_data_source.go
+++ b/internal/services/containers/kubernetes_cluster_data_source.go
@@ -339,6 +339,10 @@ func dataSourceKubernetesCluster() *pluginsdk.Resource {
 							Type:     pluginsdk.TypeString,
 							Computed: true,
 						},
+						"msi_auth_for_monitoring_enabled": {
+							Type:     pluginsdk.TypeBool,
+							Computed: true,
+						},
 						"oms_agent_identity": {
 							Type:     pluginsdk.TypeList,
 							Computed: true,


### PR DESCRIPTION
The missing property would currently cause a panic in the data source.