### PR TITLE
azurerm_resources - Add resource group to output of individual resources.

### DIFF
--- a/internal/services/resource/resources_data_source.go
+++ b/internal/services/resource/resources_data_source.go
@@ -3,7 +3,6 @@ package resource
 import (
 	"fmt"
 	"log"
-	"regexp"
 	"strings"
 	"time"
 
@@ -11,6 +10,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -166,8 +166,10 @@ func filterResource(inputs []resources.GenericResourceExpanded, requiredTags map
 
 			resResourceGroupName := ""
 			if res.ID != nil {
-				re := regexp.MustCompile(`.+/resourceGroups/([^/]+).?`)
-				resResourceGroupName = string(re.FindSubmatch([]byte(*res.ID))[1])
+				resourceObj, err := resourceids.ParseAzureResourceID(*res.ID)
+				if err == nil {
+					resResourceGroupName = resourceObj.ResourceGroup
+				}
 			}
 
 			resType := ""

--- a/internal/services/resource/resources_data_source.go
+++ b/internal/services/resource/resources_data_source.go
@@ -3,6 +3,7 @@ package resource
 import (
 	"fmt"
 	"log"
+	"regexp"
 	"strings"
 	"time"
 
@@ -52,6 +53,10 @@ func dataSourceResources() *pluginsdk.Resource {
 							Computed: true,
 						},
 						"id": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+						"resource_group_name": {
 							Type:     pluginsdk.TypeString,
 							Computed: true,
 						},
@@ -159,6 +164,12 @@ func filterResource(inputs []resources.GenericResourceExpanded, requiredTags map
 				resID = *res.ID
 			}
 
+			resResourceGroupName := ""
+			if res.ID != nil {
+				re := regexp.MustCompile(`.+/resourceGroups/([^/]+).?`)
+				resResourceGroupName = string(re.FindSubmatch([]byte(*res.ID))[1])
+			}
+
 			resType := ""
 			if res.Type != nil {
 				resType = *res.Type
@@ -180,11 +191,12 @@ func filterResource(inputs []resources.GenericResourceExpanded, requiredTags map
 			}
 
 			result = append(result, map[string]interface{}{
-				"name":     resName,
-				"id":       resID,
-				"type":     resType,
-				"location": resLocation,
-				"tags":     resTags,
+				"name":                resName,
+				"id":                  resID,
+				"resource_group_name": resResourceGroupName,
+				"type":                resType,
+				"location":            resLocation,
+				"tags":                resTags,
 			})
 		} else {
 			log.Printf("[DEBUG] azurerm_resources - resources %q (id: %q) skipped as a required tag is not set or has the wrong value.", *res.Name, *res.ID)

--- a/website/docs/d/resources.html.markdown
+++ b/website/docs/d/resources.html.markdown
@@ -72,6 +72,8 @@ The `resource` block exports the following:
 
 * `id` - The ID of this Resource.
 
+* `resource_group_name` - The name of the Resource Group in which this Resource exists.
+
 * `type` - The type of this Resource. (e.g. `Microsoft.Network/virtualNetworks`).
 
 * `location` - The Azure Region in which this Resource exists.


### PR DESCRIPTION
The azurerm_resources data source is useful for discovering resources in a subscription.  However, in order to be able to use specific data sources for a resource type, we need the name of the resource group the resource exists in.  Adding a resource_group_name attribute to each resource in the resources list makes it easy to instantiate a data source for the resulting resources.

Example:

```
data "azurerm_resources" "virtual_networks" {
  type = "Microsoft.Network/virtualNetworks"
}

data "azurerm_virtual_network" "virtual_networks" {
  for_each = { for v in data.azurerm_resources.virtual_networks.resources : v.id => v }

  name = each.value.name
  resource_group_name = each.value.resource_group_name
}

output "virtual_networks" {
  value = data.azurerm_virtual_network.virtual_networks
}

```