### PR TITLE
`azurerm_sentinel`: fix acctest

### DIFF
--- a/internal/services/sentinel/sentinel_alert_rule_anomaly_built_in_resource_test.go
+++ b/internal/services/sentinel/sentinel_alert_rule_anomaly_built_in_resource_test.go
@@ -58,7 +58,7 @@ func (SentinelAlertRuleAnomalyBuiltInResource) basic(data acceptance.TestData) s
 	return fmt.Sprintf(`
 %s
 resource "azurerm_sentinel_alert_rule_anomaly_built_in" "test" {
-  display_name               = "(Preview) Potential data staging"
+  display_name               = "Potential data staging"
   log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
   enabled                    = true
   mode                       = "Production"

--- a/internal/services/sentinel/sentinel_alert_rule_anomaly_data_source_test.go
+++ b/internal/services/sentinel/sentinel_alert_rule_anomaly_data_source_test.go
@@ -124,7 +124,7 @@ func (SentinelAlertRuleAnomalyDataSource) basic_withThreshold(data acceptance.Te
 
 data "azurerm_sentinel_alert_rule_anomaly" "test" {
   log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
-  display_name               = "(Preview) Potential data staging"
+  display_name               = "Potential data staging"
 }
 `, SecurityInsightsSentinelOnboardingStateResource{}.basic(data))
 }
@@ -135,7 +135,7 @@ func (SentinelAlertRuleAnomalyDataSource) basic_withSingleSelect(data acceptance
 
 data "azurerm_sentinel_alert_rule_anomaly" "test" {
   log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
-  display_name               = "(Preview) Suspicious geography change in Palo Alto GlobalProtect account logins"
+  display_name               = "Suspicious geography change in Palo Alto GlobalProtect account logins"
 }
 `, SecurityInsightsSentinelOnboardingStateResource{}.basic(data))
 }
@@ -146,7 +146,7 @@ func (SentinelAlertRuleAnomalyDataSource) basic_withMultiSelect(data acceptance.
 
 data "azurerm_sentinel_alert_rule_anomaly" "test" {
   log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
-  display_name               = "(Preview) Attempted user account bruteforce per logon type"
+  display_name               = "Attempted user account bruteforce per logon type"
 }
 `, SecurityInsightsSentinelOnboardingStateResource{}.basic(data))
 }
