### PR TITLE
Add `resource_guid` attribute to private endpoint

### DIFF
--- a/internal/services/network/private_endpoint_resource.go
+++ b/internal/services/network/private_endpoint_resource.go
@@ -651,6 +651,12 @@ func resourcePrivateEndpointRead(d *pluginsdk.ResourceData, meta interface{}) er
 			customNicName = *props.CustomNetworkInterfaceName
 		}
 		d.Set("custom_network_interface_name", customNicName)
+
+		resourceGuid := ""
+		if props.ResourceGuid != nil {
+			resourceGuid = *props.ResourceGuid
+		}
+		d.Set("resource_guid", resourceGuid)
 	}
 
 	privateDnsZoneConfigs := make([]interface{}, 0)

--- a/vendor/github.com/tombuildsstuff/kermit/sdk/network/2022-07-01/network/models.go
+++ b/vendor/github.com/tombuildsstuff/kermit/sdk/network/2022-07-01/network/models.go
@@ -37660,6 +37660,8 @@ type PrivateEndpointProperties struct {
 	IPConfigurations *[]PrivateEndpointIPConfiguration `json:"ipConfigurations,omitempty"`
 	// CustomNetworkInterfaceName - The custom name of the network interface attached to the private endpoint.
 	CustomNetworkInterfaceName *string `json:"customNetworkInterfaceName,omitempty"`
+	// ResourceGUID - The Resource GUID of the private endpoint. Not the same as ID of the private endpoint.
+	ResourceGuid *string `json:"resourceGuid,omitempty"`
 }
 
 // MarshalJSON is the custom marshaler for PrivateEndpointProperties.

--- a/website/docs/r/private_endpoint.html.markdown
+++ b/website/docs/r/private_endpoint.html.markdown
@@ -198,6 +198,8 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `id` - The ID of the Private Endpoint.
 
+* `resource_guid` - The resource GUID of the Private Endpoint.s
+
 * `network_interface` - A `network_interface` block as defined below.
 
 * `custom_dns_configs` - A `custom_dns_configs` block as defined below.

--- a/website/docs/r/private_endpoint.html.markdown
+++ b/website/docs/r/private_endpoint.html.markdown
@@ -198,7 +198,7 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `id` - The ID of the Private Endpoint.
 
-* `resource_guid` - The resource GUID of the Private Endpoint.s
+* `resource_guid` - The resource GUID of the Private Endpoint.
 
 * `network_interface` - A `network_interface` block as defined below.
 


### PR DESCRIPTION
- Attributes for `private_endpoint_resource` were missing `resource_guid`
- This is needed primarily for enabling private endpoint connections for Elastic Search instances
- Fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/17011