### PR TITLE
`azurerm_[windows|linux]_virtual_machine` - remove set condition for ultra ssd iops and mbps

### DIFF
--- a/internal/services/compute/virtual_machine_scale_set.go
+++ b/internal/services/compute/virtual_machine_scale_set.go
@@ -1458,24 +1458,16 @@ func FlattenVirtualMachineScaleSetDataDisk(input *[]compute.VirtualMachineScaleS
 		}
 
 		dataDisk := map[string]interface{}{
-			"name":                      name,
-			"caching":                   string(v.Caching),
-			"create_option":             string(v.CreateOption),
-			"lun":                       lun,
-			"disk_encryption_set_id":    diskEncryptionSetId,
-			"disk_size_gb":              diskSizeGb,
-			"storage_account_type":      storageAccountType,
-			"write_accelerator_enabled": writeAcceleratorEnabled,
-		}
-
-		// Do not set value unless value is greater than 0 - issue 15516
-		if iops > 0 {
-			dataDisk["ultra_ssd_disk_iops_read_write"] = iops
-		}
-
-		// Do not set value unless value is greater than 0 - issue 15516
-		if mbps > 0 {
-			dataDisk["ultra_ssd_disk_mbps_read_write"] = mbps
+			"name":                           name,
+			"caching":                        string(v.Caching),
+			"create_option":                  string(v.CreateOption),
+			"lun":                            lun,
+			"disk_encryption_set_id":         diskEncryptionSetId,
+			"disk_size_gb":                   diskSizeGb,
+			"storage_account_type":           storageAccountType,
+			"ultra_ssd_disk_iops_read_write": iops,
+			"ultra_ssd_disk_mbps_read_write": mbps,
+			"write_accelerator_enabled":      writeAcceleratorEnabled,
 		}
 
 		output = append(output, dataDisk)


### PR DESCRIPTION
The condition in flatten was added as part of the fix of #15516 but actually not correct. The fix for expand is correct, however for the error in flatten `Error: setting data_disk: Invalid address to set: []string{"data_disk", "0", "ultra_ssd_mbps_read_write"}`, it is actually due to a mismatch of schema v.s. Set():
	https://github.com/hashicorp/terraform-provider-azurerm/blob/735b6c3139b19f0d5e575531e0be2ad2b2d10181/internal/services/compute/virtual_machine_scale_set.go#L920
	https://github.com/hashicorp/terraform-provider-azurerm/blob/735b6c3139b19f0d5e575531e0be2ad2b2d10181/internal/services/compute/virtual_machine_scale_set.go#L1052.
The mismatch is already gone after the migration to 3.0 so no need to keep this additional check any more.
