### PR TITLE
`data.azurerm_linux_function_app` - Fix #21669 by adding length check

### DIFF
--- a/internal/services/appservice/linux_function_app_data_source.go
+++ b/internal/services/appservice/linux_function_app_data_source.go
@@ -425,7 +425,7 @@ func (m *LinuxFunctionAppDataSourceModel) unpackLinuxFunctionAppSettings(input w
 			}
 		case "WEBSITE_HTTPLOGGING_RETENTION_DAYS":
 		case "FUNCTIONS_WORKER_RUNTIME":
-			if m.SiteConfig[0].ApplicationStack != nil {
+			if len(m.SiteConfig[0].ApplicationStack) > 0 {
 				m.SiteConfig[0].ApplicationStack[0].CustomHandler = strings.EqualFold(*v, "custom")
 			}
 


### PR DESCRIPTION
This pr should fix #21669 by adding a length check on `SiteConfig[0].ApplicationStack`.