### PR TITLE
azurerm_batch_account - allow versionless keys for CMK

### DIFF
--- a/internal/services/batch/batch_account_data_source.go
+++ b/internal/services/batch/batch_account_data_source.go
@@ -81,7 +81,7 @@ func dataSourceBatchAccount() *pluginsdk.Resource {
 						"key_vault_key_id": {
 							Type:         pluginsdk.TypeString,
 							Required:     true,
-							ValidateFunc: keyVaultValidate.NestedItemId,
+							ValidateFunc: keyVaultValidate.NestedItemIdWithOptionalVersion,
 						},
 					},
 				},

--- a/internal/services/batch/batch_account_data_source_test.go
+++ b/internal/services/batch/batch_account_data_source_test.go
@@ -63,7 +63,7 @@ func TestAccBatchAccountDataSource_userSubscription(t *testing.T) {
 	})
 }
 
-func TestAccBatchAccountDataSource_cmk(t *testing.T) {
+func TestAccBatchAccountDataSource_cmkVersionedKey(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_batch_account", "test")
 	r := BatchAccountDataSource{}
 
@@ -71,7 +71,24 @@ func TestAccBatchAccountDataSource_cmk(t *testing.T) {
 
 	data.DataSourceTest(t, []acceptance.TestStep{
 		{
-			Config: r.cmkData(data, tenantID),
+			Config: r.cmkVersionedKeyData(data, tenantID),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("location").HasValue(azure.NormalizeLocation(data.Locations.Primary)),
+				check.That(data.ResourceName).Key("encryption.0.key_vault_key_id").IsSet(),
+			),
+		},
+	})
+}
+
+func TestAccBatchAccountDataSource_cmkVersionlessKey(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_batch_account", "test")
+	r := BatchAccountDataSource{}
+
+	tenantID := os.Getenv("ARM_TENANT_ID")
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.cmkVersionlessKeyData(data, tenantID),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("location").HasValue(azure.NormalizeLocation(data.Locations.Primary)),
 				check.That(data.ResourceName).Key("encryption.0.key_vault_key_id").IsSet(),
@@ -213,7 +230,7 @@ data "azurerm_batch_account" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomString, tenantID, tenantID, subscriptionID, data.RandomString)
 }
 
-func (BatchAccountDataSource) cmkData(data acceptance.TestData, tenantID string) string {
+func (BatchAccountDataSource) cmkVersionedKeyData(data acceptance.TestData, tenantID string) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {
@@ -260,6 +277,119 @@ resource "azurerm_batch_account" "test" {
 
   encryption {
     key_vault_key_id = "${azurerm_key_vault.test.vault_uri}keys/${azurerm_key_vault_key.test.name}/${azurerm_key_vault_key.test.version}"
+  }
+}
+
+resource "azurerm_key_vault" "test" {
+  name                            = "batchkv%s"
+  location                        = "${azurerm_resource_group.test.location}"
+  resource_group_name             = "${azurerm_resource_group.test.name}"
+  enabled_for_disk_encryption     = true
+  enabled_for_deployment          = true
+  enabled_for_template_deployment = true
+  purge_protection_enabled        = true
+  tenant_id                       = "%s"
+
+  sku_name = "standard"
+
+  access_policy {
+    tenant_id = "%s"
+    object_id = "${data.azurerm_client_config.current.object_id}"
+
+    key_permissions = [
+      "Get",
+      "Create",
+      "Delete",
+      "WrapKey",
+      "UnwrapKey",
+      "GetRotationPolicy",
+      "SetRotationPolicy",
+    ]
+  }
+
+  access_policy {
+    tenant_id = "%s"
+    object_id = "${azurerm_user_assigned_identity.test.principal_id}"
+
+    key_permissions = [
+      "Get",
+      "WrapKey",
+      "UnwrapKey"
+    ]
+  }
+}
+
+resource "azurerm_key_vault_key" "test" {
+  name         = "enckey%d"
+  key_vault_id = "${azurerm_key_vault.test.id}"
+  key_type     = "RSA"
+  key_size     = 2048
+
+  key_opts = [
+    "decrypt",
+    "encrypt",
+    "sign",
+    "unwrapKey",
+    "verify",
+    "wrapKey",
+  ]
+}
+
+data "azurerm_batch_account" "test" {
+  name                = "${azurerm_batch_account.test.name}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+}
+
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString, data.RandomString, data.RandomString, tenantID, tenantID, tenantID, data.RandomInteger)
+}
+
+func (BatchAccountDataSource) cmkVersionlessKeyData(data acceptance.TestData, tenantID string) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy       = false
+      purge_soft_deleted_keys_on_destroy = false
+    }
+  }
+}
+
+data "azurerm_client_config" "current" {
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "testaccRG-batch-%d"
+  location = "%s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "testaccsa%s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_user_assigned_identity" "test" {
+  name                = "acctest%s"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_batch_account" "test" {
+  name                                = "testaccbatch%s"
+  resource_group_name                 = azurerm_resource_group.test.name
+  location                            = azurerm_resource_group.test.location
+  pool_allocation_mode                = "BatchService"
+  storage_account_id                  = azurerm_storage_account.test.id
+  storage_account_authentication_mode = "StorageKeys"
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.test.id]
+  }
+
+  encryption {
+    key_vault_key_id = "${azurerm_key_vault.test.vault_uri}keys/${azurerm_key_vault_key.test.name}"
   }
 }
 

