### PR TITLE
azurerm_kubernetes_cluster - add default value for vertical_pod_autoscaler_update_mode

### DIFF
--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -1249,7 +1249,8 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 						},
 						"vertical_pod_autoscaler_update_mode": {
 							Type:     pluginsdk.TypeString,
-							Computed: true,
+							Optional: true,
+							Default:  "off",
 						},
 						"vertical_pod_autoscaler_controlled_values": {
 							Type:     pluginsdk.TypeString,

--- a/internal/services/containers/kubernetes_cluster_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_resource_test.go
@@ -162,14 +162,14 @@ func TestAccKubernetesCluster_workloadAutoscalerProfileVerticalPodAutoscalerTogg
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.workloadAutoscalerProfileVerticalPodAutoscaler(data, currentKubernetesVersion, true),
+			Config: r.workloadAutoscalerProfileVerticalPodAutoscaler(data, currentKubernetesVersion, true, "auto"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep(),
 		{
-			Config: r.workloadAutoscalerProfileVerticalPodAutoscaler(data, currentKubernetesVersion, false),
+			Config: r.workloadAutoscalerProfileVerticalPodAutoscaler(data, currentKubernetesVersion, false, "off"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -429,7 +429,7 @@ resource "azurerm_kubernetes_cluster" "test" {
   `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, controlPlaneVersion, kedaEnabled)
 }
 
-func (KubernetesClusterResource) workloadAutoscalerProfileVerticalPodAutoscaler(data acceptance.TestData, controlPlaneVersion string, enabled bool) string {
+func (KubernetesClusterResource) workloadAutoscalerProfileVerticalPodAutoscaler(data acceptance.TestData, controlPlaneVersion string, enabled bool, updateMode string) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -449,6 +449,7 @@ resource "azurerm_kubernetes_cluster" "test" {
 
   workload_autoscaler_profile {
     vertical_pod_autoscaler_enabled = %t
+    vertical_pod_autoscaler_update_mode = %q
   }
 
   default_node_pool {
@@ -461,7 +462,7 @@ resource "azurerm_kubernetes_cluster" "test" {
     type = "SystemAssigned"
   }
 }
-  `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, controlPlaneVersion, enabled)
+  `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, controlPlaneVersion, enabled, updateMode)
 }
 
 func (KubernetesClusterResource) imageCleanerSecurityProfile(data acceptance.TestData, controlPlaneVersion string, enabled bool) string {


### PR DESCRIPTION
Was not able to add value to `update_mode` before compute.

Now it defaults to `off`.