### PR TITLE
`azurerm_app_configuration_feature` - support `key` property

### DIFF
--- a/internal/services/appconfiguration/app_configuration_feature_resource_test.go
+++ b/internal/services/appconfiguration/app_configuration_feature_resource_test.go
@@ -60,6 +60,20 @@ func TestAccAppConfigurationFeature_basicNoLabel(t *testing.T) {
 	})
 }
 
+func TestAccAppConfigurationFeature_customKey(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_app_configuration_feature", "test")
+	r := AppConfigurationFeatureResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.customKey(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccAppConfigurationFeature_basicWithSlash(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_app_configuration_feature", "test")
 	r := AppConfigurationFeatureResource{}
@@ -200,40 +214,13 @@ func (t AppConfigurationFeatureResource) Exists(ctx context.Context, clients *cl
 
 func (t AppConfigurationFeatureResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-appconfig-%d"
-  location = "%s"
-}
-
-data "azurerm_client_config" "test" {
-}
-
-resource "azurerm_role_assignment" "test" {
-  scope                = azurerm_resource_group.test.id
-  role_definition_name = "App Configuration Data Owner"
-  principal_id         = data.azurerm_client_config.test.object_id
-}
-
-resource "azurerm_app_configuration" "test" {
-  name                = "testacc-appconf%d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-  sku                 = "standard"
-
-  depends_on = [
-    azurerm_role_assignment.test,
-  ]
-}
+%s
 
 resource "azurerm_app_configuration_feature" "test" {
   configuration_store_id = azurerm_app_configuration.test.id
   description            = "test description"
   name                   = "acctest-ackey-%d"
-  label                  = "acctest-ackeylabel-%d"
+  label                  = "acctest-ackeylabel-%[2]d"
   enabled                = true
 
   percentage_filter_value = 10
@@ -259,42 +246,12 @@ resource "azurerm_app_configuration_feature" "test" {
   }
 }
 
-
-
-
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+`, t.template(data), data.RandomInteger)
 }
 
 func (t AppConfigurationFeatureResource) basicNoLabel(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-appconfig-%d"
-  location = "%s"
-}
-
-data "azurerm_client_config" "test" {
-}
-
-resource "azurerm_role_assignment" "test" {
-  scope                = azurerm_resource_group.test.id
-  role_definition_name = "App Configuration Data Owner"
-  principal_id         = data.azurerm_client_config.test.object_id
-}
-
-resource "azurerm_app_configuration" "test" {
-  name                = "testacc-appconf%d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-  sku                 = "standard"
-
-  depends_on = [
-    azurerm_role_assignment.test,
-  ]
-}
+%s
 
 resource "azurerm_app_configuration_feature" "test" {
   configuration_store_id = azurerm_app_configuration.test.id
@@ -302,39 +259,26 @@ resource "azurerm_app_configuration_feature" "test" {
   name                   = "acctest-ackey-%d"
   enabled                = true
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+`, t.template(data), data.RandomInteger)
+}
+
+func (t AppConfigurationFeatureResource) customKey(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_app_configuration_feature" "test" {
+  configuration_store_id = azurerm_app_configuration.test.id
+  description            = "test description"
+  name                   = "acctest-ackey-%d"
+  key                    = "custom/:-key-%[2]d"
+  enabled                = true
+}
+`, t.template(data), data.RandomInteger)
 }
 
 func (t AppConfigurationFeatureResource) updateNoLabel(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-appconfig-%d"
-  location = "%s"
-}
-
-data "azurerm_client_config" "test" {
-}
-
-resource "azurerm_role_assignment" "test" {
-  scope                = azurerm_resource_group.test.id
-  role_definition_name = "App Configuration Data Owner"
-  principal_id         = data.azurerm_client_config.test.object_id
-}
-
-resource "azurerm_app_configuration" "test" {
-  name                = "testacc-appconf%d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-  sku                 = "standard"
-
-  depends_on = [
-    azurerm_role_assignment.test,
-  ]
-}
+%s
 
 resource "azurerm_app_configuration_feature" "test" {
   configuration_store_id = azurerm_app_configuration.test.id
@@ -342,39 +286,12 @@ resource "azurerm_app_configuration_feature" "test" {
   name                   = "acctest-ackey-%d"
   enabled                = false
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+`, t.template(data), data.RandomInteger)
 }
 
 func (t AppConfigurationFeatureResource) basicWithSlash(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-appconfig-%d"
-  location = "%s"
-}
-
-data "azurerm_client_config" "test" {
-}
-
-resource "azurerm_role_assignment" "test" {
-  scope                = azurerm_resource_group.test.id
-  role_definition_name = "App Configuration Data Owner"
-  principal_id         = data.azurerm_client_config.test.object_id
-}
-
-resource "azurerm_app_configuration" "test" {
-  name                = "testacc-appconf%d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-  sku                 = "standard"
-
-  depends_on = [
-    azurerm_role_assignment.test,
-  ]
-}
+%s
 
 resource "azurerm_app_configuration_feature" "test" {
   configuration_store_id = azurerm_app_configuration.test.id
@@ -383,7 +300,7 @@ resource "azurerm_app_configuration_feature" "test" {
   label                  = "acctest/label"
   enabled                = true
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+`, t.template(data), data.RandomInteger)
 }
 
 func (t AppConfigurationFeatureResource) requiresImport(data acceptance.TestData) string {
@@ -424,128 +341,61 @@ resource "azurerm_app_configuration_feature" "import" {
 
 func (t AppConfigurationFeatureResource) complicatedKeyLabel(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-appconfig-%d"
-  location = "%s"
-}
-
-data "azurerm_client_config" "test" {
-}
-
-resource "azurerm_role_assignment" "test" {
-  scope                = azurerm_resource_group.test.id
-  role_definition_name = "App Configuration Data Owner"
-  principal_id         = data.azurerm_client_config.test.object_id
-}
-
-resource "azurerm_app_configuration" "test" {
-  name                = "testacc-appconf%d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-  sku                 = "standard"
-
-  depends_on = [
-    azurerm_role_assignment.test,
-  ]
-}
+%s
 
 resource "azurerm_app_configuration_feature" "test" {
   configuration_store_id = azurerm_app_configuration.test.id
   name                   = "acctest-ackey-%d/Label/AppConfigurationKey/Label/"
-  label                  = "/Key/AppConfigurationKey/Label/acctest-ackeylabel-%d"
+  label                  = "/Key/AppConfigurationKey/Label/acctest-ackeylabel-%[2]d"
   enabled                = true
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+`, t.template(data), data.RandomInteger)
 }
 
 func (t AppConfigurationFeatureResource) lockUpdate(data acceptance.TestData, lockStatus bool) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-appconfig-%d"