--- a/internal/services/batch/batch_account_data_source_test.go
+++ b/internal/services/batch/batch_account_data_source_test.go
@@ -245,12 +245,12 @@ data "azurerm_client_config" "current" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "testaccRG-batch-%d"
-  location = "%s"
+  name     = "testaccRG-batch-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_storage_account" "test" {
-  name                     = "testaccsa%s"
+  name                     = "testaccsa%[3]s"
   resource_group_name      = azurerm_resource_group.test.name
   location                 = azurerm_resource_group.test.location
   account_tier             = "Standard"
@@ -258,13 +258,13 @@ resource "azurerm_storage_account" "test" {
 }
 
 resource "azurerm_user_assigned_identity" "test" {
-  name                = "acctest%s"
+  name                = "acctest%[3]s"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
 }
 
 resource "azurerm_batch_account" "test" {
-  name                                = "testaccbatch%s"
+  name                                = "testaccbatch%[3]s"
   resource_group_name                 = azurerm_resource_group.test.name
   location                            = azurerm_resource_group.test.location
   pool_allocation_mode                = "BatchService"
@@ -281,20 +281,20 @@ resource "azurerm_batch_account" "test" {
 }
 
 resource "azurerm_key_vault" "test" {
-  name                            = "batchkv%s"
-  location                        = "${azurerm_resource_group.test.location}"
-  resource_group_name             = "${azurerm_resource_group.test.name}"
+  name                            = "batchkv%[3]s"
+  location                        = azurerm_resource_group.test.location
+  resource_group_name             = azurerm_resource_group.test.name
   enabled_for_disk_encryption     = true
   enabled_for_deployment          = true
   enabled_for_template_deployment = true
   purge_protection_enabled        = true
-  tenant_id                       = "%s"
+  tenant_id                       = "%[4]s"
 
   sku_name = "standard"
 
   access_policy {
-    tenant_id = "%s"
-    object_id = "${data.azurerm_client_config.current.object_id}"
+    tenant_id = "%[4]s"
+    object_id = data.azurerm_client_config.current.object_id
 
     key_permissions = [
       "Get",
@@ -308,8 +308,8 @@ resource "azurerm_key_vault" "test" {
   }
 
   access_policy {
-    tenant_id = "%s"
-    object_id = "${azurerm_user_assigned_identity.test.principal_id}"
+    tenant_id = "%[4]s"
+    object_id = azurerm_user_assigned_identity.test.principal_id
 
     key_permissions = [
       "Get",
@@ -320,8 +320,8 @@ resource "azurerm_key_vault" "test" {
 }
 
 resource "azurerm_key_vault_key" "test" {
-  name         = "enckey%d"
-  key_vault_id = "${azurerm_key_vault.test.id}"
+  name         = "enckey%[1]d"
+  key_vault_id = azurerm_key_vault.test.id
   key_type     = "RSA"
   key_size     = 2048
 
@@ -336,11 +336,11 @@ resource "azurerm_key_vault_key" "test" {
 }
 
 data "azurerm_batch_account" "test" {
-  name                = "${azurerm_batch_account.test.name}"
-  resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = azurerm_batch_account.test.name
+  resource_group_name = azurerm_resource_group.test.name
 }
 
-`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString, data.RandomString, data.RandomString, tenantID, tenantID, tenantID, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, tenantID)
 }
 
 func (BatchAccountDataSource) cmkVersionlessKeyData(data acceptance.TestData, tenantID string) string {
@@ -358,12 +358,12 @@ data "azurerm_client_config" "current" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "testaccRG-batch-%d"
-  location = "%s"
+  name     = "testaccRG-batch-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_storage_account" "test" {
-  name                     = "testaccsa%s"
+  name                     = "testaccsa%[3]s"
   resource_group_name      = azurerm_resource_group.test.name
   location                 = azurerm_resource_group.test.location
   account_tier             = "Standard"
@@ -371,13 +371,13 @@ resource "azurerm_storage_account" "test" {
 }
 
 resource "azurerm_user_assigned_identity" "test" {
-  name                = "acctest%s"
+  name                = "acctest%[3]s"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
 }
 
 resource "azurerm_batch_account" "test" {
-  name                                = "testaccbatch%s"
+  name                                = "testaccbatch%[3]s"
   resource_group_name                 = azurerm_resource_group.test.name
   location                            = azurerm_resource_group.test.location
   pool_allocation_mode                = "BatchService"
@@ -389,25 +389,25 @@ resource "azurerm_batch_account" "test" {
   }
 
   encryption {
-    key_vault_key_id = "${azurerm_key_vault.test.vault_uri}keys/${azurerm_key_vault_key.test.name}"
+    key_vault_key_id = azurerm_key_vault_key.test.versionless_id
   }
 }
 
 resource "azurerm_key_vault" "test" {
-  name                            = "batchkv%s"
-  location                        = "${azurerm_resource_group.test.location}"
-  resource_group_name             = "${azurerm_resource_group.test.name}"
+  name                            = "batchkv%[3]s"
+  location                        = azurerm_resource_group.test.location
+  resource_group_name             = azurerm_resource_group.test.name
   enabled_for_disk_encryption     = true
   enabled_for_deployment          = true
   enabled_for_template_deployment = true
   purge_protection_enabled        = true
-  tenant_id                       = "%s"
+  tenant_id                       = "%[4]s"
 
   sku_name = "standard"
 
   access_policy {
-    tenant_id = "%s"
-    object_id = "${data.azurerm_client_config.current.object_id}"
+    tenant_id = "%[4]s"
+    object_id = data.azurerm_client_config.current.object_id
 
     key_permissions = [
       "Get",
@@ -421,8 +421,8 @@ resource "azurerm_key_vault" "test" {
   }
 
   access_policy {
-    tenant_id = "%s"
-    object_id = "${azurerm_user_assigned_identity.test.principal_id}"
+    tenant_id = "%[4]s"
+    object_id = azurerm_user_assigned_identity.test.principal_id
 
     key_permissions = [
       "Get",
@@ -433,8 +433,8 @@ resource "azurerm_key_vault" "test" {
 }
 
 resource "azurerm_key_vault_key" "test" {
-  name         = "enckey%d"
-  key_vault_id = "${azurerm_key_vault.test.id}"
+  name         = "enckey%[1]d"
+  key_vault_id = azurerm_key_vault.test.id
   key_type     = "RSA"
   key_size     = 2048
 
@@ -449,9 +449,9 @@ resource "azurerm_key_vault_key" "test" {
 }
 
 data "azurerm_batch_account" "test" {
-  name                = "${azurerm_batch_account.test.name}"
-  resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = azurerm_batch_account.test.name
+  resource_group_name = azurerm_resource_group.test.name
 }
 
-`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString, data.RandomString, data.RandomString, tenantID, tenantID, tenantID, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, tenantID)
 }

--- a/internal/services/batch/batch_account_resource.go
+++ b/internal/services/batch/batch_account_resource.go
@@ -159,7 +159,7 @@ func resourceBatchAccount() *pluginsdk.Resource {
 						"key_vault_key_id": {
 							Type:         pluginsdk.TypeString,
 							Required:     true,
-							ValidateFunc: keyVaultValidate.NestedItemId,
+							ValidateFunc: keyVaultValidate.NestedItemIdWithOptionalVersion,
 						},
 					},
 				},

--- a/internal/services/batch/batch_account_resource_test.go
+++ b/internal/services/batch/batch_account_resource_test.go
@@ -574,12 +574,12 @@ data "azurerm_client_config" "current" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "testaccRG-batch-%d"
-  location = "%s"
+  name     = "testaccRG-batch-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_storage_account" "test" {
-  name                     = "testaccsa%s"
+  name                     = "testaccsa%[3]s"
   resource_group_name      = azurerm_resource_group.test.name
   location                 = azurerm_resource_group.test.location
   account_tier             = "Standard"
@@ -587,13 +587,13 @@ resource "azurerm_storage_account" "test" {
 }
 
 resource "azurerm_user_assigned_identity" "test" {
-  name                = "acctest%s"
+  name                = "acctest%[3]s"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
 }
 
 resource "azurerm_batch_account" "test" {
-  name                                = "testaccbatch%s"
+  name                                = "testaccbatch%[3]s"
   resource_group_name                 = azurerm_resource_group.test.name
   location                            = azurerm_resource_group.test.location
   pool_allocation_mode                = "BatchService"
@@ -610,20 +610,20 @@ resource "azurerm_batch_account" "test" {
 }
 
 resource "azurerm_key_vault" "test" {
-  name                            = "batchkv%s"
-  location                        = "${azurerm_resource_group.test.location}"
-  resource_group_name             = "${azurerm_resource_group.test.name}"
+  name                            = "batchkv%[3]s"
+  location                        = azurerm_resource_group.test.location
+  resource_group_name             = azurerm_resource_group.test.name
   enabled_for_disk_encryption     = true
   enabled_for_deployment          = true
   enabled_for_template_deployment = true
   purge_protection_enabled        = true
-  tenant_id                       = "%s"
+  tenant_id                       = "%[4]s"
 
   sku_name = "standard"
 
   access_policy {
-    tenant_id = "%s"
-    object_id = "${data.azurerm_client_config.current.object_id}"
+    tenant_id = "%[4]s"
+    object_id = data.azurerm_client_config.current.object_id
 
     key_permissions = [
       "Get",
@@ -637,8 +637,8 @@ resource "azurerm_key_vault" "test" {
   }
 
   access_policy {
-    tenant_id = "%s"
-    object_id = "${azurerm_user_assigned_identity.test.principal_id}"
+    tenant_id = "%[4]s"
+    object_id = azurerm_user_assigned_identity.test.principal_id
 
     key_permissions = [
       "Get",
@@ -649,8 +649,8 @@ resource "azurerm_key_vault" "test" {
 }
 
 resource "azurerm_key_vault_key" "test" {
-  name         = "enckey%d"
-  key_vault_id = "${azurerm_key_vault.test.id}"
+  name         = "enckey%[1]d"
+  key_vault_id = azurerm_key_vault.test.id
   key_type     = "RSA"
   key_size     = 2048
 
@@ -664,7 +664,7 @@ resource "azurerm_key_vault_key" "test" {
   ]
 }
 
-`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString, data.RandomString, data.RandomString, tenantID, tenantID, tenantID, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, tenantID)
 }
 
 func (BatchAccountResource) cmkVersionlessKey(data acceptance.TestData, tenantID string) string {
@@ -682,12 +682,12 @@ data "azurerm_client_config" "current" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "testaccRG-batch-%d"
-  location = "%s"
+  name     = "testaccRG-batch-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_storage_account" "test" {
-  name                     = "testaccsa%s"
+  name                     = "testaccsa%[3]s"
   resource_group_name      = azurerm_resource_group.test.name
   location                 = azurerm_resource_group.test.location
   account_tier             = "Standard"
@@ -695,13 +695,13 @@ resource "azurerm_storage_account" "test" {
 }
 
 resource "azurerm_user_assigned_identity" "test" {
-  name                = "acctest%s"
+  name                = "acctest%[3]s"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
 }
 
 resource "azurerm_batch_account" "test" {
-  name                                = "testaccbatch%s"
+  name                                = "testaccbatch%[3]s"
   resource_group_name                 = azurerm_resource_group.test.name
   location                            = azurerm_resource_group.test.location
   pool_allocation_mode                = "BatchService"
@@ -713,25 +713,25 @@ resource "azurerm_batch_account" "test" {
   }
 
   encryption {
-    key_vault_key_id = "${azurerm_key_vault.test.vault_uri}keys/${azurerm_key_vault_key.test.name}"
+    key_vault_key_id = azurerm_key_vault_key.test.versionless_id
   }
 }
 
 resource "azurerm_key_vault" "test" {
-  name                            = "batchkv%s"
-  location                        = "${azurerm_resource_group.test.location}"
-  resource_group_name             = "${azurerm_resource_group.test.name}"
+  name                            = "batchkv%[3]s"
+  location                        = azurerm_resource_group.test.location
+  resource_group_name             = azurerm_resource_group.test.name
   enabled_for_disk_encryption     = true
   enabled_for_deployment          = true
   enabled_for_template_deployment = true
   purge_protection_enabled        = true
-  tenant_id                       = "%s"
+  tenant_id                       = "%[4]s"
 
   sku_name = "standard"
 
   access_policy {
-    tenant_id = "%s"
-    object_id = "${data.azurerm_client_config.current.object_id}"
+    tenant_id = "%[4]s"
+    object_id = data.azurerm_client_config.current.object_id
 
     key_permissions = [
       "Get",
@@ -745,8 +745,8 @@ resource "azurerm_key_vault" "test" {
   }
 
   access_policy {
-    tenant_id = "%s"
-    object_id = "${azurerm_user_assigned_identity.test.principal_id}"
+    tenant_id = "%[4]s"
+    object_id = azurerm_user_assigned_identity.test.principal_id
 
     key_permissions = [
       "Get",
@@ -757,8 +757,8 @@ resource "azurerm_key_vault" "test" {
 }
 
 resource "azurerm_key_vault_key" "test" {
-  name         = "enckey%d"
-  key_vault_id = "${azurerm_key_vault.test.id}"
+  name         = "enckey%[1]d"
+  key_vault_id = azurerm_key_vault.test.id
   key_type     = "RSA"
   key_size     = 2048
 
@@ -772,7 +772,7 @@ resource "azurerm_key_vault_key" "test" {
   ]
 }
 
-`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString, data.RandomString, data.RandomString, tenantID, tenantID, tenantID, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, tenantID)
 }
 
 func (BatchAccountResource) removeStorageAccount(data acceptance.TestData) string {

--- a/internal/services/batch/batch_account_resource_test.go
+++ b/internal/services/batch/batch_account_resource_test.go
@@ -158,14 +158,30 @@ func TestAccBatchAccount_identity(t *testing.T) {
 	})
 }
 
-func TestAccBatchAccount_cmk(t *testing.T) {
+func TestAccBatchAccount_cmkVersionedKey(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_batch_account", "test")
 	r := BatchAccountResource{}
 	tenantID := os.Getenv("ARM_TENANT_ID")
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.cmk(data, tenantID),
+			Config: r.cmkVersionedKey(data, tenantID),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("encryption.0.key_vault_key_id").IsSet(),
+			),
+		},
+	})
+}
+
+func TestAccBatchAccount_cmkVersionlessKey(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_batch_account", "test")
+	r := BatchAccountResource{}
+	tenantID := os.Getenv("ARM_TENANT_ID")
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.cmkVersionlessKey(data, tenantID),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("encryption.0.key_vault_key_id").IsSet(),
@@ -543,7 +559,7 @@ resource "azurerm_batch_account" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString, data.RandomString)
 }
 
-func (BatchAccountResource) cmk(data acceptance.TestData, tenantID string) string {
+func (BatchAccountResource) cmkVersionedKey(data acceptance.TestData, tenantID string) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {
@@ -590,6 +606,114 @@ resource "azurerm_batch_account" "test" {
 
   encryption {
     key_vault_key_id = "${azurerm_key_vault.test.vault_uri}keys/${azurerm_key_vault_key.test.name}/${azurerm_key_vault_key.test.version}"
+  }
+}
+
+resource "azurerm_key_vault" "test" {
+  name                            = "batchkv%s"
+  location                        = "${azurerm_resource_group.test.location}"
+  resource_group_name             = "${azurerm_resource_group.test.name}"
+  enabled_for_disk_encryption     = true
+  enabled_for_deployment          = true
+  enabled_for_template_deployment = true
+  purge_protection_enabled        = true
+  tenant_id                       = "%s"
+
+  sku_name = "standard"
+
+  access_policy {
+    tenant_id = "%s"
+    object_id = "${data.azurerm_client_config.current.object_id}"
+
+    key_permissions = [
+      "Get",
+      "Create",
+      "Delete",
+      "WrapKey",
+      "UnwrapKey",
+      "GetRotationPolicy",
+      "SetRotationPolicy",
+    ]
+  }
+
+  access_policy {
+    tenant_id = "%s"
+    object_id = "${azurerm_user_assigned_identity.test.principal_id}"
+
+    key_permissions = [
+      "Get",
+      "WrapKey",
+      "UnwrapKey"
+    ]
+  }
+}
+
+resource "azurerm_key_vault_key" "test" {
+  name         = "enckey%d"
+  key_vault_id = "${azurerm_key_vault.test.id}"
+  key_type     = "RSA"
+  key_size     = 2048
+
+  key_opts = [
+    "decrypt",
+    "encrypt",
+    "sign",
+    "unwrapKey",
+    "verify",
+    "wrapKey",
+  ]
+}
+
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString, data.RandomString, data.RandomString, tenantID, tenantID, tenantID, data.RandomInteger)
+}
+
+func (BatchAccountResource) cmkVersionlessKey(data acceptance.TestData, tenantID string) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy       = false
+      purge_soft_deleted_keys_on_destroy = false
+    }
+  }
+}
+
+data "azurerm_client_config" "current" {
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "testaccRG-batch-%d"
+  location = "%s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "testaccsa%s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_user_assigned_identity" "test" {
+  name                = "acctest%s"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_batch_account" "test" {
+  name                                = "testaccbatch%s"
+  resource_group_name                 = azurerm_resource_group.test.name
+  location                            = azurerm_resource_group.test.location
+  pool_allocation_mode                = "BatchService"
+  storage_account_id                  = azurerm_storage_account.test.id
+  storage_account_authentication_mode = "StorageKeys"
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.test.id]
+  }
+
+  encryption {
+    key_vault_key_id = "${azurerm_key_vault.test.vault_uri}keys/${azurerm_key_vault_key.test.name}"
   }
 }
 

