### PR TITLE
`azurerm_media_transform` - support `jpg_image` and `png_image` codec in `custom_preset`

### DIFF
--- a/internal/services/media/media_transform_resource.go
+++ b/internal/services/media/media_transform_resource.go
@@ -633,6 +633,162 @@ func resourceMediaTransform() *pluginsdk.Resource {
 														},
 													},
 												},
+												"jpg_image": {
+													Type:     pluginsdk.TypeList,
+													Optional: true,
+													MaxItems: 1,
+													Elem: &pluginsdk.Resource{
+														Schema: map[string]*schema.Schema{
+															"start": {
+																Type:         pluginsdk.TypeString,
+																Required:     true,
+																ValidateFunc: validation.StringIsNotEmpty,
+															},
+															"key_frame_interval": {
+																Type:         pluginsdk.TypeString,
+																Optional:     true,
+																Default:      "PT2S",
+																ValidateFunc: validate.ISO8601DurationBetween("PT0.5S", "PT20S"),
+															},
+															"label": {
+																Type:         pluginsdk.TypeString,
+																Optional:     true,
+																ValidateFunc: validation.StringIsNotEmpty,
+															},
+															"layer": {
+																Type:     pluginsdk.TypeList,
+																Optional: true,
+																MinItems: 1,
+																Elem: &pluginsdk.Resource{
+																	Schema: map[string]*schema.Schema{
+																		"height": {
+																			Type:         pluginsdk.TypeString,
+																			Optional:     true,
+																			ValidateFunc: validation.StringIsNotEmpty,
+																		},
+																		"label": {
+																			Type:         pluginsdk.TypeString,
+																			Optional:     true,
+																			ValidateFunc: validation.StringIsNotEmpty,
+																		},
+																		"quality": {
+																			Type:         pluginsdk.TypeInt,
+																			Optional:     true,
+																			Default:      70,
+																			ValidateFunc: validation.IntBetween(0, 100),
+																		},
+																		"width": {
+																			Type:         pluginsdk.TypeString,
+																			Optional:     true,
+																			ValidateFunc: validation.StringIsNotEmpty,
+																		},
+																	},
+																},
+															},
+															"range": {
+																Type:         pluginsdk.TypeString,
+																Optional:     true,
+																Default:      "100%",
+																ValidateFunc: validation.StringIsNotEmpty,
+															},
+															"sprite_column": {
+																Type:         pluginsdk.TypeInt,
+																Optional:     true,
+																Default:      0,
+																ValidateFunc: validation.IntAtLeast(0),
+															},
+															"step": {
+																Type:         pluginsdk.TypeString,
+																Optional:     true,
+																ValidateFunc: validation.StringIsNotEmpty,
+															},
+															"stretch_mode": {
+																Type:         pluginsdk.TypeString,
+																Optional:     true,
+																Default:      string(encodings.StretchModeAutoSize),
+																ValidateFunc: validation.StringInSlice(encodings.PossibleValuesForStretchMode(), false),
+															},
+															"sync_mode": {
+																Type:         pluginsdk.TypeString,
+																Optional:     true,
+																Default:      string(encodings.VideoSyncModeAuto),
+																ValidateFunc: validation.StringInSlice(encodings.PossibleValuesForVideoSyncMode(), false),
+															},
+														},
+													},
+												},
+												"png_image": {
+													Type:     pluginsdk.TypeList,
+													Optional: true,
+													MaxItems: 1,
+													Elem: &pluginsdk.Resource{
+														Schema: map[string]*schema.Schema{
+															"start": {
+																Type:         pluginsdk.TypeString,
+																Required:     true,
+																ValidateFunc: validation.StringIsNotEmpty,
+															},
+															"key_frame_interval": {
+																Type:         pluginsdk.TypeString,
+																Optional:     true,
+																Default:      "PT2S",
+																ValidateFunc: validate.ISO8601Duration,
+															},
+															"label": {
+																Type:         pluginsdk.TypeString,
+																Optional:     true,
+																ValidateFunc: validation.StringIsNotEmpty,
+															},
+															"layer": {
+																Type:     pluginsdk.TypeList,
+																Optional: true,
+																MinItems: 1,
+																Elem: &pluginsdk.Resource{
+																	Schema: map[string]*schema.Schema{
+																		"height": {
+																			Type:         pluginsdk.TypeString,
+																			Optional:     true,
+																			ValidateFunc: validation.StringIsNotEmpty,
+																		},
+																		"label": {
+																			Type:         pluginsdk.TypeString,
+																			Optional:     true,
+																			ValidateFunc: validation.StringIsNotEmpty,
+																		},
+																		"width": {
+																			Type:         pluginsdk.TypeString,
+																			Optional:     true,
+																			ValidateFunc: validation.StringIsNotEmpty,
+																		},
+																	},
+																},
+															},
+															"range": {
+																Type:         pluginsdk.TypeString,
+																Optional:     true,
+																Default:      "100%",
+																ValidateFunc: validation.StringIsNotEmpty,
+															},
+															"step": {
+																Type:         pluginsdk.TypeString,
+																Optional:     true,
+																ValidateFunc: validation.StringIsNotEmpty,
+															},
+															"stretch_mode": {
+																Type:         pluginsdk.TypeString,
+																Optional:     true,
+																Default:      string(encodings.StretchModeAutoSize),
+																ValidateFunc: validation.StringInSlice(encodings.PossibleValuesForStretchMode(), false),
+															},
+															"sync_mode": {
+																Type:         pluginsdk.TypeString,
+																Optional:     true,
+																Default:      string(encodings.VideoSyncModeAuto),
+																ValidateFunc: validation.StringInSlice(encodings.PossibleValuesForVideoSyncMode(), false),
+															},
+														},
+													},
+												},
 											},
 										},
 									},
