### PR TITLE
`mobilenetwork` - refactoring

### DIFF
--- a/internal/services/dashboard/dashboard_grafana_resource.go
+++ b/internal/services/dashboard/dashboard_grafana_resource.go
@@ -286,9 +286,7 @@ func (r DashboardGrafanaResource) Update() sdk.ResourceFunc {
 
 				properties.Properties.PublicNetworkAccess = &publicNetworkAccess
 			}
-
-			properties.SystemData = nil
-
+			
 			if metadata.ResourceData.HasChange("tags") {
 				properties.Tags = &model.Tags
 			}

--- a/internal/services/dashboard/dashboard_grafana_resource.go
+++ b/internal/services/dashboard/dashboard_grafana_resource.go
@@ -286,7 +286,7 @@ func (r DashboardGrafanaResource) Update() sdk.ResourceFunc {
 
 				properties.Properties.PublicNetworkAccess = &publicNetworkAccess
 			}
-			
+
 			if metadata.ResourceData.HasChange("tags") {
 				properties.Tags = &model.Tags
 			}

--- a/internal/services/iothub/iothub_device_update_account_resource.go
+++ b/internal/services/iothub/iothub_device_update_account_resource.go
@@ -260,9 +260,6 @@ func (r IotHubDeviceUpdateAccountResource) Update() sdk.ResourceFunc {
 				existing.Tags = &model.Tags
 			}
 
-			// todo remove this when https://github.com/hashicorp/pandora/issues/1096 is fixed
-			existing.SystemData = nil
-
 			if err := client.AccountsCreateThenPoll(ctx, *id, *existing); err != nil {
 				return fmt.Errorf("updating %s: %+v", *id, err)
 			}

--- a/internal/services/iothub/iothub_device_update_instance_resource.go
+++ b/internal/services/iothub/iothub_device_update_instance_resource.go
@@ -256,9 +256,6 @@ func (r IotHubDeviceUpdateInstanceResource) Update() sdk.ResourceFunc {
 				existing.Tags = &model.Tags
 			}
 
-			// todo remove this when https://github.com/hashicorp/pandora/issues/1096 is fixed
-			existing.SystemData = nil
-
 			if err := client.InstancesCreateThenPoll(ctx, *id, *existing); err != nil {
 				return fmt.Errorf("updating %s: %+v", *id, err)
 			}

