### PR TITLE
`azurerm_attestation`: skip attest authorize in gov/cn region

### DIFF
--- a/internal/clients/builder.go
+++ b/internal/clients/builder.go
@@ -68,7 +68,7 @@ func Build(ctx context.Context, builder ClientBuilder) (*Client, error) {
 		return nil, fmt.Errorf("unable to build authorizer for Storage API: %+v", err)
 	}
 
-	if _, ok := builder.AuthConfig.Environment.Attestation.ResourceIdentifier(); ok {
+	if _, ok := builder.AuthConfig.Environment.Attestation.Endpoint(); ok {
 		attestationAuth, err = auth.NewAuthorizerFromCredentials(ctx, *builder.AuthConfig, builder.AuthConfig.Environment.Attestation)
 		if err != nil {
 			return nil, fmt.Errorf("unable to build authorizer for Attestation API: %+v", err)


### PR DESCRIPTION
attestation data-plane [not support in gov/cn region](https://azure.microsoft.com/en-us/explore/global-infrastructure/products-by-region/?products=azure-attestation&regions=china-non-regional,china-east,china-east-2,china-east-3,china-north,china-north-2,china-north-3,us-central,us-east,us-east-2,us-north-central,us-south-central,us-west-central,us-west,us-west-2,us-west-3,usgov-non-regional,us-dod-central,us-dod-east,usgov-arizona,usgov-texas,usgov-virginia&rar=true), should skip building authorization for `go-azure-sdk` only build attestation API [in public env](https://github.com/hashicorp/go-azure-sdk/pull/373)

fixes: #21508

```
--- PASS: TestAccAttestationProviderDataSource_basic (188.91s)
--- PASS: TestAccAttestationProvider_basic (185.42s)
--- PASS: TestAccAttestationProvider_requiresImport (218.77s)
--- PASS: TestAccAttestationProvider_completeString (182.00s)
--- PASS: TestAccAttestationProvider_completeFile (186.17s)
--- PASS: TestAccAttestationProvider_WithPolicy (186.13s)
--- PASS: TestAccAttestationProvider_WithPolicyUpdate (170.33s)
--- PASS: TestAccAttestationProvider_update (216.31s)
````