### PR TITLE
`azurerm_express_route_circuit`- Support `authorization_key`

### DIFF
--- a/internal/services/network/express_route_circuit_peering_resource_test.go
+++ b/internal/services/network/express_route_circuit_peering_resource_test.go
@@ -459,6 +459,7 @@ resource "azurerm_express_route_circuit_peering" "test" {
 
   microsoft_peering_config {
     advertised_public_prefixes = ["123.3.0.0/24"]
+    advertised_communities     = ["12076:52005", "12076:52006"]
   }
 
   ipv6 {
@@ -470,6 +471,7 @@ resource "azurerm_express_route_circuit_peering" "test" {
       advertised_public_prefixes = ["2002:db01::/126"]
       customer_asn               = 64511
       routing_registry_name      = "ARIN"
+      advertised_communities     = ["12076:52005", "12076:52006"]
     }
   }
 }
@@ -623,6 +625,7 @@ resource "azurerm_express_route_circuit_peering" "test" {
 
   microsoft_peering_config {
     advertised_public_prefixes = ["123.1.0.0/24"]
+    advertised_communities     = ["12076:52005", "12076:52006"]
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)

--- a/internal/services/network/express_route_circuit_resource.go
+++ b/internal/services/network/express_route_circuit_resource.go
@@ -96,6 +96,12 @@ func resourceExpressRouteCircuit() *pluginsdk.Resource {
 				Default:  false,
 			},
 
+			"authorization_key": {
+				Type:      pluginsdk.TypeString,
+				Optional:  true,
+				Sensitive: true,
+			},
+
 			"service_provider_name": {
 				Type:             pluginsdk.TypeString,
 				Optional:         true,
@@ -183,6 +189,7 @@ func resourceExpressRouteCircuitCreateUpdate(d *pluginsdk.ResourceData, meta int
 	sku := expandExpressRouteCircuitSku(d)
 	t := d.Get("tags").(map[string]interface{})
 	allowRdfeOps := d.Get("allow_classic_operations").(bool)
+	authKey := d.Get("authorization_key").(string)
 	expandedTags := tags.Expand(t)
 
 	// There is the potential for the express route circuit to become out of sync when the service provider updates
@@ -216,6 +223,7 @@ func resourceExpressRouteCircuitCreateUpdate(d *pluginsdk.ResourceData, meta int
 
 	if !d.IsNewResource() {
 		erc.ExpressRouteCircuitPropertiesFormat.AllowClassicOperations = &allowRdfeOps
+		erc.ExpressRouteCircuitPropertiesFormat.AuthorizationKey = &authKey
 	} else {
 		erc.ExpressRouteCircuitPropertiesFormat = &network.ExpressRouteCircuitPropertiesFormat{}
 
@@ -317,6 +325,7 @@ func resourceExpressRouteCircuitRead(d *pluginsdk.ResourceData, meta interface{}
 	d.Set("service_provider_provisioning_state", string(resp.ServiceProviderProvisioningState))
 	d.Set("service_key", resp.ServiceKey)
 	d.Set("allow_classic_operations", resp.AllowClassicOperations)
+	d.Set("authorization_key", d.Get("authorization_key").(string))
 
 	return tags.FlattenAndSet(d, resp.Tags)
 }

--- a/internal/services/network/express_route_circuit_resource_test.go
+++ b/internal/services/network/express_route_circuit_resource_test.go
@@ -33,6 +33,7 @@ func TestAccExpressRouteCircuit(t *testing.T) {
 			"bandwidthReduction":           testAccExpressRouteCircuit_bandwidthReduction,
 			"port":                         testAccExpressRouteCircuit_withExpressRoutePort,
 			"updatePort":                   testAccExpressRouteCircuit_updateExpressRoutePort,
+			"authorizationKey":             testAccExpressRouteCircuit_authorizationKey,
 		},
 		"PrivatePeering": {
 			"azurePrivatePeering":           testAccExpressRouteCircuitPeering_azurePrivatePeering,
@@ -65,6 +66,28 @@ func TestAccExpressRouteCircuit(t *testing.T) {
 			}
 		})
 	}
+}
+
+func testAccExpressRouteCircuit_authorizationKey(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_express_route_circuit", "test")
+	r := ExpressRouteCircuitResource{}
+
+	data.ResourceSequentialTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basicMeteredConfig(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.authorizationKey(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("authorization_key"),
+	})
 }
 
 func testAccExpressRouteCircuit_basicMetered(t *testing.T) {
@@ -610,4 +633,39 @@ resource "azurerm_express_route_circuit" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}
+
+func (t ExpressRouteCircuitResource) authorizationKey(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_express_route_circuit" "test" {
+  name                  = "acctest-erc-%d"
+  location              = azurerm_resource_group.test.location
+  resource_group_name   = azurerm_resource_group.test.name
+  service_provider_name = "Equinix"
+  peering_location      = "Silicon Valley"
+  bandwidth_in_mbps     = 50
+  authorization_key     = "b0be57f5-1fba-463b-adec-ffe767354cdd"
+
+  sku {
+    tier   = "Standard"
+    family = "MeteredData"
+  }
+
+  allow_classic_operations = false
+
+  tags = {
+    Environment = "production"
+    Purpose     = "AcceptanceTests"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/website/docs/r/express_route_circuit.html.markdown
+++ b/website/docs/r/express_route_circuit.html.markdown
@@ -61,7 +61,7 @@ The following arguments are supported:
 
 * `allow_classic_operations` - (Optional) Allow the circuit to interact with classic (RDFE) resources. Defaults to `false`.
 
-* `authorization_key` - (Optional) The Authorization Key used to connect to the ExpressRoute circuit.
+* `authorization_key` - (Optional) The Authorization Key used to connect to the Express Route circuit.
 
 ~> **Note:** `authorization_key` can only be set after the Circuit is created. And the Circuit is not created on Express Route port.
 

--- a/website/docs/r/express_route_circuit.html.markdown
+++ b/website/docs/r/express_route_circuit.html.markdown
@@ -61,6 +61,10 @@ The following arguments are supported:
 
 * `allow_classic_operations` - (Optional) Allow the circuit to interact with classic (RDFE) resources. Defaults to `false`.
 
+* `authorization_key` - (Optional) The Authorization Key used to connect to the ExpressRoute circuit.
+
+~> **Note:** `authorization_key` can only be set after the Circuit is created. And the Circuit is not created on Express Route port.
+
 * `express_route_port_id` - (Optional) The ID of the Express Route Port this Express Route Circuit is based on. Changing this forces a new resource to be created.
 
 * `bandwidth_in_gbps` - (Optional) The bandwidth in Gbps of the circuit being created on the Express Route Port.


### PR DESCRIPTION
Support config `authorization_key` property.
```log

=== RUN   TestAccExpressRouteCircuit11111/basic/unlimited
=== RUN   TestAccExpressRouteCircuit11111/basic/authorizationKey
=== RUN   TestAccExpressRouteCircuit11111/basic/port
=== RUN   TestAccExpressRouteCircuit11111/basic/updatePort
=== RUN   TestAccExpressRouteCircuit11111/basic/metered
=== RUN   TestAccExpressRouteCircuit11111/basic/update
=== RUN   TestAccExpressRouteCircuit11111/basic/allowClassicOperationsUpdate
=== RUN   TestAccExpressRouteCircuit11111/basic/data_basic
=== PAUSE TestAccExpressRouteCircuit11111/basic/data_basic
=== CONT  TestAccExpressRouteCircuit11111/basic/data_basic
=== RUN   TestAccExpressRouteCircuit11111/PrivatePeering
=== RUN   TestAccExpressRouteCircuit11111/PrivatePeering/azurePrivatePeering
=== RUN   TestAccExpressRouteCircuit11111/PrivatePeering/azurePrivatePeeringWithUpdate
=== RUN   TestAccExpressRouteCircuit11111/PrivatePeering/requiresImport
=== RUN   TestAccExpressRouteCircuit11111/MicrosoftPeering
=== RUN   TestAccExpressRouteCircuit11111/MicrosoftPeering/microsoftPeering
=== RUN   TestAccExpressRouteCircuit11111/MicrosoftPeering/microsoftPeeringCustomerRouting
=== RUN   TestAccExpressRouteCircuit11111/MicrosoftPeering/microsoftPeeringWithRouteFilter
=== RUN   TestAccExpressRouteCircuit11111/MicrosoftPeering/microsoftPeeringIpv6
=== RUN   TestAccExpressRouteCircuit11111/MicrosoftPeering/microsoftPeeringIpv6CustomerRouting
=== RUN   TestAccExpressRouteCircuit11111/MicrosoftPeering/microsoftPeeringIpv6WithRouteFilter
=== RUN   TestAccExpressRouteCircuit11111/authorization
=== RUN   TestAccExpressRouteCircuit11111/authorization/basic
=== RUN   TestAccExpressRouteCircuit11111/authorization/multiple
=== RUN   TestAccExpressRouteCircuit11111/authorization/requiresImport
--- PASS: TestAccExpressRouteCircuit11111 (16452.66s)
    --- PASS: TestAccExpressRouteCircuit11111/basic (7790.39s)
        --- PASS: TestAccExpressRouteCircuit11111/basic/unlimited (509.38s)
        --- PASS: TestAccExpressRouteCircuit11111/basic/authorizationKey (701.73s)
        --- PASS: TestAccExpressRouteCircuit11111/basic/requiresImport (573.27s)
        --- PASS: TestAccExpressRouteCircuit11111/basic/updateTags (662.59s)
        --- PASS: TestAccExpressRouteCircuit11111/basic/tierUpdate (847.39s)
        --- PASS: TestAccExpressRouteCircuit11111/basic/premiumMetered (488.77s)
        --- PASS: TestAccExpressRouteCircuit11111/basic/premiumUnlimited (467.89s)
        --- PASS: TestAccExpressRouteCircuit11111/basic/bandwidthReduction (717.41s)
        --- PASS: TestAccExpressRouteCircuit11111/basic/port (481.63s)
        --- PASS: TestAccExpressRouteCircuit11111/basic/updatePort (600.50s)
        --- PASS: TestAccExpressRouteCircuit11111/basic/metered (465.64s)
        --- PASS: TestAccExpressRouteCircuit11111/basic/update (625.38s)
        --- PASS: TestAccExpressRouteCircuit11111/basic/allowClassicOperationsUpdate (648.79s)
        --- PASS: TestAccExpressRouteCircuit11111/basic/data_basic (446.37s)
    --- PASS: TestAccExpressRouteCircuit11111/PrivatePeering (2088.60s)
        --- PASS: TestAccExpressRouteCircuit11111/PrivatePeering/azurePrivatePeering (600.46s)
        --- PASS: TestAccExpressRouteCircuit11111/PrivatePeering/azurePrivatePeeringWithUpdate (773.42s)
        --- PASS: TestAccExpressRouteCircuit11111/PrivatePeering/requiresImport (714.71s)
    --- PASS: TestAccExpressRouteCircuit11111/MicrosoftPeering (4071.18s)
        --- PASS: TestAccExpressRouteCircuit11111/MicrosoftPeering/microsoftPeering (789.22s)
        --- PASS: TestAccExpressRouteCircuit11111/MicrosoftPeering/microsoftPeeringCustomerRouting (624.16s)
        --- PASS: TestAccExpressRouteCircuit11111/MicrosoftPeering/microsoftPeeringWithRouteFilter (560.81s)
        --- PASS: TestAccExpressRouteCircuit11111/MicrosoftPeering/microsoftPeeringIpv6 (725.85s)
        --- PASS: TestAccExpressRouteCircuit11111/MicrosoftPeering/microsoftPeeringIpv6CustomerRouting (720.44s)
        --- PASS: TestAccExpressRouteCircuit11111/MicrosoftPeering/microsoftPeeringIpv6WithRouteFilter (650.69s)
    --- PASS: TestAccExpressRouteCircuit11111/authorization (2056.13s)
        --- PASS: TestAccExpressRouteCircuit11111/authorization/basic (537.18s)
        --- PASS: TestAccExpressRouteCircuit11111/authorization/multiple (980.66s)
        --- PASS: TestAccExpressRouteCircuit11111/authorization/requiresImport (538.29s)
PASS
PASS    github.com/hashicorp/terraform-provider-azurerm/internal/services/network       16461.370s

```