### PR TITLE
refactor: `SystemData` does not need to be set to `nil`

### DIFF
--- a/internal/services/dashboard/dashboard_grafana_resource.go
+++ b/internal/services/dashboard/dashboard_grafana_resource.go
@@ -286,9 +286,7 @@ func (r DashboardGrafanaResource) Update() sdk.ResourceFunc {
 
 				properties.Properties.PublicNetworkAccess = &publicNetworkAccess
 			}
-
-			properties.SystemData = nil
-
+			
 			if metadata.ResourceData.HasChange("tags") {
 				properties.Tags = &model.Tags
 			}

--- a/internal/services/dashboard/dashboard_grafana_resource.go
+++ b/internal/services/dashboard/dashboard_grafana_resource.go
@@ -286,7 +286,7 @@ func (r DashboardGrafanaResource) Update() sdk.ResourceFunc {
 
 				properties.Properties.PublicNetworkAccess = &publicNetworkAccess
 			}
-			
+
 			if metadata.ResourceData.HasChange("tags") {
 				properties.Tags = &model.Tags
 			}

--- a/internal/services/iothub/iothub_device_update_account_resource.go
+++ b/internal/services/iothub/iothub_device_update_account_resource.go
@@ -260,9 +260,6 @@ func (r IotHubDeviceUpdateAccountResource) Update() sdk.ResourceFunc {
 				existing.Tags = &model.Tags
 			}
 
-			// todo remove this when https://github.com/hashicorp/pandora/issues/1096 is fixed
-			existing.SystemData = nil
-
 			if err := client.AccountsCreateThenPoll(ctx, *id, *existing); err != nil {
 				return fmt.Errorf("updating %s: %+v", *id, err)
 			}

--- a/internal/services/iothub/iothub_device_update_instance_resource.go
+++ b/internal/services/iothub/iothub_device_update_instance_resource.go
@@ -256,9 +256,6 @@ func (r IotHubDeviceUpdateInstanceResource) Update() sdk.ResourceFunc {
 				existing.Tags = &model.Tags
 			}
 
-			// todo remove this when https://github.com/hashicorp/pandora/issues/1096 is fixed
-			existing.SystemData = nil
-
 			if err := client.InstancesCreateThenPoll(ctx, *id, *existing); err != nil {
 				return fmt.Errorf("updating %s: %+v", *id, err)
 			}

--- a/internal/services/mobilenetwork/mobile_network_resource.go
+++ b/internal/services/mobilenetwork/mobile_network_resource.go
@@ -161,8 +161,6 @@ func (r MobileNetworkResource) Update() sdk.ResourceFunc {
 				}
 			}
 
-			properties.SystemData = nil
-
 			if metadata.ResourceData.HasChange("tags") {
 				properties.Tags = &model.Tags
 			}

--- a/internal/services/mobilenetwork/mobile_network_service_resource.go
+++ b/internal/services/mobilenetwork/mobile_network_service_resource.go
@@ -426,8 +426,6 @@ func (r MobileNetworkServiceResource) Update() sdk.ResourceFunc {
 				properties.Properties.ServiceQosPolicy = expandQosPolicyModel(model.ServiceQosPolicy)
 			}
 
-			properties.SystemData = nil
-
 			if metadata.ResourceData.HasChange("tags") {
 				properties.Tags = &model.Tags
 			}

--- a/internal/services/mobilenetwork/mobile_network_sim_group_resource.go
+++ b/internal/services/mobilenetwork/mobile_network_sim_group_resource.go
@@ -181,8 +181,6 @@ func (r SimGroupResource) Update() sdk.ResourceFunc {
 				}
 			}
 
-			properties.SystemData = nil
-
 			if metadata.ResourceData.HasChange("tags") {
 				properties.Tags = &model.Tags
 			}

--- a/internal/services/mobilenetwork/mobile_network_site_resource.go
+++ b/internal/services/mobilenetwork/mobile_network_site_resource.go
@@ -141,8 +141,6 @@ func (r SiteResource) Update() sdk.ResourceFunc {
 				return fmt.Errorf("retrieving %s: properties was nil", id)
 			}
 
-			properties.SystemData = nil
-
 			if metadata.ResourceData.HasChange("tags") {
 				properties.Tags = &model.Tags
 			}

