### PR TITLE
docs: load_test identity is block format

### DIFF
--- a/website/docs/r/load_test.html.markdown
+++ b/website/docs/r/load_test.html.markdown
@@ -34,9 +34,17 @@ The following arguments are supported:
 
 * `description` - (Optional) Description of the resource. Changing this forces a new Load Test to be created.
 
-* `identity` - (Optional) Specifies the Managed Identity which should be assigned to this Load Test.
+* `identity` - (Optional) An `identity` block as defined below.
 
 * `tags` - (Optional) A mapping of tags which should be assigned to the Load Test.
+
+---
+
+An `identity` block supports the following:
+
+* `type` - (Required) The type of Managed Identity used for this Load Test. Possible values are `SystemAssigned`.
+
+---
 
 ## Attributes Reference
 


### PR DESCRIPTION
clarifying on the documentation the input format for the optional `identity` is a block that requires type & the type needs to be 'SystemAssigned' 
reference: [identity](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/load_test#identity)
