### PR TITLE
Fix unsettling Terraform Plan: web_apps, backup_instances, sql_server_auditing_policies, nsg_associations

### DIFF
--- a/internal/services/appservice/linux_function_app_resource.go
+++ b/internal/services/appservice/linux_function_app_resource.go
@@ -22,6 +22,7 @@ import (
 	storageValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
@@ -105,10 +106,11 @@ func (r LinuxFunctionAppResource) Arguments() map[string]*pluginsdk.Schema {
 		"location": commonschema.Location(),
 
 		"service_plan_id": {
-			Type:         pluginsdk.TypeString,
-			Required:     true,
-			ValidateFunc: validate.ServicePlanID,
-			Description:  "The ID of the App Service Plan within which to create this Function App",
+			Type:             pluginsdk.TypeString,
+			Required:         true,
+			ValidateFunc:     validate.ServicePlanID,
+			Description:      "The ID of the App Service Plan within which to create this Function App",
+			DiffSuppressFunc: suppress.CaseDifference,
 		},
 
 		"storage_account_name": {

--- a/internal/services/appservice/linux_function_app_slot_resource.go
+++ b/internal/services/appservice/linux_function_app_slot_resource.go
@@ -22,6 +22,7 @@ import (
 	storageValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
@@ -98,9 +99,10 @@ func (r LinuxFunctionAppSlotResource) Arguments() map[string]*pluginsdk.Schema {
 		},
 
 		"service_plan_id": {
-			Type:         pluginsdk.TypeString,
-			Optional:     true,
-			ValidateFunc: validate.ServicePlanID,
+			Type:             pluginsdk.TypeString,
+			Optional:         true,
+			ValidateFunc:     validate.ServicePlanID,
+			DiffSuppressFunc: suppress.CaseDifference,
 		},
 
 		"storage_account_name": {

--- a/internal/services/appservice/linux_web_app_resource.go
+++ b/internal/services/appservice/linux_web_app_resource.go
@@ -19,6 +19,7 @@ import (
 	networkValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
@@ -77,9 +78,10 @@ func (r LinuxWebAppResource) Arguments() map[string]*pluginsdk.Schema {
 		"location": commonschema.Location(),
 
 		"service_plan_id": {
-			Type:         pluginsdk.TypeString,
-			Required:     true,
-			ValidateFunc: validate.ServicePlanID,
+			Type:             pluginsdk.TypeString,
+			Required:         true,
+			ValidateFunc:     validate.ServicePlanID,
+			DiffSuppressFunc: suppress.CaseDifference,
 		},
 
 		// Optional

--- a/internal/services/appservice/linux_web_app_slot_resource.go
+++ b/internal/services/appservice/linux_web_app_slot_resource.go
@@ -19,6 +19,7 @@ import (
 	networkValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
@@ -90,9 +91,10 @@ func (r LinuxWebAppSlotResource) Arguments() map[string]*pluginsdk.Schema {
 		// Optional
 
 		"service_plan_id": {
-			Type:         pluginsdk.TypeString,
-			Optional:     true,
-			ValidateFunc: validate.ServicePlanID,
+			Type:             pluginsdk.TypeString,
+			Optional:         true,
+			ValidateFunc:     validate.ServicePlanID,
+			DiffSuppressFunc: suppress.CaseDifference,
 		},
 
 		"app_settings": {

--- a/internal/services/appservice/windows_function_app_resource.go
+++ b/internal/services/appservice/windows_function_app_resource.go
@@ -22,6 +22,7 @@ import (
 	storageValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
@@ -105,10 +106,11 @@ func (r WindowsFunctionAppResource) Arguments() map[string]*pluginsdk.Schema {
 		"location": commonschema.Location(),
 
 		"service_plan_id": {
-			Type:         pluginsdk.TypeString,
-			Required:     true,
-			ValidateFunc: validate.ServicePlanID,
-			Description:  "The ID of the App Service Plan within which to create this Function App",
+			Type:             pluginsdk.TypeString,
+			Required:         true,
+			ValidateFunc:     validate.ServicePlanID,
+			Description:      "The ID of the App Service Plan within which to create this Function App",
+			DiffSuppressFunc: suppress.CaseDifference,
 		},
 
 		"storage_account_name": {

--- a/internal/services/appservice/windows_function_app_slot_resource.go
+++ b/internal/services/appservice/windows_function_app_slot_resource.go
@@ -22,6 +22,7 @@ import (
 	storageValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
@@ -98,9 +99,10 @@ func (r WindowsFunctionAppSlotResource) Arguments() map[string]*pluginsdk.Schema
 		},
 
 		"service_plan_id": {
-			Type:         pluginsdk.TypeString,
-			Optional:     true,
-			ValidateFunc: validate.ServicePlanID,
+			Type:             pluginsdk.TypeString,
+			Optional:         true,
+			ValidateFunc:     validate.ServicePlanID,
+			DiffSuppressFunc: suppress.CaseDifference,
 		},
 
 		"storage_account_name": {

--- a/internal/services/appservice/windows_web_app_resource.go
+++ b/internal/services/appservice/windows_web_app_resource.go
@@ -19,6 +19,7 @@ import (
 	networkValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
@@ -75,9 +76,10 @@ func (r WindowsWebAppResource) Arguments() map[string]*pluginsdk.Schema {
 		"location": commonschema.Location(),
 
 		"service_plan_id": {
-			Type:         pluginsdk.TypeString,
-			Required:     true,
-			ValidateFunc: validate.ServicePlanID,
+			Type:             pluginsdk.TypeString,
+			Required:         true,
+			ValidateFunc:     validate.ServicePlanID,
+			DiffSuppressFunc: suppress.CaseDifference,
 		},
 
 		// Optional

--- a/internal/services/appservice/windows_web_app_slot_resource.go
+++ b/internal/services/appservice/windows_web_app_slot_resource.go
@@ -19,6 +19,7 @@ import (
 	networkValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
@@ -90,9 +91,10 @@ func (r WindowsWebAppSlotResource) Arguments() map[string]*pluginsdk.Schema {
 		// Optional
 
 		"service_plan_id": {
-			Type:         pluginsdk.TypeString,
-			Optional:     true,
-			ValidateFunc: validate.ServicePlanID,
+			Type:             pluginsdk.TypeString,
+			Optional:         true,
+			ValidateFunc:     validate.ServicePlanID,
+			DiffSuppressFunc: suppress.CaseDifference,
 		},
 
 		"app_settings": {

--- a/internal/services/dataprotection/data_protection_backup_instance_blob_storage_resource.go
+++ b/internal/services/dataprotection/data_protection_backup_instance_blob_storage_resource.go
@@ -17,6 +17,7 @@ import (
 	storageValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	azSchema "github.com/hashicorp/terraform-provider-azurerm/internal/tf/schema"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
@@ -50,23 +51,26 @@ func resourceDataProtectionBackupInstanceBlobStorage() *schema.Resource {
 			"location": commonschema.Location(),
 
 			"vault_id": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: backupinstances.ValidateBackupVaultID,
+				Type:             schema.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				ValidateFunc:     backupinstances.ValidateBackupVaultID,
+				DiffSuppressFunc: suppress.CaseDifference,
 			},
 
 			"storage_account_id": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: storageValidate.StorageAccountID,
+				Type:             schema.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				ValidateFunc:     storageValidate.StorageAccountID,
+				DiffSuppressFunc: suppress.CaseDifference,
 			},
 
 			"backup_policy_id": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: backuppolicies.ValidateBackupPolicyID,
+				Type:             schema.TypeString,
+				Required:         true,
+				ValidateFunc:     backuppolicies.ValidateBackupPolicyID,
+				DiffSuppressFunc: suppress.CaseDifference,
 			},
 		},
 	}

--- a/internal/services/mssql/mssql_server_extended_auditing_policy_resource.go
+++ b/internal/services/mssql/mssql_server_extended_auditing_policy_resource.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/mssql/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/mssql/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
@@ -38,10 +39,11 @@ func resourceMsSqlServerExtendedAuditingPolicy() *pluginsdk.Resource {
 
 		Schema: map[string]*pluginsdk.Schema{
 			"server_id": {
-				Type:         pluginsdk.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validate.ServerID,
+				Type:             pluginsdk.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				ValidateFunc:     validate.ServerID,
+				DiffSuppressFunc: suppress.CaseDifference,
 			},
 
 			"enabled": {

--- a/internal/services/mssql/mssql_server_microsoft_support_auditing_policy_resource.go
+++ b/internal/services/mssql/mssql_server_microsoft_support_auditing_policy_resource.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/mssql/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/mssql/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
@@ -38,10 +39,11 @@ func resourceMsSqlServerMicrosoftSupportAuditingPolicy() *pluginsdk.Resource {
 
 		Schema: map[string]*pluginsdk.Schema{
 			"server_id": {
-				Type:         pluginsdk.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validate.ServerID,
+				Type:             pluginsdk.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				ValidateFunc:     validate.ServerID,
+				DiffSuppressFunc: suppress.CaseDifference,
 			},
 
 			"enabled": {

--- a/internal/services/network/subnet_network_security_group_association_resource.go
+++ b/internal/services/network/subnet_network_security_group_association_resource.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 	"github.com/tombuildsstuff/kermit/sdk/network/2022-07-01/network"
@@ -43,10 +44,11 @@ func resourceSubnetNetworkSecurityGroupAssociation() *pluginsdk.Resource {
 			},
 
 			"network_security_group_id": {
-				Type:         pluginsdk.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: azure.ValidateResourceID,
+				Type:             pluginsdk.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				ValidateFunc:     azure.ValidateResourceID,
+				DiffSuppressFunc: suppress.CaseDifference,
 			},
 		},
 	}


### PR DESCRIPTION
Fixes #21085.

#21085 provides more details and examples, but the short story would be the following: we're currently in the process of migration from ARM to Terraform. Our prod environment is long-lived, it was created some years ago. Initially some resources were created manually, later other resources were created with ARM.

After we finished the migration and imported all resources into Terraform State, we stumbled upon an issue, which results in unsettled `terraform plan` immediately after invoking `terraform apply`.

Azure is inherently case-insensitive for almost all of the resources (there are just a few exceptions, see [the docs](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules)). This lead in AzureRM wanting to modify or even re-create some of the resources. Apparently Azure in its turn ignores some updates requested by AzureRM, or even formats some properties on its own. This results in some update and re-create operations popping up for every `terraform apply`.

This PR changes these resources:
- `azurerm_data_protection_backup_instance_blob_storage`
- `azurerm_mssql_server_extended_auditing_policy`
- `azurerm_mssql_server_microsoft_support_auditing_policy`
- `azurerm_subnet_network_security_group_association`
- App Services:
  - `azurerm_linux_function_app`
  - `azurerm_linux_function_app_slot`
  - `azurerm_linux_web_app`
  - `azurerm_linux_web_app_slot`
  - `azurerm_windows_function_app`
  - `azurerm_windows_function_app_slot`
  - `azurerm_windows_web_app`
  - `azurerm_windows_web_app_slot`