### PR TITLE
Tooling - Re-enable `tfproviderlint` job and fix-up all violations

### DIFF
--- a/.github/workflows/tflint.yaml
+++ b/.github/workflows/tflint.yaml
@@ -19,7 +19,6 @@ concurrency:
 jobs:
   tflint:
     runs-on: ubuntu-latest
-    if: false # skip until https://github.com/bflad/tfproviderlint/issues/255 is fixed
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3

--- a/internal/services/appconfiguration/app_configuration_data_source.go
+++ b/internal/services/appconfiguration/app_configuration_data_source.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
@@ -223,7 +224,7 @@ func dataSourceAppConfigurationRead(d *pluginsdk.ResourceData, meta interface{})
 		if props := model.Properties; props != nil {
 			d.Set("endpoint", props.Endpoint)
 			d.Set("encryption", flattenAppConfigurationEncryption(props.Encryption))
-			d.Set("public_network_access", props.PublicNetworkAccess)
+			d.Set("public_network_access", string(pointer.From(props.PublicNetworkAccess)))
 			d.Set("soft_delete_retention_days", props.SoftDeleteRetentionInDays)
 
 			localAuthEnabled := true

--- a/internal/services/appconfiguration/app_configuration_resource.go
+++ b/internal/services/appconfiguration/app_configuration_resource.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
@@ -448,7 +449,7 @@ func resourceAppConfigurationRead(d *pluginsdk.ResourceData, meta interface{}) e
 		if props := model.Properties; props != nil {
 			d.Set("endpoint", props.Endpoint)
 			d.Set("encryption", flattenAppConfigurationEncryption(props.Encryption))
-			d.Set("public_network_access", props.PublicNetworkAccess)
+			d.Set("public_network_access", string(pointer.From(props.PublicNetworkAccess)))
 
 			localAuthEnabled := true
 			if props.DisableLocalAuth != nil {

--- a/internal/services/automation/automation_connection_resource.go
+++ b/internal/services/automation/automation_connection_resource.go
@@ -174,7 +174,7 @@ func resourceAutomationConnectionRead(d *pluginsdk.ResourceData, meta interface{
 			}
 
 			if props.FieldDefinitionValues != nil {
-				if err := d.Set("values", *props.FieldDefinitionValues); err != nil {
+				if err := d.Set("values", props.FieldDefinitionValues); err != nil {
 					return fmt.Errorf("setting `values`: %+v", err)
 				}
 			}

--- a/internal/services/automation/automation_dsc_configuration_resource.go
+++ b/internal/services/automation/automation_dsc_configuration_resource.go
@@ -172,7 +172,7 @@ func resourceAutomationDscConfigurationRead(d *pluginsdk.ResourceData, meta inte
 		if props := model.Properties; props != nil {
 			d.Set("log_verbose", props.LogVerbose)
 			d.Set("description", props.Description)
-			d.Set("state", props.State)
+			d.Set("state", string(pointer.From(props.State)))
 		}
 
 		if model.Tags != nil {

--- a/internal/services/automation/automation_runbook_resource.go
+++ b/internal/services/automation/automation_runbook_resource.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/gofrs/uuid"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/automation/2019-06-01/runbook"
@@ -401,7 +402,7 @@ func resourceAutomationRunbookRead(d *pluginsdk.ResourceData, meta interface{}) 
 	if props := model.Properties; props != nil {
 		d.Set("log_verbose", props.LogVerbose)
 		d.Set("log_progress", props.LogProgress)
-		d.Set("runbook_type", props.RunbookType)
+		d.Set("runbook_type", string(pointer.From(props.RunbookType)))
 		d.Set("description", props.Description)
 		d.Set("log_activity_trace_level", props.LogActivityTrace)
 	}

--- a/internal/services/automation/automation_schedule_resource.go
+++ b/internal/services/automation/automation_schedule_resource.go
@@ -11,6 +11,7 @@ import (
 	// add this to resolve https://github.com/hashicorp/terraform-provider-azurerm/issues/20690
 	_ "time/tzdata"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/automation/2020-01-13-preview/schedule"
@@ -316,7 +317,7 @@ func resourceAutomationScheduleRead(d *pluginsdk.ResourceData, meta interface{})
 
 	if model := resp.Model; model != nil {
 		if props := model.Properties; props != nil {
-			d.Set("frequency", props.Frequency)
+			d.Set("frequency", string(pointer.From(props.Frequency)))
 
 			startTime, err := props.GetStartTimeAsTime()
 			if err != nil {

--- a/internal/services/automation/automation_webhook_resource.go
+++ b/internal/services/automation/automation_webhook_resource.go
@@ -208,7 +208,7 @@ func resourceAutomationWebhookRead(d *pluginsdk.ResourceData, meta interface{}) 
 			d.Set("enabled", props.IsEnabled)
 
 			if props.Runbook != nil && props.Runbook.Name != nil {
-				d.Set("runbook_name", *props.Runbook.Name)
+				d.Set("runbook_name", props.Runbook.Name)
 			}
 			d.Set("run_on_worker_group", props.RunOn)
 

--- a/internal/services/batch/batch_account_data_source.go
+++ b/internal/services/batch/batch_account_data_source.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
@@ -121,7 +122,7 @@ func dataSourceBatchAccountRead(d *pluginsdk.ResourceData, meta interface{}) err
 			if autoStorage := props.AutoStorage; autoStorage != nil {
 				d.Set("storage_account_id", autoStorage.StorageAccountId)
 			}
-			d.Set("pool_allocation_mode", props.PoolAllocationMode)
+			d.Set("pool_allocation_mode", string(pointer.From(props.PoolAllocationMode)))
 			poolAllocationMode := d.Get("pool_allocation_mode").(string)
 
 			if encryption := props.Encryption; encryption != nil {

--- a/internal/services/batch/batch_account_resource.go
+++ b/internal/services/batch/batch_account_resource.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
@@ -316,7 +317,7 @@ func resourceBatchAccountRead(d *pluginsdk.ResourceData, meta interface{}) error
 			d.Set("account_endpoint", props.AccountEndpoint)
 			if autoStorage := props.AutoStorage; autoStorage != nil {
 				d.Set("storage_account_id", autoStorage.StorageAccountId)
-				d.Set("storage_account_authentication_mode", autoStorage.AuthenticationMode)
+				d.Set("storage_account_authentication_mode", string(pointer.From(autoStorage.AuthenticationMode)))
 
 				if autoStorage.NodeIdentityReference != nil {
 					d.Set("storage_account_node_identity", autoStorage.NodeIdentityReference.ResourceId)
@@ -330,7 +331,7 @@ func resourceBatchAccountRead(d *pluginsdk.ResourceData, meta interface{}) error
 				d.Set("public_network_access_enabled", *v == batchaccount.PublicNetworkAccessTypeEnabled)
 			}
 
-			d.Set("pool_allocation_mode", props.PoolAllocationMode)
+			d.Set("pool_allocation_mode", string(pointer.From(props.PoolAllocationMode)))
 
 			if err := d.Set("encryption", flattenEncryption(props.Encryption)); err != nil {
 				return fmt.Errorf("setting `encryption`: %+v", err)

--- a/internal/services/batch/batch_pool_data_source.go
+++ b/internal/services/batch/batch_pool_data_source.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/batch/2022-01-01/pool"
@@ -742,7 +743,7 @@ func dataSourceBatchPoolRead(d *pluginsdk.ResourceData, meta interface{}) error 
 		if props := model.Properties; props != nil {
 			d.Set("display_name", props.DisplayName)
 			d.Set("vm_size", props.VMSize)
-			d.Set("inter_node_communication", props.InterNodeCommunication)
+			d.Set("inter_node_communication", string(pointer.From(props.InterNodeCommunication)))
 			d.Set("max_tasks_per_node", props.TaskSlotsPerNode)
 
 			if scaleSettings := props.ScaleSettings; scaleSettings != nil {
@@ -846,7 +847,7 @@ func dataSourceBatchPoolRead(d *pluginsdk.ResourceData, meta interface{}) error 
 					d.Set("storage_image_reference", flattenBatchPoolImageReference(&config.ImageReference))
 
 					if config.LicenseType != nil {
-						d.Set("license_type", *config.LicenseType)
+						d.Set("license_type", config.LicenseType)
 					}
 
 					d.Set("node_agent_sku_id", config.NodeAgentSkuId)

--- a/internal/services/batch/batch_pool_resource.go
+++ b/internal/services/batch/batch_pool_resource.go
@@ -1093,7 +1093,7 @@ func resourceBatchPoolRead(d *pluginsdk.ResourceData, meta interface{}) error {
 		if props := model.Properties; props != nil {
 			d.Set("display_name", props.DisplayName)
 			d.Set("vm_size", props.VMSize)
-			d.Set("inter_node_communication", props.InterNodeCommunication)
+			d.Set("inter_node_communication", string(pointer.From(props.InterNodeCommunication)))
 
 			if scaleSettings := props.ScaleSettings; scaleSettings != nil {
 				if err := d.Set("auto_scale", flattenBatchPoolAutoScaleSettings(scaleSettings.AutoScale)); err != nil {
@@ -1198,7 +1198,7 @@ func resourceBatchPoolRead(d *pluginsdk.ResourceData, meta interface{}) error {
 					d.Set("storage_image_reference", flattenBatchPoolImageReference(&config.ImageReference))
 
 					if config.LicenseType != nil {
-						d.Set("license_type", *config.LicenseType)
+						d.Set("license_type", config.LicenseType)
 					}
 
 					d.Set("node_agent_sku_id", config.NodeAgentSkuId)

--- a/internal/services/batch/batch_pool_resource.go
+++ b/internal/services/batch/batch_pool_resource.go
@@ -1196,11 +1196,7 @@ func resourceBatchPoolRead(d *pluginsdk.ResourceData, meta interface{}) error {
 					}
 
 					d.Set("storage_image_reference", flattenBatchPoolImageReference(&config.ImageReference))
-
-					if config.LicenseType != nil {
-						d.Set("license_type", config.LicenseType)
-					}
-
+					d.Set("license_type", config.LicenseType)
 					d.Set("node_agent_sku_id", config.NodeAgentSkuId)
 
 					if config.NodePlacementConfiguration != nil {

--- a/internal/services/compute/dedicated_host_resource.go
+++ b/internal/services/compute/dedicated_host_resource.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
@@ -213,7 +214,7 @@ func resourceDedicatedHostRead(d *pluginsdk.ResourceData, meta interface{}) erro
 		d.Set("sku_name", model.Sku.Name)
 		if props := model.Properties; props != nil {
 			d.Set("auto_replace_on_failure", props.AutoReplaceOnFailure)
-			d.Set("license_type", props.LicenseType)
+			d.Set("license_type", string(pointer.From(props.LicenseType)))
 
 			platformFaultDomain := 0
 			if props.PlatformFaultDomain != nil {

--- a/internal/services/compute/managed_disk_data_source.go
+++ b/internal/services/compute/managed_disk_data_source.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
@@ -203,7 +204,7 @@ func dataSourceManagedDiskRead(d *pluginsdk.ResourceData, meta interface{}) erro
 			d.Set("disk_size_gb", props.DiskSizeGB)
 			d.Set("disk_iops_read_write", props.DiskIOPSReadWrite)
 			d.Set("disk_mbps_read_write", props.DiskMBpsReadWrite)
-			d.Set("os_type", props.OsType)
+			d.Set("os_type", string(pointer.From(props.OsType)))
 
 			diskEncryptionSetId := ""
 			if props.Encryption != nil && props.Encryption.DiskEncryptionSetId != nil {

--- a/internal/services/compute/managed_disk_resource.go
+++ b/internal/services/compute/managed_disk_resource.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
@@ -972,13 +973,13 @@ func resourceManagedDiskRead(d *pluginsdk.ResourceData, meta interface{}) error 
 			d.Set("disk_mbps_read_write", props.DiskMBpsReadWrite)
 			d.Set("disk_iops_read_only", props.DiskIOPSReadOnly)
 			d.Set("disk_mbps_read_only", props.DiskMBpsReadOnly)
-			d.Set("os_type", props.OsType)
+			d.Set("os_type", string(pointer.From(props.OsType)))
 			d.Set("tier", props.Tier)
 			d.Set("max_shares", props.MaxShares)
-			d.Set("hyper_v_generation", props.HyperVGeneration)
+			d.Set("hyper_v_generation", string(pointer.From(props.HyperVGeneration)))
 
 			if networkAccessPolicy := props.NetworkAccessPolicy; *networkAccessPolicy != disks.NetworkAccessPolicyAllowAll {
-				d.Set("network_access_policy", props.NetworkAccessPolicy)
+				d.Set("network_access_policy", string(pointer.From(props.NetworkAccessPolicy)))
 			}
 			d.Set("disk_access_id", props.DiskAccessId)
 

--- a/internal/services/containers/container_group_resource.go
+++ b/internal/services/containers/container_group_resource.go
@@ -130,6 +130,7 @@ func resourceContainerGroup() *pluginsdk.Resource {
 				Deprecated: "the 'network_profile_id' has been removed from the latest versions of the container instance API and has been deprecated. It no longer functions and will be removed from the 4.0 AzureRM provider. Please use the 'subnet_ids' field instead",
 			},
 
+			// lintignore:S018
 			"subnet_ids": {
 				Type:     pluginsdk.TypeSet,
 				Optional: true,

--- a/internal/services/containers/container_registry_resource.go
+++ b/internal/services/containers/container_registry_resource.go
@@ -541,7 +541,7 @@ func resourceContainerRegistryRead(d *pluginsdk.ResourceData, meta interface{}) 
 			return fmt.Errorf("setting `identity`: %+v", err)
 		}
 
-		d.Set("sku", model.Sku.Tier)
+		d.Set("sku", string(pointer.From(model.Sku.Tier)))
 
 		if props := model.Properties; props != nil {
 			d.Set("admin_enabled", props.AdminUserEnabled)
@@ -567,7 +567,7 @@ func resourceContainerRegistryRead(d *pluginsdk.ResourceData, meta interface{}) 
 			d.Set("zone_redundancy_enabled", *props.ZoneRedundancy == registries.ZoneRedundancyEnabled)
 			d.Set("anonymous_pull_enabled", props.AnonymousPullEnabled)
 			d.Set("data_endpoint_enabled", props.DataEndpointEnabled)
-			d.Set("network_rule_bypass_option", props.NetworkRuleBypassOptions)
+			d.Set("network_rule_bypass_option", string(pointer.From(props.NetworkRuleBypassOptions)))
 
 			if *props.AdminUserEnabled {
 				credsResp, errList := client.ListCredentials(ctx, *id)

--- a/internal/services/cosmos/cosmosdb_account_resource.go
+++ b/internal/services/cosmos/cosmosdb_account_resource.go
@@ -1250,7 +1250,7 @@ func resourceCosmosDbAccountRead(d *pluginsdk.ResourceData, meta interface{}) er
 		for i, v := range *connStringResp.ConnectionStrings {
 			connStrings[i] = *v.ConnectionString
 			if propertyName, propertyExists := connStringPropertyMap[*v.Description]; propertyExists {
-				d.Set(propertyName, *v.ConnectionString)
+				d.Set(propertyName, v.ConnectionString) // lintignore:R001
 			}
 		}
 	}

--- a/internal/services/cosmos/cosmosdb_cassandra_cluster_resource.go
+++ b/internal/services/cosmos/cosmosdb_cassandra_cluster_resource.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
@@ -229,7 +230,7 @@ func resourceCassandraClusterRead(d *pluginsdk.ResourceData, meta interface{}) e
 		if props := model.Properties; props != nil {
 			if res := props; res != nil {
 				d.Set("delegated_management_subnet_id", props.DelegatedManagementSubnetId)
-				d.Set("authentication_method", props.AuthenticationMethod)
+				d.Set("authentication_method", string(pointer.From(props.AuthenticationMethod)))
 				d.Set("repair_enabled", props.RepairEnabled)
 				d.Set("version", props.CassandraVersion)
 				d.Set("hours_between_backups", props.HoursBetweenBackups)

--- a/internal/services/cosmos/cosmosdb_sql_database_data_source.go
+++ b/internal/services/cosmos/cosmosdb_sql_database_data_source.go
@@ -26,7 +26,6 @@ func dataSourceCosmosDbSQLDatabase() *pluginsdk.Resource {
 			"name": {
 				Type:         pluginsdk.TypeString,
 				Required:     true,
-				ForceNew:     true,
 				ValidateFunc: validate.CosmosEntityName,
 			},
 
@@ -35,7 +34,6 @@ func dataSourceCosmosDbSQLDatabase() *pluginsdk.Resource {
 			"account_name": {
 				Type:         pluginsdk.TypeString,
 				Required:     true,
-				ForceNew:     true,
 				ValidateFunc: validate.CosmosAccountName,
 			},
 

--- a/internal/services/costmanagement/export_resource_base.go
+++ b/internal/services/costmanagement/export_resource_base.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/costmanagement/2021-10-01/exports"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2022-05-01/blobcontainers"
@@ -176,7 +177,7 @@ func (br costManagementExportBaseResource) readFunc(scopeFieldName string) sdk.R
 						status := *schedule.Status == exports.StatusTypeActive
 
 						metadata.ResourceData.Set("active", status)
-						metadata.ResourceData.Set("recurrence_type", schedule.Recurrence)
+						metadata.ResourceData.Set("recurrence_type", string(pointer.From(schedule.Recurrence)))
 					}
 
 					exportDeliveryInfo, err := flattenExportDataStorageLocation(&props.DeliveryInfo)

--- a/internal/services/costmanagement/view_resource_base.go
+++ b/internal/services/costmanagement/view_resource_base.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/costmanagement/2022-10-01/views"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
@@ -237,9 +238,7 @@ func (br costManagementViewBaseResource) readFunc(scopeFieldName string) sdk.Res
 
 			if model := resp.Model; model != nil {
 				if props := model.Properties; props != nil {
-					if chart := props.Chart; chart != nil {
-						metadata.ResourceData.Set("chart_type", chart)
-					}
+					metadata.ResourceData.Set("chart_type", string(pointer.From(props.Chart)))
 
 					accumulated := false
 					if props.Accumulated != nil {

--- a/internal/services/databricks/databricks_virtual_network_peering_resource_test.go
+++ b/internal/services/databricks/databricks_virtual_network_peering_resource_test.go
@@ -167,7 +167,7 @@ resource "azurerm_databricks_workspace" "test" {
 func (r DatabricksVirtualNetworkPeeringResource) update(data acceptance.TestData) string {
 	features := "features {}"
 	if override := checkAzSecPackOverride(); override != "" {
-		features = fmt.Sprintf("features {%[3]s}", override)
+		features = fmt.Sprintf("features {%s}", override)
 	}
 
 	return fmt.Sprintf(`
@@ -216,7 +216,7 @@ resource "azurerm_databricks_virtual_network_peering" "import" {
 func (r DatabricksVirtualNetworkPeeringResource) basic(data acceptance.TestData) string {
 	features := "features {}"
 	if override := checkAzSecPackOverride(); override != "" {
-		features = fmt.Sprintf("features {%[3]s}", override)
+		features = fmt.Sprintf("features {%s}", override)
 	}
 	return fmt.Sprintf(`
 provider "azurerm" {
@@ -246,7 +246,7 @@ resource "azurerm_virtual_network_peering" "remote" {
 func (r DatabricksVirtualNetworkPeeringResource) complete(data acceptance.TestData) string {
 	features := "features {}"
 	if override := checkAzSecPackOverride(); override != "" {
-		features = fmt.Sprintf("features {%[3]s}", override)
+		features = fmt.Sprintf("features {%s}", override)
 	}
 	return fmt.Sprintf(`
 provider "azurerm" {
@@ -281,7 +281,7 @@ resource "azurerm_virtual_network_peering" "remote" {
 func (r DatabricksVirtualNetworkPeeringResource) completeUpdate(data acceptance.TestData) string {
 	features := "features {}"
 	if override := checkAzSecPackOverride(); override != "" {
-		features = fmt.Sprintf("features {%[3]s}", override)
+		features = fmt.Sprintf("features {%s}", override)
 	}
 	return fmt.Sprintf(`
 provider "azurerm" {

--- a/internal/services/databricks/databricks_virtual_network_peering_resource_test.go
+++ b/internal/services/databricks/databricks_virtual_network_peering_resource_test.go
@@ -165,16 +165,20 @@ resource "azurerm_databricks_workspace" "test" {
 }
 
 func (r DatabricksVirtualNetworkPeeringResource) update(data acceptance.TestData) string {
-	template := r.template(data)
+	features := "features {}"
+	if override := checkAzSecPackOverride(); override != "" {
+		features = fmt.Sprintf("features {%[3]s}", override)
+	}
+
 	return fmt.Sprintf(`
 provider "azurerm" {
-  features {%[3]s}
+  %s
 }
 
-%[2]s
+%s
 
 resource "azurerm_databricks_virtual_network_peering" "test" {
-  name                = "acctest-%[1]d"
+  name                = "acctest-%[3]d"
   resource_group_name = azurerm_resource_group.test.name
   workspace_id        = azurerm_databricks_workspace.test.id
 
@@ -185,12 +189,12 @@ resource "azurerm_databricks_virtual_network_peering" "test" {
 }
 
 resource "azurerm_virtual_network_peering" "remote" {
-  name                      = "to-acctest-%[1]d"
+  name                      = "to-acctest-%[3]d"
   resource_group_name       = azurerm_resource_group.test.name
   virtual_network_name      = azurerm_virtual_network.remote.name
   remote_virtual_network_id = azurerm_databricks_virtual_network_peering.test.virtual_network_id
 }
-`, data.RandomInteger, template, checkAzSecPackOverride())
+`, features, r.template(data), data.RandomInteger)
 }
 
 func (r DatabricksVirtualNetworkPeeringResource) requiresImport(data acceptance.TestData) string {
@@ -210,16 +214,19 @@ resource "azurerm_databricks_virtual_network_peering" "import" {
 }
 
 func (r DatabricksVirtualNetworkPeeringResource) basic(data acceptance.TestData) string {
-	template := r.template(data)
+	features := "features {}"
+	if override := checkAzSecPackOverride(); override != "" {
+		features = fmt.Sprintf("features {%[3]s}", override)
+	}
 	return fmt.Sprintf(`
 provider "azurerm" {
-  features {%[3]s}
+  %s
 }
 
-%[2]s
+%s
 
 resource "azurerm_databricks_virtual_network_peering" "test" {
-  name                = "acctest-%[1]d"
+  name                = "acctest-%[3]d"
   resource_group_name = azurerm_resource_group.test.name
   workspace_id        = azurerm_databricks_workspace.test.id
 
@@ -228,25 +235,28 @@ resource "azurerm_databricks_virtual_network_peering" "test" {
 }
 
 resource "azurerm_virtual_network_peering" "remote" {
-  name                      = "to-acctest-%[1]d"
+  name                      = "to-acctest-%[3]d"
   resource_group_name       = azurerm_resource_group.test.name
   virtual_network_name      = azurerm_virtual_network.remote.name
   remote_virtual_network_id = azurerm_databricks_virtual_network_peering.test.virtual_network_id
 }
-`, data.RandomInteger, template, checkAzSecPackOverride())
+`, features, r.template(data), data.RandomInteger)
 }
 
 func (r DatabricksVirtualNetworkPeeringResource) complete(data acceptance.TestData) string {
-	template := r.template(data)
+	features := "features {}"
+	if override := checkAzSecPackOverride(); override != "" {
+		features = fmt.Sprintf("features {%[3]s}", override)
+	}
 	return fmt.Sprintf(`
 provider "azurerm" {
-  features {%[3]s}
+  %s
 }
 
-%[2]s
+%s
 
 resource "azurerm_databricks_virtual_network_peering" "test" {
-  name                = "acctest-%[1]d"
+  name                = "acctest-%[3]d"
   resource_group_name = azurerm_resource_group.test.name
   workspace_id        = azurerm_databricks_workspace.test.id
 
@@ -260,25 +270,28 @@ resource "azurerm_databricks_virtual_network_peering" "test" {
 }
 
 resource "azurerm_virtual_network_peering" "remote" {
-  name                      = "to-acctest-%[1]d"
+  name                      = "to-acctest-%[3]d"
   resource_group_name       = azurerm_resource_group.test.name
   virtual_network_name      = azurerm_virtual_network.remote.name
   remote_virtual_network_id = azurerm_databricks_virtual_network_peering.test.virtual_network_id
 }
-`, data.RandomInteger, template, checkAzSecPackOverride())
+`, features, r.template(data), data.RandomInteger)
 }
 
 func (r DatabricksVirtualNetworkPeeringResource) completeUpdate(data acceptance.TestData) string {
-	template := r.template(data)
+	features := "features {}"
+	if override := checkAzSecPackOverride(); override != "" {
+		features = fmt.Sprintf("features {%[3]s}", override)
+	}
 	return fmt.Sprintf(`
 provider "azurerm" {
-  features {%[3]s}
+  %s
 }
 
-%[2]s
+%s
 
 resource "azurerm_databricks_virtual_network_peering" "test" {
-  name                = "acctest-%[1]d"
+  name                = "acctest-%[3]d"
   resource_group_name = azurerm_resource_group.test.name
   workspace_id        = azurerm_databricks_workspace.test.id
 
@@ -292,10 +305,10 @@ resource "azurerm_databricks_virtual_network_peering" "test" {
 }
 
 resource "azurerm_virtual_network_peering" "remote" {
-  name                      = "to-acctest-%[1]d"
+  name                      = "to-acctest-%[3]d"
   resource_group_name       = azurerm_resource_group.test.name
   virtual_network_name      = azurerm_virtual_network.remote.name
   remote_virtual_network_id = azurerm_databricks_virtual_network_peering.test.virtual_network_id
 }
-`, data.RandomInteger, template, checkAzSecPackOverride())
+`, features, r.template(data), data.RandomInteger)
 }

--- a/internal/services/datadog/datadog_monitors_resource.go
+++ b/internal/services/datadog/datadog_monitors_resource.go
@@ -248,7 +248,7 @@ func resourceDatadogMonitorRead(d *pluginsdk.ResourceData, meta interface{}) err
 			}
 
 			d.Set("monitoring_enabled", monitoringEnabled)
-			d.Set("marketplace_subscription_status", props.MarketplaceSubscriptionStatus)
+			d.Set("marketplace_subscription_status", string(pointer.From(props.MarketplaceSubscriptionStatus)))
 		}
 
 		skuName := ""

--- a/internal/services/dataprotection/data_protection_backup_vault_data_source.go
+++ b/internal/services/dataprotection/data_protection_backup_vault_data_source.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
@@ -89,8 +90,8 @@ func dataSourceDataProtectionBackupVaultRead(d *pluginsdk.ResourceData, meta int
 
 		props := model.Properties
 		if props.StorageSettings != nil && len(props.StorageSettings) > 0 {
-			d.Set("datastore_type", (props.StorageSettings)[0].DatastoreType)
-			d.Set("redundancy", (props.StorageSettings)[0].Type)
+			d.Set("datastore_type", string(pointer.From((props.StorageSettings)[0].DatastoreType)))
+			d.Set("redundancy", string(pointer.From((props.StorageSettings)[0].Type)))
 		}
 
 		if err = d.Set("identity", dataSourceFlattenBackupVaultDppIdentityDetails(model.Identity)); err != nil {

--- a/internal/services/dataprotection/data_protection_backup_vault_resource.go
+++ b/internal/services/dataprotection/data_protection_backup_vault_resource.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
@@ -161,8 +162,8 @@ func resourceDataProtectionBackupVaultRead(d *pluginsdk.ResourceData, meta inter
 		d.Set("location", location.NormalizeNilable(&model.Location))
 		props := model.Properties
 		if props.StorageSettings != nil && len(props.StorageSettings) > 0 {
-			d.Set("datastore_type", (props.StorageSettings)[0].DatastoreType)
-			d.Set("redundancy", (props.StorageSettings)[0].Type)
+			d.Set("datastore_type", string(pointer.From((props.StorageSettings)[0].DatastoreType)))
+			d.Set("redundancy", string(pointer.From((props.StorageSettings)[0].Type)))
 		}
 
 		if err = d.Set("identity", flattenBackupVaultDppIdentityDetails(model.Identity)); err != nil {

--- a/internal/services/datashare/data_share_data_source.go
+++ b/internal/services/datashare/data_share_data_source.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/datashare/2019-11-01/account"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/datashare/2019-11-01/share"
@@ -106,7 +107,7 @@ func dataSourceDataShareRead(d *pluginsdk.ResourceData, meta interface{}) error 
 
 	if model := resp.Model; model != nil {
 		if props := model.Properties; props != nil {
-			d.Set("kind", props.ShareKind)
+			d.Set("kind", string(pointer.From(props.ShareKind)))
 			d.Set("description", props.Description)
 			d.Set("terms", props.Terms)
 		}

--- a/internal/services/datashare/data_share_resource.go
+++ b/internal/services/datashare/data_share_resource.go
@@ -202,7 +202,7 @@ func resourceDataShareRead(d *pluginsdk.ResourceData, meta interface{}) error {
 
 	if model := resp.Model; model != nil {
 		if props := model.Properties; props != nil {
-			d.Set("kind", props.ShareKind)
+			d.Set("kind", string(pointer.From(props.ShareKind)))
 			d.Set("description", props.Description)
 			d.Set("terms", props.Terms)
 		}

--- a/internal/services/devtestlabs/dev_test_lab_data_source.go
+++ b/internal/services/devtestlabs/dev_test_lab_data_source.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
@@ -101,7 +102,7 @@ func dataSourceDevTestLabRead(d *pluginsdk.ResourceData, meta interface{}) error
 		d.Set("location", location.NormalizeNilable(model.Location))
 
 		if props := model.Properties; props != nil {
-			d.Set("storage_type", props.LabStorageType)
+			d.Set("storage_type", string(pointer.From(props.LabStorageType)))
 
 			// Computed fields
 			d.Set("artifacts_storage_account_id", props.ArtifactsStorageAccount)

--- a/internal/services/devtestlabs/dev_test_lab_resource.go
+++ b/internal/services/devtestlabs/dev_test_lab_resource.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/devtestlab/2018-09-15/labs"
@@ -197,7 +198,7 @@ func resourceDevTestLabRead(d *pluginsdk.ResourceData, meta interface{}) error {
 
 		if props := model.Properties; props != nil {
 			if !features.FourPointOhBeta() {
-				d.Set("storage_type", props.LabStorageType)
+				d.Set("storage_type", string(pointer.From(props.LabStorageType)))
 			}
 			// Computed fields
 			d.Set("artifacts_storage_account_id", props.ArtifactsStorageAccount)

--- a/internal/services/devtestlabs/dev_test_lab_schedule_resource.go
+++ b/internal/services/devtestlabs/dev_test_lab_schedule_resource.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/devtestlab/2018-09-15/schedules"
@@ -291,7 +292,7 @@ func resourceDevTestLabSchedulesRead(d *pluginsdk.ResourceData, meta interface{}
 		props := model.Properties
 		d.Set("time_zone_id", props.TimeZoneId)
 		d.Set("task_type", props.TaskType)
-		d.Set("status", props.Status)
+		d.Set("status", string(pointer.From(props.Status)))
 
 		if err := d.Set("weekly_recurrence", flattenAzureRmDevTestLabScheduleRecurrenceWeekly(props.WeeklyRecurrence)); err != nil {
 			return fmt.Errorf("setting `weeklyRecurrence`: %#v", err)

--- a/internal/services/devtestlabs/dev_test_policy_resource.go
+++ b/internal/services/devtestlabs/dev_test_policy_resource.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/devtestlab/2018-09-15/policies"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
@@ -187,7 +188,7 @@ func resourceArmDevTestPolicyRead(d *pluginsdk.ResourceData, meta interface{}) e
 		props := model.Properties
 		d.Set("description", props.Description)
 		d.Set("fact_data", props.FactData)
-		d.Set("evaluator_type", props.EvaluatorType)
+		d.Set("evaluator_type", string(pointer.From(props.EvaluatorType)))
 		d.Set("threshold", props.Threshold)
 
 		if err = tags.FlattenAndSet(d, flattenTags(model.Tags)); err != nil {

--- a/internal/services/eventhub/eventhub_namespace_resource.go
+++ b/internal/services/eventhub/eventhub_namespace_resource.go
@@ -571,10 +571,7 @@ func resourceEventHubNamespaceRead(d *pluginsdk.ResourceData, meta interface{}) 
 				publicNetworkAccess = false
 			}
 			d.Set("public_network_access_enabled", publicNetworkAccess)
-
-			if props.MinimumTlsVersion != nil {
-				d.Set("minimum_tls_version", string(pointer.From(props.MinimumTlsVersion)))
-			}
+			d.Set("minimum_tls_version", string(pointer.From(props.MinimumTlsVersion)))
 		}
 
 		if err := tags.FlattenAndSet(d, model.Tags); err != nil {

--- a/internal/services/eventhub/eventhub_namespace_resource.go
+++ b/internal/services/eventhub/eventhub_namespace_resource.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
@@ -572,7 +573,7 @@ func resourceEventHubNamespaceRead(d *pluginsdk.ResourceData, meta interface{}) 
 			d.Set("public_network_access_enabled", publicNetworkAccess)
 
 			if props.MinimumTlsVersion != nil {
-				d.Set("minimum_tls_version", *props.MinimumTlsVersion)
+				d.Set("minimum_tls_version", string(pointer.From(props.MinimumTlsVersion)))
 			}
 		}
 

--- a/internal/services/iothub/iothub_dps_data_source.go
+++ b/internal/services/iothub/iothub_dps_data_source.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
@@ -87,7 +88,7 @@ func dataSourceIotHubDPSRead(d *pluginsdk.ResourceData, meta interface{}) error 
 		d.Set("service_operations_host_name", props.ServiceOperationsHostName)
 		d.Set("device_provisioning_host_name", props.DeviceProvisioningHostName)
 		d.Set("id_scope", props.IdScope)
-		d.Set("allocation_policy", props.AllocationPolicy)
+		d.Set("allocation_policy", string(pointer.From(props.AllocationPolicy)))
 		d.Set("tags", flattenTags(model.Tags))
 	}
 

--- a/internal/services/keyvault/key_vault_secret_data_source_test.go
+++ b/internal/services/keyvault/key_vault_secret_data_source_test.go
@@ -99,8 +99,9 @@ data "azurerm_key_vault_secret" "test" {
 func (KeyVaultSecretDataSource) specifyOldVersion(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 
+
 data "azurerm_key_vault_secret" "test" {
- name          = "${local.secret_name}"
+  name         = "${local.secret_name}"
   key_vault_id = azurerm_key_vault.test.id
 }
 
@@ -117,6 +118,7 @@ data "azurerm_key_vault_secret" "test2" {
   version      = "${local.old_version}"
   depends_on   = [data.azurerm_key_vault_secret.test]
 }
+
 
 `, data.RandomString, KeyVaultSecretResource{}.basicUpdated(data))
 }

--- a/internal/services/kusto/kusto_cluster_resource.go
+++ b/internal/services/kusto/kusto_cluster_resource.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
@@ -480,8 +481,8 @@ func resourceKustoClusterRead(d *pluginsdk.ResourceData, meta interface{}) error
 			d.Set("language_extensions", flattenKustoClusterLanguageExtensions(props.LanguageExtensions))
 			d.Set("uri", props.Uri)
 			d.Set("data_ingestion_uri", props.DataIngestionUri)
-			d.Set("engine", props.EngineType)
-			d.Set("public_ip_type", props.PublicIPType)
+			d.Set("engine", string(pointer.From(props.EngineType)))
+			d.Set("public_ip_type", string(pointer.From(props.PublicIPType)))
 
 		}
 

--- a/internal/services/kusto/kusto_eventgrid_data_connection_resource.go
+++ b/internal/services/kusto/kusto_eventgrid_data_connection_resource.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
@@ -259,11 +260,11 @@ func resourceKustoEventGridDataConnectionRead(d *pluginsdk.ResourceData, meta in
 			d.Set("eventhub_id", props.EventHubResourceId)
 			d.Set("eventhub_consumer_group_name", props.ConsumerGroup)
 			d.Set("skip_first_record", props.IgnoreFirstRecord)
-			d.Set("blob_storage_event_type", props.BlobStorageEventType)
+			d.Set("blob_storage_event_type", string(pointer.From(props.BlobStorageEventType)))
 			d.Set("table_name", props.TableName)
 			d.Set("mapping_rule_name", props.MappingRuleName)
-			d.Set("data_format", props.DataFormat)
-			d.Set("database_routing_type", props.DatabaseRouting)
+			d.Set("data_format", string(pointer.From(props.DataFormat)))
+			d.Set("database_routing_type", string(pointer.From(props.DatabaseRouting)))
 			d.Set("eventgrid_resource_id", props.EventGridResourceId)
 
 			managedIdentityResourceId := ""

--- a/internal/services/kusto/kusto_eventhub_data_connection_resource.go
+++ b/internal/services/kusto/kusto_eventhub_data_connection_resource.go
@@ -5,7 +5,8 @@ import (
 	"log"
 	"time"
 
-	"github.com/hashicorp/go-azure-helpers/lang/response" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2021-11-01/eventhubs"
@@ -228,9 +229,9 @@ func resourceKustoEventHubDataConnectionRead(d *pluginsdk.ResourceData, meta int
 				d.Set("consumer_group", props.ConsumerGroup)
 				d.Set("table_name", props.TableName)
 				d.Set("mapping_rule_name", props.MappingRuleName)
-				d.Set("data_format", props.DataFormat)
-				d.Set("database_routing_type", props.DatabaseRouting)
-				d.Set("compression", props.Compression)
+				d.Set("data_format", string(pointer.From(props.DataFormat)))
+				d.Set("database_routing_type", string(pointer.From(props.DatabaseRouting)))
+				d.Set("compression", string(pointer.From(props.Compression)))
 				d.Set("event_system_properties", props.EventSystemProperties)
 
 				identityId := ""

--- a/internal/services/kusto/kusto_iothub_data_connection_resource.go
+++ b/internal/services/kusto/kusto_iothub_data_connection_resource.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
@@ -222,8 +223,8 @@ func resourceKustoIotHubDataConnectionRead(d *pluginsdk.ResourceData, meta inter
 				d.Set("consumer_group", props.ConsumerGroup)
 				d.Set("table_name", props.TableName)
 				d.Set("mapping_rule_name", props.MappingRuleName)
-				d.Set("data_format", props.DataFormat)
-				d.Set("database_routing_type", props.DatabaseRouting)
+				d.Set("data_format", string(pointer.From(props.DataFormat)))
+				d.Set("database_routing_type", string(pointer.From(props.DatabaseRouting)))
 				d.Set("shared_access_policy_name", props.SharedAccessPolicyName)
 				d.Set("event_system_properties", utils.FlattenStringSlice(props.EventSystemProperties))
 			}

--- a/internal/services/loadbalancer/nat_rule_resource.go
+++ b/internal/services/loadbalancer/nat_rule_resource.go
@@ -267,7 +267,7 @@ func resourceArmLoadBalancerNatRuleRead(d *pluginsdk.ResourceData, meta interfac
 		d.Set("frontend_ip_configuration_id", frontendIPConfigID)
 
 		if props.BackendAddressPool != nil && props.BackendAddressPool.ID != nil {
-			d.Set("backend_address_pool_id", *props.BackendAddressPool.ID)
+			d.Set("backend_address_pool_id", props.BackendAddressPool.ID)
 		}
 
 		frontendPort := 0

--- a/internal/services/loganalytics/log_analytics_workspace_resource.go
+++ b/internal/services/loganalytics/log_analytics_workspace_resource.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	sharedKeyWorkspaces "github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/workspaces"
@@ -388,7 +389,7 @@ func resourceLogAnalyticsWorkspaceRead(d *pluginsdk.ResourceData, meta interface
 					}
 				}
 				if capacityReservationLevel := sku.CapacityReservationLevel; capacityReservationLevel != nil {
-					d.Set("reservation_capacity_in_gb_per_day", capacityReservationLevel)
+					d.Set("reservation_capacity_in_gb_per_day", int64(pointer.From(capacityReservationLevel)))
 				}
 			}
 			d.Set("sku", skuName)
@@ -410,7 +411,7 @@ func resourceLogAnalyticsWorkspaceRead(d *pluginsdk.ResourceData, meta interface
 				// Special case for "Free" tier
 				d.Set("daily_quota_gb", utils.Float(0.5))
 			case props.WorkspaceCapping != nil && props.WorkspaceCapping.DailyQuotaGb != nil:
-				d.Set("daily_quota_gb", *props.WorkspaceCapping.DailyQuotaGb)
+				d.Set("daily_quota_gb", props.WorkspaceCapping.DailyQuotaGb)
 			default:
 				d.Set("daily_quota_gb", utils.Float(-1))
 			}

--- a/internal/services/logic/integration_service_environment.go
+++ b/internal/services/logic/integration_service_environment.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
@@ -229,7 +230,7 @@ func resourceIntegrationServiceEnvironmentRead(d *pluginsdk.ResourceData, meta i
 		if props := model.Properties; props != nil {
 			if netCfg := props.NetworkConfiguration; netCfg != nil {
 				if accessEndpoint := netCfg.AccessEndpoint; accessEndpoint != nil {
-					d.Set("access_endpoint_type", accessEndpoint.Type)
+					d.Set("access_endpoint_type", string(pointer.From(accessEndpoint.Type)))
 				}
 
 				d.Set("virtual_network_subnet_ids", flattenSubnetResourceID(netCfg.Subnets))

--- a/internal/services/machinelearning/machine_learning_compute_cluster_resource.go
+++ b/internal/services/machinelearning/machine_learning_compute_cluster_resource.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
@@ -266,7 +267,7 @@ func resourceComputeClusterRead(d *pluginsdk.ResourceData, meta interface{}) err
 	d.Set("description", computeCluster.Description)
 	if props := computeCluster.Properties; props != nil {
 		d.Set("vm_size", props.VMSize)
-		d.Set("vm_priority", props.VMPriority)
+		d.Set("vm_priority", string(pointer.From(props.VMPriority)))
 		d.Set("scale_settings", flattenScaleSettings(props.ScaleSettings))
 		d.Set("ssh", flattenUserAccountCredentials(props.UserAccountCredentials))
 		if props.Subnet != nil {

--- a/internal/services/machinelearning/machine_learning_compute_instance_resource.go
+++ b/internal/services/machinelearning/machine_learning_compute_instance_resource.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
@@ -269,7 +270,7 @@ func resourceComputeInstanceRead(d *pluginsdk.ResourceData, meta interface{}) er
 		if props.Properties.Subnet != nil {
 			d.Set("subnet_resource_id", props.Properties.Subnet.Id)
 		}
-		d.Set("authorization_type", props.Properties.ComputeInstanceAuthorizationType)
+		d.Set("authorization_type", string(pointer.From(props.Properties.ComputeInstanceAuthorizationType)))
 		d.Set("ssh", flattenComputeSSHSetting(props.Properties.SshSettings))
 		d.Set("assign_to_user", flattenComputePersonalComputeInstanceSetting(props.Properties.PersonalComputeInstanceSettings))
 	}

--- a/internal/services/machinelearning/machine_learning_inference_cluster_resource.go
+++ b/internal/services/machinelearning/machine_learning_inference_cluster_resource.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
@@ -240,7 +241,11 @@ func resourceAksInferenceClusterRead(d *pluginsdk.ResourceData, meta interface{}
 		return err
 	}
 	d.Set("kubernetes_cluster_id", aksId.ID())
-	d.Set("cluster_purpose", aksComputeProperties.Properties.ClusterPurpose)
+	clusterPurpose := ""
+	if aksComputeProperties.Properties != nil {
+		clusterPurpose = string(pointer.From(aksComputeProperties.Properties.ClusterPurpose))
+	}
+	d.Set("cluster_purpose", clusterPurpose)
 	d.Set("description", aksComputeProperties.Description)
 
 	// Retrieve location

--- a/internal/services/maintenance/maintenance_configuration_data_source.go
+++ b/internal/services/maintenance/maintenance_configuration_data_source.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
@@ -185,8 +186,8 @@ func dataSourceArmMaintenanceConfigurationRead(d *pluginsdk.ResourceData, meta i
 
 	if model := resp.Model; model != nil {
 		if props := model.Properties; props != nil {
-			d.Set("scope", props.MaintenanceScope)
-			d.Set("visibility", props.Visibility)
+			d.Set("scope", string(pointer.From(props.MaintenanceScope)))
+			d.Set("visibility", string(pointer.From(props.Visibility)))
 
 			properties := flattenExtensionProperties(props.ExtensionProperties)
 			if properties["InGuestPatchMode"] != nil {

--- a/internal/services/maintenance/maintenance_configuration_resource.go
+++ b/internal/services/maintenance/maintenance_configuration_resource.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
@@ -320,8 +321,8 @@ func resourceArmMaintenanceConfigurationRead(d *pluginsdk.ResourceData, meta int
 
 	if model := resp.Model; model != nil {
 		if props := model.Properties; props != nil {
-			d.Set("scope", props.MaintenanceScope)
-			d.Set("visibility", props.Visibility)
+			d.Set("scope", string(pointer.From(props.MaintenanceScope)))
+			d.Set("visibility", string(pointer.From(props.Visibility)))
 
 			properties := flattenExtensionProperties(props.ExtensionProperties)
 			if properties["InGuestPatchMode"] != nil {

--- a/internal/services/mariadb/mariadb_server_resource.go
+++ b/internal/services/mariadb/mariadb_server_resource.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
@@ -388,7 +389,7 @@ func resourceMariaDbServerRead(d *pluginsdk.ResourceData, meta interface{}) erro
 
 		if props := model.Properties; props != nil {
 			d.Set("administrator_login", props.AdministratorLogin)
-			d.Set("ssl_minimal_tls_version_enforced", props.MinimalTlsVersion)
+			d.Set("ssl_minimal_tls_version_enforced", string(pointer.From(props.MinimalTlsVersion)))
 
 			publicNetworkAccess := false
 			if props.PublicNetworkAccess != nil {

--- a/internal/services/monitor/migration/smart_detector_alert_rule_migration_v0_to_v1.go
+++ b/internal/services/monitor/migration/smart_detector_alert_rule_migration_v0_to_v1.go
@@ -33,6 +33,9 @@ func (s SmartDetectorAlertRuleV0ToV1) Schema() map[string]*pluginsdk.Schema {
 		"scope_resource_ids": {
 			Type:     pluginsdk.TypeSet,
 			Required: true,
+			Elem: &pluginsdk.Schema{
+				Type: pluginsdk.TypeString,
+			},
 		},
 
 		"severity": {

--- a/internal/services/monitor/monitor_data_collection_rule_resource.go
+++ b/internal/services/monitor/monitor_data_collection_rule_resource.go
@@ -772,6 +772,7 @@ func (r DataCollectionRuleResource) Arguments() map[string]*pluginsdk.Schema {
 											datacollectionrules.PossibleValuesForKnownSyslogDataSourceLogLevels(), false),
 									},
 								},
+								// lintignore:S013
 								"streams": {
 									Type:     pluginsdk.TypeList,
 									Optional: !features.FourPointOhBeta(),

--- a/internal/services/monitor/monitor_scheduled_query_rules_alert_data_source.go
+++ b/internal/services/monitor/monitor_scheduled_query_rules_alert_data_source.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
@@ -202,15 +203,10 @@ func dataSourceMonitorScheduledQueryRulesAlertRead(d *pluginsdk.ResourceData, me
 			d.Set("time_window", schedule.TimeWindowInMinutes)
 		}
 
-		if props.Source.AuthorizedResources != nil {
-			d.Set("authorized_resource_ids", utils.FlattenStringSlice(props.Source.AuthorizedResources))
-		}
+		d.Set("authorized_resource_ids", utils.FlattenStringSlice(props.Source.AuthorizedResources))
 		d.Set("data_source_id", props.Source.DataSourceId)
-
-		if props.Source.Query != nil {
-			d.Set("query", props.Source.Query)
-		}
-		d.Set("query_type", props.Source.QueryType)
+		d.Set("query", props.Source.Query)
+		d.Set("query_type", string(pointer.From(props.Source.QueryType)))
 
 		if err = d.Set("tags", utils.FlattenPtrMapStringString(model.Tags)); err != nil {
 			return err

--- a/internal/services/monitor/monitor_scheduled_query_rules_alert_resource.go
+++ b/internal/services/monitor/monitor_scheduled_query_rules_alert_resource.go
@@ -353,16 +353,10 @@ func resourceMonitorScheduledQueryRulesAlertRead(d *pluginsdk.ResourceData, meta
 			d.Set("time_window", schedule.TimeWindowInMinutes)
 		}
 
-		if props.Source.AuthorizedResources != nil {
-			d.Set("authorized_resource_ids", utils.FlattenStringSlice(props.Source.AuthorizedResources))
-		}
-
+		d.Set("authorized_resource_ids", utils.FlattenStringSlice(props.Source.AuthorizedResources))
 		d.Set("data_source_id", props.Source.DataSourceId)
-
-		if props.Source.Query != nil {
-			d.Set("query", props.Source.Query)
-		}
-		d.Set("query_type", props.Source.QueryType)
+		d.Set("query", props.Source.Query)
+		d.Set("query_type", string(pointer.From(props.Source.QueryType)))
 
 		if err = d.Set("tags", utils.FlattenPtrMapStringString(model.Tags)); err != nil {
 			return err

--- a/internal/services/monitor/monitor_scheduled_query_rules_alert_v2_resource.go
+++ b/internal/services/monitor/monitor_scheduled_query_rules_alert_v2_resource.go
@@ -208,6 +208,7 @@ func (r ScheduledQueryRulesAlertV2Resource) Arguments() map[string]*pluginsdk.Sc
 			},
 		},
 
+		// lintignore:S013
 		"evaluation_frequency": {
 			Type: pluginsdk.TypeString,
 			// this field is required, missing this field will get an error from service

--- a/internal/services/mssql/mssql_virtual_machine_resource.go
+++ b/internal/services/mssql/mssql_virtual_machine_resource.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
@@ -633,7 +634,7 @@ func resourceMsSqlVirtualMachineRead(d *pluginsdk.ResourceData, meta interface{}
 				}
 				if scus := mgmtSettings.SqlConnectivityUpdateSettings; scus != nil {
 					d.Set("sql_connectivity_port", mgmtSettings.SqlConnectivityUpdateSettings.Port)
-					d.Set("sql_connectivity_type", mgmtSettings.SqlConnectivityUpdateSettings.ConnectivityType)
+					d.Set("sql_connectivity_type", string(pointer.From(mgmtSettings.SqlConnectivityUpdateSettings.ConnectivityType)))
 				}
 
 				d.Set("sql_instance", flattenSqlVirtualMachineSQLInstance(mgmtSettings.SqlInstanceSettings))

--- a/internal/services/mysql/mysql_flexible_server_data_source.go
+++ b/internal/services/mysql/mysql_flexible_server_data_source.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
@@ -191,7 +192,7 @@ func dataSourceMysqlFlexibleServerRead(d *pluginsdk.ResourceData, meta interface
 		if props := model.Properties; props != nil {
 			d.Set("administrator_login", props.AdministratorLogin)
 			d.Set("zone", props.AvailabilityZone)
-			d.Set("version", props.Version)
+			d.Set("version", string(pointer.From(props.Version)))
 			d.Set("fqdn", props.FullyQualifiedDomainName)
 
 			if network := props.Network; network != nil {
@@ -216,7 +217,7 @@ func dataSourceMysqlFlexibleServerRead(d *pluginsdk.ResourceData, meta interface
 			if err := d.Set("high_availability", flattenDataSourceFlexibleServerHighAvailability(props.HighAvailability)); err != nil {
 				return fmt.Errorf("setting `high_availability`: %+v", err)
 			}
-			d.Set("replication_role", props.ReplicationRole)
+			d.Set("replication_role", string(pointer.From(props.ReplicationRole)))
 			d.Set("replica_capacity", props.ReplicaCapacity)
 		}
 

--- a/internal/services/mysql/mysql_flexible_server_resource.go
+++ b/internal/services/mysql/mysql_flexible_server_resource.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
@@ -483,7 +484,7 @@ func resourceMysqlFlexibleServerRead(d *pluginsdk.ResourceData, meta interface{}
 		if props := model.Properties; props != nil {
 			d.Set("administrator_login", props.AdministratorLogin)
 			d.Set("zone", props.AvailabilityZone)
-			d.Set("version", props.Version)
+			d.Set("version", string(pointer.From(props.Version)))
 			d.Set("fqdn", props.FullyQualifiedDomainName)
 
 			if network := props.Network; network != nil {
@@ -524,7 +525,7 @@ func resourceMysqlFlexibleServerRead(d *pluginsdk.ResourceData, meta interface{}
 			if err := d.Set("high_availability", flattenFlexibleServerHighAvailability(props.HighAvailability)); err != nil {
 				return fmt.Errorf("setting `high_availability`: %+v", err)
 			}
-			d.Set("replication_role", props.ReplicationRole)
+			d.Set("replication_role", string(pointer.From(props.ReplicationRole)))
 			d.Set("replica_capacity", props.ReplicaCapacity)
 		}
 		sku, err := flattenFlexibleServerSku(model.Sku)

--- a/internal/services/netapp/netapp_volume_data_source.go
+++ b/internal/services/netapp/netapp_volume_data_source.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
@@ -154,9 +155,9 @@ func dataSourceNetAppVolumeRead(d *pluginsdk.ResourceData, meta interface{}) err
 
 		props := model.Properties
 		d.Set("volume_path", props.CreationToken)
-		d.Set("service_level", props.ServiceLevel)
+		d.Set("service_level", string(pointer.From(props.ServiceLevel)))
 		d.Set("subnet_id", props.SubnetId)
-		d.Set("network_features", props.NetworkFeatures)
+		d.Set("network_features", string(pointer.From(props.NetworkFeatures)))
 
 		protocolTypes := make([]string, 0)
 		if prtclTypes := props.ProtocolTypes; prtclTypes != nil {
@@ -164,7 +165,7 @@ func dataSourceNetAppVolumeRead(d *pluginsdk.ResourceData, meta interface{}) err
 		}
 		d.Set("protocols", protocolTypes)
 
-		d.Set("security_style", props.SecurityStyle)
+		d.Set("security_style", string(pointer.From(props.SecurityStyle)))
 
 		d.Set("storage_quota_in_gb", props.UsageThreshold/1073741824)
 		if err := d.Set("mount_ip_addresses", flattenNetAppVolumeMountIPAddresses(props.MountTargets)); err != nil {

--- a/internal/services/netapp/netapp_volume_resource.go
+++ b/internal/services/netapp/netapp_volume_resource.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
@@ -611,11 +612,11 @@ func resourceNetAppVolumeRead(d *pluginsdk.ResourceData, meta interface{}) error
 
 		props := model.Properties
 		d.Set("volume_path", props.CreationToken)
-		d.Set("service_level", props.ServiceLevel)
+		d.Set("service_level", string(pointer.From(props.ServiceLevel)))
 		d.Set("subnet_id", props.SubnetId)
-		d.Set("network_features", props.NetworkFeatures)
+		d.Set("network_features", string(pointer.From(props.NetworkFeatures)))
 		d.Set("protocols", props.ProtocolTypes)
-		d.Set("security_style", props.SecurityStyle)
+		d.Set("security_style", string(pointer.From(props.SecurityStyle)))
 		d.Set("snapshot_directory_visible", props.SnapshotDirectoryVisible)
 		d.Set("throughput_in_mibps", props.ThroughputMibps)
 		d.Set("storage_quota_in_gb", props.UsageThreshold/1073741824)

--- a/internal/services/network/private_endpoint_resource.go
+++ b/internal/services/network/private_endpoint_resource.go
@@ -196,6 +196,7 @@ func resourcePrivateEndpoint() *pluginsdk.Resource {
 							ForceNew:     true,
 							ValidateFunc: validation.StringIsNotEmpty,
 						},
+						// lintignore:S013
 						"member_name": {
 							Type:         pluginsdk.TypeString,
 							Required:     features.FourPointOhBeta(),

--- a/internal/services/notificationhub/notification_hub_namespace_data_source.go
+++ b/internal/services/notificationhub/notification_hub_namespace_data_source.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
@@ -94,7 +95,7 @@ func resourceArmDataSourceNotificationHubNamespaceRead(d *pluginsdk.ResourceData
 
 		if props := model.Properties; props != nil {
 			d.Set("enabled", props.Enabled)
-			d.Set("namespace_type", props.NamespaceType)
+			d.Set("namespace_type", string(pointer.From(props.NamespaceType)))
 			d.Set("servicebus_endpoint", props.ServiceBusEndpoint)
 		}
 

--- a/internal/services/postgres/postgresql_flexible_server_aad_administrator_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_aad_administrator_resource.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2022-12-01/administrators"
@@ -149,7 +150,7 @@ func resourcePostgresqlFlexibleServerAdministratorRead(d *pluginsdk.ResourceData
 		props := model.Properties
 		d.Set("object_id", props.ObjectId)
 		d.Set("principal_name", props.PrincipalName)
-		d.Set("principal_type", props.PrincipalType)
+		d.Set("principal_type", string(pointer.From(props.PrincipalType)))
 		d.Set("tenant_id", props.TenantId)
 	}
 

--- a/internal/services/postgres/postgresql_flexible_server_data_source.go
+++ b/internal/services/postgres/postgresql_flexible_server_data_source.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
@@ -105,7 +106,7 @@ func dataSourceArmPostgresqlFlexibleServerRead(d *pluginsdk.ResourceData, meta i
 
 		if props := model.Properties; props != nil {
 			d.Set("administrator_login", props.AdministratorLogin)
-			d.Set("version", props.Version)
+			d.Set("version", string(pointer.From(props.Version)))
 			d.Set("fqdn", props.FullyQualifiedDomainName)
 
 			if storage := props.Storage; storage != nil && storage.StorageSizeGB != nil {

--- a/internal/services/postgres/postgresql_flexible_server_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_resource.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
@@ -520,7 +521,7 @@ func resourcePostgresqlFlexibleServerRead(d *pluginsdk.ResourceData, meta interf
 		if props := model.Properties; props != nil {
 			d.Set("administrator_login", props.AdministratorLogin) // if pwdEnabled is set to false, then the service does not return the value of AdministratorLogin
 			d.Set("zone", props.AvailabilityZone)
-			d.Set("version", props.Version)
+			d.Set("version", string(pointer.From(props.Version)))
 			d.Set("fqdn", props.FullyQualifiedDomainName)
 
 			// Currently, `replicationRole` is set to `Primary` when `createMode` is `Replica` and `replicationRole` is updated to `None`. Service team confirmed it should be set to `None` for this scenario. See more details from https://github.com/Azure/azure-rest-api-specs/issues/22499

--- a/internal/services/postgres/postgresql_server_data_source.go
+++ b/internal/services/postgres/postgresql_server_data_source.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
@@ -90,7 +91,7 @@ func dataSourcePostgreSqlServerRead(d *pluginsdk.ResourceData, meta interface{})
 
 		if props := model.Properties; props != nil {
 			d.Set("fqdn", props.FullyQualifiedDomainName)
-			d.Set("version", props.Version)
+			d.Set("version", string(pointer.From(props.Version)))
 			d.Set("administrator_login", props.AdministratorLogin)
 		}
 

--- a/internal/services/postgres/postgresql_server_resource.go
+++ b/internal/services/postgres/postgresql_server_resource.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
@@ -728,7 +729,7 @@ func resourcePostgreSQLServerRead(d *pluginsdk.ResourceData, meta interface{}) e
 
 		if props := model.Properties; props != nil {
 			d.Set("administrator_login", props.AdministratorLogin)
-			d.Set("ssl_minimal_tls_version_enforced", props.MinimalTlsVersion)
+			d.Set("ssl_minimal_tls_version_enforced", string(pointer.From(props.MinimalTlsVersion)))
 
 			version := ""
 			if props.Version != nil {

--- a/internal/services/recoveryservices/recovery_services_vault_resource.go
+++ b/internal/services/recoveryservices/recovery_services_vault_resource.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
@@ -614,7 +615,7 @@ func resourceRecoveryServicesVaultRead(d *pluginsdk.ResourceData, meta interface
 	}
 
 	if model.Properties != nil && model.Properties.SecuritySettings != nil && model.Properties.SecuritySettings.ImmutabilitySettings != nil {
-		d.Set("immutability", *model.Properties.SecuritySettings.ImmutabilitySettings.State)
+		d.Set("immutability", string(pointer.From(model.Properties.SecuritySettings.ImmutabilitySettings.State)))
 	}
 
 	if model.Properties != nil && model.Properties.PublicNetworkAccess != nil {
@@ -637,7 +638,7 @@ func resourceRecoveryServicesVaultRead(d *pluginsdk.ResourceData, meta interface
 
 	if storageCfg.Model != nil && storageCfg.Model.Properties != nil {
 		props := storageCfg.Model.Properties
-		d.Set("storage_mode_type", props.StorageModelType)
+		d.Set("storage_mode_type", string(pointer.From(props.StorageModelType)))
 		d.Set("cross_region_restore_enabled", props.CrossRegionRestoreFlag)
 	}
 

--- a/internal/services/sentinel/sentinel_alert_rule_nrt_resource.go
+++ b/internal/services/sentinel/sentinel_alert_rule_nrt_resource.go
@@ -77,6 +77,7 @@ func resourceSentinelAlertRuleNrt() *pluginsdk.Resource {
 				ValidateFunc: validation.StringIsNotEmpty,
 			},
 
+			// lintignore:S013
 			"event_grouping": {
 				Type:     pluginsdk.TypeList,
 				Required: features.FourPointOhBeta(),

--- a/internal/services/sentinel/sentinel_log_analytics_workspace_onboard_resource.go
+++ b/internal/services/sentinel/sentinel_log_analytics_workspace_onboard_resource.go
@@ -62,6 +62,7 @@ func (r LogAnalyticsWorkspaceOnboardResource) Arguments() map[string]*pluginsdk.
 			ValidateFunc:  validation.StringIsNotEmpty,
 		},
 
+		// lintignore:S013
 		"workspace_id": {
 			Type:         pluginsdk.TypeString,
 			Required:     features.FourPointOhBeta(),

--- a/internal/services/servicebus/servicebus_namespace_resource.go
+++ b/internal/services/servicebus/servicebus_namespace_resource.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
@@ -341,7 +342,7 @@ func resourceServiceBusNamespaceRead(d *pluginsdk.ResourceData, meta interface{}
 				d.Set("public_network_access_enabled", publicNetworkAccess)
 
 				if props.MinimumTlsVersion != nil {
-					d.Set("minimum_tls_version", *props.MinimumTlsVersion)
+					d.Set("minimum_tls_version", string(pointer.From(props.MinimumTlsVersion)))
 				}
 
 				d.Set("endpoint", props.ServiceBusEndpoint)

--- a/internal/services/servicebus/servicebus_queue_data_source.go
+++ b/internal/services/servicebus/servicebus_queue_data_source.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourcegroups"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2021-06-01-preview/queues"
@@ -183,7 +184,7 @@ func dataSourceServiceBusQueueRead(d *pluginsdk.ResourceData, meta interface{}) 
 			d.Set("max_delivery_count", props.MaxDeliveryCount)
 			d.Set("requires_duplicate_detection", props.RequiresDuplicateDetection)
 			d.Set("requires_session", props.RequiresSession)
-			d.Set("status", props.Status)
+			d.Set("status", string(pointer.From(props.Status)))
 
 			if apiMaxSizeInMegabytes := props.MaxSizeInMegabytes; apiMaxSizeInMegabytes != nil {
 				maxSizeInMegabytes := int(*apiMaxSizeInMegabytes)

--- a/internal/services/servicebus/servicebus_queue_resource.go
+++ b/internal/services/servicebus/servicebus_queue_resource.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2021-06-01-preview/queues"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2022-01-01-preview/namespaces"
@@ -388,7 +389,7 @@ func resourceServiceBusQueueRead(d *pluginsdk.ResourceData, meta interface{}) er
 			d.Set("max_message_size_in_kilobytes", props.MaxMessageSizeInKilobytes)
 			d.Set("requires_duplicate_detection", props.RequiresDuplicateDetection)
 			d.Set("requires_session", props.RequiresSession)
-			d.Set("status", props.Status)
+			d.Set("status", string(pointer.From(props.Status)))
 
 			if apiMaxSizeInMegabytes := props.MaxSizeInMegabytes; apiMaxSizeInMegabytes != nil {
 				maxSizeInMegabytes := int(*apiMaxSizeInMegabytes)

--- a/internal/services/servicebus/servicebus_subscription_rule_resource.go
+++ b/internal/services/servicebus/servicebus_subscription_rule_resource.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2021-06-01-preview/rules"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2021-06-01-preview/subscriptions"
@@ -282,7 +283,7 @@ func resourceServiceBusSubscriptionRuleRead(d *pluginsdk.ResourceData, meta inte
 
 	if model := resp.Model; model != nil {
 		if props := model.Properties; props != nil {
-			d.Set("filter_type", props.FilterType)
+			d.Set("filter_type", string(pointer.From(props.FilterType)))
 
 			if props.Action != nil {
 				d.Set("action", props.Action.SqlExpression)

--- a/internal/services/signalr/web_pubsub_shared_private_link_resource.go
+++ b/internal/services/signalr/web_pubsub_shared_private_link_resource.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/webpubsub/2023-02-01/webpubsub"
@@ -145,7 +146,7 @@ func resourceWebPubsubSharedPrivateLinkServiceRead(d *pluginsdk.ResourceData, me
 	if model := resp.Model; model != nil {
 		if props := model.Properties; props != nil {
 			d.Set("request_message", props.RequestMessage)
-			d.Set("status", props.Status)
+			d.Set("status", string(pointer.From(props.Status)))
 			d.Set("subresource_name", props.GroupId)
 			d.Set("target_resource_id", props.PrivateLinkResourceId)
 		}

--- a/internal/services/springcloud/migration/gateway_route_config_migration_v0_to_v1.go
+++ b/internal/services/springcloud/migration/gateway_route_config_migration_v0_to_v1.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"log"
 
-	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/springcloud/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
@@ -39,11 +38,9 @@ func (s SpringCloudGatewayRouteConfigV0ToV1) Schema() map[string]*pluginsdk.Sche
 			},
 		},
 
-		// lintignore:S013
 		"protocol": {
 			Type:     pluginsdk.TypeString,
-			Optional: !features.FourPointOh(),
-			Required: features.FourPointOh(),
+			Optional: true,
 		},
 
 		"spring_cloud_app_id": {

--- a/internal/services/springcloud/migration/gateway_route_config_migration_v0_to_v1.go
+++ b/internal/services/springcloud/migration/gateway_route_config_migration_v0_to_v1.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log"
 
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/springcloud/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
@@ -38,9 +39,11 @@ func (s SpringCloudGatewayRouteConfigV0ToV1) Schema() map[string]*pluginsdk.Sche
 			},
 		},
 
+		// lintignore:S013
 		"protocol": {
 			Type:     pluginsdk.TypeString,
-			Required: false,
+			Optional: !features.FourPointOh(),
+			Required: features.FourPointOh(),
 		},
 
 		"spring_cloud_app_id": {

--- a/internal/services/springcloud/spring_cloud_gateway_route_config_resource.go
+++ b/internal/services/springcloud/spring_cloud_gateway_route_config_resource.go
@@ -71,6 +71,7 @@ func resourceSpringCloudGatewayRouteConfig() *pluginsdk.Resource {
 				},
 			},
 
+			// lintignore:S013
 			"protocol": {
 				Type:     pluginsdk.TypeString,
 				Optional: !features.FourPointOh(),


### PR DESCRIPTION
Note: Open PR's won't be correctly accounted for until they are rebased, so may introduce violations to `main` that will need to be corrected post-merge.