-  location = "%s"
-}
-
-data "azurerm_client_config" "test" {
-}
-
-resource "azurerm_role_assignment" "test" {
-  scope                = azurerm_resource_group.test.id
-  role_definition_name = "App Configuration Data Owner"
-  principal_id         = data.azurerm_client_config.test.object_id
-}
-
-resource "azurerm_app_configuration" "test" {
-  name                = "testacc-appconf%d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-  sku                 = "standard"
-
-  depends_on = [
-    azurerm_role_assignment.test,
-  ]
-}
+%s
 
 resource "azurerm_app_configuration_feature" "test" {
   configuration_store_id = azurerm_app_configuration.test.id
   description            = "test description"
   name                   = "acctest-ackey-%d"
-  label                  = "acctest-ackeylabel-%d"
+  label                  = "acctest-ackeylabel-%[2]d"
   enabled                = true
-  locked                 = %t
+  locked                 = %[3]t
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, lockStatus)
+`, t.template(data), data.RandomInteger, lockStatus)
 }
 
 func (t AppConfigurationFeatureResource) enabledUpdate(data acceptance.TestData, enabledStatus bool) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-appconfig-%d"
-  location = "%s"
-}
-
-data "azurerm_client_config" "test" {
-}
-
-resource "azurerm_role_assignment" "test" {
-  scope                = azurerm_resource_group.test.id
-  role_definition_name = "App Configuration Data Owner"
-  principal_id         = data.azurerm_client_config.test.object_id
-}
-
-resource "azurerm_app_configuration" "test" {
-  name                = "testacc-appconf%d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-  sku                 = "standard"
-
-  depends_on = [
-    azurerm_role_assignment.test,
-  ]
-}
+%s
 
 resource "azurerm_app_configuration_feature" "test" {
   configuration_store_id = azurerm_app_configuration.test.id
   description            = "test description"
   name                   = "acctest-ackey-%d"
-  label                  = "acctest-ackeylabel-%d"
-  enabled                = %t
+  label                  = "acctest-ackeylabel-%[2]d"
+  enabled                = %[3]t
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, enabledStatus)
+`, t.template(data), data.RandomInteger, enabledStatus)
 }
 
 func (t AppConfigurationFeatureResource) basicNoFilters(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_app_configuration_feature" "test" {
+  configuration_store_id = azurerm_app_configuration.test.id
+  description            = "test description"
+  name                   = "acctest-ackey-%[2]d"
+  label                  = "acctest-ackeylabel-%[2]d"
+  enabled                = true
+}
+`, t.template(data), data.RandomInteger)
+}
+
+func (t AppConfigurationFeatureResource) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -566,7 +416,7 @@ resource "azurerm_role_assignment" "test" {
 }
 
 resource "azurerm_app_configuration" "test" {
-  name                = "testacc-appconf%d"
+  name                = "testacc-appconf%[1]d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
   sku                 = "standard"
@@ -575,15 +425,5 @@ resource "azurerm_app_configuration" "test" {
     azurerm_role_assignment.test,
   ]
 }
-
-resource "azurerm_app_configuration_feature" "test" {
-  configuration_store_id = azurerm_app_configuration.test.id
-  description            = "test description"
-  name                   = "acctest-ackey-%d"
-  label                  = "acctest-ackeylabel-%d"
-  enabled                = true
-}
-
-
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary)
 }

--- a/internal/services/appconfiguration/validate/app_configuration_feature_name.go
+++ b/internal/services/appconfiguration/validate/app_configuration_feature_name.go
@@ -23,3 +23,16 @@ func AppConfigurationFeatureName(input interface{}, key string) ([]string, []err
 
 	return validation.StringIsNotWhiteSpace(input, key)
 }
+
+func AppConfigurationFeatureKey(input interface{}, key string) ([]string, []error) {
+	v, ok := input.(string)
+	if !ok {
+		return nil, []error{fmt.Errorf("expected type of %q to be string", key)}
+	}
+
+	if idx := strings.Index(v, "%"); idx != -1 {
+		return nil, []error{fmt.Errorf(`character "%%" is not allowed in %q`, key)}
+	}
+
+	return validation.StringIsNotWhiteSpace(input, key)
+}

--- a/website/docs/r/app_configuration_feature.html.markdown
+++ b/website/docs/r/app_configuration_feature.html.markdown
@@ -28,8 +28,8 @@ resource "azurerm_app_configuration" "appconf" {
 resource "azurerm_app_configuration_feature" "test" {
   configuration_store_id = azurerm_app_configuration.appconf.id
   description            = "test description"
-  name                   = "acctest-ackey-%d"
-  label                  = "acctest-ackeylabel-%d"
+  name                   = "test-ackey"
+  label                  = "test-ackeylabel"
   enabled                = true
 }
 ```
