### PR TITLE
storage: fixing the validation for `ip_rules` to include the value in the error

### DIFF
--- a/internal/services/storage/storage_account_network_rules_resource.go
+++ b/internal/services/storage/storage_account_network_rules_resource.go
@@ -75,7 +75,8 @@ func resourceStorageAccountNetworkRulesSchema() map[string]*pluginsdk.Schema {
 			Computed:   true,
 			ConfigMode: pluginsdk.SchemaConfigModeAttr,
 			Elem: &pluginsdk.Schema{
-				Type: pluginsdk.TypeString,
+				Type:         pluginsdk.TypeString,
+				ValidateFunc: validate.StorageAccountIpRule,
 			},
 			Set: pluginsdk.HashString,
 		},

--- a/internal/services/storage/validate/storage_account_ip_rule.go
+++ b/internal/services/storage/validate/storage_account_ip_rule.go
@@ -11,7 +11,7 @@ func StorageAccountIpRule(v interface{}, k string) (warnings []string, errors []
 	value := v.(string)
 
 	if !regexp.MustCompile(`^([0-9]{1,3}\.){3}[0-9]{1,3}(/([0-9]|[1-2][0-9]|30))?$`).MatchString(value) {
-		errors = append(errors, fmt.Errorf("%q must start with IPV4 address and/or slash, number of bits (0-30) as prefix. Example: 23.45.1.0/30.", k))
+		errors = append(errors, fmt.Errorf("%q must start with IPV4 address and/or slash, number of bits (0-30) as prefix. Example: 23.45.1.0/30 but got %q.", k, value))
 		return warnings, errors
 	}
 
@@ -19,7 +19,7 @@ func StorageAccountIpRule(v interface{}, k string) (warnings []string, errors []
 	firstIPPart := ipParts[0]
 	secondIPPart, _ := strconv.Atoi(ipParts[1])
 	if (firstIPPart == "10") || (firstIPPart == "172" && secondIPPart >= 16 && secondIPPart <= 31) || (firstIPPart == "192" && secondIPPart == 168) {
-		errors = append(errors, fmt.Errorf("%q must be public ip address", k))
+		errors = append(errors, fmt.Errorf("%q must be public ip address but got %q", k, value))
 		return warnings, errors
 	}
 


### PR DESCRIPTION
The validation function `StorageAccountIpRule` is used in a Set of values which is likely to contain a number of items - as such when this returns an error we should surface exactly which value isn't valid.

This PR also adds validation to the `ip_rules` field for `azurerm_storage_account_network_rules`, since this is present for the same field in `azurerm_storage_account` and so should match

Fixes #21169