### PR TITLE
`azurerm_api_management` - fix `capacity` of  primary location being changed by the `capacity` of `additional_location` issue

### DIFF
--- a/internal/services/apimanagement/api_management_resource.go
+++ b/internal/services/apimanagement/api_management_resource.go
@@ -784,7 +784,7 @@ func resourceApiManagementServiceCreateUpdate(d *pluginsdk.ResourceData, meta in
 
 	if _, ok := d.GetOk("additional_location"); ok {
 		var err error
-		properties.ServiceProperties.AdditionalLocations, err = expandAzureRmApiManagementAdditionalLocations(d, sku)
+		properties.ServiceProperties.AdditionalLocations, err = expandAzureRmApiManagementAdditionalLocations(d, *sku)
 		if err != nil {
 			return err
 		}
@@ -1451,7 +1451,7 @@ func expandAzureRmApiManagementCertificates(d *pluginsdk.ResourceData) *[]apiman
 	return &results
 }
 
-func expandAzureRmApiManagementAdditionalLocations(d *pluginsdk.ResourceData, sku *apimanagement.ServiceSkuProperties) (*[]apimanagement.AdditionalLocation, error) {
+func expandAzureRmApiManagementAdditionalLocations(d *pluginsdk.ResourceData, sku apimanagement.ServiceSkuProperties) (*[]apimanagement.AdditionalLocation, error) {
 	inputLocations := d.Get("additional_location").([]interface{})
 	parentVnetConfig := d.Get("virtual_network_configuration").([]interface{})
 
@@ -1467,7 +1467,7 @@ func expandAzureRmApiManagementAdditionalLocations(d *pluginsdk.ResourceData, sk
 
 		additionalLocation := apimanagement.AdditionalLocation{
 			Location:       utils.String(location),
-			Sku:            sku,
+			Sku:            &sku,
 			DisableGateway: utils.Bool(config["gateway_disabled"].(bool)),
 		}
 

--- a/internal/services/apimanagement/api_management_resource_test.go
+++ b/internal/services/apimanagement/api_management_resource_test.go
@@ -1249,6 +1249,7 @@ resource "azurerm_api_management" "test" {
 
   additional_location {
     zones    = []
+    capacity = 1
     location = azurerm_resource_group.test2.location
   }
 


### PR DESCRIPTION
Since the `capacity` of primary location is not necessarily the same as the  `capacity` of additional location. So the method `expandAzureRmApiManagementAdditionalLocations` should not pass the pointer `*apimanagement.ServiceSkuProperties`  as this would cause the `capacity` of the primary location to change.

Fix #21101.

Test:
PASS: TestAccApiManagement_complete (2196.58s)
