### PR TITLE
`azurerm_machine_learning_compute_instance` `azurerm_machine_learning_compute_cluster` - support for the `node_public_ip_enabled` property

### DIFF
--- a/internal/services/machinelearning/machine_learning_compute_cluster_resource.go
+++ b/internal/services/machinelearning/machine_learning_compute_cluster_resource.go
@@ -134,6 +134,13 @@ func resourceComputeCluster() *pluginsdk.Resource {
 				ForceNew: true,
 			},
 
+			"node_public_ip_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+				Default:  true,
+				ForceNew: true,
+			},
+
 			"ssh_public_access_enabled": {
 				Type:     pluginsdk.TypeBool,
 				Optional: true,
@@ -181,6 +188,7 @@ func resourceComputeClusterCreate(d *pluginsdk.ResourceData, meta interface{}) e
 		VMPriority:             &vmPriority,
 		ScaleSettings:          expandScaleSettings(d.Get("scale_settings").([]interface{})),
 		UserAccountCredentials: expandUserAccountCredentials(d.Get("ssh").([]interface{})),
+		EnableNodePublicIP:     utils.Bool(d.Get("node_public_ip_enabled").(bool)),
 	}
 
 	computeClusterAmlComputeProperties.RemoteLoginPortPublicAccess = utils.ToPtr(machinelearningcomputes.RemoteLoginPortPublicAccessDisabled)
@@ -270,6 +278,11 @@ func resourceComputeClusterRead(d *pluginsdk.ResourceData, meta interface{}) err
 		d.Set("vm_priority", string(pointer.From(props.VMPriority)))
 		d.Set("scale_settings", flattenScaleSettings(props.ScaleSettings))
 		d.Set("ssh", flattenUserAccountCredentials(props.UserAccountCredentials))
+		nodePublicIPEnabled := true
+		if props.EnableNodePublicIP != nil {
+			nodePublicIPEnabled = *props.EnableNodePublicIP
+		}
+		d.Set("node_public_ip_enabled", nodePublicIPEnabled)
 		if props.Subnet != nil {
 			d.Set("subnet_resource_id", props.Subnet.Id)
 		}

--- a/internal/services/machinelearning/machine_learning_compute_cluster_resource_test.go
+++ b/internal/services/machinelearning/machine_learning_compute_cluster_resource_test.go
@@ -219,6 +219,7 @@ resource "azurerm_machine_learning_compute_cluster" "test" {
     type = "SystemAssigned"
   }
 
