### PR TITLE
`azurerm_storage_account_customer_managed_key` - Example updated

### DIFF
--- a/website/docs/r/storage_account_customer_managed_key.html.markdown
+++ b/website/docs/r/storage_account_customer_managed_key.html.markdown
@@ -38,7 +38,7 @@ resource "azurerm_key_vault_access_policy" "storage" {
   tenant_id    = data.azurerm_client_config.current.tenant_id
   object_id    = azurerm_storage_account.example.identity.0.principal_id
 
-  key_permissions    = ["Get", "Create", "List", "Restore", "Recover", "UnwrapKey", "WrapKey", "Purge", "Encrypt", "Decrypt", "Sign", "Verify"]
+  key_permissions    = ["Get", "UnwrapKey", "WrapKey"]
   secret_permissions = ["Get"]
 }
 
@@ -47,7 +47,7 @@ resource "azurerm_key_vault_access_policy" "client" {
   tenant_id    = data.azurerm_client_config.current.tenant_id
   object_id    = data.azurerm_client_config.current.object_id
 
-  key_permissions    = ["Get", "Create", "Delete", "List", "Restore", "Recover", "UnwrapKey", "WrapKey", "Purge", "Encrypt", "Decrypt", "Sign", "Verify", "GetRotationPolicy"]
+  key_permissions    = ["Get", "Create", "Delete", "List", "Restore", "Recover", "UnwrapKey", "WrapKey", "Purge", "Encrypt", "Decrypt", "Sign", "Verify", "GetRotationPolicy", "SetRotationPolicy"]
   secret_permissions = ["Get"]
 }
 

--- a/website/docs/r/storage_account_customer_managed_key.html.markdown
+++ b/website/docs/r/storage_account_customer_managed_key.html.markdown
@@ -51,7 +51,23 @@ resource "azurerm_key_vault_access_policy" "client" {
   tenant_id    = data.azurerm_client_config.current.tenant_id
   object_id    = data.azurerm_client_config.current.object_id
 
-  key_permissions    = ["Get", "Create", "Delete", "List", "Restore", "Recover", "UnwrapKey", "WrapKey", "Purge", "Encrypt", "Decrypt", "Sign", "Verify", "GetRotationPolicy", "SetRotationPolicy"]
+  key_permissions    = [
+    "Get",
+    "Create", 
+    "Delete", 
+    "List", 
+    "Restore", 
+    "Recover", 
+    "UnwrapKey", 
+    "WrapKey", 
+    "Purge", 
+    "Encrypt", 
+    "Decrypt", 
+    "Sign", 
+    "Verify", 
+    "GetRotationPolicy", 
+    "SetRotationPolicy"
+  ]
   secret_permissions = ["Get"]
 }
 

