### PR TITLE
`azurerm_kubernetes_cluster[_node_pool]` - Add `KataMshvVmIsolation` as `workload_runtime` option

### DIFF
--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -351,6 +351,7 @@ func resourceKubernetesClusterNodePool() *pluginsdk.Resource {
 				ValidateFunc: validation.StringInSlice([]string{
 					string(agentpools.WorkloadRuntimeOCIContainer),
 					string(agentpools.WorkloadRuntimeWasmWasi),
+					string(agentpools.WorkloadRuntimeKataMshvVMIsolation),
 				}, false),
 			},
 			"zones": commonschema.ZonesMultipleOptionalForceNew(),

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
@@ -893,6 +893,13 @@ func TestAccKubernetesClusterNodePool_workloadRuntime(t *testing.T) {
 			),
 		},
 		data.ImportStep(),
+		{
+			Config: r.workloadRuntime(data, "KataMshvVmIsolation"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
 	})
 }
 

--- a/internal/services/containers/kubernetes_cluster_other_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_other_resource_test.go
@@ -1405,7 +1405,7 @@ resource "azurerm_kubernetes_cluster" "test" {
     node_count         = 1
     vm_size            = "Standard_D2s_v3"
     message_of_the_day = "daily message"
-		os_sku             = "Mariner"
+    os_sku             = "Mariner"
     workload_runtime   = "KataMshvVmIsolation"
   }
 

--- a/internal/services/containers/kubernetes_cluster_other_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_other_resource_test.go
@@ -215,13 +215,28 @@ func TestAccKubernetesCluster_nodeResourceGroup(t *testing.T) {
 	})
 }
 
