### PR TITLE
`azurerm_monitor_activity_log_alert` - support for `levels`, `resource_providers`, `resource_types`, `resource_groups`, `resource_ids`,  `statuses`,and `sub_statuses` properties

### DIFF
--- a/internal/services/monitor/monitor_activity_log_alert_resource.go
+++ b/internal/services/monitor/monitor_activity_log_alert_resource.go
@@ -122,24 +122,64 @@ func resourceMonitorActivityLogAlert() *pluginsdk.Resource {
 							ConflictsWith: []string{"criteria.0.level"},
 						},
 						"resource_provider": {
-							Type:         pluginsdk.TypeString,
-							Optional:     true,
-							ValidateFunc: validation.StringIsNotEmpty,
+							Type:          pluginsdk.TypeString,
+							Optional:      true,
+							ValidateFunc:  validation.StringIsNotEmpty,
+							ConflictsWith: []string{"criteria.0.resource_providers"},
+						},
+						"resource_providers": {
+							Type:     pluginsdk.TypeList,
+							Optional: true,
+							Elem: &pluginsdk.Schema{
+								Type:         pluginsdk.TypeString,
+								ValidateFunc: validation.StringIsNotEmpty,
+							},
+							ConflictsWith: []string{"criteria.0.resource_provider"},
 						},
 						"resource_type": {
-							Type:         pluginsdk.TypeString,
-							Optional:     true,
-							ValidateFunc: validation.StringIsNotEmpty,
+							Type:          pluginsdk.TypeString,
+							Optional:      true,
+							ValidateFunc:  validation.StringIsNotEmpty,
+							ConflictsWith: []string{"criteria.0.resource_types"},
+						},
+						"resource_types": {
+							Type:     pluginsdk.TypeList,
+							Optional: true,
+							Elem: &pluginsdk.Schema{
+								Type:         pluginsdk.TypeString,
+								ValidateFunc: validation.StringIsNotEmpty,
+							},
+							ConflictsWith: []string{"criteria.0.resource_type"},
 						},
 						"resource_group": {
-							Type:         pluginsdk.TypeString,
-							Optional:     true,
-							ValidateFunc: validation.StringIsNotEmpty,
+							Type:          pluginsdk.TypeString,
+							Optional:      true,
+							ValidateFunc:  validation.StringIsNotEmpty,
+							ConflictsWith: []string{"criteria.0.resource_groups"},
+						},
+						"resource_groups": {
+							Type:     pluginsdk.TypeList,
+							Optional: true,
+							Elem: &pluginsdk.Schema{
+								Type:         pluginsdk.TypeString,
+								ValidateFunc: validation.StringIsNotEmpty,
+							},
+							ConflictsWith: []string{"criteria.0.resource_group"},
 						},
 						"resource_id": {
-							Type:         pluginsdk.TypeString,
-							Optional:     true,
-							ValidateFunc: azure.ValidateResourceID,
+							Type:          pluginsdk.TypeString,
+							Optional:      true,
+							ValidateFunc:  azure.ValidateResourceID,
+							ConflictsWith: []string{"criteria.0.resource_ids"},
+						},
+						"resource_ids": {
+							Type:     pluginsdk.TypeList,
+							Optional: true,
+							Elem: &pluginsdk.Schema{
+								Type:         pluginsdk.TypeString,
+								ValidateFunc: validation.StringIsNotEmpty,
+							},
+							ConflictsWith: []string{"criteria.0.resource_id"},
 						},
 						"status": {
 							Type:          pluginsdk.TypeString,
@@ -157,9 +197,19 @@ func resourceMonitorActivityLogAlert() *pluginsdk.Resource {
 							ConflictsWith: []string{"criteria.0.status"},
 						},
 						"sub_status": {
-							Type:         pluginsdk.TypeString,
-							Optional:     true,
-							ValidateFunc: validation.StringIsNotEmpty,
+							Type:          pluginsdk.TypeString,
+							Optional:      true,
+							ValidateFunc:  validation.StringIsNotEmpty,
+							ConflictsWith: []string{"criteria.0.sub_statuses"},
+						},
+						"sub_statuses": {
+							Type:     pluginsdk.TypeList,
+							Optional: true,
+							Elem: &pluginsdk.Schema{
+								Type:         pluginsdk.TypeString,
+								ValidateFunc: validation.StringIsNotEmpty,
+							},
+							ConflictsWith: []string{"criteria.0.sub_status"},
 						},
 						"recommendation_category": {
 							Type:     pluginsdk.TypeString,
@@ -466,86 +516,112 @@ func expandMonitorActivityLogAlertCriteria(input []interface{}) activitylogalert
 			Equals: utils.String(category),
 		})
 	}
