### PR TITLE
`Sentinel`: fix acctests

### DIFF
--- a/internal/services/sentinel/sentinel_alert_rule_nrt_resource_test.go
+++ b/internal/services/sentinel/sentinel_alert_rule_nrt_resource_test.go
@@ -270,7 +270,7 @@ func (r SentinelAlertRuleNrtResource) alertRuleTemplateGuid(data acceptance.Test
 %s
 
 data "azurerm_sentinel_alert_rule_template" "test" {
-  display_name               = "NRT Base64 encoded Windows process command-lines"
+  display_name               = "NRT Base64 Encoded Windows Process Command-lines"
   log_analytics_workspace_id = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
 }
 

--- a/internal/services/sentinel/sentinel_alert_rule_template_data_source_test.go
+++ b/internal/services/sentinel/sentinel_alert_rule_template_data_source_test.go
@@ -81,7 +81,7 @@ func TestAccSentinelAlertRuleTemplateDataSource_nrt(t *testing.T) {
 
 	data.DataSourceTest(t, []acceptance.TestStep{
 		{
-			Config: r.byDisplayName(data, "NRT Base64 encoded Windows process command-lines"),
+			Config: r.byDisplayName(data, "NRT Base64 Encoded Windows Process Command-lines"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("id").Exists(),
 				check.That(data.ResourceName).Key("display_name").Exists(),


### PR DESCRIPTION
test
---
```
❯ tftest sentinel TestAccSentinelAlertRuleNrt_withAlertRuleTemplateGuid
=== RUN   TestAccSentinelAlertRuleNrt_withAlertRuleTemplateGuid
=== PAUSE TestAccSentinelAlertRuleNrt_withAlertRuleTemplateGuid
=== CONT  TestAccSentinelAlertRuleNrt_withAlertRuleTemplateGuid
--- PASS: TestAccSentinelAlertRuleNrt_withAlertRuleTemplateGuid (328.06s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/sentinel      328.121s
```
```
❯ tftest sentinel TestAccSentinelAlertRuleTemplateDataSource_nrt
=== RUN   TestAccSentinelAlertRuleTemplateDataSource_nrt
=== PAUSE TestAccSentinelAlertRuleTemplateDataSource_nrt
=== CONT  TestAccSentinelAlertRuleTemplateDataSource_nrt
--- PASS: TestAccSentinelAlertRuleTemplateDataSource_nrt (304.25s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/sentinel      304.300s
```