### PR TITLE
[Enhancement:] `azurerm_cosmosdb_account` - update the `default_identity_type` error message for `UserAssignedIdentity`

### DIFF
--- a/internal/services/cosmos/cosmosdb_account_resource.go
+++ b/internal/services/cosmos/cosmosdb_account_resource.go
@@ -243,7 +243,7 @@ func resourceCosmosDbAccount() *pluginsdk.Resource {
 				Optional: true,
 				Computed: true,
 				ValidateFunc: validation.Any(
-					validation.StringMatch(regexp.MustCompile(`^UserAssignedIdentity(.)+$`), "user assigned identities must be in the format of: 'UserAssignedIdentity=/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{userAssignedIdentityName}'"),
+					validation.StringMatch(regexp.MustCompile(`^UserAssignedIdentity(.)+$`), "user assigned identity must be in the format of: 'UserAssignedIdentity=/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{userAssignedIdentityName}'"),
 					validation.StringInSlice([]string{
 						"FirstPartyIdentity",
 						"SystemAssignedIdentity",

--- a/internal/services/cosmos/cosmosdb_account_resource.go
+++ b/internal/services/cosmos/cosmosdb_account_resource.go
@@ -243,7 +243,7 @@ func resourceCosmosDbAccount() *pluginsdk.Resource {
 				Optional: true,
 				Computed: true,
 				ValidateFunc: validation.Any(
-					validation.StringMatch(regexp.MustCompile(`^UserAssignedIdentity(.)+$`), "It may start with `UserAssignedIdentity`"),
+					validation.StringMatch(regexp.MustCompile(`^UserAssignedIdentity(.)+$`), "user assigned identities must be in the format of: 'UserAssignedIdentity=/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{userAssignedIdentityName}'"),
 					validation.StringInSlice([]string{
 						"FirstPartyIdentity",
 						"SystemAssignedIdentity",

--- a/website/docs/r/cosmosdb_account.html.markdown
+++ b/website/docs/r/cosmosdb_account.html.markdown
@@ -66,6 +66,42 @@ resource "azurerm_cosmosdb_account" "db" {
 }
 ```
 
+## User Assigned Identity Example Usage
+
+```hcl
+resource "azurerm_user_assigned_identity" "example" {
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+  name                = "example-resource"
+}
+
+resource "azurerm_cosmosdb_account" "example" {
+  name                  = "example-resource"
+  location              = azurerm_resource_group.example.location
+  resource_group_name   = azurerm_resource_group.example.name
+  default_identity_type = join("=", ["UserAssignedIdentity", azurerm_user_assigned_identity.example.id])
+  offer_type            = "Standard"
+  kind                  = "MongoDB"
+
+  capabilities {
+    name = "EnableMongo"
+  }
+
+  consistency_policy {
+    consistency_level = "Strong"
+  }
+
+  geo_location {
+    location          = "westus"
+    failover_priority = 0
+  }
+
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.example.id]
+  }
+}
+```
 ## Argument Reference
 
 The following arguments are supported:
@@ -88,7 +124,9 @@ The following arguments are supported:
 
 ~> **NOTE:** `create_mode` only works when `backup.type` is `Continuous`.
 
-* `default_identity_type` - (Optional) The default identity for accessing Key Vault. Possible values are `FirstPartyIdentity`, `SystemAssignedIdentity` or start with `UserAssignedIdentity`.
+* `default_identity_type` - (Optional) The default identity for accessing Key Vault. Possible values are `FirstPartyIdentity`, `SystemAssignedIdentity` or `UserAssignedIdentity`.
+
+~> **NOTE:** When `default_identity_type` is set to `UserAssignedIdentity` it must be in the following format: `UserAssignedIdentity=/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{userAssignedIdentityName}`.
 
 * `kind` - (Optional) Specifies the Kind of CosmosDB to create - possible values are `GlobalDocumentDB`, `MongoDB` and `Parse`. Defaults to `GlobalDocumentDB`. Changing this forces a new resource to be created.
 

--- a/website/docs/r/cosmosdb_account.html.markdown
+++ b/website/docs/r/cosmosdb_account.html.markdown
@@ -126,7 +126,7 @@ The following arguments are supported:
 
 * `default_identity_type` - (Optional) The default identity for accessing Key Vault. Possible values are `FirstPartyIdentity`, `SystemAssignedIdentity` or `UserAssignedIdentity`.
 
-~> **NOTE:** When `default_identity_type` is set to `UserAssignedIdentity` it must be in the following format: `UserAssignedIdentity=/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{userAssignedIdentityName}`.
+~> **NOTE:** When `default_identity_type` is a `UserAssignedIdentity` it must include the User Assigned Identity ID in the following format: `UserAssignedIdentity=/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{userAssignedIdentityName}`.
 
 * `kind` - (Optional) Specifies the Kind of CosmosDB to create - possible values are `GlobalDocumentDB`, `MongoDB` and `Parse`. Defaults to `GlobalDocumentDB`. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
The original error message for this filed was confusing and not helpful. I have added an example to the error message of the expected format of the input and also incorporated that into the documentation along with a sample configuration using the `UserAssignedIdentity` as the `default_identity_type`.

**NOTE:** Running the tests against this `PR` is not needed as it is only a `text` and `documentation` update, no code was actually touched in the resource.