### PR TITLE
mark search keys sensitive

### DIFF
--- a/internal/services/cognitive/cognitive_account_resource.go
+++ b/internal/services/cognitive/cognitive_account_resource.go
@@ -268,7 +268,7 @@ func resourceCognitiveAccount() *pluginsdk.Resource {
 				Type:         pluginsdk.TypeString,
 				Optional:     true,
 				ValidateFunc: validation.StringIsNotEmpty,
-				Sensitive: true,
+				Sensitive:    true,
 			},
 
 			"storage": {

--- a/internal/services/cognitive/cognitive_account_resource.go
+++ b/internal/services/cognitive/cognitive_account_resource.go
@@ -268,6 +268,7 @@ func resourceCognitiveAccount() *pluginsdk.Resource {
 				Type:         pluginsdk.TypeString,
 				Optional:     true,
 				ValidateFunc: validation.StringIsNotEmpty,
+				Sensitive: true,
 			},
 
 			"storage": {

--- a/internal/services/search/search_service_resource.go
+++ b/internal/services/search/search_service_resource.go
@@ -84,11 +84,13 @@ func resourceSearchService() *pluginsdk.Resource {
 			"primary_key": {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
+				Sensitive: true,
 			},
 
 			"secondary_key": {
 				Type:     pluginsdk.TypeString,
 				Computed: true,
+				Sensitive: true,
 			},
 
 			"query_keys": {

--- a/internal/services/search/search_service_resource.go
+++ b/internal/services/search/search_service_resource.go
@@ -82,14 +82,14 @@ func resourceSearchService() *pluginsdk.Resource {
 			},
 
 			"primary_key": {
-				Type:     pluginsdk.TypeString,
-				Computed: true,
+				Type:      pluginsdk.TypeString,
+				Computed:  true,
 				Sensitive: true,
 			},
 
 			"secondary_key": {
-				Type:     pluginsdk.TypeString,
-				Computed: true,
+				Type:      pluginsdk.TypeString,
+				Computed:  true,
 				Sensitive: true,
 			},
 


### PR DESCRIPTION
This sets the Search Service `primary_key` and `secondary_key` values as sensitive so they are redacted from console output. Additionally, this marks the Question Answering `custom_question_answering_search_service_key` key as sensitive - this key will likely often be set from the `primary_key` of a terraform-managed Search Service and so it would be redacted, but I think it makes sense to mark the field Sensitive explicitly.