### PR TITLE
New Resource: `azurerm_mobile_network_packet_core_data_plane`;New DataSource: `azurerm_mobile_network_packet_core_data_plane`

### DIFF
--- a/internal/services/mobilenetwork/client/client.go
+++ b/internal/services/mobilenetwork/client/client.go
@@ -4,6 +4,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/datanetwork"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/mobilenetwork"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/packetcorecontrolplane"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/packetcoredataplane"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/service"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/simgroup"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/simpolicy"
@@ -21,6 +22,7 @@ type Client struct {
 	DataNetworkClient            *datanetwork.DataNetworkClient
 	SIMPolicyClient              *simpolicy.SIMPolicyClient
 	PacketCoreControlPlaneClient *packetcorecontrolplane.PacketCoreControlPlaneClient
+	PacketCoreDataPlaneClient    *packetcoredataplane.PacketCoreDataPlaneClient
 }
 
 func NewClient(o *common.ClientOptions) *Client {
@@ -48,6 +50,9 @@ func NewClient(o *common.ClientOptions) *Client {
 	packetCoreControlPlaneClient := packetcorecontrolplane.NewPacketCoreControlPlaneClientWithBaseURI(o.ResourceManagerEndpoint)
 	o.ConfigureClient(&packetCoreControlPlaneClient.Client, o.ResourceManagerAuthorizer)
 
+	packetCoreDataPlaneClient := packetcoredataplane.NewPacketCoreDataPlaneClientWithBaseURI(o.ResourceManagerEndpoint)
+	o.ConfigureClient(&packetCoreDataPlaneClient.Client, o.ResourceManagerAuthorizer)
+
 	return &Client{
 		MobileNetworkClient:          &mobileNetworkClient,
 		DataNetworkClient:            &dataNetworkClient,
@@ -57,5 +62,6 @@ func NewClient(o *common.ClientOptions) *Client {
 		SliceClient:                  &sliceClient,
 		SIMPolicyClient:              &simPolicyClient,
 		PacketCoreControlPlaneClient: &packetCoreControlPlaneClient,
+		PacketCoreDataPlaneClient:    &packetCoreDataPlaneClient,
 	}
 }

--- a/internal/services/mobilenetwork/mobile_network_packet_core_data_plane_data_source.go
+++ b/internal/services/mobilenetwork/mobile_network_packet_core_data_plane_data_source.go
@@ -1,0 +1,135 @@
+package mobilenetwork
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/packetcorecontrolplane"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/packetcoredataplane"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+type PacketCoreDataPlaneDataSource struct{}
+
+var _ sdk.DataSource = PacketCoreDataPlaneDataSource{}
+
+func (r PacketCoreDataPlaneDataSource) ResourceType() string {
+	return "azurerm_mobile_network_packet_core_data_plane"
+}
+
+func (r PacketCoreDataPlaneDataSource) ModelObject() interface{} {
+	return &PacketCoreDataPlaneModel{}
+}
+
+func (r PacketCoreDataPlaneDataSource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+	return packetcoredataplane.ValidatePacketCoreDataPlaneID
+}
+
+func (r PacketCoreDataPlaneDataSource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"mobile_network_packet_core_control_plane_id": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: packetcorecontrolplane.ValidatePacketCoreControlPlaneID,
+		},
+	}
+}
+
+func (r PacketCoreDataPlaneDataSource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"location": commonschema.LocationComputed(),
+
+		"tags": commonschema.TagsDataSource(),
+
+		"user_plane_access_name": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"user_plane_access_ipv4_address": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"user_plane_access_ipv4_subnet": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"user_plane_access_ipv4_gateway": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+	}
+}
+
+func (r PacketCoreDataPlaneDataSource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			var metaModel PacketCoreDataPlaneModel
+			if err := metadata.Decode(&metaModel); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			client := metadata.Client.MobileNetwork.PacketCoreDataPlaneClient
+			packetCoreControlPlaneId, err := packetcorecontrolplane.ParsePacketCoreControlPlaneID(metaModel.MobileNetworkPacketCoreControlPlaneId)
+			if err != nil {
+				return err
+			}
+
+			id := packetcoredataplane.NewPacketCoreDataPlaneID(packetCoreControlPlaneId.SubscriptionId, packetCoreControlPlaneId.ResourceGroupName, packetCoreControlPlaneId.PacketCoreControlPlaneName, metaModel.Name)
+
+			resp, err := client.Get(ctx, id)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return fmt.Errorf("%s was not found", id)
+				}
+
+				return fmt.Errorf("retrieving %s: %+v", id, err)
+			}
+
+			state := PacketCoreDataPlaneModel{
+				Name:                                  id.PacketCoreDataPlaneName,
+				MobileNetworkPacketCoreControlPlaneId: packetcorecontrolplane.NewPacketCoreControlPlaneID(id.SubscriptionId, id.ResourceGroupName, id.PacketCoreControlPlaneName).ID(),
+			}
+
+			if resp.Model != nil {
+				state.Location = location.Normalize(resp.Model.Location)
+
+				props := resp.Model.Properties
+
+				state.UserPlaneAccessIPv4Address = pointer.From(props.UserPlaneAccessInterface.IPv4Address)
+
+				state.UserPlaneAccessIPv4Gateway = pointer.From(props.UserPlaneAccessInterface.IPv4Gateway)
+
+				state.UserPlaneAccessIPv4Subnet = pointer.From(props.UserPlaneAccessInterface.IPv4Subnet)
+
+				state.UserPlaneAccessName = pointer.From(props.UserPlaneAccessInterface.Name)
+
+				if resp.Model.Tags != nil {
+					state.Tags = *resp.Model.Tags
+				}
+			}
+
+			metadata.SetID(id)
+
+			return metadata.Encode(&state)
+		},
+	}
+}

