### PR TITLE
`azurerm_media_streaming_endpoint` - fix `TestAccMediaStreamingEndpoint_shouldStopWhenStarted`

### DIFF
--- a/internal/services/media/media_streaming_endpoint_resource_test.go
+++ b/internal/services/media/media_streaming_endpoint_resource_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-08-01/streamingendpoints"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
@@ -123,6 +124,8 @@ func (r MediaStreamingEndpointResource) Start(ctx context.Context, client *clien
 	if err != nil {
 		return err
 	}
+	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(15*time.Minute))
+	defer cancel()
 
 	if err := client.Media.V20220801Client.StreamingEndpoints.StartThenPoll(ctx, *id); err != nil {
 		return fmt.Errorf("starting %s: %+v", id, err)


### PR DESCRIPTION
original error:
```
------- Stdout: -------
=== RUN   TestAccMediaStreamingEndpoint_shouldStopWhenStarted
=== PAUSE TestAccMediaStreamingEndpoint_shouldStopWhenStarted
=== CONT  TestAccMediaStreamingEndpoint_shouldStopWhenStarted
testcase.go:110: Step 1/1 error: Check failed: 1 error occurred:
  * Check 1/4 error: Check 1/1 error: starting Streaming Endpoint (Subscription: "*******"
Resource Group Name: "acctestRG-media-230404032209172713"
Media Service Name: "acctestmsaneyz3"
Streaming Endpoint Name: "endpoint1"): performing Start: the context used must have a deadline attached for polling purposes, but got no deadline
--- FAIL: TestAccMediaStreamingEndpoint_shouldStopWhenStarted (176.79s)
FAIL
```

test:
```
TF_ACC=1 go test -v ./internal/services/media -parallel 20 -test.run=TestAccMediaStreamingEndpoint_shouldStopWhenStarted -timeout 1440m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccMediaStreamingEndpoint_shouldStopWhenStarted
=== PAUSE TestAccMediaStreamingEndpoint_shouldStopWhenStarted
=== CONT  TestAccMediaStreamingEndpoint_shouldStopWhenStarted
--- PASS: TestAccMediaStreamingEndpoint_shouldStopWhenStarted (301.76s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/media 303.643s
```
