### PR TITLE
issue template: `Bug Report` issues shouldn't be pre-tagged

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_Report.yml
+++ b/.github/ISSUE_TEMPLATE/Bug_Report.yml
@@ -1,6 +1,5 @@
 name: Bug Report
 description: If something isn't working as expected.
-labels: [bug]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
A number of the issues that come in are pre-tagged as `bug`, when these can be questions or configuration issues too - meaning that the `bug` filter becomes less accurate - so we shouldn't pre-tag these.