--- a/internal/services/mobilenetwork/mobile_network_data_network_data_source.go
+++ b/internal/services/mobilenetwork/mobile_network_data_network_data_source.go
@@ -3,11 +3,11 @@ package mobilenetwork
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/datanetwork"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/mobilenetwork"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
@@ -18,11 +18,11 @@ import (
 type DataNetworkDataSource struct{}
 
 type DataNetworkDataSourceModel struct {
-	Name                         string            `tfschema:"name"`
-	MobileNetworkMobileNetworkId string            `tfschema:"mobile_network_id"`
-	Description                  string            `tfschema:"description"`
-	Location                     string            `tfschema:"location"`
-	Tags                         map[string]string `tfschema:"tags"`
+	Name            string            `tfschema:"name"`
+	MobileNetworkId string            `tfschema:"mobile_network_id"`
+	Description     string            `tfschema:"description"`
+	Location        string            `tfschema:"location"`
+	Tags            map[string]string `tfschema:"tags"`
 }
 
 var _ sdk.DataSource = DataNetworkDataSource{}
@@ -78,7 +78,7 @@ func (r DataNetworkDataSource) Read() sdk.ResourceFunc {
 			}
 
 			client := metadata.Client.MobileNetwork.DataNetworkClient
-			mobileNetworkId, err := mobilenetwork.ParseMobileNetworkID(inputModel.MobileNetworkMobileNetworkId)
+			mobileNetworkId, err := mobilenetwork.ParseMobileNetworkID(inputModel.MobileNetworkId)
 			if err != nil {
 				return err
 			}
@@ -96,8 +96,8 @@ func (r DataNetworkDataSource) Read() sdk.ResourceFunc {
 
 			metadata.SetID(id)
 			state := DataNetworkDataSourceModel{
-				Name:                         id.DataNetworkName,
-				MobileNetworkMobileNetworkId: mobilenetwork.NewMobileNetworkID(id.SubscriptionId, id.ResourceGroupName, id.MobileNetworkName).ID(),
+				Name:            id.DataNetworkName,
+				MobileNetworkId: mobilenetwork.NewMobileNetworkID(id.SubscriptionId, id.ResourceGroupName, id.MobileNetworkName).ID(),
 			}
 
 			if model := resp.Model; model != nil {

--- a/internal/services/mobilenetwork/mobile_network_data_network_resource.go
+++ b/internal/services/mobilenetwork/mobile_network_data_network_resource.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 )
 
-type DataNetworkModel struct {
+type DataNetworkResourceModel struct {
 	Name                         string            `tfschema:"name"`
 	MobileNetworkMobileNetworkId string            `tfschema:"mobile_network_id"`
 	Description                  string            `tfschema:"description"`
@@ -33,7 +33,7 @@ func (r DataNetworkResource) ResourceType() string {
 }
 
 func (r DataNetworkResource) ModelObject() interface{} {
-	return &DataNetworkModel{}
+	return &DataNetworkResourceModel{}
 }
 
 func (r DataNetworkResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
@@ -76,7 +76,7 @@ func (r DataNetworkResource) Create() sdk.ResourceFunc {
 	return sdk.ResourceFunc{
 		Timeout: 180 * time.Minute,
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
-			var model DataNetworkModel
+			var model DataNetworkResourceModel
 			if err := metadata.Decode(&model); err != nil {
 				return fmt.Errorf("decoding: %+v", err)
 			}
@@ -128,7 +128,7 @@ func (r DataNetworkResource) Update() sdk.ResourceFunc {
 				return err
 			}
 
-			var model DataNetworkModel
+			var model DataNetworkResourceModel
 			if err := metadata.Decode(&model); err != nil {
 				return fmt.Errorf("decoding: %+v", err)
 			}
@@ -181,7 +181,7 @@ func (r DataNetworkResource) Read() sdk.ResourceFunc {
 				return fmt.Errorf("retrieving %s: %+v", *id, err)
 			}
 
-			state := DataNetworkModel{
+			state := DataNetworkResourceModel{
 				Name:                         id.DataNetworkName,
 				MobileNetworkMobileNetworkId: mobilenetwork.NewMobileNetworkID(id.SubscriptionId, id.ResourceGroupName, id.MobileNetworkName).ID(),
 			}

--- a/internal/services/mobilenetwork/mobile_network_data_network_resource.go
+++ b/internal/services/mobilenetwork/mobile_network_data_network_resource.go
@@ -17,11 +17,11 @@ import (
 )
 
 type DataNetworkResourceModel struct {
-	Name                         string            `tfschema:"name"`
-	MobileNetworkMobileNetworkId string            `tfschema:"mobile_network_id"`
-	Description                  string            `tfschema:"description"`
-	Location                     string            `tfschema:"location"`
-	Tags                         map[string]string `tfschema:"tags"`
+	Name            string            `tfschema:"name"`
+	MobileNetworkId string            `tfschema:"mobile_network_id"`
+	Description     string            `tfschema:"description"`
+	Location        string            `tfschema:"location"`
+	Tags            map[string]string `tfschema:"tags"`
 }
 
 type DataNetworkResource struct{}
@@ -82,7 +82,7 @@ func (r DataNetworkResource) Create() sdk.ResourceFunc {
 			}
 
 			client := metadata.Client.MobileNetwork.DataNetworkClient
-			mobileNetworkId, err := mobilenetwork.ParseMobileNetworkID(model.MobileNetworkMobileNetworkId)
+			mobileNetworkId, err := mobilenetwork.ParseMobileNetworkID(model.MobileNetworkId)
 			if err != nil {
 				return err
 			}
@@ -182,8 +182,8 @@ func (r DataNetworkResource) Read() sdk.ResourceFunc {
 			}
 
 			state := DataNetworkResourceModel{
-				Name:                         id.DataNetworkName,
-				MobileNetworkMobileNetworkId: mobilenetwork.NewMobileNetworkID(id.SubscriptionId, id.ResourceGroupName, id.MobileNetworkName).ID(),
+				Name:            id.DataNetworkName,
+				MobileNetworkId: mobilenetwork.NewMobileNetworkID(id.SubscriptionId, id.ResourceGroupName, id.MobileNetworkName).ID(),
 			}
 
 			if model := resp.Model; model != nil {

--- a/internal/services/mobilenetwork/mobile_network_data_network_resource_test.go
+++ b/internal/services/mobilenetwork/mobile_network_data_network_resource_test.go
@@ -109,60 +109,91 @@ func (r MobileNetworkDataNetworkResource) Exists(ctx context.Context, clients *c
 }
 
 func (r MobileNetworkDataNetworkResource) basic(data acceptance.TestData) string {
+	template := r.template(data)
 	return fmt.Sprintf(`
-				%s
+provider "azurerm" {
+  features {}
+}
+
+%s
 
 resource "azurerm_mobile_network_data_network" "test" {
   name              = "acctest-mndn-%d"
   mobile_network_id = azurerm_mobile_network.test.id
-  location          = "%s"
+  location          = azurerm_resource_group.test.location
 }
-`, MobileNetworkResource{}.basic(data), data.RandomInteger, data.Locations.Primary)
+`, template, data.RandomInteger)
 }
 
 func (r MobileNetworkDataNetworkResource) requiresImport(data acceptance.TestData) string {
-	config := r.basic(data)
+	template := r.basic(data)
 	return fmt.Sprintf(`
-			%s
+%s
 
 resource "azurerm_mobile_network_data_network" "import" {
   name              = azurerm_mobile_network_data_network.test.name
-  mobile_network_id = azurerm_mobile_network.test.id
-  location          = "%s"
+  mobile_network_id = azurerm_mobile_network_data_network.test.mobile_network_id
+  location          = azurerm_mobile_network_data_network.test.location
 }
-`, config, data.Locations.Primary)
+`, template)
 }
 
 func (r MobileNetworkDataNetworkResource) complete(data acceptance.TestData) string {
+	template := r.template(data)
 	return fmt.Sprintf(`
-			%s
+provider "azurerm" {
+  features {}
+}
+
+%s
 
 resource "azurerm_mobile_network_data_network" "test" {
   name              = "acctest-mndn-%d"
   mobile_network_id = azurerm_mobile_network.test.id
-  location          = "%s"
+  location          = azurerm_resource_group.test.location
   description       = "my favourite data network"
   tags = {
     key = "value"
   }
-
 }
-`, MobileNetworkResource{}.basic(data), data.RandomInteger, data.Locations.Primary)
+`, template, data.RandomInteger)
 }
 
 func (r MobileNetworkDataNetworkResource) update(data acceptance.TestData) string {
+	template := r.template(data)
 	return fmt.Sprintf(`
-			%s
+provider "azurerm" {
+  features {}
+}
+
+%s
 
 resource "azurerm_mobile_network_data_network" "test" {
   name              = "acctest-mndn-%d"
   mobile_network_id = azurerm_mobile_network.test.id
-  location          = "%s"
+  location          = azurerm_resource_group.test.location
   description       = "my favourite data network 2"
   tags = {
     key = "updated"
   }
 
 }
-`, MobileNetworkResource{}.basic(data), data.RandomInteger, data.Locations.Primary)
+`, template, data.RandomInteger)
+}
+
+func (r MobileNetworkDataNetworkResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctest-mn-%[1]d"
+  location = %[2]q
+}
+
+resource "azurerm_mobile_network" "test" {
+  name                = "acctest-mn-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  mobile_country_code = "001"
+  mobile_network_code = "01"
+}
+`, data.RandomInteger, data.Locations.Primary)
 }

--- a/internal/services/mobilenetwork/mobile_network_data_source.go
+++ b/internal/services/mobilenetwork/mobile_network_data_source.go
@@ -16,6 +16,16 @@ import (
 
 type MobileNetworkDataSource struct{}
 
+type MobileNetworkDataSourceModel struct {
+	Name              string            `tfschema:"name"`
+	ResourceGroupName string            `tfschema:"resource_group_name"`
+	Location          string            `tfschema:"location"`
+	MobileCountryCode string            `tfschema:"mobile_country_code"`
+	MobileNetworkCode string            `tfschema:"mobile_network_code"`
+	Tags              map[string]string `tfschema:"tags"`
+	ServiceKey        string            `tfschema:"service_key"`
+}
+
 var _ sdk.DataSource = MobileNetworkDataSource{}
 
 func (r MobileNetworkDataSource) ResourceType() string {
@@ -23,7 +33,7 @@ func (r MobileNetworkDataSource) ResourceType() string {
 }
 
 func (r MobileNetworkDataSource) ModelObject() interface{} {
-	return &MobileNetworkModel{}
+	return &MobileNetworkDataSourceModel{}
 }
 
 func (r MobileNetworkDataSource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
@@ -70,7 +80,7 @@ func (r MobileNetworkDataSource) Read() sdk.ResourceFunc {
 	return sdk.ResourceFunc{
 		Timeout: 5 * time.Minute,
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
-			var metaModel MobileNetworkModel
+			var metaModel MobileNetworkDataSourceModel
 			if err := metadata.Decode(&metaModel); err != nil {
 				return fmt.Errorf("decoding: %+v", err)
 			}
@@ -93,7 +103,7 @@ func (r MobileNetworkDataSource) Read() sdk.ResourceFunc {
 				return fmt.Errorf("retrieving %s: model was nil", id)
 			}
 
-			state := MobileNetworkModel{
+			state := MobileNetworkDataSourceModel{
 				Name:              id.MobileNetworkName,
 				ResourceGroupName: id.ResourceGroupName,
 				Location:          location.Normalize(model.Location),

--- a/internal/services/mobilenetwork/mobile_network_resource.go
+++ b/internal/services/mobilenetwork/mobile_network_resource.go
@@ -107,7 +107,7 @@ func (r MobileNetworkResource) Create() sdk.ResourceFunc {
 				return metadata.ResourceRequiresImport(r.ResourceType(), id)
 			}
 
-			properties := &mobilenetwork.MobileNetwork{
+			payload := mobilenetwork.MobileNetwork{
 				Location: location.Normalize(model.Location),
 				Properties: mobilenetwork.MobileNetworkPropertiesFormat{
 					PublicLandMobileNetworkIdentifier: mobilenetwork.PlmnId{
@@ -118,7 +118,7 @@ func (r MobileNetworkResource) Create() sdk.ResourceFunc {
 				Tags: &model.Tags,
 			}
 
-			if err := client.CreateOrUpdateThenPoll(ctx, id, *properties); err != nil {
+			if err := client.CreateOrUpdateThenPoll(ctx, id, payload); err != nil {
 				return fmt.Errorf("creating %s: %+v", id, err)
 			}
 
@@ -139,8 +139,8 @@ func (r MobileNetworkResource) Update() sdk.ResourceFunc {
 				return err
 			}
 
-			var model MobileNetworkResourceModel
-			if err := metadata.Decode(&model); err != nil {
+			var state MobileNetworkResourceModel
+			if err := metadata.Decode(&state); err != nil {
 				return fmt.Errorf("decoding: %+v", err)
 			}
 
@@ -149,23 +149,23 @@ func (r MobileNetworkResource) Update() sdk.ResourceFunc {
 				return fmt.Errorf("retrieving %s: %+v", *id, err)
 			}
 
-			properties := resp.Model
-			if properties == nil {
-				return fmt.Errorf("retrieving %s: properties was nil", id)
+			model := resp.Model
+			if model == nil {
+				return fmt.Errorf("retrieving %s: model was nil", id)
 			}
 
 			if metadata.ResourceData.HasChange("mobile_country_code") || metadata.ResourceData.HasChange("mobile_network_code") {
-				properties.Properties.PublicLandMobileNetworkIdentifier = mobilenetwork.PlmnId{
-					Mcc: model.MobileCountryCode,
-					Mnc: model.MobileNetworkCode,
+				model.Properties.PublicLandMobileNetworkIdentifier = mobilenetwork.PlmnId{
+					Mcc: state.MobileCountryCode,
+					Mnc: state.MobileNetworkCode,
 				}
 			}
 
 			if metadata.ResourceData.HasChange("tags") {
-				properties.Tags = &model.Tags
+				model.Tags = &state.Tags
 			}
 
-			if err := client.CreateOrUpdateThenPoll(ctx, *id, *properties); err != nil {
+			if err := client.CreateOrUpdateThenPoll(ctx, *id, *model); err != nil {
 				return fmt.Errorf("updating %s: %+v", *id, err)
 			}
 
@@ -194,25 +194,23 @@ func (r MobileNetworkResource) Read() sdk.ResourceFunc {
 				return fmt.Errorf("retrieving %s: %+v", *id, err)
 			}
 
-			model := resp.Model
-			if model == nil {
-				return fmt.Errorf("retrieving %s: model was nil", id)
-			}
-
 			state := MobileNetworkResourceModel{
 				Name:              id.MobileNetworkName,
 				ResourceGroupName: id.ResourceGroupName,
-				Location:          location.Normalize(model.Location),
-				MobileCountryCode: model.Properties.PublicLandMobileNetworkIdentifier.Mcc,
-				MobileNetworkCode: model.Properties.PublicLandMobileNetworkIdentifier.Mnc,
 			}
 
-			if model.Properties.ServiceKey != nil {
-				state.ServiceKey = *model.Properties.ServiceKey
-			}
+			if model := resp.Model; model != nil {
+				state.Location = location.Normalize(model.Location)
+				state.MobileCountryCode = model.Properties.PublicLandMobileNetworkIdentifier.Mcc
+				state.MobileNetworkCode = model.Properties.PublicLandMobileNetworkIdentifier.Mnc
 
-			if model.Tags != nil {
-				state.Tags = *model.Tags
+				if model.Properties.ServiceKey != nil {
+					state.ServiceKey = *model.Properties.ServiceKey
+				}
+
+				if model.Tags != nil {
+					state.Tags = *model.Tags
+				}
 			}
 
 			return metadata.Encode(&state)

--- a/internal/services/mobilenetwork/mobile_network_resource.go
+++ b/internal/services/mobilenetwork/mobile_network_resource.go
@@ -161,8 +161,6 @@ func (r MobileNetworkResource) Update() sdk.ResourceFunc {
 				}
 			}
 
-			properties.SystemData = nil
-
 			if metadata.ResourceData.HasChange("tags") {
 				properties.Tags = &model.Tags
 			}

--- a/internal/services/mobilenetwork/mobile_network_resource.go
+++ b/internal/services/mobilenetwork/mobile_network_resource.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 )
 
-type MobileNetworkModel struct {
+type MobileNetworkResourceModel struct {
 	Name              string            `tfschema:"name"`
 	ResourceGroupName string            `tfschema:"resource_group_name"`
 	Location          string            `tfschema:"location"`
@@ -34,7 +34,7 @@ func (r MobileNetworkResource) ResourceType() string {
 }
 
 func (r MobileNetworkResource) ModelObject() interface{} {
-	return &MobileNetworkModel{}
+	return &MobileNetworkResourceModel{}
 }
 
 func (r MobileNetworkResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
@@ -89,7 +89,7 @@ func (r MobileNetworkResource) Create() sdk.ResourceFunc {
 	return sdk.ResourceFunc{
 		Timeout: 180 * time.Minute,
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
-			var model MobileNetworkModel
+			var model MobileNetworkResourceModel
 			if err := metadata.Decode(&model); err != nil {
 				return fmt.Errorf("decoding: %+v", err)
 			}
@@ -139,7 +139,7 @@ func (r MobileNetworkResource) Update() sdk.ResourceFunc {
 				return err
 			}
 
-			var model MobileNetworkModel
+			var model MobileNetworkResourceModel
 			if err := metadata.Decode(&model); err != nil {
 				return fmt.Errorf("decoding: %+v", err)
 			}
@@ -199,7 +199,7 @@ func (r MobileNetworkResource) Read() sdk.ResourceFunc {
 				return fmt.Errorf("retrieving %s: model was nil", id)
 			}
 
-			state := MobileNetworkModel{
+			state := MobileNetworkResourceModel{
 				Name:              id.MobileNetworkName,
 				ResourceGroupName: id.ResourceGroupName,
 				Location:          location.Normalize(model.Location),

--- a/internal/services/mobilenetwork/mobile_network_resource_test.go
+++ b/internal/services/mobilenetwork/mobile_network_resource_test.go
@@ -110,56 +110,53 @@ func (r MobileNetworkResource) Exists(ctx context.Context, clients *clients.Clie
 	return utils.Bool(resp.Model != nil), nil
 }
 
-func (r MobileNetworkResource) template(data acceptance.TestData) string {
+func (r MobileNetworkResource) basic(data acceptance.TestData) string {
+	template := r.template(data)
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
 
-resource "azurerm_resource_group" "test" {
-  name     = "acctest-mn-%d"
-  location = "%s"
-}
-`, data.RandomInteger, data.Locations.Primary)
-}
-
-func (r MobileNetworkResource) basic(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-				%s
+%s
 
 resource "azurerm_mobile_network" "test" {
   name                = "acctest-mn-%d"
   resource_group_name = azurerm_resource_group.test.name
-  location            = "%s"
+  location            = azurerm_resource_group.test.location
   mobile_country_code = "001"
   mobile_network_code = "01"
 }
-`, r.template(data), data.RandomInteger, data.Locations.Primary)
+`, template, data.RandomInteger)
 }
 
 func (r MobileNetworkResource) requiresImport(data acceptance.TestData) string {
 	config := r.basic(data)
 	return fmt.Sprintf(`
-			%s
+%s
 
 resource "azurerm_mobile_network" "import" {
   name                = azurerm_mobile_network.test.name
-  resource_group_name = azurerm_resource_group.test.name
-  location            = "%s"
-  mobile_country_code = "001"
-  mobile_network_code = "01"
+  resource_group_name = azurerm_mobile_network.test.resource_group_name
+  location            = azurerm_mobile_network.test.location
+  mobile_country_code = azurerm_mobile_network.test.mobile_country_code
+  mobile_network_code = azurerm_mobile_network.test.mobile_network_code
 }
-`, config, data.Locations.Primary)
+`, config)
 }
 
 func (r MobileNetworkResource) complete(data acceptance.TestData) string {
+	template := r.template(data)
 	return fmt.Sprintf(`
-			%s
+provider "azurerm" {
+  features {}
+}
+
+%s
 
 resource "azurerm_mobile_network" "test" {
   name                = "acctest-mn-%d"
   resource_group_name = azurerm_resource_group.test.name
-  location            = "%s"
+  location            = azurerm_resource_group.test.location
   mobile_country_code = "001"
   mobile_network_code = "01"
 
@@ -168,17 +165,22 @@ resource "azurerm_mobile_network" "test" {
   }
 
 }
-`, r.template(data), data.RandomInteger, data.Locations.Primary)
+`, template, data.RandomInteger)
 }
 
 func (r MobileNetworkResource) update(data acceptance.TestData) string {
+	template := r.template(data)
 	return fmt.Sprintf(`
-			%s
+provider "azurerm" {
+  features {}
+}
+
+%s
 
 resource "azurerm_mobile_network" "test" {
   name                = "acctest-mn-%d"
   resource_group_name = azurerm_resource_group.test.name
-  location            = "%s"
+  location            = azurerm_resource_group.test.location
   mobile_country_code = "001"
   mobile_network_code = "01"
 
@@ -187,5 +189,14 @@ resource "azurerm_mobile_network" "test" {
   }
 
 }
-`, r.template(data), data.RandomInteger, data.Locations.Primary)
+`, template, data.RandomInteger)
+}
+
+func (r MobileNetworkResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctest-mn-%d"
+  location = "%s"
+}
+`, data.RandomInteger, data.Locations.Primary)
 }

--- a/internal/services/mobilenetwork/mobile_network_service_data_source.go
+++ b/internal/services/mobilenetwork/mobile_network_service_data_source.go
@@ -17,13 +17,13 @@ import (
 type ServiceDataSource struct{}
 
 type ServiceDataSourceModel struct {
-	Name                         string                                       `tfschema:"name"`
-	MobileNetworkMobileNetworkId string                                       `tfschema:"mobile_network_id"`
-	Location                     string                                       `tfschema:"location"`
-	PccRules                     []ServiceDataSourcePccRuleConfigurationModel `tfschema:"pcc_rule"`
-	ServicePrecedence            int64                                        `tfschema:"service_precedence"`
-	ServiceQosPolicy             []ServiceDataSourceQosPolicyModel            `tfschema:"service_qos_policy"`
-	Tags                         map[string]string                            `tfschema:"tags"`
+	Name              string                                       `tfschema:"name"`
+	MobileNetworkId   string                                       `tfschema:"mobile_network_id"`
+	Location          string                                       `tfschema:"location"`
+	PccRules          []ServiceDataSourcePccRuleConfigurationModel `tfschema:"pcc_rule"`
+	ServicePrecedence int64                                        `tfschema:"service_precedence"`
+	ServiceQosPolicy  []ServiceDataSourceQosPolicyModel            `tfschema:"service_qos_policy"`
+	Tags              map[string]string                            `tfschema:"tags"`
 }
 
 type ServiceDataSourcePccRuleConfigurationModel struct {
@@ -293,7 +293,7 @@ func (r ServiceDataSource) Read() sdk.ResourceFunc {
 			}
 
 			client := metadata.Client.MobileNetwork.ServiceClient
-			mobileNetworkId, err := mobilenetwork.ParseMobileNetworkID(metaModel.MobileNetworkMobileNetworkId)
+			mobileNetworkId, err := mobilenetwork.ParseMobileNetworkID(metaModel.MobileNetworkId)
 			if err != nil {
 				return err
 			}
@@ -307,8 +307,8 @@ func (r ServiceDataSource) Read() sdk.ResourceFunc {
 
 			metadata.SetID(id)
 			state := ServiceDataSourceModel{
-				Name:                         id.ServiceName,
-				MobileNetworkMobileNetworkId: mobilenetwork.NewMobileNetworkID(id.SubscriptionId, id.ResourceGroupName, id.MobileNetworkName).ID(),
+				Name:            id.ServiceName,
+				MobileNetworkId: mobilenetwork.NewMobileNetworkID(id.SubscriptionId, id.ResourceGroupName, id.MobileNetworkName).ID(),
 			}
 			if model := resp.Model; model != nil {
 				state.Location = location.Normalize(model.Location)

--- a/internal/services/mobilenetwork/mobile_network_service_data_source.go
+++ b/internal/services/mobilenetwork/mobile_network_service_data_source.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 )
 
-type MobileNetworkServiceDataSource struct{}
+type ServiceDataSource struct{}
 
 type ServiceDataSourceModel struct {
 	Name                         string                                       `tfschema:"name"`
@@ -64,21 +64,21 @@ type ServiceDataSourceQosPolicyModel struct {
 	PreemptionVulnerability             string                          `tfschema:"preemption_vulnerability"`
 }
 
-var _ sdk.DataSource = MobileNetworkServiceDataSource{}
+var _ sdk.DataSource = ServiceDataSource{}
 
-func (r MobileNetworkServiceDataSource) ResourceType() string {
+func (r ServiceDataSource) ResourceType() string {
 	return "azurerm_mobile_network_service"
 }
 
-func (r MobileNetworkServiceDataSource) ModelObject() interface{} {
+func (r ServiceDataSource) ModelObject() interface{} {
 	return &ServiceDataSourceModel{}
 }
 
-func (r MobileNetworkServiceDataSource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+func (r ServiceDataSource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
 	return service.ValidateServiceID
 }
 
-func (r MobileNetworkServiceDataSource) Arguments() map[string]*pluginsdk.Schema {
+func (r ServiceDataSource) Arguments() map[string]*pluginsdk.Schema {
 	return map[string]*pluginsdk.Schema{
 		"name": {
 			Type:         pluginsdk.TypeString,
@@ -94,7 +94,7 @@ func (r MobileNetworkServiceDataSource) Arguments() map[string]*pluginsdk.Schema
 	}
 }
 
-func (r MobileNetworkServiceDataSource) Attributes() map[string]*pluginsdk.Schema {
+func (r ServiceDataSource) Attributes() map[string]*pluginsdk.Schema {
 	return map[string]*pluginsdk.Schema{
 
 		"location": commonschema.LocationComputed(),
@@ -283,7 +283,7 @@ func (r MobileNetworkServiceDataSource) Attributes() map[string]*pluginsdk.Schem
 	}
 }
 
-func (r MobileNetworkServiceDataSource) Read() sdk.ResourceFunc {
+func (r ServiceDataSource) Read() sdk.ResourceFunc {
 	return sdk.ResourceFunc{
 		Timeout: 5 * time.Minute,
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {

--- a/internal/services/mobilenetwork/mobile_network_service_resource.go
+++ b/internal/services/mobilenetwork/mobile_network_service_resource.go
@@ -20,13 +20,13 @@ import (
 type ServiceResource struct{}
 
 type ServiceResourceModel struct {
-	Name                         string                                     `tfschema:"name"`
-	MobileNetworkMobileNetworkId string                                     `tfschema:"mobile_network_id"`
-	Location                     string                                     `tfschema:"location"`
-	PccRules                     []ServiceResourcePccRuleConfigurationModel `tfschema:"pcc_rule"`
-	ServicePrecedence            int64                                      `tfschema:"service_precedence"`
-	ServiceQosPolicy             []ServiceResourceQosPolicyModel            `tfschema:"service_qos_policy"`
-	Tags                         map[string]string                          `tfschema:"tags"`
+	Name              string                                     `tfschema:"name"`
+	MobileNetworkId   string                                     `tfschema:"mobile_network_id"`
+	Location          string                                     `tfschema:"location"`
+	PccRules          []ServiceResourcePccRuleConfigurationModel `tfschema:"pcc_rule"`
+	ServicePrecedence int64                                      `tfschema:"service_precedence"`
+	ServiceQosPolicy  []ServiceResourceQosPolicyModel            `tfschema:"service_qos_policy"`
+	Tags              map[string]string                          `tfschema:"tags"`
 }
 
 type ServiceResourcePccRuleConfigurationModel struct {
@@ -352,7 +352,7 @@ func (r ServiceResource) Create() sdk.ResourceFunc {
 			}
 
 			client := metadata.Client.MobileNetwork.ServiceClient
-			mobileNetworkId, err := mobilenetwork.ParseMobileNetworkID(model.MobileNetworkMobileNetworkId)
+			mobileNetworkId, err := mobilenetwork.ParseMobileNetworkID(model.MobileNetworkId)
 			if err != nil {
 				return err
 			}
@@ -466,9 +466,9 @@ func (r ServiceResource) Read() sdk.ResourceFunc {
 			model := *resp.Model
 
 			state := ServiceResourceModel{
-				Name:                         id.ServiceName,
-				MobileNetworkMobileNetworkId: mobilenetwork.NewMobileNetworkID(id.SubscriptionId, id.ResourceGroupName, id.MobileNetworkName).ID(),
-				Location:                     location.Normalize(model.Location),
+				Name:            id.ServiceName,
+				MobileNetworkId: mobilenetwork.NewMobileNetworkID(id.SubscriptionId, id.ResourceGroupName, id.MobileNetworkName).ID(),
+				Location:        location.Normalize(model.Location),
 			}
 
 			properties := model.Properties

--- a/internal/services/mobilenetwork/mobile_network_service_resource.go
+++ b/internal/services/mobilenetwork/mobile_network_service_resource.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 )
 
-type MobileNetworkServiceResource struct{}
+type ServiceResource struct{}
 
 type ServiceResourceModel struct {
 	Name                         string                                     `tfschema:"name"`
@@ -67,21 +67,21 @@ type ServiceResourceQosPolicyModel struct {
 	PreemptionVulnerability             string                        `tfschema:"preemption_vulnerability"`
 }
 
-var _ sdk.ResourceWithUpdate = MobileNetworkServiceResource{}
+var _ sdk.ResourceWithUpdate = ServiceResource{}
 
-func (r MobileNetworkServiceResource) ResourceType() string {
+func (r ServiceResource) ResourceType() string {
 	return "azurerm_mobile_network_service"
 }
 
-func (r MobileNetworkServiceResource) ModelObject() interface{} {
+func (r ServiceResource) ModelObject() interface{} {
 	return &ServiceResourceModel{}
 }
 
-func (r MobileNetworkServiceResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+func (r ServiceResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
 	return service.ValidateServiceID
 }
 
-func (r MobileNetworkServiceResource) Arguments() map[string]*pluginsdk.Schema {
+func (r ServiceResource) Arguments() map[string]*pluginsdk.Schema {
 	return map[string]*pluginsdk.Schema{
 		"name": {
 			Type:         pluginsdk.TypeString,
@@ -338,11 +338,11 @@ func (r MobileNetworkServiceResource) Arguments() map[string]*pluginsdk.Schema {
 	}
 }
 
-func (r MobileNetworkServiceResource) Attributes() map[string]*pluginsdk.Schema {
+func (r ServiceResource) Attributes() map[string]*pluginsdk.Schema {
 	return map[string]*pluginsdk.Schema{}
 }
 
-func (r MobileNetworkServiceResource) Create() sdk.ResourceFunc {
+func (r ServiceResource) Create() sdk.ResourceFunc {
 	return sdk.ResourceFunc{
 		Timeout: 180 * time.Minute,
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
@@ -387,7 +387,7 @@ func (r MobileNetworkServiceResource) Create() sdk.ResourceFunc {
 	}
 }
 
-func (r MobileNetworkServiceResource) Update() sdk.ResourceFunc {
+func (r ServiceResource) Update() sdk.ResourceFunc {
 	return sdk.ResourceFunc{
 		Timeout: 180 * time.Minute,
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
@@ -439,7 +439,7 @@ func (r MobileNetworkServiceResource) Update() sdk.ResourceFunc {
 	}
 }
 
-func (r MobileNetworkServiceResource) Read() sdk.ResourceFunc {
+func (r ServiceResource) Read() sdk.ResourceFunc {
 	return sdk.ResourceFunc{
 		Timeout: 5 * time.Minute,
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
@@ -488,7 +488,7 @@ func (r MobileNetworkServiceResource) Read() sdk.ResourceFunc {
 	}
 }
 
-func (r MobileNetworkServiceResource) Delete() sdk.ResourceFunc {
+func (r ServiceResource) Delete() sdk.ResourceFunc {
 	return sdk.ResourceFunc{
 		Timeout: 180 * time.Minute,
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {

--- a/internal/services/mobilenetwork/mobile_network_service_resource.go
+++ b/internal/services/mobilenetwork/mobile_network_service_resource.go
@@ -17,39 +17,41 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 )
 
-type ServiceModel struct {
-	Name                         string                      `tfschema:"name"`
-	MobileNetworkMobileNetworkId string                      `tfschema:"mobile_network_id"`
-	Location                     string                      `tfschema:"location"`
-	PccRules                     []PccRuleConfigurationModel `tfschema:"pcc_rule"`
-	ServicePrecedence            int64                       `tfschema:"service_precedence"`
-	ServiceQosPolicy             []QosPolicyModel            `tfschema:"service_qos_policy"`
-	Tags                         map[string]string           `tfschema:"tags"`
+type MobileNetworkServiceResource struct{}
+
+type ServiceResourceModel struct {
+	Name                         string                                     `tfschema:"name"`
+	MobileNetworkMobileNetworkId string                                     `tfschema:"mobile_network_id"`
+	Location                     string                                     `tfschema:"location"`
+	PccRules                     []ServiceResourcePccRuleConfigurationModel `tfschema:"pcc_rule"`
+	ServicePrecedence            int64                                      `tfschema:"service_precedence"`
+	ServiceQosPolicy             []ServiceResourceQosPolicyModel            `tfschema:"service_qos_policy"`
+	Tags                         map[string]string                          `tfschema:"tags"`
 }
 
-type PccRuleConfigurationModel struct {
-	RuleName                 string                         `tfschema:"name"`
-	RulePrecedence           int64                          `tfschema:"precedence"`
-	RuleQosPolicy            []PccRuleQosPolicyModel        `tfschema:"qos_policy"`
-	ServiceDataFlowTemplates []ServiceDataFlowTemplateModel `tfschema:"service_data_flow_template"`
-	TrafficControlEnabled    bool                           `tfschema:"traffic_control_enabled"`
+type ServiceResourcePccRuleConfigurationModel struct {
+	RuleName                 string                                        `tfschema:"name"`
+	RulePrecedence           int64                                         `tfschema:"precedence"`
+	RuleQosPolicy            []ServiceResourcePccRuleQosPolicyModel        `tfschema:"qos_policy"`
+	ServiceDataFlowTemplates []ServiceResourceServiceDataFlowTemplateModel `tfschema:"service_data_flow_template"`
+	TrafficControlEnabled    bool                                          `tfschema:"traffic_control_enabled"`
 }
 
-type PccRuleQosPolicyModel struct {
-	AllocationAndRetentionPriorityLevel int64          `tfschema:"allocation_and_retention_priority_level"`
-	QosIdentifier                       int64          `tfschema:"qos_indicator"`
-	GuaranteedBitRate                   []BitRateModel `tfschema:"guaranteed_bit_rate"`
-	MaximumBitRate                      []BitRateModel `tfschema:"maximum_bit_rate"`
-	PreemptionCapability                string         `tfschema:"preemption_capability"`
-	PreemptionVulnerability             string         `tfschema:"preemption_vulnerability"`
+type ServiceResourcePccRuleQosPolicyModel struct {
+	AllocationAndRetentionPriorityLevel int64                         `tfschema:"allocation_and_retention_priority_level"`
+	QosIdentifier                       int64                         `tfschema:"qos_indicator"`
+	GuaranteedBitRate                   []ServiceResourceBitRateModel `tfschema:"guaranteed_bit_rate"`
+	MaximumBitRate                      []ServiceResourceBitRateModel `tfschema:"maximum_bit_rate"`
+	PreemptionCapability                string                        `tfschema:"preemption_capability"`
+	PreemptionVulnerability             string                        `tfschema:"preemption_vulnerability"`
 }
 
-type BitRateModel struct {
+type ServiceResourceBitRateModel struct {
 	Downlink string `tfschema:"downlink"`
 	Uplink   string `tfschema:"uplink"`
 }
 
-type ServiceDataFlowTemplateModel struct {
+type ServiceResourceServiceDataFlowTemplateModel struct {
 	Direction    string   `tfschema:"direction"`
 	Ports        []string `tfschema:"ports"`
 	Protocol     []string `tfschema:"protocol"`
@@ -57,15 +59,13 @@ type ServiceDataFlowTemplateModel struct {
 	TemplateName string   `tfschema:"name"`
 }
 
-type QosPolicyModel struct {
-	AllocationAndRetentionPriorityLevel int64          `tfschema:"allocation_and_retention_priority_level"`
-	QosIdentifier                       int64          `tfschema:"qos_indicator"`
-	MaximumBitRate                      []BitRateModel `tfschema:"maximum_bit_rate"`
-	PreemptionCapability                string         `tfschema:"preemption_capability"`
-	PreemptionVulnerability             string         `tfschema:"preemption_vulnerability"`
+type ServiceResourceQosPolicyModel struct {
+	AllocationAndRetentionPriorityLevel int64                         `tfschema:"allocation_and_retention_priority_level"`
+	QosIdentifier                       int64                         `tfschema:"qos_indicator"`
+	MaximumBitRate                      []ServiceResourceBitRateModel `tfschema:"maximum_bit_rate"`
+	PreemptionCapability                string                        `tfschema:"preemption_capability"`
+	PreemptionVulnerability             string                        `tfschema:"preemption_vulnerability"`
 }
-
-type MobileNetworkServiceResource struct{}
 
 var _ sdk.ResourceWithUpdate = MobileNetworkServiceResource{}
 
@@ -74,7 +74,7 @@ func (r MobileNetworkServiceResource) ResourceType() string {
 }
 
 func (r MobileNetworkServiceResource) ModelObject() interface{} {
-	return &ServiceModel{}
+	return &ServiceResourceModel{}
 }
 
 func (r MobileNetworkServiceResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
@@ -346,7 +346,7 @@ func (r MobileNetworkServiceResource) Create() sdk.ResourceFunc {
 	return sdk.ResourceFunc{
 		Timeout: 180 * time.Minute,
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
-			var model ServiceModel
+			var model ServiceResourceModel
 			if err := metadata.Decode(&model); err != nil {
 				return fmt.Errorf("decoding: %+v", err)
 			}
@@ -371,8 +371,8 @@ func (r MobileNetworkServiceResource) Create() sdk.ResourceFunc {
 				Location: location.Normalize(model.Location),
 				Properties: service.ServicePropertiesFormat{
 					ServicePrecedence: model.ServicePrecedence,
-					PccRules:          expandPccRuleConfigurationModel(model.PccRules),
-					ServiceQosPolicy:  expandQosPolicyModel(model.ServiceQosPolicy),
+					PccRules:          expandPccRuleConfigurationResourceModel(model.PccRules),
+					ServiceQosPolicy:  expandQosPolicyResourceModel(model.ServiceQosPolicy),
 				},
 				Tags: &model.Tags,
 			}
@@ -398,7 +398,7 @@ func (r MobileNetworkServiceResource) Update() sdk.ResourceFunc {
 				return err
 			}
 
-			var model ServiceModel
+			var model ServiceResourceModel
 			if err := metadata.Decode(&model); err != nil {
 				return fmt.Errorf("decoding: %+v", err)
 			}
@@ -415,7 +415,7 @@ func (r MobileNetworkServiceResource) Update() sdk.ResourceFunc {
 			properties := *resp.Model
 
 			if metadata.ResourceData.HasChange("pcc_rule") {
-				properties.Properties.PccRules = expandPccRuleConfigurationModel(model.PccRules)
+				properties.Properties.PccRules = expandPccRuleConfigurationResourceModel(model.PccRules)
 			}
 
 			if metadata.ResourceData.HasChange("service_precedence") {
@@ -423,7 +423,7 @@ func (r MobileNetworkServiceResource) Update() sdk.ResourceFunc {
 			}
 
 			if metadata.ResourceData.HasChange("service_qos_policy") {
-				properties.Properties.ServiceQosPolicy = expandQosPolicyModel(model.ServiceQosPolicy)
+				properties.Properties.ServiceQosPolicy = expandQosPolicyResourceModel(model.ServiceQosPolicy)
 			}
 
 			if metadata.ResourceData.HasChange("tags") {
@@ -465,7 +465,7 @@ func (r MobileNetworkServiceResource) Read() sdk.ResourceFunc {
 
 			model := *resp.Model
 
-			state := ServiceModel{
+			state := ServiceResourceModel{
 				Name:                         id.ServiceName,
 				MobileNetworkMobileNetworkId: mobilenetwork.NewMobileNetworkID(id.SubscriptionId, id.ResourceGroupName, id.MobileNetworkName).ID(),
 				Location:                     location.Normalize(model.Location),
@@ -477,7 +477,7 @@ func (r MobileNetworkServiceResource) Read() sdk.ResourceFunc {
 
 			state.ServicePrecedence = properties.ServicePrecedence
 
-			state.ServiceQosPolicy = flattenQosPolicyModel(properties.ServiceQosPolicy)
+			state.ServiceQosPolicy = flattenQosPolicyResourceModel(properties.ServiceQosPolicy)
 
 			if model.Tags != nil {
 				state.Tags = *model.Tags
@@ -515,7 +515,7 @@ func (r MobileNetworkServiceResource) Delete() sdk.ResourceFunc {
 	}
 }
 
-func expandPccRuleConfigurationModel(inputList []PccRuleConfigurationModel) []service.PccRuleConfiguration {
+func expandPccRuleConfigurationResourceModel(inputList []ServiceResourcePccRuleConfigurationModel) []service.PccRuleConfiguration {
 	var outputList []service.PccRuleConfiguration
 	for _, v := range inputList {
 		input := v
@@ -530,9 +530,9 @@ func expandPccRuleConfigurationModel(inputList []PccRuleConfigurationModel) []se
 		}
 		output.TrafficControl = &trafficControlValue
 
-		output.RuleQosPolicy = expandPccRuleQosPolicyModel(input.RuleQosPolicy)
+		output.RuleQosPolicy = expandPccRuleQosPolicyResourceModel(input.RuleQosPolicy)
 
-		output.ServiceDataFlowTemplates = expandServiceDataFlowTemplateModel(input.ServiceDataFlowTemplates)
+		output.ServiceDataFlowTemplates = expandServiceDataFlowTemplateResourceModel(input.ServiceDataFlowTemplates)
 
 		outputList = append(outputList, output)
 	}
@@ -540,7 +540,7 @@ func expandPccRuleConfigurationModel(inputList []PccRuleConfigurationModel) []se
 	return outputList
 }
 
-func expandPccRuleQosPolicyModel(inputList []PccRuleQosPolicyModel) *service.PccRuleQosPolicy {
+func expandPccRuleQosPolicyResourceModel(inputList []ServiceResourcePccRuleQosPolicyModel) *service.PccRuleQosPolicy {
 	if len(inputList) == 0 {
 		return nil
 	}
@@ -555,16 +555,16 @@ func expandPccRuleQosPolicyModel(inputList []PccRuleQosPolicyModel) *service.Pcc
 		PreemptionVulnerability:             &vulnerability,
 	}
 
-	output.GuaranteedBitRate = expandBitRateModel(input.GuaranteedBitRate)
+	output.GuaranteedBitRate = expandBitRateResourceModel(input.GuaranteedBitRate)
 
-	if v := expandBitRateModel(input.MaximumBitRate); v != nil {
+	if v := expandBitRateResourceModel(input.MaximumBitRate); v != nil {
 		output.MaximumBitRate = *v
 	}
 
 	return &output
 }
 
-func expandServiceDataFlowTemplateModel(inputList []ServiceDataFlowTemplateModel) []service.ServiceDataFlowTemplate {
+func expandServiceDataFlowTemplateResourceModel(inputList []ServiceResourceServiceDataFlowTemplateModel) []service.ServiceDataFlowTemplate {
 	outputList := make([]service.ServiceDataFlowTemplate, 0)
 	for _, v := range inputList {
 		input := v
@@ -582,7 +582,7 @@ func expandServiceDataFlowTemplateModel(inputList []ServiceDataFlowTemplateModel
 	return outputList
 }
 
-func expandQosPolicyModel(inputList []QosPolicyModel) *service.QosPolicy {
+func expandQosPolicyResourceModel(inputList []ServiceResourceQosPolicyModel) *service.QosPolicy {
 	if len(inputList) == 0 {
 		return nil
 	}
@@ -597,25 +597,25 @@ func expandQosPolicyModel(inputList []QosPolicyModel) *service.QosPolicy {
 		PreemptionVulnerability:             &vulnerability,
 	}
 
-	if v := expandBitRateModel(input.MaximumBitRate); v != nil {
+	if v := expandBitRateResourceModel(input.MaximumBitRate); v != nil {
 		output.MaximumBitRate = *v
 	}
 
 	return &output
 }
 
-func flattenPccRuleConfigurationModel(inputList []service.PccRuleConfiguration) []PccRuleConfigurationModel {
-	var outputList []PccRuleConfigurationModel
+func flattenPccRuleConfigurationModel(inputList []service.PccRuleConfiguration) []ServiceResourcePccRuleConfigurationModel {
+	var outputList []ServiceResourcePccRuleConfigurationModel
 
 	for _, input := range inputList {
-		output := PccRuleConfigurationModel{
+		output := ServiceResourcePccRuleConfigurationModel{
 			RuleName:       input.RuleName,
 			RulePrecedence: input.RulePrecedence,
 		}
 
-		output.RuleQosPolicy = flattenPccRuleQosPolicyModel(input.RuleQosPolicy)
+		output.RuleQosPolicy = flattenPccRuleQosPolicyResourceModel(input.RuleQosPolicy)
 
-		output.ServiceDataFlowTemplates = flattenServiceDataFlowTemplateModel(&input.ServiceDataFlowTemplates)
+		output.ServiceDataFlowTemplates = flattenServiceDataFlowTemplateResourceModel(&input.ServiceDataFlowTemplates)
 
 		if input.TrafficControl != nil {
 			output.TrafficControlEnabled = *input.TrafficControl == service.TrafficControlPermissionEnabled
@@ -627,13 +627,12 @@ func flattenPccRuleConfigurationModel(inputList []service.PccRuleConfiguration) 
 	return outputList
 }
 
-func flattenPccRuleQosPolicyModel(input *service.PccRuleQosPolicy) []PccRuleQosPolicyModel {
-	var outputList []PccRuleQosPolicyModel
+func flattenPccRuleQosPolicyResourceModel(input *service.PccRuleQosPolicy) []ServiceResourcePccRuleQosPolicyModel {
 	if input == nil {
-		return outputList
+		return []ServiceResourcePccRuleQosPolicyModel{}
 	}
 
-	output := PccRuleQosPolicyModel{}
+	output := ServiceResourcePccRuleQosPolicyModel{}
 
 	if input.AllocationAndRetentionPriorityLevel != nil {
 		output.AllocationAndRetentionPriorityLevel = *input.AllocationAndRetentionPriorityLevel
@@ -643,9 +642,9 @@ func flattenPccRuleQosPolicyModel(input *service.PccRuleQosPolicy) []PccRuleQosP
 		output.QosIdentifier = *input.Fiveqi
 	}
 
-	output.GuaranteedBitRate = flattenBitRateModel(input.GuaranteedBitRate)
+	output.GuaranteedBitRate = flattenBitRateResourceModel(input.GuaranteedBitRate)
 
-	output.MaximumBitRate = flattenBitRateModel(&input.MaximumBitRate)
+	output.MaximumBitRate = flattenBitRateResourceModel(&input.MaximumBitRate)
 
 	if input.PreemptionCapability != nil {
 		output.PreemptionCapability = string(*input.PreemptionCapability)
@@ -655,17 +654,19 @@ func flattenPccRuleQosPolicyModel(input *service.PccRuleQosPolicy) []PccRuleQosP
 		output.PreemptionVulnerability = string(*input.PreemptionVulnerability)
 	}
 
-	return append(outputList, output)
+	return []ServiceResourcePccRuleQosPolicyModel{
+		output,
+	}
 }
 
-func flattenServiceDataFlowTemplateModel(inputList *[]service.ServiceDataFlowTemplate) []ServiceDataFlowTemplateModel {
-	var outputList []ServiceDataFlowTemplateModel
+func flattenServiceDataFlowTemplateResourceModel(inputList *[]service.ServiceDataFlowTemplate) []ServiceResourceServiceDataFlowTemplateModel {
+	var outputList []ServiceResourceServiceDataFlowTemplateModel
 	if inputList == nil {
 		return outputList
 	}
 
 	for _, input := range *inputList {
-		output := ServiceDataFlowTemplateModel{
+		output := ServiceResourceServiceDataFlowTemplateModel{
 			Direction:    string(input.Direction),
 			Protocol:     input.Protocol,
 			RemoteIPList: input.RemoteIPList,
@@ -682,13 +683,12 @@ func flattenServiceDataFlowTemplateModel(inputList *[]service.ServiceDataFlowTem
 	return outputList
 }
 
-func flattenQosPolicyModel(input *service.QosPolicy) []QosPolicyModel {
-	var outputList []QosPolicyModel
+func flattenQosPolicyResourceModel(input *service.QosPolicy) []ServiceResourceQosPolicyModel {
 	if input == nil {
-		return outputList
+		return []ServiceResourceQosPolicyModel{}
 	}
 
-	output := QosPolicyModel{}
+	output := ServiceResourceQosPolicyModel{}
 
 	if input.AllocationAndRetentionPriorityLevel != nil {
 		output.AllocationAndRetentionPriorityLevel = *input.AllocationAndRetentionPriorityLevel
@@ -698,7 +698,7 @@ func flattenQosPolicyModel(input *service.QosPolicy) []QosPolicyModel {
 		output.QosIdentifier = *input.Fiveqi
 	}
 
-	output.MaximumBitRate = flattenBitRateModel(&input.MaximumBitRate)
+	output.MaximumBitRate = flattenBitRateResourceModel(&input.MaximumBitRate)
 
 	if input.PreemptionCapability != nil {
 		output.PreemptionCapability = string(*input.PreemptionCapability)
@@ -708,11 +708,13 @@ func flattenQosPolicyModel(input *service.QosPolicy) []QosPolicyModel {
 		output.PreemptionVulnerability = string(*input.PreemptionVulnerability)
 	}
 
-	return append(outputList, output)
+	return []ServiceResourceQosPolicyModel{
+		output,
+	}
 }
 
 // make it return a pointer because some property accept nil value
-func expandBitRateModel(inputList []BitRateModel) *service.Ambr {
+func expandBitRateResourceModel(inputList []ServiceResourceBitRateModel) *service.Ambr {
 	if len(inputList) == 0 {
 		return nil
 	}
@@ -726,16 +728,15 @@ func expandBitRateModel(inputList []BitRateModel) *service.Ambr {
 	return &output
 }
 
-func flattenBitRateModel(input *service.Ambr) []BitRateModel {
-	var outputList []BitRateModel
+func flattenBitRateResourceModel(input *service.Ambr) []ServiceResourceBitRateModel {
 	if input == nil {
-		return outputList
+		return []ServiceResourceBitRateModel{}
 	}
 
-	output := BitRateModel{
-		Downlink: input.Downlink,
-		Uplink:   input.Uplink,
+	return []ServiceResourceBitRateModel{
+		{
+			Downlink: input.Downlink,
+			Uplink:   input.Uplink,
+		},
 	}
-
-	return append(outputList, output)
 }

--- a/internal/services/mobilenetwork/mobile_network_service_resource.go
+++ b/internal/services/mobilenetwork/mobile_network_service_resource.go
@@ -426,8 +426,6 @@ func (r MobileNetworkServiceResource) Update() sdk.ResourceFunc {
 				properties.Properties.ServiceQosPolicy = expandQosPolicyModel(model.ServiceQosPolicy)
 			}
 
-			properties.SystemData = nil
-
 			if metadata.ResourceData.HasChange("tags") {
 				properties.Tags = &model.Tags
 			}

--- a/internal/services/mobilenetwork/mobile_network_service_resource_test.go
+++ b/internal/services/mobilenetwork/mobile_network_service_resource_test.go
@@ -143,13 +143,18 @@ func (r MobileNetworkServiceResource) Exists(ctx context.Context, clients *clien
 }
 
 func (r MobileNetworkServiceResource) basic(data acceptance.TestData) string {
+	template := r.template(data)
 	return fmt.Sprintf(`
-				%s
+provider "azurerm" {
+  features {}
+}
+
+%s
 
 resource "azurerm_mobile_network_service" "test" {
   name               = "acctest-mns-%d"
   mobile_network_id  = azurerm_mobile_network.test.id
-  location           = "%s"
+  location           = azurerm_mobile_network.test.location
   service_precedence = 0
 
   pcc_rule {
@@ -163,15 +168,19 @@ resource "azurerm_mobile_network_service" "test" {
       protocol       = ["ip"]
       remote_ip_list = ["10.3.4.0/24"]
     }
-
   }
 }
-`, MobileNetworkResource{}.basic(data), data.RandomInteger, data.Locations.Primary)
+`, template, data.RandomInteger)
 }
 
 func (r MobileNetworkServiceResource) withQosPolicy(data acceptance.TestData) string {
+	template := r.template(data)
 	return fmt.Sprintf(`
-				%s
+provider "azurerm" {
+  features {}
+}
+
+%s
 
 resource "azurerm_mobile_network_service" "test" {
   name               = "acctest-mns-%d"
@@ -205,17 +214,22 @@ resource "azurerm_mobile_network_service" "test" {
     }
   }
 }
-`, MobileNetworkResource{}.basic(data), data.RandomInteger, data.Locations.Primary)
+`, template, data.RandomInteger, data.Locations.Primary)
 }
 
 func (r MobileNetworkServiceResource) withServiceQosPolicy(data acceptance.TestData) string {
+	template := r.template(data)
 	return fmt.Sprintf(`
-				%s
+provider "azurerm" {
+  features {}
+}
+
+%s
 
 resource "azurerm_mobile_network_service" "test" {
   name               = "acctest-mns-%d"
   mobile_network_id  = azurerm_mobile_network.test.id
-  location           = "%s"
+  location           = azurerm_mobile_network.test.location
   service_precedence = 0
 
   pcc_rule {
@@ -242,20 +256,19 @@ resource "azurerm_mobile_network_service" "test" {
       uplink   = "100 Mbps"
     }
   }
-
 }
-`, MobileNetworkResource{}.basic(data), data.RandomInteger, data.Locations.Primary)
+`, template, data.RandomInteger)
 }
 
 func (r MobileNetworkServiceResource) requiresImport(data acceptance.TestData) string {
 	config := r.basic(data)
 	return fmt.Sprintf(`
-			%s
+%s
 
 resource "azurerm_mobile_network_service" "import" {
   name               = azurerm_mobile_network_service.test.name
-  mobile_network_id  = azurerm_mobile_network.test.id
-  location           = "%s"
+  mobile_network_id  = azurerm_mobile_network_service.test.mobile_network_id
+  location           = azurerm_mobile_network_service.test.location
   service_precedence = 0
 
   pcc_rule {
@@ -272,17 +285,22 @@ resource "azurerm_mobile_network_service" "import" {
     }
   }
 }
-`, config, data.Locations.Primary)
+`, config)
 }
 
 func (r MobileNetworkServiceResource) complete(data acceptance.TestData) string {
+	template := r.template(data)
 	return fmt.Sprintf(`
-			%s
+provider "azurerm" {
+  features {}
+}
+
+%s
 
 resource "azurerm_mobile_network_service" "test" {
   name               = "acctest-mns-%d"
   mobile_network_id  = azurerm_mobile_network.test.id
-  location           = "%s"
+  location           = azurerm_mobile_network.test.location
   service_precedence = 0
   pcc_rule {
     name                    = "default-rule"
@@ -321,23 +339,29 @@ resource "azurerm_mobile_network_service" "test" {
       uplink   = "100 Mbps"
     }
   }
+
   tags = {
     key = "value"
   }
-
 }
-`, MobileNetworkResource{}.basic(data), data.RandomInteger, data.Locations.Primary)
+`, template, data.RandomInteger)
 }
 
 func (r MobileNetworkServiceResource) update(data acceptance.TestData) string {
+	template := r.template(data)
 	return fmt.Sprintf(`
-			%s
+provider "azurerm" {
+  features {}
+}
+
+%s
 
 resource "azurerm_mobile_network_service" "test" {
   name               = "acctest-mns-%d"
   mobile_network_id  = azurerm_mobile_network.test.id
-  location           = "%s"
+  location           = azurerm_mobile_network.test.location
   service_precedence = 0
+
   pcc_rule {
     name                    = "default-rule-2"
     precedence              = 1
@@ -381,5 +405,22 @@ resource "azurerm_mobile_network_service" "test" {
   }
 
 }
-`, MobileNetworkResource{}.basic(data), data.RandomInteger, data.Locations.Primary)
+`, template, data.RandomInteger)
+}
+
+func (r MobileNetworkServiceResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctest-mn-%[1]d"
+  location = %[2]q
+}
+
+resource "azurerm_mobile_network" "test" {
+  name                = "acctest-mn-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  mobile_country_code = "001"
+  mobile_network_code = "01"
+}
+`, data.RandomInteger, data.Locations.Primary)
 }

--- a/internal/services/mobilenetwork/mobile_network_sim_group_data_source_test.go
+++ b/internal/services/mobilenetwork/mobile_network_sim_group_data_source_test.go
@@ -31,7 +31,7 @@ func TestAccMobileNetworkSimGroupDataSource_complete(t *testing.T) {
 
 func (r MobileNetworkSimGroupDataSource) complete(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-	%s
+%s
 
 data "azurerm_mobile_network_sim_group" "test" {
   name              = azurerm_mobile_network_sim_group.test.name

--- a/internal/services/mobilenetwork/mobile_network_sim_group_resource.go
+++ b/internal/services/mobilenetwork/mobile_network_sim_group_resource.go
@@ -181,8 +181,6 @@ func (r SimGroupResource) Update() sdk.ResourceFunc {
 				}
 			}
 
-			properties.SystemData = nil
-
 			if metadata.ResourceData.HasChange("tags") {
 				properties.Tags = &model.Tags
 			}

--- a/internal/services/mobilenetwork/mobile_network_sim_group_resource_test.go
+++ b/internal/services/mobilenetwork/mobile_network_sim_group_resource_test.go
@@ -126,19 +126,30 @@ func (r MobileNetworkSimGroupResource) Exists(ctx context.Context, clients *clie
 }
 
 func (r MobileNetworkSimGroupResource) basic(data acceptance.TestData) string {
+	template := r.template(data)
 	return fmt.Sprintf(`
-				%s
+provider "azurerm" {
+  features {}
+}
+
+%s
+
 resource "azurerm_mobile_network_sim_group" "test" {
   name              = "acctest-mnsg-%d"
   location          = azurerm_resource_group.test.location
   mobile_network_id = azurerm_mobile_network.test.id
 }
-`, MobileNetworkResource{}.basic(data), data.RandomInteger)
+`, template, data.RandomInteger)
 }
 
 func (r MobileNetworkSimGroupResource) withEncryptionKeyUrl(data acceptance.TestData) string {
+	template := r.template(data)
 	return fmt.Sprintf(`
-			%s
+provider "azurerm" {
+  features {}
+}
+
+%s
 
 data "azurerm_client_config" "test" {}
 
@@ -191,25 +202,31 @@ resource "azurerm_mobile_network_sim_group" "test" {
     identity_ids = [azurerm_user_assigned_identity.test.id]
   }
 }
-`, MobileNetworkResource{}.basic(data), data.RandomInteger, data.Locations.Primary)
+`, template, data.RandomInteger, data.Locations.Primary)
 }
 
 func (r MobileNetworkSimGroupResource) requiresImport(data acceptance.TestData) string {
+	template := r.basic(data)
 	return fmt.Sprintf(`
-			%s
+%s
 
 resource "azurerm_mobile_network_sim_group" "import" {
   name              = azurerm_mobile_network_sim_group.test.name
-  location          = "%s"
+  location          = azurerm_mobile_network_sim_group.test.location
   mobile_network_id = azurerm_mobile_network_sim_group.test.mobile_network_id
 
 }
-`, r.basic(data), data.Locations.Primary)
+`, template)
 }
 
 func (r MobileNetworkSimGroupResource) complete(data acceptance.TestData) string {
+	template := r.template(data)
 	return fmt.Sprintf(`
-			%[1]s
+provider "azurerm" {
+  features {}
+}
+
+%s
 
 data "azurerm_client_config" "test" {}
 
@@ -254,7 +271,7 @@ resource "azurerm_user_assigned_identity" "test" {
 
 resource "azurerm_mobile_network_sim_group" "test" {
   name               = "acctest-mnsg-%[2]d"
-  location           = "%[3]s"
+  location           = azurerm_mobile_network.test.location
   mobile_network_id  = azurerm_mobile_network.test.id
   encryption_key_url = azurerm_key_vault_key.test.versionless_id
 
@@ -267,12 +284,17 @@ resource "azurerm_mobile_network_sim_group" "test" {
     key = "value"
   }
 }
-`, MobileNetworkResource{}.basic(data), data.RandomInteger, data.Locations.Primary)
+`, template, data.RandomInteger)
 }
 
 func (r MobileNetworkSimGroupResource) update(data acceptance.TestData) string {
+	template := r.template(data)
 	return fmt.Sprintf(`
-			%s
+provider "azurerm" {
+  features {}
+}
+
+%s
 
 data "azurerm_client_config" "test" {}
 
@@ -317,7 +339,7 @@ resource "azurerm_key_vault_key" "test" {
 
 resource "azurerm_mobile_network_sim_group" "test" {
   name               = "acctest-mnsg-%[2]d"
-  location           = "%[3]s"
+  location           = azurerm_mobile_network.test.location
   mobile_network_id  = azurerm_mobile_network.test.id
   encryption_key_url = azurerm_key_vault_key.test.versionless_id
 
@@ -329,7 +351,23 @@ resource "azurerm_mobile_network_sim_group" "test" {
   tags = {
     key = "updated"
   }
-
 }
-`, MobileNetworkResource{}.basic(data), data.RandomInteger, data.Locations.Primary)
+`, template, data.RandomInteger)
+}
+
+func (r MobileNetworkSimGroupResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctest-mn-%[1]d"
+  location = %[2]q
+}
+
+resource "azurerm_mobile_network" "test" {
+  name                = "acctest-mn-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  mobile_country_code = "001"
+  mobile_network_code = "01"
+}
+`, data.RandomInteger, data.Locations.Primary)
 }

--- a/internal/services/mobilenetwork/mobile_network_sim_policy_data_source.go
+++ b/internal/services/mobilenetwork/mobile_network_sim_policy_data_source.go
@@ -18,15 +18,15 @@ import (
 type SimPolicyDataSource struct{}
 
 type SimPolicyDataSourceModel struct {
-	Name                         string                              `tfschema:"name"`
-	MobileNetworkMobileNetworkId string                              `tfschema:"mobile_network_id"`
-	DefaultSliceId               string                              `tfschema:"default_slice_id"`
-	Location                     string                              `tfschema:"location"`
-	RegistrationTimer            int64                               `tfschema:"registration_timer_in_seconds"`
-	RfspIndex                    int64                               `tfschema:"rat_frequency_selection_priority_index"`
-	SliceConfigurations          []SliceConfigurationDataSourceModel `tfschema:"slice"`
-	Tags                         map[string]string                   `tfschema:"tags"`
-	UeAmbr                       []AmbrDataSourceModel               `tfschema:"user_equipment_aggregate_maximum_bit_rate"`
+	Name                string                              `tfschema:"name"`
+	MobileNetworkId     string                              `tfschema:"mobile_network_id"`
+	DefaultSliceId      string                              `tfschema:"default_slice_id"`
+	Location            string                              `tfschema:"location"`
+	RegistrationTimer   int64                               `tfschema:"registration_timer_in_seconds"`
+	RfspIndex           int64                               `tfschema:"rat_frequency_selection_priority_index"`
+	SliceConfigurations []SliceConfigurationDataSourceModel `tfschema:"slice"`
+	Tags                map[string]string                   `tfschema:"tags"`
+	UeAmbr              []AmbrDataSourceModel               `tfschema:"user_equipment_aggregate_maximum_bit_rate"`
 }
 
 type SliceConfigurationDataSourceModel struct {
@@ -230,7 +230,7 @@ func (r SimPolicyDataSource) Read() sdk.ResourceFunc {
 			}
 
 			client := metadata.Client.MobileNetwork.SIMPolicyClient
-			mobileNetworkId, err := mobilenetwork.ParseMobileNetworkID(metaModel.MobileNetworkMobileNetworkId)
+			mobileNetworkId, err := mobilenetwork.ParseMobileNetworkID(metaModel.MobileNetworkId)
 			if err != nil {
 				return err
 			}
@@ -247,8 +247,8 @@ func (r SimPolicyDataSource) Read() sdk.ResourceFunc {
 			}
 
 			state := SimPolicyDataSourceModel{
-				Name:                         id.SimPolicyName,
-				MobileNetworkMobileNetworkId: mobilenetwork.NewMobileNetworkID(id.SubscriptionId, id.ResourceGroupName, id.MobileNetworkName).ID(),
+				Name:            id.SimPolicyName,
+				MobileNetworkId: mobilenetwork.NewMobileNetworkID(id.SubscriptionId, id.ResourceGroupName, id.MobileNetworkName).ID(),
 			}
 
 			if model := resp.Model; model != nil {

--- a/internal/services/mobilenetwork/mobile_network_sim_policy_data_source.go
+++ b/internal/services/mobilenetwork/mobile_network_sim_policy_data_source.go
@@ -17,6 +17,42 @@ import (
 
 type SimPolicyDataSource struct{}
 
+type SimPolicyDataSourceModel struct {
+	Name                         string                              `tfschema:"name"`
+	MobileNetworkMobileNetworkId string                              `tfschema:"mobile_network_id"`
+	DefaultSliceId               string                              `tfschema:"default_slice_id"`
+	Location                     string                              `tfschema:"location"`
+	RegistrationTimer            int64                               `tfschema:"registration_timer_in_seconds"`
+	RfspIndex                    int64                               `tfschema:"rat_frequency_selection_priority_index"`
+	SliceConfigurations          []SliceConfigurationDataSourceModel `tfschema:"slice"`
+	Tags                         map[string]string                   `tfschema:"tags"`
+	UeAmbr                       []AmbrDataSourceModel               `tfschema:"user_equipment_aggregate_maximum_bit_rate"`
+}
+
+type SliceConfigurationDataSourceModel struct {
+	DataNetworkConfigurations []DataNetworkConfigurationDataSourceModel `tfschema:"data_network"`
+	DefaultDataNetworkId      string                                    `tfschema:"default_data_network_id"`
+	SliceId                   string                                    `tfschema:"slice_id"`
+}
+
+type DataNetworkConfigurationDataSourceModel struct {
+	AdditionalAllowedSessionTypes       []string              `tfschema:"additional_allowed_session_types"`
+	AllocationAndRetentionPriorityLevel int64                 `tfschema:"allocation_and_retention_priority_level"`
+	AllowedServices                     []string              `tfschema:"allowed_services_ids"`
+	DataNetworkId                       string                `tfschema:"data_network_id"`
+	DefaultSessionType                  string                `tfschema:"default_session_type"`
+	QosIdentifier                       int64                 `tfschema:"qos_indicator"`
+	MaximumNumberOfBufferedPackets      int64                 `tfschema:"max_buffered_packets"`
+	PreemptionCapability                string                `tfschema:"preemption_capability"`
+	PreemptionVulnerability             string                `tfschema:"preemption_vulnerability"`
+	SessionAmbr                         []AmbrDataSourceModel `tfschema:"session_aggregate_maximum_bit_rate"`
+}
+
+type AmbrDataSourceModel struct {
+	Downlink string `tfschema:"downlink"`
+	Uplink   string `tfschema:"uplink"`
+}
+
 var _ sdk.DataSource = SimPolicyDataSource{}
 
 func (r SimPolicyDataSource) ResourceType() string {
@@ -24,7 +60,7 @@ func (r SimPolicyDataSource) ResourceType() string {
 }
 
 func (r SimPolicyDataSource) ModelObject() interface{} {
-	return &SimPolicyModel{}
+	return &SimPolicyDataSourceModel{}
 }
 
 func (r SimPolicyDataSource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
@@ -188,7 +224,7 @@ func (r SimPolicyDataSource) Read() sdk.ResourceFunc {
 	return sdk.ResourceFunc{
 		Timeout: 5 * time.Minute,
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
-			var metaModel SimPolicyModel
+			var metaModel SimPolicyDataSourceModel
 			if err := metadata.Decode(&metaModel); err != nil {
 				return fmt.Errorf("decoding: %+v", err)
 			}
@@ -210,7 +246,7 @@ func (r SimPolicyDataSource) Read() sdk.ResourceFunc {
 				return fmt.Errorf("retrieving %s: %+v", id, err)
 			}
 
-			state := SimPolicyModel{
+			state := SimPolicyDataSourceModel{
 				Name:                         id.SimPolicyName,
 				MobileNetworkMobileNetworkId: mobilenetwork.NewMobileNetworkID(id.SubscriptionId, id.ResourceGroupName, id.MobileNetworkName).ID(),
 			}
@@ -228,9 +264,8 @@ func (r SimPolicyDataSource) Read() sdk.ResourceFunc {
 					state.RfspIndex = *model.Properties.RfspIndex
 				}
 
-				state.SliceConfigurations = flattenSliceConfigurationModel(model.Properties.SliceConfigurations)
-
-				state.UeAmbr = flattenSimPolicyAmbrModel(model.Properties.UeAmbr)
+				state.SliceConfigurations = flattenSliceConfigurationDataSourceModel(model.Properties.SliceConfigurations)
+				state.UeAmbr = flattenSimPolicyAmbrDataSourceModel(model.Properties.UeAmbr)
 
 				if model.Tags != nil {
 					state.Tags = *model.Tags
@@ -241,6 +276,94 @@ func (r SimPolicyDataSource) Read() sdk.ResourceFunc {
 			metadata.SetID(id)
 
 			return metadata.Encode(&state)
+		},
+	}
+}
+
+func flattenSliceConfigurationDataSourceModel(input []simpolicy.SliceConfiguration) []SliceConfigurationDataSourceModel {
+	output := make([]SliceConfigurationDataSourceModel, 0)
+
+	for _, v := range input {
+		output = append(output, SliceConfigurationDataSourceModel{
+			DataNetworkConfigurations: flattenDataNetworkConfigurationDataSourceModel(v.DataNetworkConfigurations),
+			DefaultDataNetworkId:      v.DefaultDataNetwork.Id,
+			SliceId:                   v.Slice.Id,
+		})
+	}
+
+	return output
+}
+
+func flattenDataNetworkConfigurationDataSourceModel(inputList []simpolicy.DataNetworkConfiguration) []DataNetworkConfigurationDataSourceModel {
+	output := make([]DataNetworkConfigurationDataSourceModel, 0)
+
+	for _, input := range inputList {
+		item := DataNetworkConfigurationDataSourceModel{
+			DataNetworkId: input.DataNetwork.Id,
+		}
+
+		item.AdditionalAllowedSessionTypes = flattenSimPolicyAllowedSessionTypeDataSource(input.AdditionalAllowedSessionTypes)
+
+		if input.AllocationAndRetentionPriorityLevel != nil {
+			item.AllocationAndRetentionPriorityLevel = *input.AllocationAndRetentionPriorityLevel
+		}
+
+		item.AllowedServices = flattenServiceResourceIdDataSourceModel(input.AllowedServices)
+
+		if input.DefaultSessionType != nil {
+			item.DefaultSessionType = string(*input.DefaultSessionType)
+		}
+
+		if input.Fiveqi != nil {
+			item.QosIdentifier = *input.Fiveqi
+		}
+
+		if input.MaximumNumberOfBufferedPackets != nil {
+			item.MaximumNumberOfBufferedPackets = *input.MaximumNumberOfBufferedPackets
+		}
+
+		if input.PreemptionCapability != nil {
+			item.PreemptionCapability = string(*input.PreemptionCapability)
+		}
+
+		if input.PreemptionVulnerability != nil {
+			item.PreemptionVulnerability = string(*input.PreemptionVulnerability)
+		}
+
+		item.SessionAmbr = flattenSimPolicyAmbrDataSourceModel(input.SessionAmbr)
+
+		output = append(output, item)
+	}
+
+	return output
+}
+
+func flattenSimPolicyAllowedSessionTypeDataSource(input *[]simpolicy.PduSessionType) []string {
+	output := make([]string, 0)
+	if input == nil {
+		return output
+	}
+	for _, v := range *input {
+		output = append(output, string(v))
+	}
+	return output
+}
+
+func flattenServiceResourceIdDataSourceModel(input []simpolicy.ServiceResourceId) []string {
+	output := make([]string, 0)
+
+	for _, v := range input {
+		output = append(output, v.Id)
+	}
+
+	return output
+}
+
+func flattenSimPolicyAmbrDataSourceModel(input simpolicy.Ambr) []AmbrDataSourceModel {
+	return []AmbrDataSourceModel{
+		{
+			Downlink: input.Downlink,
+			Uplink:   input.Uplink,
 		},
 	}
 }

--- a/internal/services/mobilenetwork/mobile_network_sim_policy_data_source_test.go
+++ b/internal/services/mobilenetwork/mobile_network_sim_policy_data_source_test.go
@@ -46,7 +46,7 @@ func TestAccMobileNetworkSimPolicyDataSource_complete(t *testing.T) {
 
 func (r MobileNetworkSimPolicyDataSource) complete(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-	%s
+%s
 
 data "azurerm_mobile_network_sim_policy" "test" {
   name              = azurerm_mobile_network_sim_policy.test.name

--- a/internal/services/mobilenetwork/mobile_network_sim_policy_resource.go
+++ b/internal/services/mobilenetwork/mobile_network_sim_policy_resource.go
@@ -20,43 +20,43 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 )
 
-type SimPolicyModel struct {
-	Name                         string                    `tfschema:"name"`
-	MobileNetworkMobileNetworkId string                    `tfschema:"mobile_network_id"`
-	DefaultSliceId               string                    `tfschema:"default_slice_id"`
-	Location                     string                    `tfschema:"location"`
-	RegistrationTimer            int64                     `tfschema:"registration_timer_in_seconds"`
-	RfspIndex                    int64                     `tfschema:"rat_frequency_selection_priority_index"`
-	SliceConfigurations          []SliceConfigurationModel `tfschema:"slice"`
-	Tags                         map[string]string         `tfschema:"tags"`
-	UeAmbr                       []AmbrModel               `tfschema:"user_equipment_aggregate_maximum_bit_rate"`
+type SimPolicyResource struct{}
+
+type SimPolicyResourceModel struct {
+	Name                         string                            `tfschema:"name"`
+	MobileNetworkMobileNetworkId string                            `tfschema:"mobile_network_id"`
+	DefaultSliceId               string                            `tfschema:"default_slice_id"`
+	Location                     string                            `tfschema:"location"`
+	RegistrationTimer            int64                             `tfschema:"registration_timer_in_seconds"`
+	RfspIndex                    int64                             `tfschema:"rat_frequency_selection_priority_index"`
+	SliceConfigurations          []SliceConfigurationResourceModel `tfschema:"slice"`
+	Tags                         map[string]string                 `tfschema:"tags"`
+	UeAmbr                       []AmbrResourceModel               `tfschema:"user_equipment_aggregate_maximum_bit_rate"`
 }
 
-type SliceConfigurationModel struct {
-	DataNetworkConfigurations []DataNetworkConfigurationModel `tfschema:"data_network"`
-	DefaultDataNetworkId      string                          `tfschema:"default_data_network_id"`
-	SliceId                   string                          `tfschema:"slice_id"`
+type SliceConfigurationResourceModel struct {
+	DataNetworkConfigurations []DataNetworkConfigurationResourceModel `tfschema:"data_network"`
+	DefaultDataNetworkId      string                                  `tfschema:"default_data_network_id"`
+	SliceId                   string                                  `tfschema:"slice_id"`
 }
 
-type DataNetworkConfigurationModel struct {
-	AdditionalAllowedSessionTypes       []string    `tfschema:"additional_allowed_session_types"`
-	AllocationAndRetentionPriorityLevel int64       `tfschema:"allocation_and_retention_priority_level"`
-	AllowedServices                     []string    `tfschema:"allowed_services_ids"`
-	DataNetworkId                       string      `tfschema:"data_network_id"`
-	DefaultSessionType                  string      `tfschema:"default_session_type"`
-	QosIdentifier                       int64       `tfschema:"qos_indicator"`
-	MaximumNumberOfBufferedPackets      int64       `tfschema:"max_buffered_packets"`
-	PreemptionCapability                string      `tfschema:"preemption_capability"`
-	PreemptionVulnerability             string      `tfschema:"preemption_vulnerability"`
-	SessionAmbr                         []AmbrModel `tfschema:"session_aggregate_maximum_bit_rate"`
+type DataNetworkConfigurationResourceModel struct {
+	AdditionalAllowedSessionTypes       []string            `tfschema:"additional_allowed_session_types"`
+	AllocationAndRetentionPriorityLevel int64               `tfschema:"allocation_and_retention_priority_level"`
+	AllowedServices                     []string            `tfschema:"allowed_services_ids"`
+	DataNetworkId                       string              `tfschema:"data_network_id"`
+	DefaultSessionType                  string              `tfschema:"default_session_type"`
+	QosIdentifier                       int64               `tfschema:"qos_indicator"`
+	MaximumNumberOfBufferedPackets      int64               `tfschema:"max_buffered_packets"`
+	PreemptionCapability                string              `tfschema:"preemption_capability"`
+	PreemptionVulnerability             string              `tfschema:"preemption_vulnerability"`
+	SessionAmbr                         []AmbrResourceModel `tfschema:"session_aggregate_maximum_bit_rate"`
 }
 
-type AmbrModel struct {
+type AmbrResourceModel struct {
 	Downlink string `tfschema:"downlink"`
 	Uplink   string `tfschema:"uplink"`
 }
-
-type SimPolicyResource struct{}
 
 var _ sdk.ResourceWithUpdate = SimPolicyResource{}
 
@@ -65,7 +65,7 @@ func (r SimPolicyResource) ResourceType() string {
 }
 
 func (r SimPolicyResource) ModelObject() interface{} {
-	return &SimPolicyModel{}
+	return &SimPolicyResourceModel{}
 }
 
 func (r SimPolicyResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
@@ -280,7 +280,7 @@ func (r SimPolicyResource) Create() sdk.ResourceFunc {
 	return sdk.ResourceFunc{
 		Timeout: 180 * time.Minute,
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
-			var model SimPolicyModel
+			var model SimPolicyResourceModel
 			if err := metadata.Decode(&model); err != nil {
 				return fmt.Errorf("decoding: %+v", err)
 			}
@@ -316,9 +316,9 @@ func (r SimPolicyResource) Create() sdk.ResourceFunc {
 				properties.Properties.RfspIndex = &model.RfspIndex
 			}
 
-			properties.Properties.SliceConfigurations = expandSliceConfigurationModel(model.SliceConfigurations)
+			properties.Properties.SliceConfigurations = expandSliceConfigurationResourceModel(model.SliceConfigurations)
 
-			properties.Properties.UeAmbr = expandAmbrModel(model.UeAmbr)
+			properties.Properties.UeAmbr = expandAmbrResourceModel(model.UeAmbr)
 
 			if err := client.SimPoliciesCreateOrUpdateThenPoll(ctx, id, properties); err != nil {
 				return fmt.Errorf("creating %s: %+v", id, err)
@@ -342,7 +342,7 @@ func (r SimPolicyResource) Update() sdk.ResourceFunc {
 				return err
 			}
 
-			var plan SimPolicyModel
+			var plan SimPolicyResourceModel
 			if err := metadata.Decode(&plan); err != nil {
 				return fmt.Errorf("decoding: %+v", err)
 			}
@@ -372,11 +372,11 @@ func (r SimPolicyResource) Update() sdk.ResourceFunc {
 			}
 
 			if metadata.ResourceData.HasChange("slice") {
-				model.Properties.SliceConfigurations = expandSliceConfigurationModel(plan.SliceConfigurations)
+				model.Properties.SliceConfigurations = expandSliceConfigurationResourceModel(plan.SliceConfigurations)
 			}
 
 			if metadata.ResourceData.HasChange("user_equipment_aggregate_maximum_bit_rate") {
-				model.Properties.UeAmbr = expandAmbrModel(plan.UeAmbr)
+				model.Properties.UeAmbr = expandAmbrResourceModel(plan.UeAmbr)
 			}
 
 			if metadata.ResourceData.HasChange("tags") {
@@ -412,7 +412,7 @@ func (r SimPolicyResource) Read() sdk.ResourceFunc {
 				return fmt.Errorf("retrieving %s: %+v", *id, err)
 			}
 
-			state := SimPolicyModel{
+			state := SimPolicyResourceModel{
 				Name:                         id.SimPolicyName,
 				MobileNetworkMobileNetworkId: mobilenetwork.NewMobileNetworkID(id.SubscriptionId, id.ResourceGroupName, id.MobileNetworkName).ID(),
 			}
@@ -430,9 +430,8 @@ func (r SimPolicyResource) Read() sdk.ResourceFunc {
 					state.RfspIndex = *model.Properties.RfspIndex
 				}
 
-				state.SliceConfigurations = flattenSliceConfigurationModel(model.Properties.SliceConfigurations)
-
-				state.UeAmbr = flattenSimPolicyAmbrModel(model.Properties.UeAmbr)
+				state.SliceConfigurations = flattenSliceConfigurationResourceModel(model.Properties.SliceConfigurations)
+				state.UeAmbr = flattenSimPolicyAmbrResourceModel(model.Properties.UeAmbr)
 
 				if model.Tags != nil {
 					state.Tags = *model.Tags
@@ -471,15 +470,17 @@ func (r SimPolicyResource) Delete() sdk.ResourceFunc {
 	}
 }
 
-func expandSliceConfigurationModel(inputList []SliceConfigurationModel) []simpolicy.SliceConfiguration {
+func expandSliceConfigurationResourceModel(inputList []SliceConfigurationResourceModel) []simpolicy.SliceConfiguration {
 	var outputList []simpolicy.SliceConfiguration
 	for _, v := range inputList {
 		input := v
 		output := simpolicy.SliceConfiguration{
-			Slice: simpolicy.SliceResourceId{Id: input.SliceId},
+			Slice: simpolicy.SliceResourceId{
+				Id: input.SliceId,
+			},
 		}
 
-		output.DataNetworkConfigurations = expandDataNetworkConfigurationModel(input.DataNetworkConfigurations)
+		output.DataNetworkConfigurations = expandDataNetworkConfigurationResourceModel(input.DataNetworkConfigurations)
 
 		if input.DefaultDataNetworkId != "" {
 			output.DefaultDataNetwork = simpolicy.DataNetworkResourceId{
@@ -493,7 +494,7 @@ func expandSliceConfigurationModel(inputList []SliceConfigurationModel) []simpol
 	return outputList
 }
 
-func expandDataNetworkConfigurationModel(inputList []DataNetworkConfigurationModel) []simpolicy.DataNetworkConfiguration {
+func expandDataNetworkConfigurationResourceModel(inputList []DataNetworkConfigurationResourceModel) []simpolicy.DataNetworkConfiguration {
 	var outputList []simpolicy.DataNetworkConfiguration
 	for _, v := range inputList {
 		input := v
@@ -502,14 +503,14 @@ func expandDataNetworkConfigurationModel(inputList []DataNetworkConfigurationMod
 		preemptionCapability := simpolicy.PreemptionCapability(input.PreemptionCapability)
 		preemptionVulnerability := simpolicy.PreemptionVulnerability(input.PreemptionVulnerability)
 		output := simpolicy.DataNetworkConfiguration{
-			AdditionalAllowedSessionTypes:       expandSimPolicyAdditionalAllowedSessionType(input.AdditionalAllowedSessionTypes),
+			AdditionalAllowedSessionTypes:       expandSimPolicyAdditionalAllowedSessionTypeResource(input.AdditionalAllowedSessionTypes),
 			AllocationAndRetentionPriorityLevel: &input.AllocationAndRetentionPriorityLevel,
 			DefaultSessionType:                  &defaultSessionType,
 			Fiveqi:                              &input.QosIdentifier,
 			PreemptionCapability:                &preemptionCapability,
 			PreemptionVulnerability:             &preemptionVulnerability,
 			MaximumNumberOfBufferedPackets:      &input.MaximumNumberOfBufferedPackets,
-			AllowedServices:                     expandServiceResourceIdModel(input.AllowedServices),
+			AllowedServices:                     expandServiceResourceIdResourceModel(input.AllowedServices),
 		}
 
 		if input.DataNetworkId != "" {
@@ -518,7 +519,7 @@ func expandDataNetworkConfigurationModel(inputList []DataNetworkConfigurationMod
 			}
 		}
 
-		output.SessionAmbr = expandAmbrModel(input.SessionAmbr)
+		output.SessionAmbr = expandAmbrResourceModel(input.SessionAmbr)
 
 		outputList = append(outputList, output)
 	}
@@ -526,7 +527,7 @@ func expandDataNetworkConfigurationModel(inputList []DataNetworkConfigurationMod
 	return outputList
 }
 
-func expandSimPolicyAdditionalAllowedSessionType(inputList []string) *[]simpolicy.PduSessionType {
+func expandSimPolicyAdditionalAllowedSessionTypeResource(inputList []string) *[]simpolicy.PduSessionType {
 	var outputList []simpolicy.PduSessionType
 	for _, v := range inputList {
 		outputList = append(outputList, simpolicy.PduSessionType(v))
@@ -535,7 +536,7 @@ func expandSimPolicyAdditionalAllowedSessionType(inputList []string) *[]simpolic
 	return &outputList
 }
 
-func expandServiceResourceIdModel(inputList []string) []simpolicy.ServiceResourceId {
+func expandServiceResourceIdResourceModel(inputList []string) []simpolicy.ServiceResourceId {
 	var outputList []simpolicy.ServiceResourceId
 	for _, v := range inputList {
 		input := v
@@ -549,85 +550,82 @@ func expandServiceResourceIdModel(inputList []string) []simpolicy.ServiceResourc
 	return outputList
 }
 
-func expandAmbrModel(inputList []AmbrModel) simpolicy.Ambr {
+func expandAmbrResourceModel(inputList []AmbrResourceModel) simpolicy.Ambr {
 	output := simpolicy.Ambr{}
 
 	if len(inputList) == 0 {
 		return output
 	}
 
-	input := &inputList[0]
+	input := inputList[0]
 	output.Downlink = input.Downlink
 	output.Uplink = input.Uplink
 
 	return output
 }
 
-func flattenSliceConfigurationModel(inputList []simpolicy.SliceConfiguration) []SliceConfigurationModel {
-	var outputList []SliceConfigurationModel
+func flattenSliceConfigurationResourceModel(input []simpolicy.SliceConfiguration) []SliceConfigurationResourceModel {
+	output := make([]SliceConfigurationResourceModel, 0)
 
-	for _, input := range inputList {
-		output := SliceConfigurationModel{
-			SliceId:              input.Slice.Id,
-			DefaultDataNetworkId: input.DefaultDataNetwork.Id,
+	for _, v := range input {
+		item := SliceConfigurationResourceModel{
+			SliceId:              v.Slice.Id,
+			DefaultDataNetworkId: v.DefaultDataNetwork.Id,
 		}
 
-		output.DataNetworkConfigurations = flattenDataNetworkConfigurationModel(&input.DataNetworkConfigurations)
+		item.DataNetworkConfigurations = flattenDataNetworkConfigurationResourceModel(v.DataNetworkConfigurations)
 
-		outputList = append(outputList, output)
+		output = append(output, item)
 	}
 
-	return outputList
+	return output
 }
 
-func flattenDataNetworkConfigurationModel(inputList *[]simpolicy.DataNetworkConfiguration) []DataNetworkConfigurationModel {
-	var outputList []DataNetworkConfigurationModel
-	if inputList == nil {
-		return outputList
+func flattenDataNetworkConfigurationResourceModel(input []simpolicy.DataNetworkConfiguration) []DataNetworkConfigurationResourceModel {
+	output := make([]DataNetworkConfigurationResourceModel, 0)
+
+	for _, v := range input {
+		item := DataNetworkConfigurationResourceModel{
+			DataNetworkId: v.DataNetwork.Id,
+		}
+
+		item.AdditionalAllowedSessionTypes = flattenSimPolicyAllowedSessionTypeResource(v.AdditionalAllowedSessionTypes)
+
+		if v.AllocationAndRetentionPriorityLevel != nil {
+			item.AllocationAndRetentionPriorityLevel = *v.AllocationAndRetentionPriorityLevel
+		}
+
+		item.AllowedServices = flattenServiceResourceIdResourceModel(v.AllowedServices)
+
+		if v.DefaultSessionType != nil {
+			item.DefaultSessionType = string(*v.DefaultSessionType)
+		}
+
+		if v.Fiveqi != nil {
+			item.QosIdentifier = *v.Fiveqi
+		}
+
+		if v.MaximumNumberOfBufferedPackets != nil {
+			item.MaximumNumberOfBufferedPackets = *v.MaximumNumberOfBufferedPackets
+		}
+
+		if v.PreemptionCapability != nil {
+			item.PreemptionCapability = string(*v.PreemptionCapability)
+		}
+
+		if v.PreemptionVulnerability != nil {
+			item.PreemptionVulnerability = string(*v.PreemptionVulnerability)
+		}
+
+		item.SessionAmbr = flattenSimPolicyAmbrResourceModel(v.SessionAmbr)
+
+		output = append(output, item)
 	}
 
-	for _, input := range *inputList {
-		output := DataNetworkConfigurationModel{
-			DataNetworkId: input.DataNetwork.Id,
-		}
-
-		output.AdditionalAllowedSessionTypes = flattenSimPolicyAllowedSessionType(input.AdditionalAllowedSessionTypes)
-
-		if input.AllocationAndRetentionPriorityLevel != nil {
-			output.AllocationAndRetentionPriorityLevel = *input.AllocationAndRetentionPriorityLevel
-		}
-
-		output.AllowedServices = flattenServiceResourceIdModel(&input.AllowedServices)
-
-		if input.DefaultSessionType != nil {
-			output.DefaultSessionType = string(*input.DefaultSessionType)
-		}
-
-		if input.Fiveqi != nil {
-			output.QosIdentifier = *input.Fiveqi
-		}
-
-		if input.MaximumNumberOfBufferedPackets != nil {
-			output.MaximumNumberOfBufferedPackets = *input.MaximumNumberOfBufferedPackets
-		}
-
-		if input.PreemptionCapability != nil {
-			output.PreemptionCapability = string(*input.PreemptionCapability)
-		}
-
-		if input.PreemptionVulnerability != nil {
-			output.PreemptionVulnerability = string(*input.PreemptionVulnerability)
-		}
-
-		output.SessionAmbr = flattenSimPolicyAmbrModel(input.SessionAmbr)
-
-		outputList = append(outputList, output)
-	}
-
-	return outputList
+	return output
 }
 
-func flattenSimPolicyAllowedSessionType(input *[]simpolicy.PduSessionType) []string {
+func flattenSimPolicyAllowedSessionTypeResource(input *[]simpolicy.PduSessionType) []string {
 	output := make([]string, 0)
 	if input == nil {
 		return output
@@ -638,27 +636,19 @@ func flattenSimPolicyAllowedSessionType(input *[]simpolicy.PduSessionType) []str
 	return output
 }
 
-func flattenServiceResourceIdModel(inputList *[]simpolicy.ServiceResourceId) []string {
-	var outputList []string
-	if inputList == nil {
-		return outputList
+func flattenServiceResourceIdResourceModel(input []simpolicy.ServiceResourceId) []string {
+	output := make([]string, 0)
+	for _, v := range input {
+		output = append(output, v.Id)
 	}
-
-	for _, input := range *inputList {
-		output := input.Id
-		outputList = append(outputList, output)
-	}
-
-	return outputList
+	return output
 }
 
-func flattenSimPolicyAmbrModel(input simpolicy.Ambr) []AmbrModel {
-	var outputList []AmbrModel
-
-	output := AmbrModel{
-		Downlink: input.Downlink,
-		Uplink:   input.Uplink,
+func flattenSimPolicyAmbrResourceModel(input simpolicy.Ambr) []AmbrResourceModel {
+	return []AmbrResourceModel{
+		{
+			Downlink: input.Downlink,
+			Uplink:   input.Uplink,
+		},
 	}
-
-	return append(outputList, output)
 }

--- a/internal/services/mobilenetwork/mobile_network_sim_policy_resource.go
+++ b/internal/services/mobilenetwork/mobile_network_sim_policy_resource.go
@@ -23,15 +23,15 @@ import (
 type SimPolicyResource struct{}
 
 type SimPolicyResourceModel struct {
-	Name                         string                            `tfschema:"name"`
-	MobileNetworkMobileNetworkId string                            `tfschema:"mobile_network_id"`
-	DefaultSliceId               string                            `tfschema:"default_slice_id"`
-	Location                     string                            `tfschema:"location"`
-	RegistrationTimer            int64                             `tfschema:"registration_timer_in_seconds"`
-	RfspIndex                    int64                             `tfschema:"rat_frequency_selection_priority_index"`
-	SliceConfigurations          []SliceConfigurationResourceModel `tfschema:"slice"`
-	Tags                         map[string]string                 `tfschema:"tags"`
-	UeAmbr                       []AmbrResourceModel               `tfschema:"user_equipment_aggregate_maximum_bit_rate"`
+	Name                string                            `tfschema:"name"`
+	MobileNetworkId     string                            `tfschema:"mobile_network_id"`
+	DefaultSliceId      string                            `tfschema:"default_slice_id"`
+	Location            string                            `tfschema:"location"`
+	RegistrationTimer   int64                             `tfschema:"registration_timer_in_seconds"`
+	RfspIndex           int64                             `tfschema:"rat_frequency_selection_priority_index"`
+	SliceConfigurations []SliceConfigurationResourceModel `tfschema:"slice"`
+	Tags                map[string]string                 `tfschema:"tags"`
+	UeAmbr              []AmbrResourceModel               `tfschema:"user_equipment_aggregate_maximum_bit_rate"`
 }
 
 type SliceConfigurationResourceModel struct {
@@ -286,7 +286,7 @@ func (r SimPolicyResource) Create() sdk.ResourceFunc {
 			}
 
 			client := metadata.Client.MobileNetwork.SIMPolicyClient
-			mobileNetworkId, err := mobilenetwork.ParseMobileNetworkID(model.MobileNetworkMobileNetworkId)
+			mobileNetworkId, err := mobilenetwork.ParseMobileNetworkID(model.MobileNetworkId)
 			if err != nil {
 				return err
 			}
@@ -413,8 +413,8 @@ func (r SimPolicyResource) Read() sdk.ResourceFunc {
 			}
 
 			state := SimPolicyResourceModel{
-				Name:                         id.SimPolicyName,
-				MobileNetworkMobileNetworkId: mobilenetwork.NewMobileNetworkID(id.SubscriptionId, id.ResourceGroupName, id.MobileNetworkName).ID(),
+				Name:            id.SimPolicyName,
+				MobileNetworkId: mobilenetwork.NewMobileNetworkID(id.SubscriptionId, id.ResourceGroupName, id.MobileNetworkName).ID(),
 			}
 
 			if model := resp.Model; model != nil {

--- a/internal/services/mobilenetwork/mobile_network_sim_policy_resource_test.go
+++ b/internal/services/mobilenetwork/mobile_network_sim_policy_resource_test.go
@@ -109,12 +109,192 @@ func (r MobileNetworkSimPolicyResource) Exists(ctx context.Context, clients *cli
 	return utils.Bool(resp.Model != nil), nil
 }
 
-func (r MobileNetworkSimPolicyResource) template(data acceptance.TestData) string {
+func (r MobileNetworkSimPolicyResource) basic(data acceptance.TestData) string {
+	template := r.template(data)
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
 
+%s
+
+resource "azurerm_mobile_network_sim_policy" "test" {
+  name                          = "acctest-mnsp-%d"
+  mobile_network_id             = azurerm_mobile_network.test.id
+  location                      = azurerm_mobile_network.test.location
+  default_slice_id              = azurerm_mobile_network_slice.test.id
+  registration_timer_in_seconds = 3240
+
+  user_equipment_aggregate_maximum_bit_rate {
+    downlink = "1 Gbps"
+    uplink   = "500 Mbps"
+  }
+
+  slice {
+    default_data_network_id = azurerm_mobile_network_data_network.test.id
+    slice_id                = azurerm_mobile_network_slice.test.id
+    data_network {
+      data_network_id                         = azurerm_mobile_network_data_network.test.id
+      allocation_and_retention_priority_level = 9
+      default_session_type                    = "IPv4"
+      qos_indicator                           = 9
+      preemption_capability                   = "NotPreempt"
+      preemption_vulnerability                = "Preemptable"
+      allowed_services_ids                    = [azurerm_mobile_network_service.test.id]
+      session_aggregate_maximum_bit_rate {
+        downlink = "1 Gbps"
+        uplink   = "500 Mbps"
+      }
+    }
+  }
+
+  tags = {
+    key = "value"
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func (r MobileNetworkSimPolicyResource) requiresImport(data acceptance.TestData) string {
+	config := r.basic(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_mobile_network_sim_policy" "import" {
+  name                          = azurerm_mobile_network_sim_policy.test.name
+  mobile_network_id             = azurerm_mobile_network_sim_policy.test.mobile_network_id
+  default_slice_id              = azurerm_mobile_network_sim_policy.test.default_slice_id
+  location                      = azurerm_mobile_network_sim_policy.test.location
+  registration_timer_in_seconds = 3240
+
+  slice {
+    default_data_network_id = azurerm_mobile_network_data_network.test.id
+    slice_id                = azurerm_mobile_network_slice.test.id
+
+    data_network {
+      allocation_and_retention_priority_level = 9
+      default_session_type                    = "IPv4"
+      qos_indicator                           = 9
+      preemption_capability                   = "NotPreempt"
+      preemption_vulnerability                = "Preemptable"
+      allowed_services_ids                    = [azurerm_mobile_network_service.test.id]
+      data_network_id                         = azurerm_mobile_network_data_network.test.id
+      session_aggregate_maximum_bit_rate {
+        downlink = "1 Gbps"
+        uplink   = "500 Mbps"
+      }
+    }
+  }
+
+  user_equipment_aggregate_maximum_bit_rate {
+    downlink = "1 Gbps"
+    uplink   = "500 Mbps"
+  }
+  tags = {
+    key = "value"
+  }
+
+}
+`, config)
+}
+
+func (r MobileNetworkSimPolicyResource) complete(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_mobile_network_sim_policy" "test" {
+  name                                   = "acctest-mnsp-%d"
+  mobile_network_id                      = azurerm_mobile_network.test.id
+  location                               = azurerm_mobile_network.test.location
+  default_slice_id                       = azurerm_mobile_network_slice.test.id
+  registration_timer_in_seconds          = 3240
+  rat_frequency_selection_priority_index = 1
+
+  slice {
+    default_data_network_id = azurerm_mobile_network_data_network.test.id
+    slice_id                = azurerm_mobile_network_slice.test.id
+    data_network {
+      allocation_and_retention_priority_level = 9
+      default_session_type                    = "IPv4"
+      qos_indicator                           = 9
+      preemption_capability                   = "NotPreempt"
+      preemption_vulnerability                = "Preemptable"
+      allowed_services_ids                    = [azurerm_mobile_network_service.test.id]
+      data_network_id                         = azurerm_mobile_network_data_network.test.id
+      max_buffered_packets                    = 200
+      session_aggregate_maximum_bit_rate {
+        downlink = "1 Gbps"
+        uplink   = "500 Mbps"
+      }
+    }
+  }
+
+  user_equipment_aggregate_maximum_bit_rate {
+    downlink = "1 Gbps"
+    uplink   = "500 Mbps"
+  }
+  tags = {
+    key = "value"
+  }
+
+}
+`, template, data.RandomInteger)
+}
+
+func (r MobileNetworkSimPolicyResource) update(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_mobile_network_sim_policy" "test" {
+  name                                   = "acctest-mnsp-%d"
+  mobile_network_id                      = azurerm_mobile_network.test.id
+  location                               = azurerm_mobile_network.test.location
+  default_slice_id                       = azurerm_mobile_network_slice.test.id
+  registration_timer_in_seconds          = 3240
+  rat_frequency_selection_priority_index = 1
+
+  slice {
+    default_data_network_id = azurerm_mobile_network_data_network.test.id
+    slice_id                = azurerm_mobile_network_slice.test.id
+    data_network {
+      allocation_and_retention_priority_level = 9
+      default_session_type                    = "IPv4"
+      qos_indicator                           = 9
+      preemption_capability                   = "NotPreempt"
+      preemption_vulnerability                = "Preemptable"
+      allowed_services_ids                    = [azurerm_mobile_network_service.test.id]
+      data_network_id                         = azurerm_mobile_network_data_network.test.id
+      session_aggregate_maximum_bit_rate {
+        downlink = "1 Gbps"
+        uplink   = "500 Mbps"
+      }
+    }
+  }
+
+  user_equipment_aggregate_maximum_bit_rate {
+    downlink = "1 Gbps"
+    uplink   = "500 Mbps"
+  }
+  tags = {
+    key = "value2"
+  }
+
+}
+`, template, data.RandomInteger)
+}
+
+func (r MobileNetworkSimPolicyResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name     = "acctest-mn-%[1]d"
   location = "%[2]s"
@@ -165,178 +345,5 @@ resource "azurerm_mobile_network_data_network" "test" {
   mobile_network_id = azurerm_mobile_network.test.id
   location          = "%[2]s"
 }
-
-
 `, data.RandomInteger, data.Locations.Primary)
-}
-
-func (r MobileNetworkSimPolicyResource) basic(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-				%s
-
-resource "azurerm_mobile_network_sim_policy" "test" {
-  name                          = "acctest-mnsp-%d"
-  mobile_network_id             = azurerm_mobile_network.test.id
-  location                      = "%s"
-  default_slice_id              = azurerm_mobile_network_slice.test.id
-  registration_timer_in_seconds = 3240
-
-  user_equipment_aggregate_maximum_bit_rate {
-    downlink = "1 Gbps"
-    uplink   = "500 Mbps"
-  }
-
-  slice {
-    default_data_network_id = azurerm_mobile_network_data_network.test.id
-    slice_id                = azurerm_mobile_network_slice.test.id
-    data_network {
-      data_network_id                         = azurerm_mobile_network_data_network.test.id
-      allocation_and_retention_priority_level = 9
-      default_session_type                    = "IPv4"
-      qos_indicator                           = 9
-      preemption_capability                   = "NotPreempt"
-      preemption_vulnerability                = "Preemptable"
-      allowed_services_ids                    = [azurerm_mobile_network_service.test.id]
-      session_aggregate_maximum_bit_rate {
-        downlink = "1 Gbps"
-        uplink   = "500 Mbps"
-      }
-    }
-  }
-
-  tags = {
-    key = "value"
-  }
-
-}
-`, r.template(data), data.RandomInteger, data.Locations.Primary)
-}
-
-func (r MobileNetworkSimPolicyResource) requiresImport(data acceptance.TestData) string {
-	config := r.basic(data)
-	return fmt.Sprintf(`
-			%s
-
-resource "azurerm_mobile_network_sim_policy" "import" {
-  name                          = azurerm_mobile_network_sim_policy.test.name
-  mobile_network_id             = azurerm_mobile_network.test.id
-  default_slice_id              = azurerm_mobile_network_slice.test.id
-  location                      = "%s"
-  registration_timer_in_seconds = 3240
-
-  slice {
-    default_data_network_id = azurerm_mobile_network_data_network.test.id
-    slice_id                = azurerm_mobile_network_slice.test.id
-
-    data_network {
-      allocation_and_retention_priority_level = 9
-      default_session_type                    = "IPv4"
-      qos_indicator                           = 9
-      preemption_capability                   = "NotPreempt"
-      preemption_vulnerability                = "Preemptable"
-      allowed_services_ids                    = [azurerm_mobile_network_service.test.id]
-      data_network_id                         = azurerm_mobile_network_data_network.test.id
-      session_aggregate_maximum_bit_rate {
-        downlink = "1 Gbps"
-        uplink   = "500 Mbps"
-      }
-    }
-  }
-
-  user_equipment_aggregate_maximum_bit_rate {
-    downlink = "1 Gbps"
-    uplink   = "500 Mbps"
-  }
-  tags = {
-    key = "value"
-  }
-
-}
-`, config, data.Locations.Primary)
-}
-
-func (r MobileNetworkSimPolicyResource) complete(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-			%s
-
-resource "azurerm_mobile_network_sim_policy" "test" {
-  name                                   = "acctest-mnsp-%d"
-  mobile_network_id                      = azurerm_mobile_network.test.id
-  location                               = "%s"
-  default_slice_id                       = azurerm_mobile_network_slice.test.id
-  registration_timer_in_seconds          = 3240
-  rat_frequency_selection_priority_index = 1
-
-  slice {
-    default_data_network_id = azurerm_mobile_network_data_network.test.id
-    slice_id                = azurerm_mobile_network_slice.test.id
-    data_network {
-      allocation_and_retention_priority_level = 9
-      default_session_type                    = "IPv4"
-      qos_indicator                           = 9
-      preemption_capability                   = "NotPreempt"
-      preemption_vulnerability                = "Preemptable"
-      allowed_services_ids                    = [azurerm_mobile_network_service.test.id]
-      data_network_id                         = azurerm_mobile_network_data_network.test.id
-      max_buffered_packets                    = 200
-      session_aggregate_maximum_bit_rate {
-        downlink = "1 Gbps"
-        uplink   = "500 Mbps"
-      }
-    }
-  }
-
-  user_equipment_aggregate_maximum_bit_rate {
-    downlink = "1 Gbps"
-    uplink   = "500 Mbps"
-  }
-  tags = {
-    key = "value"
-  }
-
-}
-`, r.template(data), data.RandomInteger, data.Locations.Primary)
-}
-
-func (r MobileNetworkSimPolicyResource) update(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-			%s
-
-
-resource "azurerm_mobile_network_sim_policy" "test" {
-  name                                   = "acctest-mnsp-%d"
-  mobile_network_id                      = azurerm_mobile_network.test.id
-  location                               = "%s"
-  default_slice_id                       = azurerm_mobile_network_slice.test.id
-  registration_timer_in_seconds          = 3240
-  rat_frequency_selection_priority_index = 1
-
-  slice {
-    default_data_network_id = azurerm_mobile_network_data_network.test.id
-    slice_id                = azurerm_mobile_network_slice.test.id
-    data_network {
-      allocation_and_retention_priority_level = 9
-      default_session_type                    = "IPv4"
-      qos_indicator                           = 9
-      preemption_capability                   = "NotPreempt"
-      preemption_vulnerability                = "Preemptable"
-      allowed_services_ids                    = [azurerm_mobile_network_service.test.id]
-      data_network_id                         = azurerm_mobile_network_data_network.test.id
-      session_aggregate_maximum_bit_rate {
-        downlink = "1 Gbps"
-        uplink   = "500 Mbps"
-      }
-    }
-  }
-
-  user_equipment_aggregate_maximum_bit_rate {
-    downlink = "1 Gbps"
-    uplink   = "500 Mbps"
-  }
-  tags = {
-    key = "value2"
-  }
-
-}
-`, r.template(data), data.RandomInteger, data.Locations.Primary)
 }

--- a/internal/services/mobilenetwork/mobile_network_site_data_source.go
+++ b/internal/services/mobilenetwork/mobile_network_site_data_source.go
@@ -17,6 +17,14 @@ import (
 
 type SiteDataSource struct{}
 
+type SiteDataSourceModel struct {
+	Name                string            `tfschema:"name"`
+	MobileNetworkId     string            `tfschema:"mobile_network_id"`
+	Location            string            `tfschema:"location"`
+	NetworkFunctionsIds []string          `tfschema:"network_function_ids"`
+	Tags                map[string]string `tfschema:"tags"`
+}
+
 var _ sdk.DataSource = SiteDataSource{}
 
 func (r SiteDataSource) ResourceType() string {
@@ -24,7 +32,7 @@ func (r SiteDataSource) ResourceType() string {
 }
 
 func (r SiteDataSource) ModelObject() interface{} {
-	return &SiteModel{}
+	return &SiteDataSourceModel{}
 }
 
 func (r SiteDataSource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
@@ -67,19 +75,18 @@ func (r SiteDataSource) Read() sdk.ResourceFunc {
 	return sdk.ResourceFunc{
 		Timeout: 5 * time.Minute,
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
-			var metaModel SiteModel
-			if err := metadata.Decode(&metaModel); err != nil {
+			var state SiteDataSourceModel
+			if err := metadata.Decode(&state); err != nil {
 				return fmt.Errorf("decoding: %+v", err)
 			}
 
 			client := metadata.Client.MobileNetwork.SiteClient
-			mobileNetworkId, err := mobilenetwork.ParseMobileNetworkID(metaModel.MobileNetworkId)
+			mobileNetworkId, err := mobilenetwork.ParseMobileNetworkID(state.MobileNetworkId)
 			if err != nil {
 				return err
 			}
 
-			id := site.NewSiteID(mobileNetworkId.SubscriptionId, mobileNetworkId.ResourceGroupName, mobileNetworkId.MobileNetworkName, metaModel.Name)
-
+			id := site.NewSiteID(mobileNetworkId.SubscriptionId, mobileNetworkId.ResourceGroupName, mobileNetworkId.MobileNetworkName, state.Name)
 			resp, err := client.Get(ctx, id)
 			if err != nil {
 				if response.WasNotFound(resp.HttpResponse) {
@@ -89,25 +96,21 @@ func (r SiteDataSource) Read() sdk.ResourceFunc {
 				return fmt.Errorf("retrieving %s: %+v", id, err)
 			}
 
-			model := resp.Model
-			if model == nil {
-				return fmt.Errorf("retrieving %s: model was nil", id)
-			}
-
-			state := SiteModel{
+			metadata.SetID(id)
+			state = SiteDataSourceModel{
 				Name:            id.SiteName,
 				MobileNetworkId: mobileNetworkId.ID(),
-				Location:        location.Normalize(model.Location),
 			}
 
-			if properties := model.Properties; properties != nil {
-				state.NetworkFunctions = flattenSubResourceModel(properties.NetworkFunctions)
+			if model := resp.Model; model != nil {
+				state.Location = location.Normalize(model.Location)
+				if properties := model.Properties; properties != nil {
+					state.NetworkFunctionsIds = flattenSubResourceModel(properties.NetworkFunctions)
+				}
+				if model.Tags != nil {
+					state.Tags = *model.Tags
+				}
 			}
-			if model.Tags != nil {
-				state.Tags = *model.Tags
-			}
-
-			metadata.SetID(id)
 
 			return metadata.Encode(&state)
 		},

--- a/internal/services/mobilenetwork/mobile_network_site_data_source_test.go
+++ b/internal/services/mobilenetwork/mobile_network_site_data_source_test.go
@@ -30,7 +30,7 @@ func TestAccMobileNetworkSiteDataSource_complete(t *testing.T) {
 
 func (r MobileNetworkSiteDataSource) complete(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-	%s
+%s
 
 data "azurerm_mobile_network_site" "test" {
   name              = azurerm_mobile_network_site.test.name

--- a/internal/services/mobilenetwork/mobile_network_site_resource.go
+++ b/internal/services/mobilenetwork/mobile_network_site_resource.go
@@ -141,8 +141,6 @@ func (r SiteResource) Update() sdk.ResourceFunc {
 				return fmt.Errorf("retrieving %s: properties was nil", id)
 			}
 
-			properties.SystemData = nil
-
 			if metadata.ResourceData.HasChange("tags") {
 				properties.Tags = &model.Tags
 			}

--- a/internal/services/mobilenetwork/mobile_network_site_resource_test.go
+++ b/internal/services/mobilenetwork/mobile_network_site_resource_test.go
@@ -113,59 +113,91 @@ func (r MobileNetworkSiteResource) Exists(ctx context.Context, clients *clients.
 }
 
 func (r MobileNetworkSiteResource) basic(data acceptance.TestData) string {
+	template := r.template(data)
 	return fmt.Sprintf(`
-				%s
+provider "azurerm" {
+  features {}
+}
+
+%s
 
 resource "azurerm_mobile_network_site" "test" {
   name              = "acctest-mns-%d"
   mobile_network_id = azurerm_mobile_network.test.id
-  location          = "%s"
+  location          = azurerm_mobile_network.test.location
 }
-`, MobileNetworkResource{}.basic(data), data.RandomInteger, data.Locations.Primary)
+`, template, data.RandomInteger)
 }
 
 func (r MobileNetworkSiteResource) requiresImport(data acceptance.TestData) string {
+	template := r.basic(data)
 	return fmt.Sprintf(`
-			%s
+%s
 
 resource "azurerm_mobile_network_site" "import" {
   name              = azurerm_mobile_network_site.test.name
-  mobile_network_id = azurerm_mobile_network.test.id
-  location          = "%s"
+  mobile_network_id = azurerm_mobile_network_site.test.mobile_network_id
+  location          = azurerm_mobile_network_site.test.location
 }
-`, r.basic(data), data.Locations.Primary)
+`, template)
 }
 
 func (r MobileNetworkSiteResource) complete(data acceptance.TestData) string {
+	template := r.template(data)
 	return fmt.Sprintf(`
-			%s
+provider "azurerm" {
+  features {}
+}
+
+%s
 
 resource "azurerm_mobile_network_site" "test" {
   name              = "acctest-mns-%d"
   mobile_network_id = azurerm_mobile_network.test.id
-  location          = "%s"
+  location          = azurerm_mobile_network.test.location
 
   tags = {
     key = "value"
   }
 
 }
-`, MobileNetworkResource{}.basic(data), data.RandomInteger, data.Locations.Primary)
+`, template, data.RandomInteger)
 }
 
 func (r MobileNetworkSiteResource) update(data acceptance.TestData) string {
+	template := r.template(data)
 	return fmt.Sprintf(`
-			%s
+provider "azurerm" {
+  features {}
+}
+
+%s
 
 resource "azurerm_mobile_network_site" "test" {
   name              = "acctest-mns-%d"
   mobile_network_id = azurerm_mobile_network.test.id
-  location          = "%s"
+  location          = azurerm_mobile_network.test.location
 
   tags = {
     key = "update"
   }
-
 }
-`, MobileNetworkResource{}.basic(data), data.RandomInteger, data.Locations.Primary)
+`, template, data.RandomInteger)
+}
+
+func (r MobileNetworkSiteResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctest-mn-%[1]d"
+  location = %[2]q
+}
+
+resource "azurerm_mobile_network" "test" {
+  name                = "acctest-mn-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  mobile_country_code = "001"
+  mobile_network_code = "01"
+}
+`, data.RandomInteger, data.Locations.Primary)
 }

--- a/internal/services/mobilenetwork/mobile_network_slice_resource.go
+++ b/internal/services/mobilenetwork/mobile_network_slice_resource.go
@@ -189,8 +189,6 @@ func (r SliceResource) Update() sdk.ResourceFunc {
 				updateModel.Properties.Snssai = expandSnssaiModel(model.Snssai)
 			}
 
-			updateModel.SystemData = nil
-
 			if metadata.ResourceData.HasChange("tags") {
 				updateModel.Tags = &model.Tags
 			}

--- a/internal/services/mobilenetwork/mobile_network_slice_resource_test.go
+++ b/internal/services/mobilenetwork/mobile_network_slice_resource_test.go
@@ -109,65 +109,84 @@ func (r MobileNetworkSliceResource) Exists(ctx context.Context, clients *clients
 }
 
 func (r MobileNetworkSliceResource) basic(data acceptance.TestData) string {
+	template := r.template(data)
 	return fmt.Sprintf(`
-				%s
-
-resource "azurerm_mobile_network_slice" "test" {
-  name              = "acctest-mns-%d"
-  mobile_network_id = azurerm_mobile_network.test.id
-  location          = "%s"
-  single_network_slice_selection_assistance_information {
-    slice_service_type = 1
-  }
-}
-`, MobileNetworkResource{}.basic(data), data.RandomInteger, data.Locations.Primary)
+provider "azurerm" {
+  features {}
 }
 
-func (r MobileNetworkSliceResource) requiresImport(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-			%s
-
-resource "azurerm_mobile_network_slice" "import" {
-  name              = azurerm_mobile_network_slice.test.name
-  mobile_network_id = azurerm_mobile_network_slice.test.mobile_network_id
-
-  location = "%s"
-  single_network_slice_selection_assistance_information {
-    slice_service_type = 1
-  }
-}
-`, r.basic(data), data.Locations.Primary)
-}
-
-func (r MobileNetworkSliceResource) complete(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-			%s
-
-resource "azurerm_mobile_network_slice" "test" {
-  name              = "acctest-mns-%d"
-  mobile_network_id = azurerm_mobile_network.test.id
-  location          = "%s"
-  description       = "my favorite slice"
-  single_network_slice_selection_assistance_information {
-    slice_service_type = 1
-  }
-  tags = {
-    key = "value"
-  }
-
-}
-`, MobileNetworkResource{}.basic(data), data.RandomInteger, data.Locations.Primary)
-}
-
-func (r MobileNetworkSliceResource) update(data acceptance.TestData) string {
-	return fmt.Sprintf(`
 %s
 
 resource "azurerm_mobile_network_slice" "test" {
   name              = "acctest-mns-%d"
   mobile_network_id = azurerm_mobile_network.test.id
-  location          = "%s"
+  location          = azurerm_mobile_network.test.location
+
+  single_network_slice_selection_assistance_information {
+    slice_service_type = 1
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func (r MobileNetworkSliceResource) requiresImport(data acceptance.TestData) string {
+	template := r.basic(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_mobile_network_slice" "import" {
+  name              = azurerm_mobile_network_slice.test.name
+  mobile_network_id = azurerm_mobile_network_slice.test.mobile_network_id
+  location          = azurerm_mobile_network_slice.test.location
+
+  single_network_slice_selection_assistance_information {
+    slice_service_type = 1
+  }
+}
+`, template)
+}
+
+func (r MobileNetworkSliceResource) complete(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_mobile_network_slice" "test" {
+  name              = "acctest-mns-%d"
+  mobile_network_id = azurerm_mobile_network.test.id
+  location          = azurerm_mobile_network.test.location
+  description       = "my favorite slice"
+
+  single_network_slice_selection_assistance_information {
+    slice_service_type = 1
+  }
+
+  tags = {
+    key = "value"
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func (r MobileNetworkSliceResource) update(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_mobile_network_slice" "test" {
+  name              = "acctest-mns-%d"
+  mobile_network_id = azurerm_mobile_network.test.id
+  location          = azurerm_mobile_network.test.location
   description       = "my favorite slice2"
+
   single_network_slice_selection_assistance_information {
     slice_service_type = 1
   }
@@ -177,5 +196,22 @@ resource "azurerm_mobile_network_slice" "test" {
   }
 
 }
-`, MobileNetworkResource{}.basic(data), data.RandomInteger, data.Locations.Primary)
+`, template, data.RandomInteger)
+}
+
+func (r MobileNetworkSliceResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+  name     = "acctest-mn-%[1]d"
+  location = %[2]q
+}
+
+resource "azurerm_mobile_network" "test" {
+  name                = "acctest-mn-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  mobile_country_code = "001"
+  mobile_network_code = "01"
+}
+`, data.RandomInteger, data.Locations.Primary)
 }

--- a/internal/services/mobilenetwork/registration.go
+++ b/internal/services/mobilenetwork/registration.go
@@ -2,15 +2,11 @@ package mobilenetwork
 
 import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
 type Registration struct{}
 
-var (
-	_ sdk.TypedServiceRegistrationWithAGitHubLabel   = Registration{}
-	_ sdk.UntypedServiceRegistrationWithAGitHubLabel = Registration{}
-)
+var _ sdk.TypedServiceRegistrationWithAGitHubLabel = Registration{}
 
 func (r Registration) AssociatedGitHubLabel() string {
 	return "service/mobile-network"
@@ -28,22 +24,12 @@ func (r Registration) WebsiteCategories() []string {
 	}
 }
 
-// SupportedDataSources returns the supported Data Sources supported by this Service
-func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
-	return map[string]*pluginsdk.Resource{}
-}
-
-// SupportedResources returns the supported Resources supported by this Service
-func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
-	return map[string]*pluginsdk.Resource{}
-}
-
 // DataSources returns a list of Data Sources supported by this Service
 func (r Registration) DataSources() []sdk.DataSource {
 	return []sdk.DataSource{
 		DataNetworkDataSource{},
 		MobileNetworkDataSource{},
-		MobileNetworkServiceDataSource{},
+		ServiceDataSource{},
 		SiteDataSource{},
 		SimGroupDataSource{},
 		SliceDataSource{},
@@ -55,11 +41,11 @@ func (r Registration) DataSources() []sdk.DataSource {
 func (r Registration) Resources() []sdk.Resource {
 	return []sdk.Resource{
 		DataNetworkResource{},
-		MobileNetworkServiceResource{},
-		SimGroupResource{},
-		SliceResource{},
 		MobileNetworkResource{},
-		SiteResource{},
+		ServiceResource{},
+		SimGroupResource{},
 		SimPolicyResource{},
+		SiteResource{},
+		SliceResource{},
 	}
 }

--- a/internal/services/monitor/monitor_alert_processing_rule_action_group_resource.go
+++ b/internal/services/monitor/monitor_alert_processing_rule_action_group_resource.go
@@ -165,7 +165,6 @@ func (r AlertProcessingRuleActionGroupResource) Update() sdk.ResourceFunc {
 				model.Tags = &resourceModel.Tags
 			}
 
-			model.SystemData = nil
 			if _, err := client.AlertProcessingRulesCreateOrUpdate(ctx, *id, *model); err != nil {
 				return fmt.Errorf("updating %s: %+v", *id, err)
 			}

--- a/internal/services/monitor/monitor_alert_processing_rule_suppression_resource.go
+++ b/internal/services/monitor/monitor_alert_processing_rule_suppression_resource.go
@@ -152,7 +152,6 @@ func (r AlertProcessingRuleSuppressionResource) Update() sdk.ResourceFunc {
 				model.Tags = &resourceModel.Tags
 			}
 
-			model.SystemData = nil
 			if _, err := client.AlertProcessingRulesCreateOrUpdate(ctx, *id, *model); err != nil {
 				return fmt.Errorf("updating %s: %+v", *id, err)
 			}

--- a/internal/services/monitor/monitor_data_collection_rule_association_resource.go
+++ b/internal/services/monitor/monitor_data_collection_rule_association_resource.go
@@ -216,8 +216,6 @@ func (r DataCollectionRuleAssociationResource) Update() sdk.ResourceFunc {
 				existing.Properties.Description = utils.String(model.Description)
 			}
 
-			existing.SystemData = nil
-
 			if _, err := client.Create(ctx, *id, *existing); err != nil {
 				return fmt.Errorf("updating %s: %+v", *id, err)
 			}

--- a/internal/services/monitor/monitor_data_collection_rule_resource.go
+++ b/internal/services/monitor/monitor_data_collection_rule_resource.go
@@ -528,9 +528,6 @@ func (r DataCollectionRuleResource) Update() sdk.ResourceFunc {
 				existing.Properties.Destinations = expandDataCollectionRuleDestinations(state.Destinations)
 			}
 
-			// otherwise Service will return an error: "The resource definition is invalid."
-			existing.SystemData = nil
-
 			if _, err := client.Create(ctx, *id, *existing); err != nil {
 				return fmt.Errorf("updating %s: %+v", *id, err)
 			}

--- a/internal/services/monitor/monitor_scheduled_query_rules_alert_v2_resource.go
+++ b/internal/services/monitor/monitor_scheduled_query_rules_alert_v2_resource.go
@@ -580,8 +580,6 @@ func (r ScheduledQueryRulesAlertV2Resource) Update() sdk.ResourceFunc {
 				}
 			}
 
-			model.SystemData = nil
-
 			if metadata.ResourceData.HasChange("tags") {
 				model.Tags = &resourceModel.Tags
 			}

--- a/internal/services/network/network_manager_network_group_resource.go
+++ b/internal/services/network/network_manager_network_group_resource.go
@@ -140,8 +140,6 @@ func (r ManagerNetworkGroupResource) Update() sdk.ResourceFunc {
 				}
 			}
 
-			existing.SystemData = nil
-
 			if _, err := client.CreateOrUpdate(ctx, existing, id.ResourceGroup, id.NetworkManagerName, id.NetworkGroupName, ""); err != nil {
 				return fmt.Errorf("updating %s: %+v", *id, err)
 			}

--- a/internal/services/privatednsresolver/private_dns_resolver_dns_forwarding_ruleset_resource.go
+++ b/internal/services/privatednsresolver/private_dns_resolver_dns_forwarding_ruleset_resource.go
@@ -146,8 +146,6 @@ func (r PrivateDNSResolverDnsForwardingRulesetResource) Update() sdk.ResourceFun
 				}
 			}
 
-			properties.SystemData = nil
-
 			if metadata.ResourceData.HasChange("tags") {
 				properties.Tags = &model.Tags
 			}

--- a/internal/services/privatednsresolver/private_dns_resolver_forwarding_rule_resource.go
+++ b/internal/services/privatednsresolver/private_dns_resolver_forwarding_rule_resource.go
@@ -206,8 +206,6 @@ func (r PrivateDNSResolverForwardingRuleResource) Update() sdk.ResourceFunc {
 				}
 			}
 
-			properties.SystemData = nil
-
 			if _, err := client.CreateOrUpdate(ctx, *id, *properties, forwardingrules.CreateOrUpdateOperationOptions{}); err != nil {
 				return fmt.Errorf("updating %s: %+v", *id, err)
 			}

--- a/internal/services/privatednsresolver/private_dns_resolver_inbound_endpoint_resource.go
+++ b/internal/services/privatednsresolver/private_dns_resolver_inbound_endpoint_resource.go
@@ -182,8 +182,6 @@ func (r PrivateDNSResolverInboundEndpointResource) Update() sdk.ResourceFunc {
 				}
 			}
 
-			properties.SystemData = nil
-
 			if metadata.ResourceData.HasChange("tags") {
 				properties.Tags = &model.Tags
 			}

--- a/internal/services/privatednsresolver/private_dns_resolver_outbound_endpoint_resource.go
+++ b/internal/services/privatednsresolver/private_dns_resolver_outbound_endpoint_resource.go
@@ -145,8 +145,6 @@ func (r PrivateDNSResolverOutboundEndpointResource) Update() sdk.ResourceFunc {
 				return fmt.Errorf("retrieving %s: properties was nil", id)
 			}
 
-			properties.SystemData = nil
-
 			if metadata.ResourceData.HasChange("tags") {
 				properties.Tags = &model.Tags
 			}

--- a/internal/services/privatednsresolver/private_dns_resolver_resource.go
+++ b/internal/services/privatednsresolver/private_dns_resolver_resource.go
@@ -134,8 +134,6 @@ func (r PrivateDNSResolverDnsResolverResource) Update() sdk.ResourceFunc {
 				return fmt.Errorf("retrieving %s: properties was nil", id)
 			}
 
-			properties.SystemData = nil
-
 			if metadata.ResourceData.HasChange("tags") {
 				properties.Tags = &model.Tags
 			}

--- a/internal/services/privatednsresolver/private_dns_resolver_virtual_network_link_resource.go
+++ b/internal/services/privatednsresolver/private_dns_resolver_virtual_network_link_resource.go
@@ -154,8 +154,6 @@ func (r PrivateDNSResolverVirtualNetworkLinkResource) Update() sdk.ResourceFunc 
 				}
 			}
 
-			properties.SystemData = nil
-
 			if err := client.CreateOrUpdateThenPoll(ctx, *id, *properties, virtualnetworklinks.CreateOrUpdateOperationOptions{}); err != nil {
 				return fmt.Errorf("updating %s: %+v", *id, err)
 			}

--- a/internal/services/signalr/signalr_service_network_acl_resource.go
+++ b/internal/services/signalr/signalr_service_network_acl_resource.go
@@ -197,9 +197,6 @@ func resourceSignalRServiceNetworkACLCreateUpdate(d *pluginsdk.ResourceData, met
 		model.Properties.NetworkACLs = &networkACL
 	}
 
-	// todo remove this when https://github.com/hashicorp/pandora/issues/1096 is fixed
-	model.SystemData = nil
-
 	if err := client.UpdateThenPoll(ctx, *id, model); err != nil {
 		return fmt.Errorf("creating/updating NetworkACL for %s: %v", id, err)
 	}
@@ -301,9 +298,6 @@ func resourceSignalRServiceNetworkACLDelete(d *pluginsdk.ResourceData, meta inte
 	if model.Properties != nil {
 		model.Properties.NetworkACLs = networkACL
 	}
-
-	// todo remove this when https://github.com/hashicorp/pandora/issues/1096 is fixed
-	model.SystemData = nil
 
 	if err := client.UpdateThenPoll(ctx, *id, model); err != nil {
 		return fmt.Errorf("resetting the default Network ACL configuration for %s: %+v", *id, err)


### PR DESCRIPTION
This PR refactors the `mobilenetwork` package to fix issues that should have been caught at review time, namely:

1. Splitting the models and flatten functions used in each Data Source/Resource - reusing these models has been a frequent source of bugs where a field gets added to say the Data Source but not the Resource. Since not all fields make sense in a Data Source, and others may not make sense in the Resource - these should not be reused.
2. The flatten functions define the `output` types as a nil-slice, meaning that if these aren't appended to we'll be setting `nil` into the state rather than an empty slice, which will become an issue in the future when we adopt `terraform-plugin-framework`.
3. Updating the tests to include a `template` as is standard across the provider, which helps avoid issues where changes to one resource can impact another.

Dependent on #21060