### PR TITLE
`azurerm_monitor_metric_alert` - fix crash when `dynamic_criteria.0.ignore_data_before` isn't set

### DIFF
--- a/internal/services/monitor/monitor_metric_alert_resource_test.go
+++ b/internal/services/monitor/monitor_metric_alert_resource_test.go
@@ -78,6 +78,21 @@ func TestAccMonitorMetricAlert_complete(t *testing.T) {
 	})
 }
 
+func TestAccMonitorMetricAlert_dynamicCriteria(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_monitor_metric_alert", "test")
+	r := MonitorMetricAlertResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.dynamicCriteria(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccMonitorMetricAlert_basicAndCompleteUpdate(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_monitor_metric_alert", "test")
 	r := MonitorMetricAlertResource{}
@@ -225,6 +240,50 @@ resource "azurerm_monitor_metric_alert" "import" {
   window_size = "PT1H"
 }
 `, r.basic(data))
+}
+
+func (MonitorMetricAlertResource) dynamicCriteria(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "acctestsa1%[3]s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_monitor_metric_alert" "test" {
+  name                = "acctestMetricAlert-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  scopes              = [azurerm_storage_account.test.id]
+
+  dynamic_criteria {
+    metric_namespace  = "Microsoft.Storage/storageAccounts"
+    metric_name       = "Availability"
+    aggregation       = "Minimum"
+    operator          = "GreaterThan"
+    alert_sensitivity = "High"
+
+    dimension {
+      name     = "ApiName"
+      operator = "Include"
+      values   = ["*"]
+    }
+
+    evaluation_total_count   = 4
+    evaluation_failure_count = 1
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }
 
 func (MonitorMetricAlertResource) multiCriteria(data acceptance.TestData) string {
@@ -448,12 +507,10 @@ resource "azurerm_monitor_metric_alert" "test" {
     metric_name      = "CPU Credits Consumed"
     aggregation      = "Average"
 
-    operator                 = "GreaterOrLessThan"
-    alert_sensitivity        = "Medium"
-    skip_metric_validation   = true
-    evaluation_failure_count = 4
-    evaluation_total_count   = 5
-    ignore_data_before       = "2022-03-02T15:04:05Z"
+    operator               = "GreaterOrLessThan"
+    alert_sensitivity      = "Medium"
+    skip_metric_validation = true
+
   }
   window_size              = "PT5M"
   frequency                = "PT5M"

--- a/internal/services/monitor/monitor_metric_alert_resource_test.go
+++ b/internal/services/monitor/monitor_metric_alert_resource_test.go
@@ -510,7 +510,9 @@ resource "azurerm_monitor_metric_alert" "test" {
     operator               = "GreaterOrLessThan"
     alert_sensitivity      = "Medium"
     skip_metric_validation = true
-
+    evaluation_failure_count = 4	
+    evaluation_total_count   = 5	
+    ignore_data_before       = "2022-03-02T15:04:05Z"
   }
   window_size              = "PT5M"
   frequency                = "PT5M"

--- a/internal/services/monitor/monitor_metric_alert_resource_test.go
+++ b/internal/services/monitor/monitor_metric_alert_resource_test.go
@@ -507,11 +507,11 @@ resource "azurerm_monitor_metric_alert" "test" {
     metric_name      = "CPU Credits Consumed"
     aggregation      = "Average"
 
-    operator               = "GreaterOrLessThan"
-    alert_sensitivity      = "Medium"
-    skip_metric_validation = true
-    evaluation_failure_count = 4	
-    evaluation_total_count   = 5	
+    operator                 = "GreaterOrLessThan"
+    alert_sensitivity        = "Medium"
+    skip_metric_validation   = true
+    evaluation_failure_count = 4
+    evaluation_total_count   = 5
     ignore_data_before       = "2022-03-02T15:04:05Z"
   }
   window_size              = "PT5M"


### PR DESCRIPTION
resolves https://github.com/hashicorp/terraform-provider-azurerm/issues/21445

```
TF_ACC=1 go test -v ./internal/services/monitor -parallel 20 -test.run=TestAccMonitorMetricAlert_dyna -timeout 1440m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccMonitorMetricAlert_dynamicCriteria
=== PAUSE TestAccMonitorMetricAlert_dynamicCriteria
=== CONT  TestAccMonitorMetricAlert_dynamicCriteria
--- PASS: TestAccMonitorMetricAlert_dynamicCriteria (389.53s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/monitor       389.579s
```