### PR TITLE
`data.azurerm_key_vault_secret` - support specifying the keyvault secret version

### DIFF
--- a/internal/services/keyvault/key_vault_secret_data_source.go
+++ b/internal/services/keyvault/key_vault_secret_data_source.go
@@ -48,7 +48,7 @@ func dataSourceKeyVaultSecret() *pluginsdk.Resource {
 
 			"version": {
 				Type:     pluginsdk.TypeString,
-				Computed: true,
+				Optional: true,
 			},
 
 			"versionless_id": {
@@ -78,6 +78,7 @@ func dataSourceKeyVaultSecretRead(d *pluginsdk.ResourceData, meta interface{}) e
 	defer cancel()
 
 	name := d.Get("name").(string)
+	version := d.Get("version").(string)
 	keyVaultId, err := parse.VaultID(d.Get("key_vault_id").(string))
 	if err != nil {
 		return err
@@ -88,8 +89,7 @@ func dataSourceKeyVaultSecretRead(d *pluginsdk.ResourceData, meta interface{}) e
 		return fmt.Errorf("looking up Secret %q vault url from id %q: %+v", name, *keyVaultId, err)
 	}
 
-	// we always want to get the latest version
-	resp, err := client.GetSecret(ctx, *keyVaultBaseUri, name, "")
+	resp, err := client.GetSecret(ctx, *keyVaultBaseUri, name, version)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
 			return fmt.Errorf("KeyVault Secret %q (KeyVault URI %q) does not exist", name, *keyVaultBaseUri)

--- a/internal/services/keyvault/key_vault_secret_data_source_test.go
+++ b/internal/services/keyvault/key_vault_secret_data_source_test.go
@@ -63,6 +63,7 @@ func (KeyVaultSecretDataSource) complete(data acceptance.TestData) string {
 data "azurerm_key_vault_secret" "test" {
   name         = azurerm_key_vault_secret.test.name
   key_vault_id = azurerm_key_vault.test.id
+  version      = azurerm_key_vault_secret.test.version
 }
 `, KeyVaultSecretResource{}.complete(data))
 }

--- a/internal/services/keyvault/key_vault_secret_data_source_test.go
+++ b/internal/services/keyvault/key_vault_secret_data_source_test.go
@@ -45,6 +45,32 @@ func TestAccDataSourceKeyVaultSecret_complete(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceKeyVaultSecret_specifyVersion(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_key_vault_secret", "test")
+	r := KeyVaultSecretDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("value").HasValue("rick-and-morty"),
+				check.That(data.ResourceName).Key("tags.%").HasValue("0"),
+				check.That(data.ResourceName).Key("resource_id").MatchesRegex(regexp.MustCompile(`^/subscriptions/[\w-]+/resourceGroups/[\w-]+/providers/Microsoft.KeyVault/vaults/[\w-]+/secrets/[\w-]+/versions/[\w-]+$`)),
+				check.That(data.ResourceName).Key("resource_versionless_id").MatchesRegex(regexp.MustCompile(`^/subscriptions/[\w-]+/resourceGroups/[\w-]+/providers/Microsoft.KeyVault/vaults/[\w-]+/secrets/[\w-]+$`)),
+			),
+		},
+		{
+			Config: r.specifyOldVersion(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("value").HasValue("rick-and-morty"),
+				check.That(data.ResourceName).Key("tags.%").HasValue("0"),
+				check.That(data.ResourceName).Key("resource_id").MatchesRegex(regexp.MustCompile(`^/subscriptions/[\w-]+/resourceGroups/[\w-]+/providers/Microsoft.KeyVault/vaults/[\w-]+/secrets/[\w-]+/versions/[\w-]+$`)),
+				check.That(data.ResourceName).Key("resource_versionless_id").MatchesRegex(regexp.MustCompile(`^/subscriptions/[\w-]+/resourceGroups/[\w-]+/providers/Microsoft.KeyVault/vaults/[\w-]+/secrets/[\w-]+$`)),
+			),
+		},
+	})
+}
+
 func (KeyVaultSecretDataSource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
@@ -52,6 +78,7 @@ func (KeyVaultSecretDataSource) basic(data acceptance.TestData) string {
 data "azurerm_key_vault_secret" "test" {
   name         = azurerm_key_vault_secret.test.name
   key_vault_id = azurerm_key_vault.test.id
+  version      = azurerm_key_vault_secret.test.version
 }
 `, KeyVaultSecretResource{}.basic(data))
 }
@@ -63,7 +90,31 @@ func (KeyVaultSecretDataSource) complete(data acceptance.TestData) string {
 data "azurerm_key_vault_secret" "test" {
   name         = azurerm_key_vault_secret.test.name
   key_vault_id = azurerm_key_vault.test.id
-  version      = azurerm_key_vault_secret.test.version
 }
 `, KeyVaultSecretResource{}.complete(data))
+}
+
+func (KeyVaultSecretDataSource) specifyOldVersion(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+
+data "azurerm_key_vault_secret" "test" {
+ name          = "${local.secret_name}"
+  key_vault_id = azurerm_key_vault.test.id
+}
+
+locals {
+  old_version = "${data.azurerm_key_vault_secret.test.version}"
+  secret_name = "secret-%s"
+}
+
+%s
+
+data "azurerm_key_vault_secret" "test2" {
+  name         = azurerm_key_vault_secret.test.name
+  key_vault_id = azurerm_key_vault.test.id
+  version      = "${local.old_version}"
+  depends_on   = [data.azurerm_key_vault_secret.test]
+}
+
+`, data.RandomString, KeyVaultSecretResource{}.basicUpdated(data))
 }

--- a/website/docs/d/key_vault_secret.html.markdown
+++ b/website/docs/d/key_vault_secret.html.markdown
@@ -35,6 +35,8 @@ The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the Key Vault Secret.
 
+* `version` - (Optional) Specifies the version of the Key Vault Secret. Defaults to the current version of the Key Vault Secret.
+
 **NOTE:** The vault must be in the same subscription as the provider. If the vault is in another subscription, you must create an aliased provider for that subscription.
 
 ## Attributes Reference
@@ -52,8 +54,6 @@ In addition to the Arguments listed above - the following Attributes are exporte
 * `tags` - Any tags assigned to this resource.
 
 * `value` - The value of the Key Vault Secret.
-
-* `version` - The current version of the Key Vault Secret.
 
 * `versionless_id` - The Versionless ID of the Key Vault Secret. This can be used to always get latest secret value, and enable fetching automatically rotating secrets.
 


### PR DESCRIPTION
Fix [#21283](https://github.com/hashicorp/terraform-provider-azurerm/issues/21283).