--- a/website/docs/d/batch_account.html.markdown
+++ b/website/docs/d/batch_account.html.markdown
@@ -52,17 +52,25 @@ The following attributes are exported:
 
 * `key_vault_reference` - The `key_vault_reference` block that describes the Azure KeyVault reference to use when deploying the Azure Batch account using the `UserSubscription` pool allocation mode.
 
+* `encryption` - The `encryption` block that describes the Azure KeyVault key reference used to encrypt data for the Azure Batch account.
+
 * `tags` - A map of tags assigned to the Batch account.
 
 ~> **Note:** Primary and secondary access keys are only available when `pool_allocation_mode` is set to `BatchService`. See [documentation](https://docs.microsoft.com/azure/batch/batch-api-basics) for more information.
 
 ---
 
-A `key_vault_reference` block have the following properties:
+A `key_vault_reference` block has the following properties:
 
 * `id` - The Azure identifier of the Azure KeyVault reference.
 
 * `url` - The HTTPS URL of the Azure KeyVault reference.
+
+---
+
+An `encryption` block has the following properties:
+
+* `key_vault_key_id` - The Azure identifier of the Azure KeyVault key reference.
 
 ---
 

--- a/website/docs/d/batch_account.html.markdown
+++ b/website/docs/d/batch_account.html.markdown
@@ -60,7 +60,7 @@ The following attributes are exported:
 
 ---
 
-A `key_vault_reference` block has the following properties:
+A `key_vault_reference` block exports the following:
 
 * `id` - The Azure identifier of the Azure KeyVault reference.
 
@@ -68,9 +68,9 @@ A `key_vault_reference` block has the following properties:
 
 ---
 
-An `encryption` block has the following properties:
+An `encryption` block exports the following:
 
-* `key_vault_key_id` - The Azure identifier of the Azure KeyVault key reference.
+* `key_vault_key_id` - The full URL path of the Key Vault Key used to encrypt data for this Batch account.
 
 ---
 

--- a/website/docs/r/batch_account.html.markdown
+++ b/website/docs/r/batch_account.html.markdown
@@ -103,7 +103,7 @@ A `key_vault_reference` block supports the following:
 
 A `encryption` block supports the following:
 
-* `key_vault_key_id` - (Required) The Azure key vault reference id that should be used to encrypt data, as documented [here](https://docs.microsoft.com/azure/batch/batch-customer-managed-key). Both versioned and versionless keys are supported.
+* `key_vault_key_id` - (Required) The full URL path to the Azure key vault key id that should be used to encrypt data, as documented [here](https://docs.microsoft.com/azure/batch/batch-customer-managed-key). Both versioned and versionless keys are supported.
 
 ## Attributes Reference
 

--- a/website/docs/r/batch_account.html.markdown
+++ b/website/docs/r/batch_account.html.markdown
@@ -103,7 +103,7 @@ A `key_vault_reference` block supports the following:
 
 A `encryption` block supports the following:
 
-* `key_vault_key_id` - (Required) The Azure key vault reference id with version that should be used to encrypt data, as documented [here](https://docs.microsoft.com/azure/batch/batch-customer-managed-key). Key rotation is not yet supported.
+* `key_vault_key_id` - (Required) The Azure key vault reference id that should be used to encrypt data, as documented [here](https://docs.microsoft.com/azure/batch/batch-customer-managed-key). Both versioned and versionless keys are supported.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Batch accounts can have an optionally specified encryption key. This fix allows Batch accounts to have encryption enabled with a Key Vault versionless key (to allow for autorotation scenarios).