### PR TITLE
azurerm_postgresql_flexible_server_configuration - set value from tf config

### DIFF
--- a/internal/services/postgres/postgresql_flexible_server_configuration_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_configuration_resource.go
@@ -136,10 +136,7 @@ func resourceFlexibleServerConfigurationRead(d *pluginsdk.ResourceData, meta int
 
 	d.Set("name", id.ConfigurationName)
 	d.Set("server_id", configurations.NewFlexibleServerID(subscriptionId, id.ResourceGroupName, id.FlexibleServerName).ID())
-
-	if resp.Model != nil && resp.Model.Properties != nil {
-		d.Set("value", resp.Model.Properties.Value)
-	}
+	d.Set("value", d.Get("value").(string))
 
 	return nil
 }

--- a/internal/services/postgres/postgresql_flexible_server_configuration_resource_test.go
+++ b/internal/services/postgres/postgresql_flexible_server_configuration_resource_test.go
@@ -29,7 +29,7 @@ func TestAccFlexibleServerConfiguration_backslashQuote(t *testing.T) {
 				check.That(data.ResourceName).Key("value").HasValue("on"),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("value"),
 		{
 			Config: r.template(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -52,7 +52,7 @@ func TestAccFlexibleServerConfiguration_azureExtensions(t *testing.T) {
 				check.That(data.ResourceName).Key("value").HasValue("CUBE,CITEXT,BTREE_GIST"),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("value"),
 		{
 			Config: r.template(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -75,7 +75,7 @@ func TestAccFlexibleServerConfiguration_pgbouncerEnabled(t *testing.T) {
 				check.That(data.ResourceName).Key("value").HasValue("true"),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("value"),
 		{
 			Config: r.template(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -98,7 +98,7 @@ func TestAccFlexibleServerConfiguration_updateApplicationName(t *testing.T) {
 				check.That(data.ResourceName).Key("value").HasValue("true"),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("value"),
 		{
 			Config: r.basic(data, name, "false"),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -155,7 +155,7 @@ func TestAccFlexibleServerConfiguration_multiplePostgresqlFlexibleServerConfigur
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("value"),
 	})
 }
 
@@ -172,7 +172,7 @@ func TestAccFlexibleServerConfiguration_restartServerForStaticParameters(t *test
 				check.That(data.ResourceName).Key("value").HasValue("5"),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("value"),
 		{
 			Config: r.template(data),
 			Check: acceptance.ComposeTestCheckFunc(

--- a/internal/services/postgres/postgresql_flexible_server_configuration_resource_test.go
+++ b/internal/services/postgres/postgresql_flexible_server_configuration_resource_test.go
@@ -182,6 +182,28 @@ func TestAccFlexibleServerConfiguration_restartServerForStaticParameters(t *test
 	})
 }
 
+func TestAccFlexibleServerConfiguration_staticParameters(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_postgresql_flexible_server_configuration", "test")
+	r := PostgresqlFlexibleServerConfigurationResource{}
+	name := "shared_preload_libraries"
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data, name, "pg_cron,wal2json,pg_stat_statements"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("value"),
+		{
+			Config: r.template(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				data.CheckWithClientForResource(r.checkReset(name), "azurerm_postgresql_flexible_server.test"),
+			),
+		},
+	})
+}
+
 // Helper functions for verification
 func (r PostgresqlFlexibleServerConfigurationResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := configurations.ParseConfigurationID(state.ID)


### PR DESCRIPTION
fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/21356

The value content returned by GET API is sorted alphabetically. Service team confirmed that it's expected. So we have to resolve this issue from TF side.

![image](https://user-images.githubusercontent.com/19754191/231704316-c03516ba-a416-487d-834c-c191e8c5601d.png)
