### PR TITLE
azurerm_log_analytics_linked_service - fix the validation of workspace_id

### DIFF
--- a/internal/services/loganalytics/log_analytics_linked_service_resource.go
+++ b/internal/services/loganalytics/log_analytics_linked_service_resource.go
@@ -215,7 +215,7 @@ func resourceLogAnalyticsLinkedServiceSchema() map[string]*pluginsdk.Schema {
 			Type:             pluginsdk.TypeString,
 			Required:         true,
 			DiffSuppressFunc: suppress.CaseDifference,
-			ValidateFunc:     linkedservices.ValidateLinkedServiceID,
+			ValidateFunc:     linkedservices.ValidateWorkspaceID,
 		},
 
 		"read_access_id": {

--- a/internal/services/loganalytics/log_analytics_linked_service_resource.go
+++ b/internal/services/loganalytics/log_analytics_linked_service_resource.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
@@ -212,10 +211,9 @@ func resourceLogAnalyticsLinkedServiceSchema() map[string]*pluginsdk.Schema {
 		"resource_group_name": azure.SchemaResourceGroupNameDiffSuppress(),
 
 		"workspace_id": {
-			Type:             pluginsdk.TypeString,
-			Required:         true,
-			DiffSuppressFunc: suppress.CaseDifference,
-			ValidateFunc:     linkedservices.ValidateWorkspaceID,
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ValidateFunc: linkedservices.ValidateWorkspaceID,
 		},
 
 		"read_access_id": {


### PR DESCRIPTION
Recently, below test cases are failed in teamcity. I found workspace_id is using incorrect validation. See more details from this [PR](https://github.com/hashicorp/terraform-provider-azurerm/pull/21129/files#diff-5ffc98fdebaf9b47f4edcba5d3b1ee5316c2facc35e53a491ea641c94dbff1a5).
![image](https://user-images.githubusercontent.com/19754191/228396865-0e8ca3df-b00e-415f-b401-bc67ce45f51c.png)

So I raised this PR and here is the test result.
![image](https://user-images.githubusercontent.com/19754191/228397183-82ccd6d8-1f5b-4007-ae61-30c584de150f.png)

