### PR TITLE
Tooling: drop use of the actions-ecosystem/action-add-labels action

### DIFF
--- a/.github/workflows/depscheck.yaml
+++ b/.github/workflows/depscheck.yaml
@@ -25,9 +25,12 @@ jobs:
       - run: make depscheck
       - name: Add waiting-response on fail
         if: failure()
-        uses: actions-ecosystem/action-add-labels@v1
+        uses: actions/github-script@v6
         with:
-          labels: waiting-response
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          number: ${{ github.event.number }}
-          repo: ${{ github.event.repository.full_name }}
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ["waiting-response"]
+            })

--- a/.github/workflows/gencheck.yaml
+++ b/.github/workflows/gencheck.yaml
@@ -28,9 +28,12 @@ jobs:
       - run: make gencheck
       - name: Add waiting-response on fail
         if: failure()
-        uses: actions-ecosystem/action-add-labels@v1
+        uses: actions/github-script@v6
         with:
-          labels: waiting-response
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          number: ${{ github.event.number }}
-          repo: ${{ github.event.repository.full_name }}
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ["waiting-response"]
+            })

--- a/.github/workflows/golint.yaml
+++ b/.github/workflows/golint.yaml
@@ -31,9 +31,12 @@ jobs:
           args: -v ./internal/...
       - name: Add waiting-response on fail
         if: failure()
-        uses: actions-ecosystem/action-add-labels@v1
+        uses: actions/github-script@v6
         with:
-          labels: waiting-response
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          number: ${{ github.event.number }}
-          repo: ${{ github.event.repository.full_name }}
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ["waiting-response"]
+            })

--- a/.github/workflows/gradually-deprecated.yaml
+++ b/.github/workflows/gradually-deprecated.yaml
@@ -10,8 +10,8 @@ on:
     types: ['opened', 'synchronize']
     paths:
       - '.github/workflows/gradually-deprecated.yaml'
-      - '**.go'
       - './scripts/run-gradually-deprecated.sh'
+      - '**.go'
 
 jobs:
   test:
@@ -26,9 +26,12 @@ jobs:
       - run: bash ./scripts/run-gradually-deprecated.sh
       - name: Add waiting-response on fail
         if: failure()
-        uses: actions-ecosystem/action-add-labels@v1
+        uses: actions/github-script@v6
         with:
-          labels: waiting-response
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          number: ${{ github.event.number }}
-          repo: ${{ github.event.repository.full_name }}
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ["waiting-response"]
+            })

--- a/.github/workflows/provider-test.yaml
+++ b/.github/workflows/provider-test.yaml
@@ -69,11 +69,12 @@ jobs:
 
       - name: Add waiting-response on fail
         if: failure()
-        uses: actions-ecosystem/action-add-labels@v1
+        uses: actions/github-script@v6
         with:
-          labels: waiting-response
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          number: ${{ github.event.number }}
-          repo: ${{ github.event.repository.full_name }}
-
-# vim: set ts=2 sts=2 sw=2 et:
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ["waiting-response"]
+            })

--- a/.github/workflows/tflint.yaml
+++ b/.github/workflows/tflint.yaml
@@ -30,9 +30,12 @@ jobs:
       - run: make tflint
       - name: Add waiting-response on fail
         if: failure()
-        uses: actions-ecosystem/action-add-labels@v1
+        uses: actions/github-script@v6
         with:
-          labels: waiting-response
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          number: ${{ github.event.number }}
-          repo: ${{ github.event.repository.full_name }}
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ["waiting-response"]
+            })

--- a/.github/workflows/thirty-two-bit.yaml
+++ b/.github/workflows/thirty-two-bit.yaml
@@ -29,9 +29,12 @@ jobs:
       - run: GOARCH=386 GOOS=linux go build -o 32bitbuild .
       - name: Add waiting-response on fail
         if: failure()
-        uses: actions-ecosystem/action-add-labels@v1
+        uses: actions/github-script@v6
         with:
-          labels: waiting-response
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          number: ${{ github.event.number }}
-          repo: ${{ github.event.repository.full_name }}
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ["waiting-response"]
+            })

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -31,9 +31,12 @@ jobs:
           GITHUB_ACTIONS_STAGE: "UNIT_TESTS"
       - name: Add waiting-response on fail
         if: failure()
-        uses: actions-ecosystem/action-add-labels@v1
+        uses: actions/github-script@v6
         with:
-          labels: waiting-response
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          number: ${{ github.event.number }}
-          repo: ${{ github.event.repository.full_name }}
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ["waiting-response"]
+            })

--- a/.github/workflows/validate-examples.yaml
+++ b/.github/workflows/validate-examples.yaml
@@ -29,9 +29,12 @@ jobs:
       - run: make validate-examples
       - name: Add waiting-response on fail
         if: failure()
-        uses: actions-ecosystem/action-add-labels@v1
+        uses: actions/github-script@v6
         with:
-          labels: waiting-response
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          number: ${{ github.event.number }}
-          repo: ${{ github.event.repository.full_name }}
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ["waiting-response"]
+            })

--- a/.github/workflows/website-lint.yaml
+++ b/.github/workflows/website-lint.yaml
@@ -25,9 +25,12 @@ jobs:
       - run: make website-lint
       - name: Add waiting-response on fail
         if: failure()
-        uses: actions-ecosystem/action-add-labels@v1
+        uses: actions/github-script@v6
         with:
-          labels: waiting-response
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          number: ${{ github.event.number }}
-          repo: ${{ github.event.repository.full_name }}
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ["waiting-response"]
+            })


### PR DESCRIPTION
Drop this upstream action due to maintenance concerns, use GitHub script instead

Tested in https://github.com/manicminer/terraform-provider-azurerm/pull/3:

<img width="664" alt="Screenshot 2023-04-28 at 17 32 28" src="https://user-images.githubusercontent.com/251987/235203715-8ca7766c-ca89-414a-8c0c-4331c6f38ae6.png">
