### PR TITLE
`azurerm_service_plan` - New SKUs

### DIFF
--- a/internal/services/appservice/helpers/service_plan.go
+++ b/internal/services/appservice/helpers/service_plan.go
@@ -21,7 +21,8 @@ var appServicePlanSkus = []string{
 	"B1", "B2", "B3", // basic
 	"S1", "S2", "S3", // standard
 	"P1v2", "P2v2", "P3v2", // Premium V2
-	"P1v3", "P2v3", "P3v3", // Premium V3
+	"P0v3", "P1v3", "P2v3", "P3v3", // Premium V3
+	"P1mv3", "P2mv3", "P3mv3", "P4mv3", "P5mv3", // Premium V3 memory optimized
 }
 
 var freeSkus = []string{
@@ -43,7 +44,7 @@ var elasticSkus = []string{
 
 var isolatedSkus = []string{
 	"I1", "I2", "I3", // Isolated V1 - ASEV2
-	"I1v2", "I2v2", "I3v2", // Isolated v2 - ASEv3
+	"I1v2", "I2v2", "I3v2", "I4v2", "I5v2", "I6v2", // Isolated v2 - ASEv3
 }
 
 var workflowSkus = []string{

--- a/internal/services/appservice/service_plan_resource_test.go
+++ b/internal/services/appservice/service_plan_resource_test.go
@@ -177,6 +177,21 @@ func TestAccServicePlanIsolated_appServiceEnvironmentV3(t *testing.T) {
 	})
 }
 
+func TestAccServicePlanIsolated_memoryOptimized(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_service_plan", "test")
+	r := ServicePlanResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.memoryOptimized(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (r ServicePlanResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := parse.ServicePlanID(state.ID)
 	if err != nil {
@@ -377,6 +392,36 @@ resource "azurerm_service_plan" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, sku, count)
+}
+
+func (r ServicePlanResource) memoryOptimized(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-appserviceplan-%[1]d"
+  location = "%s"
+}
+
+resource "azurerm_service_plan" "test" {
+  name                     = "acctest-SP-%[1]d"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  sku_name                 = "P1mV3"
+  os_type                  = "Linux"
+  per_site_scaling_enabled = true
+  worker_count             = 3
+
+  zone_balancing_enabled = true
+
+  tags = {
+    environment = "AccTest"
+    Foo         = "bar"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary)
 }
 
 func (r ServicePlanResource) aseV2(data acceptance.TestData) string {

--- a/internal/services/appservice/service_plan_resource_test.go
+++ b/internal/services/appservice/service_plan_resource_test.go
@@ -145,6 +145,21 @@ func TestAccServicePlan_maxElasticWorkerCount(t *testing.T) {
 	})
 }
 
+func TestAccServicePlan_memoryOptimized(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_service_plan", "test")
+	r := ServicePlanResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.memoryOptimized(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 // ASE tests given longer prefix to allow them to be more easily filtered out due to exceptionally long running time
 func TestAccServicePlanIsolated_appServiceEnvironmentV2(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_service_plan", "test")
@@ -169,21 +184,6 @@ func TestAccServicePlanIsolated_appServiceEnvironmentV3(t *testing.T) {
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.aseV3(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep(),
-	})
-}
-
-func TestAccServicePlanIsolated_memoryOptimized(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_service_plan", "test")
-	r := ServicePlanResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.memoryOptimized(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -409,7 +409,7 @@ resource "azurerm_service_plan" "test" {
   name                     = "acctest-SP-%[1]d"
   resource_group_name      = azurerm_resource_group.test.name
   location                 = azurerm_resource_group.test.location
-  sku_name                 = "P1mV3"
+  sku_name                 = "P1mv3"
   os_type                  = "Linux"
   per_site_scaling_enabled = true
   worker_count             = 3

--- a/internal/services/appservice/service_plan_resource_test.go
+++ b/internal/services/appservice/service_plan_resource_test.go
@@ -421,7 +421,7 @@ resource "azurerm_service_plan" "test" {
     Foo         = "bar"
   }
 }
-`, data.RandomInteger, data.Locations.Primary)
+`, data.RandomInteger, data.Locations.Secondary)
 }
 
 func (r ServicePlanResource) aseV2(data acceptance.TestData) string {

--- a/website/docs/r/service_plan.html.markdown
+++ b/website/docs/r/service_plan.html.markdown
@@ -43,7 +43,7 @@ The following arguments are supported:
 
 * `resource_group_name` - (Required) The name of the Resource Group where the AppService should exist. Changing this forces a new AppService to be created.
 
-* `sku_name` - (Required) The SKU for the plan. Possible values include `B1`, `B2`, `B3`, `D1`, `F1`, `I1`, `I2`, `I3`, `I1v2`, `I2v2`, `I3v2`, `I4v2`, `I5v2`, `I6v2`, `P1v2`, `P2v2`, `P3v2`, `P1v3`, `P2v3`, `P3v3`, `P1mV3`, `P2mV3`, `P3mV3`, `P3mV4`, `P3mV5`, `S1`, `S2`, `S3`, `SHARED`, `EP1`, `EP2`, `EP3`, `WS1`, `WS2`, `WS3`, and `Y1`.
+* `sku_name` - (Required) The SKU for the plan. Possible values include `B1`, `B2`, `B3`, `D1`, `F1`, `I1`, `I2`, `I3`, `I1v2`, `I2v2`, `I3v2`, `I4v2`, `I5v2`, `I6v2`, `P1v2`, `P2v2`, `P3v2`, `P1v3`, `P2v3`, `P3v3`, `P1mv3`, `P2mv3`, `P3mv3`, `P4mv3`, `P5mv3`, `S1`, `S2`, `S3`, `SHARED`, `EP1`, `EP2`, `EP3`, `WS1`, `WS2`, `WS3`, and `Y1`.
 
 ~> **NOTE:** Isolated SKUs (`I1`, `I2`, `I3`, `I1v2`, `I2v2`, and `I3v2`) can only be used with App Service Environments
 

--- a/website/docs/r/service_plan.html.markdown
+++ b/website/docs/r/service_plan.html.markdown
@@ -43,7 +43,7 @@ The following arguments are supported:
 
 * `resource_group_name` - (Required) The name of the Resource Group where the AppService should exist. Changing this forces a new AppService to be created.
 
-* `sku_name` - (Required) The SKU for the plan. Possible values include `B1`, `B2`, `B3`, `D1`, `F1`, `I1`, `I2`, `I3`, `I1v2`, `I2v2`, `I3v2`, `P1v2`, `P2v2`, `P3v2`, `P1v3`, `P2v3`, `P3v3`, `S1`, `S2`, `S3`, `SHARED`, `EP1`, `EP2`, `EP3`, `WS1`, `WS2`, `WS3`, and `Y1`.
+* `sku_name` - (Required) The SKU for the plan. Possible values include `B1`, `B2`, `B3`, `D1`, `F1`, `I1`, `I2`, `I3`, `I1v2`, `I2v2`, `I3v2`, `I4v2`, `I5v2`, `I6v2`, `P1v2`, `P2v2`, `P3v2`, `P1v3`, `P2v3`, `P3v3`, `P1mV3`, `P2mV3`, `P3mV3`, `P3mV4`, `P3mV5`, `S1`, `S2`, `S3`, `SHARED`, `EP1`, `EP2`, `EP3`, `WS1`, `WS2`, `WS3`, and `Y1`.
 
 ~> **NOTE:** Isolated SKUs (`I1`, `I2`, `I3`, `I1v2`, `I2v2`, and `I3v2`) can only be used with App Service Environments
 


### PR DESCRIPTION
Fixes #21365

## AccTests
- [ ] Due to limited availability of the new Service Plans yet (`az appservice list-locations --sku P1mV3`), we'd probably need to make some changes to the test setup

```bash

❯ export ARM_TEST_LOCATION="northeurope"
❯ go install && make acctests SERVICE='appservice' TESTARGS='-run=TestAccServicePlan_memoryOptimized'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/appservice -run=TestAccServicePlan_memoryOptimized -timeout 180m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccServicePlan_memoryOptimized
=== PAUSE TestAccServicePlan_memoryOptimized
=== CONT  TestAccServicePlan_memoryOptimized
--- PASS: TestAccServicePlan_memoryOptimized (122.91s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/appservice124.851s
```