### PR TITLE
`azurerm_signalr_service` - adding `upstream_auth` property

### DIFF
--- a/internal/services/signalr/signalr_service_resource.go
+++ b/internal/services/signalr/signalr_service_resource.go
@@ -2,13 +2,13 @@ package signalr
 
 import (
 	"fmt"
-	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"log"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"

--- a/internal/services/signalr/signalr_service_resource_test.go
+++ b/internal/services/signalr/signalr_service_resource_test.go
@@ -484,6 +484,27 @@ func TestAccSignalRService_upstreamSetting(t *testing.T) {
 	})
 }
 
+func TestAccSignalRService_upstreamSettingAuth(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_signalr_service", "test")
+	r := SignalRServiceResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.withUpstreamEndpoints(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.withUpstreamEndpointsAuth(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccSignalRService_withTags(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_signalr_service", "test")
 	r := SignalRServiceResource{}
@@ -843,6 +864,61 @@ resource "azurerm_signalr_service" "test" {
   }
 }
   `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (r SignalRServiceResource) withUpstreamEndpointsAuth(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_user_assigned_identity" "test" {
+  name                = "acctestuai-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_signalr_service" "test" {
+  name                = "acctestSignalR-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  sku {
+    name     = "Free_F1"
+    capacity = 1
+  }
+
+  service_mode              = "Serverless"
+  connectivity_logs_enabled = false
+  messaging_logs_enabled    = false
+
+  upstream_endpoint {
+    category_pattern = ["*"]
+    event_pattern    = ["*"]
+    hub_pattern      = ["*"]
+    url_template     = "http://foo.com/{hub}/api/{category}/{event}"
+    upstream_auth {
+      type = "None"
+    }
+  }
+
+  upstream_endpoint {
+    category_pattern = ["connections", "messages"]
+    event_pattern    = ["*"]
+    hub_pattern      = ["hub1"]
+    url_template     = "http://foo.com"
+    upstream_auth {
+      type                         = "ManagedIdentity"
+      managed_identity_resource_id = azurerm_user_assigned_identity.test.id
+    }
+  }
+}
+  `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
 }
 
 func (r SignalRServiceResource) withFeatureFlags(data acceptance.TestData) string {

--- a/website/docs/r/signalr_service.html.markdown
+++ b/website/docs/r/signalr_service.html.markdown
@@ -109,6 +109,8 @@ An `upstream_endpoint` block supports the following:
 
 * `hub_pattern` - (Required) The hubs to match on, or `*` for all.
 
+* `upstream_auth` - (Optional) An `upstream_auth` block as defined below.
+
 ---
 
 A `live_trace` block supports the following:
@@ -138,6 +140,14 @@ An `identity` block supports the following:
 * `identity_ids` - (Optional) Specifies a list of User Assigned Managed Identity IDs to be assigned to this signalR.
 
 ~> **NOTE:** This is required when `type` is set to `UserAssigned`
+
+---
+
+An `upstream_auth` block supports the following:
+
+* `type` - (Required) Specifies the type of Managed Service Identity that should be configured on this signalR upstream setting. Possible values are `None`, `ManagedIdentity`.
+
+* `managed_identity_resource_id` - (Optional) Specifies the Managed Identity IDs to be assigned to this signalR upstream setting.
 
 ## Attributes Reference
 


### PR DESCRIPTION
adding terraform support for SignalR upstream settings.

acc tests:
```
--- PASS: TestAccSignalRService_upstreamSettingAuth (558.31s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/signalr       559.096s


```