### PR TITLE
`test` - Fix `TestAccWindowsVirtualMachineScaleSet_otherWinRMHTTPS`

### DIFF
--- a/internal/services/compute/windows_virtual_machine_scale_set_other_resource_test.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_other_resource_test.go
@@ -2190,8 +2190,6 @@ resource "azurerm_windows_virtual_machine_scale_set" "test" {
 }
 
 func (r WindowsVirtualMachineScaleSetResource) otherWinRMHTTPS(data acceptance.TestData) string {
-	// key vault name can only be up to 24 chars
-	trimmedName := fmt.Sprintf("%d", data.RandomInteger)[0:5]
 	return fmt.Sprintf(`
 %s
 
@@ -2356,7 +2354,7 @@ resource "azurerm_windows_virtual_machine_scale_set" "test" {
     protocol        = "Https"
   }
 }
-`, r.template(data), trimmedName)
+`, r.template(data), data.RandomString)
 }
 
 func (r WindowsVirtualMachineScaleSetResource) updateLoadBalancerHealthProbeSKU(data acceptance.TestData, isStandardSku bool) string {


### PR DESCRIPTION
This test failed with `"The vault name 'acctestkv23032' is already in use.`, the trimmed random integer still has `yymmd` thus causing a conflict. Fixing it by using random string instead.
Fix is taken from VM resource: https://github.com/hashicorp/terraform-provider-azurerm/blob/81f695dc539290716d192ff9b32bcadb1e8f9549/internal/services/compute/windows_virtual_machine_resource_other_test.go#L2817-L2824