@@ -44,11 +44,13 @@ The following arguments are supported:
 
 * `enabled` - (Optional) The status of the App Configuration Feature. By default, this is set to false.
 
+* `key` - (Optional) The key of the App Configuration Feature. `%` character is not allowed in key. If not specified, `name` will be used as the key. Changing this forces a new resource to be created.
+
 * `label` - (Optional) The label of the App Configuration Feature. Changing this forces a new resource to be created.
 
 * `locked` - (Optional) Should this App Configuration Feature be Locked to prevent changes?
 
-* `name` - (Required) The name of the App Configuration Feature. Changing this forces a new resource to be created.
+* `name` - (Required) The name of the App Configuration Feature. `:` or `%` characters are not allowed in name. Changing this forces a new resource to be created.
 
 * `percentage_filter_value` - (Optional) A list of one or more numbers representing the value of the percentage required to enable this feature.
 

--- a/website/docs/r/app_configuration_feature.html.markdown
+++ b/website/docs/r/app_configuration_feature.html.markdown
@@ -44,13 +44,13 @@ The following arguments are supported:
 
 * `enabled` - (Optional) The status of the App Configuration Feature. By default, this is set to false.
 
-* `key` - (Optional) The key of the App Configuration Feature. `%` character is not allowed in key. If not specified, `name` will be used as the key. Changing this forces a new resource to be created.
+* `key` - (Optional) The key of the App Configuration Feature. The value for `name` will be used if this is unspecified. Changing this forces a new resource to be created.
 
 * `label` - (Optional) The label of the App Configuration Feature. Changing this forces a new resource to be created.
 
 * `locked` - (Optional) Should this App Configuration Feature be Locked to prevent changes?
 
-* `name` - (Required) The name of the App Configuration Feature. `:` or `%` characters are not allowed in name. Changing this forces a new resource to be created.
+* `name` - (Required) The name of the App Configuration Feature. Changing this forces a new resource to be created.
 
 * `percentage_filter_value` - (Optional) A list of one or more numbers representing the value of the percentage required to enable this feature.
 


### PR DESCRIPTION
resolves https://github.com/hashicorp/terraform-provider-azurerm/issues/20985
The key is generated from the feature flag `name` by default, this PR export a customizable `key` property, which support `:` character in feature key. From Portal:
<img width="500" alt="image" src="https://user-images.githubusercontent.com/104055472/229425049-b31e3be3-15ee-497c-9b44-f1fb094825c3.png">

test:
![image](https://user-images.githubusercontent.com/104055472/229429276-a6185213-9aa5-4269-8e47-918d44fc3f61.png)