@@ -157,7 +157,7 @@ func (SentinelAlertRuleAnomalyDataSource) basic_withPrioritizeExclude(data accep
 
 data "azurerm_sentinel_alert_rule_anomaly" "test" {
   log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
-  display_name               = "(Preview) Anomalous web request activity"
+  display_name               = "Anomalous web request activity"
 }
 `, SecurityInsightsSentinelOnboardingStateResource{}.basic(data))
 }

--- a/internal/services/sentinel/sentinel_alert_rule_anomaly_duplicate_resource_test.go
+++ b/internal/services/sentinel/sentinel_alert_rule_anomaly_duplicate_resource_test.go
@@ -183,11 +183,11 @@ func (SentinelAlertRuleAnomalyDuplicateResource) basicWithMultiSelectObservation
 
 data "azurerm_sentinel_alert_rule_anomaly" "test" {
   log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
-  display_name               = "(Preview) Anomalous scanning activity"
+  display_name               = "Anomalous scanning activity"
 }
 
 resource "azurerm_sentinel_alert_rule_anomaly_duplicate" "test" {
-  display_name               = "acctest duplicate (Preview) Anomalous scanning activity"
+  display_name               = "acctest duplicate Anomalous scanning activity"
   log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
   built_in_rule_id           = data.azurerm_sentinel_alert_rule_anomaly.test.id
   enabled                    = true

--- a/internal/services/sentinel/sentinel_alert_rule_anomaly_duplicate_resource_test.go
+++ b/internal/services/sentinel/sentinel_alert_rule_anomaly_duplicate_resource_test.go
@@ -159,11 +159,11 @@ func (SentinelAlertRuleAnomalyDuplicateResource) basicWithSingleSelectObservatio
 
 data "azurerm_sentinel_alert_rule_anomaly" "test" {
   log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
-  display_name               = "(Preview) Unusual web traffic detected with IP in URL path"
+  display_name               = "Unusual web traffic detected with IP in URL path"
 }
 
 resource "azurerm_sentinel_alert_rule_anomaly_duplicate" "test" {
-  display_name               = "acctest duplicate (Preview) Unusual web traffic detected with IP in URL path"
+  display_name               = "acctest duplicate Unusual web traffic detected with IP in URL path"
   log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
   built_in_rule_id           = data.azurerm_sentinel_alert_rule_anomaly.test.id
   enabled                    = true

--- a/internal/services/sentinel/sentinel_alert_rule_anomaly_duplicate_resource_test.go
+++ b/internal/services/sentinel/sentinel_alert_rule_anomaly_duplicate_resource_test.go
@@ -115,7 +115,7 @@ func (SentinelAlertRuleAnomalyDuplicateResource) basic(data acceptance.TestData)
 
 data "azurerm_sentinel_alert_rule_anomaly" "test" {
   log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
-  display_name               = "(Preview) Potential data staging"
+  display_name               = "Potential data staging"
 }
 
 resource "azurerm_sentinel_alert_rule_anomaly_duplicate" "test" {
@@ -134,7 +134,7 @@ func (SentinelAlertRuleAnomalyDuplicateResource) basicWithThresholdObservation(d
 
 data "azurerm_sentinel_alert_rule_anomaly" "test" {
   log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
-  display_name               = "(Preview) UEBA Anomalous Sign In"
+  display_name               = "UEBA Anomalous Sign In"
 }
 
 resource "azurerm_sentinel_alert_rule_anomaly_duplicate" "test" {
@@ -206,11 +206,11 @@ func (SentinelAlertRuleAnomalyDuplicateResource) basicWithPrioritizeExcludeObser
 
 data "azurerm_sentinel_alert_rule_anomaly" "test" {
   log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
-  display_name               = "(Preview) Anomalous web request activity"
+  display_name               = "Anomalous web request activity"
 }
 
 resource "azurerm_sentinel_alert_rule_anomaly_duplicate" "test" {
-  display_name               = "acctest duplicate (Preview) Anomalous web request activity"
+  display_name               = "acctest duplicate Anomalous web request activity"
   log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
   built_in_rule_id           = data.azurerm_sentinel_alert_rule_anomaly.test.id
   enabled                    = true

--- a/internal/services/sentinel/sentinel_alert_rule_threat_intelligence_resouce_test.go
+++ b/internal/services/sentinel/sentinel_alert_rule_threat_intelligence_resouce_test.go
@@ -178,7 +178,7 @@ resource "azurerm_sentinel_log_analytics_workspace_onboarding" "test" {
 }
 
 data "azurerm_sentinel_alert_rule_template" "test" {
-  display_name               = "(Preview) Microsoft Threat Intelligence Analytics"
+  display_name               = "(Preview) Microsoft Defender Threat Intelligence Analytics"
   log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)

--- a/website/docs/d/sentinel_alert_rule_anomaly.html.markdown
+++ b/website/docs/d/sentinel_alert_rule_anomaly.html.markdown
@@ -33,7 +33,7 @@ resource "azurerm_security_insights_sentinel_onboarding" "example" {
 
 data "azurerm_sentinel_alert_rule_anomaly" "example" {
   log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
-  display_name               = "(Preview) Potential data staging"
+  display_name               = "Potential data staging"
 
   depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.example]
 }

--- a/website/docs/r/sentinel_alert_rule_anomaly_built_in.html.markdown
+++ b/website/docs/r/sentinel_alert_rule_anomaly_built_in.html.markdown
@@ -36,12 +36,12 @@ resource "azurerm_security_insights_sentinel_onboarding" "example" {
 
 data "azurerm_sentinel_alert_rule_anomaly" "example" {
   log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
-  display_name               = "(Preview) Potential data staging"
+  display_name               = "Potential data staging"
   depends_on                 = [azurerm_sentinel_log_analytics_workspace_onboarding.example]
 }
 
 resource "azurerm_sentinel_alert_rule_anomaly_built_in" "example" {
-  display_name               = "(Preview) Potential data staging"
+  display_name               = "Potential data staging"
   log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
   mode                       = "Production"
   enabled                    = false

--- a/website/docs/r/sentinel_alert_rule_anomaly_duplicate.html.markdown
+++ b/website/docs/r/sentinel_alert_rule_anomaly_duplicate.html.markdown
@@ -32,7 +32,7 @@ resource "azurerm_security_insights_sentinel_onboarding" "example" {
 
 data "azurerm_sentinel_alert_rule_anomaly" "example" {
   log_analytics_workspace_id = azurerm_log_analytics_workspace.example.id
-  display_name               = "(Preview) UEBA Anomalous Sign In"
+  display_name               = "UEBA Anomalous Sign In"
 
   depends_on = [azurerm_sentinel_log_analytics_workspace_onboarding.example]
 }

--- a/website/docs/r/sentinel_alert_rule_threat_intelligence.html.markdown
+++ b/website/docs/r/sentinel_alert_rule_threat_intelligence.html.markdown
@@ -43,7 +43,7 @@ resource "azurerm_log_analytics_solution" "example" {
 }
 
 data "azurerm_sentinel_alert_rule_template" "example" {
-  display_name               = "(Preview) Microsoft Threat Intelligence Analytics"
+  display_name               = "(Preview) Microsoft Defender Threat Intelligence Analytics"
   log_analytics_workspace_id = azurerm_log_analytics_solution.example.workspace_resource_id
 }
 


### PR DESCRIPTION
the name of these templates and built-in rules has been edited and caused acctests failure, update test cases..

<img width="474" alt="Screenshot 2023-04-07 at 13 15 56" src="https://user-images.githubusercontent.com/51212351/230545694-18635e12-136b-495f-8e0d-2673472f33ad.png">
the rest failure are caused by `InvalidLicense`