### PR TITLE
New DataSource: `azurerm_container_app`

### DIFF
--- a/internal/services/containerapps/container_app_data_source.go
+++ b/internal/services/containerapps/container_app_data_source.go
@@ -1,0 +1,186 @@
+package containerapps
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2022-03-01/containerapps"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2022-03-01/managedenvironments"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/containerapps/helpers"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+type ContainerAppDataSource struct{}
+
+type ContainerAppDataSourceModel struct {
+	Name                       string                                     `tfschema:"name"`
+	ResourceGroup              string                                     `tfschema:"resource_group_name"`
+	ManagedEnvironmentId       string                                     `tfschema:"container_app_environment_id"`
+	Location                   string                                     `tfschema:"location"`
+	RevisionMode               string                                     `tfschema:"revision_mode"`
+	Ingress                    []helpers.Ingress                          `tfschema:"ingress"`
+	Registries                 []helpers.Registry                         `tfschema:"registry"`
+	Secrets                    []helpers.Secret                           `tfschema:"secret"`
+	Dapr                       []helpers.Dapr                             `tfschema:"dapr"`
+	Template                   []helpers.ContainerTemplate                `tfschema:"template"`
+	Identity                   []identity.ModelSystemAssignedUserAssigned `tfschema:"identity"`
+	Tags                       map[string]interface{}                     `tfschema:"tags"`
+	OutboundIpAddresses        []string                                   `tfschema:"outbound_ip_addresses"`
+	LatestRevisionName         string                                     `tfschema:"latest_revision_name"`
+	LatestRevisionFqdn         string                                     `tfschema:"latest_revision_fqdn"`
+	CustomDomainVerificationId string                                     `tfschema:"custom_domain_verification_id"`
+}
+
+var _ sdk.DataSource = ContainerAppDataSource{}
+
+func (r ContainerAppDataSource) Arguments() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"name": {
+			Type:         schema.TypeString,
+			Required:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"resource_group_name": commonschema.ResourceGroupNameForDataSource(),
+	}
+}
+
+func (r ContainerAppDataSource) Attributes() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"container_app_environment_id": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+
+		"template": helpers.ContainerTemplateSchemaComputed(),
+
+		"revision_mode": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+
+		"ingress": helpers.ContainerAppIngressSchemaComputed(),
+
+		"registry": helpers.ContainerAppRegistrySchemaComputed(),
+
+		"secret": helpers.SecretsDataSourceSchema(),
+
+		"dapr": helpers.ContainerDaprSchemaComputed(),
+
+		"identity": commonschema.SystemOrUserAssignedIdentityComputed(),
+
+		"tags": commonschema.TagsDataSource(),
+
+		"location": commonschema.LocationComputed(),
+
+		"outbound_ip_addresses": {
+			Type:     schema.TypeList,
+			Computed: true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
+
+		"latest_revision_name": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "The name of the latest Container Revision.",
+		},
+
+		"latest_revision_fqdn": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "The fully qualified domain name of the latest Container App.",
+		},
+
+		"custom_domain_verification_id": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Sensitive:   true,
+			Description: "The ID of the Custom Domain Verification for this Container App.",
+		},
+	}
+}
+
+func (r ContainerAppDataSource) ModelObject() interface{} {
+	return &ContainerAppDataSourceModel{}
+}
+
+func (r ContainerAppDataSource) ResourceType() string {
+	return "azurerm_container_app"
+}
+
+func (r ContainerAppDataSource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.ContainerApps.ContainerAppClient
+			subscriptionId := metadata.Client.Account.SubscriptionId
+
+			var containerApp ContainerAppDataSourceModel
+			if err := metadata.Decode(&containerApp); err != nil {
+				return err
+			}
+
+			id := containerapps.NewContainerAppID(subscriptionId, containerApp.ResourceGroup, containerApp.Name)
+
+			existing, err := client.Get(ctx, id)
+			if err != nil {
+				if response.WasNotFound(existing.HttpResponse) {
+					return fmt.Errorf("%s was not found", id)
+				}
+				return fmt.Errorf("reading %s: %+v", id, err)
+			}
+
+			containerApp.Name = id.ContainerAppName
+			containerApp.ResourceGroup = id.ResourceGroupName
+
+			if model := existing.Model; model != nil {
+				containerApp.Location = location.Normalize(model.Location)
+				containerApp.Tags = tags.Flatten(model.Tags)
+
+				if props := model.Properties; props != nil {
+					envId, err := managedenvironments.ParseManagedEnvironmentIDInsensitively(pointer.From(props.ManagedEnvironmentId))
+					if err != nil {
+						return err
+					}
+					containerApp.ManagedEnvironmentId = envId.ID()
+					containerApp.Template = helpers.FlattenContainerAppTemplate(props.Template)
+					if config := props.Configuration; config != nil {
+						if config.ActiveRevisionsMode != nil {
+							if config.ActiveRevisionsMode != nil {
+								containerApp.RevisionMode = string(pointer.From(config.ActiveRevisionsMode))
+							}
+							containerApp.Ingress = helpers.FlattenContainerAppIngress(config.Ingress, id.ContainerAppName)
+							containerApp.Registries = helpers.FlattenContainerAppRegistries(config.Registries)
+							containerApp.Dapr = helpers.FlattenContainerAppDapr(config.Dapr)
+						}
+					}
+					containerApp.LatestRevisionName = pointer.From(props.LatestRevisionName)
+					containerApp.LatestRevisionFqdn = pointer.From(props.LatestRevisionFqdn)
+					containerApp.CustomDomainVerificationId = pointer.From(props.CustomDomainVerificationId)
+					containerApp.OutboundIpAddresses = pointer.From(props.OutboundIPAddresses)
+				}
+			}
+
+			secretsResp, err := client.ListSecrets(ctx, id)
+			if err != nil {
+				return fmt.Errorf("listing secrets for %s: %+v", id, err)
+			}
+
+			containerApp.Secrets = helpers.FlattenContainerAppSecrets(secretsResp.Model)
+			metadata.SetID(id)
+
+			return metadata.Encode(&containerApp)
+		},
+	}
+}

