### PR TITLE
docs: small typo in `cdn_frontdoor_origin_group` resource

### DIFF
--- a/website/docs/r/cdn_frontdoor_origin_group.html.markdown
+++ b/website/docs/r/cdn_frontdoor_origin_group.html.markdown
@@ -83,7 +83,7 @@ A `health_probe` block supports the following:
 
 A `load_balancing` block supports the following:
 
-* `additional_latency_in_milliseconds` - (Optional) Specifies the additional latency in milliseconds for probes to fall into the lowest latency bucket. Possible values are between `0` and `1000` seconds (inclusive). Defaults to `50`.
+* `additional_latency_in_milliseconds` - (Optional) Specifies the additional latency in milliseconds for probes to fall into the lowest latency bucket. Possible values are between `0` and `1000` milliseconds (inclusive). Defaults to `50`.
 
 * `sample_size` - (Optional) Specifies the number of samples to consider for load balancing decisions. Possible values are between `0` and `255` (inclusive). Defaults to `4`.
 


### PR DESCRIPTION
Just noticed this in the docs, so thought I'd submit a PR to fix it :)

Please let me know if I need to provide any more information - still pretty new to submitting PRs.