### PR TITLE
`azurerm_monitor_action_rule_{action_group|suppression}` - deprecate in favour of  `azurerm_monitor_alert_processing_rule_{action_group|suppression}`

### DIFF
--- a/internal/services/monitor/monitor_action_rule_action_group_resource.go
+++ b/internal/services/monitor/monitor_action_rule_action_group_resource.go
@@ -34,6 +34,8 @@ func resourceMonitorActionRuleActionGroup() *pluginsdk.Resource {
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 
+		DeprecationMessage: `This resource has been deprecated in favour of the 'azurerm_monitor_alert_processing_rule_action_group' resource and will be removed in v4.0 of the AzureRM Provider`,
+
 		Importer: pluginsdk.ImporterValidatingResourceIdThen(func(id string) error {
 			_, err := parse.ActionRuleID(id)
 			return err

--- a/internal/services/monitor/monitor_action_rule_suppression_resource.go
+++ b/internal/services/monitor/monitor_action_rule_suppression_resource.go
@@ -34,6 +34,8 @@ func resourceMonitorActionRuleSuppression() *pluginsdk.Resource {
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 
+		DeprecationMessage: `This resource has been deprecated in favour of the 'azurerm_monitor_alert_processing_rule_suppression' resource and will be removed in v4.0 of the AzureRM Provider`,
+
 		Importer: pluginsdk.ImporterValidatingResourceIdThen(func(id string) error {
 			_, err := parse.ActionRuleID(id)
 			return err

--- a/website/docs/r/monitor_action_rule_action_group.html.markdown
+++ b/website/docs/r/monitor_action_rule_action_group.html.markdown
@@ -8,7 +8,9 @@ description: |-
 
 # azurerm_monitor_action_rule_action_group
 
-Manages an Monitor Action Rule which type is action group.
+Manages a Monitor Action Rule which type is action group.
+
+!> **NOTE:** This resource has been deprecated in version 3.0 of the AzureRM provider and will be removed in version 4.0. Please use [`azurerm_monitor_alert_processing_rule_action_group`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_alert_processing_rule_action_group) resources instead.
 
 ## Example Usage
 

--- a/website/docs/r/monitor_action_rule_action_group.html.markdown
+++ b/website/docs/r/monitor_action_rule_action_group.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Manages a Monitor Action Rule which type is action group.
 
-!> **NOTE:** This resource has been deprecated in version 3.0 of the AzureRM provider and will be removed in version 4.0. Please use [`azurerm_monitor_alert_processing_rule_action_group`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_alert_processing_rule_action_group) resources instead.
+!> **NOTE:** This resource has been deprecated in version 3.0 of the AzureRM provider and will be removed in version 4.0. Please use [`azurerm_monitor_alert_processing_rule_action_group`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_alert_processing_rule_action_group) resource instead.
 
 ## Example Usage
 

--- a/website/docs/r/monitor_action_rule_suppression.html.markdown
+++ b/website/docs/r/monitor_action_rule_suppression.html.markdown
@@ -8,7 +8,9 @@ description: |-
 
 # azurerm_monitor_action_rule_suppression
 
-Manages an Monitor Action Rule which type is suppression.
+Manages a Monitor Action Rule which type is suppression.
+
+!> **NOTE:** This resource has been deprecated in version 3.0 of the AzureRM provider and will be removed in version 4.0. Please use [`azurerm_monitor_alert_processing_rule_suppression`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_alert_processing_rule_suppression) resources instead.
 
 ## Example Usage
 

--- a/website/docs/r/monitor_action_rule_suppression.html.markdown
+++ b/website/docs/r/monitor_action_rule_suppression.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Manages a Monitor Action Rule which type is suppression.
 
-!> **NOTE:** This resource has been deprecated in version 3.0 of the AzureRM provider and will be removed in version 4.0. Please use [`azurerm_monitor_alert_processing_rule_suppression`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_alert_processing_rule_suppression) resources instead.
+!> **NOTE:** This resource has been deprecated in version 3.0 of the AzureRM provider and will be removed in version 4.0. Please use [`azurerm_monitor_alert_processing_rule_suppression`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_alert_processing_rule_suppression) resource instead.
 
 ## Example Usage
 


### PR DESCRIPTION
`azurerm_monitor_action_rule_{action_group|suppression}` is based on API version 2019-06-01-preview, and `azurerm_monitor_alert_processing_rule_{action_group|suppression}` is based on 2021-08-08 which can cover the function of the previous one.