### PR TITLE
`azurerm_active_directory_domain_service` - `domain_name` now supports a length of `30`

### DIFF
--- a/internal/services/domainservices/validate/domain_service_name.go
+++ b/internal/services/domainservices/validate/domain_service_name.go
@@ -12,7 +12,7 @@ func DomainServiceName(input interface{}, key string) (warnings []string, errors
 		return
 	}
 
-	p := regexp.MustCompile(`^(([0-9a-zA-Z])|(([0-9a-zA-Z][0-9a-zA-Z-]{0,13}[0-9a-zA-Z])))(\.[0-9a-zA-Z-]+)+$`)
+	p := regexp.MustCompile(`^(([0-9a-zA-Z])|(([0-9a-zA-Z][0-9a-zA-Z-]{0,28}[0-9a-zA-Z])))(\.[0-9a-zA-Z-]+)+$`)
 	if !p.MatchString(v) {
 		errors = append(errors, fmt.Errorf("domain_name must be a valid FQDN and the first element must be 15 or fewer characters"))
 	}

--- a/internal/services/domainservices/validate/domain_service_name_test.go
+++ b/internal/services/domainservices/validate/domain_service_name_test.go
@@ -36,8 +36,8 @@ func TestDomainServiceName(t *testing.T) {
 		},
 
 		{
-			// subdomain longer than 15
-			Input: strings.Repeat("a", 16) + ".com",
+			// subdomain longer than 30
+			Input: strings.Repeat("a", 31) + ".com",
 			Valid: false,
 		},
 
@@ -55,7 +55,7 @@ func TestDomainServiceName(t *testing.T) {
 
 		{
 			// wide length subdomain
-			Input: strings.Repeat("a", 15) + ".com",
+			Input: strings.Repeat("a", 30) + ".com",
 			Valid: true,
 		},
 
@@ -85,7 +85,7 @@ func TestDomainServiceName(t *testing.T) {
 
 		{
 			// wide length subdomain
-			Input: strings.Repeat("a", 14) + ".com",
+			Input: strings.Repeat("a", 29) + ".com",
 			Valid: true,
 		},
 	}


### PR DESCRIPTION
I actually originally contributed the domain_name validation, including lenght, but it turns out even though the [Microsoft documentation](https://learn.microsoft.com/en-us/azure/active-directory-domain-services/tutorial-create-instance) describes a max length of 15 characters in the first element of the domain, it works just fine with longer, and I have found environments now unable to upgrade as they have 20-something characters.

Updated the validation and the tests of the validation.