--- a/website/docs/r/storage_account_customer_managed_key.html.markdown
+++ b/website/docs/r/storage_account_customer_managed_key.html.markdown
@@ -77,7 +77,14 @@ resource "azurerm_key_vault_key" "example" {
   key_vault_id = azurerm_key_vault.example.id
   key_type     = "RSA"
   key_size     = 2048
-  key_opts     = ["decrypt", "encrypt", "sign", "unwrapKey", "verify", "wrapKey"]
+  key_opts     = [
+    "decrypt",
+    "encrypt",
+    "sign",
+    "unwrapKey",
+    "verify",
+    "wrapKey"
+    ]
 
   depends_on = [
     azurerm_key_vault_access_policy.client,
@@ -101,6 +108,7 @@ resource "azurerm_storage_account" "example" {
     ignore_changes = [
       customer_managed_key
     ]
+  }
 }
 
 resource "azurerm_storage_account_customer_managed_key" "example" {

--- a/website/docs/r/storage_account_customer_managed_key.html.markdown
+++ b/website/docs/r/storage_account_customer_managed_key.html.markdown
@@ -38,7 +38,11 @@ resource "azurerm_key_vault_access_policy" "storage" {
   tenant_id    = data.azurerm_client_config.current.tenant_id
   object_id    = azurerm_storage_account.example.identity.0.principal_id
 
-  key_permissions    = ["Get", "UnwrapKey", "WrapKey"]
+  key_permissions    = [
+    "Get",
+    "UnwrapKey",
+    "WrapKey"
+  ]
   secret_permissions = ["Get"]
 }
 

--- a/website/docs/r/storage_account_customer_managed_key.html.markdown
+++ b/website/docs/r/storage_account_customer_managed_key.html.markdown
@@ -76,6 +76,11 @@ resource "azurerm_storage_account" "example" {
   identity {
     type = "SystemAssigned"
   }
+  
+  lifecycle {
+    ignore_changes = [
+      customer_managed_key
+    ]
 }
 
 resource "azurerm_storage_account_customer_managed_key" "example" {

--- a/website/docs/r/storage_account_customer_managed_key.html.markdown
+++ b/website/docs/r/storage_account_customer_managed_key.html.markdown
@@ -15,7 +15,6 @@ Manages a Customer Managed Key for a Storage Account.
 ## Example Usage
 
 ```hcl
-
 data "azurerm_client_config" "current" {}
 
 resource "azurerm_resource_group" "example" {

--- a/website/docs/r/storage_account_customer_managed_key.html.markdown
+++ b/website/docs/r/storage_account_customer_managed_key.html.markdown
@@ -38,12 +38,12 @@ resource "azurerm_key_vault_access_policy" "storage" {
   tenant_id    = data.azurerm_client_config.current.tenant_id
   object_id    = azurerm_storage_account.example.identity.0.principal_id
 
-  key_permissions    = [
+  secret_permissions = ["Get"]
+  key_permissions = [
     "Get",
     "UnwrapKey",
     "WrapKey"
   ]
-  secret_permissions = ["Get"]
 }
 
 resource "azurerm_key_vault_access_policy" "client" {
@@ -51,24 +51,24 @@ resource "azurerm_key_vault_access_policy" "client" {
   tenant_id    = data.azurerm_client_config.current.tenant_id
   object_id    = data.azurerm_client_config.current.object_id
 
-  key_permissions    = [
+  secret_permissions = ["Get"]
+  key_permissions = [
     "Get",
-    "Create", 
-    "Delete", 
-    "List", 
-    "Restore", 
-    "Recover", 
-    "UnwrapKey", 
-    "WrapKey", 
-    "Purge", 
-    "Encrypt", 
-    "Decrypt", 
-    "Sign", 
-    "Verify", 
-    "GetRotationPolicy", 
+    "Create",
+    "Delete",
+    "List",
+    "Restore",
+    "Recover",
+    "UnwrapKey",
+    "WrapKey",
+    "Purge",
+    "Encrypt",
+    "Decrypt",
+    "Sign",
+    "Verify",
+    "GetRotationPolicy",
     "SetRotationPolicy"
   ]
-  secret_permissions = ["Get"]
 }
 
 
@@ -77,18 +77,18 @@ resource "azurerm_key_vault_key" "example" {
   key_vault_id = azurerm_key_vault.example.id
   key_type     = "RSA"
   key_size     = 2048
-  key_opts     = [
+  key_opts = [
     "decrypt",
     "encrypt",
     "sign",
     "unwrapKey",
     "verify",
     "wrapKey"
-    ]
+  ]
 
   depends_on = [
     azurerm_key_vault_access_policy.client,
-    azurerm_key_vault_access_policy.storage,
+    azurerm_key_vault_access_policy.storage
   ]
 }
 
@@ -103,7 +103,7 @@ resource "azurerm_storage_account" "example" {
   identity {
     type = "SystemAssigned"
   }
-  
+
   lifecycle {
     ignore_changes = [
       customer_managed_key


### PR DESCRIPTION
1. Updating the needed access policies to configure customer managed key for storage accounts.
   - Only `["Get", "UnwrapKey", "WrapKey"]` is needed for the storage accounts managed identity. Least privilege🤘
   - The user/service principal running Terraform also needs `SetRotationPolicy` when setting a rotation policy like done in the example.
2. Added `ignore_changes = [customer_managed_key]` on the `azurerm_storage_account` resource in the example. If not done, when running tf apply the next time, it will try to delete the customer managed key we configure in `azurerm_storage_account_customer_managed_key`.