### PR TITLE
`azurerm_sentinel_alert_rule_template`: fix the id trim when reading by display name

### DIFF
--- a/internal/services/sentinel/sentinel_alert_rule_template_data_source.go
+++ b/internal/services/sentinel/sentinel_alert_rule_template_data_source.go
@@ -155,7 +155,6 @@ func dataSourceSentinelAlertRuleTemplateRead(d *pluginsdk.ResourceData, meta int
 	if err != nil {
 		return err
 	}
-	id := parse.NewSentinelAlertRuleTemplateID(subscriptionId, workspaceID.ResourceGroupName, workspaceID.WorkspaceName, name)
 
 	// Either "name" or "display_name" must have been specified, constrained by the pluginsdk.
 	var resp securityinsight.BasicAlertRuleTemplate
@@ -176,7 +175,7 @@ func dataSourceSentinelAlertRuleTemplateRead(d *pluginsdk.ResourceData, meta int
 		return fmt.Errorf("retrieving Sentinel Alert Rule Template %q (Workspace %q / Resource Group %q): `name` was nil", nameToLog, workspaceID.WorkspaceName, workspaceID.ResourceGroupName)
 	}
 
-	id = parse.NewSentinelAlertRuleTemplateID(subscriptionId, workspaceID.ResourceGroupName, workspaceID.WorkspaceName, *realName)
+	id := parse.NewSentinelAlertRuleTemplateID(subscriptionId, workspaceID.ResourceGroupName, workspaceID.WorkspaceName, *realName)
 
 	switch template := resp.(type) {
 	case securityinsight.MLBehaviorAnalyticsAlertRuleTemplate:

--- a/internal/services/sentinel/sentinel_alert_rule_template_data_source.go
+++ b/internal/services/sentinel/sentinel_alert_rule_template_data_source.go
@@ -159,23 +159,23 @@ func dataSourceSentinelAlertRuleTemplateRead(d *pluginsdk.ResourceData, meta int
 	// Either "name" or "display_name" must have been specified, constrained by the pluginsdk.
 	var resp securityinsight.BasicAlertRuleTemplate
 	var nameToLog string
-	var realName *string
 	if name != "" {
 		nameToLog = name
-		realName = &name
 		resp, err = getAlertRuleTemplateByName(ctx, client, workspaceID, name)
+		if err != nil {
+			return fmt.Errorf("an Alert Rule Template named %q was not found", name)
+		}
 	} else {
 		nameToLog = displayName
+		var realName *string
 		resp, realName, err = getAlertRuleTemplateByDisplayName(ctx, client, workspaceID, displayName)
-	}
-	if err != nil {
-		return fmt.Errorf("retrieving Sentinel Alert Rule Template %q (Workspace %q / Resource Group %q): %+v", nameToLog, workspaceID.WorkspaceName, workspaceID.ResourceGroupName, err)
-	}
-	if realName == nil {
-		return fmt.Errorf("retrieving Sentinel Alert Rule Template %q (Workspace %q / Resource Group %q): `name` was nil", nameToLog, workspaceID.WorkspaceName, workspaceID.ResourceGroupName)
+		if err != nil {
+			return fmt.Errorf("an Alert Rule Template with the Display Name %q was not found", displayName)
+		}
+		name = *realName
 	}
 
-	id := parse.NewSentinelAlertRuleTemplateID(subscriptionId, workspaceID.ResourceGroupName, workspaceID.WorkspaceName, *realName)
+	id := parse.NewSentinelAlertRuleTemplateID(subscriptionId, workspaceID.ResourceGroupName, workspaceID.WorkspaceName, name)
 
 	switch template := resp.(type) {
 	case securityinsight.MLBehaviorAnalyticsAlertRuleTemplate:


### PR DESCRIPTION
fix https://github.com/hashicorp/terraform-provider-azurerm/issues/21040

Test
---
```
terraform-provider-azurerm ❯ TF_ACC=1 go test -v ./internal/services/sentinel -run=TestAccSentinelAlertRuleTemplateDataSource -timeout=600m
=== RUN   TestAccSentinelAlertRuleTemplateDataSource_fusion
=== PAUSE TestAccSentinelAlertRuleTemplateDataSource_fusion
=== RUN   TestAccSentinelAlertRuleTemplateDataSource_securityIncident
=== PAUSE TestAccSentinelAlertRuleTemplateDataSource_securityIncident
=== RUN   TestAccSentinelAlertRuleTemplateDataSource_scheduled
=== PAUSE TestAccSentinelAlertRuleTemplateDataSource_scheduled
=== RUN   TestAccSentinelAlertRuleTemplateDataSource_nrt
=== PAUSE TestAccSentinelAlertRuleTemplateDataSource_nrt
=== CONT  TestAccSentinelAlertRuleTemplateDataSource_fusion
=== CONT  TestAccSentinelAlertRuleTemplateDataSource_scheduled
=== CONT  TestAccSentinelAlertRuleTemplateDataSource_securityIncident
=== CONT  TestAccSentinelAlertRuleTemplateDataSource_nrt
--- PASS: TestAccSentinelAlertRuleTemplateDataSource_securityIncident (273.88s)
--- PASS: TestAccSentinelAlertRuleTemplateDataSource_scheduled (274.09s)
--- PASS: TestAccSentinelAlertRuleTemplateDataSource_nrt (275.56s)
--- PASS: TestAccSentinelAlertRuleTemplateDataSource_fusion (282.20s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/sentinel      282.269s

```