### PR TITLE
`azurerm_application_gateway` - `ssl_certificate.x.data` must be a base64 string

### DIFF
--- a/internal/services/network/application_gateway_resource.go
+++ b/internal/services/network/application_gateway_resource.go
@@ -1158,10 +1158,11 @@ func resourceApplicationGateway() *pluginsdk.Resource {
 						},
 
 						"data": {
-							Type:      pluginsdk.TypeString,
-							Optional:  true,
-							Sensitive: true,
-							StateFunc: base64EncodedStateFunc,
+							Type:         pluginsdk.TypeString,
+							Optional:     true,
+							Sensitive:    true,
+							StateFunc:    base64EncodedStateFunc,
+							ValidateFunc: validation.StringIsBase64,
 						},
 
 						"password": {

--- a/website/docs/r/application_gateway.html.markdown
+++ b/website/docs/r/application_gateway.html.markdown
@@ -461,7 +461,7 @@ A `ssl_certificate` block supports the following:
 
 * `name` - (Required) The Name of the SSL certificate that is unique within this Application Gateway
 
-* `data` - (Optional) PFX certificate. Required if `key_vault_secret_id` is not set. Must be a base64 encoded string. 
+* `data` - (Optional) The base64-encoded PFX certificate data. Required if `key_vault_secret_id` is not set.
 
 -> **NOTE:** When specifying a file, use `data = filebase64("path/to/file")` to encode the contents of that file.
 

--- a/website/docs/r/application_gateway.html.markdown
+++ b/website/docs/r/application_gateway.html.markdown
@@ -461,7 +461,9 @@ A `ssl_certificate` block supports the following:
 
 * `name` - (Required) The Name of the SSL certificate that is unique within this Application Gateway
 
-* `data` - (Optional) PFX certificate. Required if `key_vault_secret_id` is not set.
+* `data` - (Optional) PFX certificate. Required if `key_vault_secret_id` is not set. Must be a base64 encoded string. 
+
+-> **NOTE:** When specifying a file, use `data = filebase64("path/to/file")` to encode the contents of that file.
 
 * `password` - (Optional) Password for the pfx file specified in data. Required if `data` is set.
 


### PR DESCRIPTION
Adding a validation check and updating the docs with more information about how to use `ssl_certificate.x.data`