### PR TITLE
`azurerm_recovery_services_vault`: Support new block `monitoring`

### DIFF
--- a/internal/services/recoveryservices/recovery_services_vault_resource_test.go
+++ b/internal/services/recoveryservices/recovery_services_vault_resource_test.go
@@ -504,6 +504,21 @@ func TestAccRecoveryServicesVault_basicWithClassicVmwareReplicateEnabled(t *test
 	})
 }
 
+func TestAccRecoveryServicesVault_basicWithMonitorDisabled(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_recovery_services_vault", "test")
+	r := RecoveryServicesVaultResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basicWithMonitor(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (RecoveryServicesVaultResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
@@ -687,6 +702,33 @@ resource "azurerm_recovery_services_vault" "test" {
   soft_delete_enabled = false
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, immutability)
+}
+
+func (RecoveryServicesVaultResource) basicWithMonitor(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-recovery-%d"
+  location = "%s"
+}
+
+resource "azurerm_recovery_services_vault" "test" {
+  name                = "acctest-Vault-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "Standard"
+
+  monitoring {
+    alerts_for_all_job_failures_enabled            = false
+    alerts_for_critical_operation_failures_enabled = false
+  }
+
+  soft_delete_enabled = false
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
 
 func (RecoveryServicesVaultResource) complete(data acceptance.TestData) string {

--- a/website/docs/r/recovery_services_vault.html.markdown
+++ b/website/docs/r/recovery_services_vault.html.markdown
@@ -62,6 +62,8 @@ The following arguments are supported:
 
 * `classic_vmware_replication_enabled` - (Optional) Whether to enable the Classic experience for VMware replication. If set to `false` VMware machines will be protected using the new stateless ASR replication appliance. Changing this forces a new resource to be created.
 
+* `monitoring` - (Optional) A `monitoring` block as defined below.
+
 ---
 
 An `identity` block supports the following:
@@ -87,6 +89,14 @@ An `encryption` block supports the following:
 !> **Note:** `use_system_assigned_identity` only be able to set to `false` for **new** vaults. Any vaults containing existing items registered or attempted to be registered to it are not supported. Details can be found in [the document](https://learn.microsoft.com/en-us/azure/backup/encryption-at-rest-with-cmk?tabs=portal#before-you-start)
 
 !> **Note:** Once `infrastructure_encryption_enabled` has been set it's not possible to change it.
+
+---
+
+A `monitoring` block supports the following:
+
+* `alerts_for_all_job_failures_enabled` - (Optional) Enabling/Disabling built-in Azure Monitor alerts for security scenarios and job failure scenarios. Defaults to `true`.
+
+* `alerts_for_critical_operation_failures_enabled` - (Optional) Enabling/Disabling alerts from the older (classic alerts) solution. Defaults to `true`. More details could be found [here](https://learn.microsoft.com/en-us/azure/backup/monitoring-and-alerts-overview).
 
 ---
 


### PR DESCRIPTION
fix #20080

test
---
```
❯ tftest recoveryservices TestAccRecoveryServicesVault
=== RUN   TestAccRecoveryServicesVault_basic
=== PAUSE TestAccRecoveryServicesVault_basic
=== RUN   TestAccRecoveryServicesVault_ToggleCrossRegionRestore
=== PAUSE TestAccRecoveryServicesVault_ToggleCrossRegionRestore
=== RUN   TestAccRecoveryServicesVault_basicWithCrossRegionRestoreAndWrongStorageType
=== PAUSE TestAccRecoveryServicesVault_basicWithCrossRegionRestoreAndWrongStorageType
=== RUN   TestAccRecoveryServicesVault_zrs
=== PAUSE TestAccRecoveryServicesVault_zrs
=== RUN   TestAccRecoveryServicesVault_complete
=== PAUSE TestAccRecoveryServicesVault_complete
=== RUN   TestAccRecoveryServicesVault_update
=== PAUSE TestAccRecoveryServicesVault_update
=== RUN   TestAccRecoveryServicesVault_requiresImport
=== PAUSE TestAccRecoveryServicesVault_requiresImport
=== RUN   TestAccRecoveryServicesVault_SystemAssignedIdentity
=== PAUSE TestAccRecoveryServicesVault_SystemAssignedIdentity
=== RUN   TestAccRecoveryServicesVault_UserAssignedIdentity
=== PAUSE TestAccRecoveryServicesVault_UserAssignedIdentity
=== RUN   TestAccRecoveryServicesVault_immutability
=== PAUSE TestAccRecoveryServicesVault_immutability
=== RUN   TestAccRecoveryServicesVault_softDelete
=== PAUSE TestAccRecoveryServicesVault_softDelete
=== RUN   TestAccRecoveryServicesVault_storageModeType
=== PAUSE TestAccRecoveryServicesVault_storageModeType
=== RUN   TestAccRecoveryServicesVault_crossRegionRestore
=== PAUSE TestAccRecoveryServicesVault_crossRegionRestore
=== RUN   TestAccRecoveryServicesVault_sku
=== PAUSE TestAccRecoveryServicesVault_sku
=== RUN   TestAccRecoveryServicesVault_updateSkuWithExistingEncryption
=== PAUSE TestAccRecoveryServicesVault_updateSkuWithExistingEncryption
=== RUN   TestAccRecoveryServicesVault_encryptionWithKeyVaultKey
=== PAUSE TestAccRecoveryServicesVault_encryptionWithKeyVaultKey
=== RUN   TestAccRecoveryServicesVault_turnOnEncryptionWithKeyVaultKey
=== PAUSE TestAccRecoveryServicesVault_turnOnEncryptionWithKeyVaultKey
=== RUN   TestAccRecoveryServicesVault_turnOffEncryptionWithKeyVaultKeyShouldHaveClearlyErrorMessage
=== PAUSE TestAccRecoveryServicesVault_turnOffEncryptionWithKeyVaultKeyShouldHaveClearlyErrorMessage
=== RUN   TestAccRecoveryServicesVault_changeInfrastructureEncryptionEnabledShouldHaveClearlyErrorMessage
=== PAUSE TestAccRecoveryServicesVault_changeInfrastructureEncryptionEnabledShouldHaveClearlyErrorMessage
=== RUN   TestAccRecoveryServicesVault_encryptionWithInfrastructureEncryption
=== PAUSE TestAccRecoveryServicesVault_encryptionWithInfrastructureEncryption
=== RUN   TestAccRecoveryServicesVault_switchEncryptionKeyVaultKey
=== PAUSE TestAccRecoveryServicesVault_switchEncryptionKeyVaultKey
=== RUN   TestAccRecoveryServicesVault_encryptionWithUserAssignedIdentity
=== PAUSE TestAccRecoveryServicesVault_encryptionWithUserAssignedIdentity
=== RUN   TestAccRecoveryServicesVault_TogglePublicNetworkAccessEnabled
=== PAUSE TestAccRecoveryServicesVault_TogglePublicNetworkAccessEnabled
=== RUN   TestAccRecoveryServicesVault_basicWithClassicVmwareReplicateEnabled
=== PAUSE TestAccRecoveryServicesVault_basicWithClassicVmwareReplicateEnabled
=== RUN   TestAccRecoveryServicesVault_basicWithMonitorDisabled
=== PAUSE TestAccRecoveryServicesVault_basicWithMonitorDisabled
=== CONT  TestAccRecoveryServicesVault_basic
=== CONT  TestAccRecoveryServicesVault_sku
=== CONT  TestAccRecoveryServicesVault_SystemAssignedIdentity
=== CONT  TestAccRecoveryServicesVault_encryptionWithInfrastructureEncryption
=== CONT  TestAccRecoveryServicesVault_crossRegionRestore
=== CONT  TestAccRecoveryServicesVault_requiresImport
=== CONT  TestAccRecoveryServicesVault_update
=== CONT  TestAccRecoveryServicesVault_complete
--- PASS: TestAccRecoveryServicesVault_complete (369.49s)
=== CONT  TestAccRecoveryServicesVault_zrs
--- PASS: TestAccRecoveryServicesVault_basic (431.10s)
=== CONT  TestAccRecoveryServicesVault_basicWithCrossRegionRestoreAndWrongStorageType
--- PASS: TestAccRecoveryServicesVault_SystemAssignedIdentity (443.47s)
=== CONT  TestAccRecoveryServicesVault_ToggleCrossRegionRestore
 --- PASS: TestAccRecoveryServicesVault_requiresImport (464.77s)
=== CONT  TestAccRecoveryServicesVault_softDelete
--- PASS: TestAccRecoveryServicesVault_basicWithCrossRegionRestoreAndWrongStorageType (169.09s)
=== CONT  TestAccRecoveryServicesVault_storageModeType
--- PASS: TestAccRecoveryServicesVault_crossRegionRestore (660.63s)
=== CONT  TestAccRecoveryServicesVault_immutability
--- PASS: TestAccRecoveryServicesVault_encryptionWithInfrastructureEncryption (715.44s)
=== CONT  TestAccRecoveryServicesVault_turnOnEncryptionWithKeyVaultKey
--- PASS: TestAccRecoveryServicesVault_zrs (401.40s)
=== CONT  TestAccRecoveryServicesVault_changeInfrastructureEncryptionEnabledShouldHaveClearlyErrorMessage
--- PASS: TestAccRecoveryServicesVault_update (857.75s)
=== CONT  TestAccRecoveryServicesVault_turnOffEncryptionWithKeyVaultKeyShouldHaveClearlyErrorMessage
--- PASS: TestAccRecoveryServicesVault_sku (1155.06s)
=== CONT  TestAccRecoveryServicesVault_UserAssignedIdentity
--- PASS: TestAccRecoveryServicesVault_storageModeType (591.92s)
=== CONT  TestAccRecoveryServicesVault_basicWithMonitorDisabled
--- PASS: TestAccRecoveryServicesVault_ToggleCrossRegionRestore (841.39s)
=== CONT  TestAccRecoveryServicesVault_encryptionWithUserAssignedIdentity
--- PASS: TestAccRecoveryServicesVault_immutability (793.84s)
=== CONT  TestAccRecoveryServicesVault_encryptionWithKeyVaultKey
--- PASS: TestAccRecoveryServicesVault_changeInfrastructureEncryptionEnabledShouldHaveClearlyErrorMessage (725.75s)
=== CONT  TestAccRecoveryServicesVault_basicWithClassicVmwareReplicateEnabled
--- PASS: TestAccRecoveryServicesVault_UserAssignedIdentity (423.38s)
=== CONT  TestAccRecoveryServicesVault_switchEncryptionKeyVaultKey
--- PASS: TestAccRecoveryServicesVault_softDelete (1139.25s)
=== CONT  TestAccRecoveryServicesVault_updateSkuWithExistingEncryption
--- PASS: TestAccRecoveryServicesVault_turnOnEncryptionWithKeyVaultKey (898.56s)
=== CONT  TestAccRecoveryServicesVault_TogglePublicNetworkAccessEnabled
--- PASS: TestAccRecoveryServicesVault_basicWithMonitorDisabled (432.80s)
--- PASS: TestAccRecoveryServicesVault_turnOffEncryptionWithKeyVaultKeyShouldHaveClearlyErrorMessage (797.00s)
--- PASS: TestAccRecoveryServicesVault_basicWithClassicVmwareReplicateEnabled (397.61s)
--- PASS: TestAccRecoveryServicesVault_encryptionWithUserAssignedIdentity (770.26s)
--- PASS: TestAccRecoveryServicesVault_encryptionWithKeyVaultKey (716.54s)
--- PASS: TestAccRecoveryServicesVault_updateSkuWithExistingEncryption (784.57s)
--- PASS: TestAccRecoveryServicesVault_switchEncryptionKeyVaultKey (1004.26s)
--- PASS: TestAccRecoveryServicesVault_TogglePublicNetworkAccessEnabled (988.60s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/recoveryservices      2602.671s

```