### PR TITLE
d/azurerm_platform_image: fix crash for empty image list

### DIFF
--- a/internal/services/compute/platform_image_data_source.go
+++ b/internal/services/compute/platform_image_data_source.go
@@ -76,8 +76,11 @@ func dataSourcePlatformImageRead(d *pluginsdk.ResourceData, meta interface{}) er
 			return fmt.Errorf("could not find image (location %q / publisher %q / offer %q / sku %q / version % q): %+v", location, publisher, offer, sku, version, err)
 		}
 	} else {
-		// get the latest image
-		// the last value is the latest, apparently.
+		// get the latest image (the last value is the latest, apparently)
+		// list can be empty if user hasn't licensed any matching images
+		if len(*result.Value) == 0 {
+			return fmt.Errorf("no images available to this user (location %q / publisher %q / offer %q / sku %q)", location, publisher, offer, sku)
+		}
 		image = &(*result.Value)[len(*result.Value)-1]
 	}
 

--- a/internal/services/compute/platform_image_data_source.go
+++ b/internal/services/compute/platform_image_data_source.go
@@ -59,7 +59,7 @@ func dataSourcePlatformImageRead(d *pluginsdk.ResourceData, meta interface{}) er
 	sku := d.Get("sku").(string)
 
 	result, err := client.List(ctx, location, publisher, offer, sku, "", utils.Int32(int32(1000)), "name")
-	if err != nil {
+	if err != nil || result.Value == nil {
 		return fmt.Errorf("reading Platform Images: %+v", err)
 	}
 


### PR DESCRIPTION
The `azurerm_platform_image` data source crashes if a valid image spec is given without a version but the user isn't licensed for any matching images. For example,

```
data "azurerm_platform_image" "ubuntu_pro" {
  location  = "australiaeast"
  publisher = "Canonical"
  offer = "ubuntu"
  sku   = "22_04-lts"
}
```
gives
```
│ Error: Request cancelled
│ 
│   with data.azurerm_platform_image.ubuntu_pro,
│   on main.tf line 15, in data "azurerm_platform_image" "ubuntu_pro":
│   15: data "azurerm_platform_image" "ubuntu_pro" {
│ 
│ The plugin.(*GRPCProvider).ReadDataSource request was cancelled.
╵

Stack trace from the terraform-provider-azurerm_v3.52.0_x5 plugin:

panic: runtime error: index out of range [-1]

goroutine 145 [running]:
github.com/hashicorp/terraform-provider-azurerm/internal/services/compute.dataSourcePlatformImageRead(0x0?, {0x6178440?, 0xc002647000?})
	github.com/hashicorp/terraform-provider-azurerm/internal/services/compute/platform_image_data_source.go:81 +0x571
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).read(0x75dcbc0?, {0x75dcbc0?, 0xc000360d80?}, 0xd?, {0x6178440?, 0xc002647000?})
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.24.1/helper/schema/resource.go:712 +0x178
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).ReadDataApply(0xc000d50540, {0x75dcbc0, 0xc000360d80}, 0xc0026fc500, {0x6178440, 0xc002647000})
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.24.1/helper/schema/resource.go:943 +0x145
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ReadDataSource(0xc0004a05e8, {0x75dcbc0?, 0xc000360c60?}, 0xc002a42180)
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.24.1/helper/schema/grpc_provider.go:1179 +0x38f
github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(*server).ReadDataSource(0xc000ac6c80, {0x75dcbc0?, 0xc0003602d0?}, 0xc00015e0a0)
	github.com/hashicorp/terraform-plugin-go@v0.14.3/tfprotov5/tf5server/server.go:658 +0x403
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ReadDataSource_Handler({0x68f7820?, 0xc000ac6c80}, {0x75dcbc0, 0xc0003602d0}, 0xc000f28000, 0x0)
	github.com/hashicorp/terraform-plugin-go@v0.14.3/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:421 +0x170
google.golang.org/grpc.(*Server).processUnaryRPC(0xc00024c000, {0x75ec040, 0xc0017fa4e0}, 0xc00100f200, 0xc00156c600, 0xbad2470, 0x0)
	google.golang.org/grpc@v1.51.0/server.go:1340 +0xd23
google.golang.org/grpc.(*Server).handleStream(0xc00024c000, {0x75ec040, 0xc0017fa4e0}, 0xc00100f200, 0x0)
	google.golang.org/grpc@v1.51.0/server.go:1713 +0xa2f
google.golang.org/grpc.(*Server).serveStreams.func1.2()
	google.golang.org/grpc@v1.51.0/server.go:965 +0x98
created by google.golang.org/grpc.(*Server).serveStreams.func1
	google.golang.org/grpc@v1.51.0/server.go:963 +0x28a

Error: The terraform-provider-azurerm_v3.52.0_x5 plugin crashed!
```
This PR checks for this case and returns a more helpful error message.