### PR TITLE
`data.azurerm_key_vault_encrypted_value`: add support for `decoded_plain_text_value`

### DIFF
--- a/internal/services/keyvault/encrypted_value_data_source_test.go
+++ b/internal/services/keyvault/encrypted_value_data_source_test.go
@@ -15,20 +15,22 @@ func TestAccEncryptedValueDataSource_encryptAndDecrypt(t *testing.T) {
 	// so we only need a single test here
 	data := acceptance.BuildTestData(t, "data.azurerm_key_vault_encrypted_value", "decrypted")
 	r := EncryptedValueDataSourceTest{}
+	plainText, plainText2 := "this is a test", "some-secret"
+
 	data.DataSourceTest(t, []acceptance.TestStep{
 		{
-			Config: r.decrypt(data),
+			Config: r.decrypt(data, plainText, plainText2),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("encrypted_value").MatchesOtherKey(check.That("data.azurerm_key_vault_encrypted_value.encrypted").Key("encrypted_value")),
 				check.That(data.ResourceName).Key("plain_text_value").MatchesOtherKey(check.That("data.azurerm_key_vault_encrypted_value.encrypted").Key("plain_text_value")),
-				check.That("data.azurerm_key_vault_encrypted_value.decrypted_space").Key("encrypted_value").MatchesOtherKey(check.That("data.azurerm_key_vault_encrypted_value.encrypted_space").Key("encrypted_value")),
-				check.That("data.azurerm_key_vault_encrypted_value.decrypted_space").Key("plain_text_value").MatchesOtherKey(check.That("data.azurerm_key_vault_encrypted_value.encrypted_space").Key("plain_text_value")),
+				check.That("data.azurerm_key_vault_encrypted_value.decrypted2").Key("decoded_plain_text_value").HasValue(plainText),
+				check.That("data.azurerm_key_vault_encrypted_value.decrypted3").Key("decoded_plain_text_value").HasValue(plainText2),
 			),
 		},
 	})
 }
 
-func (t EncryptedValueDataSourceTest) decrypt(data acceptance.TestData) string {
+func (t EncryptedValueDataSourceTest) decrypt(data acceptance.TestData, plainText, plainText2 string) string {
 	template := t.template(data)
 	return fmt.Sprintf(`
 provider "azurerm" {
@@ -49,18 +51,30 @@ data "azurerm_key_vault_encrypted_value" "decrypted" {
   encrypted_data   = data.azurerm_key_vault_encrypted_value.encrypted.encrypted_data
 }
 
-data "azurerm_key_vault_encrypted_value" "encrypted_space" {
+data "azurerm_key_vault_encrypted_value" "encrypted2" {
   key_vault_key_id = azurerm_key_vault_key.test.id
   algorithm        = "RSA1_5"
-  plain_text_value = "some encrypted value "
+  plain_text_value = base64encode("%s")
 }
 
-data "azurerm_key_vault_encrypted_value" "decrypted_space" {
+data "azurerm_key_vault_encrypted_value" "decrypted2" {
   key_vault_key_id = azurerm_key_vault_key.test.id
   algorithm        = "RSA1_5"
-  encrypted_data   = data.azurerm_key_vault_encrypted_value.encrypted_space.encrypted_data
+  encrypted_data   = data.azurerm_key_vault_encrypted_value.encrypted2.encrypted_data
 }
-`, template)
+
+data "azurerm_key_vault_encrypted_value" "encrypted3" {
+  key_vault_key_id = azurerm_key_vault_key.test.id
+  algorithm        = "RSA1_5"
+  plain_text_value = base64encode("%s")
+}
+
+data "azurerm_key_vault_encrypted_value" "decrypted3" {
+  key_vault_key_id = azurerm_key_vault_key.test.id
+  algorithm        = "RSA1_5"
+  encrypted_data   = data.azurerm_key_vault_encrypted_value.encrypted3.encrypted_data
+}
+`, template, plainText, plainText2)
 }
 
 func (t EncryptedValueDataSourceTest) template(data acceptance.TestData) string {

--- a/internal/services/keyvault/encrypted_value_data_source_test.go
+++ b/internal/services/keyvault/encrypted_value_data_source_test.go
@@ -21,6 +21,8 @@ func TestAccEncryptedValueDataSource_encryptAndDecrypt(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("encrypted_value").MatchesOtherKey(check.That("data.azurerm_key_vault_encrypted_value.encrypted").Key("encrypted_value")),
 				check.That(data.ResourceName).Key("plain_text_value").MatchesOtherKey(check.That("data.azurerm_key_vault_encrypted_value.encrypted").Key("plain_text_value")),
+				check.That("data.azurerm_key_vault_encrypted_value.decrypted_space").Key("encrypted_value").MatchesOtherKey(check.That("data.azurerm_key_vault_encrypted_value.encrypted_space").Key("encrypted_value")),
+				check.That("data.azurerm_key_vault_encrypted_value.decrypted_space").Key("plain_text_value").MatchesOtherKey(check.That("data.azurerm_key_vault_encrypted_value.encrypted_space").Key("plain_text_value")),
 			),
 		},
 	})
@@ -45,6 +47,18 @@ data "azurerm_key_vault_encrypted_value" "decrypted" {
   key_vault_key_id = azurerm_key_vault_key.test.id
   algorithm        = "RSA1_5"
   encrypted_data   = data.azurerm_key_vault_encrypted_value.encrypted.encrypted_data
+}
+
+data "azurerm_key_vault_encrypted_value" "encrypted_space" {
+  key_vault_key_id = azurerm_key_vault_key.test.id
+  algorithm        = "RSA1_5"
+  plain_text_value = "some encrypted value "
+}
+
+data "azurerm_key_vault_encrypted_value" "decrypted_space" {
+  key_vault_key_id = azurerm_key_vault_key.test.id
+  algorithm        = "RSA1_5"
+  encrypted_data   = data.azurerm_key_vault_encrypted_value.encrypted_space.encrypted_data
 }
 `, template)
 }

