### PR TITLE
`azurerm_site_recovery_replication_recovery_plan`: support `azure_to_azure_settings`

### DIFF
--- a/internal/services/recoveryservices/site_recovery_replication_recovery_plan_resource.go
+++ b/internal/services/recoveryservices/site_recovery_replication_recovery_plan_resource.go
@@ -623,9 +623,7 @@ func flattenRecoveryPlanActions(input *[]replicationrecoveryplans.RecoveryPlanAc
 func flattenRecoveryPlanProviderSpecficInput(input *[]replicationrecoveryplans.RecoveryPlanProviderSpecificDetails) []ReplicationRecoveryPlanA2ASpecificInputModel {
 	output := make([]ReplicationRecoveryPlanA2ASpecificInputModel, 0)
 	for _, providerSpecificInput := range *input {
-		switch providerSpecificInput.(type) {
-		case replicationrecoveryplans.RecoveryPlanA2AInput:
-			a2aInput := providerSpecificInput.(replicationrecoveryplans.RecoveryPlanA2AInput)
+		if a2aInput, ok := providerSpecificInput.(replicationrecoveryplans.RecoveryPlanA2ADetails); ok {
 			o := ReplicationRecoveryPlanA2ASpecificInputModel{
 				PrimaryZone:      pointer.From(a2aInput.PrimaryZone),
 				RecoveryZone:     pointer.From(a2aInput.RecoveryZone),

--- a/internal/services/recoveryservices/site_recovery_replication_recovery_plan_resource_test.go
+++ b/internal/services/recoveryservices/site_recovery_replication_recovery_plan_resource_test.go
@@ -61,6 +61,21 @@ func TestAccSiteRecoveryReplicationRecoveryPlan_withPostActions(t *testing.T) {
 	})
 }
 
+func TestAccSiteRecoveryReplicationRecoveryPlan_withZones(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_site_recovery_replication_recovery_plan", "test")
+	r := SiteRecoveryReplicationRecoveryPlan{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.withZones(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (SiteRecoveryReplicationRecoveryPlan) template(data acceptance.TestData) string {
 	tags := ""
 	if strings.HasPrefix(strings.ToLower(data.Client().SubscriptionID), "85b3dbca") {
@@ -376,6 +391,37 @@ resource "azurerm_site_recovery_replication_recovery_plan" "test" {
 }
 `, r.template(data), data.RandomInteger)
 
+}
+
+func (r SiteRecoveryReplicationRecoveryPlan) withZones(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_site_recovery_replication_recovery_plan" "test" {
+  name                      = "acctest-%[2]d"
+  recovery_vault_id         = azurerm_recovery_services_vault.test.id
+  source_recovery_fabric_id = azurerm_site_recovery_fabric.test1.id
+  target_recovery_fabric_id = azurerm_site_recovery_fabric.test2.id
+
+  recovery_group {
+    type                       = "Boot"
+    replicated_protected_items = [azurerm_site_recovery_replicated_vm.test.id]
+  }
+
+  recovery_group {
+    type = "Failover"
+  }
+
+  recovery_group {
+    type = "Shutdown"
+  }
+
+  azure_to_azure_settings {
+    primary_zone  = "1"
+    recovery_zone = "2"
+  }
+}
+`, r.template(data), data.RandomInteger)
 }
 
 func (r SiteRecoveryReplicationRecoveryPlan) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {

--- a/website/docs/r/site_recovery_replication_recovery_plan.html.markdown
+++ b/website/docs/r/site_recovery_replication_recovery_plan.html.markdown
@@ -3,12 +3,12 @@ subcategory: "Recovery Services"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_site_recovery_replication_recovery_plan"
 description: |-
-    Manages an Azure Site Recovery Plan within a Recovery Services vault.
+    Manages an Site Recovery Replication Recovery Plan within a Recovery Services vault.
 ---
 
 # azurerm_site_recovery_replication_recovery_plan
 
-Manages an Azure Site Recovery Plan within a Recovery Services vault. A recovery plan gathers machines into recovery groups for the purpose of failover.
+Manages an Site Recovery Replication Recovery Plan within a Recovery Services vault. A recovery plan gathers machines into recovery groups for the purpose of failover.
 
 ## Example Usage
 
@@ -78,13 +78,15 @@ The following arguments are supported:
 
 * `target_recovery_fabric_id` - (Required) ID of target fabric to recover. Changing this forces a new Replication Plan to be created.
 
-* `recovery_group` - (Optional) Three or more `recovery_group` block.
+* `recovery_group` - (Optional) Three or more `recovery_group` block defined as below.
+
+* `azure_to_azure_settings` - (Optional) An `azure_to_azure_settings` block defined as block.
 
 ---
 
 A `recovery_group` block supports the following:
 
-*  `type` - (Required) The Recovery Plan Group Type. Possible values are `Boot`, `Failover` and `Shutdown`.
+* `type` - (Required) The Recovery Plan Group Type. Possible values are `Boot`, `Failover` and `Shutdown`.
 
 * `replicated_protected_items` - (Optional) (required) one or more id of protected VM.
 
@@ -120,6 +122,21 @@ An `action` block supports the following:
 
 -> **NOTE:** This property is required when `type` is set to `ScriptActionDetails`.
 
+---
+
+An `azure_to_azure_settings` block supports the following:
+
+* `primary_zone` - (Optional) The Availability Zone in which the VM is located. Changing this forces a new Site Recovery Replication Recovery Plan to be created.
+
+* `recovery_zone` - (Optional) The Availability Zone in which the VM is recovered. Changing this forces a new Site Recovery Replication Recovery Plan to be created.
+
+-> **Note:** `primary_zone` and `recovery_zone` must be specified together.
+
+* `primary_edge_zone` - (Optional) The Edge Zone within the Azure Region where the VM exists. Changing this forces a new Site Recovery Replication Recovery Plan to be created.
+
+* `recovery_edge_zone` - (Optional) The Edge Zone within the Azure Region where the VM is recovered. Changing this forces a new Site Recovery Replication Recovery Plan to be created.
+
+-> **Note:** `primary_edge_zone` and `recovery_edge_zone` must be specified together.
 
 ## Attributes Reference
 

--- a/website/docs/r/site_recovery_replication_recovery_plan.html.markdown
+++ b/website/docs/r/site_recovery_replication_recovery_plan.html.markdown
@@ -3,12 +3,12 @@ subcategory: "Recovery Services"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_site_recovery_replication_recovery_plan"
 description: |-
-    Manages an Site Recovery Replication Recovery Plan within a Recovery Services vault.
+    Manages a Site Recovery Replication Recovery Plan within a Recovery Services vault.
 ---
 
 # azurerm_site_recovery_replication_recovery_plan
 
-Manages an Site Recovery Replication Recovery Plan within a Recovery Services vault. A recovery plan gathers machines into recovery groups for the purpose of failover.
+Manages a Site Recovery Replication Recovery Plan within a Recovery Services vault. A recovery plan gathers machines into recovery groups for the purpose of failover.
 
 ## Example Usage
 


### PR DESCRIPTION
fix #21584

test
---
```
tftest recoveryservices TestAccSiteRecoveryReplicationRecoveryPlan          
=== RUN   TestAccSiteRecoveryReplicationRecoveryPlan_basic
=== PAUSE TestAccSiteRecoveryReplicationRecoveryPlan_basic
=== RUN   TestAccSiteRecoveryReplicationRecoveryPlan_withPreActions
=== PAUSE TestAccSiteRecoveryReplicationRecoveryPlan_withPreActions
=== RUN   TestAccSiteRecoveryReplicationRecoveryPlan_withPostActions
=== PAUSE TestAccSiteRecoveryReplicationRecoveryPlan_withPostActions
=== RUN   TestAccSiteRecoveryReplicationRecoveryPlan_withZones
=== PAUSE TestAccSiteRecoveryReplicationRecoveryPlan_withZones
=== CONT  TestAccSiteRecoveryReplicationRecoveryPlan_basic
=== CONT  TestAccSiteRecoveryReplicationRecoveryPlan_withPreActions
=== CONT  TestAccSiteRecoveryReplicationRecoveryPlan_withZones
=== CONT  TestAccSiteRecoveryReplicationRecoveryPlan_withPostActions
--- PASS: TestAccSiteRecoveryReplicationRecoveryPlan_withPreActions (2968.79s)
--- PASS: TestAccSiteRecoveryReplicationRecoveryPlan_basic (3000.41s)
--- PASS: TestAccSiteRecoveryReplicationRecoveryPlan_withPostActions (3096.27s)
--- PASS: TestAccSiteRecoveryReplicationRecoveryPlan_withZones (3352.37s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/recoveryservices      3352.441s
```