+  node_public_ip_enabled    = true
   ssh_public_access_enabled = false
   ssh {
     admin_username = "adminuser"

--- a/internal/services/machinelearning/machine_learning_compute_cluster_resource_test.go
+++ b/internal/services/machinelearning/machine_learning_compute_cluster_resource_test.go
@@ -368,7 +368,11 @@ resource "azurerm_machine_learning_compute_cluster" "test" {
 func (r ComputeClusterResource) template_basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
-  features {}
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
 }
 
 data "azurerm_client_config" "current" {}
@@ -427,7 +431,11 @@ resource "azurerm_machine_learning_workspace" "test" {
 func (r ComputeClusterResource) template_complete(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
-  features {}
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
 }
 
 data "azurerm_client_config" "current" {}

--- a/internal/services/machinelearning/machine_learning_compute_instance_resource.go
+++ b/internal/services/machinelearning/machine_learning_compute_instance_resource.go
@@ -116,6 +116,13 @@ func resourceComputeInstance() *pluginsdk.Resource {
 				ForceNew: true,
 			},
 
+			"node_public_ip_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+				Default:  true,
+				ForceNew: true,
+			},
+
 			"ssh": {
 				Type:     pluginsdk.TypeList,
 				Optional: true,
@@ -188,6 +195,7 @@ func resourceComputeInstanceCreate(d *pluginsdk.ResourceData, meta interface{}) 
 
 	computeInstance := &machinelearningcomputes.ComputeInstance{
 		Properties: &machinelearningcomputes.ComputeInstanceProperties{
+			EnableNodePublicIP:              utils.Bool(d.Get("node_public_ip_enabled").(bool)),
 			VMSize:                          utils.String(d.Get("virtual_machine_size").(string)),
 			Subnet:                          subnet,
 			SshSettings:                     expandComputeSSHSetting(d.Get("ssh").([]interface{})),
@@ -266,6 +274,11 @@ func resourceComputeInstanceRead(d *pluginsdk.ResourceData, meta interface{}) er
 	}
 	d.Set("description", props.Description)
 	if props.Properties != nil {
+		nodePublicIPEnabled := true
+		if props.Properties.EnableNodePublicIP != nil {
+			nodePublicIPEnabled = *props.Properties.EnableNodePublicIP
+		}
+		d.Set("node_public_ip_enabled", nodePublicIPEnabled)
 		d.Set("virtual_machine_size", props.Properties.VMSize)
 		if props.Properties.Subnet != nil {
 			d.Set("subnet_resource_id", props.Properties.Subnet.Id)

--- a/internal/services/machinelearning/machine_learning_compute_instance_resource_test.go
+++ b/internal/services/machinelearning/machine_learning_compute_instance_resource_test.go
@@ -189,8 +189,9 @@ resource "azurerm_machine_learning_compute_instance" "test" {
   ssh {
     public_key = var.ssh_key
   }
-  subnet_resource_id = azurerm_subnet.test.id
-  description        = "this is desc"
+  subnet_resource_id     = azurerm_subnet.test.id
+  description            = "this is desc"
+  node_public_ip_enabled = true
   tags = {
     Label1 = "Value1"
   }

--- a/internal/services/machinelearning/machine_learning_compute_instance_resource_test.go
+++ b/internal/services/machinelearning/machine_learning_compute_instance_resource_test.go
@@ -288,7 +288,11 @@ resource "azurerm_machine_learning_compute_instance" "test" {
 func (r ComputeInstanceResource) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
-  features {}
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
 }
 
 data "azurerm_client_config" "current" {}

--- a/internal/services/machinelearning/machine_learning_inference_cluster_resource_test.go
+++ b/internal/services/machinelearning/machine_learning_inference_cluster_resource_test.go
@@ -376,7 +376,11 @@ resource "azurerm_machine_learning_inference_cluster" "test" {
 func (r InferenceClusterResource) template(data acceptance.TestData, vmSize string, nodeCount int) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
-  features {}
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
 }
 
 data "azurerm_client_config" "current" {}
@@ -468,7 +472,11 @@ resource "azurerm_kubernetes_cluster" "test" {
 func (r InferenceClusterResource) privateTemplate(data acceptance.TestData, vmSize string, nodeCount int) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
-  features {}
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
 }
 
 data "azurerm_client_config" "current" {}

--- a/internal/services/machinelearning/machine_learning_synapse_spark_resource_test.go
+++ b/internal/services/machinelearning/machine_learning_synapse_spark_resource_test.go
@@ -239,7 +239,11 @@ resource "azurerm_machine_learning_synapse_spark" "test" {
 func (r SynapseSparkResource) template(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
-  features {}
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
 }
 
 data "azurerm_client_config" "current" {}

--- a/website/docs/r/machine_learning_compute_cluster.html.markdown
+++ b/website/docs/r/machine_learning_compute_cluster.html.markdown
@@ -123,6 +123,8 @@ The following arguments are supported:
 
 * `local_auth_enabled` - (Optional) Whether local authentication methods is enabled. Defaults to `true`. Changing this forces a new Machine Learning Compute Cluster to be created.
 
+* `node_public_ip_enabled` - (Optional) Whether to enable public IP address on nodes. Defaults to `true`. Changing this forces a new Machine Learning Compute Cluster to be created.
+
 * `ssh_public_access_enabled` - (Optional) A boolean value indicating whether enable the public SSH port. Changing this forces a new Machine Learning Compute Cluster to be created.
 
 * `subnet_resource_id` - (Optional) The ID of the Subnet that the Compute Cluster should reside in. Changing this forces a new Machine Learning Compute Cluster to be created.

--- a/website/docs/r/machine_learning_compute_instance.html.markdown
+++ b/website/docs/r/machine_learning_compute_instance.html.markdown
@@ -117,6 +117,8 @@ The following arguments are supported:
 
 * `local_auth_enabled` - (Optional) Whether local authentication methods is enabled. Defaults to `true`. Changing this forces a new Machine Learning Compute Instance to be created.
 
+* `node_public_ip_enabled` - (Optional) Whether public IP is enabled. Defaults to `true`. Changing this forces a new Machine Learning Compute Instance to be created.
+
 * `ssh` - (Optional) A `ssh` block as defined below. Specifies policy and settings for SSH access. Changing this forces a new Machine Learning Compute Instance to be created.
 
 * `subnet_resource_id` - (Optional) Virtual network subnet resource ID the compute nodes belong to. Changing this forces a new Machine Learning Compute Instance to be created.


### PR DESCRIPTION
![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/79895375/15bda376-3f1b-4170-9bfb-75369eb35c83)

I've added the `prevent_deletion_if_contains_resources = false` flag to destroy the `Microsoft.alertsmanagement/smartDetectorAlertRules/Failure Anomalies` rule which is auto-applied by the policy.
