### PR TITLE
`azurerm_hdinsight_hbase_cluster`: remove unsupported field `autoscale`

### DIFF
--- a/internal/services/hdinsight/hdinsight_hbase_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_hbase_cluster_resource_test.go
@@ -555,43 +555,6 @@ func TestAccHDInsightHBaseCluster_updateAzureMonitor(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMHDInsightHBaseCluster_autoscale(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_hdinsight_hbase_cluster", "test")
-	r := HDInsightHBaseClusterResource{}
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.autoscale_schedule(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("https_endpoint").Exists(),
-				check.That(data.ResourceName).Key("ssh_endpoint").Exists(),
-			),
-		},
-		data.ImportStep("roles.0.head_node.0.password",
-			"roles.0.head_node.0.vm_size",
-			"roles.0.worker_node.0.password",
-			"roles.0.worker_node.0.vm_size",
-			"roles.0.zookeeper_node.0.password",
-			"roles.0.zookeeper_node.0.vm_size",
-			"storage_account"),
-		{
-			Config: r.basic(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("https_endpoint").Exists(),
-				check.That(data.ResourceName).Key("ssh_endpoint").Exists(),
-			),
-		},
-		data.ImportStep("roles.0.head_node.0.password",
-			"roles.0.head_node.0.vm_size",
-			"roles.0.worker_node.0.password",
-			"roles.0.worker_node.0.vm_size",
-			"roles.0.zookeeper_node.0.password",
-			"roles.0.zookeeper_node.0.vm_size",
-			"storage_account"),
-	})
-}
-
 func testAccHDInsightHBaseCluster_securityProfile(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_hdinsight_hbase_cluster", "test")
 	r := HDInsightHBaseClusterResource{}
@@ -1928,71 +1891,6 @@ resource "azurerm_hdinsight_hbase_cluster" "test" {
   }
 }
 `, r.template(data), data.RandomString, data.RandomInteger, data.RandomInteger)
-}
-
-func (r HDInsightHBaseClusterResource) autoscale_schedule(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-%s
-
-resource "azurerm_hdinsight_hbase_cluster" "test" {
-  name                = "acctesthdi-%d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-  cluster_version     = "4.0"
-  tier                = "Standard"
-
-  component_version {
-    hbase = "2.1"
-  }
-
-  gateway {
-    username = "acctestusrgw"
-    password = "TerrAform123!"
-  }
-
-  storage_account {
-    storage_container_id = azurerm_storage_container.test.id
-    storage_account_key  = azurerm_storage_account.test.primary_access_key
-    is_default           = true
-  }
-
-  roles {
-    head_node {
-      vm_size  = "Standard_D3_V2"
-      username = "acctestusrvm"
-      password = "AccTestvdSC4daf986!"
-    }
-
-    worker_node {
-      vm_size               = "Standard_D3_V2"
-      username              = "acctestusrvm"
-      password              = "AccTestvdSC4daf986!"
-      target_instance_count = 2
-      autoscale {
-        recurrence {
-          timezone = "Pacific Standard Time"
-          schedule {
-            days                  = ["Monday"]
-            time                  = "10:00"
-            target_instance_count = 5
-          }
-          schedule {
-            days                  = ["Saturday", "Sunday"]
-            time                  = "10:00"
-            target_instance_count = 3
-          }
-        }
-      }
-    }
-
-    zookeeper_node {
-      vm_size  = "Standard_D3_V2"
-      username = "acctestusrvm"
-      password = "AccTestvdSC4daf986!"
-    }
-  }
-}
-`, r.template(data), data.RandomInteger)
 }
 
 func (r HDInsightHBaseClusterResource) securityProfile(data acceptance.TestData) string {

--- a/website/docs/r/hdinsight_hbase_cluster.html.markdown
+++ b/website/docs/r/hdinsight_hbase_cluster.html.markdown
@@ -255,8 +255,6 @@ A `worker_node` block supports the following:
 
 * `virtual_network_id` - (Optional) The ID of the Virtual Network where the Worker Nodes should be provisioned within. Changing this forces a new resource to be created.
 
-* `autoscale` - (Optional) A `autoscale` block as defined below.
-
 ---
 
 A `disk_encryption` block supports the following:
@@ -352,32 +350,6 @@ A `extension` block supports the following:
 * `log_analytics_workspace_id` - (Required) The workspace ID of the log analytics extension.
 
 * `primary_key` - (Required) The workspace key of the log analytics extension.
-
----
-
-An `autoscale` block supports the following:
-
-* `recurrence` - (Optional) A `recurrence` block as defined below.
-
--> **NOTE:** Capacity based autoscaling isn't supported to HBase clusters.
-
----
-
-A `recurrence` block supports the following:
-
-* `schedule` - (Required) A list of `schedule` blocks as defined below.
-
-* `timezone` - (Required) The time zone for the autoscale schedule times.
-
----
-
-A `schedule` block supports the following:
-
-* `days` - (Required) The days of the week to perform autoscale. Possible values are `Monday`, `Tuesday`, `Wednesday`, `Thursday`, `Friday`, `Saturday` and `Sunday`.
-
-* `target_instance_count` - (Required) The number of worker nodes to autoscale at the specified time.
-
-* `time` - (Required) The time of day to perform the autoscale in 24hour format.
 
 ---
 


### PR DESCRIPTION
* This test keep failing of `Autocale is not supported on HBase cluster type.` 
* Removing since it's longer supported.