### PR TITLE
`app_service` - mark `site_credential` block as `Sensitive`

### DIFF
--- a/internal/services/appservice/helpers/shared_schema.go
+++ b/internal/services/appservice/helpers/shared_schema.go
@@ -358,13 +358,15 @@ type SiteCredential struct {
 
 func SiteCredentialSchema() *pluginsdk.Schema { // TODO - This can apparently be disabled as a security option for the service?
 	return &pluginsdk.Schema{
-		Type:     pluginsdk.TypeList,
-		Computed: true,
+		Type:      pluginsdk.TypeList,
+		Computed:  true,
+		Sensitive: true,
 		Elem: &pluginsdk.Resource{
 			Schema: map[string]*pluginsdk.Schema{
 				"name": {
 					Type:        pluginsdk.TypeString,
 					Computed:    true,
+					Sensitive:   true,
 					Description: "The Site Credentials Username used for publishing.",
 				},
 


### PR DESCRIPTION
* `azurerm_linux_function_app` - mark `site_credential` block as `Sensitive`
* `azurerm_linux_function_app_slot` - mark `site_credential` block as `Sensitive`
* `azurerm_linux_web_app` - mark `site_credential` block as `Sensitive`
* `azurerm_linux_web_app_slot`  - mark `site_credential` block as `Sensitive`
* `azurerm_windows_function_app` - mark `site_credential` block as `Sensitive`
* `azurerm_windows_function_app_slot` - mark `site_credential` block as `Sensitive`
* `azurerm_windows_web_app` - mark `site_credential` block as `Sensitive`
* `azurerm_windows_web_app_slot` - mark `site_credential` block as `Sensitive`
