### PR TITLE
`azurerm_key_vault`: set `createMode` as `default` in create instead of null

### DIFF
--- a/internal/services/keyvault/key_vault_resource.go
+++ b/internal/services/keyvault/key_vault_resource.go
@@ -333,6 +333,7 @@ func resourceKeyVaultCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 		parameters.Properties.SoftDeleteRetentionInDays = pointer.To(int64(v.(int)))
 	}
 
+	parameters.Properties.CreateMode = pointer.To(vaults.CreateModeDefault)
 	if recoverSoftDeletedKeyVault {
 		parameters.Properties.CreateMode = pointer.To(vaults.CreateModeRecover)
 	}


### PR DESCRIPTION
always set createMode when creating a keyvault instance. resolves: #21334

```
--- PASS: TestAccKeyVault_basic (401.95s)
PASS
```