### PR TITLE
`azurerm_healthcare_medtech_service` - fix eventhub namespace suffix trim issue

### DIFF
--- a/internal/services/healthcare/healthcare_medtech_service_data_source.go
+++ b/internal/services/healthcare/healthcare_medtech_service_data_source.go
@@ -109,7 +109,8 @@ func dataSourceHealthcareIotConnectorRead(d *pluginsdk.ResourceData, meta interf
 			}
 
 			if props.IngestionEndpointConfiguration.FullyQualifiedEventHubNamespace != nil {
-				eventHubNamespaceName = strings.TrimSuffix(*props.IngestionEndpointConfiguration.FullyQualifiedEventHubNamespace, *domainSuffix)
+				suffixToTrim := "." + *domainSuffix
+				eventHubNamespaceName = strings.TrimSuffix(*props.IngestionEndpointConfiguration.FullyQualifiedEventHubNamespace, suffixToTrim)
 			}
 		}
 		d.Set("eventhub_consumer_group_name", eventHubConsumerGroupName)

--- a/internal/services/healthcare/healthcare_medtech_service_resource.go
+++ b/internal/services/healthcare/healthcare_medtech_service_resource.go
@@ -222,7 +222,8 @@ func resourceHealthcareApisMedTechServiceRead(d *pluginsdk.ResourceData, meta in
 			}
 
 			if props.IngestionEndpointConfiguration.FullyQualifiedEventHubNamespace != nil {
-				eventHubNamespaceName = strings.TrimSuffix(*props.IngestionEndpointConfiguration.FullyQualifiedEventHubNamespace, *domainSuffix)
+				suffixToTrim := "." + *domainSuffix
+				eventHubNamespaceName = strings.TrimSuffix(*props.IngestionEndpointConfiguration.FullyQualifiedEventHubNamespace, suffixToTrim)
 			}
 		}
 		d.Set("eventhub_consumer_group_name", eventHubConsumerGroupName)


### PR DESCRIPTION
we should also remove the `.` from the namespace name

![image](https://user-images.githubusercontent.com/92154856/228711401-0c3dd982-5426-4de4-88e7-e7c4a1c7e420.png)
