### PR TITLE
Fix some Storage AccTests

### DIFF
--- a/internal/services/storage/storage_account_resource_test.go
+++ b/internal/services/storage/storage_account_resource_test.go
@@ -3889,6 +3889,11 @@ resource "azurerm_storage_account" "test" {
   account_tier             = "Standard"
   account_replication_type = "LRS"
   account_kind             = "StorageV2"
+
+  # These need to be the same as in customerManagedKey, since they are all force new properties.
+  infrastructure_encryption_enabled = true
+  table_encryption_key_type         = "Account"
+  queue_encryption_key_type         = "Account"
 }
 `, r.cmkTemplate(data), data.RandomString)
 }

--- a/internal/services/storage/storage_encryption_scope_resource_test.go
+++ b/internal/services/storage/storage_encryption_scope_resource_test.go
@@ -404,7 +404,7 @@ resource "azurerm_key_vault_access_policy" "client" {
   tenant_id    = data.azurerm_client_config.current.tenant_id
   object_id    = data.azurerm_client_config.current.object_id
 
-  key_permissions = ["Get", "Create", "Delete", "List", "Restore", "Recover", "UnwrapKey", "WrapKey", "Purge", "Encrypt", "Decrypt", "Sign", "Verify"]
+  key_permissions = ["Get", "Create", "Delete", "List", "Restore", "Recover", "UnwrapKey", "WrapKey", "Purge", "Encrypt", "Decrypt", "Sign", "Verify", "GetRotationPolicy"]
 }
 
 resource "azurerm_key_vault_key" "first" {


### PR DESCRIPTION
1. azurerm_storage_encryption_scope - Adding the required key vault key permission "GetRotationPolicy"
2. Ensure the force new properties in subtests of TestAccStorageAccount_pdateToUsingIdentityAndCustomerManagedKey are the same to avoid re-creation