--- a/internal/services/mobilenetwork/mobile_network_slice_resource.go
+++ b/internal/services/mobilenetwork/mobile_network_slice_resource.go
@@ -189,8 +189,6 @@ func (r SliceResource) Update() sdk.ResourceFunc {
 				updateModel.Properties.Snssai = expandSnssaiModel(model.Snssai)
 			}
 
-			updateModel.SystemData = nil
-
 			if metadata.ResourceData.HasChange("tags") {
 				updateModel.Tags = &model.Tags
 			}

--- a/internal/services/monitor/monitor_alert_processing_rule_action_group_resource.go
+++ b/internal/services/monitor/monitor_alert_processing_rule_action_group_resource.go
@@ -165,7 +165,6 @@ func (r AlertProcessingRuleActionGroupResource) Update() sdk.ResourceFunc {
 				model.Tags = &resourceModel.Tags
 			}
 
-			model.SystemData = nil
 			if _, err := client.AlertProcessingRulesCreateOrUpdate(ctx, *id, *model); err != nil {
 				return fmt.Errorf("updating %s: %+v", *id, err)
 			}

--- a/internal/services/monitor/monitor_alert_processing_rule_suppression_resource.go
+++ b/internal/services/monitor/monitor_alert_processing_rule_suppression_resource.go
@@ -152,7 +152,6 @@ func (r AlertProcessingRuleSuppressionResource) Update() sdk.ResourceFunc {
 				model.Tags = &resourceModel.Tags
 			}
 
-			model.SystemData = nil
 			if _, err := client.AlertProcessingRulesCreateOrUpdate(ctx, *id, *model); err != nil {
 				return fmt.Errorf("updating %s: %+v", *id, err)
 			}

--- a/internal/services/monitor/monitor_data_collection_rule_association_resource.go
+++ b/internal/services/monitor/monitor_data_collection_rule_association_resource.go
@@ -216,8 +216,6 @@ func (r DataCollectionRuleAssociationResource) Update() sdk.ResourceFunc {
 				existing.Properties.Description = utils.String(model.Description)
 			}
 
-			existing.SystemData = nil
-
 			if _, err := client.Create(ctx, *id, *existing); err != nil {
 				return fmt.Errorf("updating %s: %+v", *id, err)
 			}

--- a/internal/services/monitor/monitor_data_collection_rule_resource.go
+++ b/internal/services/monitor/monitor_data_collection_rule_resource.go
@@ -528,9 +528,6 @@ func (r DataCollectionRuleResource) Update() sdk.ResourceFunc {
 				existing.Properties.Destinations = expandDataCollectionRuleDestinations(state.Destinations)
 			}
 
-			// otherwise Service will return an error: "The resource definition is invalid."
-			existing.SystemData = nil
-
 			if _, err := client.Create(ctx, *id, *existing); err != nil {
 				return fmt.Errorf("updating %s: %+v", *id, err)
 			}

--- a/internal/services/monitor/monitor_scheduled_query_rules_alert_v2_resource.go
+++ b/internal/services/monitor/monitor_scheduled_query_rules_alert_v2_resource.go
@@ -580,8 +580,6 @@ func (r ScheduledQueryRulesAlertV2Resource) Update() sdk.ResourceFunc {
 				}
 			}
 
-			model.SystemData = nil
-
 			if metadata.ResourceData.HasChange("tags") {
 				model.Tags = &resourceModel.Tags
 			}

--- a/internal/services/network/network_manager_network_group_resource.go
+++ b/internal/services/network/network_manager_network_group_resource.go
@@ -140,8 +140,6 @@ func (r ManagerNetworkGroupResource) Update() sdk.ResourceFunc {
 				}
 			}
 
-			existing.SystemData = nil
-
 			if _, err := client.CreateOrUpdate(ctx, existing, id.ResourceGroup, id.NetworkManagerName, id.NetworkGroupName, ""); err != nil {
 				return fmt.Errorf("updating %s: %+v", *id, err)
 			}

--- a/internal/services/privatednsresolver/private_dns_resolver_dns_forwarding_ruleset_resource.go
+++ b/internal/services/privatednsresolver/private_dns_resolver_dns_forwarding_ruleset_resource.go
@@ -146,8 +146,6 @@ func (r PrivateDNSResolverDnsForwardingRulesetResource) Update() sdk.ResourceFun
 				}
 			}
 
