### PR TITLE
`azurerm_role_definition` - Increase the continuous 404 counts on delete to tolerate propagation delay

### DIFF
--- a/internal/services/authorization/role_definition_resource.go
+++ b/internal/services/authorization/role_definition_resource.go
@@ -340,7 +340,7 @@ func resourceArmRoleDefinitionDelete(d *pluginsdk.ResourceData, meta interface{}
 		},
 		Refresh:                   roleDefinitionDeleteStateRefreshFunc(ctx, client, id.ResourceID),
 		MinTimeout:                10 * time.Second,
-		ContinuousTargetOccurence: 10,
+		ContinuousTargetOccurence: 20,
 		Timeout:                   d.Timeout(pluginsdk.TimeoutDelete),
 	}
 


### PR DESCRIPTION
There are intermittent errors caught by the TC test cases like:

```
testing_new.go:86: Error running post-test destroy, there may be dangling resources: "azurerm_role_definition.test" still exists
--- FAIL: TestAccRoleDefinition_basic (346.42s)
```

And

```
testing_new.go:86: Error running post-test destroy, there may be dangling resources: "azurerm_role_definition.test" still exists
--- FAIL: TestAccRoleDefinition_emptyName (324.49s)
FAIL
```

There isn't really a good way to fully eliminate it, but it appears the current continuous count for 404 is not long enough.