### PR TITLE
`azurerm_cdn_endpoint` - Remove the length limit of the `query_string`

### DIFF
--- a/internal/services/cdn/cdn_endpoint_resource_test.go
+++ b/internal/services/cdn/cdn_endpoint_resource_test.go
@@ -305,6 +305,22 @@ func TestAccCdnEndpoint_deliveryRuleOptionalMatchValue(t *testing.T) {
 	})
 }
 
+// Covers https://github.com/hashicorp/terraform-provider-azurerm/issue/21450
+func TestAccCdnEndpoint_longQueryString(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cdn_endpoint", "test")
+	r := CdnEndpointResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.longQueryString(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (r CdnEndpointResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := parse.EndpointID(state.ID)
 	if err != nil {
@@ -1352,4 +1368,92 @@ resource "azurerm_cdn_endpoint" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}
+
+func (r CdnEndpointResource) longQueryString(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "acctesa%[3]s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+data "azurerm_storage_account_sas" "test" {
+  connection_string = azurerm_storage_account.test.primary_connection_string
+  https_only        = true
+
+  resource_types {
+    service   = false
+    container = false
+    object    = true
+  }
+
+  services {
+    blob  = true
+    queue = false
+    table = false
+    file  = false
+  }
+
+  start  = "2023-04-01T00:00:00Z"
+  expiry = "2123-04-01T00:00:00Z"
+
+  permissions {
+    read    = true
+    write   = false
+    delete  = false
+    list    = false
+    add     = false
+    create  = false
+    update  = false
+    process = false
+    tag     = false
+    filter  = false
+  }
+}
+
+resource "azurerm_cdn_profile" "test" {
+  name                = "acctestcdnprof%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "Standard_Microsoft"
+}
+
+resource "azurerm_cdn_endpoint" "test" {
+  name                = "acctestcdnend%[1]d"
+  profile_name        = azurerm_cdn_profile.test.name
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  origin {
+    name      = "acceptanceTestCdnOrigin1"
+    host_name = "www.contoso.com"
+  }
+
+  delivery_rule {
+    name  = "TokenSAS"
+    order = 1
+    query_string_condition {
+      operator         = "Contains"
+      negate_condition = true
+      match_values     = ["sig"]
+    }
+    url_redirect_action {
+      redirect_type = "PermanentRedirect"
+      query_string  = trimprefix(data.azurerm_storage_account_sas.test.sas, "?")
+    }
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomStringOfLength(8))
 }

--- a/internal/services/cdn/validate/cdn.go
+++ b/internal/services/cdn/validate/cdn.go
@@ -34,10 +34,6 @@ func RuleActionUrlRedirectQueryString() pluginsdk.SchemaValidateFunc {
 	return func(i interface{}, s string) ([]string, []error) {
 		querystring := i.(string)
 
-		if len(querystring) > 100 {
-			return nil, []error{fmt.Errorf("the Url Query String's max length is 100")}
-		}
-
 		re := regexp.MustCompile("^[?&]")
 		if re.MatchString(querystring) {
 			return nil, []error{fmt.Errorf("the Url Query String must not start with a question mark or ampersand")}


### PR DESCRIPTION
Fix #21450 

`terraform apply` then can succesfully run for the config provided in above issue, with a minor change as below:

```hcl
resource "azurerm_cdn_endpoint" "cdn_endpoint" {
  #...
  delivery_rule {
    #...
    url_redirect_action {
      #...
      query_string  = trimprefix(data.azurerm_storage_account_sas.example.sas, "?")
    }
  }
  #...
}
```

This is needed to pass the other validation logic for the `query_string`.