### PR TITLE
azurerm_data_protection_backup_vault - Added ZoneRedundancy option to redundancy

### DIFF
--- a/internal/services/dataprotection/data_protection_backup_vault_resource.go
+++ b/internal/services/dataprotection/data_protection_backup_vault_resource.go
@@ -72,6 +72,7 @@ func resourceDataProtectionBackupVault() *pluginsdk.Resource {
 				ValidateFunc: validation.StringInSlice([]string{
 					string(backupvaults.StorageSettingTypesGeoRedundant),
 					string(backupvaults.StorageSettingTypesLocallyRedundant),
+					string(backupvaults.StorageSettingTypesZoneRedundant),
 				}, false),
 			},
 

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dataprotection/2022-04-01/backupvaults/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dataprotection/2022-04-01/backupvaults/constants.go
@@ -158,12 +158,14 @@ type StorageSettingTypes string
 const (
 	StorageSettingTypesGeoRedundant     StorageSettingTypes = "GeoRedundant"
 	StorageSettingTypesLocallyRedundant StorageSettingTypes = "LocallyRedundant"
+	StorageSettingTypesZoneRedundant    StorageSettingTypes = "ZoneRedundant"
 )
 
 func PossibleValuesForStorageSettingTypes() []string {
 	return []string{
 		string(StorageSettingTypesGeoRedundant),
 		string(StorageSettingTypesLocallyRedundant),
+		string(StorageSettingTypesZoneRedundant),
 	}
 }
 
@@ -171,6 +173,7 @@ func parseStorageSettingTypes(input string) (*StorageSettingTypes, error) {
 	vals := map[string]StorageSettingTypes{
 		"georedundant":     StorageSettingTypesGeoRedundant,
 		"locallyredundant": StorageSettingTypesLocallyRedundant,
+		"zoneredundant":    StorageSettingTypesZoneRedundant,
 	}
 	if v, ok := vals[strings.ToLower(input)]; ok {
 		return &v, nil


### PR DESCRIPTION
The backup vault now supports Zone Redundancy, the API supports passing this type as a parameter. Fixes #21300