### PR TITLE
parse `HybridConnectionID` insensitively in Read

### DIFF
--- a/internal/services/appservice/web_app_hybrid_connection_resource.go
+++ b/internal/services/appservice/web_app_hybrid_connection_resource.go
@@ -220,7 +220,7 @@ func (r WebAppHybridConnectionResource) Read() sdk.ResourceFunc {
 
 			if appHybridConn.ServiceBusNamespace != "" && appHybridConn.SendKeyName != "" {
 				relayNamespaceClient := metadata.Client.Relay.NamespacesClient
-				relayId, err := hybridconnections.ParseHybridConnectionID(appHybridConn.RelayId)
+				relayId, err := hybridconnections.ParseHybridConnectionIDInsensitively(appHybridConn.RelayId)
 				if err != nil {
 					return err
 				}
@@ -231,7 +231,7 @@ func (r WebAppHybridConnectionResource) Read() sdk.ResourceFunc {
 				}
 
 				hybridConnectionsClient := metadata.Client.Relay.HybridConnectionsClient
-				hybridConnectionID, err := hybridconnections.ParseHybridConnectionID(appHybridConn.RelayId)
+				hybridConnectionID, err := hybridconnections.ParseHybridConnectionIDInsensitively(appHybridConn.RelayId)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
Fix #20756
#20764 may require more discussions, opening this as a mitigation to resolve the incorrect API issue in Read().