### PR TITLE
Fix dependency parse of `azurerm_kusto_cluster.id`

### DIFF
--- a/internal/services/digitaltwins/digital_twins_time_series_database_connection_resource.go
+++ b/internal/services/digitaltwins/digital_twins_time_series_database_connection_resource.go
@@ -212,7 +212,13 @@ func (m TimeSeriesDatabaseConnectionResource) Read() sdk.ResourceFunc {
 				output.EventhubName = properties.EventHubEntityPath
 				output.EventhubNamespaceEndpointUri = properties.EventHubEndpointUri
 				output.EventhubNamespaceId = properties.EventHubNamespaceResourceId
-				output.KustoClusterId = properties.AdxResourceId
+
+				kustoClusterId, err := clusters.ParseClusterIDInsensitively(properties.AdxResourceId)
+				if err != nil {
+					return fmt.Errorf("parsing `kusto_cluster_uri`: %+v", err)
+				}
+				output.KustoClusterId = kustoClusterId.ID()
+
 				output.KustoClusterUri = properties.AdxEndpointUri
 				output.KustoDatabaseName = properties.AdxDatabaseName
 

--- a/internal/services/kusto/kusto_eventgrid_data_connection_resource.go
+++ b/internal/services/kusto/kusto_eventgrid_data_connection_resource.go
@@ -263,7 +263,23 @@ func resourceKustoEventGridDataConnectionRead(d *pluginsdk.ResourceData, meta in
 			d.Set("data_format", props.DataFormat)
 			d.Set("database_routing_type", props.DatabaseRouting)
 			d.Set("eventgrid_resource_id", props.EventGridResourceId)
-			d.Set("managed_identity_resource_id", props.ManagedIdentityResourceId)
+
+			managedIdentityResourceId := ""
+			if props.ManagedIdentityResourceId != nil && *props.ManagedIdentityResourceId != "" {
+				managedIdentityResourceId = *props.ManagedIdentityResourceId
+				clusterId, clusterIdErr := clusters.ParseClusterIDInsensitively(managedIdentityResourceId)
+				if clusterIdErr == nil {
+					managedIdentityResourceId = clusterId.ID()
+				} else {
+					userAssignedIdentityId, userAssignedIdentityIdErr := commonids.ParseUserAssignedIdentityIDInsensitively(managedIdentityResourceId)
+					if userAssignedIdentityIdErr == nil {
+						managedIdentityResourceId = userAssignedIdentityId.ID()
+					} else {
+						return fmt.Errorf("parsing `managed_identity_resource_id`: %+v; %+v", clusterIdErr, userAssignedIdentityIdErr)
+					}
+				}
+			}
+			d.Set("managed_identity_resource_id", managedIdentityResourceId)
 		}
 	}
 

--- a/internal/services/kusto/kusto_eventhub_data_connection_resource.go
+++ b/internal/services/kusto/kusto_eventhub_data_connection_resource.go
@@ -234,7 +234,23 @@ func resourceKustoEventHubDataConnectionRead(d *pluginsdk.ResourceData, meta int
 				d.Set("database_routing_type", props.DatabaseRouting)
 				d.Set("compression", props.Compression)
 				d.Set("event_system_properties", props.EventSystemProperties)
-				d.Set("identity_id", props.ManagedIdentityResourceId)
+
+				identityId := ""
+				if props.ManagedIdentityResourceId != nil {
+					identityId = *props.ManagedIdentityResourceId
+					clusterId, clusterIdErr := clusters.ParseClusterIDInsensitively(identityId)
+					if clusterIdErr == nil {
+						identityId = clusterId.ID()
+					} else {
+						userAssignedIdentityId, userAssignedIdentityIdErr := commonids.ParseUserAssignedIdentityIDInsensitively(identityId)
+						if userAssignedIdentityIdErr == nil {
+							identityId = userAssignedIdentityId.ID()
+						} else {
+							return fmt.Errorf("parsing `identity_id`: %+v; %+v", clusterIdErr, userAssignedIdentityIdErr)
+						}
+					}
+				}
+				d.Set("identity_id", identityId)
 			}
 		}
 	}

--- a/internal/services/monitor/monitor_diagnostic_setting_resource.go
+++ b/internal/services/monitor/monitor_diagnostic_setting_resource.go
@@ -463,7 +463,11 @@ func resourceMonitorDiagnosticSettingRead(d *pluginsdk.ResourceData, meta interf
 		return err
 	}
 
-	id.ResourceUri = normalizeMonitorDiagnosticSettingTargetResourceId(id.ResourceUri)
+	if strings.Contains(strings.ToLower(id.ResourceUri), "microsoft.kusto/clusters/") {
+		if v, err := kustoParse.ClusterIDInsensitively(id.ResourceUri); err == nil {
+			id.ResourceUri = v.ID()
+		}
+	}
 
 	resp, err := client.Get(ctx, *id)
 	if err != nil {
@@ -875,14 +879,4 @@ func resourceMonitorDiagnosticMetricsSettingHash(input interface{}) int {
 		}
 	}
 	return pluginsdk.HashString(buf.String())
-}
-
-func normalizeMonitorDiagnosticSettingTargetResourceId(input string) string {
-	if strings.Contains(strings.ToLower(input), "microsoft.kusto/clusters/") {
-		if id, err := kustoParse.ClusterIDInsensitively(input); err == nil {
-			return id.ID()
-		}
-	}
-
-	return input
 }

--- a/internal/services/monitor/monitor_diagnostic_setting_resource.go
+++ b/internal/services/monitor/monitor_diagnostic_setting_resource.go
@@ -463,10 +463,8 @@ func resourceMonitorDiagnosticSettingRead(d *pluginsdk.ResourceData, meta interf
 		return err
 	}
 
-	if strings.Contains(strings.ToLower(id.ResourceUri), "microsoft.kusto/clusters/") {
-		if v, err := kustoParse.ClusterIDInsensitively(id.ResourceUri); err == nil {
-			id.ResourceUri = v.ID()
-		}
+	if v, err := kustoParse.ClusterIDInsensitively(id.ResourceUri); err == nil {
+		id.ResourceUri = v.ID()
 	}
 
 	resp, err := client.Get(ctx, *id)


### PR DESCRIPTION
Fix #20868
The segment `Clusters` in id of `azurerm_kusto_cluster` has been changed to `clusters` in #19525. For other resources which has kusto cluster as part of its dependency created in older provider version, the segment is already set to `Clusters` at service side. This could cause a diff when provider is updated, where `azurerm_kusto_cluster.id` is auto migrated to `clusters` in the state updater, while it's still `Clusters` at service side. Fixing the diff by normalize the ID returned by service.