### PR TITLE
`azurerm_eventgrid_system_topic` - fix `source_arm_resource_id` validation

### DIFF
--- a/internal/services/eventgrid/eventgrid_system_topic_resource.go
+++ b/internal/services/eventgrid/eventgrid_system_topic_resource.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/eventgrid/parse"
+	mgmtGroupValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/managementgroup/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
@@ -61,10 +62,13 @@ func resourceEventGridSystemTopic() *pluginsdk.Resource {
 
 			// TODO: remove `_arm` in 4.0. Can we be more descriptive about /what/ this is?
 			"source_arm_resource_id": {
-				Type:         pluginsdk.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: azure.ValidateResourceID,
+				Type:     pluginsdk.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.Any(
+					azure.ValidateResourceID,
+					mgmtGroupValidate.ManagementGroupID,
+				),
 			},
 
 			"topic_type": {


### PR DESCRIPTION
fixes #18034

added validation for ManagementGroupID which doesn't include a subscription id