### PR TITLE
`azurerm_nginx_certificate` - add missing certificate permissions in the basic test

### DIFF
--- a/internal/services/nginx/nginx_certificate_resource_test.go
+++ b/internal/services/nginx/nginx_certificate_resource_test.go
@@ -163,6 +163,15 @@ resource "azurerm_key_vault" "test" {
       "Get",
     ]
 
+    certificate_permissions = [
+      "Get",
+      "Create",
+      "Delete",
+      "List",
+      "Purge",
+      "Recover",
+    ]
+
     secret_permissions = [
       "Get",
       "Delete",


### PR DESCRIPTION
Basic test template was updated but it's missing certificate permissions for the test to pass.