### PR TITLE
`azurerm_app_configuration_{key|feature}` - prelong wait time for the role permission to be done propagated

### DIFF
--- a/internal/services/appconfiguration/app_configuration_feature_resource.go
+++ b/internal/services/appconfiguration/app_configuration_feature_resource.go
@@ -211,7 +211,7 @@ func (k FeatureResource) Create() sdk.ResourceFunc {
 			}
 
 			// from https://learn.microsoft.com/en-us/azure/azure-app-configuration/concept-enable-rbac#azure-built-in-roles-for-azure-app-configuration
-			// allow up to some time for role permission to be done propagated
+			// allow some time for role permission to be done propagated
 			metadata.Logger.Infof("[DEBUG] Waiting for App Configuration Key %q read permission to be done propagated", featureKey)
 			stateConf := &pluginsdk.StateChangeConf{
 				Pending:      []string{"Forbidden"},

--- a/internal/services/appconfiguration/app_configuration_feature_resource.go
+++ b/internal/services/appconfiguration/app_configuration_feature_resource.go
@@ -207,7 +207,7 @@ func (k FeatureResource) Create() sdk.ResourceFunc {
 
 			deadline, ok := ctx.Deadline()
 			if !ok {
-				return fmt.Errorf("could not determine context deadline for create for %s", nestedItemId)
+				return fmt.Errorf("internal-error: context had no deadline")
 			}
 
 			// from https://learn.microsoft.com/en-us/azure/azure-app-configuration/concept-enable-rbac#azure-built-in-roles-for-azure-app-configuration

--- a/internal/services/appconfiguration/app_configuration_key_resource.go
+++ b/internal/services/appconfiguration/app_configuration_key_resource.go
@@ -150,7 +150,7 @@ func (k KeyResource) Create() sdk.ResourceFunc {
 			}
 
 			// from https://learn.microsoft.com/en-us/azure/azure-app-configuration/concept-enable-rbac#azure-built-in-roles-for-azure-app-configuration
-			// allow up to some time for role permission to be done propagated
+			// allow some time for role permission to be done propagated
 			metadata.Logger.Infof("[DEBUG] Waiting for App Configuration Key %q read permission to be done propagated", model.Key)
 			stateConf := &pluginsdk.StateChangeConf{
 				Pending:      []string{"Forbidden"},

--- a/internal/services/appconfiguration/app_configuration_key_resource.go
+++ b/internal/services/appconfiguration/app_configuration_key_resource.go
@@ -144,15 +144,20 @@ func (k KeyResource) Create() sdk.ResourceFunc {
 				return err
 			}
 
+			deadline, ok := ctx.Deadline()
+			if !ok {
+				return fmt.Errorf("could not determine context deadline for create for %s", nestedItemId)
+			}
+
 			// from https://learn.microsoft.com/en-us/azure/azure-app-configuration/concept-enable-rbac#azure-built-in-roles-for-azure-app-configuration
-			// allow up to 15 min for role permission to be done propagated
+			// allow up to some time for role permission to be done propagated
 			metadata.Logger.Infof("[DEBUG] Waiting for App Configuration Key %q read permission to be done propagated", model.Key)
 			stateConf := &pluginsdk.StateChangeConf{
 				Pending:      []string{"Forbidden"},
 				Target:       []string{"Error", "Exists"},
 				Refresh:      appConfigurationGetKeyRefreshFunc(ctx, client, model.Key, model.Label),
 				PollInterval: 20 * time.Second,
-				Timeout:      15 * time.Minute,
+				Timeout:      time.Until(deadline),
 			}
 
 			if _, err = stateConf.WaitForStateContext(ctx); err != nil {

--- a/internal/services/appconfiguration/app_configuration_key_resource.go
+++ b/internal/services/appconfiguration/app_configuration_key_resource.go
@@ -146,7 +146,7 @@ func (k KeyResource) Create() sdk.ResourceFunc {
 
 			deadline, ok := ctx.Deadline()
 			if !ok {
-				return fmt.Errorf("could not determine context deadline for create for %s", nestedItemId)
+				return fmt.Errorf("internal-error: context had no deadline")
 			}
 
 			// from https://learn.microsoft.com/en-us/azure/azure-app-configuration/concept-enable-rbac#azure-built-in-roles-for-azure-app-configuration


### PR DESCRIPTION
original failure:
```
------- Stdout: -------
=== RUN   TestAccAppConfigurationKey_requiresImport
=== PAUSE TestAccAppConfigurationKey_requiresImport
=== CONT  TestAccAppConfigurationKey_requiresImport
testcase.go:110: Step 1/2 error: Error running apply: exit status 1
Error: waiting for App Configuration Key "acctest-ackey-230407021123907459" read permission to be propagated: timeout while waiting for state to become 'Error, Exists' (last state: 'Forbidden', timeout: 15m0s)
with azurerm_app_configuration_key.test,
on terraform_plugin_test.tf line 43, in resource "azurerm_app_configuration_key" "test":
43: resource "azurerm_app_configuration_key" "test" {
waiting for App Configuration Key "acctest-ackey-230407021123907459" read
permission to be propagated: timeout while waiting for state to become
'Error, Exists' (last state: 'Forbidden', timeout: 15m0s)
--- FAIL: TestAccAppConfigurationKey_requiresImport (975.21s)
FAIL

```

Test:
TODO