### PR TITLE
Correct the import example for IoT Hub

### DIFF
--- a/website/docs/r/iothub.html.markdown
+++ b/website/docs/r/iothub.html.markdown
@@ -378,5 +378,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 IoTHubs can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_iothub.hub1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Devices/iotHubs/hub1
+terraform import azurerm_iothub.hub1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Devices/IotHubs/hub1
 ```


### PR DESCRIPTION
IonHubs should have a capital I