+
 	if op := v["operation_name"].(string); op != "" {
 		conditions = append(conditions, activitylogalertsapis.AlertRuleAnyOfOrLeafCondition{
 			Field:  utils.String("operationName"),
 			Equals: utils.String(op),
 		})
 	}
+
 	if caller := v["caller"].(string); caller != "" {
 		conditions = append(conditions, activitylogalertsapis.AlertRuleAnyOfOrLeafCondition{
 			Field:  utils.String("caller"),
 			Equals: utils.String(caller),
 		})
 	}
+
 	if level := v["level"].(string); level != "" {
 		conditions = append(conditions, activitylogalertsapis.AlertRuleAnyOfOrLeafCondition{
 			Field:  utils.String("level"),
 			Equals: utils.String(level),
 		})
 	}
+
 	if levels := v["levels"].([]interface{}); len(levels) > 0 {
-		ruleLeafCondition := make([]activitylogalertsapis.AlertRuleLeafCondition, 0)
-		for _, rawValue := range levels {
-			level := rawValue.(string)
-			ruleLeafCondition = append(ruleLeafCondition, activitylogalertsapis.AlertRuleLeafCondition{
-				Field:  utils.String("level"),
-				Equals: utils.String(level),
-			})
-		}
 		conditions = append(conditions, activitylogalertsapis.AlertRuleAnyOfOrLeafCondition{
-			AnyOf: &ruleLeafCondition,
+			AnyOf: expandAnyOfCondition(levels, "level"),
 		})
 	}
+
 	if resourceProvider := v["resource_provider"].(string); resourceProvider != "" {
 		conditions = append(conditions, activitylogalertsapis.AlertRuleAnyOfOrLeafCondition{
 			Field:  utils.String("resourceProvider"),
 			Equals: utils.String(resourceProvider),
 		})
 	}
+
+	if resourceProviders := v["resource_providers"].([]interface{}); len(resourceProviders) > 0 {
+		conditions = append(conditions, activitylogalertsapis.AlertRuleAnyOfOrLeafCondition{
+			AnyOf: expandAnyOfCondition(resourceProviders, "resourceProvider"),
+		})
+	}
+
 	if resourceType := v["resource_type"].(string); resourceType != "" {
 		conditions = append(conditions, activitylogalertsapis.AlertRuleAnyOfOrLeafCondition{
 			Field:  utils.String("resourceType"),
 			Equals: utils.String(resourceType),
 		})
 	}
+
+	if resourceTypes := v["resource_types"].([]interface{}); len(resourceTypes) > 0 {
+		conditions = append(conditions, activitylogalertsapis.AlertRuleAnyOfOrLeafCondition{
+			AnyOf: expandAnyOfCondition(resourceTypes, "resourceType"),
+		})
+	}
+
 	if resourceGroup := v["resource_group"].(string); resourceGroup != "" {
 		conditions = append(conditions, activitylogalertsapis.AlertRuleAnyOfOrLeafCondition{
 			Field:  utils.String("resourceGroup"),
 			Equals: utils.String(resourceGroup),
 		})
 	}
+
+	if resourceGroups := v["resource_groups"].([]interface{}); len(resourceGroups) > 0 {
+		conditions = append(conditions, activitylogalertsapis.AlertRuleAnyOfOrLeafCondition{
+			AnyOf: expandAnyOfCondition(resourceGroups, "resourceGroup"),
+		})
+	}
+
 	if id := v["resource_id"].(string); id != "" {
 		conditions = append(conditions, activitylogalertsapis.AlertRuleAnyOfOrLeafCondition{
 			Field:  utils.String("resourceId"),
 			Equals: utils.String(id),
 		})
 	}
