### PR TITLE
Data source: azurerm_keyvault_secret - support not_before_date and expiration_date

### DIFF
--- a/internal/services/keyvault/key_vault_secret_data_source.go
+++ b/internal/services/keyvault/key_vault_secret_data_source.go
@@ -46,6 +46,16 @@ func dataSourceKeyVaultSecret() *pluginsdk.Resource {
 				Computed: true,
 			},
 
+			"not_before_date": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
+			"expiration_date": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
 			"version": {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
@@ -110,6 +120,14 @@ func dataSourceKeyVaultSecretRead(d *pluginsdk.ResourceData, meta interface{}) e
 	d.Set("value", resp.Value)
 	d.Set("version", respID.Version)
 	d.Set("content_type", resp.ContentType)
+	if attributes := resp.Attributes; attributes != nil {
+		if notBefore := attributes.NotBefore; notBefore != nil {
+			d.Set("not_before_date", time.Time(*notBefore).Format(time.RFC3339))
+		}
+		if expires := attributes.Expires; expires != nil {
+			d.Set("expiration_date", time.Time(*expires).Format(time.RFC3339))
+		}
+	}
 	d.Set("versionless_id", respID.VersionlessID())
 
 	d.Set("resource_id", parse.NewSecretID(keyVaultId.SubscriptionId, keyVaultId.ResourceGroup, keyVaultId.Name, respID.Name, respID.Version).ID())

--- a/internal/services/keyvault/key_vault_secret_data_source_test.go
+++ b/internal/services/keyvault/key_vault_secret_data_source_test.go
@@ -40,6 +40,8 @@ func TestAccDataSourceKeyVaultSecret_complete(t *testing.T) {
 				check.That(data.ResourceName).Key("tags.%").HasValue("1"),
 				check.That(data.ResourceName).Key("tags.hello").HasValue("world"),
 				check.That(data.ResourceName).Key("versionless_id").HasValue(fmt.Sprintf("https://acctestkv-%s.vault.azure.net/secrets/secret-%s", data.RandomString, data.RandomString)),
+				check.That(data.ResourceName).Key("not_before_date").HasValue("2019-01-01T01:02:03Z"),
+				check.That(data.ResourceName).Key("expiration_date").HasValue("2020-01-01T01:02:03Z"),
 			),
 		},
 	})

--- a/website/docs/d/key_vault_secret.html.markdown
+++ b/website/docs/d/key_vault_secret.html.markdown
@@ -57,6 +57,10 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `versionless_id` - The Versionless ID of the Key Vault Secret. This can be used to always get latest secret value, and enable fetching automatically rotating secrets.
 
+* `not_before_date` - The earliest date at which the Key Vault Secret can be used.
+
+* `expiration_date` - The date and time at which the Key Vault Secret expires and is no longer valid.
+
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:


### PR DESCRIPTION
Attribute `not_before_date` and `expiration_date` is already supported in resource `azurerm_key_vault_secret` but not supported in data source.

Here is the test I run:
```
 % TF_ACC=1 ARM_TEST_LOCATION=westus3 ARM_SUBSCRIPTION_ID=... ARM_TENANT_ID=... go test -v ./in
ternal/services/keyvault -run=TestAccDataSourceKeyVaultSecret_complete -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccDataSourceKeyVaultSecret_complete
=== PAUSE TestAccDataSourceKeyVaultSecret_complete
=== CONT  TestAccDataSourceKeyVaultSecret_complete

--- PASS: TestAccDataSourceKeyVaultSecret_complete (338.69s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault      338.697s
```
I didn't use a service principal to run this time but used the user principal instead.