### PR TITLE
refactor: updating the Compute Tests to use the `VirtualMachinesClient` from `hashicorp/go-azure-sdk` rather than `Azure/azure-sdk-for-go`

### DIFF
--- a/internal/services/compute/client/client.go
+++ b/internal/services/compute/client/client.go
@@ -168,7 +168,9 @@ func NewClient(o *common.ClientOptions) *Client {
 		VMScaleSetExtensionsClient:       &vmScaleSetExtensionsClient,
 		VMScaleSetRollingUpgradesClient:  &vmScaleSetRollingUpgradesClient,
 		VMScaleSetVMsClient:              &vmScaleSetVMsClient,
-		VMClient:                         &vmClient,
 		VMImageClient:                    &vmImageClient,
+
+		// NOTE: use `VirtualMachinesClient` instead
+		VMClient: &vmClient,
 	}
 }

--- a/internal/services/compute/linux_virtual_machine_resource_test.go
+++ b/internal/services/compute/linux_virtual_machine_resource_test.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-11-01/virtualmachines"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/compute/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
@@ -14,17 +14,17 @@ import (
 type LinuxVirtualMachineResource struct{}
 
 func (t LinuxVirtualMachineResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
-	id, err := parse.VirtualMachineID(state.ID)
+	id, err := virtualmachines.ParseVirtualMachineID(state.ID)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := clients.Compute.VMClient.Get(ctx, id.ResourceGroup, id.Name, "")
+	resp, err := clients.Compute.VirtualMachinesClient.Get(ctx, *id, virtualmachines.DefaultGetOperationOptions())
 	if err != nil {
 		return nil, fmt.Errorf("retrieving Compute Linux Virtual Machine %q", id)
 	}
 
-	return utils.Bool(resp.ID != nil), nil
+	return utils.Bool(resp.Model != nil), nil
 }
 
 func (LinuxVirtualMachineResource) templateBase(data acceptance.TestData) string {

--- a/internal/services/compute/windows_virtual_machine_resource_test.go
+++ b/internal/services/compute/windows_virtual_machine_resource_test.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-11-01/virtualmachines"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/compute/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
@@ -14,17 +14,17 @@ import (
 type WindowsVirtualMachineResource struct{}
 
 func (t WindowsVirtualMachineResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
-	id, err := parse.VirtualMachineID(state.ID)
+	id, err := virtualmachines.ParseVirtualMachineID(state.ID)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := clients.Compute.VMClient.Get(ctx, id.ResourceGroup, id.Name, "")
+	resp, err := clients.Compute.VirtualMachinesClient.Get(ctx, *id, virtualmachines.DefaultGetOperationOptions())
 	if err != nil {
-		return nil, fmt.Errorf("retrieving Compute Windows Virtual Machine %q", id)
+		return nil, fmt.Errorf("retrieving Windows %s: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.ID != nil), nil
+	return utils.Bool(resp.Model != nil), nil
 }
 
 func (WindowsVirtualMachineResource) templateBase(data acceptance.TestData) string {


### PR DESCRIPTION
Since both Clients are currently imported, refactoring the tests before moving the resources makes this easier