### PR TITLE
`azurerm_express_route_circuit`- can now set `authorization_key` during creation

### DIFF
--- a/internal/services/network/express_route_circuit_resource.go
+++ b/internal/services/network/express_route_circuit_resource.go
@@ -268,6 +268,18 @@ func resourceExpressRouteCircuitCreateUpdate(d *pluginsdk.ResourceData, meta int
 		return fmt.Errorf("for %s to be able to be queried: %+v", id, err)
 	}
 
+	//  authorization_key can only be set after Circuit is created
+	if erc.AuthorizationKey != nil && *erc.AuthorizationKey != "" {
+		future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.Name, erc)
+		if err != nil {
+			return fmt.Errorf(" Updating %s: %+v", id, err)
+		}
+
+		if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
+			return fmt.Errorf(" Updating %s: %+v", id, err)
+		}
+	}
+
 	d.SetId(id.ID())
 
 	return resourceExpressRouteCircuitRead(d, meta)

--- a/website/docs/r/express_route_circuit.html.markdown
+++ b/website/docs/r/express_route_circuit.html.markdown
@@ -69,8 +69,6 @@ The following arguments are supported:
 
 * `authorization_key` - (Optional) The authorization key. This can be used to set up an ExpressRoute Circuit with an ExpressRoute Port from another subscription.
 
-~> **Note:** `authorization_key` can only be set after the Circuit is created.
-
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ---

--- a/website/docs/r/express_route_circuit.html.markdown
+++ b/website/docs/r/express_route_circuit.html.markdown
@@ -69,6 +69,8 @@ The following arguments are supported:
 
 * `authorization_key` - (Optional) The authorization key. This can be used to set up an ExpressRoute Circuit with an ExpressRoute Port from another subscription.
 
+~> **Note:** `authorization_key` can only be set after the Circuit is created.
+
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ---


### PR DESCRIPTION
`authorization_key` can only be set after Circuit is created