### PR TITLE
[Enhancement:] fix code that would cause a `nil` dereference panic

### DIFF
--- a/internal/services/aadb2c/aadb2c_directory_resource.go
+++ b/internal/services/aadb2c/aadb2c_directory_resource.go
@@ -168,6 +168,10 @@ func (r AadB2cDirectoryResource) Create() sdk.ResourceFunc {
 				return fmt.Errorf("checking availability of `domain_name`: %v", err)
 			}
 
+			if availabilityResult.Model == nil {
+				return fmt.Errorf("checking availability of `domain_name`: the response from the API was nil")
+			}
+
 			if availabilityResult.Model.NameAvailable == nil || !*availabilityResult.Model.NameAvailable {
 				reason := "unknown reason"
 				if availabilityResult.Model.Reason != nil {

--- a/internal/services/aadb2c/aadb2c_directory_resource.go
+++ b/internal/services/aadb2c/aadb2c_directory_resource.go
@@ -168,19 +168,17 @@ func (r AadB2cDirectoryResource) Create() sdk.ResourceFunc {
 				return fmt.Errorf("checking availability of `domain_name`: %v", err)
 			}
 
-			if availabilityResult.Model == nil {
-				return fmt.Errorf("checking availability of `domain_name`: the response from the API was nil")
-			}
-
-			if availabilityResult.Model.NameAvailable == nil || !*availabilityResult.Model.NameAvailable {
-				reason := "unknown reason"
-				if availabilityResult.Model.Reason != nil {
-					reason = *availabilityResult.Model.Reason
+			if availabilityResult.Model != nil {
+				if availabilityResult.Model.NameAvailable == nil || !*availabilityResult.Model.NameAvailable {
+					reason := "unknown reason"
+					if availabilityResult.Model.Reason != nil {
+						reason = *availabilityResult.Model.Reason
+					}
+					if availabilityResult.Model.Message != nil {
+						reason = fmt.Sprintf("%s (%s)", reason, *availabilityResult.Model.Message)
+					}
+					return fmt.Errorf("checking availability of `domain_name`: the specified domain %q is unavailable: %s", model.DomainName, reason)
 				}
-				if availabilityResult.Model.Message != nil {
-					reason = fmt.Sprintf("%s (%s)", reason, *availabilityResult.Model.Message)
-				}
-				return fmt.Errorf("checking availability of `domain_name`: the specified domain %q is unavailable: %s", model.DomainName, reason)
 			}
 
 			metadata.Logger.Infof("Creating %s", id)

--- a/internal/services/containers/container_connected_registry_resource.go
+++ b/internal/services/containers/container_connected_registry_resource.go
@@ -407,11 +407,9 @@ func (r ContainerConnectedRegistryResource) Update() sdk.ResourceFunc {
 			if err != nil {
 				return fmt.Errorf("retrieving %s: %+v", id, err)
 			}
-			if existing.Model == nil {
-				return fmt.Errorf("retrieving %s: `model` was nil", id)
-			}
 
-			if props := existing.Model.Properties; props != nil {
+			if existing.Model != nil && existing.Model.Properties != nil {
+				props := existing.Model.Properties
 				if metadata.ResourceData.HasChange("mode") {
 					props.Mode = connectedregistries.ConnectedRegistryMode(state.Mode)
 				}

--- a/internal/services/containers/container_connected_registry_resource.go
+++ b/internal/services/containers/container_connected_registry_resource.go
@@ -407,6 +407,9 @@ func (r ContainerConnectedRegistryResource) Update() sdk.ResourceFunc {
 			if err != nil {
 				return fmt.Errorf("retrieving %s: %+v", id, err)
 			}
+			if existing.Model == nil {
+				return fmt.Errorf("retrieving %s: `model` was nil", id)
+			}
 
 			if props := existing.Model.Properties; props != nil {
 				if metadata.ResourceData.HasChange("mode") {

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -680,7 +680,7 @@ func resourceKubernetesClusterNodePoolUpdate(d *pluginsdk.ResourceData, meta int
 		if err != nil {
 			return fmt.Errorf("retrieving Node Pool %s: %+v", *id, err)
 		}
-		if existingNodePool := existingNodePoolResp.Model; existingNodePool != nil {
+		if existingNodePool := existingNodePoolResp.Model; existingNodePool != nil && existingNodePool.Properties != nil {
 			orchestratorVersion := d.Get("orchestrator_version").(string)
 			currentOrchestratorVersion := ""
 			if v := existingNodePool.Properties.CurrentOrchestratorVersion; v != nil {

--- a/internal/services/loadbalancer/rule_resource.go
+++ b/internal/services/loadbalancer/rule_resource.go
@@ -74,6 +74,10 @@ func resourceArmLoadBalancerRuleCreateUpdate(d *pluginsdk.ResourceData, meta int
 		return fmt.Errorf("failed to retrieve Load Balancer %q (resource group %q) for Rule %q: %+v", id.LoadBalancerName, id.ResourceGroup, id.Name, err)
 	}
 
+	if loadBalancer.LoadBalancerPropertiesFormat == nil {
+		return fmt.Errorf("retrieving Load Balancer %s: `properties` was nil", id)
+	}
+
 	newLbRule, err := expandAzureRmLoadBalancerRule(d, &loadBalancer)
 	if err != nil {
 		return fmt.Errorf("expanding Load Balancer Rule: %+v", err)
@@ -245,6 +249,10 @@ func resourceArmLoadBalancerRuleDelete(d *pluginsdk.ResourceData, meta interface
 		return fmt.Errorf("failed to retrieve Load Balancer %q (resource group %q) for Rule %q: %+v", id.LoadBalancerName, id.ResourceGroup, id.Name, err)
 	}
 
+	if loadBalancer.LoadBalancerPropertiesFormat == nil {
+		return fmt.Errorf("retrieving Load Balancer %q (resource group %q) for Rule %q: `properties` was nil", id.LoadBalancerName, id.ResourceGroup, id.Name)
+	}
+
 	_, index, exists := FindLoadBalancerRuleByName(&loadBalancer, d.Get("name").(string))
 	if !exists {
 		return nil
@@ -297,7 +305,7 @@ func expandAzureRmLoadBalancerRule(d *pluginsdk.ResourceData, lb *network.LoadBa
 	}
 
 	var isGateway bool
-	if lb.Sku != nil && lb.Sku.Name == network.LoadBalancerSkuNameGateway {
+	if lb != nil && lb.Sku != nil && lb.Sku.Name == network.LoadBalancerSkuNameGateway {
 		isGateway = true
 	}
 

--- a/internal/services/postgres/postgresql_flexible_server_configuration_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_configuration_resource.go
@@ -92,7 +92,7 @@ func resourceFlexibleServerConfigurationUpdate(d *pluginsdk.ResourceData, meta i
 		return fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
-	if model := resp.Model; model != nil {
+	if model := resp.Model; model != nil && model.Properties != nil {
 		props := model.Properties
 
 		if isDynamicConfig := props.IsDynamicConfig; isDynamicConfig != nil && !*isDynamicConfig {

--- a/internal/services/redisenterprise/redis_enterprise_database_resource.go
+++ b/internal/services/redisenterprise/redis_enterprise_database_resource.go
@@ -296,7 +296,7 @@ func resourceRedisEnterpriseDatabaseCreate(d *pluginsdk.ResourceData, meta inter
 				return fmt.Errorf("retrieving %s: %+v", *clusterId, err)
 			}
 
-			if strings.Contains(strings.ToLower(string(resp.Model.Sku.Name)), "flash") {
+			if resp.Model != nil && strings.Contains(strings.ToLower(string(resp.Model.Sku.Name)), "flash") {
 				return fmt.Errorf("creating a Redis Enterprise Database with modules in a Redis Enterprise Cluster that has an incompatible Flash SKU type %q - please remove the Redis Enterprise Database modules or change the Redis Enterprise Cluster SKU type %s", string(resp.Model.Sku.Name), id)
 			}
 		}


### PR DESCRIPTION
Hi, i created a tool to detect the vulnerable code lines that may cause plugin crash for nil dereference. The result shows there are  **200+ such kind of problem**. i try to fix some of them in this PR as an example. if this work is valuable to you then i will make an effort to address all of them in my next work.

they are different kinds:
- do not check the API response's Model or property pointer before using it. this kind may take half of the result
- Chaining call fields of a complex struct did not check if the pointer is nil
- not check if pointer is nil before assign to its field