--- a/website/docs/d/key_vault_encrypted_value.html.markdown
+++ b/website/docs/d/key_vault_encrypted_value.html.markdown
@@ -26,11 +26,21 @@ data "azurerm_key_vault_key" "example" {
 data "azurerm_key_vault_encrypted_value" "encrypted" {
   key_vault_key_id = azurerm_key_vault_key.test.id
   algorithm        = "RSA1_5"
-  plain_text_value = "some-encrypted-value"
+  plain_text_value = base64encode("some-encrypted-value")
+}
+
+data "azurerm_key_vault_encrypted_value" "decrypted" {
+  key_vault_key_id = azurerm_key_vault_key.test.id
+  algorithm        = "RSA1_5"
+  encrypted_data   = data.azurerm_key_vault_encrypted_value.encrypted.encrypted_data
 }
 
 output "id" {
   value = data.azurerm_key_vault_encrypted_value.example.encrypted_data
+}
+
+output "decrypted_text" {
+  value = nonsensitive(data.azurerm_key_vault_encrypted_value.decrypted.decoded_plain_text_value)
 }
 ```
 
@@ -55,6 +65,8 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - The ID of this Encrypted Value
+
+* `decoded_plain_text_value` - The Base64URL decoded string of `plain_text_value`. Because the API would remove padding characters of `plain_text_value` when encrypting, this attribute is useful to get the original value.
 
 ## Timeouts
 


### PR DESCRIPTION
according to the [swagger format](https://github.com/Azure/azure-rest-api-specs/blob/b2fe1573f29f056930d79b1b8abf2611b98fa81a/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.1/keys.json#L1463-L1466), we should pass a base64url encoded string to encrypt. more discussion see #20763 and https://github.com/Azure/azure-rest-api-specs/issues/23829

resolves #20763 

```
--- PASS: TestAccEncryptedValueDataSource_encryptAndDecrypt (459.34s)
PASS
```

*Note*: when base64url decode failed in decrypt stage, it just prints a DEBUG log and assign the API response as plainTextValue to make it compatible with old resources (that encrypt/decrypt accept non-encoded string too).