### PR TITLE
Fix example for creating NGINX Certificate resource

### DIFF
--- a/website/docs/r/nginx_certificate.html.markdown
+++ b/website/docs/r/nginx_certificate.html.markdown
@@ -18,7 +18,7 @@ resource "azurerm_nginx_certificate" "test" {
   nginx_deployment_id      = azurerm_nginx_deployment.test.id
   key_virtual_path         = "/src/cert/soservermekey.key"
   certificate_virtual_path = "/src/cert/server.cert"
-  key_vault_secret_id      = azurerm_key_vault_secret.test.id
+  key_vault_secret_id      = azurerm_key_vault_certificate.test.secret_id
 }
 ```
 


### PR DESCRIPTION
NGINXaaS accepts the secret ID of an AKV certificate and the AKV certificate is a complex object which is made of AKV secret and key.

The example here states that the user can just reference the secret ID from the AKV secret resource but the user workflow is a little different.

The user will first create an AKV certificate using terraform (NOT a secret), and then reference the secret ID attribute of the certificate resource.

The [code snippet](https://github.com/nginxinc/nginxaas-for-azure-snippets/blob/main/snippets/terraform/certificates/main.tf#L44) shows how to create an AKV cert and then [reference it while creating an NGINX certificate](https://github.com/nginxinc/nginxaas-for-azure-snippets/blob/main/snippets/terraform/certificates/main.tf#L128) which accurately represents the Azure user workflow.