### PR TITLE
docs: add max length for `name` to docs `policy_assignment` resources

### DIFF
--- a/website/docs/r/management_group_policy_assignment.html.markdown
+++ b/website/docs/r/management_group_policy_assignment.html.markdown
@@ -52,7 +52,7 @@ The following arguments are supported:
 
 * `management_group_id` - (Required) The ID of the Management Group. Changing this forces a new Policy Assignment to be created.
 
-* `name` - (Required) The name which should be used for this Policy Assignment. Changing this forces a new Policy Assignment to be created.
+* `name` - (Required) The name which should be used for this Policy Assignment. Changing this forces a new Policy Assignment to be created. Cannot exceed 24 characters in length.
 
 * `policy_definition_id` - (Required) The ID of the Policy Definition or Policy Definition Set. Changing this forces a new Policy Assignment to be created.
 

--- a/website/docs/r/resource_group_policy_assignment.html.markdown
+++ b/website/docs/r/resource_group_policy_assignment.html.markdown
@@ -61,7 +61,7 @@ PARAMS
 
 The following arguments are supported:
 
-* `name` - (Required) The name which should be used for this Policy Assignment. Changing this forces a new Policy Assignment to be created.
+* `name` - (Required) The name which should be used for this Policy Assignment. Changing this forces a new Policy Assignment to be created. Cannot exceed 64 characters in length.
 
 * `policy_definition_id` - (Required) The ID of the Policy Definition or Policy Definition Set. Changing this forces a new Policy Assignment to be created.
 

--- a/website/docs/r/resource_policy_assignment.html.markdown
+++ b/website/docs/r/resource_policy_assignment.html.markdown
@@ -49,7 +49,7 @@ resource "azurerm_resource_policy_assignment" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name which should be used for this Policy Assignment. Changing this forces a new Resource Policy Assignment to be created.
+* `name` - (Required) The name which should be used for this Policy Assignment. Changing this forces a new Resource Policy Assignment to be created. Cannot exceed 64 characters in length.
 
 * `policy_definition_id` - (Required) The ID of the Policy Definition or Policy Definition Set. Changing this forces a new Policy Assignment to be created.
 

--- a/website/docs/r/subscription_policy_assignment.html.markdown
+++ b/website/docs/r/subscription_policy_assignment.html.markdown
@@ -47,7 +47,7 @@ resource "azurerm_subscription_policy_assignment" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name which should be used for this Policy Assignment. Changing this forces a new Policy Assignment to be created.
+* `name` - (Required) The name which should be used for this Policy Assignment. Changing this forces a new Policy Assignment to be created. Cannot exceed 64 characters in length.
 
 * `policy_definition_id` - (Required) The ID of the Policy Definition or Policy Definition Set. Changing this forces a new Policy Assignment to be created.
 


### PR DESCRIPTION
The creation of a `policy_assignment` fails if the `name` is too long. I consider it of great help to others to be aware of the maximum length through the documentation. 

Source: https://github.com/Azure/azure-powershell/issues/9464#issuecomment-504171204