### PR TITLE
`azurerm_monitor_metric_alert` - fix using `SingleResourceMultiMetricCriteria` for new metric alerts regression

### DIFF
--- a/internal/services/monitor/monitor_metric_alert_resource.go
+++ b/internal/services/monitor/monitor_metric_alert_resource.go
@@ -430,7 +430,7 @@ func resourceMonitorMetricAlertCreateUpdate(d *pluginsdk.ResourceData, meta inte
 		if existing.Model == nil || existing.Model.Properties.Criteria == nil {
 			return fmt.Errorf("unexpected nil properties of Monitor %s", id)
 		}
-		_, isLegacy = existing.Model.Properties.Criteria.(metricalerts.MetricAlertMultipleResourceMultipleMetricCriteria)
+		_, isLegacy = existing.Model.Properties.Criteria.(metricalerts.MetricAlertSingleResourceMultipleMetricCriteria)
 
 	}
 


### PR DESCRIPTION
resolves https://github.com/hashicorp/terraform-provider-azurerm/issues/21589
regression was introduced in https://github.com/hashicorp/terraform-provider-azurerm/pull/21392/files#diff-3bc8e0195dad4eb2f1b96e12773a17f667f2c171b427beaa0a213841c80b0765L435
fix the regression that misuse `MultipleResourceMultipleMetricCriteria` for legacy metric alerts and `SingleResourceMultipleMetricCriteria` for new metric alerts.
related to https://github.com/hashicorp/terraform-provider-azurerm/pull/7995

