### PR TITLE
fix(documentation): create_option values are incorrects in virtual_machine_data_disk_attachment

### DIFF
--- a/website/docs/r/virtual_machine_data_disk_attachment.html.markdown
+++ b/website/docs/r/virtual_machine_data_disk_attachment.html.markdown
@@ -117,7 +117,7 @@ The following arguments are supported:
 
 * `caching` - (Required) Specifies the caching requirements for this Data Disk. Possible values include `None`, `ReadOnly` and `ReadWrite`.
 
-* `create_option` - (Optional) The Create Option of the Data Disk, such as `Empty` or `Attach`. Defaults to `Attach`. Changing this forces a new resource to be created.
+* `create_option` - (Optional) The Create Option of the Data Disk. Possible values include `Copy`, `Empty`, `FromImage`, `Import`, `ImportSecure`, `Restore`, `Upload`. Defaults to `Empty`. Changing this forces a new resource to be created.
 
 * `write_accelerator_enabled` - (Optional) Specifies if Write Accelerator is enabled on the disk. This can only be enabled on `Premium_LRS` managed disks with no caching and [M-Series VMs](https://docs.microsoft.com/azure/virtual-machines/workloads/sap/how-to-enable-write-accelerator). Defaults to `false`.
 


### PR DESCRIPTION
fix(documentation): create_option values are incorrects in virtual_machine_data_disk_attachment.html.markdown

