### PR TITLE
Cleanup user-facing error regarding ACR SKU revert

### DIFF
--- a/internal/services/containers/container_registry_resource.go
+++ b/internal/services/containers/container_registry_resource.go
@@ -180,7 +180,7 @@ func resourceContainerRegistryCreate(d *pluginsdk.ResourceData, meta interface{}
 
 	networkRuleSet := expandNetworkRuleSet(d.Get("network_rule_set").([]interface{}))
 	if networkRuleSet != nil && !strings.EqualFold(sku, string(containerregistry.SkuNamePremium)) {
-		return fmt.Errorf("`network_rule_set_set` can only be specified for a Premium Sku. If you are reverting from a Premium to Basic SKU plese set network_rule_set = []")
+		return fmt.Errorf("`network_rule_set_set` can only be specified for a Premium SKU. If you are reverting from a Premium to Basic SKU, set `network_rule_set = []`")
 	}
 
 	quarantinePolicy := expandQuarantinePolicy(d.Get("quarantine_policy_enabled").(bool))


### PR DESCRIPTION
Simply some aesthetic changes (and a typo fix) to the alert message that shows up when you try to change a Premium ACR SKU to a Basic that has existing network rules.