### PR TITLE
data source `azurerm_app_configuration_keys` - fix to use `LinkWorkaroundDataPlaneClientWithEndpoint`

### DIFF
--- a/internal/services/appconfiguration/app_configuration_keys_data_source.go
+++ b/internal/services/appconfiguration/app_configuration_keys_data_source.go
@@ -135,12 +135,12 @@ func (k KeysDataSource) Read() sdk.ResourceFunc {
 			// Link: "</kv?somepath...>; rel=next;"
 			// whereas the client expects a complete URI to be present and therefore fails to fetch all results if
 			// store contains more than 100 entries
-			client, err := metadata.Client.AppConfiguration.DataPlaneClientWithEndpoint(*configurationStoreEndpoint)
+			client, err := metadata.Client.AppConfiguration.LinkWorkaroundDataPlaneClientWithEndpoint(*configurationStoreEndpoint)
 			if err != nil {
 				return err
 			}
 
-			nestedItemId, err := parse.NewNestedItemID(client.Endpoint, model.Key, model.Label)
+			nestedItemId, err := parse.NewNestedItemID(*configurationStoreEndpoint, model.Key, model.Label)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
resolves https://github.com/hashicorp/terraform-provider-azurerm/issues/21206

```
--- PASS: TestAccAppConfigurationKeysDataSource_key (104.59s)
--- PASS: TestAccAppConfigurationKeyDataSource_basic (104.82s)
--- PASS: TestAccAppConfigurationKeyDataSource_basicNoLabel (105.55s)
--- PASS: TestAccAppConfigurationKeysDataSource_allkeys (107.31s)
--- PASS: TestAccAppConfigurationKey_basicNoLabel_afterLabel (107.33s)
--- PASS: TestAccAppConfigurationKey_basic (108.76s)
--- PASS: TestAccAppConfigurationKey_slash (109.53s)
--- PASS: TestAccAppConfigurationKey_complicatedKeyLabel (109.86s)
--- PASS: TestAccAppConfigurationKey_basicNoLabel (109.91s)
--- PASS: TestAccAppConfigurationKey_requiresImport (111.50s)
--- PASS: TestAccAppConfigurationKey_lockUpdate (121.19s)
--- PASS: TestAccAppConfigurationKeysDataSource_label (167.13s)
--- PASS: TestAccAppConfigurationKeyDataSource_basicVault (255.46s)
--- PASS: TestAccAppConfigurationKey_basicVault (257.31s)
--- PASS: TestAccAppConfigurationKey_KVToVault (314.16s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/appconfiguration      315.387s

```