### PR TITLE
`azurerm_monitor_data_collection_rule` - fix data source failed test case

### DIFF
--- a/internal/services/monitor/monitor_activity_log_alert_resource_test.go
+++ b/internal/services/monitor/monitor_activity_log_alert_resource_test.go
@@ -683,6 +683,7 @@ resource "azurerm_monitor_activity_log_alert" "test" {
   description         = "This is just a test acceptance."
 
   scopes = [
+    azurerm_resource_group.test.id,
     azurerm_storage_account.test.id,
   ]
 
@@ -749,6 +750,7 @@ resource "azurerm_monitor_activity_log_alert" "test" {
   description         = "This is just a test acceptance."
 
   scopes = [
+    azurerm_resource_group.test.id,
     azurerm_storage_account.test.id,
   ]
 
@@ -825,6 +827,7 @@ resource "azurerm_monitor_activity_log_alert" "test" {
   description         = "This is just a test acceptance."
 
   scopes = [
+    azurerm_resource_group.test.id,
     azurerm_storage_account.test.id,
   ]
 

--- a/internal/services/monitor/monitor_activity_log_alert_resource_test.go
+++ b/internal/services/monitor/monitor_activity_log_alert_resource_test.go
@@ -683,7 +683,6 @@ resource "azurerm_monitor_activity_log_alert" "test" {
   description         = "This is just a test acceptance."
 
   scopes = [
-    azurerm_resource_group.test.id,
     azurerm_storage_account.test.id,
   ]
 
@@ -750,7 +749,6 @@ resource "azurerm_monitor_activity_log_alert" "test" {
   description         = "This is just a test acceptance."
 
   scopes = [
-    azurerm_resource_group.test.id,
     azurerm_storage_account.test.id,
   ]
 
@@ -827,7 +825,6 @@ resource "azurerm_monitor_activity_log_alert" "test" {
   description         = "This is just a test acceptance."
 
   scopes = [
-    azurerm_resource_group.test.id,
     azurerm_storage_account.test.id,
   ]
 

--- a/internal/services/monitor/monitor_data_collection_rule_data_source_test.go
+++ b/internal/services/monitor/monitor_data_collection_rule_data_source_test.go
@@ -39,7 +39,7 @@ func TestAccMonitorDataCollectionRuleDataSource_complete(t *testing.T) {
 				check.That(data.ResourceName).Key("data_sources.0.windows_event_log.0.x_path_queries.0").HasValue("System!*[System[EventID=4648]]"),
 				check.That(data.ResourceName).Key("data_sources.0.extension.0.extension_json").Exists(),
 				check.That(data.ResourceName).Key("immutable_id").Exists(),
-				check.That(data.ResourceName).Key("stream_declaration.#").HasValue("1"),
+				check.That(data.ResourceName).Key("stream_declaration.#").HasValue("2"),
 				check.That(data.ResourceName).Key("stream_declaration.0.column.#").HasValue("3"),
 			),
 		},


### PR DESCRIPTION
```
TF_ACC=1 go test -v ./internal/services/monitor -parallel 20 -test.run=TestAccMonitorDataCollectionRuleD -timeout 1440m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccMonitorDataCollectionRuleDataSource_complete
=== PAUSE TestAccMonitorDataCollectionRuleDataSource_complete
=== CONT  TestAccMonitorDataCollectionRuleDataSource_complete
--- PASS: TestAccMonitorDataCollectionRuleDataSource_complete (337.27s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/monitor       340.762s
```