### PR TITLE
[Documentation:] `azurerm_databricks_workspace` - Remove `private preview` warning from the document

### DIFF
--- a/website/docs/r/databricks_workspace.html.markdown
+++ b/website/docs/r/databricks_workspace.html.markdown
@@ -8,8 +8,6 @@ description: |-
 
 # azurerm_databricks_workspace
 
-~> **NOTE:** Some Databricks Workspace features are in Private Preview(e.g. Private Link Endpoint, Customer Managed Keys for Managed Services, etc.) and potentially subject to breaking change without notice. If you would like to use these features please contact your Microsoft support representative on how to opt-in to the Databricks Workspace Private Preview feature program.
-
 Manages a Databricks Workspace
 
 ## Example Usage


### PR DESCRIPTION
The resource has been upgraded the the GA version of the API (e.g. `2023-02-01`)