### PR TITLE
azurerm_kubernetes_cluster: Fix maintenance window order

### DIFF
--- a/internal/services/containers/kubernetes_cluster_other_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_other_resource_test.go
@@ -508,6 +508,8 @@ func TestAccKubernetesCluster_basicMaintenanceConfig(t *testing.T) {
 			Config: r.basicMaintenanceConfig(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("maintenance_window.0.allowed.0.hours.0").HasValue("2"),
+				check.That(data.ResourceName).Key("maintenance_window.0.allowed.0.hours.1").HasValue("1"),
 			),
 		},
 		data.ImportStep(),
@@ -553,6 +555,8 @@ func TestAccKubernetesCluster_updateMaintenanceConfig(t *testing.T) {
 			Config: r.basicMaintenanceConfig(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("maintenance_window.0.allowed.0.hours.0").HasValue("2"),
+				check.That(data.ResourceName).Key("maintenance_window.0.allowed.0.hours.1").HasValue("1"),
 			),
 		},
 		data.ImportStep(),
@@ -567,6 +571,8 @@ func TestAccKubernetesCluster_updateMaintenanceConfig(t *testing.T) {
 			Config: r.basicMaintenanceConfig(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("maintenance_window.0.allowed.0.hours.0").HasValue("2"),
+				check.That(data.ResourceName).Key("maintenance_window.0.allowed.0.hours.1").HasValue("1"),
 			),
 		},
 		data.ImportStep(),
@@ -1900,7 +1906,7 @@ resource "azurerm_kubernetes_cluster" "test" {
   maintenance_window {
     allowed {
       day   = "Monday"
-      hours = [1, 2]
+      hours = [2, 1]
     }
   }
 }

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -689,7 +689,7 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 									},
 
 									"hours": {
-										Type:     pluginsdk.TypeSet,
+										Type:     pluginsdk.TypeList,
 										Required: true,
 										MinItems: 1,
 										Elem: &pluginsdk.Schema{


### PR DESCRIPTION
At the moment, is not possible to define a maintenance windows like this

```
  maintenance_window {
    allowed {
      day   = "Monday"
      hours = [2, 1]
    }
  }
```

hours is defined as a `set` at the moment however `set` is not ordered by default [ unordered data type ] which changes 2,1 into 1,2 which is not correct.

The order is important here, since the first value indicate the start hour, the second value the timeSpan