-			properties.SystemData = nil
-
 			if metadata.ResourceData.HasChange("tags") {
 				properties.Tags = &model.Tags
 			}

--- a/internal/services/privatednsresolver/private_dns_resolver_forwarding_rule_resource.go
+++ b/internal/services/privatednsresolver/private_dns_resolver_forwarding_rule_resource.go
@@ -206,8 +206,6 @@ func (r PrivateDNSResolverForwardingRuleResource) Update() sdk.ResourceFunc {
 				}
 			}
 
-			properties.SystemData = nil
-
 			if _, err := client.CreateOrUpdate(ctx, *id, *properties, forwardingrules.CreateOrUpdateOperationOptions{}); err != nil {
 				return fmt.Errorf("updating %s: %+v", *id, err)
 			}

--- a/internal/services/privatednsresolver/private_dns_resolver_inbound_endpoint_resource.go
+++ b/internal/services/privatednsresolver/private_dns_resolver_inbound_endpoint_resource.go
@@ -182,8 +182,6 @@ func (r PrivateDNSResolverInboundEndpointResource) Update() sdk.ResourceFunc {
 				}
 			}
 
-			properties.SystemData = nil
-
 			if metadata.ResourceData.HasChange("tags") {
 				properties.Tags = &model.Tags
 			}

--- a/internal/services/privatednsresolver/private_dns_resolver_outbound_endpoint_resource.go
+++ b/internal/services/privatednsresolver/private_dns_resolver_outbound_endpoint_resource.go
@@ -145,8 +145,6 @@ func (r PrivateDNSResolverOutboundEndpointResource) Update() sdk.ResourceFunc {
 				return fmt.Errorf("retrieving %s: properties was nil", id)
 			}
 
-			properties.SystemData = nil
-
 			if metadata.ResourceData.HasChange("tags") {
 				properties.Tags = &model.Tags
 			}

--- a/internal/services/privatednsresolver/private_dns_resolver_resource.go
+++ b/internal/services/privatednsresolver/private_dns_resolver_resource.go
@@ -134,8 +134,6 @@ func (r PrivateDNSResolverDnsResolverResource) Update() sdk.ResourceFunc {
 				return fmt.Errorf("retrieving %s: properties was nil", id)
 			}
 
-			properties.SystemData = nil
-
 			if metadata.ResourceData.HasChange("tags") {
 				properties.Tags = &model.Tags
 			}

--- a/internal/services/privatednsresolver/private_dns_resolver_virtual_network_link_resource.go
+++ b/internal/services/privatednsresolver/private_dns_resolver_virtual_network_link_resource.go
@@ -154,8 +154,6 @@ func (r PrivateDNSResolverVirtualNetworkLinkResource) Update() sdk.ResourceFunc 
 				}
 			}
 
-			properties.SystemData = nil
-
 			if err := client.CreateOrUpdateThenPoll(ctx, *id, *properties, virtualnetworklinks.CreateOrUpdateOperationOptions{}); err != nil {
 				return fmt.Errorf("updating %s: %+v", *id, err)
 			}

--- a/internal/services/signalr/signalr_service_network_acl_resource.go
+++ b/internal/services/signalr/signalr_service_network_acl_resource.go
@@ -197,9 +197,6 @@ func resourceSignalRServiceNetworkACLCreateUpdate(d *pluginsdk.ResourceData, met
 		model.Properties.NetworkACLs = &networkACL
 	}
 
-	// todo remove this when https://github.com/hashicorp/pandora/issues/1096 is fixed
-	model.SystemData = nil
-
 	if err := client.UpdateThenPoll(ctx, *id, model); err != nil {
 		return fmt.Errorf("creating/updating NetworkACL for %s: %v", id, err)
 	}
@@ -301,9 +298,6 @@ func resourceSignalRServiceNetworkACLDelete(d *pluginsdk.ResourceData, meta inte
 	if model.Properties != nil {
 		model.Properties.NetworkACLs = networkACL
 	}
-
-	// todo remove this when https://github.com/hashicorp/pandora/issues/1096 is fixed
-	model.SystemData = nil
 
 	if err := client.UpdateThenPoll(ctx, *id, model); err != nil {
 		return fmt.Errorf("resetting the default Network ACL configuration for %s: %+v", *id, err)


### PR DESCRIPTION
This is handled by the transport layer when using `go-azure-sdk`, so shouldn't be set