### PR TITLE
`azurerm_machine_learning_workspace` - Fix Key Vault ID validation error

### DIFF
--- a/internal/services/machinelearning/machine_learning_workspace_resource.go
+++ b/internal/services/machinelearning/machine_learning_workspace_resource.go
@@ -328,7 +328,6 @@ func resourceMachineLearningWorkspaceRead(d *pluginsdk.ResourceData, meta interf
 	if props := resp.Model.Properties; props != nil {
 		d.Set("application_insights_id", props.ApplicationInsights)
 		d.Set("storage_account_id", props.StorageAccount)
-		d.Set("key_vault_id", props.KeyVault)
 		d.Set("container_registry_id", props.ContainerRegistry)
 		d.Set("description", props.Description)
 		d.Set("friendly_name", props.FriendlyName)
@@ -338,6 +337,12 @@ func resourceMachineLearningWorkspaceRead(d *pluginsdk.ResourceData, meta interf
 		d.Set("primary_user_assigned_identity", props.PrimaryUserAssignedIdentity)
 		d.Set("public_network_access_enabled", *props.PublicNetworkAccess == workspaces.PublicNetworkAccessEnabled)
 		d.Set("v1_legacy_mode_enabled", props.V1LegacyMode)
+
+		kvId, err := commonids.ParseKeyVaultIDInsensitively(*props.KeyVault)
+		if err != nil {
+			return err
+		}
+		d.Set("key_vault_id", kvId.ID())
 
 		if !features.FourPointOhBeta() {
 			d.Set("public_access_behind_virtual_network_enabled", props.AllowPublicAccessWhenBehindVnet)

--- a/internal/services/machinelearning/machine_learning_workspace_resource_test.go
+++ b/internal/services/machinelearning/machine_learning_workspace_resource_test.go
@@ -515,6 +515,7 @@ resource "azurerm_key_vault_access_policy" "test" {
     "Get",
     "Delete",
     "Purge",
+    "GetRotationPolicy",
   ]
 }
 


### PR DESCRIPTION
1. Fix ID validation error. The Key Vault ID returned by service is case insensitive.
2. Fix AccTest failure.

```log
=== RUN   TestAccMachineLearningWorkspace_requiresImport
=== PAUSE TestAccMachineLearningWorkspace_requiresImport
=== CONT  TestAccMachineLearningWorkspace_requiresImport
--- PASS: TestAccMachineLearningWorkspace_requiresImport (689.67s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/machinelearning       706.525s

=== RUN   TestAccMachineLearningWorkspaceDataSource_basic
=== PAUSE TestAccMachineLearningWorkspaceDataSource_basic
=== CONT  TestAccMachineLearningWorkspaceDataSource_basic
--- PASS: TestAccMachineLearningWorkspaceDataSource_basic (1993.35s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/machinelearning       2023.477s

=== RUN   TestAccMachineLearningWorkspace_complete
=== PAUSE TestAccMachineLearningWorkspace_complete
=== RUN   TestAccMachineLearningWorkspace_completeUpdate
=== PAUSE TestAccMachineLearningWorkspace_completeUpdate
=== CONT  TestAccMachineLearningWorkspace_complete
=== CONT  TestAccMachineLearningWorkspace_completeUpdate
--- PASS: TestAccMachineLearningWorkspace_complete (1886.00s)
--- PASS: TestAccMachineLearningWorkspace_completeUpdate (2078.67s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/machinelearning       2084.885s

```