+
+	if resourceIds := v["resource_ids"].([]interface{}); len(resourceIds) > 0 {
+		conditions = append(conditions, activitylogalertsapis.AlertRuleAnyOfOrLeafCondition{
+			AnyOf: expandAnyOfCondition(resourceIds, "resourceId"),
+		})
+	}
+
 	if status := v["status"].(string); status != "" {
 		conditions = append(conditions, activitylogalertsapis.AlertRuleAnyOfOrLeafCondition{
 			Field:  utils.String("status"),
 			Equals: utils.String(status),
 		})
 	}
+
 	if statuses := v["statuses"].([]interface{}); len(statuses) > 0 {
-		ruleLeafCondition := make([]activitylogalertsapis.AlertRuleLeafCondition, 0)
-		for _, rawValue := range statuses {
-			status := rawValue.(string)
-			ruleLeafCondition = append(ruleLeafCondition, activitylogalertsapis.AlertRuleLeafCondition{
-				Field:  utils.String("status"),
-				Equals: utils.String(status),
-			})
-		}
 		conditions = append(conditions, activitylogalertsapis.AlertRuleAnyOfOrLeafCondition{
-			AnyOf: &ruleLeafCondition,
+			AnyOf: expandAnyOfCondition(statuses, "status"),
 		})
 	}
+
 	if subStatus := v["sub_status"].(string); subStatus != "" {
 		conditions = append(conditions, activitylogalertsapis.AlertRuleAnyOfOrLeafCondition{
 			Field:  utils.String("subStatus"),
 			Equals: utils.String(subStatus),
 		})
 	}
