### PR TITLE
Fix azurerm_cognitive_account identity example

### DIFF
--- a/website/docs/r/cognitive_account_customer_managed_key.html.markdown
+++ b/website/docs/r/cognitive_account_customer_managed_key.html.markdown
@@ -35,7 +35,7 @@ resource "azurerm_cognitive_account" "example" {
   sku_name              = "E0"
   custom_subdomain_name = "example-account"
   identity {
-    type         = "SystemAssigned, UserAssigned"
+    type         = "UserAssigned"
     identity_ids = [azurerm_user_assigned_identity.example.id]
   }
 }


### PR DESCRIPTION
The string "SystemAssigned, UserAssigned" is not a valid value like the example suggest. Those are the valid values but only one of them should be used.

Because the example is creating a User Identity and passing the ID the correct value in this example should be UserAssigned