### PR TITLE
`azurerm_[linux|windows]_[function|web]_app[_slot]` - fix AAD auth and token_store

### DIFF
--- a/internal/services/appservice/helpers/auth_v2_schema.go
+++ b/internal/services/appservice/helpers/auth_v2_schema.go
@@ -838,7 +838,7 @@ func AadAuthV2SettingsSchemaComputed() *pluginsdk.Schema {
 					Description: "The ID of the Client to use to authenticate with Azure Active Directory.",
 				},
 
-				"tenant_id": {
+				"tenant_auth_endpoint": {
 					Type:        pluginsdk.TypeString,
 					Computed:    true,
 					Description: "The Azure Tenant URI for the Authenticating Tenant. e.g. `https://login.microsoftonline.com/v2.0/{tenant-guid}/`",
@@ -872,6 +872,12 @@ func AadAuthV2SettingsSchemaComputed() *pluginsdk.Schema {
 						Type: pluginsdk.TypeString,
 					},
 					Description: "A list of Allowed Client Applications in the JWT Claim.",
+				},
+
+				"www_authentication_disabled": {
+					Type:        pluginsdk.TypeBool,
+					Computed:    true,
+					Description: "Is the www-authenticate provider omitted from the request?",
 				},
 
 				"allowed_groups": {
@@ -921,9 +927,9 @@ func AadAuthV2SettingsSchemaComputed() *pluginsdk.Schema {
 
 func expandAadAuthV2Settings(input []AadAuthV2Settings) *web.AzureActiveDirectory {
 	result := &web.AzureActiveDirectory{
-		Enabled:      pointer.To(false),
-		Registration: &web.AzureActiveDirectoryRegistration{},
+		Enabled: pointer.To(false),
 	}
+
 	if len(input) == 1 {
 		aad := input[0]
 		result = &web.AzureActiveDirectory{
@@ -987,7 +993,7 @@ func expandAadAuthV2Settings(input []AadAuthV2Settings) *web.AzureActiveDirector
 }
 
 func flattenAadAuthV2Settings(input *web.AzureActiveDirectory) []AadAuthV2Settings {
-	if input == nil {
+	if input == nil || !pointer.From(input.Enabled) {
 		return []AadAuthV2Settings{}
 	}
 

--- a/internal/services/appservice/helpers/auth_v2_schema.go
+++ b/internal/services/appservice/helpers/auth_v2_schema.go
@@ -537,6 +537,7 @@ func flattenAuthV2LoginSettings(input *web.Login) []AuthV2Login {
 		result.LogoutEndpoint = pointer.From(routes.LogoutEndpoint)
 	}
 	if token := input.TokenStore; token != nil {
+		result.TokenStoreEnabled = pointer.From(token.Enabled)
 		result.TokenRefreshExtension = pointer.From(token.TokenRefreshExtensionHours)
 		if fs := token.FileSystem; fs != nil {
 			result.TokenFilesystemPath = pointer.From(fs.Directory)

--- a/internal/services/appservice/helpers/auth_v2_schema.go
+++ b/internal/services/appservice/helpers/auth_v2_schema.go
@@ -730,8 +730,7 @@ func AadAuthV2SettingsSchema() *pluginsdk.Schema {
 					Type:         pluginsdk.TypeString,
 					Optional:     true,
 					ValidateFunc: validation.StringIsNotEmpty,
-					ExactlyOneOf: []string{
-						"auth_settings_v2.0.active_directory_v2.0.client_secret_setting_name",
+					ConflictsWith: []string{
 						"auth_settings_v2.0.active_directory_v2.0.client_secret_certificate_thumbprint",
 					},
 					Description: "The App Setting name that contains the client secret of the Client.",
@@ -741,9 +740,8 @@ func AadAuthV2SettingsSchema() *pluginsdk.Schema {
 					Type:         pluginsdk.TypeString,
 					Optional:     true,
 					ValidateFunc: validation.StringIsNotEmpty,
-					ExactlyOneOf: []string{
+					ConflictsWith: []string{
 						"auth_settings_v2.0.active_directory_v2.0.client_secret_setting_name",
-						"auth_settings_v2.0.active_directory_v2.0.client_secret_certificate_thumbprint",
 					},
 					Description: "The thumbprint of the certificate used for signing purposes.",
 				},

--- a/internal/services/appservice/helpers/auth_v2_schema.go
+++ b/internal/services/appservice/helpers/auth_v2_schema.go
@@ -730,7 +730,8 @@ func AadAuthV2SettingsSchema() *pluginsdk.Schema {
 					Type:         pluginsdk.TypeString,
 					Optional:     true,
 					ValidateFunc: validation.StringIsNotEmpty,
-					ConflictsWith: []string{
+					ExactlyOneOf: []string{
+						"auth_settings_v2.0.active_directory_v2.0.client_secret_setting_name",
 						"auth_settings_v2.0.active_directory_v2.0.client_secret_certificate_thumbprint",
 					},
 					Description: "The App Setting name that contains the client secret of the Client.",
@@ -740,8 +741,9 @@ func AadAuthV2SettingsSchema() *pluginsdk.Schema {
 					Type:         pluginsdk.TypeString,
 					Optional:     true,
 					ValidateFunc: validation.StringIsNotEmpty,
-					ConflictsWith: []string{
+					ExactlyOneOf: []string{
 						"auth_settings_v2.0.active_directory_v2.0.client_secret_setting_name",
+						"auth_settings_v2.0.active_directory_v2.0.client_secret_certificate_thumbprint",
 					},
 					Description: "The thumbprint of the certificate used for signing purposes.",
 				},

--- a/internal/services/appservice/linux_function_app_resource_authv2_test.go
+++ b/internal/services/appservice/linux_function_app_resource_authv2_test.go
@@ -24,6 +24,30 @@ func TestAccLinuxFunctionApp_authV2AzureActiveDirectory(t *testing.T) {
 	})
 }
 
+func TestAccLinuxFunctionApp_authV2AzureActiveDirectoryRemove(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_function_app", "test")
+	r := LinuxFunctionAppResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.authV2AzureActiveDirectory(data, SkuBasicPlan),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("kind").HasValue("functionapp,linux"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basic(data, SkuStandardPlan),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("kind").HasValue("functionapp,linux"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccLinuxFunctionApp_authV2Apple(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_linux_function_app", "test")
 	r := LinuxFunctionAppResource{}

--- a/internal/services/appservice/linux_function_app_resource_authv2_test.go
+++ b/internal/services/appservice/linux_function_app_resource_authv2_test.go
@@ -279,7 +279,10 @@ resource "azurerm_linux_function_app" "test" {
       client_secret_setting_name = "%[3]s"
       tenant_auth_endpoint       = "https://sts.windows.net/%[5]s/v2.0"
     }
-    login {}
+
+    login {
+      token_store_enabled = true
+    }
   }
 }
 `, r.template(data, planSku), data.RandomInteger, secretSettingName, secretSettingValue, data.Client().TenantID)

--- a/internal/services/appservice/linux_function_app_resource_authv2_test.go
+++ b/internal/services/appservice/linux_function_app_resource_authv2_test.go
@@ -198,7 +198,7 @@ func TestAccLinuxFunctionApp_authV2Update(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.standardComplete(data),
+			Config: r.authV2AzureActiveDirectory(data, SkuBasicPlan),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("kind").HasValue("functionapp,linux"),
@@ -206,7 +206,7 @@ func TestAccLinuxFunctionApp_authV2Update(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
-			Config: r.completeAuthV2(data, SkuBasicPlan),
+			Config: r.authV2Google(data, SkuBasicPlan),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("kind").HasValue("functionapp,linux"),


### PR DESCRIPTION
* `azurerm_linux_function_app` - fix auth_v2 `active_directory_v2` sending empty data
* `azurerm_linux_function_app` - fix read for `token_store_enabled` to correctly set returned value in state
* `azurerm_linux_function_app_slot` - fix auth_v2 `active_directory_v2` sending empty data
* `azurerm_linux_function_app_slot` - fix read for `token_store_enabled` to correctly set returned value in state
* `azurerm_linux_web_app` - fix auth_v2 `active_directory_v2` sending empty data
* `azurerm_linux_web_app` - fix read for `token_store_enabled` to correctly set returned value in state
* `azurerm_linux_web_app_slot` - fix auth_v2 `active_directory_v2` sending empty data
* `azurerm_linux_web_app_slot` - fix read for `token_store_enabled` to correctly set returned value in state

* `azurerm_windows_function_app` - fix auth_v2 `active_directory_v2` sending empty data
* `azurerm_windows_function_app` - fix read for `token_store_enabled` to correctly set returned value in state
* `azurerm_windows_function_app_slot` - fix auth_v2 `active_directory_v2` sending empty data
* `azurerm_windows_function_app_slot` - fix read for `token_store_enabled` to correctly set returned value in state
* `azurerm_windows_web_app` - fix auth_v2 `active_directory_v2` sending empty data
* `azurerm_windows_web_app` - fix read for `token_store_enabled` to correctly set returned value in state
* `azurerm_windows_web_app_slot` - fix auth_v2 `active_directory_v2` sending empty data
* `azurerm_windows_web_app_slot` - fix read for `token_store_enabled` to correctly set returned value in state

closes #20913
closes #21021
closes #20820