### PR TITLE
`azurerm_web_application_firewall_policy`: set `match_values` as optional

### DIFF
--- a/internal/services/network/web_application_firewall_policy_resource.go
+++ b/internal/services/network/web_application_firewall_policy_resource.go
@@ -72,7 +72,7 @@ func resourceWebApplicationFirewallPolicy() *pluginsdk.Resource {
 								Schema: map[string]*pluginsdk.Schema{
 									"match_values": {
 										Type:     pluginsdk.TypeList,
-										Required: true,
+										Optional: true,
 										Elem: &pluginsdk.Schema{
 											Type: pluginsdk.TypeString,
 										},

--- a/website/docs/r/web_application_firewall_policy.html.markdown
+++ b/website/docs/r/web_application_firewall_policy.html.markdown
@@ -150,7 +150,7 @@ The `match_conditions` block supports the following:
 
 * `match_variables` - (Required) One or more `match_variables` blocks as defined below.
 
-* `match_values` - (Required) A list of match values.
+* `match_values` - (Optional) A list of match values. This is **Required** when the `operator` is not `Any`.
 
 * `operator` - (Required) Describes operator to be matched. Possible values are `Any`, `IPMatch`, `GeoMatch`, `Equal`, `Contains`, `LessThan`, `GreaterThan`, `LessThanOrEqual`, `GreaterThanOrEqual`, `BeginsWith`, `EndsWith` and `Regex`.
 


### PR DESCRIPTION
`match_vaules` should be optional after supporting of `Any` Operator. 

document: https://learn.microsoft.com/en-us/azure/web-application-firewall/ag/custom-waf-rules-overview#operator-required

resolves: #21118 

```
--- PASS: TestAccWebApplicationFirewallPolicy_OperatorAny (300.65s)
PASS
```