### PR TITLE
Add note and example code for `azurerm_app_configuration_feature` resource

### DIFF
--- a/website/docs/r/app_configuration_feature.html.markdown
+++ b/website/docs/r/app_configuration_feature.html.markdown
@@ -11,6 +11,8 @@ description: |-
 
 Manages an Azure App Configuration Feature.
 
+-> **Note:** App Configuration Features are provisioned using a Data Plane API which requires the role `App Configuration Data Owner` on either the App Configuration or a parent scope (such as the Resource Group/Subscription). [More information can be found in the Azure Documentation for App Configuration](https://docs.microsoft.com/azure/azure-app-configuration/concept-enable-rbac#azure-built-in-roles-for-azure-app-configuration). This is similar to providing App Configuration Keys.
+
 ## Example Usage
 
 ```hcl
@@ -23,6 +25,14 @@ resource "azurerm_app_configuration" "appconf" {
   name                = "appConf1"
   resource_group_name = azurerm_resource_group.example.name
   location            = azurerm_resource_group.example.location
+}
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_role_assignment" "appconf_dataowner" {
+  scope                = azurerm_app_configuration.appconf.id
+  role_definition_name = "App Configuration Data Owner"
+  principal_id         = data.azurerm_client_config.current.object_id
 }
 
 resource "azurerm_app_configuration_feature" "test" {


### PR DESCRIPTION
- I noticed that the example implementation of `azurerm_app_configuration_feature` does not work correctly as is.
- The reason it doesn't work correctly is that the `App Configuration Data Owner` role was required, as in the case of `azurerm_app_configuration_key`.
    - [azurerm_app_configuration_key | Resources | hashicorp/azurerm | Terraform Registry](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/app_configuration_key)
- Therefore, I think it is better to add a similar Note and implementation example.