### PR TITLE
`azurerm_site_recovery_protection_container_mapping`: Support new property `automatic_update.authentication_type`

### DIFF
--- a/internal/services/recoveryservices/site_recovery_protection_container_mapping_resource.go
+++ b/internal/services/recoveryservices/site_recovery_protection_container_mapping_resource.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/recoveryservices/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/recoveryservices/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -103,7 +104,12 @@ func resourceSiteRecoveryProtectionContainerMapping() *pluginsdk.Resource {
 						"authentication_type": {
 							Type:     pluginsdk.TypeString,
 							Optional: true,
-							Default:  string(replicationprotectioncontainermappings.AutomationAccountAuthenticationTypeSystemAssignedIdentity),
+							Default: func() interface{} {
+								if !features.FourPointOhBeta() {
+									return nil
+								}
+								return string(replicationprotectioncontainermappings.AutomationAccountAuthenticationTypeSystemAssignedIdentity)
+							}(),
 							// The Swagger definition defaults to `RunAsAccount` but it is deprecated.
 							// deprecation details: https://learn.microsoft.com/en-us/azure/automation/whats-new#support-for-run-as-accounts
 							ValidateFunc: validation.StringInSlice(replicationprotectioncontainermappings.PossibleValuesForAutomationAccountAuthenticationType(), false),

--- a/website/docs/r/site_recovery_protection_container_mapping.html.markdown
+++ b/website/docs/r/site_recovery_protection_container_mapping.html.markdown
@@ -109,9 +109,11 @@ An `automatic_update` block supports the following:
 
 ~> **Note:** `automation_account_id` is required when `enabled` is specified.
 
-* `authentication_type` - (Optional) The authentication type used for automation account. Possible values are `RunAsAccount` and `SystemAssignedIdentity`. Defaults to `SystemAssignedIdentity`.
+* `authentication_type` - (Optional) The authentication type used for automation account. Possible values are `RunAsAccount` and `SystemAssignedIdentity`.
 
 ~> **Note:** `RunAsAccount` of `authentication_type` is deprecated and will retire on September 30, 2023. Details could be found [here](https://learn.microsoft.com/en-us/azure/automation/whats-new#support-for-run-as-accounts).
+
+~> **Note:**: `authentication_type` will default to `SystemAssignedIdentity` in version 4.0.
 
 ## Attributes Reference
 

--- a/website/docs/r/site_recovery_protection_container_mapping.html.markdown
+++ b/website/docs/r/site_recovery_protection_container_mapping.html.markdown
@@ -107,7 +107,11 @@ An `automatic_update` block supports the following:
 
 * `automation_account_id` - (Optional) The automation account ID which holds the automatic update runbook and authenticates to Azure resources.
 
-~> **Note:** `automation_account_id` is required when `enabled` is sepcified.
+~> **Note:** `automation_account_id` is required when `enabled` is specified.
+
+* `authentication_type` - (Optional) The authentication type used for automation account. Possible values are `RunAsAccount` and `SystemAssignedIdentity`. Defaults to `SystemAssignedIdentity`.
+
+~> **Note:** `RunAsAccount` of `authentication_type` is deprecated and will retire on September 30, 2023. Details could be found [here](https://learn.microsoft.com/en-us/azure/automation/whats-new#support-for-run-as-accounts).
 
 ## Attributes Reference
 


### PR DESCRIPTION
fix #20304

test case `TestAccSiteRecoveryProtectionContainerMapping_withAutoUpdateExtension` skipped as creation of [new Run As Account is not allowed](https://learn.microsoft.com/en-us/azure/automation/migrate-run-as-accounts-managed-identity?tabs=run-as-account#:~:text=Azure%20Automation%20Run,not%20be%20possible.). 

test
---
```
❯ tftest recoveryservices TestAccSiteRecoveryProtectionContainerMapping                        
=== RUN   TestAccSiteRecoveryProtectionContainerMapping_basic
=== PAUSE TestAccSiteRecoveryProtectionContainerMapping_basic
=== RUN   TestAccSiteRecoveryProtectionContainerMapping_withSystemAssignedAutoUpdate
=== PAUSE TestAccSiteRecoveryProtectionContainerMapping_withSystemAssignedAutoUpdate
=== RUN   TestAccSiteRecoveryProtectionContainerMapping_withAutoUpdateExtension
    site_recovery_protection_container_mapping_resource_test.go:62: skipped as RunAsAccount is deprecated and it's not allowed to create new ones
--- SKIP: TestAccSiteRecoveryProtectionContainerMapping_withAutoUpdateExtension (0.00s)
=== CONT  TestAccSiteRecoveryProtectionContainerMapping_basic
=== CONT  TestAccSiteRecoveryProtectionContainerMapping_withSystemAssignedAutoUpdate
--- PASS: TestAccSiteRecoveryProtectionContainerMapping_basic (971.37s)
--- PASS: TestAccSiteRecoveryProtectionContainerMapping_withSystemAssignedAutoUpdate (1341.36s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/recoveryservices      1341.402s

```