### PR TITLE
`azurerm_monitor_activity_log_alert` - fix `TestAccMonitorActivityLogAlert_ServiceHealth`

### DIFF
--- a/internal/services/monitor/monitor_activity_log_alert_resource_test.go
+++ b/internal/services/monitor/monitor_activity_log_alert_resource_test.go
@@ -651,6 +651,9 @@ provider "azurerm" {
   features {}
 }
 
+data "azurerm_subscription" "current" {
+}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
   location = "%s"
@@ -683,8 +686,7 @@ resource "azurerm_monitor_activity_log_alert" "test" {
   description         = "This is just a test acceptance."
 
   scopes = [
-    azurerm_resource_group.test.id,
-    azurerm_storage_account.test.id,
+    data.azurerm_subscription.current.id
   ]
 
   criteria {
@@ -718,6 +720,9 @@ provider "azurerm" {
   features {}
 }
 
+data "azurerm_subscription" "current" {
+}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
   location = "%s"
@@ -750,8 +755,7 @@ resource "azurerm_monitor_activity_log_alert" "test" {
   description         = "This is just a test acceptance."
 
   scopes = [
-    azurerm_resource_group.test.id,
-    azurerm_storage_account.test.id,
+    data.azurerm_subscription.current.id
   ]
 
   criteria {
@@ -795,6 +799,9 @@ provider "azurerm" {
   features {}
 }
 
+data "azurerm_subscription" "current" {
+}
+
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
   location = "%s"
@@ -827,8 +834,7 @@ resource "azurerm_monitor_activity_log_alert" "test" {
   description         = "This is just a test acceptance."
 
   scopes = [
-    azurerm_resource_group.test.id,
-    azurerm_storage_account.test.id,
+    data.azurerm_subscription.current.id
   ]
 
   criteria {


### PR DESCRIPTION
From API response, now the ServiceHealth activity log alert must use a single subscription ID in the scope.
```
TF_ACC=1 go test -v ./internal/services/monitor -parallel 20 -test.run=TestAccMonitorActivityLogAlert_ServiceHealth -timeout 1440m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccMonitorActivityLogAlert_ServiceHealth_basicAndUpdate
=== PAUSE TestAccMonitorActivityLogAlert_ServiceHealth_basicAndUpdate
=== RUN   TestAccMonitorActivityLogAlert_ServiceHealth_basicAndDelete
=== PAUSE TestAccMonitorActivityLogAlert_ServiceHealth_basicAndDelete
=== CONT  TestAccMonitorActivityLogAlert_ServiceHealth_basicAndUpdate
=== CONT  TestAccMonitorActivityLogAlert_ServiceHealth_basicAndDelete
--- PASS: TestAccMonitorActivityLogAlert_ServiceHealth_basicAndDelete (210.27s)
--- PASS: TestAccMonitorActivityLogAlert_ServiceHealth_basicAndUpdate (245.44s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/monitor       247.187s

```