### PR TITLE
`azurerm_[linux|windows]_[function|web]_app[_slot]` - Fix another nilpointer for `auth_v2`

### DIFF
--- a/internal/services/appservice/helpers/auth_v2_schema.go
+++ b/internal/services/appservice/helpers/auth_v2_schema.go
@@ -978,9 +978,14 @@ func expandAadAuthV2Settings(input []AadAuthV2Settings) *web.AzureActiveDirector
 			}
 			result.Validation.DefaultAuthorizationPolicy = &web.DefaultAuthorizationPolicy{}
 			if len(aad.AllowedGroups) > 0 {
-				result.Validation.DefaultAuthorizationPolicy.AllowedPrincipals.Groups = pointer.To(aad.AllowedGroups)
+				result.Validation.DefaultAuthorizationPolicy.AllowedPrincipals = &web.AllowedPrincipals{
+					Groups: pointer.To(aad.AllowedGroups),
+				}
 			}
 			if len(aad.AllowedIdentities) > 0 {
+				if result.Validation.DefaultAuthorizationPolicy.AllowedPrincipals == nil {
+					result.Validation.DefaultAuthorizationPolicy.AllowedPrincipals = &web.AllowedPrincipals{}
+				}
 				result.Validation.DefaultAuthorizationPolicy.AllowedPrincipals.Identities = pointer.To(aad.AllowedIdentities)
 			}
 		}

--- a/internal/services/appservice/helpers/auth_v2_schema.go
+++ b/internal/services/appservice/helpers/auth_v2_schema.go
@@ -976,16 +976,13 @@ func expandAadAuthV2Settings(input []AadAuthV2Settings) *web.AzureActiveDirector
 			if result.Validation == nil {
 				result.Validation = &web.AzureActiveDirectoryValidation{}
 			}
-			result.Validation.DefaultAuthorizationPolicy = &web.DefaultAuthorizationPolicy{}
+			result.Validation.DefaultAuthorizationPolicy = &web.DefaultAuthorizationPolicy{
+				AllowedPrincipals: &web.AllowedPrincipals{},
+			}
 			if len(aad.AllowedGroups) > 0 {
-				result.Validation.DefaultAuthorizationPolicy.AllowedPrincipals = &web.AllowedPrincipals{
-					Groups: pointer.To(aad.AllowedGroups),
-				}
+				result.Validation.DefaultAuthorizationPolicy.AllowedPrincipals.Groups = pointer.To(aad.AllowedGroups)
 			}
 			if len(aad.AllowedIdentities) > 0 {
-				if result.Validation.DefaultAuthorizationPolicy.AllowedPrincipals == nil {
-					result.Validation.DefaultAuthorizationPolicy.AllowedPrincipals = &web.AllowedPrincipals{}
-				}
 				result.Validation.DefaultAuthorizationPolicy.AllowedPrincipals.Identities = pointer.To(aad.AllowedIdentities)
 			}
 		}

--- a/internal/services/appservice/linux_function_app_resource_authv2_test.go
+++ b/internal/services/appservice/linux_function_app_resource_authv2_test.go
@@ -248,12 +248,19 @@ provider "azurerm" {
   features {}
 }
 
+provider "azuread" {}
+
 %s
 
 data "azurerm_client_config" "current" {}
 
+resource "azuread_group" "test" {
+  display_name     = "acctestspa-%d"
+  security_enabled = true
+}
+
 resource "azurerm_linux_function_app" "test" {
-  name                = "acctest-LFA-%d"
+  name                = "acctest-LFA-%[2]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   service_plan_id     = azurerm_service_plan.test.id
@@ -278,6 +285,7 @@ resource "azurerm_linux_function_app" "test" {
       client_id                  = data.azurerm_client_config.current.client_id
       client_secret_setting_name = "%[3]s"
       tenant_auth_endpoint       = "https://sts.windows.net/%[5]s/v2.0"
+      allowed_groups             = [azuread_group.test.object_id]
     }
 
     login {


### PR DESCRIPTION
Fixes #21375

```bash
❯ go install && make acctests SERVICE='appservice' TESTARGS='-run=TestAccLinuxFunctionApp_authV2AzureActiveDirectory'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/appservice -run=TestAccLinuxFunctionApp_authV2AzureActiveDirectory -timeout 180m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccLinuxFunctionApp_authV2AzureActiveDirectory
=== PAUSE TestAccLinuxFunctionApp_authV2AzureActiveDirectory
=== RUN   TestAccLinuxFunctionApp_authV2AzureActiveDirectoryRemove
=== PAUSE TestAccLinuxFunctionApp_authV2AzureActiveDirectoryRemove
=== CONT  TestAccLinuxFunctionApp_authV2AzureActiveDirectory
=== CONT  TestAccLinuxFunctionApp_authV2AzureActiveDirectoryRemove
--- PASS: TestAccLinuxFunctionApp_authV2AzureActiveDirectory (266.30s)
--- PASS: TestAccLinuxFunctionApp_authV2AzureActiveDirectoryRemove (309.23s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/appservice      311.203s
```