@@ -642,6 +798,20 @@ func resourceMediaTransform() *pluginsdk.Resource {
 										MinItems: 1,
 										Elem: &pluginsdk.Resource{
 											Schema: map[string]*schema.Schema{
+												"jpg": {
+													Type:     pluginsdk.TypeList,
+													Optional: true,
+													MaxItems: 1,
+													Elem: &pluginsdk.Resource{
+														Schema: map[string]*schema.Schema{
+															"filename_pattern": {
+																Type:         pluginsdk.TypeString,
+																Required:     true,
+																ValidateFunc: validation.StringIsNotEmpty,
+															},
+														},
+													},
+												},
 												"mp4": {
 													Type:     pluginsdk.TypeList,
 													Optional: true,
@@ -670,6 +840,20 @@ func resourceMediaTransform() *pluginsdk.Resource {
 																		},
 																	},
 																},
+															},
+														},
+													},
+												},
+												"png": {
+													Type:     pluginsdk.TypeList,
+													Optional: true,
+													MaxItems: 1,
+													Elem: &pluginsdk.Resource{
+														Schema: map[string]*schema.Schema{
+															"filename_pattern": {
+																Type:         pluginsdk.TypeString,
+																Required:     true,
+																ValidateFunc: validation.StringIsNotEmpty,
 															},
 														},
 													},
@@ -1541,6 +1725,8 @@ func expandCustomPresetCodecs(input []interface{}) ([]encodings.Codec, error) {
 		ddAudio := codec["dd_audio"].([]interface{})
 		h264Video := codec["h264_video"].([]interface{})
 		h265Video := codec["h265_video"].([]interface{})
+		jpgImage := codec["jpg_image"].([]interface{})
+		pngImage := codec["png_image"].([]interface{})
 
 		codecsCount := 0
 		if len(aacAudio) > 0 {
@@ -1559,6 +1745,12 @@ func expandCustomPresetCodecs(input []interface{}) ([]encodings.Codec, error) {
 			codecsCount++
 		}
 		if len(h265Video) > 0 {
+			codecsCount++
+		}
+		if len(jpgImage) > 0 {
+			codecsCount++
+		}
+		if len(pngImage) > 0 {
 			codecsCount++
 		}
 		if codecsCount == 0 {
@@ -1586,6 +1778,12 @@ func expandCustomPresetCodecs(input []interface{}) ([]encodings.Codec, error) {
 		if len(h265Video) > 0 {
 			results = append(results, expandCustomPresetCodecsH265Video(h265Video))
 		}
+		if len(jpgImage) > 0 {
+			results = append(results, expandCustomPresetCodecsJpgImage(jpgImage))
+		}
+		if len(pngImage) > 0 {
+			results = append(results, expandCustomPresetCodecsPngImage(pngImage))
+		}
 	}
 
 	return results, nil
@@ -1598,6 +1796,8 @@ type flattenedCustomPresetsCodec struct {
 	ddAudio   []interface{}
 	h264Video []interface{}
 	h265Video []interface{}
+	jpgImage  []interface{}
+	pngImage  []interface{}
 }
 
 func flattenCustomPresetCodecs(input []encodings.Codec) []interface{} {
@@ -1615,6 +1815,8 @@ func flattenCustomPresetCodecs(input []encodings.Codec) []interface{} {
 			ddAudio:   []interface{}{},
 			h264Video: []interface{}{},
 			h265Video: []interface{}{},
+			jpgImage:  []interface{}{},
+			pngImage:  []interface{}{},
 		}
 
 		if codec, ok := v.(encodings.AacAudio); ok {
@@ -1641,6 +1843,14 @@ func flattenCustomPresetCodecs(input []encodings.Codec) []interface{} {
 			result.h265Video = flattenCustomPresetCodecsH265Video(codec)
 		}
 
+		if codec, ok := v.(encodings.JpgImage); ok {
+			result.jpgImage = flattenCustomPresetCodecsJpgImage(codec)
+		}
+
+		if codec, ok := v.(encodings.PngImage); ok {
+			result.pngImage = flattenCustomPresetCodecsPngImage(codec)
+		}
+
 		results = append(results, map[string]interface{}{
 			"aac_audio":  result.aacAudio,
 			"copy_audio": result.copyAudio,
@@ -1648,6 +1858,8 @@ func flattenCustomPresetCodecs(input []encodings.Codec) []interface{} {
 			"dd_audio":   result.ddAudio,
 			"h264_video": result.h264Video,
 			"h265_video": result.h265Video,
+			"jpg_image":  result.jpgImage,
+			"png_image":  result.pngImage,
 		})
 	}
 
@@ -2331,6 +2543,319 @@ func flattenCustomPresetCodecsH265VideoLayers(input *[]encodings.H265Layer) []in
 
 	return results
 }
+func expandCustomPresetCodecsJpgImage(input []interface{}) encodings.JpgImage {
+	if len(input) == 0 || input[0] == nil {
+		return encodings.JpgImage{}
+	}
+
+	jpgImage := input[0].(map[string]interface{})
+	result := encodings.JpgImage{
+		Start:  jpgImage["start"].(string),
+		Layers: expandCustomPresetCodecsJpgImageLayer(jpgImage["layer"].([]interface{})),
+	}
+
+	if v := jpgImage["key_frame_interval"].(string); v != "" {
+		result.KeyFrameInterval = utils.String(v)
+	}
+
+	if v := jpgImage["label"].(string); v != "" {
+		result.Label = utils.String(v)
+	}
+
+	if v := jpgImage["range"].(string); v != "" {
+		result.Range = utils.String(v)
+	}
+
+	if v := jpgImage["sprite_column"].(int); v != 0 {
+		result.SpriteColumn = utils.Int64(int64(v))
+	}
+
+	if v := jpgImage["step"].(string); v != "" {
+		result.Step = utils.String(v)
+	}
+
+	if v := jpgImage["stretch_mode"].(string); v != "" {
+		result.StretchMode = pointer.To(encodings.StretchMode(v))
+	}
+
+	if v := jpgImage["sync_mode"].(string); v != "" {
+		result.SyncMode = pointer.To(encodings.VideoSyncMode(v))
+	}
+
+	return result
+}
+
+func flattenCustomPresetCodecsJpgImage(input encodings.JpgImage) []interface{} {
+	keyFrameInterval := ""
+	if input.KeyFrameInterval != nil {
+		keyFrameInterval = *input.KeyFrameInterval
+	}
+
+	label := ""
+	if input.Label != nil {
+		label = *input.Label
+	}
+
+	rang := ""
+	if input.Range != nil {
+		rang = *input.Range
+	}
+
+	spriteColumn := 0
+	if input.SpriteColumn != nil {
+		spriteColumn = int(*input.SpriteColumn)
+	}
+
+	step := ""
+	if input.Step != nil {
+		step = *input.Step
+	}
+
+	stretchMode := ""
+	if input.StretchMode != nil {
+		stretchMode = string(*input.StretchMode)
+	}
+
+	syncMode := ""
+	if input.SyncMode != nil {
+		syncMode = string(*input.SyncMode)
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"key_frame_interval": keyFrameInterval,
+			"label":              label,
+			"layer":              flattenCustomPresetCodecsJpgImageLayer(input.Layers),
+			"range":              rang,
+			"start":              input.Start,
+			"step":               step,
+			"sprite_column":      spriteColumn,
+			"stretch_mode":       stretchMode,
+			"sync_mode":          syncMode,
+		},
+	}
+}
+
+func expandCustomPresetCodecsJpgImageLayer(input []interface{}) *[]encodings.JpgLayer {
+	if len(input) == 0 || input[0] == nil {
+		return nil
+	}
+
+	results := make([]encodings.JpgLayer, 0)
+	for _, layerRaw := range input {
+		if layerRaw == nil {
+			continue
+		}
+
+		layer := layerRaw.(map[string]interface{})
+		result := encodings.JpgLayer{}
+
+		if v := layer["height"].(string); v != "" {
+			result.Height = utils.String(v)
+		}
+
+		if v := layer["label"].(string); v != "" {
+			result.Label = utils.String(v)
+		}
+
+		if v := layer["quality"].(int); v != 0 {
+			result.Quality = utils.Int64(int64(v))
+		}
+
+		if v := layer["width"].(string); v != "" {
+			result.Width = utils.String(v)
+		}
+
+		results = append(results, result)
+	}
+
+	return &results
+}
+
+func flattenCustomPresetCodecsJpgImageLayer(input *[]encodings.JpgLayer) []interface{} {
+	if input == nil {
+		return make([]interface{}, 0)
+	}
+
+	results := make([]interface{}, 0)
+
+	for _, v := range *input {
+		height := ""
+		if v.Height != nil {
+			height = *v.Height
+		}
+
+		label := ""
+		if v.Label != nil {
+			label = *v.Label
+		}
+
+		quality := 0
+		if v.Quality != nil {
+			quality = int(*v.Quality)
+		}
+
+		width := ""
+		if v.Width != nil {
+			width = *v.Width
+		}
+
+		results = append(results, map[string]interface{}{
+			"height":  height,
+			"label":   label,
+			"quality": quality,
+			"width":   width,
+		})
+	}
+
+	return results
+}
+
+func expandCustomPresetCodecsPngImage(input []interface{}) encodings.PngImage {
+	if len(input) == 0 || input[0] == nil {
+		return encodings.PngImage{}
+	}
+
+	jpgImage := input[0].(map[string]interface{})
+	result := encodings.PngImage{
+		Start:  jpgImage["start"].(string),
+		Layers: expandCustomPresetCodecsPngImageLayer(jpgImage["layer"].([]interface{})),
+	}
+	if v := jpgImage["key_frame_interval"].(string); v != "" {
+		result.KeyFrameInterval = utils.String(v)
+	}
+
+	if v := jpgImage["label"].(string); v != "" {
+		result.Label = utils.String(v)
+	}
+
+	if v := jpgImage["range"].(string); v != "" {
+		result.Range = utils.String(v)
+	}
+
+	if v := jpgImage["step"].(string); v != "" {
+		result.Step = utils.String(v)
+	}
+
+	if v := jpgImage["stretch_mode"].(string); v != "" {
+		result.StretchMode = pointer.To(encodings.StretchMode(v))
+	}
+
+	if v := jpgImage["sync_mode"].(string); v != "" {
+		result.SyncMode = pointer.To(encodings.VideoSyncMode(v))
+	}
+
+	return result
+}
+
+func flattenCustomPresetCodecsPngImage(input encodings.PngImage) []interface{} {
+	keyFrameInterval := ""
+	if input.KeyFrameInterval != nil {
+		keyFrameInterval = *input.KeyFrameInterval
+	}
+
+	label := ""
+	if input.Label != nil {
+		label = *input.Label
+	}
+
+	rang := ""
+	if input.Range != nil {
+		rang = *input.Range
+	}
+
+	step := ""
+	if input.Step != nil {
+		step = *input.Step
+	}
+
+	stretchMode := ""
+	if input.StretchMode != nil {
+		stretchMode = string(*input.StretchMode)
+	}
+
+	syncMode := ""
+	if input.SyncMode != nil {
+		syncMode = string(*input.SyncMode)
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"key_frame_interval": keyFrameInterval,
+			"label":              label,
+			"layer":              flattenCustomPresetCodecsPngImageLayer(input.Layers),
+			"range":              rang,
+			"start":              input.Start,
+			"step":               step,
+			"stretch_mode":       stretchMode,
+			"sync_mode":          syncMode,
+		},
+	}
+}
+
+func expandCustomPresetCodecsPngImageLayer(input []interface{}) *[]encodings.Layer {
+	if len(input) == 0 || input[0] == nil {
+		return nil
+	}
+
+	results := make([]encodings.Layer, 0)
+	for _, layerRaw := range input {
+		if layerRaw == nil {
+			continue
+		}
+
+		layer := layerRaw.(map[string]interface{})
+		result := encodings.Layer{}
+
+		if v := layer["height"].(string); v != "" {
+			result.Height = utils.String(v)
+		}
+
+		if v := layer["label"].(string); v != "" {
+			result.Label = utils.String(v)
+		}
+
+		if v := layer["width"].(string); v != "" {
+			result.Width = utils.String(v)
+		}
+
+		results = append(results, result)
+	}
+
+	return &results
+}
+
+func flattenCustomPresetCodecsPngImageLayer(input *[]encodings.Layer) []interface{} {
+	if input == nil {
+		return make([]interface{}, 0)
+	}
+	results := make([]interface{}, 0)
+
+	for _, v := range *input {
+		height := ""
+		if v.Height != nil {
+			height = *v.Height
+		}
+
+		label := ""
+		if v.Label != nil {
+			label = *v.Label
+		}
+
+		width := ""
+		if v.Width != nil {
+			width = *v.Width
+		}
+
+		results = append(results, map[string]interface{}{
+			"height": height,
+			"label":  label,
+			"width":  width,
+		})
+	}
+
+	return results
+}
 
 func expandCustomPresetFilters(input []interface{}) (*encodings.Filters, error) {
 	if len(input) == 0 || input[0] == nil {
@@ -2777,15 +3302,23 @@ func expandCustomPresetFormats(input []interface{}) ([]encodings.Format, error) 
 		}
 
 		format := v.(map[string]interface{})
+
+		jpg := format["jpg"].([]interface{})
 		mp4 := format["mp4"].([]interface{})
+		png := format["png"].([]interface{})
 		transportStream := format["transport_stream"].([]interface{})
 
 		formatCount := 0
 
+		if len(jpg) > 0 {
+			formatCount++
+		}
 		if len(mp4) > 0 {
 			formatCount++
 		}
-
+		if len(png) > 0 {
+			formatCount++
+		}
 		if len(transportStream) > 0 {
 			formatCount++
 		}
@@ -2797,9 +3330,16 @@ func expandCustomPresetFormats(input []interface{}) ([]encodings.Format, error) 
 			return nil, fmt.Errorf("more than one type of format in the same custom preset format is not allowed")
 		}
 
+		if len(jpg) > 0 {
+			results = append(results, expandCustomPresetFormatsJpg(jpg))
+		}
 		if len(mp4) > 0 {
 			results = append(results, expandCustomPresetFormatsMp4(mp4))
-		} else if len(transportStream) > 0 {
+		}
+		if len(png) > 0 {
+			results = append(results, expandCustomPresetFormatsPng(png))
+		}
+		if len(transportStream) > 0 {
 			results = append(results, expandCustomPresetFormatsTransportStream(transportStream))
 		}
 	}
@@ -2808,7 +3348,9 @@ func expandCustomPresetFormats(input []interface{}) ([]encodings.Format, error) 
 }
 
 type flattenedCustomPresetFormat struct {
+	jpg             []interface{}
 	mp4             []interface{}
+	png             []interface{}
 	transportStream []interface{}
 }
 
@@ -2817,25 +3359,56 @@ func flattenCustomPresetFormats(input []encodings.Format) []interface{} {
 
 	for _, v := range input {
 		result := flattenedCustomPresetFormat{
+			jpg:             []interface{}{},
 			mp4:             []interface{}{},
+			png:             []interface{}{},
 			transportStream: []interface{}{},
 		}
 
+		if format, ok := v.(encodings.JpgFormat); ok {
+			result.jpg = flattenCustomPresetFormatsJpg(format)
+		}
 		if format, ok := v.(encodings.Mp4Format); ok {
 			result.mp4 = flattenCustomPresetFormatsMp4(format)
 		}
-
+		if format, ok := v.(encodings.PngFormat); ok {
+			result.png = flattenCustomPresetFormatsPng(format)
+		}
 		if format, ok := v.(encodings.TransportStreamFormat); ok {
 			result.transportStream = flattenCustomPresetFormatsTransportStream(format)
 		}
 
 		results = append(results, map[string]interface{}{
+			"jpg":              result.jpg,
 			"mp4":              result.mp4,
+			"png":              result.png,
 			"transport_stream": result.transportStream,
 		})
 	}
 
 	return results
+}
+
+func expandCustomPresetFormatsJpg(input []interface{}) encodings.JpgFormat {
+	if len(input) == 0 || input[0] == nil {
+		return encodings.JpgFormat{}
+	}
+
+	jpg := input[0].(map[string]interface{})
+
+	result := encodings.JpgFormat{
+		FilenamePattern: jpg["filename_pattern"].(string),
+	}
+
+	return result
+}
+
+func flattenCustomPresetFormatsJpg(input encodings.JpgFormat) []interface{} {
+	return []interface{}{
+		map[string]interface{}{
+			"filename_pattern": input.FilenamePattern,
+		},
+	}
 }
 
 func expandCustomPresetFormatsMp4(input []interface{}) encodings.Mp4Format {
@@ -2857,6 +3430,27 @@ func flattenCustomPresetFormatsMp4(input encodings.Mp4Format) []interface{} {
 		map[string]interface{}{
 			"filename_pattern": input.FilenamePattern,
 			"output_file":      flattenCustomPresetFormatOutputFiles(input.OutputFiles),
+		},
+	}
+}
+
+func expandCustomPresetFormatsPng(input []interface{}) encodings.PngFormat {
+	if len(input) == 0 || input[0] == nil {
+		return encodings.PngFormat{}
+	}
+
+	jpg := input[0].(map[string]interface{})
+	result := encodings.PngFormat{
+		FilenamePattern: jpg["filename_pattern"].(string),
+	}
+
+	return result
+}
+
+func flattenCustomPresetFormatsPng(input encodings.PngFormat) []interface{} {
+	return []interface{}{
+		map[string]interface{}{
+			"filename_pattern": input.FilenamePattern,
 		},
 	}
 }

--- a/internal/services/media/media_transform_resource_test.go
+++ b/internal/services/media/media_transform_resource_test.go
@@ -433,12 +433,56 @@ resource "azurerm_media_transform" "test" {
         }
       }
 
