### PR TITLE
`azurerm_storage_account` - Mark `shared_properties.smb` as O+C

### DIFF
--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -691,6 +691,7 @@ func resourceStorageAccount() *pluginsdk.Resource {
 						"smb": {
 							Type:     pluginsdk.TypeList,
 							Optional: true,
+							Computed: true,
 							MaxItems: 1,
 							Elem: &pluginsdk.Resource{
 								Schema: map[string]*pluginsdk.Schema{

--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -691,7 +691,6 @@ func resourceStorageAccount() *pluginsdk.Resource {
 						"smb": {
 							Type:     pluginsdk.TypeList,
 							Optional: true,
-							Computed: true,
 							MaxItems: 1,
 							Elem: &pluginsdk.Resource{
 								Schema: map[string]*pluginsdk.Schema{
@@ -3402,6 +3401,19 @@ func flattenedSharePropertiesSMB(input *storage.SmbSetting) []interface{} {
 	if input == nil {
 		return []interface{}{}
 	}
+
+	// The service API returns smb for premium file storage account no matter it is specified in the creation request.
+	// The returned default value in this case only has the `smb.multichannel.enabled = false`.
+	// We need to explicitly check for above case to ensure we didn't write this "unset" block back to the state file, which wil result into a plan diff.
+	if input.Versions == nil && input.ChannelEncryption == nil && input.AuthenticationMethods == nil && input.KerberosTicketEncryption == nil {
+		if input.Multichannel == nil {
+			return []interface{}{}
+		}
+		if input.Multichannel.Enabled == nil || !*input.Multichannel.Enabled {
+			return []interface{}{}
+		}
+	}
+
 	versions := []interface{}{}
 	if input.Versions != nil {
 		versions = utils.FlattenStringSliceWithDelimiter(input.Versions, ";")

--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -3402,18 +3402,6 @@ func flattenedSharePropertiesSMB(input *storage.SmbSetting) []interface{} {
 		return []interface{}{}
 	}
 
-	// The service API returns smb for premium file storage account no matter it is specified in the creation request.
-	// The returned default value in this case only has the `smb.multichannel.enabled = false`.
-	// We need to explicitly check for above case to ensure we didn't write this "unset" block back to the state file, which wil result into a plan diff.
-	if input.Versions == nil && input.ChannelEncryption == nil && input.AuthenticationMethods == nil && input.KerberosTicketEncryption == nil {
-		if input.Multichannel == nil {
-			return []interface{}{}
-		}
-		if input.Multichannel.Enabled == nil || !*input.Multichannel.Enabled {
-			return []interface{}{}
-		}
-	}
-
 	versions := []interface{}{}
 	if input.Versions != nil {
 		versions = utils.FlattenStringSliceWithDelimiter(input.Versions, ";")

--- a/internal/services/storage/storage_account_resource_test.go
+++ b/internal/services/storage/storage_account_resource_test.go
@@ -1482,6 +1482,21 @@ func TestAccStorageAccount_emptyShareProperties(t *testing.T) {
 	})
 }
 
+func TestAccStorageAccount_emptySharePropertiesPremiumFileStorage(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_account", "test")
+	r := StorageAccountResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.emptySharePropertiesPremiumFileStorage(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (r StorageAccountResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := parse.StorageAccountID(state.ID)
 	if err != nil {
@@ -4351,6 +4366,31 @@ resource "azurerm_storage_account" "test" {
   account_tier             = "Standard"
   account_replication_type = "LRS"
   account_kind             = "StorageV2"
+
+  share_properties {}
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}
+
+func (r StorageAccountResource) emptySharePropertiesPremiumFileStorage(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-storage-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                = "unlikely23exst2acct%[3]s"
+  resource_group_name = azurerm_resource_group.test.name
+
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Premium"
+  account_replication_type = "LRS"
+  account_kind             = "FileStorage"
 
   share_properties {}
 }

--- a/internal/services/storage/storage_account_resource_test.go
+++ b/internal/services/storage/storage_account_resource_test.go
@@ -1467,13 +1467,13 @@ func TestAccStorageAccount_isSftpEnabled(t *testing.T) {
 	})
 }
 
-func TestAccStorageAccount_emptyShareProperties(t *testing.T) {
+func TestAccStorageAccount_minimalShareProperties(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_storage_account", "test")
 	r := StorageAccountResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.emptyShareProperties(data),
+			Config: r.minimalShareProperties(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -1482,13 +1482,13 @@ func TestAccStorageAccount_emptyShareProperties(t *testing.T) {
 	})
 }
 
-func TestAccStorageAccount_emptySharePropertiesPremiumFileStorage(t *testing.T) {
+func TestAccStorageAccount_minimalSharePropertiesPremiumFileStorage(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_storage_account", "test")
 	r := StorageAccountResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.emptySharePropertiesPremiumFileStorage(data),
+			Config: r.minimalSharePropertiesPremiumFileStorage(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -4347,7 +4347,7 @@ resource "azurerm_storage_account" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomString, scope)
 }
 
-func (r StorageAccountResource) emptyShareProperties(data acceptance.TestData) string {
+func (r StorageAccountResource) minimalShareProperties(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -4367,12 +4367,16 @@ resource "azurerm_storage_account" "test" {
   account_replication_type = "LRS"
   account_kind             = "StorageV2"
 
-  share_properties {}
+  share_properties {
+    retention_policy {
+      days = 5
+    }
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }
 
-func (r StorageAccountResource) emptySharePropertiesPremiumFileStorage(data acceptance.TestData) string {
+func (r StorageAccountResource) minimalSharePropertiesPremiumFileStorage(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -4392,7 +4396,11 @@ resource "azurerm_storage_account" "test" {
   account_replication_type = "LRS"
   account_kind             = "FileStorage"
 
-  share_properties {}
+  share_properties {
+    retention_policy {
+      days = 5
+    }
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }

--- a/internal/services/storage/storage_account_resource_test.go
+++ b/internal/services/storage/storage_account_resource_test.go
@@ -1493,7 +1493,7 @@ func TestAccStorageAccount_minimalSharePropertiesPremiumFileStorage(t *testing.T
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("share_properties.0.smb"),
 	})
 }
 
@@ -4400,6 +4400,10 @@ resource "azurerm_storage_account" "test" {
     retention_policy {
       days = 5
     }
+  }
+
+  lifecycle {
+    ignore_changes = [share_properties.0.smb]
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)


### PR DESCRIPTION
For premium file storage account, even there is no special config for the `shared_properties`, the `smb` will be returned with `multichannel.enabled = false`. This causing plan diff as is reported by #21182. Making the `smb` block as O+C is one solution. Alternatively, we can guide the users to explicitly ignore that change.

Fix #21182

## Test

```shell
💤  TF_ACC=1 go test -v -timeout=20h ./internal/services/storage -run=TestAccStorageAccount_emptySharePropertiesPremiumFileStorage
=== RUN   TestAccStorageAccount_emptySharePropertiesPremiumFileStorage
=== PAUSE TestAccStorageAccount_emptySharePropertiesPremiumFileStorage
=== CONT  TestAccStorageAccount_emptySharePropertiesPremiumFileStorage
--- PASS: TestAccStorageAccount_emptySharePropertiesPremiumFileStorage (170.23s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/storage       170.241s
```