### PR TITLE
`azurerm_monitor_aad_diagnostic_setting` - deprecate `log` in favour of `enabled_log`

### DIFF
--- a/internal/services/monitor/monitor_aad_diagnostic_setting_resource.go
+++ b/internal/services/monitor/monitor_aad_diagnostic_setting_resource.go
@@ -285,7 +285,7 @@ func resourceMonitorAADDiagnosticSettingUpdate(d *pluginsdk.ResourceData, meta i
 
 	if d.HasChange("enabled_log") {
 		logsChanged = true
-		logs = expandMonitorAADDiagnosticsSettingsEnabledLogs(d.Get("enabled_log").(*pluginsdk.Set).List())
+		logs = append(logs, expandMonitorAADDiagnosticsSettingsEnabledLogs(d.Get("enabled_log").(*pluginsdk.Set).List())...)
 		valid = true
 	}
 

--- a/internal/services/monitor/monitor_aad_diagnostic_setting_resource.go
+++ b/internal/services/monitor/monitor_aad_diagnostic_setting_resource.go
@@ -194,14 +194,14 @@ func resourceMonitorAADDiagnosticSettingCreate(d *pluginsdk.ResourceData, meta i
 	// If there is no `enabled` log entry, the PUT will succeed while the next GET will return a 404.
 	// Therefore, ensure users has at least one enabled log entry.
 	valid := false
-	logs := []aad.LogSettings{}
+	var logs []aad.LogSettings
 
 	if !features.FourPointOhBeta() {
 		if logsRaw, ok := d.GetOk("log"); ok && len(logsRaw.(*pluginsdk.Set).List()) > 0 {
 			logs = expandMonitorAADDiagnosticsSettingsLogs(d.Get("log").(*pluginsdk.Set).List())
 
-			for _, log := range logs {
-				if log.Enabled != nil && *log.Enabled {
+			for _, v := range logs {
+				if v.Enabled != nil && *v.Enabled {
 					valid = true
 					break
 				}
@@ -266,7 +266,7 @@ func resourceMonitorAADDiagnosticSettingUpdate(d *pluginsdk.ResourceData, meta i
 		return fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	logs := []aad.LogSettings{}
+	var logs []aad.LogSettings
 	logsChanged := false
 	valid := false
 
@@ -274,8 +274,8 @@ func resourceMonitorAADDiagnosticSettingUpdate(d *pluginsdk.ResourceData, meta i
 		if d.HasChange("log") {
 			logsChanged = true
 			logs = expandMonitorAADDiagnosticsSettingsLogs(d.Get("log").(*pluginsdk.Set).List())
-			for _, log := range logs {
-				if log.Enabled != nil && *log.Enabled {
+			for _, v := range logs {
+				if v.Enabled != nil && *v.Enabled {
 					valid = true
 					break
 				}
@@ -291,8 +291,8 @@ func resourceMonitorAADDiagnosticSettingUpdate(d *pluginsdk.ResourceData, meta i
 
 	if !logsChanged && existing.Logs != nil {
 		logs = *existing.Logs
-		for _, log := range logs {
-			if log.Enabled != nil && *log.Enabled {
+		for _, v := range logs {
+			if v.Enabled != nil && *v.Enabled {
 				valid = true
 				break
 			}

--- a/internal/services/monitor/monitor_aad_diagnostic_setting_resource.go
+++ b/internal/services/monitor/monitor_aad_diagnostic_setting_resource.go
@@ -27,7 +27,7 @@ func resourceMonitorAADDiagnosticSetting() *pluginsdk.Resource {
 	resource := &pluginsdk.Resource{
 		Create: resourceMonitorAADDiagnosticSettingCreate,
 		Read:   resourceMonitorAADDiagnosticSettingRead,
-		Update: resourceMonitorAADDiagnosticSettingCreate,
+		Update: resourceMonitorAADDiagnosticSettingUpdate,
 		Delete: resourceMonitorAADDiagnosticSettingDelete,
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
 			_, err := parse.MonitorAADDiagnosticSettingID(id)

--- a/internal/services/monitor/monitor_aad_diagnostic_setting_resource.go
+++ b/internal/services/monitor/monitor_aad_diagnostic_setting_resource.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2022-05-01/storageaccounts"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/monitor/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/monitor/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -23,10 +24,10 @@ import (
 )
 
 func resourceMonitorAADDiagnosticSetting() *pluginsdk.Resource {
-	return &pluginsdk.Resource{
-		Create: resourceMonitorAADDiagnosticSettingCreateUpdate,
+	resource := &pluginsdk.Resource{
+		Create: resourceMonitorAADDiagnosticSettingCreate,
 		Read:   resourceMonitorAADDiagnosticSettingRead,
-		Update: resourceMonitorAADDiagnosticSettingCreateUpdate,
+		Update: resourceMonitorAADDiagnosticSettingCreate,
 		Delete: resourceMonitorAADDiagnosticSettingDelete,
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
 			_, err := parse.MonitorAADDiagnosticSettingID(id)
@@ -82,20 +83,17 @@ func resourceMonitorAADDiagnosticSetting() *pluginsdk.Resource {
 				AtLeastOneOf: []string{"eventhub_authorization_rule_id", "log_analytics_workspace_id", "storage_account_id"},
 			},
 
-			"log": {
-				Type:     pluginsdk.TypeSet,
-				Required: true,
+			"enabled_log": {
+				Type:          pluginsdk.TypeSet,
+				Optional:      true,
+				Computed:      !features.FourPointOhBeta(),
+				ConflictsWith: []string{"log"},
+				AtLeastOneOf:  []string{"enabled_log", "log"},
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
 						"category": {
 							Type:     pluginsdk.TypeString,
 							Required: true,
-						},
-
-						"enabled": {
-							Type:     pluginsdk.TypeBool,
-							Optional: true,
-							Default:  true,
 						},
 
 						"retention_policy": {
@@ -124,9 +122,57 @@ func resourceMonitorAADDiagnosticSetting() *pluginsdk.Resource {
 			},
 		},
 	}
+
+	if !features.FourPointOhBeta() {
+		resource.Schema["log"] = &pluginsdk.Schema{
+			Type:         pluginsdk.TypeSet,
+			Optional:     true,
+			Computed:     true,
+			Deprecated:   "`log` has been superseded by `enabled_log` and will be removed in version 4.0 of the AzureRM Provider.",
+			AtLeastOneOf: []string{"enabled_log", "log"},
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"category": {
+						Type:     pluginsdk.TypeString,
+						Required: true,
+					},
+
+					"enabled": {
+						Type:     pluginsdk.TypeBool,
+						Optional: true,
+						Default:  true,
+					},
+
+					"retention_policy": {
+						Type:     pluginsdk.TypeList,
+						Required: true,
+						MaxItems: 1,
+						Elem: &pluginsdk.Resource{
+							Schema: map[string]*pluginsdk.Schema{
+								"enabled": {
+									Type:     pluginsdk.TypeBool,
+									Optional: true,
+									Default:  false,
+								},
+
+								"days": {
+									Type:         pluginsdk.TypeInt,
+									Optional:     true,
+									ValidateFunc: validation.IntAtLeast(0),
+									Default:      0,
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	return resource
 }
 
-func resourceMonitorAADDiagnosticSettingCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+func resourceMonitorAADDiagnosticSettingCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Monitor.AADDiagnosticSettingsClient
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
@@ -134,32 +180,42 @@ func resourceMonitorAADDiagnosticSettingCreateUpdate(d *pluginsdk.ResourceData, 
 
 	id := parse.NewMonitorAADDiagnosticSettingID(d.Get("name").(string))
 
-	if d.IsNewResource() {
-		existing, err := client.Get(ctx, id.Name)
-		if err != nil {
-			if !utils.ResponseWasNotFound(existing.Response) {
-				return fmt.Errorf("checking for presence of existing %s: %s", id, err)
-			}
-		}
-
+	existing, err := client.Get(ctx, id.Name)
+	if err != nil {
 		if !utils.ResponseWasNotFound(existing.Response) {
-			return tf.ImportAsExistsError("azurerm_monitor_aad_diagnostic_setting", id.ID())
+			return fmt.Errorf("checking for presence of existing %s: %s", id, err)
 		}
 	}
 
-	logs := expandMonitorAADDiagnosticsSettingsLogs(d.Get("log").(*pluginsdk.Set).List())
+	if !utils.ResponseWasNotFound(existing.Response) {
+		return tf.ImportAsExistsError("azurerm_monitor_aad_diagnostic_setting", id.ID())
+	}
 
 	// If there is no `enabled` log entry, the PUT will succeed while the next GET will return a 404.
 	// Therefore, ensure users has at least one enabled log entry.
 	valid := false
-	for _, log := range logs {
-		if log.Enabled != nil && *log.Enabled {
-			valid = true
-			break
+	logs := []aad.LogSettings{}
+
+	if !features.FourPointOhBeta() {
+		if logsRaw, ok := d.GetOk("log"); ok && len(logsRaw.(*pluginsdk.Set).List()) > 0 {
+			logs = expandMonitorAADDiagnosticsSettingsLogs(d.Get("log").(*pluginsdk.Set).List())
+
+			for _, log := range logs {
+				if log.Enabled != nil && *log.Enabled {
+					valid = true
+					break
+				}
+			}
 		}
 	}
+
+	if enabledLogs, ok := d.GetOk("enabled_log"); ok && len(enabledLogs.(*pluginsdk.Set).List()) > 0 {
+		logs = expandMonitorAADDiagnosticsSettingsEnabledLogs(enabledLogs.(*pluginsdk.Set).List())
+		valid = true
+	}
+
 	if !valid {
-		return fmt.Errorf("At least one of the `log` of the %s should be enabled", id)
+		return fmt.Errorf("at least one of the `log` of the %s should be enabled", id)
 	}
 
 	properties := aad.DiagnosticSettingsResource{
@@ -190,6 +246,89 @@ func resourceMonitorAADDiagnosticSettingCreateUpdate(d *pluginsdk.ResourceData, 
 	}
 
 	d.SetId(id.ID())
+
+	return resourceMonitorAADDiagnosticSettingRead(d, meta)
+}
+
+func resourceMonitorAADDiagnosticSettingUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Monitor.AADDiagnosticSettingsClient
+	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+	log.Printf("[INFO] preparing arguments for Azure ARM AAD Diagnostic Setting.")
+
+	id, err := parse.MonitorAADDiagnosticSettingID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	existing, err := client.Get(ctx, id.Name)
+	if err != nil {
+		return fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+
+	logs := []aad.LogSettings{}
+	logsChanged := false
+	valid := false
+
+	if !features.FourPointOhBeta() {
+		if d.HasChange("log") {
+			logsChanged = true
+			logs = expandMonitorAADDiagnosticsSettingsLogs(d.Get("log").(*pluginsdk.Set).List())
+			for _, log := range logs {
+				if log.Enabled != nil && *log.Enabled {
+					valid = true
+					break
+				}
+			}
+		}
+	}
+
+	if d.HasChange("enabled_log") {
+		logsChanged = true
+		logs = expandMonitorAADDiagnosticsSettingsEnabledLogs(d.Get("enabled_log").(*pluginsdk.Set).List())
+		valid = true
+	}
+
+	if !logsChanged && existing.Logs != nil {
+		logs = *existing.Logs
+		for _, log := range logs {
+			if log.Enabled != nil && *log.Enabled {
+				valid = true
+				break
+			}
+		}
+	}
+
+	if !valid {
+		return fmt.Errorf("at least one of the `log` of the %s should be enabled", id)
+	}
+
+	properties := aad.DiagnosticSettingsResource{
+		DiagnosticSettings: &aad.DiagnosticSettings{
+			Logs: &logs,
+		},
+	}
+
+	eventHubAuthorizationRuleId := d.Get("eventhub_authorization_rule_id").(string)
+	eventHubName := d.Get("eventhub_name").(string)
+	if eventHubAuthorizationRuleId != "" {
+		properties.DiagnosticSettings.EventHubAuthorizationRuleID = utils.String(eventHubAuthorizationRuleId)
+		properties.DiagnosticSettings.EventHubName = utils.String(eventHubName)
+	}
+
+	workspaceId := d.Get("log_analytics_workspace_id").(string)
+	if workspaceId != "" {
+		properties.DiagnosticSettings.WorkspaceID = utils.String(workspaceId)
+	}
+
+	storageAccountId := d.Get("storage_account_id").(string)
+	if storageAccountId != "" {
+		properties.DiagnosticSettings.StorageAccountID = utils.String(storageAccountId)
+	}
+
+	if _, err := client.CreateOrUpdate(ctx, properties, id.Name); err != nil {
+		return fmt.Errorf("creating %s: %+v", id, err)
+	}
 
 	return resourceMonitorAADDiagnosticSettingRead(d, meta)
 }
@@ -251,8 +390,14 @@ func resourceMonitorAADDiagnosticSettingRead(d *pluginsdk.ResourceData, meta int
 	}
 	d.Set("storage_account_id", storageAccountId)
 
-	if err := d.Set("log", flattenMonitorAADDiagnosticLogs(resp.Logs)); err != nil {
-		return fmt.Errorf("setting `log`: %+v", err)
+	if err := d.Set("enabled_log", flattenMonitorAADDiagnosticEnabledLogs(resp.Logs)); err != nil {
+		return fmt.Errorf("setting `enabled_log`: %+v", err)
+	}
+
+	if !features.FourPointOhBeta() {
+		if err := d.Set("log", flattenMonitorAADDiagnosticLogs(resp.Logs)); err != nil {
+			return fmt.Errorf("setting `log`: %+v", err)
+		}
 	}
 
 	return nil
@@ -336,6 +481,32 @@ func expandMonitorAADDiagnosticsSettingsLogs(input []interface{}) []aad.LogSetti
 	return results
 }
 
+func expandMonitorAADDiagnosticsSettingsEnabledLogs(input []interface{}) []aad.LogSettings {
+	results := make([]aad.LogSettings, 0)
+
+	for _, raw := range input {
+		v := raw.(map[string]interface{})
+
+		category := v["category"].(string)
+		policyRaw := v["retention_policy"].([]interface{})[0].(map[string]interface{})
+		retentionDays := policyRaw["days"].(int)
+		retentionEnabled := policyRaw["enabled"].(bool)
+
+		output := aad.LogSettings{
+			Category: aad.Category(category),
+			Enabled:  utils.Bool(true),
+			RetentionPolicy: &aad.RetentionPolicy{
+				Days:    utils.Int32(int32(retentionDays)),
+				Enabled: utils.Bool(retentionEnabled),
+			},
+		}
+
+		results = append(results, output)
+	}
+
+	return results
+}
+
 func flattenMonitorAADDiagnosticLogs(input *[]aad.LogSettings) []interface{} {
 	results := make([]interface{}, 0)
 	if input == nil {
@@ -371,6 +542,50 @@ func flattenMonitorAADDiagnosticLogs(input *[]aad.LogSettings) []interface{} {
 		results = append(results, map[string]interface{}{
 			"category":         category,
 			"enabled":          enabled,
+			"retention_policy": policies,
+		})
+	}
+
+	return results
+}
+
+func flattenMonitorAADDiagnosticEnabledLogs(input *[]aad.LogSettings) []interface{} {
+	results := make([]interface{}, 0)
+	if input == nil {
+		return results
+	}
+
+	for _, v := range *input {
+		category := string(v.Category)
+
+		enabled := false
+		if v.Enabled != nil {
+			enabled = *v.Enabled
+		}
+		if !enabled {
+			continue
+		}
+
+		policies := make([]interface{}, 0)
+		if inputPolicy := v.RetentionPolicy; inputPolicy != nil {
+			days := 0
+			if inputPolicy.Days != nil {
+				days = int(*inputPolicy.Days)
+			}
+
+			enabled := false
+			if inputPolicy.Enabled != nil {
+				enabled = *inputPolicy.Enabled
+			}
+
+			policies = append(policies, map[string]interface{}{
+				"days":    days,
+				"enabled": enabled,
+			})
+		}
+
+		results = append(results, map[string]interface{}{
+			"category":         category,
 			"retention_policy": policies,
 		})
 	}

--- a/internal/services/monitor/monitor_aad_diagnostic_setting_resource.go
+++ b/internal/services/monitor/monitor_aad_diagnostic_setting_resource.go
@@ -85,10 +85,9 @@ func resourceMonitorAADDiagnosticSetting() *pluginsdk.Resource {
 			},
 
 			"enabled_log": {
-				Type:         pluginsdk.TypeSet,
-				Optional:     true,
-				Computed:     !features.FourPointOhBeta(),
-				ExactlyOneOf: []string{"enabled_log", "log"},
+				Type:     pluginsdk.TypeSet,
+				Optional: true,
+				Computed: !features.FourPointOhBeta(),
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
 						"category": {
@@ -124,6 +123,7 @@ func resourceMonitorAADDiagnosticSetting() *pluginsdk.Resource {
 	}
 
 	if !features.FourPointOhBeta() {
+		resource.Schema["enabled_log"].ExactlyOneOf = []string{"enabled_log", "log"}
 		resource.Schema["log"] = &pluginsdk.Schema{
 			Type:         pluginsdk.TypeSet,
 			Optional:     true,

--- a/internal/services/monitor/monitor_aad_diagnostic_setting_resource_test.go
+++ b/internal/services/monitor/monitor_aad_diagnostic_setting_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/monitor/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
@@ -171,87 +172,50 @@ resource "azurerm_monitor_aad_diagnostic_setting" "test" {
   name                           = "acctest-DS-%[1]d"
   eventhub_authorization_rule_id = azurerm_eventhub_namespace_authorization_rule.test.id
   eventhub_name                  = azurerm_eventhub.test.name
-  log {
+  enabled_log {
     category = "SignInLogs"
-    enabled  = true
     retention_policy {
       enabled = true
       days    = 1
     }
   }
-  log {
+  enabled_log {
     category = "AuditLogs"
-    enabled  = true
     retention_policy {
       enabled = true
       days    = 1
     }
   }
-  log {
+  enabled_log {
     category = "NonInteractiveUserSignInLogs"
-    enabled  = true
     retention_policy {
       enabled = true
       days    = 1
     }
   }
-  log {
+  enabled_log {
     category = "ServicePrincipalSignInLogs"
-    enabled  = true
     retention_policy {
       enabled = true
       days    = 1
     }
   }
-  log {
+  enabled_log {
     category = "RiskyUsers"
-    enabled  = true
     retention_policy {
       enabled = true
       days    = 1
     }
   }
-  log {
+  enabled_log {
     category = "UserRiskEvents"
-    enabled  = true
     retention_policy {
       enabled = true
       days    = 1
     }
   }
-  log {
-    category = "ManagedIdentitySignInLogs"
-    enabled  = false
-    retention_policy {}
-  }
-  log {
-    category = "ProvisioningLogs"
-    enabled  = false
-    retention_policy {}
-  }
-  log {
-    category = "ADFSSignInLogs"
-    enabled  = false
-    retention_policy {}
-  }
-  log {
-    category = "NetworkAccessTrafficLogs"
-    enabled  = false
-    retention_policy {}
-  }
-  log {
-    category = "RiskyServicePrincipals"
-    enabled  = false
-    retention_policy {}
-  }
-  log {
-    category = "ServicePrincipalRiskEvents"
-    enabled  = false
-    retention_policy {}
-  }
-  log {
+  enabled_log {
     category = "B2CRequestLogs"
-    enabled  = true
     retention_policy {
       enabled = true
       days    = 1
@@ -291,87 +255,50 @@ resource "azurerm_eventhub_namespace_authorization_rule" "test" {
 resource "azurerm_monitor_aad_diagnostic_setting" "test" {
   name                           = "acctest-DS-%[1]d"
   eventhub_authorization_rule_id = azurerm_eventhub_namespace_authorization_rule.test.id
-  log {
+  enabled_log {
     category = "SignInLogs"
-    enabled  = true
     retention_policy {
       enabled = true
       days    = 1
     }
   }
-  log {
+  enabled_log {
     category = "AuditLogs"
-    enabled  = true
     retention_policy {
       enabled = true
       days    = 1
     }
   }
-  log {
+  enabled_log {
     category = "NonInteractiveUserSignInLogs"
-    enabled  = true
     retention_policy {
       enabled = true
       days    = 1
     }
   }
-  log {
+  enabled_log {
     category = "ServicePrincipalSignInLogs"
-    enabled  = true
     retention_policy {
       enabled = true
       days    = 1
     }
   }
-  log {
-    category = "ManagedIdentitySignInLogs"
-    enabled  = false
-    retention_policy {}
-  }
-  log {
-    category = "ProvisioningLogs"
-    enabled  = false
-    retention_policy {}
-  }
-  log {
-    category = "ADFSSignInLogs"
-    enabled  = false
-    retention_policy {}
-  }
-  log {
+  enabled_log {
     category = "RiskyUsers"
-    enabled  = true
     retention_policy {
       enabled = true
       days    = 1
     }
   }
-  log {
+  enabled_log {
     category = "UserRiskEvents"
-    enabled  = true
     retention_policy {
       enabled = true
       days    = 1
     }
   }
-  log {
-    category = "NetworkAccessTrafficLogs"
-    enabled  = false
-    retention_policy {}
-  }
-  log {
-    category = "RiskyServicePrincipals"
-    enabled  = false
-    retention_policy {}
-  }
-  log {
-    category = "ServicePrincipalRiskEvents"
-    enabled  = false
-    retention_policy {}
-  }
-  log {
+  enabled_log {
     category = "B2CRequestLogs"
-    enabled  = true
     retention_policy {
       enabled = true
       days    = 1
@@ -390,24 +317,8 @@ resource "azurerm_monitor_aad_diagnostic_setting" "import" {
   eventhub_authorization_rule_id = azurerm_monitor_aad_diagnostic_setting.test.eventhub_authorization_rule_id
   eventhub_name                  = azurerm_monitor_aad_diagnostic_setting.test.eventhub_name
 
-  log {
+  enabled_log {
     category = "SignInLogs"
-    enabled  = true
-    retention_policy {}
-  }
-  log {
-    category = "NetworkAccessTrafficLogs"
-    enabled  = false
-    retention_policy {}
-  }
-  log {
-    category = "RiskyServicePrincipals"
-    enabled  = false
-    retention_policy {}
-  }
-  log {
-    category = "ServicePrincipalRiskEvents"
-    enabled  = false
     retention_policy {}
   }
 }
@@ -436,87 +347,50 @@ resource "azurerm_log_analytics_workspace" "test" {
 resource "azurerm_monitor_aad_diagnostic_setting" "test" {
   name                       = "acctest-DS-%[1]d"
   log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
-  log {
+  enabled_log {
     category = "SignInLogs"
-    enabled  = true
     retention_policy {
       enabled = true
       days    = 1
     }
   }
-  log {
+  enabled_log {
     category = "AuditLogs"
-    enabled  = true
     retention_policy {
       enabled = true
       days    = 1
     }
   }
-  log {
+  enabled_log {
     category = "NonInteractiveUserSignInLogs"
-    enabled  = true
     retention_policy {
       enabled = true
       days    = 1
     }
   }
-  log {
+  enabled_log {
     category = "ServicePrincipalSignInLogs"
-    enabled  = true
     retention_policy {
       enabled = true
       days    = 1
     }
   }
-  log {
-    category = "ManagedIdentitySignInLogs"
-    enabled  = false
-    retention_policy {}
-  }
-  log {
-    category = "ProvisioningLogs"
-    enabled  = false
-    retention_policy {}
-  }
-  log {
-    category = "ADFSSignInLogs"
-    enabled  = false
-    retention_policy {}
-  }
-  log {
+  enabled_log {
     category = "RiskyUsers"
-    enabled  = true
     retention_policy {
       enabled = true
       days    = 1
     }
   }
-  log {
+  enabled_log {
     category = "UserRiskEvents"
-    enabled  = true
     retention_policy {
       enabled = true
       days    = 1
     }
   }
-  log {
-    category = "NetworkAccessTrafficLogs"
-    enabled  = false
-    retention_policy {}
-  }
-  log {
-    category = "RiskyServicePrincipals"
-    enabled  = false
-    retention_policy {}
-  }
-  log {
-    category = "ServicePrincipalRiskEvents"
-    enabled  = false
-    retention_policy {}
-  }
-  log {
+  enabled_log {
     category = "B2CRequestLogs"
-    enabled  = true
     retention_policy {
       enabled = true
       days    = 1
@@ -527,7 +401,8 @@ resource "azurerm_monitor_aad_diagnostic_setting" "test" {
 }
 
 func (MonitorAADDiagnosticSettingResource) storageAccount(data acceptance.TestData) string {
-	return fmt.Sprintf(`
+	if !features.FourPointOhBeta() {
+		return fmt.Sprintf(`
 provider "azurerm" {
   features {}
 }
@@ -630,6 +505,91 @@ resource "azurerm_monitor_aad_diagnostic_setting" "test" {
   log {
     category = "B2CRequestLogs"
     enabled  = true
+    retention_policy {
+      enabled = true
+      days    = 1
+    }
+  }
+  log {
+    category = "EnrichedOffice365AuditLogs"
+    enabled  = false
+    retention_policy {}
+  }
+  log {
+    category = "MicrosoftGraphActivityLogs"
+    enabled  = false
+    retention_policy {}
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomStringOfLength(5))
+	}
+
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "acctestsa%[3]s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_kind             = "StorageV2"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_monitor_aad_diagnostic_setting" "test" {
+  name               = "acctest-DS-%[1]d"
+  storage_account_id = azurerm_storage_account.test.id
+  enabled_log {
+    category = "SignInLogs"
+    retention_policy {
+      enabled = true
+      days    = 1
+    }
+  }
+  enabled_log {
+    category = "AuditLogs"
+    retention_policy {
+      enabled = true
+      days    = 1
+    }
+  }
+  enabled_log {
+    category = "NonInteractiveUserSignInLogs"
+    retention_policy {
+      enabled = true
+      days    = 1
+    }
+  }
+  enabled_log {
+    category = "ServicePrincipalSignInLogs"
+    retention_policy {
+      enabled = true
+      days    = 1
+    }
+  }
+  enabled_log {
+    category = "RiskyUsers"
+    retention_policy {
+      enabled = true
+      days    = 1
+    }
+  }
+  enabled_log {
+    category = "UserRiskEvents"
+    retention_policy {
+      enabled = true
+      days    = 1
+    }
+  }
+  enabled_log {
+    category = "B2CRequestLogs"
     retention_policy {
       enabled = true
       days    = 1

--- a/internal/services/monitor/monitor_aad_diagnostic_setting_resource_test.go
+++ b/internal/services/monitor/monitor_aad_diagnostic_setting_resource_test.go
@@ -737,6 +737,7 @@ resource "azurerm_monitor_aad_diagnostic_setting" "test" {
   }
   enabled_log {
     category = "SignInLogs"
+    retention_policy {}
   }
   enabled_log {
     category = "NonInteractiveUserSignInLogs"

--- a/internal/services/monitor/monitor_aad_diagnostic_setting_resource_test.go
+++ b/internal/services/monitor/monitor_aad_diagnostic_setting_resource_test.go
@@ -31,7 +31,7 @@ func TestAccMonitorAADDiagnosticSetting(t *testing.T) {
 			"storageAccount":        testAccMonitorAADDiagnosticSetting_storageAccount,
 			"storageAccountUpdate":  testAccMonitorAADDiagnosticSetting_updateToEnabledLog,
 			"updateEnabledLog":      testAccMonitorAADDiagnosticSetting_updateEnabledLog,
-			"updateToDisabled":      testAccMonitorAADDiagnosticSetting_updateToDisabled, //remove this test in 4.0 version
+			"updateToDisabled":      testAccMonitorAADDiagnosticSetting_updateToDisabled, // remove this test in 4.0 version
 		},
 	}
 
@@ -814,6 +814,7 @@ resource "azurerm_monitor_aad_diagnostic_setting" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomStringOfLength(5))
 }
 
+// remove this in 4.0 version
 func (MonitorAADDiagnosticSettingResource) disabled(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {

--- a/internal/services/monitor/monitor_aad_diagnostic_setting_resource_test.go
+++ b/internal/services/monitor/monitor_aad_diagnostic_setting_resource_test.go
@@ -705,7 +705,7 @@ resource "azurerm_monitor_aad_diagnostic_setting" "test" {
   storage_account_id = azurerm_storage_account.test.id
   log {
     category = "SignInLogs"
-	enabled = false
+    enabled  = false
     retention_policy {
       enabled = true
       days    = 1

--- a/website/docs/r/monitor_aad_diagnostic_setting.html.markdown
+++ b/website/docs/r/monitor_aad_diagnostic_setting.html.markdown
@@ -36,52 +36,33 @@ resource "azurerm_storage_account" "example" {
 resource "azurerm_monitor_aad_diagnostic_setting" "example" {
   name               = "setting1"
   storage_account_id = azurerm_storage_account.example.id
-  log {
+  enabled_log {
     category = "SignInLogs"
-    enabled  = true
     retention_policy {
       enabled = true
       days    = 1
     }
   }
-  log {
+  enabled_log {
     category = "AuditLogs"
-    enabled  = true
     retention_policy {
       enabled = true
       days    = 1
     }
   }
-  log {
+  enabled_log {
     category = "NonInteractiveUserSignInLogs"
-    enabled  = true
     retention_policy {
       enabled = true
       days    = 1
     }
   }
-  log {
+  enabled_log {
     category = "ServicePrincipalSignInLogs"
-    enabled  = true
     retention_policy {
       enabled = true
       days    = 1
     }
-  }
-  log {
-    category = "ManagedIdentitySignInLogs"
-    enabled  = false
-    retention_policy {}
-  }
-  log {
-    category = "ProvisioningLogs"
-    enabled  = false
-    retention_policy {}
-  }
-  log {
-    category = "ADFSSignInLogs"
-    enabled  = false
-    retention_policy {}
   }
 }
 ```
@@ -92,9 +73,13 @@ The following arguments are supported:
 
 * `name` - (Required) The name which should be used for this Monitor Azure Active Directory Diagnostic Setting. Changing this forces a new Monitor Azure Active Directory Diagnostic Setting to be created.
   
-* `log` - (Required) One or more `log` blocks as defined below.
+* `log` - (Optional) One or more `log` blocks as defined below.
 
-~> **Note:** At least one of the `log` blocks must have the `enabled` property set to `true`.
+-> **NOTE:** `log` is deprecated in favour of the `enabled_log` property and will be removed in version 4.0 of the AzureRM Provider.
+
+* `enabled_log` - (Optional) One or more `enabled_log` blocks as defined below.
+
+-> **NOTE:** At least one `log` or `enabled_log` block must be specified. At least one type of Log must be enabled.
 
 ---
 
@@ -119,6 +104,14 @@ A `log` block supports the following:
 * `retention_policy` - (Required) A `retention_policy` block as defined below.
 
 * `enabled` - (Optional) Is this Diagnostic Log enabled? Defaults to `true`.
+ 
+---
+
+A `enabled_log` block supports the following:
+
+* `category` - (Required) The log category for the Azure Active Directory Diagnostic.
+
+* `retention_policy` - (Required) A `retention_policy` block as defined below.
 
 ---
 


### PR DESCRIPTION
related to https://github.com/hashicorp/terraform-provider-azurerm/pull/19504  & https://github.com/hashicorp/terraform-provider-azurerm/pull/19931

test:
![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/104055472/5ebbf079-df21-48d9-81a5-6c6a03b04840)