+      codec {
+        jpg_image {
+          stretch_mode  = "AutoSize"
+          sync_mode     = "Auto"
+          start         = "10"
+          range         = "100%%"
+          sprite_column = 1
+          step          = "10"
+          layer {
+            quality = 70
+            height  = "180"
+            label   = "test"
+            width   = "120"
+          }
+        }
+      }
+
+      codec {
+        png_image {
+          stretch_mode = "AutoSize"
+          sync_mode    = "Auto"
+          start        = "{Best}"
+          range        = "80"
+          step         = "10"
+          layer {
+            height = "180"
+            label  = "test"
+            width  = "120"
+          }
+        }
+      }
+
+      format {
+        jpg {
+          filename_pattern = "test{Basename}"
+        }
+      }
+
       format {
         mp4 {
           filename_pattern = "test{Bitrate}"
           output_file {
             labels = ["test", "ppe"]
           }
+        }
+      }
+
+      format {
+        png {
+          filename_pattern = "test{Basename}"
         }
       }
 

--- a/website/docs/r/media_transform.html.markdown
+++ b/website/docs/r/media_transform.html.markdown
@@ -287,6 +287,15 @@ resource "azurerm_media_transform" "example" {
         }
       }
 
+      format {
+        transport_stream {
+          filename_pattern = "test{Bitrate}"
+          output_file {
+            labels = ["prod"]
+          }
+        }
+      }
+
       filter {
         crop_rectangle {
           height = "240"

--- a/website/docs/r/media_transform.html.markdown
+++ b/website/docs/r/media_transform.html.markdown
@@ -557,11 +557,11 @@ A `format` block supports the following:
 
 * `mp4` - (Optional) A `mp4` block as defined below.
 
-* `transport_stream` - (Optional) A `transport_stream` block as defined below.
-
 * `png` - (Optional) A `png` block as defined below.
+
+* `transport_stream` - (Optional) A `transport_stream` block as defined below.
  
--> **NOTE:** Each format can only have one type: `jpg`, `mp4`, `transport_stream` or `png`. If you need to apply different type you must create one format for each one.
+-> **NOTE:** Each format can only have one type: `jpg`, `mp4`, `png` or `transport_stream`. If you need to apply different type you must create one format for each one.
 
 ---
 


### PR DESCRIPTION

ref:
1. [Transform and Jobs Concept](https://learn.microsoft.com/en-us/azure/media-services/latest/transform-jobs-concept)
2. [swagger](https://github.com/Azure/azure-rest-api-specs/blob/main/specification/mediaservices/resource-manager/Microsoft.Media/Encoding/stable/2022-07-01/Encoding.json)

test:
```
TF_ACC=1 go test -v ./internal/services/media -parallel 50 -test.run=TestAccMediaTransform -timeout 1440m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccMediaTransform_basic
=== PAUSE TestAccMediaTransform_basic
=== RUN   TestAccMediaTransform_requiresImport
=== PAUSE TestAccMediaTransform_requiresImport
=== RUN   TestAccMediaTransform_complete
=== PAUSE TestAccMediaTransform_complete
=== RUN   TestAccMediaTransform_update
=== PAUSE TestAccMediaTransform_update
=== CONT  TestAccMediaTransform_basic
=== CONT  TestAccMediaTransform_complete
=== CONT  TestAccMediaTransform_update
=== CONT  TestAccMediaTransform_requiresImport
--- PASS: TestAccMediaTransform_basic (282.89s)
--- PASS: TestAccMediaTransform_complete (285.10s)
--- PASS: TestAccMediaTransform_requiresImport (307.31s)
--- PASS: TestAccMediaTransform_update (562.99s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/media 563.008s

```
