### PR TITLE
storage account docs - updated note for `nfsv3_enabled` argument

### DIFF
--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -124,7 +124,7 @@ The following arguments are supported:
 
 * `nfsv3_enabled` - (Optional) Is NFSv3 protocol enabled? Changing this forces a new resource to be created. Defaults to `false`.
 
--> **NOTE:** This can only be `true` when `account_tier` is `Standard` and `account_kind` is `StorageV2`, or `account_tier` is `Premium` and `account_kind` is `BlockBlobStorage`. Additionally, the `is_hns_enabled` is `true`.
+-> **NOTE:** This can only be `true` when `account_tier` is `Standard` and `account_kind` is `StorageV2`, or `account_tier` is `Premium` and `account_kind` is `BlockBlobStorage`. Additionally, the `is_hns_enabled` is `true` and `account_replication_type` must be `LRS` or `RAGRS`.
 
 * `custom_domain` - (Optional) A `custom_domain` block as documented below.
 


### PR DESCRIPTION
Updated the note for the requirements of the `nfsv3_enabled` argument in the azure storage account docs. Choosing `GRS`, `ZRS`, `GZRS` or `RAGZRS` for the `account_replication_type` argument causes an error while applying changes. The error takes one of the following forms depending on the value chosen: │ Error: creating Azure Storage Account ... : Failure sending request: StatusCode=400 -- Original Error: Code="InvalidRequestPropertyValue" Message="The value 'True' is not allowed for property isNfsv3Enabled." │ Error: reading share properties for AzureRM Storage Account ... : Failure responding to request: StatusCode=404 -- Original Error: autorest/azure: Service returned an error. Status=404 Code="ResourceNotFound" Message="The specified resource does not exist.\n ... " Only `LRS` and `RAGRS` are valid values.