### PR TITLE
Fix deprecation workflow error for `d/netapp_volume_group_sap_hana`

### DIFF
--- a/internal/services/netapp/netapp_volume_group_sap_hana_data_source.go
+++ b/internal/services/netapp/netapp_volume_group_sap_hana_data_source.go
@@ -256,7 +256,7 @@ func (r NetAppVolumeGroupSapHanaDataSource) Read() sdk.ResourceFunc {
 			resp, err := client.VolumeGroupsGet(ctx, id)
 			if err != nil {
 				if resp.HttpResponse.StatusCode == http.StatusNotFound {
-					return metadata.MarkAsGone(id)
+					return fmt.Errorf("%s was not found", id)
 				}
 				return fmt.Errorf("retrieving %s: %v", id, err)
 			}


### PR DESCRIPTION
See #21564 and #21566

- [x] Fixed the cause of the error
- [ ] Didn't fix the workflow, as it is unsure whether this was a conscious choice.

Failure still showing on PR, but that is because deprecation flow runs against `main` (`pull_request_target` instead of `pull_request`): https://github.com/hashicorp/terraform-provider-azurerm/blob/908eae961c8a105f2ae5192fdd8d3e55c2166921/.github/workflows/gradually-deprecated.yaml#L9 :

Locally ran:
```bash
❯ ./scripts/run-gradually-deprecated.sh
==> Checking for use of gradually deprecated functions...
==> Checking for use of deprecated functions...
```