### PR TITLE
`dashboard_grafana_resource`: add support for `UserAssigned` identity

### DIFF
--- a/internal/services/dashboard/dashboard_grafana_resource.go
+++ b/internal/services/dashboard/dashboard_grafana_resource.go
@@ -105,7 +105,7 @@ func (r DashboardGrafanaResource) Arguments() map[string]*pluginsdk.Schema {
 			},
 		},
 
-		"identity": commonschema.SystemAssignedIdentityOptionalForceNew(),
+		"identity": commonschema.SystemOrUserAssignedIdentityRequiredForceNew(),
 
 		"public_network_access_enabled": {
 			Type:     pluginsdk.TypeBool,
@@ -449,13 +449,16 @@ func expandAzureMonitorWorkspaceIntegrationModelArray(inputList []AzureMonitorWo
 }
 
 func expandLegacySystemAndUserAssignedMap(input []interface{}) *identity.LegacySystemAndUserAssignedMap {
-	identityValue, err := identity.ExpandSystemAssigned(input)
+	identityValue, err := identity.ExpandSystemOrUserAssignedMap(input)
 	if err != nil {
 		return nil
 	}
 
 	return &identity.LegacySystemAndUserAssignedMap{
-		Type: identityValue.Type,
+		Type:        identityValue.Type,
+		PrincipalId: identityValue.PrincipalId,
+		TenantId:    identityValue.TenantId,
+		IdentityIds: identityValue.IdentityIds,
 	}
 }
 
@@ -483,12 +486,16 @@ func flattenLegacySystemAndUserAssignedMap(input *identity.LegacySystemAndUserAs
 		return &[]interface{}{}
 	}
 
-	identityValue := &identity.SystemAssigned{
+	identityValue := &identity.SystemOrUserAssignedMap{
 		Type:        input.Type,
 		PrincipalId: input.PrincipalId,
 		TenantId:    input.TenantId,
+		IdentityIds: input.IdentityIds,
 	}
 
-	output := identity.FlattenSystemAssigned(identityValue)
-	return &output
+	output, err := identity.FlattenSystemOrUserAssignedMap(identityValue)
+	if err != nil {
+		return &[]interface{}{}
+	}
+	return output
 }

--- a/internal/services/dashboard/dashboard_grafana_resource_test.go
+++ b/internal/services/dashboard/dashboard_grafana_resource_test.go
@@ -139,6 +139,11 @@ func (r DashboardGrafanaResource) complete(data acceptance.TestData) string {
 	template := r.template(data)
 	return fmt.Sprintf(`
 			%[1]s
+resource "azurerm_user_assigned_identity" "test" {
+  name				= "a-uid-%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location			= azurerm_resource_group.test.location
+}
 
 resource "azurerm_dashboard_grafana" "test" {
   name                              = "a-dg-%[2]d"
@@ -149,7 +154,8 @@ resource "azurerm_dashboard_grafana" "test" {
   public_network_access_enabled     = false
 
   identity {
-    type = "SystemAssigned"
+    type = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.test.id]
   }
 
   azure_monitor_workspace_integrations {

--- a/website/docs/r/dashboard_grafana.html.markdown
+++ b/website/docs/r/dashboard_grafana.html.markdown
@@ -74,7 +74,9 @@ An `azure_monitor_workspace_integrations` block supports the following:
 
 An `identity` block supports the following:
 
-* `type` - (Required) Specifies the type of Managed Service Identity. The only possible values is `SystemAssigned`. Changing this forces a new resource to be created.
+* `type` - (Required) Specifies the type of Managed Service Identity. Possible values are `SystemAssigned`, `UserAssigned`. Changing this forces a new resource to be created.
+
+* `identity_ids` - (Optional) Specifies the list of User Assigned Managed Service Identity IDs which should be assigned to this Dashboard Grafana.
 
 ## Attributes Reference
 


### PR DESCRIPTION
* Add support for `UserAssigned` identity for grafana resource.

* All related tests passed.

```
=== RUN   TestAccDashboardGrafana_basic
--- PASS: TestAccDashboardGrafana_basic (808.85s)
=== RUN   TestAccDashboardGrafana_requiresImport
--- PASS: TestAccDashboardGrafana_requiresImport (922.38s)
=== RUN   TestAccDashboardGrafana_complete
--- PASS: TestAccDashboardGrafana_complete (883.12s)
```