### PR TITLE
`azurerm_automation_software_update_configuration`: add default definition in software update

### DIFF
--- a/internal/services/automation/automation_software_update_configuration_resource.go
+++ b/internal/services/automation/automation_software_update_configuration_resource.go
@@ -839,6 +839,7 @@ func (m SoftwareUpdateConfigurationResource) Arguments() map[string]*pluginsdk.S
 					"time_zone": {
 						Type:         pluginsdk.TypeString,
 						Optional:     true,
+						Default:      "Etc/UTC",
 						ValidateFunc: validation.StringIsNotEmpty,
 					},
 

--- a/internal/services/automation/automation_software_update_configuration_resource_test.go
+++ b/internal/services/automation/automation_software_update_configuration_resource_test.go
@@ -58,6 +58,29 @@ func TestAccSoftwareUpdateConfiguration_basic(t *testing.T) {
 	})
 }
 
+func TestAccSoftwareUpdateConfiguration_defaultTimeZone(t *testing.T) {
+	data := acceptance.BuildTestData(t, automation.SoftwareUpdateConfigurationResource{}.ResourceType(), "test")
+	r := newSoftwareUpdateConfigurationResource()
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.defaultTimeZone(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		// scheduleInfo.advancedSchedule always return null
+		data.ImportStep("schedule.0.advanced", "schedule.0.monthly_occurrence"),
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		// scheduleInfo.advancedSchedule always return null
+		data.ImportStep("schedule.0.advanced", "schedule.0.monthly_occurrence"),
+	})
+}
+
 func TestAccSoftwareUpdateConfiguration_update(t *testing.T) {
 	data := acceptance.BuildTestData(t, automation.SoftwareUpdateConfigurationResource{}.ResourceType(), "test")
 	r := newSoftwareUpdateConfigurationResource()
@@ -94,6 +117,58 @@ func TestAccSoftwareUpdateConfiguration_windows(t *testing.T) {
 		// scheduleInfo.advancedSchedule always return null
 		data.ImportStep("schedule.0.advanced", "schedule.0.monthly_occurrence"),
 	})
+}
+
+func (a SoftwareUpdateConfigurationResource) defaultTimeZone(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+
+
+%s
+
+resource "azurerm_automation_software_update_configuration" "test" {
+  automation_account_id = azurerm_automation_account.test.id
+  name                  = "acctest-suc-%[2]d"
+  operating_system      = "Linux"
+
+  linux {
+    classification_included = "Security"
+    excluded_packages       = ["apt"]
+    included_packages       = ["vim"]
+    reboot                  = "IfRequired"
+  }
+
+  duration            = "PT1H1M1S"
+  virtual_machine_ids = []
+
+  target {
+    azure_query {
+      scope     = [azurerm_resource_group.test.id]
+      locations = [azurerm_resource_group.test.location]
+    }
+
+    non_azure_query {
+      function_alias = "savedSearch1"
+      workspace_id   = azurerm_log_analytics_workspace.test.id
+    }
+  }
+
+  schedule {
+    description         = "foo-schedule"
+    start_time          = "%[3]s"
+    is_enabled          = true
+    interval            = 1
+    frequency           = "Hour"
+    advanced_week_days  = ["Monday", "Tuesday"]
+    advanced_month_days = [1, 10, 15]
+    monthly_occurrence {
+      occurrence = 1
+      day        = "Tuesday"
+    }
+  }
+
+  depends_on = [azurerm_log_analytics_linked_service.test]
+}
+`, a.template(data), data.RandomInteger, a.startTime, a.expireTime)
 }
 
 func (a SoftwareUpdateConfigurationResource) basic(data acceptance.TestData) string {

--- a/website/docs/r/automation_schedule.html.markdown
+++ b/website/docs/r/automation_schedule.html.markdown
@@ -58,7 +58,7 @@ The following arguments are supported:
 
 * `expiry_time` - (Optional) The end time of the schedule.
 
-* `timezone` - (Optional) The timezone of the start time. Defaults to `UTC`. For possible values see: <https://docs.microsoft.com/en-us/rest/api/maps/timezone/gettimezoneenumwindows>
+* `timezone` - (Optional) The timezone of the start time. Defaults to `Etc/UTC`. For possible values see: <https://docs.microsoft.com/en-us/rest/api/maps/timezone/gettimezoneenumwindows>
 
 * `week_days` - (Optional) List of days of the week that the job should execute on. Only valid when frequency is `Week`. Possible values are `Monday`, `Tuesday`, `Wednesday`, `Thursday`, `Friday`, `Saturday` and `Sunday`.
 

--- a/website/docs/r/automation_software_update_configuration.html.markdown
+++ b/website/docs/r/automation_software_update_configuration.html.markdown
@@ -169,7 +169,7 @@ A `schedule` block supports the following:
 
 * `expiry_time` - (Optional) The end time of the schedule.
 
-* `time_zone` - (Optional) The timezone of the start time. Defaults to `UTC`. For possible values see: <https://docs.microsoft.com/en-us/rest/api/maps/timezone/gettimezoneenumwindows>
+* `time_zone` - (Optional) The timezone of the start time. Defaults to `Etc/UTC`. For possible values see: <https://docs.microsoft.com/en-us/rest/api/maps/timezone/gettimezoneenumwindows>
 
 * `advanced_week_days` - (Optional) List of days of the week that the job should execute on. Only valid when frequency is `Week`.
 


### PR DESCRIPTION
resolves: #21180 .

the document has mark this field `Defaults to 'Etc/UTC'` already.

```
--- PASS: TestAccSoftwareUpdateConfiguration_defaultTimeZone (297.21s)
PASS
```
