### PR TITLE
`azurerm_kusto_cluster_customer_managed_key` - add state migration for sdk upgrade

### DIFF
--- a/internal/services/kusto/kusto_cluster_customer_managed_key_resource.go
+++ b/internal/services/kusto/kusto_cluster_customer_managed_key_resource.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	keyVaultParse "github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/parse"
 	keyVaultValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/kusto/migration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
@@ -25,6 +26,11 @@ func resourceKustoClusterCustomerManagedKey() *pluginsdk.Resource {
 		Read:   resourceKustoClusterCustomerManagedKeyRead,
 		Update: resourceKustoClusterCustomerManagedKeyCreateUpdate,
 		Delete: resourceKustoClusterCustomerManagedKeyDelete,
+
+		SchemaVersion: 1,
+		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
+			0: migration.KustoClusterCustomerManagedKeyV0ToV1{},
+		}),
 
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
 			_, err := clusters.ParseClusterID(id)

--- a/internal/services/kusto/migration/kusto_cluster_customer_managed_key_v0_to_v1.go
+++ b/internal/services/kusto/migration/kusto_cluster_customer_managed_key_v0_to_v1.go
@@ -1,0 +1,56 @@
+package migration
+
+import (
+	"context"
+	"log"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/kusto/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+type KustoClusterCustomerManagedKeyV0ToV1 struct{}
+
+func (s KustoClusterCustomerManagedKeyV0ToV1) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"cluster_id": {
+			ForceNew: true,
+			Required: true,
+			Type:     pluginsdk.TypeString,
+		},
+
+		"key_name": {
+			Required: true,
+			Type:     pluginsdk.TypeString,
+		},
+
+		"key_vault_id": {
+			Required: true,
+			Type:     pluginsdk.TypeString,
+		},
+
+		"key_version": {
+			Optional: true,
+			Type:     pluginsdk.TypeString,
+		},
+
+		"user_identity": {
+			Optional: true,
+			Type:     pluginsdk.TypeString,
+		},
+	}
+}
+
+func (s KustoClusterCustomerManagedKeyV0ToV1) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		oldId := rawState["id"].(string)
+		newId, err := parse.ClusterIDInsensitively(oldId)
+		if err != nil {
+			return nil, err
+		}
+
+		log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newId)
+
+		rawState["id"] = newId.ID()
+		return rawState, nil
+	}
+}


### PR DESCRIPTION
 Seems to be missing in #19525, this resource uses same id as `azurerm_kusto_cluster`