### PR TITLE
r/legacy_virtual_machine: updating the read function to parse the `disk_id` case-insensitively from the remote API

### DIFF
--- a/internal/services/legacy/virtual_machine_resource.go
+++ b/internal/services/legacy/virtual_machine_resource.go
@@ -1964,7 +1964,7 @@ func resourceVirtualMachineGetManagedDiskInfo(d *pluginsdk.ResourceData, disk *c
 	}
 
 	diskId := *disk.ID
-	id, err := disks.ParseDiskID(diskId)
+	id, err := disks.ParseDiskIDInsensitively(diskId)
 	if err != nil {
 		return nil, fmt.Errorf("parsing Disk ID %q: %+v", diskId, err)
 	}


### PR DESCRIPTION
This resource is feature-frozen however this is a recently introduced bug which should be fixed, fixes #21605