### PR TITLE
GHA: add waiting-response on build failure and update issue labeller 

### DIFF
--- a/.github/workflows/depscheck.yaml
+++ b/.github/workflows/depscheck.yaml
@@ -3,6 +3,7 @@ name: Vendor Dependencies Check
 
 permissions:
   contents: read
+  pull-requests: write
 
 on:
   pull_request:
@@ -22,3 +23,11 @@ jobs:
           go-version-file: ./.go-version
       - run: bash scripts/gogetcookie.sh
       - run: make depscheck
+      - name: Add waiting-response on fail
+        if: failure()
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          labels: waiting-response
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          number: ${{ github.event.number }}
+          repo: ${{ github.event.repository.full_name }}

--- a/.github/workflows/gencheck.yaml
+++ b/.github/workflows/gencheck.yaml
@@ -3,6 +3,7 @@ name: Generation Check
 
 permissions:
   contents: read
+  pull-requests: write
 
 on:
   pull_request:
@@ -25,3 +26,11 @@ jobs:
           go-version-file: ./.go-version
       - run: bash scripts/gogetcookie.sh
       - run: make gencheck
+      - name: Add waiting-response on fail
+        if: failure()
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          labels: waiting-response
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          number: ${{ github.event.number }}
+          repo: ${{ github.event.repository.full_name }}

--- a/.github/workflows/golint.yaml
+++ b/.github/workflows/golint.yaml
@@ -3,6 +3,7 @@ name: GoLang Linting
 
 permissions:
   contents: read
+  pull-requests: write
 
 on:
   pull_request:
@@ -28,3 +29,11 @@ jobs:
         with:
           version: 'v1.51.1'
           args: -v ./internal/...
+      - name: Add waiting-response on fail
+        if: failure()
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          labels: waiting-response
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          number: ${{ github.event.number }}
+          repo: ${{ github.event.repository.full_name }}

--- a/.github/workflows/gradually-deprecated.yaml
+++ b/.github/workflows/gradually-deprecated.yaml
@@ -32,19 +32,3 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           number: ${{ github.event.number }}
           repo: ${{ github.event.repository.full_name }}
-      - name: Get run url
-        if: failure()
-        run: |
-          echo "gha_url=https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}" >> $GITHUB_ENV
-      - name: Send build failure comment
-        if: failure()
-        uses: actions/github-script@v6
-        with:
-          result-encoding: string
-          script: |
-            github.rest.issues.createComment({
-             issue_number: ${{ github.event.number }},
-             owner: context.repo.owner,
-             repo: context.repo.repo,
-             body: '<b>Build failure</b> \n\n Found new usages of deprecated functionality: \n\n ${{ env.gha_url}}'
-             })

--- a/.github/workflows/issue-opened.yaml
+++ b/.github/workflows/issue-opened.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: github/issue-labeler@v2.4
+    - uses: github/issue-labeler@v3.1
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         configuration-path: .github/labeler-issue-triage.yml

--- a/.github/workflows/provider-test.yml
+++ b/.github/workflows/provider-test.yml
@@ -12,7 +12,7 @@ on:
 permissions:
   contents: read
   id-token: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   secrets-check:
@@ -66,5 +66,14 @@ jobs:
       - name: Clean Up OIDC Token File Path
         run: rm -f "${RUNNER_TEMP}/oidc-token.jwt"
         if: always()
+
+      - name: Add waiting-response on fail
+        if: failure()
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          labels: waiting-response
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          number: ${{ github.event.number }}
+          repo: ${{ github.event.repository.full_name }}
 
 # vim: set ts=2 sts=2 sw=2 et:

--- a/.github/workflows/tflint.yaml
+++ b/.github/workflows/tflint.yaml
@@ -3,6 +3,7 @@ name: Terraform Schema Linting
 
 permissions:
   contents: read
+  pull-requests: write
 
 on:
   pull_request:
@@ -28,3 +29,11 @@ jobs:
       - run: bash scripts/gogetcookie.sh
       - run: make tools
       - run: make tflint
+      - name: Add waiting-response on fail
+        if: failure()
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          labels: waiting-response
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          number: ${{ github.event.number }}
+          repo: ${{ github.event.repository.full_name }}

--- a/.github/workflows/thirty-two-bit.yaml
+++ b/.github/workflows/thirty-two-bit.yaml
@@ -3,7 +3,7 @@ name: 32 Bit Build
 
 permissions:
   contents: read
-  pull-requests: read
+  pull-requests: write
 
 on:
   pull_request:
@@ -27,3 +27,11 @@ jobs:
           go-version-file: ./.go-version
       - run: bash scripts/gogetcookie.sh
       - run: GOARCH=386 GOOS=linux go build -o 32bitbuild .
+      - name: Add waiting-response on fail
+        if: failure()
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          labels: waiting-response
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          number: ${{ github.event.number }}
+          repo: ${{ github.event.repository.full_name }}

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -3,7 +3,7 @@ name: Unit Tests
 
 permissions:
   contents: read
-  pull-requests: read
+  pull-requests: write
 
 on:
   pull_request:
@@ -29,3 +29,11 @@ jobs:
       - run: make test
         env:
           GITHUB_ACTIONS_STAGE: "UNIT_TESTS"
+      - name: Add waiting-response on fail
+        if: failure()
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          labels: waiting-response
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          number: ${{ github.event.number }}
+          repo: ${{ github.event.repository.full_name }}

--- a/.github/workflows/validate-examples.yaml
+++ b/.github/workflows/validate-examples.yaml
@@ -3,7 +3,7 @@ name: Validate Examples
 
 permissions:
   contents: read
-  pull-requests: read
+  pull-requests: write
 
 on:
   pull_request:
@@ -27,3 +27,11 @@ jobs:
       - run: bash scripts/gogetcookie.sh
       - run: make tools
       - run: make validate-examples
+      - name: Add waiting-response on fail
+        if: failure()
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          labels: waiting-response
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          number: ${{ github.event.number }}
+          repo: ${{ github.event.repository.full_name }}

--- a/.github/workflows/website-lint.yaml
+++ b/.github/workflows/website-lint.yaml
@@ -3,7 +3,7 @@ name: Website Linting
 
 permissions:
   contents: read
-  pull-requests: read
+  pull-requests: write
 
 on:
   pull_request:
@@ -23,3 +23,11 @@ jobs:
       - run: bash scripts/gogetcookie.sh
       - run: make tools
       - run: make website-lint
+      - name: Add waiting-response on fail
+        if: failure()
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          labels: waiting-response
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          number: ${{ github.event.number }}
+          repo: ${{ github.event.repository.full_name }}


### PR DESCRIPTION
- Add waiting-response to failed builds that require changes
- Remove adding comment on failed builds for deprecated functionality
- Update issue labeller to latest version which prevents issue labels being removed incorrectly