### PR TITLE
Docs: add a note to `azure_firewall` document about multiple public ip address

### DIFF
--- a/website/docs/r/firewall.html.markdown
+++ b/website/docs/r/firewall.html.markdown
@@ -104,6 +104,8 @@ An `ip_configuration` block supports the following:
 
 * `public_ip_address_id` - (Required) The ID of the Public IP Address associated with the firewall.
 
+-> **NOTE** When multiple `ip_configuration` blocks with `public_ip_address_id` provided, `terraform apply` will raise an error when remove one or some of `ip_configuration` blocks. because the `public_ip_address_id` is still used by the `firewall` resource until the `firewall` resource is updated. and the destruction of `azurerm_public_ip` happens before the update of firewall by default. to destroy of `azurerm_public_ip` will cause the error. The workaround is to set `create_before_destroy=true` to the `azurerm_public_ip` resource `lifecycle` block. See more detail: [destroying.md#create-before-destroy](https://github.com/hashicorp/terraform/blob/main/docs/destroying.md#create-before-destroy)
+
 -> **NOTE** The Public IP must have a `Static` allocation and `Standard` SKU.
 
 ---

--- a/website/docs/r/firewall.html.markdown
+++ b/website/docs/r/firewall.html.markdown
@@ -104,7 +104,7 @@ An `ip_configuration` block supports the following:
 
 * `public_ip_address_id` - (Required) The ID of the Public IP Address associated with the firewall.
 
--> **NOTE** When multiple `ip_configuration` blocks with `public_ip_address_id` provided, `terraform apply` will raise an error when remove one or some of `ip_configuration` blocks. because the `public_ip_address_id` is still used by the `firewall` resource until the `firewall` resource is updated. and the destruction of `azurerm_public_ip` happens before the update of firewall by default. to destroy of `azurerm_public_ip` will cause the error. The workaround is to set `create_before_destroy=true` to the `azurerm_public_ip` resource `lifecycle` block. See more detail: [destroying.md#create-before-destroy](https://github.com/hashicorp/terraform/blob/main/docs/destroying.md#create-before-destroy)
+-> **NOTE** When multiple `ip_configuration` blocks with `public_ip_address_id` are configured, `terraform apply` will raise an error when one or some of these `ip_configuration` blocks are removed. because the `public_ip_address_id` is still used by the `firewall` resource until the `firewall` resource is updated. and the destruction of `azurerm_public_ip` happens before the update of firewall by default. to destroy of `azurerm_public_ip` will cause the error. The workaround is to set `create_before_destroy=true` to the `azurerm_public_ip` resource `lifecycle` block. See more detail: [destroying.md#create-before-destroy](https://github.com/hashicorp/terraform/blob/main/docs/destroying.md#create-before-destroy)
 
 -> **NOTE** The Public IP must have a `Static` allocation and `Standard` SKU.
 


### PR DESCRIPTION
part of issue #21122 . update the document first as a workaround.

i have tried to add a association resource between firewall and public ip. but that would introduce a breaking change to the firewall in the schema of `ip_configuration`. is this reasonable to add such association resource under this condition?