### PR TITLE
`azurerm_container_registry_token_password` - Eliminate callilng `listCredentials`

### DIFF
--- a/internal/services/containers/container_registry_token_password_resource.go
+++ b/internal/services/containers/container_registry_token_password_resource.go
@@ -450,9 +450,6 @@ PasswordGenLoop:
 		}
 
 		registryId := registries.NewRegistryID(id.SubscriptionId, id.ResourceGroupName, id.RegistryName)
-		if err := clients.ContainerRegistryClient_v2021_08_01_preview.Registries.GenerateCredentialsThenPoll(ctx, registryId, param); err != nil {
-			return nil, fmt.Errorf("generating password credential %s: %v", string(*password.Name), err)
-		}
 
 		result, err := clients.ContainerRegistryClient_v2021_08_01_preview.Registries.GenerateCredentials(ctx, registryId, param)
 		if err != nil {

--- a/internal/services/containers/container_registry_token_password_resource.go
+++ b/internal/services/containers/container_registry_token_password_resource.go
@@ -2,6 +2,7 @@ package containers
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -453,14 +454,23 @@ PasswordGenLoop:
 			return nil, fmt.Errorf("generating password credential %s: %v", string(*password.Name), err)
 		}
 
-		res, err := clients.ContainerRegistryClient_v2021_08_01_preview.Registries.ListCredentials(ctx, registryId)
+		result, err := clients.ContainerRegistryClient_v2021_08_01_preview.Registries.GenerateCredentials(ctx, registryId, param)
 		if err != nil {
-			return nil, fmt.Errorf("retrieving credentials for %s: %+v", registryId, err)
+			return nil, fmt.Errorf("generating password credential %s: %v", string(*password.Name), err)
+		}
+
+		if err := result.Poller.PollUntilDone(ctx); err != nil {
+			return nil, fmt.Errorf("polling generation of password credential %s: %v", string(*password.Name), err)
+		}
+
+		var res registries.GenerateCredentialsResult
+		if err := json.NewDecoder(result.HttpResponse.Body).Decode(&res); err != nil {
+			return nil, fmt.Errorf("decoding generated password credentials: %v", err)
 		}
 
 		value := ""
-		if model := res.Model; model != nil {
-			value = *(*res.Model.Passwords)[idx].Value
+		if res.Passwords != nil && len(*res.Passwords) > idx && (*res.Passwords)[idx].Value != nil {
+			value = *(*res.Passwords)[idx].Value
 		}
 
 		genPasswords = append(genPasswords, tokens.TokenPassword{


### PR DESCRIPTION
Fix #21440, fix #21497

## Test

Testing by comment out the `admin_enabled = true` (which is also added in #21315, not sure about the reason) in the `azurerm_container_registry` and check whether the `listCredentials` is called in the mitmproxy:

```shell
$ TF_ACC=1 go test -v -timeout=20h ./internal/services/containers -run=TestAccContainerRegistryTokenPassword_basic
=== RUN   TestAccContainerRegistryTokenPassword_basic
=== PAUSE TestAccContainerRegistryTokenPassword_basic
=== CONT  TestAccContainerRegistryTokenPassword_basic
--- PASS: TestAccContainerRegistryTokenPassword_basic (260.69s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/containers    260.700s
```

While, if I keep the `admin_enabled = true` and try to create a ACR, it wil fail with:

```
<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN""http://www.w3.org/TR/html4/strict.dtd">
<HTML><HEAD><TITLE>Length Required</TITLE>
<META HTTP-EQUIV="Content-Type" Content="text/html; charset=us-ascii"></HEAD>
<BODY><h2>Length Required</h2>
<hr><p>HTTP Error 411. The request must be chunked or have a content length.</p>
</BODY></HTML>
```

But I checked that the TC test cases are all working well, not sure what's going wrong, but probably related to the `go-azure-sdk` request header.