### PR TITLE
Moving kubernetes fleet manager from containers to container category for consistency

### DIFF
--- a/website/allowed-subcategories
+++ b/website/allowed-subcategories
@@ -24,7 +24,6 @@ Connections
 Consumption
 Container
 Container Apps
-Containers
 CosmosDB (DocumentDB)
 Cost Management
 Custom Providers

--- a/website/docs/r/kubernetes_fleet_manager.html.markdown
+++ b/website/docs/r/kubernetes_fleet_manager.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Containers"
+subcategory: "Container"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_kubernetes_fleet_manager"
 description: |-


### PR DESCRIPTION
As kubernetes fleet manager is the only resource in the containers category and the rest of the kubernetes resources are under container I would like to propose we move the article