+
+	if statuses := v["sub_statuses"].([]interface{}); len(statuses) > 0 {
+		conditions = append(conditions, activitylogalertsapis.AlertRuleAnyOfOrLeafCondition{
+			AnyOf: expandAnyOfCondition(statuses, "subStatus"),
+		})
+	}
+
 	if recommendationType := v["recommendation_type"].(string); recommendationType != "" {
 		conditions = append(conditions, activitylogalertsapis.AlertRuleAnyOfOrLeafCondition{
 			Field:  utils.String("properties.recommendationType"),
@@ -578,6 +654,17 @@ func expandMonitorActivityLogAlertCriteria(input []interface{}) activitylogalert
 	return activitylogalertsapis.AlertRuleAllOfCondition{
 		AllOf: conditions,
 	}
+}
+
+func expandAnyOfCondition(input []interface{}, field string) *[]activitylogalertsapis.AlertRuleLeafCondition {
+	conditions := make([]activitylogalertsapis.AlertRuleLeafCondition, 0)
+	for _, v := range input {
+		conditions = append(conditions, activitylogalertsapis.AlertRuleLeafCondition{
+			Field:  utils.String(field),
+			Equals: utils.String(v.(string)),
+		})
+	}
+	return &conditions
 }
 
 func expandResourceHealth(resourceHealth []interface{}, conditions []activitylogalertsapis.AlertRuleAnyOfOrLeafCondition) []activitylogalertsapis.AlertRuleAnyOfOrLeafCondition {
@@ -727,6 +814,23 @@ func flattenMonitorActivityLogAlertCriteria(input activitylogalertsapis.AlertRul
 			case "caller", "category", "level", "status":
 				result[*condition.Field] = *condition.Equals
 			}
+		} else if condition.Field != nil && condition.ContainsAny != nil && len(*condition.ContainsAny) > 0 {
+			switch strings.ToLower(*condition.Field) {
+			case "resourceprovider":
+				result["resource_providers"] = *condition.ContainsAny
+			case "resourcetype":
+				result["resource_types"] = *condition.ContainsAny
+			case "resourcegroup":
+				result["resource_groups"] = *condition.ContainsAny
+			case "resourceid":
+				result["resource_ids"] = *condition.ContainsAny
+			case "substatus":
+				result["sub_statuses"] = *condition.ContainsAny
+			case "level":
+				result["levels"] = *condition.ContainsAny
+			case "status":
+				result["statuses"] = *condition.ContainsAny
+			}
 		} else if condition.AnyOf != nil && len(*condition.AnyOf) > 0 {
 			values := make([]string, 0)
 			for _, leafCondition := range *condition.AnyOf {
@@ -734,6 +838,16 @@ func flattenMonitorActivityLogAlertCriteria(input activitylogalertsapis.AlertRul
 					values = append(values, *leafCondition.Equals)
 				}
 				switch strings.ToLower(*leafCondition.Field) {
+				case "resourceprovider":
+					result["resource_providers"] = values
+				case "resourcetype":
+					result["resource_types"] = values
+				case "resourcegroup":
+					result["resource_groups"] = values
+				case "resourceid":
+					result["resource_ids"] = values
+				case "substatus":
+					result["sub_statuses"] = values
 				case "level":
 					result["levels"] = values
 				case "status":

--- a/internal/services/monitor/monitor_activity_log_alert_resource.go
+++ b/internal/services/monitor/monitor_activity_log_alert_resource.go
@@ -814,7 +814,9 @@ func flattenMonitorActivityLogAlertCriteria(input activitylogalertsapis.AlertRul
 			case "caller", "category", "level", "status":
 				result[*condition.Field] = *condition.Equals
 			}
-		} else if condition.Field != nil && condition.ContainsAny != nil && len(*condition.ContainsAny) > 0 {
+		}
+
+		if condition.Field != nil && condition.ContainsAny != nil && len(*condition.ContainsAny) > 0 {
 			switch strings.ToLower(*condition.Field) {
 			case "resourceprovider":
 				result["resource_providers"] = *condition.ContainsAny
@@ -831,7 +833,9 @@ func flattenMonitorActivityLogAlertCriteria(input activitylogalertsapis.AlertRul
 			case "status":
 				result["statuses"] = *condition.ContainsAny
 			}
-		} else if condition.AnyOf != nil && len(*condition.AnyOf) > 0 {
+		}
+
+		if condition.AnyOf != nil && len(*condition.AnyOf) > 0 {
 			values := make([]string, 0)
 			for _, leafCondition := range *condition.AnyOf {
 				if leafCondition.Field != nil && leafCondition.Equals != nil {

--- a/internal/services/monitor/monitor_activity_log_alert_resource_test.go
+++ b/internal/services/monitor/monitor_activity_log_alert_resource_test.go
@@ -553,8 +553,8 @@ resource "azurerm_monitor_activity_log_alert" "test" {
     recommendation_category = "OperationalExcellence"
     recommendation_impact   = "High"
     caller                  = "test email address"
-    level                   = "Critical"
-    status                  = "Succeeded"
+    levels                  = ["Critical", "Error"]
+    statuses                = ["Failed", "Succeeded"]
     sub_status              = "Succeeded"
   }
 

--- a/website/docs/r/monitor_activity_log_alert.html.markdown
+++ b/website/docs/r/monitor_activity_log_alert.html.markdown
@@ -91,7 +91,15 @@ A `criteria` block supports the following:
 * `resource_id` - (Optional) The specific resource monitored by the activity log alert. It should be within one of the `scopes`.
 * `caller` - (Optional) The email address or Azure Active Directory identifier of the user who performed the operation.
 * `level` - (Optional) The severity level of the event. Possible values are `Verbose`, `Informational`, `Warning`, `Error`, and `Critical`.
+* `levels` - (Optional) A list of severity level of the event. Possible values are `Verbose`, `Informational`, `Warning`, `Error`, and `Critical`.
+
+~> **NOTE:** `level` and `levels` are mutually exclusive.
+
 * `status` - (Optional) The status of the event. For example, `Started`, `Failed`, or `Succeeded`.
+* `statuses` - (Optional) A list of status of the event. For example, `Started`, `Failed`, or `Succeeded`.
+
+~> **NOTE:** `status` and `statuses` are mutually exclusive.
+
 * `sub_status` - (Optional) The sub status of the event.
 * `recommendation_type` - (Optional) The recommendation type of the event. It is only allowed when `category` is `Recommendation`.
 * `recommendation_category` - (Optional) The recommendation category of the event. Possible values are `Cost`, `Reliability`, `OperationalExcellence` and `Performance`. It is only allowed when `category` is `Recommendation`.

--- a/website/docs/r/monitor_activity_log_alert.html.markdown
+++ b/website/docs/r/monitor_activity_log_alert.html.markdown
@@ -83,13 +83,29 @@ An `action` block supports the following:
 
 A `criteria` block supports the following:
 
+* `caller` - (Optional) The email address or Azure Active Directory identifier of the user who performed the operation.
 * `category` - (Required) The category of the operation. Possible values are `Administrative`, `Autoscale`, `Policy`, `Recommendation`, `ResourceHealth`, `Security` and `ServiceHealth`.
 * `operation_name` - (Optional) The Resource Manager Role-Based Access Control operation name. Supported operation should be of the form: `<resourceProvider>/<resourceType>/<operation>`.
 * `resource_provider` - (Optional) The name of the resource provider monitored by the activity log alert.
+* `resource_providers` - (Optional) A list of names of resource providers monitored by the activity log alert.
+
+~> **NOTE:** `resource_provider` and `resource_providers` are mutually exclusive.
+
 * `resource_type` - (Optional) The resource type monitored by the activity log alert.
+* `resource_types` - (Optional) A list of resource types monitored by the activity log alert.
+
+~> **NOTE:** `resource_type` and `resource_types` are mutually exclusive.
+
 * `resource_group` - (Optional) The name of resource group monitored by the activity log alert.
+* `resource_groups` - (Optional) A list of names of resource groups monitored by the activity log alert.
+
+~> **NOTE:** `resource_group` and `resource_groups` are mutually exclusive.
+
 * `resource_id` - (Optional) The specific resource monitored by the activity log alert. It should be within one of the `scopes`.
-* `caller` - (Optional) The email address or Azure Active Directory identifier of the user who performed the operation.
+* `resource_ids` - (Optional) A list of specific resources monitored by the activity log alert. It should be within one of the `scopes`.
+
+~> **NOTE:** `resource_id` and `resource_ids` are mutually exclusive.
+
 * `level` - (Optional) The severity level of the event. Possible values are `Verbose`, `Informational`, `Warning`, `Error`, and `Critical`.
 * `levels` - (Optional) A list of severity level of the event. Possible values are `Verbose`, `Informational`, `Warning`, `Error`, and `Critical`.
 
@@ -101,6 +117,10 @@ A `criteria` block supports the following:
 ~> **NOTE:** `status` and `statuses` are mutually exclusive.
 
 * `sub_status` - (Optional) The sub status of the event.
+* `sub_statuses` - (Optional) A list of sub status of the event.
+
+~> **NOTE:** `sub_status` and `sub_statuses` are mutually exclusive.
+ 
 * `recommendation_type` - (Optional) The recommendation type of the event. It is only allowed when `category` is `Recommendation`.
 * `recommendation_category` - (Optional) The recommendation category of the event. Possible values are `Cost`, `Reliability`, `OperationalExcellence` and `Performance`. It is only allowed when `category` is `Recommendation`.
 * `recommendation_impact` - (Optional) The recommendation impact of the event. Possible values are `High`, `Medium` and `Low`. It is only allowed when `category` is `Recommendation`.

--- a/website/docs/r/monitor_activity_log_alert.html.markdown
+++ b/website/docs/r/monitor_activity_log_alert.html.markdown
@@ -83,8 +83,8 @@ An `action` block supports the following:
 
 A `criteria` block supports the following:
 
-* `caller` - (Optional) The email address or Azure Active Directory identifier of the user who performed the operation.
 * `category` - (Required) The category of the operation. Possible values are `Administrative`, `Autoscale`, `Policy`, `Recommendation`, `ResourceHealth`, `Security` and `ServiceHealth`.
+* `caller` - (Optional) The email address or Azure Active Directory identifier of the user who performed the operation.
 * `operation_name` - (Optional) The Resource Manager Role-Based Access Control operation name. Supported operation should be of the form: `<resourceProvider>/<resourceType>/<operation>`.
 * `resource_provider` - (Optional) The name of the resource provider monitored by the activity log alert.
 * `resource_providers` - (Optional) A list of names of resource providers monitored by the activity log alert.


### PR DESCRIPTION
resolves https://github.com/hashicorp/terraform-provider-azurerm/issues/21186
resolves https://github.com/hashicorp/terraform-provider-azurerm/issues/20759
resolves https://github.com/hashicorp/terraform-provider-azurerm/issues/21496

```
TF_ACC=1 go test -v ./internal/services/monitor -parallel 20 -test.run=TestAccMonitorActivityLogAlert_listCriteria -timeout 1440m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccMonitorActivityLogAlert_listCriteria
=== PAUSE TestAccMonitorActivityLogAlert_listCriteria
=== CONT  TestAccMonitorActivityLogAlert_listCriteria
--- PASS: TestAccMonitorActivityLogAlert_listCriteria (204.76s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/monitor       204.786s

```