--- a/internal/services/mobilenetwork/mobile_network_packet_core_data_plane_data_source.go
+++ b/internal/services/mobilenetwork/mobile_network_packet_core_data_plane_data_source.go
@@ -115,11 +115,8 @@ func (r PacketCoreDataPlaneDataSource) Read() sdk.ResourceFunc {
 				props := resp.Model.Properties
 
 				state.UserPlaneAccessIPv4Address = pointer.From(props.UserPlaneAccessInterface.IPv4Address)
-
 				state.UserPlaneAccessIPv4Gateway = pointer.From(props.UserPlaneAccessInterface.IPv4Gateway)
-
 				state.UserPlaneAccessIPv4Subnet = pointer.From(props.UserPlaneAccessInterface.IPv4Subnet)
-
 				state.UserPlaneAccessName = pointer.From(props.UserPlaneAccessInterface.Name)
 
 				if resp.Model.Tags != nil {

--- a/internal/services/mobilenetwork/mobile_network_packet_core_data_plane_data_source_test.go
+++ b/internal/services/mobilenetwork/mobile_network_packet_core_data_plane_data_source_test.go
@@ -1,0 +1,43 @@
+package mobilenetwork_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+)
+
+type MobileNetworkPacketCoreDataPlaneDataSource struct{}
+
+func TestAccMobileNetworkPacketCoreDataPlaneDataSource_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_mobile_network_packet_core_data_plane", "test")
+	// Limited regional availability for Mobile Network
+	data.Locations.Primary = "eastus"
+
+	d := MobileNetworkPacketCoreDataPlaneDataSource{}
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: d.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key(`location`).Exists(),
+				check.That(data.ResourceName).Key(`user_plane_access_name`).HasValue("default-interface"),
+				check.That(data.ResourceName).Key(`user_plane_access_ipv4_address`).HasValue("192.168.1.199"),
+				check.That(data.ResourceName).Key(`user_plane_access_ipv4_gateway`).HasValue("192.168.1.1"),
+				check.That(data.ResourceName).Key(`user_plane_access_ipv4_subnet`).HasValue("192.168.1.0/25"),
+				check.That(data.ResourceName).Key("tags.%").HasValue("1"),
+			),
+		},
+	})
+}
+
+func (r MobileNetworkPacketCoreDataPlaneDataSource) complete(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+	%s
+
+data "azurerm_mobile_network_packet_core_data_plane" "test" {
+  name                                        = azurerm_mobile_network_packet_core_data_plane.test.name
+  mobile_network_packet_core_control_plane_id = azurerm_mobile_network_packet_core_data_plane.test.mobile_network_packet_core_control_plane_id
+}
+`, MobileNetworkPacketCoreDataPlaneResource{}.complete(data))
+}

--- a/internal/services/mobilenetwork/mobile_network_packet_core_data_plane_resource.go
+++ b/internal/services/mobilenetwork/mobile_network_packet_core_data_plane_resource.go
@@ -1,0 +1,286 @@
+package mobilenetwork
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/packetcorecontrolplane"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/packetcoredataplane"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+type PacketCoreDataPlaneModel struct {
+	Name                                  string            `tfschema:"name"`
+	MobileNetworkPacketCoreControlPlaneId string            `tfschema:"mobile_network_packet_core_control_plane_id"`
+	Location                              string            `tfschema:"location"`
+	Tags                                  map[string]string `tfschema:"tags"`
+	UserPlaneAccessIPv4Address            string            `tfschema:"user_plane_access_ipv4_address"`
+	UserPlaneAccessIPv4Gateway            string            `tfschema:"user_plane_access_ipv4_gateway"`
+	UserPlaneAccessIPv4Subnet             string            `tfschema:"user_plane_access_ipv4_subnet"`
+	UserPlaneAccessName                   string            `tfschema:"user_plane_access_name"`
+}
+
+type PacketCoreDataPlaneResource struct{}
+
+var _ sdk.ResourceWithUpdate = PacketCoreDataPlaneResource{}
+
+func (r PacketCoreDataPlaneResource) ResourceType() string {
+	return "azurerm_mobile_network_packet_core_data_plane"
+}
+
+func (r PacketCoreDataPlaneResource) ModelObject() interface{} {
+	return &PacketCoreDataPlaneModel{}
+}
+
+func (r PacketCoreDataPlaneResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+	return packetcoredataplane.ValidatePacketCoreDataPlaneID
+}
+
+func (r PacketCoreDataPlaneResource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"mobile_network_packet_core_control_plane_id": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: packetcorecontrolplane.ValidatePacketCoreControlPlaneID,
+		},
+
+		"location": commonschema.Location(),
+
+		"user_plane_access_name": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"user_plane_access_ipv4_address": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ValidateFunc: validation.IsIPv4Address,
+		},
+
+		"user_plane_access_ipv4_subnet": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ValidateFunc: validate.CIDR,
+		},
+
+		"user_plane_access_ipv4_gateway": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ValidateFunc: validation.IsIPv4Address,
+		},
+
+		"tags": commonschema.Tags(),
+	}
+}
+
+func (r PacketCoreDataPlaneResource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{}
+}
+
+func (r PacketCoreDataPlaneResource) Create() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 180 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			var model PacketCoreDataPlaneModel
+			if err := metadata.Decode(&model); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			client := metadata.Client.MobileNetwork.PacketCoreDataPlaneClient
+			packetCoreControlPlaneId, err := packetcorecontrolplane.ParsePacketCoreControlPlaneID(model.MobileNetworkPacketCoreControlPlaneId)
+			if err != nil {
+				return err
+			}
+
+			id := packetcoredataplane.NewPacketCoreDataPlaneID(packetCoreControlPlaneId.SubscriptionId, packetCoreControlPlaneId.ResourceGroupName, packetCoreControlPlaneId.PacketCoreControlPlaneName, model.Name)
+			existing, err := client.Get(ctx, id)
+			if err != nil && !response.WasNotFound(existing.HttpResponse) {
+				return fmt.Errorf("checking for existing %s: %+v", id, err)
+			}
+
+			if !response.WasNotFound(existing.HttpResponse) {
+				return metadata.ResourceRequiresImport(r.ResourceType(), id)
+			}
+
+			dataPlane := packetcoredataplane.PacketCoreDataPlane{
+				Location: location.Normalize(model.Location),
+				Properties: packetcoredataplane.PacketCoreDataPlanePropertiesFormat{
+					UserPlaneAccessInterface: packetcoredataplane.InterfaceProperties{},
+				},
+				Tags: &model.Tags,
+			}
+
+			if model.UserPlaneAccessName != "" {
+				dataPlane.Properties.UserPlaneAccessInterface.Name = &model.UserPlaneAccessName
+			}
+
+			if model.UserPlaneAccessIPv4Address != "" {
+				dataPlane.Properties.UserPlaneAccessInterface.IPv4Address = &model.UserPlaneAccessIPv4Address
+			}
+
+			if model.UserPlaneAccessIPv4Subnet != "" {
+				dataPlane.Properties.UserPlaneAccessInterface.IPv4Subnet = &model.UserPlaneAccessIPv4Subnet
+			}
+
+			if model.UserPlaneAccessIPv4Gateway != "" {
+				dataPlane.Properties.UserPlaneAccessInterface.IPv4Gateway = &model.UserPlaneAccessIPv4Gateway
+			}
+
+			if err := client.CreateOrUpdateThenPoll(ctx, id, dataPlane); err != nil {
+				return fmt.Errorf("creating %s: %+v", id, err)
+			}
+
+			metadata.SetID(id)
+			return nil
+		},
+	}
+}
+
+func (r PacketCoreDataPlaneResource) Update() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 180 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.MobileNetwork.PacketCoreDataPlaneClient
+
+			id, err := packetcoredataplane.ParsePacketCoreDataPlaneID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			var plan PacketCoreDataPlaneModel
+			if err := metadata.Decode(&plan); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			resp, err := client.Get(ctx, *id)
+			if err != nil {
+				return fmt.Errorf("retrieving %s: %+v", *id, err)
+			}
+
+			if resp.Model == nil {
+				return fmt.Errorf("retrieving %s: properties was nil", id)
+			}
+
+			model := *resp.Model
+
+			if metadata.ResourceData.HasChange("user_plane_access_name") {
+				model.Properties.UserPlaneAccessInterface.Name = &plan.UserPlaneAccessName
+			}
+
+			if metadata.ResourceData.HasChange("user_plane_access_ipv4_address") {
+				model.Properties.UserPlaneAccessInterface.IPv4Address = &plan.UserPlaneAccessIPv4Address
+			}
+
+			if metadata.ResourceData.HasChange("user_plane_access_ipv4_subnet") {
+				model.Properties.UserPlaneAccessInterface.IPv4Subnet = &plan.UserPlaneAccessIPv4Subnet
+			}
+
+			if metadata.ResourceData.HasChange("user_plane_access_ipv4_gateway") {
+				model.Properties.UserPlaneAccessInterface.IPv4Gateway = &plan.UserPlaneAccessIPv4Gateway
+			}
+
+			if metadata.ResourceData.HasChange("tags") {
+				model.Tags = &plan.Tags
+			}
+
+			if err := client.CreateOrUpdateThenPoll(ctx, *id, model); err != nil {
+				return fmt.Errorf("updating %s: %+v", *id, err)
+			}
+
+			return nil
+		},
+	}
+}
+
+func (r PacketCoreDataPlaneResource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.MobileNetwork.PacketCoreDataPlaneClient
+
+			id, err := packetcoredataplane.ParsePacketCoreDataPlaneID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.Get(ctx, *id)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return metadata.MarkAsGone(id)
+				}
+
+				return fmt.Errorf("retrieving %s: %+v", *id, err)
+			}
+
+			state := PacketCoreDataPlaneModel{
+				Name:                                  id.PacketCoreDataPlaneName,
+				MobileNetworkPacketCoreControlPlaneId: packetcorecontrolplane.NewPacketCoreControlPlaneID(id.SubscriptionId, id.ResourceGroupName, id.PacketCoreControlPlaneName).ID(),
+			}
+
+			if resp.Model != nil {
+				state.Location = location.Normalize(resp.Model.Location)
+
+				props := resp.Model.Properties
+
+				state.UserPlaneAccessIPv4Address = pointer.From(props.UserPlaneAccessInterface.IPv4Address)
+
+				state.UserPlaneAccessIPv4Gateway = pointer.From(props.UserPlaneAccessInterface.IPv4Gateway)
+
+				state.UserPlaneAccessIPv4Subnet = pointer.From(props.UserPlaneAccessInterface.IPv4Subnet)
+
+				state.UserPlaneAccessName = pointer.From(props.UserPlaneAccessInterface.Name)
+
+				if resp.Model.Tags != nil {
+					state.Tags = *resp.Model.Tags
+				}
+			}
+
+			return metadata.Encode(&state)
+		},
+	}
+}
+
+func (r PacketCoreDataPlaneResource) Delete() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 180 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.MobileNetwork.PacketCoreDataPlaneClient
+
+			id, err := packetcoredataplane.ParsePacketCoreDataPlaneID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			if err := client.DeleteThenPoll(ctx, *id); err != nil {
+				return fmt.Errorf("deleting %s: %+v", id, err)
+			}
+
+			if err := resourceMobileNetworkChildWaitForDeletion(ctx, id.ID(), func() (*http.Response, error) {
+				resp, err := client.Get(ctx, *id)
+				return resp.HttpResponse, err
+			}); err != nil {
+				return err
+			}
+
+			return nil
+		},
+	}
+}

--- a/internal/services/mobilenetwork/mobile_network_packet_core_data_plane_resource.go
+++ b/internal/services/mobilenetwork/mobile_network_packet_core_data_plane_resource.go
@@ -241,11 +241,8 @@ func (r PacketCoreDataPlaneResource) Read() sdk.ResourceFunc {
 				props := resp.Model.Properties
 
 				state.UserPlaneAccessIPv4Address = pointer.From(props.UserPlaneAccessInterface.IPv4Address)
-
 				state.UserPlaneAccessIPv4Gateway = pointer.From(props.UserPlaneAccessInterface.IPv4Gateway)
-
 				state.UserPlaneAccessIPv4Subnet = pointer.From(props.UserPlaneAccessInterface.IPv4Subnet)
-
 				state.UserPlaneAccessName = pointer.From(props.UserPlaneAccessInterface.Name)
 
 				if resp.Model.Tags != nil {

--- a/internal/services/mobilenetwork/mobile_network_packet_core_data_plane_resource_test.go
+++ b/internal/services/mobilenetwork/mobile_network_packet_core_data_plane_resource_test.go
@@ -1,0 +1,216 @@
+package mobilenetwork_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/packetcoredataplane"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+type MobileNetworkPacketCoreDataPlaneResource struct{}
+
+func TestAccMobileNetworkPacketCoreDataPlane_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_mobile_network_packet_core_data_plane", "test")
+	// Limited regional availability for Mobile Network
+	data.Locations.Primary = "eastus"
+
+	r := MobileNetworkPacketCoreDataPlaneResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccMobileNetworkPacketCoreDataPlane_withAccessInterface(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_mobile_network_packet_core_data_plane", "test")
+	// Limited regional availability for Mobile Network
+	data.Locations.Primary = "eastus"
+
+	r := MobileNetworkPacketCoreDataPlaneResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.withAccessInterface(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccMobileNetworkPacketCoreDataPlane_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_mobile_network_packet_core_data_plane", "test")
+	// Limited regional availability for Mobile Network
+	data.Locations.Primary = "eastus"
+
+	r := MobileNetworkPacketCoreDataPlaneResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.RequiresImportErrorStep(r.requiresImport),
+	})
+}
+
+func TestAccMobileNetworkPacketCoreDataPlane_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_mobile_network_packet_core_data_plane", "test")
+	// Limited regional availability for Mobile Network
+	data.Locations.Primary = "eastus"
+
+	r := MobileNetworkPacketCoreDataPlaneResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccMobileNetworkPacketCoreDataPlane_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_mobile_network_packet_core_data_plane", "test")
+	// Limited regional availability for Mobile Network
+	data.Locations.Primary = "eastus"
+
+	r := MobileNetworkPacketCoreDataPlaneResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.update(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func (r MobileNetworkPacketCoreDataPlaneResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := packetcoredataplane.ParsePacketCoreDataPlaneID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	client := clients.MobileNetwork.PacketCoreDataPlaneClient
+	resp, err := client.Get(ctx, *id)
+	if err != nil {
+		if response.WasNotFound(resp.HttpResponse) {
+			return utils.Bool(false), nil
+		}
+		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+	return utils.Bool(resp.Model != nil), nil
+}
+
+func (r MobileNetworkPacketCoreDataPlaneResource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+				%s
+
+resource "azurerm_mobile_network_packet_core_data_plane" "test" {
+  name                                        = "acctest-mnpcdp-%d"
+  mobile_network_packet_core_control_plane_id = azurerm_mobile_network_packet_core_control_plane.test.id
+  location                                    = "%s"
+}
+`, MobileNetworkPacketCoreControlPlaneResource{}.basic(data), data.RandomInteger, data.Locations.Primary)
+}
+
+func (r MobileNetworkPacketCoreDataPlaneResource) withAccessInterface(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+				%s
+
+resource "azurerm_mobile_network_packet_core_data_plane" "test" {
+  name                                        = "acctest-mnpcdp-%d"
+  mobile_network_packet_core_control_plane_id = azurerm_mobile_network_packet_core_control_plane.test.id
+  location                                    = "%s"
+
+  user_plane_access_name         = "default-interface"
+  user_plane_access_ipv4_address = "192.168.1.199"
+  user_plane_access_ipv4_gateway = "192.168.1.1"
+  user_plane_access_ipv4_subnet  = "192.168.1.0/25"
+
+
+}
+`, MobileNetworkPacketCoreControlPlaneResource{}.basic(data), data.RandomInteger, data.Locations.Primary)
+}
+
+func (r MobileNetworkPacketCoreDataPlaneResource) requiresImport(data acceptance.TestData) string {
+	config := r.basic(data)
+	return fmt.Sprintf(`
+			%s
+
+resource "azurerm_mobile_network_packet_core_data_plane" "import" {
+  name                                        = azurerm_mobile_network_packet_core_data_plane.test.name
+  mobile_network_packet_core_control_plane_id = azurerm_mobile_network_packet_core_control_plane.test.id
+  location                                    = "%s"
+
+  user_plane_access_name         = "default-interface"
+  user_plane_access_ipv4_address = "192.168.1.199"
+  user_plane_access_ipv4_gateway = "192.168.1.1"
+  user_plane_access_ipv4_subnet  = "192.168.1.0/25"
+}
+`, config, data.Locations.Primary)
+}
+
+func (r MobileNetworkPacketCoreDataPlaneResource) complete(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+			%s
+
+resource "azurerm_mobile_network_packet_core_data_plane" "test" {
+  name                                        = "acctest-mnpcdp-%d"
+  mobile_network_packet_core_control_plane_id = azurerm_mobile_network_packet_core_control_plane.test.id
+  location                                    = "%s"
+  user_plane_access_name                      = "default-interface"
+  user_plane_access_ipv4_address              = "192.168.1.199"
+  user_plane_access_ipv4_gateway              = "192.168.1.1"
+  user_plane_access_ipv4_subnet               = "192.168.1.0/25"
+
+  tags = {
+    key = "value"
+  }
+
+}
+`, MobileNetworkPacketCoreControlPlaneResource{}.basic(data), data.RandomInteger, data.Locations.Primary)
+}
+
+func (r MobileNetworkPacketCoreDataPlaneResource) update(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+			%s
+
+resource "azurerm_mobile_network_packet_core_data_plane" "test" {
+  name                                        = "acctest-mnpcdp-%d"
+  mobile_network_packet_core_control_plane_id = azurerm_mobile_network_packet_core_control_plane.test.id
+  location                                    = "%s"
+  user_plane_access_name                      = "default-interface"
+  user_plane_access_ipv4_address              = "192.168.1.199"
+  user_plane_access_ipv4_gateway              = "192.168.1.1"
+  user_plane_access_ipv4_subnet               = "192.168.1.0/25"
+
+  tags = {
+    key = "value 2"
+  }
+}
+`, MobileNetworkPacketCoreControlPlaneResource{}.basic(data), data.RandomInteger, data.Locations.Primary)
+}

--- a/internal/services/mobilenetwork/registration.go
+++ b/internal/services/mobilenetwork/registration.go
@@ -35,6 +35,7 @@ func (r Registration) DataSources() []sdk.DataSource {
 		SliceDataSource{},
 		SimPolicyDataSource{},
 		PacketCoreControlPlaneDataSource{},
+		PacketCoreDataPlaneDataSource{},
 	}
 }
 
@@ -49,5 +50,6 @@ func (r Registration) Resources() []sdk.Resource {
 		SiteResource{},
 		SliceResource{},
 		PacketCoreControlPlaneResource{},
+		PacketCoreDataPlaneResource{},
 	}
 }

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/packetcoredataplane/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/packetcoredataplane/README.md
@@ -1,0 +1,86 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/packetcoredataplane` Documentation
+
+The `packetcoredataplane` SDK allows for interaction with the Azure Resource Manager Service `mobilenetwork` (API Version `2022-11-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/packetcoredataplane"
+```
+
+
+### Client Initialization
+
+```go
+client := packetcoredataplane.NewPacketCoreDataPlaneClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `PacketCoreDataPlaneClient.CreateOrUpdate`
+
+```go
+ctx := context.TODO()
+id := packetcoredataplane.NewPacketCoreDataPlaneID("12345678-1234-9876-4563-123456789012", "example-resource-group", "packetCoreControlPlaneValue", "packetCoreDataPlaneValue")
+
+payload := packetcoredataplane.PacketCoreDataPlane{
+	// ...
+}
+
+
+if err := client.CreateOrUpdateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `PacketCoreDataPlaneClient.Delete`
+
+```go
+ctx := context.TODO()
+id := packetcoredataplane.NewPacketCoreDataPlaneID("12345678-1234-9876-4563-123456789012", "example-resource-group", "packetCoreControlPlaneValue", "packetCoreDataPlaneValue")
+
+if err := client.DeleteThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `PacketCoreDataPlaneClient.Get`
+
+```go
+ctx := context.TODO()
+id := packetcoredataplane.NewPacketCoreDataPlaneID("12345678-1234-9876-4563-123456789012", "example-resource-group", "packetCoreControlPlaneValue", "packetCoreDataPlaneValue")
+
+read, err := client.Get(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `PacketCoreDataPlaneClient.UpdateTags`
+
+```go
+ctx := context.TODO()
+id := packetcoredataplane.NewPacketCoreDataPlaneID("12345678-1234-9876-4563-123456789012", "example-resource-group", "packetCoreControlPlaneValue", "packetCoreDataPlaneValue")
+
+payload := packetcoredataplane.TagsObject{
+	// ...
+}
+
+
+read, err := client.UpdateTags(ctx, id, payload)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/packetcoredataplane/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/packetcoredataplane/client.go
@@ -1,0 +1,18 @@
+package packetcoredataplane
+
+import "github.com/Azure/go-autorest/autorest"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PacketCoreDataPlaneClient struct {
+	Client  autorest.Client
+	baseUri string
+}
+
+func NewPacketCoreDataPlaneClientWithBaseURI(endpoint string) PacketCoreDataPlaneClient {
+	return PacketCoreDataPlaneClient{
+		Client:  autorest.NewClientWithUserAgent(userAgent()),
+		baseUri: endpoint,
+	}
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/packetcoredataplane/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/packetcoredataplane/constants.go
@@ -1,0 +1,49 @@
+package packetcoredataplane
+
+import "strings"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ProvisioningState string
+
+const (
+	ProvisioningStateAccepted  ProvisioningState = "Accepted"
+	ProvisioningStateCanceled  ProvisioningState = "Canceled"
+	ProvisioningStateDeleted   ProvisioningState = "Deleted"
+	ProvisioningStateDeleting  ProvisioningState = "Deleting"
+	ProvisioningStateFailed    ProvisioningState = "Failed"
+	ProvisioningStateSucceeded ProvisioningState = "Succeeded"
+	ProvisioningStateUnknown   ProvisioningState = "Unknown"
+)
+
+func PossibleValuesForProvisioningState() []string {
+	return []string{
+		string(ProvisioningStateAccepted),
+		string(ProvisioningStateCanceled),
+		string(ProvisioningStateDeleted),
+		string(ProvisioningStateDeleting),
+		string(ProvisioningStateFailed),
+		string(ProvisioningStateSucceeded),
+		string(ProvisioningStateUnknown),
+	}
+}
+
+func parseProvisioningState(input string) (*ProvisioningState, error) {
+	vals := map[string]ProvisioningState{
+		"accepted":  ProvisioningStateAccepted,
+		"canceled":  ProvisioningStateCanceled,
+		"deleted":   ProvisioningStateDeleted,
+		"deleting":  ProvisioningStateDeleting,
+		"failed":    ProvisioningStateFailed,
+		"succeeded": ProvisioningStateSucceeded,
+		"unknown":   ProvisioningStateUnknown,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ProvisioningState(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/packetcoredataplane/id_packetcoredataplane.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/packetcoredataplane/id_packetcoredataplane.go
@@ -1,0 +1,140 @@
+package packetcoredataplane
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ resourceids.ResourceId = PacketCoreDataPlaneId{}
+
+// PacketCoreDataPlaneId is a struct representing the Resource ID for a Packet Core Data Plane
+type PacketCoreDataPlaneId struct {
+	SubscriptionId             string
+	ResourceGroupName          string
+	PacketCoreControlPlaneName string
+	PacketCoreDataPlaneName    string
+}
+
+// NewPacketCoreDataPlaneID returns a new PacketCoreDataPlaneId struct
+func NewPacketCoreDataPlaneID(subscriptionId string, resourceGroupName string, packetCoreControlPlaneName string, packetCoreDataPlaneName string) PacketCoreDataPlaneId {
+	return PacketCoreDataPlaneId{
+		SubscriptionId:             subscriptionId,
+		ResourceGroupName:          resourceGroupName,
+		PacketCoreControlPlaneName: packetCoreControlPlaneName,
+		PacketCoreDataPlaneName:    packetCoreDataPlaneName,
+	}
+}
+
+// ParsePacketCoreDataPlaneID parses 'input' into a PacketCoreDataPlaneId
+func ParsePacketCoreDataPlaneID(input string) (*PacketCoreDataPlaneId, error) {
+	parser := resourceids.NewParserFromResourceIdType(PacketCoreDataPlaneId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := PacketCoreDataPlaneId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
+	}
+
+	if id.PacketCoreControlPlaneName, ok = parsed.Parsed["packetCoreControlPlaneName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "packetCoreControlPlaneName", *parsed)
+	}
+
+	if id.PacketCoreDataPlaneName, ok = parsed.Parsed["packetCoreDataPlaneName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "packetCoreDataPlaneName", *parsed)
+	}
+
+	return &id, nil
+}
+
+// ParsePacketCoreDataPlaneIDInsensitively parses 'input' case-insensitively into a PacketCoreDataPlaneId
+// note: this method should only be used for API response data and not user input
+func ParsePacketCoreDataPlaneIDInsensitively(input string) (*PacketCoreDataPlaneId, error) {
+	parser := resourceids.NewParserFromResourceIdType(PacketCoreDataPlaneId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := PacketCoreDataPlaneId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
+	}
+
+	if id.PacketCoreControlPlaneName, ok = parsed.Parsed["packetCoreControlPlaneName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "packetCoreControlPlaneName", *parsed)
+	}
+
+	if id.PacketCoreDataPlaneName, ok = parsed.Parsed["packetCoreDataPlaneName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "packetCoreDataPlaneName", *parsed)
+	}
+
+	return &id, nil
+}
+
+// ValidatePacketCoreDataPlaneID checks that 'input' can be parsed as a Packet Core Data Plane ID
+func ValidatePacketCoreDataPlaneID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParsePacketCoreDataPlaneID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Packet Core Data Plane ID
+func (id PacketCoreDataPlaneId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.MobileNetwork/packetCoreControlPlanes/%s/packetCoreDataPlanes/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.PacketCoreControlPlaneName, id.PacketCoreDataPlaneName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Packet Core Data Plane ID
+func (id PacketCoreDataPlaneId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftMobileNetwork", "Microsoft.MobileNetwork", "Microsoft.MobileNetwork"),
+		resourceids.StaticSegment("staticPacketCoreControlPlanes", "packetCoreControlPlanes", "packetCoreControlPlanes"),
+		resourceids.UserSpecifiedSegment("packetCoreControlPlaneName", "packetCoreControlPlaneValue"),
+		resourceids.StaticSegment("staticPacketCoreDataPlanes", "packetCoreDataPlanes", "packetCoreDataPlanes"),
+		resourceids.UserSpecifiedSegment("packetCoreDataPlaneName", "packetCoreDataPlaneValue"),
+	}
+}
+
+// String returns a human-readable description of this Packet Core Data Plane ID
+func (id PacketCoreDataPlaneId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Packet Core Control Plane Name: %q", id.PacketCoreControlPlaneName),
+		fmt.Sprintf("Packet Core Data Plane Name: %q", id.PacketCoreDataPlaneName),
+	}
+	return fmt.Sprintf("Packet Core Data Plane (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/packetcoredataplane/method_createorupdate_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/packetcoredataplane/method_createorupdate_autorest.go
@@ -1,0 +1,79 @@
+package packetcoredataplane
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CreateOrUpdateOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// CreateOrUpdate ...
+func (c PacketCoreDataPlaneClient) CreateOrUpdate(ctx context.Context, id PacketCoreDataPlaneId, input PacketCoreDataPlane) (result CreateOrUpdateOperationResponse, err error) {
+	req, err := c.preparerForCreateOrUpdate(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "packetcoredataplane.PacketCoreDataPlaneClient", "CreateOrUpdate", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForCreateOrUpdate(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "packetcoredataplane.PacketCoreDataPlaneClient", "CreateOrUpdate", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// CreateOrUpdateThenPoll performs CreateOrUpdate then polls until it's completed
+func (c PacketCoreDataPlaneClient) CreateOrUpdateThenPoll(ctx context.Context, id PacketCoreDataPlaneId, input PacketCoreDataPlane) error {
+	result, err := c.CreateOrUpdate(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing CreateOrUpdate: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after CreateOrUpdate: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForCreateOrUpdate prepares the CreateOrUpdate request.
+func (c PacketCoreDataPlaneClient) preparerForCreateOrUpdate(ctx context.Context, id PacketCoreDataPlaneId, input PacketCoreDataPlane) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPut(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForCreateOrUpdate sends the CreateOrUpdate request. The method will close the
+// http.Response Body if it receives an error.
+func (c PacketCoreDataPlaneClient) senderForCreateOrUpdate(ctx context.Context, req *http.Request) (future CreateOrUpdateOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/packetcoredataplane/method_delete_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/packetcoredataplane/method_delete_autorest.go
@@ -1,0 +1,78 @@
+package packetcoredataplane
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DeleteOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// Delete ...
+func (c PacketCoreDataPlaneClient) Delete(ctx context.Context, id PacketCoreDataPlaneId) (result DeleteOperationResponse, err error) {
+	req, err := c.preparerForDelete(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "packetcoredataplane.PacketCoreDataPlaneClient", "Delete", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForDelete(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "packetcoredataplane.PacketCoreDataPlaneClient", "Delete", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// DeleteThenPoll performs Delete then polls until it's completed
+func (c PacketCoreDataPlaneClient) DeleteThenPoll(ctx context.Context, id PacketCoreDataPlaneId) error {
+	result, err := c.Delete(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing Delete: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after Delete: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForDelete prepares the Delete request.
+func (c PacketCoreDataPlaneClient) preparerForDelete(ctx context.Context, id PacketCoreDataPlaneId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsDelete(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForDelete sends the Delete request. The method will close the
+// http.Response Body if it receives an error.
+func (c PacketCoreDataPlaneClient) senderForDelete(ctx context.Context, req *http.Request) (future DeleteOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/packetcoredataplane/method_get_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/packetcoredataplane/method_get_autorest.go
@@ -1,0 +1,68 @@
+package packetcoredataplane
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *PacketCoreDataPlane
+}
+
+// Get ...
+func (c PacketCoreDataPlaneClient) Get(ctx context.Context, id PacketCoreDataPlaneId) (result GetOperationResponse, err error) {
+	req, err := c.preparerForGet(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "packetcoredataplane.PacketCoreDataPlaneClient", "Get", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "packetcoredataplane.PacketCoreDataPlaneClient", "Get", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForGet(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "packetcoredataplane.PacketCoreDataPlaneClient", "Get", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForGet prepares the Get request.
+func (c PacketCoreDataPlaneClient) preparerForGet(ctx context.Context, id PacketCoreDataPlaneId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForGet handles the response to the Get request. The method always
+// closes the http.Response Body.
+func (c PacketCoreDataPlaneClient) responderForGet(resp *http.Response) (result GetOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/packetcoredataplane/method_updatetags_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/packetcoredataplane/method_updatetags_autorest.go
@@ -1,0 +1,69 @@
+package packetcoredataplane
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UpdateTagsOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *PacketCoreDataPlane
+}
+
+// UpdateTags ...
+func (c PacketCoreDataPlaneClient) UpdateTags(ctx context.Context, id PacketCoreDataPlaneId, input TagsObject) (result UpdateTagsOperationResponse, err error) {
+	req, err := c.preparerForUpdateTags(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "packetcoredataplane.PacketCoreDataPlaneClient", "UpdateTags", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "packetcoredataplane.PacketCoreDataPlaneClient", "UpdateTags", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForUpdateTags(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "packetcoredataplane.PacketCoreDataPlaneClient", "UpdateTags", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForUpdateTags prepares the UpdateTags request.
+func (c PacketCoreDataPlaneClient) preparerForUpdateTags(ctx context.Context, id PacketCoreDataPlaneId, input TagsObject) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPatch(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForUpdateTags handles the response to the UpdateTags request. The method always
+// closes the http.Response Body.
+func (c PacketCoreDataPlaneClient) responderForUpdateTags(resp *http.Response) (result UpdateTagsOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/packetcoredataplane/model_interfaceproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/packetcoredataplane/model_interfaceproperties.go
@@ -1,0 +1,11 @@
+package packetcoredataplane
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type InterfaceProperties struct {
+	IPv4Address *string `json:"ipv4Address,omitempty"`
+	IPv4Gateway *string `json:"ipv4Gateway,omitempty"`
+	IPv4Subnet  *string `json:"ipv4Subnet,omitempty"`
+	Name        *string `json:"name,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/packetcoredataplane/model_packetcoredataplane.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/packetcoredataplane/model_packetcoredataplane.go
@@ -1,0 +1,18 @@
+package packetcoredataplane
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/systemdata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PacketCoreDataPlane struct {
+	Id         *string                             `json:"id,omitempty"`
+	Location   string                              `json:"location"`
+	Name       *string                             `json:"name,omitempty"`
+	Properties PacketCoreDataPlanePropertiesFormat `json:"properties"`
+	SystemData *systemdata.SystemData              `json:"systemData,omitempty"`
+	Tags       *map[string]string                  `json:"tags,omitempty"`
+	Type       *string                             `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/packetcoredataplane/model_packetcoredataplanepropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/packetcoredataplane/model_packetcoredataplanepropertiesformat.go
@@ -1,0 +1,9 @@
+package packetcoredataplane
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PacketCoreDataPlanePropertiesFormat struct {
+	ProvisioningState        *ProvisioningState  `json:"provisioningState,omitempty"`
+	UserPlaneAccessInterface InterfaceProperties `json:"userPlaneAccessInterface"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/packetcoredataplane/model_tagsobject.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/packetcoredataplane/model_tagsobject.go
@@ -1,0 +1,8 @@
+package packetcoredataplane
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type TagsObject struct {
+	Tags *map[string]string `json:"tags,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/packetcoredataplane/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/packetcoredataplane/version.go
@@ -1,0 +1,12 @@
+package packetcoredataplane
+
+import "fmt"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2022-11-01"
+
+func userAgent() string {
+	return fmt.Sprintf("hashicorp/go-azure-sdk/packetcoredataplane/%s", defaultApiVersion)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -443,6 +443,7 @@ github.com/hashicorp/go-azure-sdk/resource-manager/mixedreality/2021-01-01/resou
 github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/datanetwork
 github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/mobilenetwork
 github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/packetcorecontrolplane
+github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/packetcoredataplane
 github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/service
 github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/simgroup
 github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/simpolicy

--- a/website/docs/d/mobile_network_packet_core_data_plane.html.markdown
+++ b/website/docs/d/mobile_network_packet_core_data_plane.html.markdown
@@ -1,0 +1,59 @@
+---
+subcategory: "Mobile Network"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_mobile_network_packet_core_data_plane"
+description: |-
+  Get information a Mobile Network Packet Core Data Plane.
+---
+
+# azurerm_mobile_network_packet_core_data_plane
+
+Get information a Mobile Network Packet Core Data Plane.
+
+## Example Usage
+
+```hcl
+data "azurerm_mobile_network_packet_core_control_plane" "example" {
+  name                = "example-mnpccp"
+  resource_group_name = "example-rg"
+}
+
+data "azurerm_mobile_network_packet_core_data_plane" "example" {
+  name                                        = "example-mnpcdp"
+  mobile_network_packet_core_control_plane_id = data.azurerm_mobile_network_packet_core_control_plane.example.id
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the Mobile Network Packet Core Data Plane. 
+
+* `mobile_network_packet_core_control_plane_id` - (Required) The ID of the Mobile Network Packet Core Data Plane.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `id` - The ID of the Mobile Network Packet Core Data Plane.
+
+* `location` - The Azure Region where the Mobile Network Packet Core Data Plane should exist.
+
+* `user_plane_access_name` - The logical name for thie user plane interface.
+
+* `user_plane_access_ipv4_address` - The IPv4 address for the user plane interface.
+
+* `user_plane_access_ipv4_subnet` - The IPv4 subnet for the user plane interface.
+
+* `user_plane_access_ipv4_gateway` - The default IPv4 gateway for the user plane interface.
+
+* `tags` - A mapping of tags which should be assigned to the Mobile Network Packet Core Data Plane.
+
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the Mobile Network Packet Core Data Plane.
+

--- a/website/docs/r/mobile_network_packet_core_data_plane.html.markdown
+++ b/website/docs/r/mobile_network_packet_core_data_plane.html.markdown
@@ -1,0 +1,112 @@
+---
+subcategory: "Mobile Network"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_mobile_network_packet_core_data_plane"
+description: |-
+  Manages a Mobile Network Packet Core Data Plane.
+---
+
+# azurerm_mobile_network_packet_core_data_plane
+
+Manages a Mobile Network Packet Core Data Plane.
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_databox_edge_device" "example" {
+  name                = "example-device"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+
+  sku_name = "EdgeP_Base-Standard"
+}
+
+resource "azurerm_mobile_network" "example" {
+  name                = "example-mn"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+  mobile_country_code = "001"
+  mobile_network_code = "01"
+}
+
+resource "azurerm_mobile_network_packet_core_control_plane" "example" {
+  name                              = "example-mnpccp"
+  resource_group_name               = azurerm_resource_group.example.name
+  location                          = azurerm_resource_group.example.location
+  sku                               = "G0"
+  mobile_network_id                 = azurerm_mobile_network.example.id
+  control_plane_access_name         = "default-interface"
+  control_plane_access_ipv4_address = "192.168.1.199"
+  control_plane_access_ipv4_gateway = "192.168.1.1"
+  control_plane_access_ipv4_subnet  = "192.168.1.0/25"
+
+  platform {
+    type           = "AKS-HCI"
+    edge_device_id = azurerm_databox_edge_device.example.id
+  }
+}
+
+resource "azurerm_mobile_network_packet_core_data_plane" "example" {
+  name                                        = "example-mnpcdp"
+  mobile_network_packet_core_control_plane_id = azurerm_mobile_network_packet_core_control_plane.example.id
+  location                                    = azurerm_resource_group.example.location
+  user_plane_access_name                      = "default-interface"
+  user_plane_access_ipv4_address              = "192.168.1.199"
+  user_plane_access_ipv4_gateway              = "192.168.1.1"
+  user_plane_access_ipv4_subnet               = "192.168.1.0/25"
+
+  tags = {
+    key = "value"
+  }
+
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Specifies the name which should be used for this Mobile Network Packet Core Data Plane. Changing this forces a new Mobile Network Packet Core Data Plane to be created.
+
+* `mobile_network_packet_core_control_plane_id` - (Required) Specifies the ID of the Mobile Network Packet Core Data Plane. Changing this forces a new Mobile Network Packet Core Data Plane to be created.
+
+* `location` - (Required) Specifies the Azure Region where the Mobile Network Packet Core Data Plane should exist. Changing this forces a new Mobile Network Packet Core Data Plane to be created.
+
+* `user_plane_access_name` - (Optional) Specifies the logical name for thie user plane interface. This should match one of the interfaces configured on your Azure Stack Edge device.
+
+* `user_plane_access_ipv4_address` - (Optional) The IPv4 address for the user plane interface. This should match one of the interfaces configured on your Azure Stack Edge device.
+
+* `user_plane_access_ipv4_subnet` - (Optional) The IPv4 subnet for the user plane interface. This should match one of the interfaces configured on your Azure Stack Edge device.
+
+* `user_plane_access_ipv4_gateway` - (Optional) The default IPv4 gateway for the user plane interface. This should match one of the interfaces configured on your Azure Stack Edge device.
+
+* `tags` - (Optional) A mapping of tags which should be assigned to the Mobile Network Packet Core Data Plane.
+
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `id` - The ID of the Mobile Network Packet Core Data Plane.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 180 minutes) Used when creating the Mobile Network Packet Core Data Plane.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Mobile Network Packet Core Data Plane.
+* `update` - (Defaults to 180 minutes) Used when updating the Mobile Network Packet Core Data Plane.
+* `delete` - (Defaults to 180 minutes) Used when deleting the Mobile Network Packet Core Data Plane.
+
+## Import
+
+Mobile Network Packet Core Data Plane can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_mobile_network_packet_core_data_plane.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup1/providers/Microsoft.MobileNetwork/packetCoreControlPlanes/packetCoreControlPlane1/packetCoreDataPlanes/packetCoreDataPlane1
+```


### PR DESCRIPTION
over all
---
```
order | name 
0     | azurerm_mobile_network                              ✅
1     | azurerm_mobile_network_site                         ✅
1     | azurerm_mobile_network_data_network                 ✅
1     | azurerm_mobile_network_service                      ✅
1     | azurerm_mobile_network_slice                        ✅
1     | azurerm_mobile_network_sim_group                    ✅
2     | azurerm_mobile_network_packet_core_control_plane    ✅
2     | azurerm_mobile_network_sim_policy                   ✅
3     | azurerm_mobile_network_packet_core_data_plane       <- this one
4     | azurerm_mobile_network_attached_data_network        
5     | azurerm_mobile_network_sim        
```

Test
---
```
❯ tftest mobilenetwork TestAccMobileNetworkPacketCoreDataPlane
=== RUN   TestAccMobileNetworkPacketCoreDataPlaneDataSource_complete
=== PAUSE TestAccMobileNetworkPacketCoreDataPlaneDataSource_complete
=== RUN   TestAccMobileNetworkPacketCoreDataPlane_basic
=== PAUSE TestAccMobileNetworkPacketCoreDataPlane_basic
=== RUN   TestAccMobileNetworkPacketCoreDataPlane_withAccessInterface
=== PAUSE TestAccMobileNetworkPacketCoreDataPlane_withAccessInterface
=== RUN   TestAccMobileNetworkPacketCoreDataPlane_requiresImport
=== PAUSE TestAccMobileNetworkPacketCoreDataPlane_requiresImport
=== RUN   TestAccMobileNetworkPacketCoreDataPlane_complete
=== PAUSE TestAccMobileNetworkPacketCoreDataPlane_complete
=== RUN   TestAccMobileNetworkPacketCoreDataPlane_update
=== PAUSE TestAccMobileNetworkPacketCoreDataPlane_update
=== CONT  TestAccMobileNetworkPacketCoreDataPlaneDataSource_complete
=== CONT  TestAccMobileNetworkPacketCoreDataPlane_requiresImport
=== CONT  TestAccMobileNetworkPacketCoreDataPlane_withAccessInterface
=== CONT  TestAccMobileNetworkPacketCoreDataPlane_update
=== CONT  TestAccMobileNetworkPacketCoreDataPlane_complete
=== CONT  TestAccMobileNetworkPacketCoreDataPlane_basic
r--- PASS: TestAccMobileNetworkPacketCoreDataPlaneDataSource_complete (702.24s)
--- PASS: TestAccMobileNetworkPacketCoreDataPlane_requiresImport (729.92s)
--- PASS: TestAccMobileNetworkPacketCoreDataPlane_withAccessInterface (730.98s)
--- PASS: TestAccMobileNetworkPacketCoreDataPlane_basic (752.58s)
--- PASS: TestAccMobileNetworkPacketCoreDataPlane_complete (822.84s)
--- PASS: TestAccMobileNetworkPacketCoreDataPlane_update (1036.32s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/mobilenetwork 1036.391s
```