### PR TITLE
`azurerm_api_management` - Restore request does not need to handle the response which does not have

### DIFF
--- a/internal/services/apimanagement/api_management_resource.go
+++ b/internal/services/apimanagement/api_management_resource.go
@@ -729,6 +729,7 @@ func resourceApiManagementServiceCreateUpdate(d *pluginsdk.ResourceData, meta in
 				},
 			}
 
+			// We only handle the error here because no request body is returned https://github.com/Azure/azure-rest-api-specs/issues/23456
 			_, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.ServiceName, params)
 			if err != nil {
 				return fmt.Errorf("recovering %s: %+v", id, err)

--- a/internal/services/apimanagement/api_management_resource.go
+++ b/internal/services/apimanagement/api_management_resource.go
@@ -729,12 +729,9 @@ func resourceApiManagementServiceCreateUpdate(d *pluginsdk.ResourceData, meta in
 				},
 			}
 
-			future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.ServiceName, params)
+			_, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.ServiceName, params)
 			if err != nil {
 				return fmt.Errorf("recovering %s: %+v", id, err)
-			}
-			if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
-				return fmt.Errorf("waiting for recovery of %q: %+v", id, err)
 			}
 
 			// Wait for the ProvisioningState to become "Succeeded" before attempting to update


### PR DESCRIPTION
Fixes: #17206 
This recover request is different from the create/update. The response does not have any response body or HTTP headers like create/update. A successful recover request will have an HTTP status code of 201. Handle the response error is enough. 

```log
=== RUN   TestAccApiManagement_softDeleteRecovery
=== PAUSE TestAccApiManagement_softDeleteRecovery
=== CONT  TestAccApiManagement_softDeleteRecovery
--- PASS: TestAccApiManagement_softDeleteRecovery (959.33s)
PASS

```