-func TestAccKubernetesCluster_nodePoolOther(t *testing.T) {
+func TestAccKubernetesCluster_nodePoolOCIContainer(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
 	r := KubernetesClusterResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.nodePoolOther(data),
+			Config: r.nodePoolWorkloadRuntime(data, "Ubuntu", "OCIContainer"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccKubernetesCluster_nodePoolKataMshvVmIsolation(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
+	r := KubernetesClusterResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.nodePoolWorkloadRuntime(data, "Mariner", "KataMshvVmIsolation"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -1334,7 +1349,7 @@ resource "azurerm_kubernetes_cluster" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, nodeResourceGroupName)
 }
 
-func (KubernetesClusterResource) nodePoolOther(data acceptance.TestData) string {
+func (KubernetesClusterResource) nodePoolWorkloadRuntime(data acceptance.TestData, sku string, workloadRuntime string) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -1358,14 +1373,15 @@ resource "azurerm_kubernetes_cluster" "test" {
     fips_enabled       = true
     kubelet_disk_type  = "OS"
     message_of_the_day = "daily message"
-    workload_runtime   = "OCIContainer"
+		os_sku             = "%s"
+    workload_runtime   = "%s"
   }
 
   identity {
     type = "SystemAssigned"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, sku, workloadRuntime)
 }
 
 func (KubernetesClusterResource) paidSkuConfig(data acceptance.TestData) string {

--- a/internal/services/containers/kubernetes_nodepool.go
+++ b/internal/services/containers/kubernetes_nodepool.go
@@ -275,6 +275,7 @@ func SchemaDefaultNodePool() *pluginsdk.Schema {
 						Computed: true,
 						ValidateFunc: validation.StringInSlice([]string{
 							string(managedclusters.WorkloadRuntimeOCIContainer),
+							string(agentpools.WorkloadRuntimeKataMshvVMIsolation),
 						}, false),
 					},
 				}

--- a/internal/services/containers/kubernetes_nodepool.go
+++ b/internal/services/containers/kubernetes_nodepool.go
@@ -275,7 +275,7 @@ func SchemaDefaultNodePool() *pluginsdk.Schema {
 						Computed: true,
 						ValidateFunc: validation.StringInSlice([]string{
 							string(managedclusters.WorkloadRuntimeOCIContainer),
-							string(agentpools.WorkloadRuntimeKataMshvVMIsolation),
+							string(managedclusters.WorkloadRuntimeKataMshvVMIsolation),
 						}, false),
 					},
 				}

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -432,7 +432,9 @@ A `default_node_pool` block supports the following:
 
 ~> **Note:** A Route Table must be configured on this Subnet.
 
-* `workload_runtime` - (Optional) Specifies the workload runtime used by the node pool. The only possible value is `OCIContainer`.
+* `workload_runtime` - (Optional) Specifies the workload runtime used by the node pool. Possible values are `OCIContainer` and `KataMshvVmIsolation`.
+
+~> **Note:** Pod Sandboxing / KataVM Isolation node pools are in Public Preview - more information and details on how to opt into the preview can be found in [this article](https://learn.microsoft.com/azure/aks/use-pod-sandboxing)
 
 * `zones` - (Optional) Specifies a list of Availability Zones in which this Kubernetes Cluster should be located. Changing this forces a new Kubernetes Cluster to be created.
 
@@ -453,14 +455,6 @@ If `enable_auto_scaling` is set to `false`, then the following fields can also b
 * `node_count` - (Optional) The number of nodes which should exist in this Node Pool. If specified this must be between `1` and `1000`.
 
 -> **Note:** If `enable_auto_scaling` is set to `false` both `min_count` and `max_count` fields need to be set to `null` or omitted from the configuration.
-
-* `workload_runtime` - (Optional) Specifies the workload runtime used by the node pool. Possible values are `OCIContainer` and `KataMshvVmIsolation`.
-
-~> **Note:** Pod Sandboxing / KataVM Isolation node pools are in Public Preview - more information and details on how to opt into the preview can be found in [this article](https://learn.microsoft.com/azure/aks/use-pod-sandboxing)
-
-* `zones` - (Optional) Specifies a list of Availability Zones in which this Kubernetes Cluster should be located. Changing this forces a new Kubernetes Cluster to be created.
-
--> **Note:** This requires that the `type` is set to `VirtualMachineScaleSets` and that `load_balancer_sku` is set to `standard`.
 
 ---
 

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -454,6 +454,14 @@ If `enable_auto_scaling` is set to `false`, then the following fields can also b
 
 -> **Note:** If `enable_auto_scaling` is set to `false` both `min_count` and `max_count` fields need to be set to `null` or omitted from the configuration.
 
+* `workload_runtime` - (Optional) Specifies the workload runtime used by the node pool. Possible values are `OCIContainer` and `KataMshvVmIsolation`.
+
+~> **Note:** Pod Sandboxing / KataVM Isolation node pools are in Public Preview - more information and details on how to opt into the preview can be found in [this article](https://learn.microsoft.com/azure/aks/use-pod-sandboxing)
+
+* `zones` - (Optional) Specifies a list of Availability Zones in which this Kubernetes Cluster should be located. Changing this forces a new Kubernetes Cluster to be created.
+
+-> **Note:** This requires that the `type` is set to `VirtualMachineScaleSets` and that `load_balancer_sku` is set to `standard`.
+
 ---
 
 An `identity` block supports the following:

--- a/website/docs/r/kubernetes_cluster_node_pool.html.markdown
+++ b/website/docs/r/kubernetes_cluster_node_pool.html.markdown
@@ -154,9 +154,11 @@ The following arguments are supported:
 
 * `windows_profile` - (Optional) A `windows_profile` block as documented below. Changing this forces a new resource to be created.
 
-* `workload_runtime` - (Optional) Used to specify the workload runtime. Allowed values are `OCIContainer` and `WasmWasi`.
+* `workload_runtime` - (Optional) Used to specify the workload runtime. Allowed values are `OCIContainer`, `WasmWasi` and `KataMshvVmIsolation`.
 
 ~> **Note:** WebAssembly System Interface node pools are in Public Preview - more information and details on how to opt into the preview can be found in [this article](https://docs.microsoft.com/azure/aks/use-wasi-node-pools)
+
+~> **Note:** Pod Sandboxing / KataVM Isolation node pools are in Public Preview - more information and details on how to opt into the preview can be found in [this article](https://learn.microsoft.com/azure/aks/use-pod-sandboxing)
 
 * `zones` - (Optional) Specifies a list of Availability Zones in which this Kubernetes Cluster Node Pool should be located. Changing this forces a new Kubernetes Cluster Node Pool to be created.
 


### PR DESCRIPTION
Fixes #21168


## AccTests
- [x] `azurerm_kubernetes_cluster` test
```bash
❯ go install && make acctests SERVICE='containers' TESTARGS='-run=TestAccKubernetesCluster_nodePoolKataMshvVmIsolation'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/containers -run=TestAccKubernetesCluster_nodePoolKataMshvVmIsolation -timeout 180m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccKubernetesCluster_nodePoolKataMshvVmIsolation
=== PAUSE TestAccKubernetesCluster_nodePoolKataMshvVmIsolation
=== CONT  TestAccKubernetesCluster_nodePoolKataMshvVmIsolation
--- PASS: TestAccKubernetesCluster_nodePoolKataMshvVmIsolation (612.37s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/containers    614.317s
```

- [x] `azurerm_kubernetes_cluster_node_pool` test
```bash
❯ go install && make acctests SERVICE='containers' TESTARGS='-run=TestAccKubernetesClusterNodePool_workloadRuntime'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/containers -run=TestAccKubernetesClusterNodePool_workloadRuntime -timeout 180m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccKubernetesClusterNodePool_workloadRuntime
=== PAUSE TestAccKubernetesClusterNodePool_workloadRuntime
=== CONT  TestAccKubernetesClusterNodePool_workloadRuntime
--- PASS: TestAccKubernetesClusterNodePool_workloadRuntime (766.34s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/containers       768.281s
```