### PR TITLE
`azurerm_storage_account_local_user` - Supports updating `ssh_authorized_key`

### DIFF
--- a/internal/services/storage/storage_account_local_user_resource.go
+++ b/internal/services/storage/storage_account_local_user_resource.go
@@ -84,7 +84,6 @@ func (r LocalUserResource) Arguments() map[string]*pluginsdk.Schema {
 		"ssh_authorized_key": {
 			Type:         pluginsdk.TypeList,
 			Optional:     true,
-			ForceNew:     true,
 			RequiredWith: []string{"ssh_key_enabled"},
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*pluginsdk.Schema{
@@ -382,6 +381,10 @@ func (r LocalUserResource) Update() sdk.ResourceFunc {
 
 			if metadata.ResourceData.HasChange("ssh_key_enabled") {
 				props.HasSshKey = &plan.SshKeyEnabled
+			}
+
+			if metadata.ResourceData.HasChange("ssh_authorized_key") {
+				props.SshAuthorizedKeys = r.expandSSHAuthorizedKeys(plan.SshAuthorizedKey)
 			}
 
 			if metadata.ResourceData.HasChange("ssh_password_enabled") {

--- a/internal/services/storage/storage_account_local_user_resource_test.go
+++ b/internal/services/storage/storage_account_local_user_resource_test.go
@@ -89,6 +89,13 @@ func TestAccLocalUser_passwordAndSSHKey(t *testing.T) {
 			),
 		},
 		data.ImportStep("ssh_authorized_key"),
+		{
+			Config: r.passwordOnly(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("password"),
 	})
 }
 

--- a/internal/services/storage/storage_account_local_user_resource_test.go
+++ b/internal/services/storage/storage_account_local_user_resource_test.go
@@ -43,6 +43,20 @@ func TestAccLocalUser_sshKeyOnly(t *testing.T) {
 			),
 		},
 		data.ImportStep("ssh_authorized_key"),
+		{
+			Config: r.sshKeyOnlyUpdate(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("ssh_authorized_key"),
+		{
+			Config: r.sshKeyOnly(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("ssh_authorized_key"),
 	})
 }
 
@@ -186,6 +200,27 @@ resource "azurerm_storage_account_local_user" "test" {
   ssh_key_enabled    = true
   ssh_authorized_key {
     description = "key1"
+    key         = local.first_public_key
+  }
+}
+`, template)
+}
+
+func (r LocalUserResource) sshKeyOnlyUpdate(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_storage_account_local_user" "test" {
+  name               = "user"
+  storage_account_id = azurerm_storage_account.test.id
+  ssh_key_enabled    = true
+  ssh_authorized_key {
+    description = "key1"
+    key         = local.first_public_key
+  }
+  ssh_authorized_key {
+    description = "key2"
     key         = local.first_public_key
   }
 }

--- a/website/docs/r/storage_account_local_user.html.markdown
+++ b/website/docs/r/storage_account_local_user.html.markdown
@@ -76,7 +76,7 @@ The following arguments are supported:
 
 * `permission_scope` - (Optional) One or more `permission_scope` blocks as defined below.
 
-* `ssh_authorized_key` - (Optional) One or more `ssh_authorized_key` blocks as defined below. Changing this forces a new Storage Account Local User to be created.
+* `ssh_authorized_key` - (Optional) One or more `ssh_authorized_key` blocks as defined below.
 
 * `ssh_key_enabled` - (Optional) Specifies whether SSH Key Authentication is enabled. Defaults to `false`.
 


### PR DESCRIPTION
Fix #21333 

## Test

```shell
💢  TF_ACC=1 go test -v -timeout=20h -run='TestAccLocalUser_sshKeyOnly$' ./internal/services/storage
=== RUN   TestAccLocalUser_sshKeyOnly
=== PAUSE TestAccLocalUser_sshKeyOnly
=== CONT  TestAccLocalUser_sshKeyOnly
--- PASS: TestAccLocalUser_sshKeyOnly (230.48s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/storage       230.494s
```