### PR TITLE
New Data Source: `azurerm_cdn_frontdoor_route`

### DIFF
--- a/examples/cdn/frontdoor/frontdoor-cmk-byoc-custom-domain/main.tf
+++ b/examples/cdn/frontdoor/frontdoor-cmk-byoc-custom-domain/main.tf
@@ -301,9 +301,6 @@ resource "azurerm_cdn_frontdoor_route" "example" {
   supported_protocols        = ["Http", "Https"]
   cdn_frontdoor_rule_set_ids = [azurerm_cdn_frontdoor_rule_set.example.id]
 
-  cdn_frontdoor_custom_domain_ids = [azurerm_cdn_frontdoor_custom_domain.contoso.id]
-  link_to_default_domain          = false
-
   cache {
     compression_enabled           = true
     content_types_to_compress     = ["text/html", "text/javascript", "text/xml"]
@@ -326,8 +323,9 @@ resource "azurerm_cdn_frontdoor_custom_domain" "contoso" {
 }
 
 resource "azurerm_cdn_frontdoor_custom_domain_association" "contoso" {
-  cdn_frontdoor_custom_domain_id = azurerm_cdn_frontdoor_custom_domain.contoso.id
-  cdn_frontdoor_route_ids        = [azurerm_cdn_frontdoor_route.example.id]
+  cdn_frontdoor_route_id          = azurerm_cdn_frontdoor_route.example.id
+  cdn_frontdoor_custom_domain_ids = [azurerm_cdn_frontdoor_custom_domain.contoso.id]
+  link_to_default_domain          = false
 }
 
 resource "azurerm_dns_txt_record" "contoso" {

--- a/examples/cdn/frontdoor/frontdoor-managed-ssl-certificate-with-multiple-custom-domains/main.tf
+++ b/examples/cdn/frontdoor/frontdoor-managed-ssl-certificate-with-multiple-custom-domains/main.tf
@@ -223,9 +223,6 @@ resource "azurerm_cdn_frontdoor_route" "example" {
   supported_protocols        = ["Http", "Https"]
   cdn_frontdoor_rule_set_ids = [azurerm_cdn_frontdoor_rule_set.example.id]
 
-  cdn_frontdoor_custom_domain_ids = [azurerm_cdn_frontdoor_custom_domain.contoso.id, azurerm_cdn_frontdoor_custom_domain.fabrikam.id]
-  link_to_default_domain          = false
-
   cache {
     compression_enabled           = true
     content_types_to_compress     = ["text/html", "text/javascript", "text/xml"]
@@ -258,14 +255,12 @@ resource "azurerm_cdn_frontdoor_custom_domain" "fabrikam" {
   }
 }
 
-resource "azurerm_cdn_frontdoor_custom_domain_association" "contoso" {
-  cdn_frontdoor_custom_domain_id = azurerm_cdn_frontdoor_custom_domain.contoso.id
-  cdn_frontdoor_route_ids        = [azurerm_cdn_frontdoor_route.example.id]
-}
-
-resource "azurerm_cdn_frontdoor_custom_domain_association" "fabrikam" {
-  cdn_frontdoor_custom_domain_id = azurerm_cdn_frontdoor_custom_domain.fabrikam.id
-  cdn_frontdoor_route_ids        = [azurerm_cdn_frontdoor_route.example.id]
+# You only need one azurerm_cdn_frontdoor_custom_domain_association here since both of the azurerm_cdn_frontdoor_custom_domain's
+# are connected to a single azurerm_cdn_frontdoor_route...
+resource "azurerm_cdn_frontdoor_custom_domain_association" "example" {
+  cdn_frontdoor_route_id          = azurerm_cdn_frontdoor_route.example.id
+  cdn_frontdoor_custom_domain_ids = [azurerm_cdn_frontdoor_custom_domain.contoso.id, azurerm_cdn_frontdoor_custom_domain.fabrikam.id]
+  link_to_default_domain          = false
 }
 
 resource "azurerm_dns_txt_record" "contoso" {

--- a/internal/services/cdn/cdn_frontdoor_custom_domain_association_import.go
+++ b/internal/services/cdn/cdn_frontdoor_custom_domain_association_import.go
@@ -2,30 +2,12 @@ package cdn
 
 import (
 	"context"
-	"fmt"
 
-	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/cdn/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
 func importCdnFrontDoorCustomDomainAssociation() pluginsdk.ImporterFunc {
 	return func(ctx context.Context, d *pluginsdk.ResourceData, meta interface{}) (data []*pluginsdk.ResourceData, err error) {
-		id, err := parse.FrontDoorCustomDomainAssociationID(d.Id())
-		if err != nil {
-			return []*pluginsdk.ResourceData{}, err
-		}
-
-		client := meta.(*clients.Client).Cdn.FrontDoorCustomDomainsClient
-		resp, err := client.Get(ctx, id.ResourceGroup, id.ProfileName, id.AssociationName)
-		if err != nil {
-			return []*pluginsdk.ResourceData{}, fmt.Errorf("retrieving %s: %+v", id, err)
-		}
-
-		if resp.AFDDomainProperties == nil {
-			return []*pluginsdk.ResourceData{}, fmt.Errorf("retrieving %s: `AFDDomainProperties` was nil", id)
-		}
-
 		return []*pluginsdk.ResourceData{d}, nil
 	}
 }

--- a/internal/services/cdn/cdn_frontdoor_custom_domain_association_resource.go
+++ b/internal/services/cdn/cdn_frontdoor_custom_domain_association_resource.go
@@ -1,11 +1,16 @@
 package cdn
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/services/cdn/mgmt/2021-06-01/cdn"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/cdn/azuresdkhacks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/cdn/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/cdn/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -36,65 +41,103 @@ func resourceCdnFrontDoorCustomDomainAssociation() *pluginsdk.Resource {
 		}, importCdnFrontDoorCustomDomainAssociation()),
 
 		Schema: map[string]*pluginsdk.Schema{
-			"cdn_frontdoor_custom_domain_id": {
+			"cdn_frontdoor_route_id": {
 				Type:         pluginsdk.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validate.FrontDoorCustomDomainID,
+				ValidateFunc: validate.FrontDoorRouteID,
 			},
 
-			"cdn_frontdoor_route_ids": {
-				Type:     pluginsdk.TypeList,
+			"cdn_frontdoor_custom_domain_ids": {
+				Type:     pluginsdk.TypeSet,
 				Required: true,
 
 				Elem: &pluginsdk.Schema{
 					Type:         pluginsdk.TypeString,
-					ValidateFunc: validate.FrontDoorRouteID,
+					ValidateFunc: validate.FrontDoorCustomDomainID,
 				},
+			},
+
+			"link_to_default_domain": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+				Default:  true,
 			},
 		},
 	}
 }
 
 func resourceCdnFrontDoorCustomDomainAssociationCreate(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Cdn.FrontDoorCustomDomainsClient
-	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
+	client := meta.(*clients.Client).Cdn.FrontDoorRoutesClient
+	workaroundsClient := azuresdkhacks.NewCdnFrontDoorRoutesWorkaroundClient(client)
+	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
 	log.Printf("[INFO] preparing arguments for CDN FrontDoor Route <-> CDN FrontDoor Custom Domain Association creation")
 
-	cdId, err := parse.FrontDoorCustomDomainID(d.Get("cdn_frontdoor_custom_domain_id").(string))
+	locks.ByID(cdnFrontDoorRouteResourceName)
+	defer locks.UnlockByID(cdnFrontDoorRouteResourceName)
+
+	rId, err := parse.FrontDoorRouteID(d.Get("cdn_frontdoor_route_id").(string))
 	if err != nil {
 		return err
 	}
 
-	id := parse.NewFrontDoorCustomDomainAssociationID(cdId.SubscriptionId, cdId.ResourceGroup, cdId.ProfileName, cdId.CustomDomainName)
+	id := parse.NewFrontDoorCustomDomainAssociationID(rId.SubscriptionId, rId.ResourceGroup, rId.ProfileName, rId.AfdEndpointName, rId.RouteName)
 
-	existing, err := client.Get(ctx, cdId.ResourceGroup, cdId.ProfileName, cdId.CustomDomainName)
+	existing, err := client.Get(ctx, id.ResourceGroup, id.ProfileName, id.AfdEndpointName, id.AssociationName)
 	if err != nil {
-		if utils.ResponseWasNotFound(existing.Response) {
-			return fmt.Errorf("creating %s: %s was not found", id, cdId)
-		}
-
-		return fmt.Errorf("creating %s: %+v", id, err)
+		return fmt.Errorf("retrieving existing %s: %+v", id, err)
 	}
 
-	// make sure the routes exist and are valid for this custom domain...
-	routes, err := validateRoutes(d, meta, cdId)
-	if err != nil {
-		return fmt.Errorf("creating %s: %+v", id, err)
+	if existing.RouteProperties == nil {
+		return fmt.Errorf("retrieving existing %s: 'properties' was nil", id)
+	}
+
+	customDomains := d.Get("cdn_frontdoor_custom_domain_ids").(*pluginsdk.Set).List()
+	linkToDefaultDomain := d.Get("link_to_default_domain").(bool)
+
+	if !linkToDefaultDomain && len(customDomains) == 0 {
+		return fmt.Errorf("it is invalid to disable the 'LinkToDefaultDomain' for the associated CDN Front Door Route(Name: %s) since the route will not have any CDN Front Door Custom Domains associated with it", id.AssociationName)
+	} else if len(customDomains) != 0 {
+		if err := validateRoutesCustomDomainProfile(customDomains, id.ProfileName); err != nil {
+			return err
+		}
+	}
+
+	if props := existing.RouteProperties; props != nil {
+		updateProps := azuresdkhacks.RouteUpdatePropertiesParameters{
+			CacheConfiguration: props.CacheConfiguration,
+		}
+
+		updateProps.CustomDomains = expandCustomDomainActivatedResourceArray(customDomains)
+		updateProps.LinkToDefaultDomain = expandEnabledBoolToLinkToDefaultDomain(linkToDefaultDomain)
+
+		updateParams := azuresdkhacks.RouteUpdateParameters{
+			RouteUpdatePropertiesParameters: pointer.To(updateProps),
+		}
+
+		future, err := workaroundsClient.Update(ctx, id.ResourceGroup, id.ProfileName, id.AfdEndpointName, id.AssociationName, updateParams)
+		if err != nil {
+			return fmt.Errorf("creating %s: %+v", id, err)
+		}
+
+		if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
+			return fmt.Errorf("waiting for the creation of %s: %+v", id, err)
+		}
 	}
 
 	d.SetId(id.ID())
-	d.Set("cdn_frontdoor_custom_domain_id", cdId.ID())
-	d.Set("cdn_frontdoor_route_ids", routes)
+	d.Set("cdn_frontdoor_custom_domain_ids", customDomains)
+	d.Set("cdn_frontdoor_route_id", rId.ID())
+	d.Set("link_to_default_domain", linkToDefaultDomain)
 
 	return resourceCdnFrontDoorCustomDomainAssociationRead(d, meta)
 }
 
 func resourceCdnFrontDoorCustomDomainAssociationRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Cdn.FrontDoorCustomDomainsClient
-	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
+	client := meta.(*clients.Client).Cdn.FrontDoorRoutesClient
+	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
 	id, err := parse.FrontDoorCustomDomainAssociationID(d.Id())
@@ -102,7 +145,7 @@ func resourceCdnFrontDoorCustomDomainAssociationRead(d *pluginsdk.ResourceData, 
 		return err
 	}
 
-	resp, err := client.Get(ctx, id.ResourceGroup, id.ProfileName, id.AssociationName)
+	resp, err := client.Get(ctx, id.ResourceGroup, id.ProfileName, id.AfdEndpointName, id.AssociationName)
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
 			d.SetId("")
@@ -112,69 +155,178 @@ func resourceCdnFrontDoorCustomDomainAssociationRead(d *pluginsdk.ResourceData, 
 		return fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	return nil
-}
+	if resp.RouteProperties == nil {
+		return fmt.Errorf("retrieving existing %s: 'properties' was nil", id)
+	}
 
-func resourceCdnFrontDoorCustomDomainAssociationUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Cdn.FrontDoorCustomDomainsClient
-	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
-	defer cancel()
-
-	if d.HasChange("cdn_frontdoor_route_ids") {
-		cdId, err := parse.FrontDoorCustomDomainID(d.Get("cdn_frontdoor_custom_domain_id").(string))
+	if props := resp.RouteProperties; props != nil {
+		customDomains, err := flattenCustomDomainActivatedResourceArray(props.CustomDomains)
 		if err != nil {
 			return err
 		}
 
-		id := parse.NewFrontDoorCustomDomainAssociationID(cdId.SubscriptionId, cdId.ResourceGroup, cdId.ProfileName, cdId.CustomDomainName)
+		// Need to normalize it here since the RP may have changed the casing...
+		rId, err := parse.FrontDoorRouteIDInsensitively(pointer.From(resp.ID))
+		if err != nil {
+			return err
+		}
 
-		existing, err := client.Get(ctx, cdId.ResourceGroup, cdId.ProfileName, cdId.CustomDomainName)
+		d.Set("cdn_frontdoor_route_id", rId.ID())
+		d.Set("cdn_frontdoor_custom_domain_ids", customDomains)
+		d.Set("link_to_default_domain", flattenLinkToDefaultDomainToBool(props.LinkToDefaultDomain))
+	}
+
+	return nil
+}
+
+func resourceCdnFrontDoorCustomDomainAssociationUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Cdn.FrontDoorRoutesClient
+	workaroundsClient := azuresdkhacks.NewCdnFrontDoorRoutesWorkaroundClient(client)
+	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	if d.HasChange("cdn_frontdoor_custom_domain_ids") {
+		id, err := parse.FrontDoorCustomDomainAssociationID(d.Id())
+		if err != nil {
+			return err
+		}
+
+		locks.ByID(cdnFrontDoorRouteResourceName)
+		defer locks.UnlockByID(cdnFrontDoorRouteResourceName)
+
+		existing, err := client.Get(ctx, id.ResourceGroup, id.ProfileName, id.AfdEndpointName, id.AssociationName)
 		if err != nil {
 			if utils.ResponseWasNotFound(existing.Response) {
-				return fmt.Errorf("updating %s: %s was not found", id, cdId)
+				return fmt.Errorf("updating %s: was not found %+v", id, err)
 			}
 
 			return fmt.Errorf("updating %s: %+v", id, err)
 		}
 
-		// make sure the routes exist and are valid for this custom domain...
-		routes, err := validateRoutes(d, meta, cdId)
-		if err != nil {
-			return fmt.Errorf("updating %s: %+v", id, err)
+		if existing.RouteProperties == nil {
+			return fmt.Errorf("retrieving existing %s: 'properties' was nil", id)
 		}
 
-		d.Set("cdn_frontdoor_route_ids", routes)
+		customDomains := d.Get("cdn_frontdoor_custom_domain_ids").(*pluginsdk.Set).List()
+		linkToDefaultDomain := d.Get("link_to_default_domain").(bool)
+
+		if !linkToDefaultDomain && len(customDomains) == 0 {
+			return fmt.Errorf("it is invalid to disable the 'LinkToDefaultDomain' for the associated CDN Front Door Route(Name: %s) since the route will not have any CDN Front Door Custom Domains associated with it", id.AssociationName)
+		} else if len(customDomains) != 0 {
+			if err := validateRoutesCustomDomainProfile(customDomains, id.ProfileName); err != nil {
+				return err
+			}
+		}
+
+		if props := existing.RouteProperties; props != nil {
+			updateProps := azuresdkhacks.RouteUpdatePropertiesParameters{
+				CacheConfiguration:  props.CacheConfiguration,
+				CustomDomains:       props.CustomDomains,
+				LinkToDefaultDomain: props.LinkToDefaultDomain,
+			}
+
+			if d.HasChange("cdn_frontdoor_custom_domain_ids") {
+				updateProps.CustomDomains = expandCustomDomainActivatedResourceArray(customDomains)
+			}
+
+			if d.HasChange("link_to_default_domain") {
+				updateProps.LinkToDefaultDomain = expandEnabledBoolToLinkToDefaultDomain(linkToDefaultDomain)
+			}
+
+			updateParams := azuresdkhacks.RouteUpdateParameters{
+				RouteUpdatePropertiesParameters: pointer.To(updateProps),
+			}
+
+			future, err := workaroundsClient.Update(ctx, id.ResourceGroup, id.ProfileName, id.AfdEndpointName, id.AssociationName, updateParams)
+			if err != nil {
+				return fmt.Errorf("updating %s: %+v", id, err)
+			}
+
+			if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
+				return fmt.Errorf("waiting for the update of %s: %+v", id, err)
+			}
+		}
+
+		// Don't need to update Route ID here since it's force new...
+		d.Set("cdn_frontdoor_custom_domain_ids", customDomains)
+		d.Set("link_to_default_domain", linkToDefaultDomain)
 	}
 
 	return resourceCdnFrontDoorCustomDomainAssociationRead(d, meta)
 }
 
 func resourceCdnFrontDoorCustomDomainAssociationDelete(d *pluginsdk.ResourceData, meta interface{}) error {
-	// since you are deleting the resource you cannot grab the value from the config
-	// because it will be empty, you have to get it from the states old value...
-	oCdId, _ := d.GetChange("cdn_frontdoor_custom_domain_id")
-
-	cdId, err := parse.FrontDoorCustomDomainID(oCdId.(string))
-	if err != nil {
-		return err
-	}
+	client := meta.(*clients.Client).Cdn.FrontDoorRoutesClient
+	workaroundsClient := azuresdkhacks.NewCdnFrontDoorRoutesWorkaroundClient(client)
+	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
 
 	id, err := parse.FrontDoorCustomDomainAssociationID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	oRids, _ := d.GetChange("cdn_frontdoor_route_ids")
-	oR := oRids.([]interface{})
+	// TODO: Need to poll the resource to see if another operation is in progress else you will get a conflict error returned from the service...
+	// need to check to see if the route is currently being modified, if so wait...
+	log.Printf("[DEBUG] Waiting for %s to become ready", id)
 
-	v, _, err := expandRoutes(oR)
-	if err != nil {
-		return err
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return fmt.Errorf("context had no deadline")
 	}
 
-	if len(*v) != 0 {
-		if err := removeCustomDomainAssociationFromRoutes(d, meta, v, cdId); err != nil {
+	stateConf := &pluginsdk.StateChangeConf{
+		Pending:                   []string{"Creating", "Updating", "Deleting"},
+		Target:                    []string{"Succeeded", "NotFound"},
+		Refresh:                   frontDoorRouteRefreshFunc(ctx, client, id),
+		MinTimeout:                15 * time.Second,
+		ContinuousTargetOccurence: 2,
+		Timeout:                   time.Until(deadline),
+	}
+
+	if _, err = stateConf.WaitForStateContext(ctx); err != nil {
+		return fmt.Errorf("waiting for %s to become ready: %+v", id, err)
+	}
+
+	locks.ByID(cdnFrontDoorRouteResourceName)
+	defer locks.UnlockByID(cdnFrontDoorRouteResourceName)
+
+	existing, err := client.Get(ctx, id.ResourceGroup, id.ProfileName, id.AfdEndpointName, id.AssociationName)
+	if err != nil {
+		if utils.ResponseWasNotFound(existing.Response) {
+			// The route was already deleted...
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("deleting %s: %+v", id, err)
+	}
+
+	if existing.RouteProperties == nil {
+		return fmt.Errorf("retrieving existing %s: 'properties' was nil", id)
+	}
+
+	// You must set the LinkToDefaultDomain to 'true' here
+	// else the route will be in an invalid state...
+	if props := existing.RouteProperties; props != nil {
+		updateProps := azuresdkhacks.RouteUpdatePropertiesParameters{
+			CacheConfiguration:  props.CacheConfiguration,
+			LinkToDefaultDomain: cdn.LinkToDefaultDomainEnabled,
+		}
+
+		updateProps.CustomDomains = nil
+
+		updateParams := azuresdkhacks.RouteUpdateParameters{
+			RouteUpdatePropertiesParameters: pointer.To(updateProps),
+		}
+
+		future, err := workaroundsClient.Update(ctx, id.ResourceGroup, id.ProfileName, id.AfdEndpointName, id.AssociationName, updateParams)
+		if err != nil {
 			return fmt.Errorf("deleting %s: %+v", id, err)
+		}
+
+		if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
+			return fmt.Errorf("waiting for the deletion of %s: %+v", id, err)
 		}
 	}
 
@@ -183,55 +335,27 @@ func resourceCdnFrontDoorCustomDomainAssociationDelete(d *pluginsdk.ResourceData
 	return nil
 }
 
-func validateRoutes(d *pluginsdk.ResourceData, meta interface{}, id *parse.FrontDoorCustomDomainId) ([]interface{}, error) {
-	out := make([]interface{}, 0)
-	o, n := d.GetChange("cdn_frontdoor_route_ids")
-	oRoutes := o.([]interface{})
-	nRoutes := n.([]interface{})
+func frontDoorRouteRefreshFunc(ctx context.Context, client *cdn.RoutesClient, id *parse.FrontDoorCustomDomainAssociationId) pluginsdk.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		log.Printf("[DEBUG] Checking to see if CDN Front Door Route %q (Resource Group: %q) is available...", id.AssociationName, id.ResourceGroup)
 
-	if len(nRoutes) == 0 || nRoutes == nil || id == nil {
-		return out, nil
-	}
-
-	oIds, _, err := expandRoutes(oRoutes)
-	if err != nil {
-		return out, err
-	}
-
-	nIds, result, err := expandRoutes(nRoutes)
-	if err != nil {
-		return out, err
-	}
-
-	// validate the new routes...
-	if len(*nIds) != 0 {
-		for _, v := range *nIds {
-			// Make sure the route exists and get the routes custom domain association list...
-			associations, _, err := getRouteProperties(d, meta, &v, "cdn_frontdoor_custom_domain_association")
-			if err != nil {
-				return out, err
+		resp, err := client.Get(ctx, id.ResourceGroup, id.ProfileName, id.AfdEndpointName, id.AssociationName)
+		if err != nil {
+			if utils.ResponseWasNotFound(resp.Response) {
+				log.Printf("[DEBUG] Retrieving CDN Front Door Route %q (Resource Group: %q) returned 404.", id.AssociationName, id.ResourceGroup)
+				return nil, "NotFound", nil
 			}
 
-			// Make sure the custom domain is in the routes association list
-			if len(associations) == 0 || !sliceContainsString(associations, id.ID()) {
-				return out, fmt.Errorf("the CDN FrontDoor Route(Name: %q) is currently not associated with the CDN FrontDoor Custom Domain(Name: %q). Please remove the CDN FrontDoor Route from your 'cdn_frontdoor_custom_domain_association' configuration block", v.RouteName, id.CustomDomainName)
+			return nil, "", fmt.Errorf("polling for the state of the CDN Front Door Route %q (Resource Group: %q): %+v", id.AssociationName, id.ResourceGroup, err)
+		}
+
+		state := ""
+		if props := resp.RouteProperties; props != nil {
+			if props.ProvisioningState != "" {
+				state = string(props.ProvisioningState)
 			}
 		}
 
-		if err := validateCustomDomainRoutes(nIds, id); err != nil {
-			return out, err
-		}
+		return resp, state, nil
 	}
-
-	if len(oRoutes) != 0 {
-		// now get the delta between the old and the new list, if any custom domains were removed from
-		// the list we need to remove the custom domain association from those routes...
-		if delta, _ := routeDelta(oIds, nIds); len(*delta) != 0 {
-			if err = removeCustomDomainAssociationFromRoutes(d, meta, delta, id); err != nil {
-				return out, err
-			}
-		}
-	}
-
-	return result, nil
 }

--- a/internal/services/cdn/cdn_frontdoor_custom_domain_association_resource.go
+++ b/internal/services/cdn/cdn_frontdoor_custom_domain_association_resource.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/services/cdn/mgmt/2021-06-01/cdn"
+	"github.com/Azure/azure-sdk-for-go/services/cdn/mgmt/2021-06-01/cdn" // nolint: staticcheck
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"

--- a/internal/services/cdn/cdn_frontdoor_custom_domain_association_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_custom_domain_association_resource_test.go
@@ -218,9 +218,9 @@ resource "azurerm_cdn_frontdoor_route" "contoso" {
   cdn_frontdoor_origin_ids      = [azurerm_cdn_frontdoor_origin.test.id]
   enabled                       = true
 
-  forwarding_protocol    = "HttpsOnly"
-  patterns_to_match      = ["/contoso-%[3]s"]
-  supported_protocols    = ["Http", "Https"]
+  forwarding_protocol = "HttpsOnly"
+  patterns_to_match   = ["/contoso-%[3]s"]
+  supported_protocols = ["Http", "Https"]
 
   cache {
     compression_enabled           = true

--- a/internal/services/cdn/cdn_frontdoor_helpers.go
+++ b/internal/services/cdn/cdn_frontdoor_helpers.go
@@ -395,24 +395,6 @@ func validateRoutesCustomDomainProfile(customDomains []interface{}, routeProfile
 	return nil
 }
 
-// Checks to make sure the list of CDN FrontDoor Custom Domains does not contain duplicate entries
-func sliceHasDuplicates(input []interface{}, resourceTxt string) error {
-	k := make(map[string]bool)
-	if len(input) == 0 || input == nil {
-		return nil
-	}
-
-	for _, v := range input {
-		if _, d := k[strings.ToLower(v.(string))]; !d {
-			k[strings.ToLower(v.(string))] = true
-		} else {
-			return fmt.Errorf("duplicate %[1]s detected, please remove all duplicate entries for the %[1]s(ID: %q) from your configuration block", resourceTxt, v.(string))
-		}
-	}
-
-	return nil
-}
-
 func expandRuleSetIds(input []interface{}) ([]interface{}, error) {
 	out := make([]interface{}, 0)
 	if len(input) == 0 || input == nil {

--- a/internal/services/cdn/cdn_frontdoor_helpers.go
+++ b/internal/services/cdn/cdn_frontdoor_helpers.go
@@ -7,13 +7,8 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/cdn/mgmt/2021-06-01/cdn"             // nolint: staticcheck
 	"github.com/Azure/azure-sdk-for-go/services/frontdoor/mgmt/2020-11-01/frontdoor" // nolint: staticcheck
 	dnsValidate "github.com/hashicorp/go-azure-sdk/resource-manager/dns/2018-05-01/zones"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/cdn/azuresdkhacks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/cdn/parse"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
@@ -314,131 +309,6 @@ func sliceContainsString(input []interface{}, value string) bool {
 	return false
 }
 
-// determines if the slice contains the value case-insensitively
-func routeSliceContains(input *[]parse.FrontDoorRouteId, value string) bool {
-	if len(*input) == 0 || input == nil {
-		return false
-	}
-
-	for _, key := range *input {
-		v := key.ID()
-		if strings.EqualFold(v, value) {
-			return true
-		}
-	}
-
-	return false
-}
-
-// returns the slice with the value removed case-insensitively
-func sliceRemoveString(input []interface{}, value string) []interface{} {
-	out := make([]interface{}, 0)
-	if len(input) == 0 {
-		return out
-	}
-
-	for _, key := range input {
-		v := key.(string)
-		if strings.EqualFold(v, value) {
-			continue
-		}
-		out = append(out, key)
-	}
-
-	return out
-}
-
-func getRouteProperties(d *pluginsdk.ResourceData, meta interface{}, id *parse.FrontDoorRouteId, resourceName string) ([]interface{}, *cdn.RouteProperties, error) {
-	client := meta.(*clients.Client).Cdn.FrontDoorRoutesClient
-	ctx, routeCancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
-	defer routeCancel()
-
-	// Check to see if the route exists
-	resp, err := client.Get(ctx, id.ResourceGroup, id.ProfileName, id.AfdEndpointName, id.RouteName)
-	if err != nil {
-		return nil, nil, fmt.Errorf("%s: retrieving existing %s: %+v", resourceName, *id, err)
-	}
-
-	props := resp.RouteProperties
-	if props == nil {
-		return nil, nil, fmt.Errorf("%s: %s properties are 'nil': %+v", resourceName, *id, err)
-	}
-
-	customDomains, err := flattenCustomDomainActivatedResourceArray(props.CustomDomains)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return customDomains, props, nil
-}
-
-func removeCustomDomainAssociationFromRoutes(d *pluginsdk.ResourceData, meta interface{}, routes *[]parse.FrontDoorRouteId, customDomainID *parse.FrontDoorCustomDomainId) error {
-	if len(*routes) != 0 && routes != nil {
-		for _, route := range *routes {
-			// lock the route resource for update...
-			locks.ByName(route.RouteName, cdnFrontDoorRouteResourceName)
-			defer locks.UnlockByName(route.RouteName, cdnFrontDoorRouteResourceName)
-
-			// Check to see if the route still exists and grab its properties...
-			// NOTE: cdnFrontDoorRouteResourceName is defined in the "cdn_frontdoor_route_disable_link_to_default_domain_resource" file
-			// ignore the error because that could just mean that the route has already been deleted...
-			customDomains, props, err := getRouteProperties(d, meta, &route, cdnFrontDoorCustomDomainResourceName)
-			if err == nil {
-				// Check to make sure the custom domain is still associated with the route
-				isAssociated := sliceContainsString(customDomains, customDomainID.ID())
-
-				if isAssociated {
-					// it is, now removed the association...
-					newDomains := sliceRemoveString(customDomains, customDomainID.ID())
-					if err := updateRouteAssociations(d, meta, &route, newDomains, props, customDomainID); err != nil {
-						return err
-					}
-				}
-			}
-		}
-	}
-
-	return nil
-}
-
-func updateRouteAssociations(d *pluginsdk.ResourceData, meta interface{}, routeId *parse.FrontDoorRouteId, customDomains []interface{}, props *cdn.RouteProperties, customDomainID *parse.FrontDoorCustomDomainId) error {
-	client := meta.(*clients.Client).Cdn.FrontDoorRoutesClient
-	workaroundsClient := azuresdkhacks.NewCdnFrontDoorRoutesWorkaroundClient(client)
-	ctx, routeCancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
-	defer routeCancel()
-
-	updateProps := azuresdkhacks.RouteUpdatePropertiesParameters{
-		CustomDomains: expandCustomDomainActivatedResourceArray(customDomains),
-	}
-
-	// NOTE: You must pull the Cache Configuration from the existing route else you will get a diff
-	// because a nil value means disabled
-	if props.CacheConfiguration != nil {
-		updateProps.CacheConfiguration = props.CacheConfiguration
-	}
-
-	// NOTE: If there are no more custom domains associated with the route you must flip the
-	// 'link to default domain' field to 'true' else the route will be in an invalid state...
-	if len(customDomains) == 0 {
-		updateProps.LinkToDefaultDomain = cdn.LinkToDefaultDomainEnabled
-	}
-
-	updateParams := azuresdkhacks.RouteUpdateParameters{
-		RouteUpdatePropertiesParameters: &updateProps,
-	}
-
-	future, err := workaroundsClient.Update(ctx, routeId.ResourceGroup, routeId.ProfileName, routeId.AfdEndpointName, routeId.RouteName, updateParams)
-	if err != nil {
-		return fmt.Errorf("%s: updating the association with %s: %+v", *customDomainID, *routeId, err)
-	}
-
-	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("%s: waiting to update the association with %s: %+v", *customDomainID, *routeId, err)
-	}
-
-	return nil
-}
-
 func validateCustomDomainLinkToDefaultDomainState(resourceCustomDomains []interface{}, routeCustomDomains []interface{}, routeName string, routeProfile string) error {
 	// NOTE: Only used in the deprecated custom domain link to default domain resource
 	if !features.FourPointOhBeta() {
@@ -525,39 +395,6 @@ func validateRoutesCustomDomainProfile(customDomains []interface{}, routeProfile
 	return nil
 }
 
-// Validates that the CDN FrontDoor Custom Domain can be associated with the CDN FrontDoor Route
-func validateCustomDomainRoutes(input *[]parse.FrontDoorRouteId, customDomainID *parse.FrontDoorCustomDomainId) error {
-	if input == nil || len(*input) == 0 {
-		return nil
-	}
-
-	// check for duplicates...
-	if err := routeSliceHasDuplicates(input, "CDN FrontDoor Route"); err != nil {
-		return err
-	}
-
-	for i, route := range *input {
-		// the route and custom domain profiles must match...
-		if customDomainID.ProfileName != route.ProfileName {
-			return fmt.Errorf("the CDN FrontDoor Custom Domain(Name: %q, Profile: %q) and the CDN FrontDoor Route(Name: %q, Profile: %q) must belong to the same CDN FrontDoor Profile", customDomainID.CustomDomainName, customDomainID.ProfileName, route.RouteName, route.ProfileName)
-		}
-
-		// validate all routes are using the same endpoint because a custom domain can not
-		// be associated with routes that target two different endpoints...
-		for t, v := range *input {
-			if i == t {
-				continue
-			}
-
-			if route.AfdEndpointName != v.AfdEndpointName {
-				return fmt.Errorf("the CDN FrontDoor Route(Name: %q) and CDN FrontDoor Route(Name: %q) do not reference the same CDN FrontDoor Endpoint(Name: %q). All CDN FrontDoor Routes must reference the same CDN FrontDoor Endpoint %q to associate the CDN FrontDoor Custom Domain(Name: %q) with more than one CDN FrontDoor Route", route.RouteName, v.RouteName, route.AfdEndpointName, route.AfdEndpointName, customDomainID.CustomDomainName)
-			}
-		}
-	}
-
-	return nil
-}
-
 // Checks to make sure the list of CDN FrontDoor Custom Domains does not contain duplicate entries
 func sliceHasDuplicates(input []interface{}, resourceTxt string) error {
 	k := make(map[string]bool)
@@ -576,47 +413,6 @@ func sliceHasDuplicates(input []interface{}, resourceTxt string) error {
 	return nil
 }
 
-func routeSliceHasDuplicates(input *[]parse.FrontDoorRouteId, resourceName string) error {
-	k := make(map[string]bool)
-	if len(*input) == 0 || input == nil {
-		return nil
-	}
-
-	for _, route := range *input {
-		if _, d := k[strings.ToLower(route.ID())]; !d {
-			k[strings.ToLower(route.ID())] = true
-		} else {
-			return fmt.Errorf("duplicate %[1]s detected, please remove all duplicate entries for the %[1]s(ID: %q) from your configuration block", resourceName, route.ID())
-		}
-	}
-
-	return nil
-}
-
-// Determines what CDN FrontDoor Routes need to be removed/disassociated from this CDN FrontDoor Custom Domain
-func routeDelta(oldRoutes *[]parse.FrontDoorRouteId, newRoutes *[]parse.FrontDoorRouteId) (*[]parse.FrontDoorRouteId, *[]parse.FrontDoorRouteId) {
-	remove := make([]parse.FrontDoorRouteId, 0)
-	shared := make([]parse.FrontDoorRouteId, 0)
-	if len(*newRoutes) == 0 || newRoutes == nil {
-		return oldRoutes, &shared
-	}
-
-	if len(*oldRoutes) == 0 || oldRoutes == nil {
-		return &remove, &shared
-	}
-
-	// just find what old routes are not in the new route list...
-	for _, oldRoute := range *oldRoutes {
-		if !routeSliceContains(newRoutes, oldRoute.ID()) {
-			remove = append(remove, oldRoute)
-		} else {
-			shared = append(shared, oldRoute)
-		}
-	}
-
-	return &remove, &shared
-}
-
 func expandRuleSetIds(input []interface{}) ([]interface{}, error) {
 	out := make([]interface{}, 0)
 	if len(input) == 0 || input == nil {
@@ -625,44 +421,6 @@ func expandRuleSetIds(input []interface{}) ([]interface{}, error) {
 
 	for _, ruleSet := range input {
 		id, err := parse.FrontDoorRuleSetID(ruleSet.(string))
-		if err != nil {
-			return nil, err
-		}
-
-		out = append(out, id.ID())
-	}
-
-	return out, nil
-}
-
-func expandRoutes(input []interface{}) (*[]parse.FrontDoorRouteId, []interface{}, error) {
-	out := make([]parse.FrontDoorRouteId, 0)
-	config := make([]interface{}, 0)
-	if len(input) == 0 || input == nil {
-		return &out, config, nil
-	}
-
-	for _, v := range input {
-		id, err := parse.FrontDoorRouteID(v.(string))
-		if err != nil {
-			return nil, nil, err
-		}
-
-		out = append(out, *id)
-		config = append(config, id.ID())
-	}
-
-	return &out, config, nil
-}
-
-func expandCustomDomains(input []interface{}) ([]interface{}, error) {
-	out := make([]interface{}, 0)
-	if len(input) == 0 || input == nil {
-		return out, nil
-	}
-
-	for _, v := range input {
-		id, err := parse.FrontDoorCustomDomainID(v.(string))
 		if err != nil {
 			return nil, err
 		}

--- a/internal/services/cdn/cdn_frontdoor_route_data_source.go
+++ b/internal/services/cdn/cdn_frontdoor_route_data_source.go
@@ -1,0 +1,203 @@
+package cdn
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/cdn/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/cdn/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+func dataSourceCdnFrontDoorRoute() *pluginsdk.Resource {
+	return &pluginsdk.Resource{
+		Read: dataSourceCdnFrontDoorRouteRead,
+
+		Timeouts: &pluginsdk.ResourceTimeout{
+			Read: pluginsdk.DefaultTimeout(5 * time.Minute),
+		},
+
+		Schema: map[string]*pluginsdk.Schema{
+			"cdn_frontdoor_route_id": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.FrontDoorRouteID,
+			},
+
+			"cdn_frontdoor_endpoint_id": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
+			"cdn_frontdoor_origin_group_id": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
+			"cdn_frontdoor_custom_domain_ids": {
+				Type:     pluginsdk.TypeSet,
+				Computed: true,
+
+				Elem: &pluginsdk.Schema{
+					Type: pluginsdk.TypeString,
+				},
+			},
+
+			"link_to_default_domain": {
+				Type:     pluginsdk.TypeBool,
+				Computed: true,
+			},
+
+			"cache": {
+				Type:     pluginsdk.TypeList,
+				Computed: true,
+
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"query_strings": {
+							Type:     pluginsdk.TypeList,
+							Computed: true,
+
+							Elem: &pluginsdk.Schema{
+								Type: pluginsdk.TypeString,
+							},
+						},
+
+						"query_string_caching_behavior": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+
+						"compression_enabled": {
+							Type:     pluginsdk.TypeBool,
+							Computed: true,
+						},
+
+						"content_types_to_compress": {
+							Type:     pluginsdk.TypeList,
+							Computed: true,
+
+							Elem: &pluginsdk.Schema{
+								Type: pluginsdk.TypeString,
+							},
+						},
+					},
+				},
+			},
+
+			"enabled": {
+				Type:     pluginsdk.TypeBool,
+				Computed: true,
+			},
+
+			"forwarding_protocol": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
+			"https_redirect_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Computed: true,
+			},
+
+			"cdn_frontdoor_origin_path": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
+			"patterns_to_match": {
+				Type:     pluginsdk.TypeList,
+				Computed: true,
+
+				Elem: &pluginsdk.Schema{
+					Type: pluginsdk.TypeString,
+				},
+			},
+
+			"cdn_frontdoor_rule_set_ids": {
+				Type:     pluginsdk.TypeSet,
+				Computed: true,
+
+				Elem: &pluginsdk.Schema{
+					Type: pluginsdk.TypeString,
+				},
+			},
+
+			"supported_protocols": {
+				Type:     pluginsdk.TypeSet,
+				Computed: true,
+
+				Elem: &pluginsdk.Schema{
+					Type: pluginsdk.TypeString,
+				},
+			},
+		},
+	}
+}
+
+func dataSourceCdnFrontDoorRouteRead(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Cdn.FrontDoorRoutesClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	idRaw := d.Get("cdn_frontdoor_route_id").(string)
+	id, err := parse.FrontDoorRouteID(idRaw)
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Get(ctx, id.ResourceGroup, id.ProfileName, id.AfdEndpointName, id.RouteName)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+
+	d.Set("name", id.RouteName)
+	d.Set("cdn_frontdoor_endpoint_id", parse.NewFrontDoorEndpointID(id.SubscriptionId, id.ResourceGroup, id.ProfileName, id.AfdEndpointName).ID())
+
+	if props := resp.RouteProperties; props != nil {
+		customDomains, err := flattenCustomDomainActivatedResourceArray(props.CustomDomains)
+		if err != nil {
+			return err
+		}
+
+		d.Set("cdn_frontdoor_custom_domain_ids", customDomains)
+		d.Set("enabled", flattenEnabledBool(props.EnabledState))
+		d.Set("forwarding_protocol", props.ForwardingProtocol)
+		d.Set("https_redirect_enabled", flattenHttpsRedirectToBool(props.HTTPSRedirect))
+		d.Set("cdn_frontdoor_origin_path", props.OriginPath)
+		d.Set("patterns_to_match", props.PatternsToMatch)
+		d.Set("link_to_default_domain", flattenLinkToDefaultDomainToBool(props.LinkToDefaultDomain))
+
+		if err := d.Set("cache", flattenCdnFrontdoorRouteCacheConfiguration(props.CacheConfiguration)); err != nil {
+			return fmt.Errorf("setting `cache`: %+v", err)
+		}
+
+		originGroupId, err := flattenOriginGroupResourceReference(props.OriginGroup)
+		if err != nil {
+			return fmt.Errorf("flattening `cdn_frontdoor_origin_group_id`: %+v", err)
+		}
+
+		if err := d.Set("cdn_frontdoor_origin_group_id", originGroupId); err != nil {
+			return fmt.Errorf("setting `cdn_frontdoor_origin_group_id`: %+v", err)
+		}
+
+		if err := d.Set("cdn_frontdoor_rule_set_ids", flattenRuleSetResourceArray(props.RuleSets)); err != nil {
+			return fmt.Errorf("setting `cdn_frontdoor_rule_set_ids`: %+v", err)
+		}
+
+		if err := d.Set("supported_protocols", flattenCdnFrontdoorRouteEndpointProtocolsArray(props.SupportedProtocols)); err != nil {
+			return fmt.Errorf("setting `supported_protocols`: %+v", err)
+		}
+	}
+
+	return nil
+}

--- a/internal/services/cdn/cdn_frontdoor_route_data_source.go
+++ b/internal/services/cdn/cdn_frontdoor_route_data_source.go
@@ -163,6 +163,7 @@ func dataSourceCdnFrontDoorRouteRead(d *pluginsdk.ResourceData, meta interface{}
 		return fmt.Errorf("retrieving %s: %+v", id, err)
 	}
 
+	d.SetId(id.ID())
 	d.Set("name", id.RouteName)
 	d.Set("cdn_frontdoor_endpoint_id", endpointId.ID())
 

--- a/internal/services/cdn/cdn_frontdoor_route_data_source.go
+++ b/internal/services/cdn/cdn_frontdoor_route_data_source.go
@@ -38,6 +38,8 @@ func dataSourceCdnFrontDoorRoute() *pluginsdk.Resource {
 				Computed: true,
 			},
 
+			// I have to expose this here because that is the only way the user will
+			// know that the resource has been modified outside of terraform...
 			"cdn_frontdoor_custom_domain_ids": {
 				Type:     pluginsdk.TypeSet,
 				Computed: true,
@@ -47,6 +49,8 @@ func dataSourceCdnFrontDoorRoute() *pluginsdk.Resource {
 				},
 			},
 
+			// I have to expose this here because that is the only way the user will
+			// know that the resource has been modified outside of terraform...
 			"link_to_default_domain": {
 				Type:     pluginsdk.TypeBool,
 				Computed: true,

--- a/internal/services/cdn/cdn_frontdoor_route_data_source_test.go
+++ b/internal/services/cdn/cdn_frontdoor_route_data_source_test.go
@@ -25,6 +25,25 @@ func TestAccCdnFrontDoorRouteDataSource_basic(t *testing.T) {
 	})
 }
 
+func TestAccCdnFrontDoorRouteDataSource_useCase(t *testing.T) {
+	// this test case was added to validate customer use case in issue #21639
+	data := acceptance.BuildTestData(t, "data.azurerm_cdn_frontdoor_route", "test")
+	d := CdnFrontDoorRouteDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: d.stepOne(data),
+		},
+		{
+			Config: d.stepTwo(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("enabled").HasValue("true"),
+				check.That(data.ResourceName).Key("forwarding_protocol").HasValue("HttpsOnly"),
+			),
+		},
+	})
+}
+
 func (CdnFrontDoorRouteDataSource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
@@ -34,4 +53,66 @@ data "azurerm_cdn_frontdoor_route" "test" {
   cdn_frontdoor_endpoint_id = azurerm_cdn_frontdoor_endpoint.test.id
 }
 `, CdnFrontDoorRouteResource{}.complete(data))
+}
+
+func (CdnFrontDoorRouteDataSource) stepOne(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+# NOTE: This simulates a configuration being created in a different config
+%s
+
+resource "azurerm_cdn_frontdoor_route" "test" {
+	name                          = "acctestRoute-%[2]d"
+	cdn_frontdoor_endpoint_id     = azurerm_cdn_frontdoor_endpoint.test.id
+	cdn_frontdoor_origin_group_id = azurerm_cdn_frontdoor_origin_group.test.id
+	cdn_frontdoor_origin_ids      = [azurerm_cdn_frontdoor_origin.test.id]
+
+	# cdn_frontdoor_custom_domain_ids = [azurerm_cdn_frontdoor_custom_domain.test.id]
+
+	enabled                    = true
+	forwarding_protocol        = "HttpsOnly"
+	https_redirect_enabled     = false
+	patterns_to_match          = ["/*"]
+	cdn_frontdoor_rule_set_ids = [azurerm_cdn_frontdoor_rule_set.test.id]
+	supported_protocols        = ["Https"]
+  
+	cache {
+	  query_strings                 = ["bar"]
+	  query_string_caching_behavior = "IncludeSpecifiedQueryStrings"
+	}
+  }
+`, CdnFrontDoorRouteResource{}.template(data), data.RandomInteger)
+}
+
+func (r CdnFrontDoorRouteDataSource) stepTwo(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_cdn_frontdoor_custom_domain" "test" {
+  name                     = "acctest-contoso-%[2]d"
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.test.id
+  host_name                = "test.%[2]d.com"
+  
+  tls {
+    certificate_type    = "ManagedCertificate"
+    minimum_tls_version = "TLS12"
+  }
+} 
+
+data "azurerm_cdn_frontdoor_endpoint" "test" {
+	name                = "accTestEndpoint-%[2]d"
+	profile_name        = "accTestProfile-%[2]d"
+	resource_group_name = "acctestRG-cdn-afdx-%[2]d"
+}
+
+data "azurerm_cdn_frontdoor_route" "test" {
+  name                      = "acctestRoute-%[2]d"
+  cdn_frontdoor_endpoint_id = data.azurerm_cdn_frontdoor_endpoint.test.id
+}
+
+resource "azurerm_cdn_frontdoor_custom_domain_association" "test" {
+  cdn_frontdoor_route_id          = data.azurerm_cdn_frontdoor_route.test.id
+  cdn_frontdoor_custom_domain_ids = [azurerm_cdn_frontdoor_custom_domain.test.id]
+  link_to_default_domain          = false
+}
+`, r.stepOne(data), data.RandomInteger)
 }

--- a/internal/services/cdn/cdn_frontdoor_route_data_source_test.go
+++ b/internal/services/cdn/cdn_frontdoor_route_data_source_test.go
@@ -11,7 +11,7 @@ import (
 type CdnFrontDoorRouteDataSource struct{}
 
 func TestAccCdnFrontDoorRouteDataSource_basic(t *testing.T) {
-	data := acceptance.BuildTestData(t, "data.azurerm_cdn_frontdoor_profile", "test")
+	data := acceptance.BuildTestData(t, "data.azurerm_cdn_frontdoor_route", "test")
 	d := CdnFrontDoorRouteDataSource{}
 
 	data.DataSourceTest(t, []acceptance.TestStep{

--- a/internal/services/cdn/cdn_frontdoor_route_data_source_test.go
+++ b/internal/services/cdn/cdn_frontdoor_route_data_source_test.go
@@ -61,25 +61,25 @@ func (CdnFrontDoorRouteDataSource) stepOne(data acceptance.TestData) string {
 %s
 
 resource "azurerm_cdn_frontdoor_route" "test" {
-	name                          = "acctestRoute-%[2]d"
-	cdn_frontdoor_endpoint_id     = azurerm_cdn_frontdoor_endpoint.test.id
-	cdn_frontdoor_origin_group_id = azurerm_cdn_frontdoor_origin_group.test.id
-	cdn_frontdoor_origin_ids      = [azurerm_cdn_frontdoor_origin.test.id]
+  name                          = "acctestRoute-%[2]d"
+  cdn_frontdoor_endpoint_id     = azurerm_cdn_frontdoor_endpoint.test.id
+  cdn_frontdoor_origin_group_id = azurerm_cdn_frontdoor_origin_group.test.id
+  cdn_frontdoor_origin_ids      = [azurerm_cdn_frontdoor_origin.test.id]
 
-	# cdn_frontdoor_custom_domain_ids = [azurerm_cdn_frontdoor_custom_domain.test.id]
+  # cdn_frontdoor_custom_domain_ids = [azurerm_cdn_frontdoor_custom_domain.test.id]
 
-	enabled                    = true
-	forwarding_protocol        = "HttpsOnly"
-	https_redirect_enabled     = false
-	patterns_to_match          = ["/*"]
-	cdn_frontdoor_rule_set_ids = [azurerm_cdn_frontdoor_rule_set.test.id]
-	supported_protocols        = ["Https"]
-  
-	cache {
-	  query_strings                 = ["bar"]
-	  query_string_caching_behavior = "IncludeSpecifiedQueryStrings"
-	}
+  enabled                    = true
+  forwarding_protocol        = "HttpsOnly"
+  https_redirect_enabled     = false
+  patterns_to_match          = ["/*"]
+  cdn_frontdoor_rule_set_ids = [azurerm_cdn_frontdoor_rule_set.test.id]
+  supported_protocols        = ["Https"]
+
+  cache {
+    query_strings                 = ["bar"]
+    query_string_caching_behavior = "IncludeSpecifiedQueryStrings"
   }
+}
 `, CdnFrontDoorRouteResource{}.template(data), data.RandomInteger)
 }
 
@@ -91,17 +91,17 @@ resource "azurerm_cdn_frontdoor_custom_domain" "test" {
   name                     = "acctest-contoso-%[2]d"
   cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.test.id
   host_name                = "test.%[2]d.com"
-  
+
   tls {
     certificate_type    = "ManagedCertificate"
     minimum_tls_version = "TLS12"
   }
-} 
+}
 
 data "azurerm_cdn_frontdoor_endpoint" "test" {
-	name                = "accTestEndpoint-%[2]d"
-	profile_name        = "accTestProfile-%[2]d"
-	resource_group_name = "acctestRG-cdn-afdx-%[2]d"
+  name                = "accTestEndpoint-%[2]d"
+  profile_name        = "accTestProfile-%[2]d"
+  resource_group_name = "acctestRG-cdn-afdx-%[2]d"
 }
 
 data "azurerm_cdn_frontdoor_route" "test" {

--- a/internal/services/cdn/cdn_frontdoor_route_data_source_test.go
+++ b/internal/services/cdn/cdn_frontdoor_route_data_source_test.go
@@ -25,7 +25,7 @@ func TestAccCdnFrontDoorRouteDataSource_basic(t *testing.T) {
 	})
 }
 
-func TestAccCdnFrontDoorRouteDataSource_useCase(t *testing.T) {
+func TestAccCdnFrontDoorRouteDataSource_customerUseCase(t *testing.T) {
 	// this test case was added to validate customer use case in issue #21639
 	data := acceptance.BuildTestData(t, "data.azurerm_cdn_frontdoor_route", "test")
 	d := CdnFrontDoorRouteDataSource{}

--- a/internal/services/cdn/cdn_frontdoor_route_data_source_test.go
+++ b/internal/services/cdn/cdn_frontdoor_route_data_source_test.go
@@ -1,0 +1,37 @@
+package cdn_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+)
+
+type CdnFrontDoorRouteDataSource struct{}
+
+func TestAccCdnFrontDoorRouteDataSource_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_cdn_frontdoor_profile", "test")
+	d := CdnFrontDoorRouteDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: d.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("enabled").HasValue("true"),
+				check.That(data.ResourceName).Key("forwarding_protocol").HasValue("HttpsOnly"),
+			),
+		},
+	})
+}
+
+func (CdnFrontDoorRouteDataSource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_cdn_frontdoor_route" "test" {
+  name                      = azurerm_cdn_frontdoor_route.test.name
+  cdn_frontdoor_endpoint_id = azurerm_cdn_frontdoor_endpoint.test.id
+}
+`, CdnFrontDoorRouteResource{}.complete(data))
+}

--- a/internal/services/cdn/cdn_frontdoor_route_disable_link_to_default_domain_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_route_disable_link_to_default_domain_resource_test.go
@@ -123,8 +123,6 @@ resource "azurerm_cdn_frontdoor_route" "test" {
   cdn_frontdoor_origin_ids      = [azurerm_cdn_frontdoor_origin.test.id]
   patterns_to_match             = ["/*"]
   supported_protocols           = ["Http", "Https"]
-
-  cdn_frontdoor_custom_domain_ids = [azurerm_cdn_frontdoor_custom_domain.test.id]
 }
 
 resource "azurerm_cdn_frontdoor_custom_domain" "test" {
@@ -140,8 +138,8 @@ resource "azurerm_cdn_frontdoor_custom_domain" "test" {
 }
 
 resource "azurerm_cdn_frontdoor_custom_domain_association" "test" {
-  cdn_frontdoor_custom_domain_id = azurerm_cdn_frontdoor_custom_domain.test.id
-  cdn_frontdoor_route_ids        = [azurerm_cdn_frontdoor_route.test.id]
+  cdn_frontdoor_route_id          = azurerm_cdn_frontdoor_route.test.id
+  cdn_frontdoor_custom_domain_ids = [azurerm_cdn_frontdoor_custom_domain.test.id]
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomStringOfLength(8))
 }

--- a/internal/services/cdn/cdn_frontdoor_route_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_route_resource_test.go
@@ -15,10 +15,6 @@ import (
 
 type CdnFrontDoorRouteResource struct{}
 
-// TODO: Add test with real custom domain once I figure out how to do that
-// in the meantime I will use the link_to_default_domain_enabled to make the
-// Frontdoor endpoint our "Custom Domain".
-
 func TestAccCdnFrontDoorRoute_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_route", "test")
 	r := CdnFrontDoorRouteResource{}

--- a/internal/services/cdn/parse/front_door_custom_domain_association.go
+++ b/internal/services/cdn/parse/front_door_custom_domain_association.go
@@ -13,14 +13,16 @@ type FrontDoorCustomDomainAssociationId struct {
 	SubscriptionId  string
 	ResourceGroup   string
 	ProfileName     string
+	AfdEndpointName string
 	AssociationName string
 }
 
-func NewFrontDoorCustomDomainAssociationID(subscriptionId, resourceGroup, profileName, associationName string) FrontDoorCustomDomainAssociationId {
+func NewFrontDoorCustomDomainAssociationID(subscriptionId, resourceGroup, profileName, afdEndpointName, associationName string) FrontDoorCustomDomainAssociationId {
 	return FrontDoorCustomDomainAssociationId{
 		SubscriptionId:  subscriptionId,
 		ResourceGroup:   resourceGroup,
 		ProfileName:     profileName,
+		AfdEndpointName: afdEndpointName,
 		AssociationName: associationName,
 	}
 }
@@ -28,6 +30,7 @@ func NewFrontDoorCustomDomainAssociationID(subscriptionId, resourceGroup, profil
 func (id FrontDoorCustomDomainAssociationId) String() string {
 	segments := []string{
 		fmt.Sprintf("Association Name %q", id.AssociationName),
+		fmt.Sprintf("Afd Endpoint Name %q", id.AfdEndpointName),
 		fmt.Sprintf("Profile Name %q", id.ProfileName),
 		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 	}
@@ -36,8 +39,8 @@ func (id FrontDoorCustomDomainAssociationId) String() string {
 }
 
 func (id FrontDoorCustomDomainAssociationId) ID() string {
-	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Cdn/profiles/%s/associations/%s"
-	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.ProfileName, id.AssociationName)
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Cdn/profiles/%s/afdEndpoints/%s/associations/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.ProfileName, id.AfdEndpointName, id.AssociationName)
 }
 
 // FrontDoorCustomDomainAssociationID parses a FrontDoorCustomDomainAssociation ID into an FrontDoorCustomDomainAssociationId struct
@@ -61,6 +64,9 @@ func FrontDoorCustomDomainAssociationID(input string) (*FrontDoorCustomDomainAss
 	}
 
 	if resourceId.ProfileName, err = id.PopSegment("profiles"); err != nil {
+		return nil, err
+	}
+	if resourceId.AfdEndpointName, err = id.PopSegment("afdEndpoints"); err != nil {
 		return nil, err
 	}
 	if resourceId.AssociationName, err = id.PopSegment("associations"); err != nil {

--- a/internal/services/cdn/parse/front_door_custom_domain_association_test.go
+++ b/internal/services/cdn/parse/front_door_custom_domain_association_test.go
@@ -11,8 +11,8 @@ import (
 var _ resourceids.Id = FrontDoorCustomDomainAssociationId{}
 
 func TestFrontDoorCustomDomainAssociationIDFormatter(t *testing.T) {
-	actual := NewFrontDoorCustomDomainAssociationID("12345678-1234-9876-4563-123456789012", "resGroup1", "profile1", "assoc1").ID()
-	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Cdn/profiles/profile1/associations/assoc1"
+	actual := NewFrontDoorCustomDomainAssociationID("12345678-1234-9876-4563-123456789012", "resGroup1", "profile1", "endpoint1", "route1").ID()
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Cdn/profiles/profile1/afdEndpoints/endpoint1/associations/route1"
 	if actual != expected {
 		t.Fatalf("Expected %q but got %q", expected, actual)
 	}
@@ -68,31 +68,44 @@ func TestFrontDoorCustomDomainAssociationID(t *testing.T) {
 		},
 
 		{
-			// missing AssociationName
+			// missing AfdEndpointName
 			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Cdn/profiles/profile1/",
 			Error: true,
 		},
 
 		{
+			// missing value for AfdEndpointName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Cdn/profiles/profile1/afdEndpoints/",
+			Error: true,
+		},
+
+		{
+			// missing AssociationName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Cdn/profiles/profile1/afdEndpoints/endpoint1/",
+			Error: true,
+		},
+
+		{
 			// missing value for AssociationName
-			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Cdn/profiles/profile1/associations/",
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Cdn/profiles/profile1/afdEndpoints/endpoint1/associations/",
 			Error: true,
 		},
 
 		{
 			// valid
-			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Cdn/profiles/profile1/associations/assoc1",
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Cdn/profiles/profile1/afdEndpoints/endpoint1/associations/route1",
 			Expected: &FrontDoorCustomDomainAssociationId{
 				SubscriptionId:  "12345678-1234-9876-4563-123456789012",
 				ResourceGroup:   "resGroup1",
 				ProfileName:     "profile1",
-				AssociationName: "assoc1",
+				AfdEndpointName: "endpoint1",
+				AssociationName: "route1",
 			},
 		},
 
 		{
 			// upper-cased
-			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.CDN/PROFILES/PROFILE1/ASSOCIATIONS/ASSOC1",
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.CDN/PROFILES/PROFILE1/AFDENDPOINTS/ENDPOINT1/ASSOCIATIONS/ROUTE1",
 			Error: true,
 		},
 	}
@@ -120,6 +133,9 @@ func TestFrontDoorCustomDomainAssociationID(t *testing.T) {
 		}
 		if actual.ProfileName != v.Expected.ProfileName {
 			t.Fatalf("Expected %q but got %q for ProfileName", v.Expected.ProfileName, actual.ProfileName)
+		}
+		if actual.AfdEndpointName != v.Expected.AfdEndpointName {
+			t.Fatalf("Expected %q but got %q for AfdEndpointName", v.Expected.AfdEndpointName, actual.AfdEndpointName)
 		}
 		if actual.AssociationName != v.Expected.AssociationName {
 			t.Fatalf("Expected %q but got %q for AssociationName", v.Expected.AssociationName, actual.AssociationName)

--- a/internal/services/cdn/registration.go
+++ b/internal/services/cdn/registration.go
@@ -37,6 +37,7 @@ func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
 		"azurerm_cdn_frontdoor_firewall_policy": dataSourceCdnFrontDoorFirewallPolicy(),
 		"azurerm_cdn_frontdoor_origin_group":    dataSourceCdnFrontDoorOriginGroup(),
 		"azurerm_cdn_frontdoor_profile":         dataSourceCdnFrontDoorProfile(),
+		"azurerm_cdn_frontdoor_route":           dataSourceCdnFrontDoorRoute(),
 		"azurerm_cdn_frontdoor_rule_set":        dataSourceCdnFrontDoorRuleSet(),
 		"azurerm_cdn_frontdoor_secret":          dataSourceCdnFrontDoorSecret(),
 	}

--- a/internal/services/cdn/resourceids.go
+++ b/internal/services/cdn/resourceids.go
@@ -20,4 +20,4 @@ package cdn
 
 // CDN FrontDoor "Associations"
 //go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=FrontDoorRouteDisableLinkToDefaultDomain -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Cdn/profiles/profile1/afdEndpoints/endpoint1/routes/route1/disableLinkToDefaultDomain/disableLinkToDefaultDomain1
-//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=FrontDoorCustomDomainAssociation -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Cdn/profiles/profile1/associations/assoc1
+//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=FrontDoorCustomDomainAssociation -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Cdn/profiles/profile1/afdEndpoints/endpoint1/associations/route1

--- a/internal/services/cdn/validate/front_door_custom_domain_association_id_test.go
+++ b/internal/services/cdn/validate/front_door_custom_domain_association_id_test.go
@@ -53,26 +53,38 @@ func TestFrontDoorCustomDomainAssociationID(t *testing.T) {
 		},
 
 		{
-			// missing AssociationName
+			// missing AfdEndpointName
 			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Cdn/profiles/profile1/",
 			Valid: false,
 		},
 
 		{
+			// missing value for AfdEndpointName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Cdn/profiles/profile1/afdEndpoints/",
+			Valid: false,
+		},
+
+		{
+			// missing AssociationName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Cdn/profiles/profile1/afdEndpoints/endpoint1/",
+			Valid: false,
+		},
+
+		{
 			// missing value for AssociationName
-			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Cdn/profiles/profile1/associations/",
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Cdn/profiles/profile1/afdEndpoints/endpoint1/associations/",
 			Valid: false,
 		},
 
 		{
 			// valid
-			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Cdn/profiles/profile1/associations/assoc1",
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Cdn/profiles/profile1/afdEndpoints/endpoint1/associations/route1",
 			Valid: true,
 		},
 
 		{
 			// upper-cased
-			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.CDN/PROFILES/PROFILE1/ASSOCIATIONS/ASSOC1",
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.CDN/PROFILES/PROFILE1/AFDENDPOINTS/ENDPOINT1/ASSOCIATIONS/ROUTE1",
 			Valid: false,
 		},
 	}

--- a/website/docs/d/cdn_frontdoor_route.html.markdown
+++ b/website/docs/d/cdn_frontdoor_route.html.markdown
@@ -14,7 +14,8 @@ Use this data source to access information about an existing Front Door (standar
 
 ```hcl
 data "azurerm_cdn_frontdoor_route" "example" {
-  cdn_frontdoor_route_id = "existing-cdn-route-id"
+  name                      = "existing-cdn-route-name"
+  cdn_frontdoor_endpoint_id = "existing-cdn-endpoint-id"
 }
 ```
 
@@ -22,7 +23,9 @@ data "azurerm_cdn_frontdoor_route" "example" {
 
 The following arguments are supported:
 
-* `cdn_frontdoor_route_id` - Specifies The Resource ID of the existing Front Door Route.
+* `name` - (Required) Specifies the name of the Front Door Route.
+
+* `cdn_frontdoor_endpoint_id` - (Required) Specifies The Resource ID of the Front Door Endpoint.
 
 ## Attributes Reference
 
@@ -30,43 +33,43 @@ The following attributes are exported:
 
 * `id` - The ID of the Front Door Route.
 
-* `name` - Specifies The name which should be used for this Front Door Route. Valid values must begin with a letter or number, end with a letter or number and may only contain letters, numbers and hyphens with a maximum length of 90 characters. Changing this forces a new Front Door Route to be created.
+* `name` - Specifies The name of the Front Door Route.
 
-* `cdn_frontdoor_endpoint_id` - Specifies The resource ID of the Front Door Endpoint where this Front Door Route should exist. Changing this forces a new Front Door Route to be created.
+* `cdn_frontdoor_endpoint_id` - Specifies the resource ID of the Front Door Endpoint.
 
-* `cdn_frontdoor_origin_group_id` - Specifies The resource ID of the Front Door Origin Group where this Front Door Route should be created.
+* `cdn_frontdoor_origin_group_id` - Specifies The resource ID of the Front Door Origin Group.
 
-* `forwarding_protocol` - Specifies The Protocol that will be use when forwarding traffic to backends. Possible values are `HttpOnly`, `HttpsOnly` or `MatchRequest`.
+* `forwarding_protocol` - Specifies the Protocol that will be use when forwarding traffic to backends.
 
-* `patterns_to_match` - Specifies The route patterns of the rule.
+* `patterns_to_match` - Specifies the route patterns of the rule.
 
-* `supported_protocols` - Specifies One or more Protocols supported by this Front Door Route. Possible values are `Http` or `Https`.
+* `supported_protocols` - Specifies the supported Protocols by this Front Door Route.
 
 * `cache` - A `cache` block as defined below.
 
-* `cdn_frontdoor_custom_domain_ids` - Specifies The IDs of the Front Door Custom Domains which are associated with this Front Door Route.
+* `cdn_frontdoor_custom_domain_ids` - Specifies the IDs of the Front Door Custom Domains which are associated with this Front Door Route.
 
-* `cdn_frontdoor_origin_path` - Specifies A directory path on the Front Door Origin that can be used to retrieve content (e.g. `contoso.cloudapp.net/originpath`).
+* `cdn_frontdoor_origin_path` - Specifies a directory path on the Front Door Origin that can be used to retrieve content.
 
-* `cdn_frontdoor_rule_set_ids` - Specifies A list of the Front Door Rule Set IDs which should be assigned to this Front Door Route.
+* `cdn_frontdoor_rule_set_ids` - Specifies a list of the Front Door Rule Set IDs which are assigned to this Front Door Route.
 
-* `enabled` - Specifies Is this Front Door Route enabled? Possible values are `true` or `false`. Defaults to `true`.
+* `enabled` - Specifies if this Front Door Route enabled or not.
 
-* `https_redirect_enabled` - Specifies Automatically redirect HTTP traffic to HTTPS traffic? Possible values are `true` or `false`. Defaults to `true`.
+* `https_redirect_enabled` - Specifies if automatically redirect HTTP traffic to HTTPS traffic are enabled or not.
 
-* `link_to_default_domain` - Specifies Should this Front Door Route be linked to the default endpoint? Possible values include `true` or `false`. Defaults to `true`.
+* `link_to_default_domain` - Specifies if this Front Door Route is linked to the default endpoint or not.
 
 ---
 
 A `cache` block supports the following:
 
-* `query_string_caching_behavior` - Specifies Defines how the Front Door Route will cache requests that include query strings. Possible values include `IgnoreQueryString`, `IgnoreSpecifiedQueryStrings`, `IncludeSpecifiedQueryStrings` or `UseQueryString`. Defaults it `IgnoreQueryString`.
+* `query_string_caching_behavior` - Specifies the Front Door Routes query string behavior.
 
-* `query_strings` - Specifies Query strings to include or ignore.
+* `query_strings` - Specifies the Front Door Routes Query strings.
 
-* `compression_enabled` - Specifies Is content compression enabled? Possible values are `true` or `false`. Defaults to `false`.
+* `compression_enabled` - Specifies if content compression is enabled or not?
 
-* `content_types_to_compress` - Specifies A list of one or more `Content types` (formerly known as `MIME types`) to compress.
+* `content_types_to_compress` - Specifies a list of `Content types` that are being compressed.
 
 ## Timeouts
 

--- a/website/docs/d/cdn_frontdoor_route.html.markdown
+++ b/website/docs/d/cdn_frontdoor_route.html.markdown
@@ -1,0 +1,75 @@
+---
+subcategory: "CDN"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_cdn_frontdoor_route"
+description: |-
+  Gets information about an existing Front Door (standard/premium) Route.
+---
+
+# Data Source: azurerm_cdn_frontdoor_route
+
+Use this data source to access information about an existing Front Door (standard/premium) Route.
+
+## Example Usage
+
+```hcl
+data "azurerm_cdn_frontdoor_route" "example" {
+  cdn_frontdoor_route_id = "existing-cdn-route-id"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `cdn_frontdoor_route_id` - Specifies The Resource ID of the existing Front Door Route.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the Front Door Route.
+
+* `name` - Specifies The name which should be used for this Front Door Route. Valid values must begin with a letter or number, end with a letter or number and may only contain letters, numbers and hyphens with a maximum length of 90 characters. Changing this forces a new Front Door Route to be created.
+
+* `cdn_frontdoor_endpoint_id` - Specifies The resource ID of the Front Door Endpoint where this Front Door Route should exist. Changing this forces a new Front Door Route to be created.
+
+* `cdn_frontdoor_origin_group_id` - Specifies The resource ID of the Front Door Origin Group where this Front Door Route should be created.
+
+* `forwarding_protocol` - Specifies The Protocol that will be use when forwarding traffic to backends. Possible values are `HttpOnly`, `HttpsOnly` or `MatchRequest`.
+
+* `patterns_to_match` - Specifies The route patterns of the rule.
+
+* `supported_protocols` - Specifies One or more Protocols supported by this Front Door Route. Possible values are `Http` or `Https`.
+
+* `cache` - A `cache` block as defined below.
+
+* `cdn_frontdoor_custom_domain_ids` - Specifies The IDs of the Front Door Custom Domains which are associated with this Front Door Route.
+
+* `cdn_frontdoor_origin_path` - Specifies A directory path on the Front Door Origin that can be used to retrieve content (e.g. `contoso.cloudapp.net/originpath`).
+
+* `cdn_frontdoor_rule_set_ids` - Specifies A list of the Front Door Rule Set IDs which should be assigned to this Front Door Route.
+
+* `enabled` - Specifies Is this Front Door Route enabled? Possible values are `true` or `false`. Defaults to `true`.
+
+* `https_redirect_enabled` - Specifies Automatically redirect HTTP traffic to HTTPS traffic? Possible values are `true` or `false`. Defaults to `true`.
+
+* `link_to_default_domain` - Specifies Should this Front Door Route be linked to the default endpoint? Possible values include `true` or `false`. Defaults to `true`.
+
+---
+
+A `cache` block supports the following:
+
+* `query_string_caching_behavior` - Specifies Defines how the Front Door Route will cache requests that include query strings. Possible values include `IgnoreQueryString`, `IgnoreSpecifiedQueryStrings`, `IncludeSpecifiedQueryStrings` or `UseQueryString`. Defaults it `IgnoreQueryString`.
+
+* `query_strings` - Specifies Query strings to include or ignore.
+
+* `compression_enabled` - Specifies Is content compression enabled? Possible values are `true` or `false`. Defaults to `false`.
+
+* `content_types_to_compress` - Specifies A list of one or more `Content types` (formerly known as `MIME types`) to compress.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the Front Door Route.

--- a/website/docs/r/cdn_frontdoor_custom_domain_association.html.markdown
+++ b/website/docs/r/cdn_frontdoor_custom_domain_association.html.markdown
@@ -3,19 +3,35 @@ subcategory: "CDN"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_cdn_frontdoor_custom_domain_association"
 description: |-
-  Manages the association between a Front Door (standard/premium) Custom Domain and one or more Front Door (standard/premium) Routes.
+  Manages the Custom Domain associations between one or more Front Door (standard/premium) Custom Domains and a Front Door (standard/premium) Route.
 ---
 
 # azurerm_cdn_frontdoor_custom_domain_association
 
-Manages the association between a Front Door (standard/premium) Custom Domain and one or more Front Door (standard/premium) Routes.
+Manages the Custom Domain associations between one or more Front Door (standard/premium) Custom Domains and a Front Door (standard/premium) Route.
 
 ## Example Usage
 
 ```hcl
 resource "azurerm_cdn_frontdoor_custom_domain_association" "example" {
-  cdn_frontdoor_custom_domain_id = azurerm_cdn_frontdoor_custom_domain.contoso.id
-  cdn_frontdoor_route_ids        = [azurerm_cdn_frontdoor_route.contoso.id, azurerm_cdn_frontdoor_route.fabrikam.id]
+  cdn_frontdoor_route_id          = azurerm_cdn_frontdoor_route.contoso.id
+  cdn_frontdoor_custom_domain_ids = [azurerm_cdn_frontdoor_custom_domain.contoso.id]
+  link_to_default_domain          = false
+}
+```
+
+## Example Usage using the `azurerm_cdn_frontdoor_route` Data Source
+
+```hcl
+data "azurerm_cdn_frontdoor_route" "example" {
+  name                      = azurerm_cdn_frontdoor_route.example.name
+  cdn_frontdoor_endpoint_id = azurerm_cdn_frontdoor_endpoint.example.id
+}
+
+resource "azurerm_cdn_frontdoor_custom_domain_association" "example" {
+  cdn_frontdoor_route_id          = data.azurerm_cdn_frontdoor_route.example.id
+  cdn_frontdoor_custom_domain_ids = [azurerm_cdn_frontdoor_custom_domain.example.id]
+  link_to_default_domain          = false
 }
 ```
 
@@ -23,11 +39,13 @@ resource "azurerm_cdn_frontdoor_custom_domain_association" "example" {
 
 The following arguments are supported:
 
-* `cdn_frontdoor_custom_domain_id` - (Required) The ID of the Front Door Custom Domain that should be managed by the association resource. Changing this forces a new association resource to be created.
+* `cdn_frontdoor_route_id` - (Required) The Resource ID of the Front Door Route which this Front Door Custom Domain Association resource will manage. Changing this forces a new Front Door Custom Domain Association resource to be created.
 
-* `cdn_frontdoor_route_ids` - (Required) One or more IDs of the Front Door Route to which the Front Door Custom Domain is associated with.
+* `cdn_frontdoor_custom_domain_ids` - (Required) The Resource IDs of the Front Door Custom Domain(s) which are to be associated with the Front Door Route.
 
--> **NOTE:** This should include all of the Front Door Route resources that the Front Door Custom Domain is associated with. If the list of Front Door Routes is not complete you will receive the service side error `This resource is still associated with a route. Please delete the association with the route first before deleting this resource` when you attempt to `destroy`/`delete` your Front Door Custom Domain.
+* `link_to_default_domain` - (Optional) Should this Front Door Route be linked to the default endpoint? Possible values include `true` or `false`. Defaults to `true`.
+
+-> **NOTE:** The `link_to_default_domain` value will be automatically toggled to `true` on deletion of this resource.
 
 ## Attributes Reference
 
@@ -51,5 +69,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 Front Door Custom Domain Associations can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_cdn_frontdoor_custom_domain_association.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup1/providers/Microsoft.Cdn/profiles/profile1/associations/assoc1
+terraform import azurerm_cdn_frontdoor_custom_domain_association.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroup1/providers/Microsoft.Cdn/profiles/profile1/afdEndpoints/endpoint1/associations/route1
 ```

--- a/website/docs/r/cdn_frontdoor_route.html.markdown
+++ b/website/docs/r/cdn_frontdoor_route.html.markdown
@@ -136,8 +136,6 @@ The following arguments are supported:
 
 ~> **NOTE:** To disable caching, do not provide the `cache` block in the configuration file.
 
-* `cdn_frontdoor_custom_domain_ids` - (Optional) The IDs of the Front Door Custom Domains which are associated with this Front Door Route.
-
 * `cdn_frontdoor_origin_path` - (Optional) A directory path on the Front Door Origin that can be used to retrieve content (e.g. `contoso.cloudapp.net/originpath`).
 
 * `cdn_frontdoor_rule_set_ids` - (Optional) A list of the Front Door Rule Set IDs which should be assigned to this Front Door Route.
@@ -147,8 +145,6 @@ The following arguments are supported:
 * `https_redirect_enabled` - (Optional) Automatically redirect HTTP traffic to HTTPS traffic? Possible values are `true` or `false`. Defaults to `true`.
 
 ~> **NOTE:** The `https_redirect_enabled` rule is the first rule that will be executed.
-
-* `link_to_default_domain` - (Optional) Should this Front Door Route be linked to the default endpoint? Possible values include `true` or `false`. Defaults to `true`.
 
 ---
 


### PR DESCRIPTION
(fixes #21639)

## BREAKING CHANGES:

To facilitate the requested functionality with the new `azurerm_cdn_frontdoor_route` data source in the above referenced issue the following `breaking changes` had to be introduced:

* `azurerm_cdn_frontdoor_route`: The fields  `cdn_frontdoor_custom_domain_ids` and `link_to_default_domain` had to be removed from the `azurerm_cdn_frontdoor_route` resource and re-mapped into the `azurerm_cdn_frontdoor_custom_domain_association` resource.

*  `azurerm_cdn_frontdoor_custom_domain_association`: The fields  `cdn_frontdoor_route_ids` and `cdn_frontdoor_custom_domain_id` had to be re-mapped to be `cdn_frontdoor_route_id` and `cdn_frontdoor_custom_domain_ids` and also expose the `link_to_default_domain` field. This had to be done so the `azurerm_cdn_frontdoor_custom_domain_association` resource would actually own the `cdn_frontdoor_route`'s `cdn_frontdoor_custom_domain_ids` and `link_to_default_domain` fields instead of just modifying them upon deletion of the `azurerm_cdn_frontdoor_custom_domain_association` resource.

* `azurerm_cdn_frontdoor_custom_domain_association`: Updated the resource ID from `/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Cdn/profiles/profile1/associations/assoc1` to `/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Cdn/profiles/profile1/afdEndpoints/endpoint1/associations/route1`