### PR TITLE
`azurerm_mysql_flexible_server` - fix `identity`

### DIFF
--- a/website/docs/r/mysql_flexible_server.html.markdown
+++ b/website/docs/r/mysql_flexible_server.html.markdown
@@ -97,6 +97,8 @@ The following arguments are supported:
 
 * `customer_managed_key` - (Optional) A `customer_managed_key` block as defined below.
 
+~> **NOTE:** `identity` is required when `customer_managed_key` is specified.
+
 * `delegated_subnet_id` - (Optional) The ID of the virtual network subnet to create the MySQL Flexible Server. Changing this forces a new MySQL Flexible Server to be created.
 
 * `geo_redundant_backup_enabled` - (Optional) Should geo redundant backup enabled? Defaults to `false`. Changing this forces a new MySQL Flexible Server to be created.
@@ -149,11 +151,9 @@ A `customer_managed_key` block supports the following:
 
 An `identity` block supports the following:
 
-* `type` - (Required) Specifies the type of Managed Service Identity that should be configured on this API Management Service. Should be set to `UserAssigned`, `SystemAssigned, UserAssigned` (to enable both).
+* `type` - (Required) Specifies the type of Managed Service Identity that should be configured on this MySQL Flexible Server. The only possible value is `UserAssigned`.
 
-* `identity_ids` - (Optional) A list of User Assigned Managed Identity IDs to be assigned to this API Management Service. Required if used together with `customer_managed_key` block.
-
-~> **NOTE:** This is required when `type` is set to `UserAssigned` or `SystemAssigned, UserAssigned`.
+* `identity_ids` - (Required) A list of User Assigned Managed Identity IDs to be assigned to this MySQL Flexible Server.
 
 ---
 


### PR DESCRIPTION
Fix #21164
`identity` only supports `UserAssigned` per swagger: https://github.com/Azure/azure-rest-api-specs/blob/4467600952c38cc11eeb1e80e5f09e07065f524e/specification/mysql/resource-manager/Microsoft.DBforMySQL/legacy/stable/2021-05-01/mysql.json#L2608-L2613