### PR TITLE
Updated `static_ip` attribute for azurerm_container_app_environment

### DIFF
--- a/website/docs/d/container_app_environment.html.markdown
+++ b/website/docs/d/container_app_environment.html.markdown
@@ -58,7 +58,7 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 ~> **NOTE:** This will only be populated for Environments that have `internal_load_balancer_enabled` set to true.
 
-* `static_ip` - The Static IP of the Environment.
+* `static_ip_address` - The Static IP address of the Environment.
 
 ~> **NOTE:** If `internal_load_balancer_enabled` is true, this will be a Private IP in the subnet, otherwise this will be allocated a Public IPv4 address. 
 

--- a/website/docs/r/container_app_environment.html.markdown
+++ b/website/docs/r/container_app_environment.html.markdown
@@ -80,7 +80,7 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 ~> **NOTE:** This property only has a value when `infrastructure_subnet_id` is configured and will be a value within the CIDR of the Subnet.
 
-* `static_ip_address` - The Static IP of the Environment.
+* `static_ip_address` - The Static IP address of the Environment.
 
 ~> **NOTE:** This will be a Public IP unless `internal_load_balancer_enabled` is set to `true`, in which case an IP in the Internal Subnet will be reserved. 
 


### PR DESCRIPTION
**Description**
The data source `azurerm_container_app_environment` had an invalid field `static_ip`. This caused some confusion as the actual property is call `static_ip_address`, similarly to what is defined in the resource type. I've updated the attribute and aligned the description between the resource and data source type documentation.