--- a/internal/services/containerapps/container_app_data_source_test.go
+++ b/internal/services/containerapps/container_app_data_source_test.go
@@ -1,0 +1,33 @@
+package containerapps_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+)
+
+type ContainerAppDataSource struct{}
+
+func TestAccContainerAppDataSource_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_container_app", "test")
+	r := ContainerAppDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check:  acceptance.ComposeTestCheckFunc(),
+		},
+	})
+}
+
+func (d ContainerAppDataSource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_container_app" "test" {
+  name                = azurerm_container_app.test.name
+  resource_group_name = azurerm_container_app.test.resource_group_name
+}
+`, ContainerAppResource{}.basic(data))
+}

--- a/internal/services/containerapps/helpers/container_apps.go
+++ b/internal/services/containerapps/helpers/container_apps.go
@@ -57,6 +57,40 @@ func ContainerAppRegistrySchema() *pluginsdk.Schema {
 	}
 }
 
+func ContainerAppRegistrySchemaComputed() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Computed: true,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"server": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The hostname for the Container Registry.",
+				},
+
+				"username": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The username to use for this Container Registry.",
+				},
+
+				"password_secret_name": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The name of the Secret Reference containing the password value for this user on the Container Registry.",
+				},
+
+				"identity": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "ID of the System or User Managed Identity used to pull images from the Container Registry",
+				},
+			},
+		},
+	}
+}
+
 func ValidateContainerAppRegistry(r Registry) error {
 	if r.Identity != "" && (r.UserName != "" || r.PasswordSecretRef != "") {
 		return fmt.Errorf("identity and username/password_secret_name are mutually exclusive")
@@ -169,6 +203,50 @@ func ContainerAppIngressSchema() *pluginsdk.Schema {
 	}
 }
 
+func ContainerAppIngressSchemaComputed() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Computed: true,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"allow_insecure_connections": {
+					Type:        pluginsdk.TypeBool,
+					Computed:    true,
+					Description: "Should this ingress allow insecure connections?",
+				},
+
+				"custom_domain": ContainerAppIngressCustomDomainSchemaComputed(),
+
+				"external_enabled": {
+					Type:        pluginsdk.TypeBool,
+					Computed:    true,
+					Description: "Is this an external Ingress.",
+				},
+
+				"fqdn": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The FQDN of the ingress.",
+				},
+
+				"target_port": {
+					Type:        pluginsdk.TypeInt,
+					Computed:    true,
+					Description: "The target port on the container for the Ingress traffic.",
+				},
+
+				"traffic_weight": ContainerAppIngressTrafficWeightComputed(),
+
+				"transport": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The transport method for the Ingress. Possible values include `auto`, `http`, and `http2`. Defaults to `auto`",
+				},
+			},
+		},
+	}
+}
+
 func ExpandContainerAppIngress(input []Ingress, appName string) *containerapps.Ingress {
 	if len(input) == 0 {
 		return nil
@@ -243,6 +321,34 @@ func ContainerAppIngressCustomDomainSchema() *pluginsdk.Schema {
 					Required:     true,
 					ValidateFunc: validation.StringIsNotEmpty,
 					Description:  "The hostname of the Certificate. Must be the CN or a named SAN in the certificate.",
+				},
+			},
+		},
+	}
+}
+
+func ContainerAppIngressCustomDomainSchemaComputed() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Computed: true,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"certificate_binding_type": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The Binding type. Possible values include `Disabled` and `SniEnabled`. Defaults to `Disabled`",
+				},
+
+				"certificate_id": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The ID of the Certificate.",
+				},
+
+				"name": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The hostname of the Certificate. Must be the CN or a named SAN in the certificate.",
 				},
 			},
 		},
@@ -337,6 +443,40 @@ func ContainerAppIngressTrafficWeight() *pluginsdk.Schema {
 	}
 }
 
+func ContainerAppIngressTrafficWeightComputed() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Computed: true,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"label": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The label to apply to the revision as a name prefix for routing traffic.",
+				},
+
+				"revision_suffix": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The suffix string to append to the revision. This must be unique for the Container App's lifetime. A default hash created by the service will be used if this value is omitted.",
+				},
+
+				"latest_revision": {
+					Type:        pluginsdk.TypeBool,
+					Computed:    true,
+					Description: "This traffic Weight relates to the latest stable Container Revision.",
+				},
+
+				"percentage": {
+					Type:        pluginsdk.TypeInt,
+					Computed:    true,
+					Description: "The percentage of traffic to send to this revision.",
+				},
+			},
+		},
+	}
+}
+
 func expandContainerAppIngressTraffic(input []TrafficWeight, appName string) *[]containerapps.TrafficWeight {
 	if len(input) == 0 {
 		return nil
@@ -416,6 +556,34 @@ func ContainerDaprSchema() *pluginsdk.Schema {
 						string(containerapps.AppProtocolHTTP),
 						string(containerapps.AppProtocolGrpc),
 					}, false),
+					Description: "The protocol for the app. Possible values include `http` and `grpc`. Defaults to `http`.",
+				},
+			},
+		},
+	}
+}
+
+func ContainerDaprSchemaComputed() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Computed: true,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"app_id": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The Dapr Application Identifier.",
+				},
+
+				"app_port": {
+					Type:        pluginsdk.TypeInt,
+					Computed:    true,
+					Description: "The port which the application is listening on. This is the same as the `ingress` port.",
+				},
+
+				"app_protocol": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
 					Description: "The protocol for the app. Possible values include `http` and `grpc`. Defaults to `http`.",
 				},
 			},
@@ -571,6 +739,38 @@ func ContainerTemplateSchema() *pluginsdk.Schema {
 	}
 }
 
+func ContainerTemplateSchemaComputed() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Computed: true,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"container": ContainerAppContainerSchemaComputed(),
+
+				"min_replicas": {
+					Type:        pluginsdk.TypeInt,
+					Computed:    true,
+					Description: "The minimum number of replicas for this container.",
+				},
+
+				"max_replicas": {
+					Type:        pluginsdk.TypeInt,
+					Computed:    true,
+					Description: "The maximum number of replicas for this container.",
+				},
+
+				"volume": ContainerVolumeSchema(),
+
+				"revision_suffix": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The suffix for the revision. This value must be unique for the lifetime of the Resource. If omitted the service will use a hash function to create one.",
+				},
+			},
+		},
+	}
+}
+
 func ExpandContainerAppTemplate(input []ContainerTemplate, metadata sdk.ResourceMetaData) *containerapps.Template {
 	if len(input) != 1 {
 		return nil
@@ -715,6 +915,74 @@ func ContainerAppContainerSchema() *pluginsdk.Schema {
 				"startup_probe": ContainerAppStartupProbeSchema(),
 
 				"volume_mounts": ContainerVolumeMountSchema(),
+			},
+		},
+	}
+}
+
+func ContainerAppContainerSchemaComputed() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Computed: true,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"name": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The name of the container.",
+				},
+
+				"image": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The image to use to create the container.",
+				},
+
+				"cpu": {
+					Type:        pluginsdk.TypeFloat,
+					Computed:    true,
+					Description: "The amount of vCPU to allocate to the container. Possible values include `0.25`, `0.5`, `0.75`, `1.0`, `1.25`, `1.5`, `1.75`, and `2.0`. **NOTE:** `cpu` and `memory` must be specified in `0.25'/'0.5Gi` combination increments. e.g. `1.0` / `2.0` or `0.5` / `1.0`",
+				},
+
+				"memory": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The amount of memory to allocate to the container. Possible values include `0.5Gi`, `1.0Gi`, `1.5Gi`, `2.0Gi`, `2.5Gi`, `3.0Gi`, `3.5Gi`, and `4.0Gi`. **NOTE:** `cpu` and `memory` must be specified in `0.25'/'0.5Gi` combination increments. e.g. `1.25` / `2.5Gi` or `0.75` / `1.5Gi`",
+				},
+
+				"ephemeral_storage": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The amount of ephemeral storage available to the Container App.",
+				},
+
+				"env": ContainerEnvVarSchemaComputed(),
+
+				"args": {
+					Type:     pluginsdk.TypeList,
+					Computed: true,
+					Elem: &pluginsdk.Schema{
+						Type: pluginsdk.TypeString,
+					},
+					Description: "A list of args to pass to the container.",
+				},
+
+				"command": {
+					Type:     pluginsdk.TypeList,
+					Computed: true,
+					Elem: &pluginsdk.Schema{
+						Type: pluginsdk.TypeString,
+					},
+					Description: "A command to pass to the container to override the default. This is provided as a list of command line elements without spaces.",
+				},
+
+				"liveness_probe": ContainerAppLivenessProbeSchemaComputed(),
+
+				"readiness_probe": ContainerAppReadinessProbeSchemaComputed(),
+
+				"startup_probe": ContainerAppStartupProbeSchemaComputed(),
+
+				"volume_mounts": ContainerVolumeMountSchemaComputed(),
 			},
 		},
 	}
@@ -904,6 +1172,28 @@ func ContainerVolumeMountSchema() *pluginsdk.Schema {
 	}
 }
 
+func ContainerVolumeMountSchemaComputed() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Computed: true,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"name": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The name of the Volume to be mounted in the container.",
+				},
+
+				"path": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The path in the container at which to mount this volume.",
+				},
+			},
+		},
+	}
+}
+
 func expandContainerVolumeMounts(input []ContainerVolumeMount) *[]containerapps.VolumeMount {
 	if input == nil {
 		return nil
@@ -965,6 +1255,34 @@ func ContainerEnvVarSchema() *pluginsdk.Schema {
 				"secret_name": {
 					Type:        pluginsdk.TypeString,
 					Optional:    true,
+					Description: "The name of the secret that contains the value for this environment variable.",
+				},
+			},
+		},
+	}
+}
+
+func ContainerEnvVarSchemaComputed() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Computed: true,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"name": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The name of the environment variable for the container.",
+				},
+
+				"value": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The value for this environment variable. **NOTE:** This value is ignored if `secret_name` is used",
+				},
+
+				"secret_name": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
 					Description: "The name of the secret that contains the value for this environment variable.",
 				},
 			},
@@ -1113,6 +1431,84 @@ func ContainerAppReadinessProbeSchema() *pluginsdk.Schema {
 					Default:      3,
 					ValidateFunc: validation.IntBetween(1, 10),
 					Description:  "The number of consecutive successful responses required to consider this probe as successful. Possible values are between `1` and `10`. Defaults to `3`.",
+				},
+			},
+		},
+	}
+}
+
+func ContainerAppReadinessProbeSchemaComputed() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Computed: true,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"transport": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "Type of probe. Possible values are `TCP`, `HTTP`, and `HTTPS`.",
+				},
+
+				"port": {
+					Type:        pluginsdk.TypeInt,
+					Computed:    true,
+					Description: "The port number on which to connect. Possible values are between `1` and `65535`.",
+				},
+
+				"host": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The probe hostname. Defaults to the pod IP address. Setting a value for `Host` in `headers` can be used to override this for `http` and `https` type probes.",
+				},
+
+				"path": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The URI to use for http type probes. Not valid for `TCP` type probes. Defaults to `/`.",
+				},
+
+				"header": {
+					Type:     pluginsdk.TypeList,
+					Computed: true,
+					Elem: &pluginsdk.Resource{
+						Schema: map[string]*pluginsdk.Schema{
+							"name": {
+								Type:        pluginsdk.TypeString,
+								Computed:    true,
+								Description: "The HTTP Header Name.",
+							},
+
+							"value": {
+								Type:        pluginsdk.TypeString,
+								Computed:    true,
+								Description: "The HTTP Header value.",
+							},
+						},
+					},
+				},
+
+				"interval_seconds": {
+					Type:        pluginsdk.TypeInt,
+					Computed:    true,
+					Description: "How often, in seconds, the probe should run. Possible values are between `1` and `240`. Defaults to `10`",
+				},
+
+				"timeout": {
+					Type:        pluginsdk.TypeInt,
+					Computed:    true,
+					Description: "Time in seconds after which the probe times out. Possible values are between `1` an `240`. Defaults to `1`.",
+				},
+
+				"failure_count_threshold": {
+					Type:        pluginsdk.TypeInt,
+					Computed:    true,
+					Description: "The number of consecutive failures required to consider this probe as failed. Possible values are between `1` and `10`. Defaults to `3`.",
+				},
+
+				"success_count_threshold": {
+					Type:        pluginsdk.TypeInt,
+					Computed:    true,
+					Description: "The number of consecutive successful responses required to consider this probe as successful. Possible values are between `1` and `10`. Defaults to `3`.",
 				},
 			},
 		},
@@ -1314,6 +1710,90 @@ func ContainerAppLivenessProbeSchema() *pluginsdk.Schema {
 	}
 }
 
+func ContainerAppLivenessProbeSchemaComputed() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Computed: true,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"transport": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "Type of probe. Possible values are `TCP`, `HTTP`, and `HTTPS`.",
+				},
+
+				"port": {
+					Type:        pluginsdk.TypeInt,
+					Computed:    true,
+					Description: "The port number on which to connect. Possible values are between `1` and `65535`.",
+				},
+
+				"host": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The probe hostname. Defaults to the pod IP address. Setting a value for `Host` in `headers` can be used to override this for `http` and `https` type probes.",
+				},
+
+				"path": {
+					Type:        pluginsdk.TypeString,
+					Computed:    true,
+					Description: "The URI to use with the `host` for http type probes. Not valid for `TCP` type probes. Defaults to `/`.",
+				},
+
+				"header": {
+					Type:     pluginsdk.TypeList,
+					Computed: true,
+					Elem: &pluginsdk.Resource{
+						Schema: map[string]*pluginsdk.Schema{
+							"name": {
+								Type:        pluginsdk.TypeString,
+								Computed:    true,
+								Description: "The HTTP Header Name.",
+							},
+
+							"value": {
+								Type:        pluginsdk.TypeString,
+								Computed:    true,
+								Description: "The HTTP Header value.",
+							},
+						},
+					},
+				},
+
+				"initial_delay": {
+					Type:        pluginsdk.TypeInt,
+					Computed:    true,
+					Description: "The time in seconds to wait after the container has started before the probe is started.",
+				},
+
+				"interval_seconds": {
+					Type:        pluginsdk.TypeInt,
+					Computed:    true,
+					Description: "How often, in seconds, the probe should run. Possible values are between `1` and `240`. Defaults to `10`",
+				},
+
+				"timeout": {
+					Type:        pluginsdk.TypeInt,
+					Computed:    true,
+					Description: "Time in seconds after which the probe times out. Possible values are between `1` an `240`. Defaults to `1`.",
+				},
+
+				"failure_count_threshold": {
+					Type:        pluginsdk.TypeInt,
+					Computed:    true,
+					Description: "The number of consecutive failures required to consider this probe as failed. Possible values are between `1` and `10`. Defaults to `3`.",
+				},
+
+				"termination_grace_period_seconds": {
+					Type:        pluginsdk.TypeInt,
+					Computed:    true,
+					Description: "The time in seconds after the container is sent the termination signal before the process if forcibly killed.",
+				},
+			},
+		},
+	}
+}
+
 func expandContainerAppLivenessProbe(input ContainerAppLivenessProbe) containerapps.ContainerAppProbe {
 	probeType := containerapps.TypeLiveness
 	result := containerapps.ContainerAppProbe{
@@ -1488,6 +1968,80 @@ func ContainerAppStartupProbeSchema() *pluginsdk.Schema {
 					Default:      3,
 					ValidateFunc: validation.IntBetween(1, 10),
 					Description:  "The number of consecutive failures required to consider this probe as failed. Possible values are between `1` and `10`. Defaults to `3`.",
+				},
+
+				"termination_grace_period_seconds": {
+					Type:        pluginsdk.TypeInt,
+					Computed:    true,
+					Description: "The time in seconds after the container is sent the termination signal before the process if forcibly killed.",
+				},
+			},
+		},
+	}
+}
+
+func ContainerAppStartupProbeSchemaComputed() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Computed: true,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"transport": {
+					Type:     pluginsdk.TypeString,
+					Computed: true,
+				},
+
+				"port": {
+					Type:     pluginsdk.TypeInt,
+					Computed: true,
+				},
+
+				"host": {
+					Type:     pluginsdk.TypeString,
+					Computed: true,
+				},
+
+				"path": {
+					Type:     pluginsdk.TypeString,
+					Computed: true,
+				},
+
+				"header": {
+					Type:     pluginsdk.TypeList,
+					Computed: true,
+					Elem: &pluginsdk.Resource{
+						Schema: map[string]*pluginsdk.Schema{
+							"name": {
+								Type:        pluginsdk.TypeString,
+								Computed:    true,
+								Description: "The HTTP Header Name.",
+							},
+
+							"value": {
+								Type:        pluginsdk.TypeString,
+								Computed:    true,
+								Description: "The HTTP Header value.",
+							},
+						},
+					},
+				},
+
+				"interval_seconds": {
+					Type:        pluginsdk.TypeInt,
+					Computed:    true,
+					Description: "How often, in seconds, the probe should run. Possible values are between `1` and `240`. Defaults to `10`",
+				},
+
+				"timeout": {
+					Type:        pluginsdk.TypeInt,
+					Computed:    true,
+					Description: "Time in seconds after which the probe times out. Possible values are between `1` an `240`. Defaults to `1`.",
+				},
+
+				"failure_count_threshold": {
+					Type:        pluginsdk.TypeInt,
+					Computed:    true,
+					Description: "The number of consecutive failures required to consider this probe as failed. Possible values are between `1` and `10`. Defaults to `3`.",
 				},
 
 				"termination_grace_period_seconds": {

--- a/internal/services/containerapps/registration.go
+++ b/internal/services/containerapps/registration.go
@@ -20,6 +20,7 @@ func (r Registration) Name() string {
 
 func (r Registration) DataSources() []sdk.DataSource {
 	return []sdk.DataSource{
+		ContainerAppDataSource{},
 		ContainerAppEnvironmentDataSource{},
 		ContainerAppEnvironmentCertificateDataSource{},
 	}

--- a/website/docs/d/container_app.html.markdown
+++ b/website/docs/d/container_app.html.markdown
@@ -1,0 +1,298 @@
+---
+subcategory: "Container Apps"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_container_app"
+description: |-
+  Get information of a Container App.
+---
+
+# Data Source: azurerm_container_app
+
+Use this data source to access information about an existing Container App.
+
+## Example Usage
+
+```hcl
+data "azurerm_container_app" "example" {
+  name                = "example-app"
+  resource_group_name = "example-resources"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the Container App.
+
+* `resource_group_name` - (Required) The name of the Resource Group where this Container App exists.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `container_app_environment_id` - The ID of the Container App Environment this Container App is linked to.
+
+* `revision_mode` - The revision mode of the Container App.
+
+* `template` - A `template` block as detailed below.
+
+---
+
+* `dapr` - A `dapr` block as detailed below.
+
+* `identity` - An `identity` block as detailed below.
+
+* `ingress` - An `ingress` block as detailed below.
+
+* `registry` - A `registry` block as detailed below.
+
+* `secret` - One or more `secret` block as detailed below.
+
+* `tags` - A mapping of tags to assign to the Container App.
+
+---
+
+A `secret` block supports the following:
+
+* `name` - The Secret name.
+
+* `value` - The value for this secret.
+
+---
+
+A `template` block supports the following:
+
+* `container` - One or more `container` blocks as detailed below.
+
+* `max_replicas` - The maximum number of replicas for this container.
+
+* `min_replicas` - The minimum number of replicas for this container.
+
+* `revision_suffix` - The suffix for the revision. This value must be unique for the lifetime of the Resource. If omitted the service will use a hash function to create one.
+
+* `volume` - A `volume` block as detailed below.
+
+---
+
+A `volume` block supports the following:
+
+* `name` - The name of the volume.
+
+* `storage_name` - The name of the `AzureFile` storage.
+
+* `storage_type` - The type of storage volume. Possible values include `AzureFile` and `EmptyDir`. Defaults to `EmptyDir`.
+
+---
+
+A `container` block supports the following:
+
+* `args` - A list of extra arguments to pass to the container.
+
+* `command` - A command to pass to the container to override the default. This is provided as a list of command line elements without spaces.
+
+* `cpu` - The amount of vCPU to allocate to the container. Possible values include `0.25`, `0.5`, `0.75`, `1.0`, `1.25`, `1.5`, `1.75`, and `2.0`.
+
+* `env` - One or more `env` blocks as detailed below.
+
+* `ephemeral_storage` - The amount of ephemeral storage available to the Container App.
+
+* `image` - The image to use to create the container.
+
+* `liveness_probe` - A `liveness_probe` block as detailed below.
+
+* `memory` - The amount of memory to allocate to the container. Possible values include `0.5Gi`, `1.0Gi`, `1.5Gi`, `2.0Gi`, `2.5Gi`, `3.0Gi`, `3.5Gi`, and `4.0Gi`.
+
+* `name` - The name of the container
+
+* `readiness_probe` - A `readiness_probe` block as detailed below.
+
+* `startup_probe` - A `startup_probe` block as detailed below.
+
+* `volume_mounts` - A `volume_mounts` block as detailed below.
+
+---
+
+A `liveness_probe` block supports the following:
+
+* `failure_count_threshold` - The number of consecutive failures required to consider this probe as failed. Possible values are between `1` and `10`. Defaults to `3`.
+
+* `header` - A `header` block as detailed below.
+
+* `host` - The probe hostname. Defaults to the pod IP address. Setting a value for `Host` in `headers` can be used to override this for `HTTP` and `HTTPS` type probes.
+
+* `initial_delay` - The time in seconds to wait after the container has started before the probe is started.
+
+* `interval_seconds` - How often, in seconds, the probe should run. Possible values are in the range `1` - `240`. Defaults to `10`.
+
+* `path` - The URI to use with the `host` for http type probes. Not valid for `TCP` type probes. Defaults to `/`.
+
+* `port` - The port number on which to connect. Possible values are between `1` and `65535`.
+
+* `termination_grace_period_seconds` -  The time in seconds after the container is sent the termination signal before the process if forcibly killed.
+
+* `timeout` - Time in seconds after which the probe times out. Possible values are in the range `1` - `240`. Defaults to `1`.
+
+* `transport` - Type of probe. Possible values are `TCP`, `HTTP`, and `HTTPS`.
+
+---
+
+A `header` block supports the following:
+
+* `name` - The HTTP Header Name.
+
+* `value` - The HTTP Header value.
+
+---
+
+An `env` block supports the following:
+
+* `name` - The name of the environment variable for the container.
+
+* `secret_name` - The name of the secret that contains the value for this environment variable.
+
+* `value` - The value for this environment variable.
+
+---
+
+A `readiness_probe` block supports the following:
+
+* `failure_count_threshold` - The number of consecutive failures required to consider this probe as failed. Possible values are between `1` and `10`. Defaults to `3`.
+
+* `header` - A `header` block as detailed below.
+
+* `host` - The probe hostname. Defaults to the pod IP address. Setting a value for `Host` in `headers` can be used to override this for `HTTP` and `HTTPS` type probes.
+
+* `interval_seconds` - How often, in seconds, the probe should run. Possible values are between `1` and `240`. Defaults to `10`
+
+* `path` - The URI to use for http type probes. Not valid for `TCP` type probes. Defaults to `/`.
+
+* `port` - The port number on which to connect. Possible values are between `1` and `65535`.
+
+* `success_count_threshold` - The number of consecutive successful responses required to consider this probe as successful. Possible values are between `1` and `10`. Defaults to `3`.
+
+* `timeout` - Time in seconds after which the probe times out. Possible values are in the range `1` - `240`. Defaults to `1`.
+
+* `transport` - Type of probe. Possible values are `TCP`, `HTTP`, and `HTTPS`.
+
+---
+
+A `header` block supports the following:
+
+* `name` - The HTTP Header Name.
+
+* `value` - The HTTP Header value.
+
+---
+
+A `startup_probe` block supports the following:
+
+* `failure_count_threshold` - The number of consecutive failures required to consider this probe as failed. Possible values are between `1` and `10`. Defaults to `3`.
+
+* `header` - A `header` block as detailed below.
+
+* `host` - The value for the host header which should be sent with this probe. If unspecified, the IP Address of the Pod is used as the host header. Setting a value for `Host` in `headers` can be used to override this for `HTTP` and `HTTPS` type probes.
+
+* `interval_seconds` - How often, in seconds, the probe should run. Possible values are between `1` and `240`. Defaults to `10`
+
+* `path` - The URI to use with the `host` for http type probes. Not valid for `TCP` type probes. Defaults to `/`.
+
+* `port` - The port number on which to connect. Possible values are between `1` and `65535`.
+
+* `termination_grace_period_seconds` -  The time in seconds after the container is sent the termination signal before the process if forcibly killed.
+
+* `timeout` - Time in seconds after which the probe times out. Possible values are in the range `1` - `240`. Defaults to `1`.
+
+* `transport` - Type of probe. Possible values are `TCP`, `HTTP`, and `HTTPS`.
+
+---
+
+A `header` block supports the following:
+
+* `name` - The HTTP Header Name.
+
+* `value` - The HTTP Header value.
+
+---
+
+A `volume_mounts` block supports the following:
+
+* `name` - The name of the Volume to be mounted in the container.
+
+* `path` - The path in the container at which to mount this volume.
+
+---
+
+An `identity` block supports the following:
+
+* `type` - The type of managed identity to assign. Possible values are `UserAssigned` and `SystemAssigned`
+
+* `identity_ids` - A list of one or more Resource IDs for User Assigned Managed identities to assign. Required when `type` is set to `UserAssigned`.
+
+---
+
+An `ingress` block supports the following:
+
+* `allow_insecure_connections` - Should this ingress allow insecure connections?
+
+* `custom_domain` - One or more `custom_domain` block as detailed below.
+
+* `fqdn` -  The FQDN of the ingress.
+
+* `external_enabled` - Is this an external Ingress.
+
+* `target_port` - The target port on the container for the Ingress traffic.
+
+* `traffic_weight` - A `traffic_weight` block as detailed below.
+
+* `transport` - The transport method for the Ingress. Possible values include `auto`, `http`, and `http2`. Defaults to `auto`
+
+---
+
+A `custom_domain` block supports the following:
+
+* `certificate_binding_type` - The Binding type. Possible values include `Disabled` and `SniEnabled`. Defaults to `Disabled`.
+
+* `certificate_id` - The ID of the Container App Environment Certificate.
+
+* `name` - The hostname of the Certificate. Must be the CN or a named SAN in the certificate.
+
+---
+
+A `traffic_weight` block supports the following:
+
+* `label` - The label to apply to the revision as a name prefix for routing traffic.
+
+* `latest_revision` - This traffic Weight relates to the latest stable Container Revision.
+
+* `revision_suffix` - The suffix string to which this `traffic_weight` applies.
+
+* `percentage` - The percentage of traffic which should be sent this revision.
+
+---
+
+A `dapr` block supports the following:
+
+* `app_id` - The Dapr Application Identifier.
+
+* `app_port` - The port which the application is listening on. This is the same as the `ingress` port.
+
+* `app_protocol` - The protocol for the app. Possible values include `http` and `grpc`. Defaults to `http`.
+
+---
+
+A `registry` block supports the following:
+
+* `server` - The hostname for the Container Registry.
+
+* `identity` - Resource ID for the User Assigned Managed identity to use when pulling from the Container Registry.
+
+* `password_secret_name` - The name of the Secret Reference containing the password value for this user on the Container Registry, `username` must also be supplied.
+
+* `username` - The username to use for this Container Registry, `password_secret_name` must also be supplied..
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the Container App.


### PR DESCRIPTION
All tests passed.

```
=== RUN   TestAccContainerAppDataSource_basic
=== PAUSE TestAccContainerAppDataSource_basic
=== CONT  TestAccContainerAppDataSource_basic
--- PASS: TestAccContainerAppDataSource_basic (727.75s)
PASS
```