### PR TITLE
`azurerm_backup_policy_vm` - Support for the `days` and `include_last_days` properties

### DIFF
--- a/internal/services/recoveryservices/backup_policy_vm_resource_test.go
+++ b/internal/services/recoveryservices/backup_policy_vm_resource_test.go
@@ -545,6 +545,36 @@ func TestAccBackupProtectionPolicyVM_withCustomRGName(t *testing.T) {
 	})
 }
 
+func TestAccBackupProtectionPolicyVM_basicDays(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_backup_policy_vm", "test")
+	r := BackupProtectionPolicyVMResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.daysBasic(data),
+			Check: acceptance.ComposeAggregateTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccBackupProtectionPolicyVM_completeDays(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_backup_policy_vm", "test")
+	r := BackupProtectionPolicyVMResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.daysComplete(data),
+			Check: acceptance.ComposeAggregateTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (t BackupProtectionPolicyVMResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := protectionpolicies.ParseBackupPolicyID(state.ID)
 	if err != nil {
@@ -903,6 +933,74 @@ resource "azurerm_backup_policy_vm" "test" {
   retention_daily {
     count = 10
   }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r BackupProtectionPolicyVMResource) daysBasic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_backup_policy_vm" "test" {
+  name                = "acctest-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  recovery_vault_name = azurerm_recovery_services_vault.test.name
+
+  backup {
+    frequency = "Daily"
+    time      = "23:00"
+  }
+
+  retention_daily {
+    count = 10
+  }
+
+  retention_monthly {
+    count = 10
+    days  = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+  }
+
+  retention_yearly {
+    count  = 10
+    months = ["January", "July"]
+    days   = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+  }
+
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r BackupProtectionPolicyVMResource) daysComplete(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_backup_policy_vm" "test" {
+  name                = "acctest-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  recovery_vault_name = azurerm_recovery_services_vault.test.name
+
+  backup {
+    frequency = "Daily"
+    time      = "23:00"
+  }
+
+  retention_daily {
+    count = 10
+  }
+
+  retention_monthly {
+    count             = 10
+    days              = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    include_last_days = true
+  }
+
+  retention_yearly {
+    count             = 10
+    months            = ["January", "July"]
+    days              = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    include_last_days = true
+  }
+
 }
 `, r.template(data), data.RandomInteger)
 }

--- a/website/docs/r/backup_policy_vm.html.markdown
+++ b/website/docs/r/backup_policy_vm.html.markdown
@@ -134,9 +134,15 @@ The `retention_monthly` block supports:
 
 * `count` - (Required) The number of monthly backups to keep. Must be between `1` and `9999`
 
-* `weekdays` - (Required) The weekday backups to retain . Must be one of `Sunday`, `Monday`, `Tuesday`, `Wednesday`, `Thursday`, `Friday` or `Saturday`.
+* `weekdays` - (Optional) The weekday backups to retain . Must be one of `Sunday`, `Monday`, `Tuesday`, `Wednesday`, `Thursday`, `Friday` or `Saturday`.
 
-* `weeks` - (Required) The weeks of the month to retain backups of. Must be one of `First`, `Second`, `Third`, `Fourth`, `Last`.
+* `weeks` - (Optional) The weeks of the month to retain backups of. Must be one of `First`, `Second`, `Third`, `Fourth`, `Last`.
+
+* `days` - (Optional) The days of the month to retain backups of. Must be between `1` and `31`.
+
+* `include_last_days` - (Optional) Including the last day of the month, default to `false`.
+
+-> **NOTE:**: Either `weekdays` and `weeks` or `days` and `include_last_days` must be specified.
 
 ---
 
@@ -144,11 +150,17 @@ The `retention_yearly` block supports:
 
 * `count` - (Required) The number of yearly backups to keep. Must be between `1` and `9999`
 
-* `weekdays` - (Required) The weekday backups to retain . Must be one of `Sunday`, `Monday`, `Tuesday`, `Wednesday`, `Thursday`, `Friday` or `Saturday`.
-
-* `weeks` - (Required) The weeks of the month to retain backups of. Must be one of `First`, `Second`, `Third`, `Fourth`, `Last`.
-
 * `months` - (Required) The months of the year to retain backups of. Must be one of `January`, `February`, `March`, `April`, `May`, `June`, `July`, `August`, `September`, `October`, `November` and `December`.
+
+* `weekdays` - (Optional) The weekday backups to retain . Must be one of `Sunday`, `Monday`, `Tuesday`, `Wednesday`, `Thursday`, `Friday` or `Saturday`.
+
+* `weeks` - (Optional) The weeks of the month to retain backups of. Must be one of `First`, `Second`, `Third`, `Fourth`, `Last`.
+
+* `days` - (Optional) The days of the month to retain backups of. Must be between `1` and `31`.
+
+* `include_last_days` - (Optional) Including the last day of the month, default to `false`.
+
+-> **NOTE:**: Either `weekdays` and `weeks` or `days` and `include_last_days` must be specified.
 
 ---
 


### PR DESCRIPTION
 support day based retention config.

Test
---
```
❯ tftest recoveryservices TestAccBackupProtectionPolicyVM
=== RUN   TestAccBackupProtectionPolicyVM_policyTypeDefault
=== PAUSE TestAccBackupProtectionPolicyVM_policyTypeDefault
=== RUN   TestAccBackupProtectionPolicyVM_basicDaily
=== PAUSE TestAccBackupProtectionPolicyVM_basicDaily
=== RUN   TestAccBackupProtectionPolicyVM_withInstantRestoreRetentionRangeUpdate
=== PAUSE TestAccBackupProtectionPolicyVM_withInstantRestoreRetentionRangeUpdate
=== RUN   TestAccBackupProtectionPolicyVM_requiresImport
=== PAUSE TestAccBackupProtectionPolicyVM_requiresImport
=== RUN   TestAccBackupProtectionPolicyVM_basicWeekly
=== PAUSE TestAccBackupProtectionPolicyVM_basicWeekly
=== RUN   TestAccBackupProtectionPolicyVM_completeDaily
=== PAUSE TestAccBackupProtectionPolicyVM_completeDaily
=== RUN   TestAccBackupProtectionPolicyVM_completeWeekly
=== PAUSE TestAccBackupProtectionPolicyVM_completeWeekly
=== RUN   TestAccBackupProtectionPolicyVM_updateDaily
=== PAUSE TestAccBackupProtectionPolicyVM_updateDaily
=== RUN   TestAccBackupProtectionPolicyVM_updateWeekly
=== PAUSE TestAccBackupProtectionPolicyVM_updateWeekly
=== RUN   TestAccBackupProtectionPolicyVM_updateDailyToWeekly
=== PAUSE TestAccBackupProtectionPolicyVM_updateDailyToWeekly
=== RUN   TestAccBackupProtectionPolicyVM_updateWeeklyToDaily
=== PAUSE TestAccBackupProtectionPolicyVM_updateWeeklyToDaily
=== RUN   TestAccBackupProtectionPolicyVM_updateWeeklyToPartial
=== PAUSE TestAccBackupProtectionPolicyVM_updateWeeklyToPartial
=== RUN   TestAccBackupProtectionPolicyVM_basicHourlyV2
=== PAUSE TestAccBackupProtectionPolicyVM_basicHourlyV2
=== RUN   TestAccBackupProtectionPolicyVM_basicDailyV2
=== PAUSE TestAccBackupProtectionPolicyVM_basicDailyV2
=== RUN   TestAccBackupProtectionPolicyVM_withInstantRestoreRetentionRangeUpdateV2
=== PAUSE TestAccBackupProtectionPolicyVM_withInstantRestoreRetentionRangeUpdateV2
=== RUN   TestAccBackupProtectionPolicyVM_basicWeeklyV2
=== PAUSE TestAccBackupProtectionPolicyVM_basicWeeklyV2
=== RUN   TestAccBackupProtectionPolicyVM_completeHourlyV2
=== PAUSE TestAccBackupProtectionPolicyVM_completeHourlyV2
=== RUN   TestAccBackupProtectionPolicyVM_completeDailyV2
=== PAUSE TestAccBackupProtectionPolicyVM_completeDailyV2
=== RUN   TestAccBackupProtectionPolicyVM_completeWeeklyV2
=== PAUSE TestAccBackupProtectionPolicyVM_completeWeeklyV2
=== RUN   TestAccBackupProtectionPolicyVM_updateHourlyV2
=== PAUSE TestAccBackupProtectionPolicyVM_updateHourlyV2
=== RUN   TestAccBackupProtectionPolicyVM_updateDailyV2
=== PAUSE TestAccBackupProtectionPolicyVM_updateDailyV2
=== RUN   TestAccBackupProtectionPolicyVM_updateWeeklyV2
=== PAUSE TestAccBackupProtectionPolicyVM_updateWeeklyV2
=== RUN   TestAccBackupProtectionPolicyVM_updateHourlyAndWeeklyV2
=== PAUSE TestAccBackupProtectionPolicyVM_updateHourlyAndWeeklyV2
=== RUN   TestAccBackupProtectionPolicyVM_updateDailyAndWeeklyV2
=== PAUSE TestAccBackupProtectionPolicyVM_updateDailyAndWeeklyV2
=== RUN   TestAccBackupProtectionPolicyVM_updateWeeklyToPartialV2
=== PAUSE TestAccBackupProtectionPolicyVM_updateWeeklyToPartialV2
=== RUN   TestAccBackupProtectionPolicyVM_withCustomRGName
=== PAUSE TestAccBackupProtectionPolicyVM_withCustomRGName
=== RUN   TestAccBackupProtectionPolicyVM_basicDays
=== PAUSE TestAccBackupProtectionPolicyVM_basicDays
=== RUN   TestAccBackupProtectionPolicyVM_completeDays
=== PAUSE TestAccBackupProtectionPolicyVM_completeDays
=== RUN   TestAccBackupProtectionPolicyVMWorkload_basic
=== PAUSE TestAccBackupProtectionPolicyVMWorkload_basic
=== RUN   TestAccBackupProtectionPolicyVMWorkload_update
=== PAUSE TestAccBackupProtectionPolicyVMWorkload_update
=== CONT  TestAccBackupProtectionPolicyVM_policyTypeDefault
=== CONT  TestAccBackupProtectionPolicyVM_basicWeeklyV2
=== CONT  TestAccBackupProtectionPolicyVM_updateDailyAndWeeklyV2
=== CONT  TestAccBackupProtectionPolicyVM_completeDays
=== CONT  TestAccBackupProtectionPolicyVM_updateHourlyV2
=== CONT  TestAccBackupProtectionPolicyVM_completeDailyV2
=== CONT  TestAccBackupProtectionPolicyVM_completeWeeklyV2
=== CONT  TestAccBackupProtectionPolicyVMWorkload_update
--- PASS: TestAccBackupProtectionPolicyVM_completeDays (541.97s)
=== CONT  TestAccBackupProtectionPolicyVM_withCustomRGName
--- PASS: TestAccBackupProtectionPolicyVM_policyTypeDefault (580.11s)
=== CONT  TestAccBackupProtectionPolicyVM_basicDays
--- PASS: TestAccBackupProtectionPolicyVM_completeDailyV2 (615.26s)
=== CONT  TestAccBackupProtectionPolicyVM_updateWeeklyV2
--- PASS: TestAccBackupProtectionPolicyVM_basicWeeklyV2 (660.94s)
=== CONT  TestAccBackupProtectionPolicyVM_updateHourlyAndWeeklyV2
--- PASS: TestAccBackupProtectionPolicyVM_completeWeeklyV2 (732.57s)
=== CONT  TestAccBackupProtectionPolicyVM_updateDailyV2
--- PASS: TestAccBackupProtectionPolicyVM_updateHourlyV2 (812.59s)
=== CONT  TestAccBackupProtectionPolicyVMWorkload_basic
--- PASS: TestAccBackupProtectionPolicyVMWorkload_update (931.05s)
=== CONT  TestAccBackupProtectionPolicyVM_updateDaily
--- PASS: TestAccBackupProtectionPolicyVM_updateDailyAndWeeklyV2 (987.95s)
=== CONT  TestAccBackupProtectionPolicyVM_updateWeekly
--- PASS: TestAccBackupProtectionPolicyVM_withCustomRGName (572.60s)
=== CONT  TestAccBackupProtectionPolicyVM_completeWeekly
=== NAME  TestAccBackupProtectionPolicyVM_basicDays
    testing_new.go:86: Error running post-test destroy, there may be dangling resources: exit status 1
        
        Error: deleting Vault (Subscription: "85b3dbca-5974-4067-9669-67a141095a76"
        Resource Group Name: "acctestRG-backup-230428102128192589"
        Vault Name: "acctest-230428102128192589"): vaults.VaultsClient#Delete: Failure responding to request: StatusCode=204 -- Original Error: autorest/azure: error response cannot be parsed: {"" '\x00' '\x00'} error: EOF
        
--- FAIL: TestAccBackupProtectionPolicyVM_basicDays (615.31s)
=== CONT  TestAccBackupProtectionPolicyVM_withInstantRestoreRetentionRangeUpdateV2
--- PASS: TestAccBackupProtectionPolicyVM_updateDaily (470.73s)
=== CONT  TestAccBackupProtectionPolicyVM_requiresImport
--- PASS: TestAccBackupProtectionPolicyVMWorkload_basic (609.27s)
=== CONT  TestAccBackupProtectionPolicyVM_withInstantRestoreRetentionRangeUpdate
--- PASS: TestAccBackupProtectionPolicyVM_updateWeeklyV2 (900.37s)
=== CONT  TestAccBackupProtectionPolicyVM_basicHourlyV2
--- PASS: TestAccBackupProtectionPolicyVM_updateWeekly (804.27s)
=== CONT  TestAccBackupProtectionPolicyVM_basicDaily
--- PASS: TestAccBackupProtectionPolicyVM_completeWeekly (682.09s)
=== CONT  TestAccBackupProtectionPolicyVM_updateWeeklyToPartial
--- PASS: TestAccBackupProtectionPolicyVM_updateHourlyAndWeeklyV2 (1135.90s)
=== CONT  TestAccBackupProtectionPolicyVM_updateWeeklyToPartialV2
--- PASS: TestAccBackupProtectionPolicyVM_updateDailyV2 (1064.27s)
=== CONT  TestAccBackupProtectionPolicyVM_updateWeeklyToDaily
--- PASS: TestAccBackupProtectionPolicyVM_requiresImport (576.86s)
=== CONT  TestAccBackupProtectionPolicyVM_basicWeekly
--- PASS: TestAccBackupProtectionPolicyVM_basicHourlyV2 (631.78s)
=== CONT  TestAccBackupProtectionPolicyVM_basicDailyV2
--- PASS: TestAccBackupProtectionPolicyVM_basicDaily (490.43s)
=== CONT  TestAccBackupProtectionPolicyVM_updateDailyToWeekly
--- PASS: TestAccBackupProtectionPolicyVM_withInstantRestoreRetentionRangeUpdateV2 (1145.69s)
=== CONT  TestAccBackupProtectionPolicyVM_completeDaily
--- PASS: TestAccBackupProtectionPolicyVM_withInstantRestoreRetentionRangeUpdate (957.68s)
=== CONT  TestAccBackupProtectionPolicyVM_completeHourlyV2
--- PASS: TestAccBackupProtectionPolicyVM_updateWeeklyToPartialV2 (677.80s)
--- PASS: TestAccBackupProtectionPolicyVM_basicWeekly (641.05s)
--- PASS: TestAccBackupProtectionPolicyVM_updateWeeklyToPartial (828.55s)
--- PASS: TestAccBackupProtectionPolicyVM_basicDailyV2 (497.91s)
--- PASS: TestAccBackupProtectionPolicyVM_updateWeeklyToDaily (898.28s)
--- PASS: TestAccBackupProtectionPolicyVM_completeHourlyV2 (442.40s)
--- PASS: TestAccBackupProtectionPolicyVM_completeDaily (491.31s)
--- PASS: TestAccBackupProtectionPolicyVM_updateDailyToWeekly (669.80s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-azurerm/internal/services/recoveryservices      2952.532s
FAIL
```

rerun the failed one
```
❯ tftest recoveryservices TestAccBackupProtectionPolicyVM_basicDays
=== RUN   TestAccBackupProtectionPolicyVM_basicDays
=== PAUSE TestAccBackupProtectionPolicyVM_basicDays
=== CONT  TestAccBackupProtectionPolicyVM_basicDays
--- PASS: TestAccBackupProtectionPolicyVM_basicDays (612.34s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/recoveryservices      612.385s
```