### PR TITLE
Docs: update example of azurerm_subscription_cost_management_view and azurerm_resource_group_cost_management_view

### DIFF
--- a/website/docs/r/resource_group_cost_management_view.html.markdown
+++ b/website/docs/r/resource_group_cost_management_view.html.markdown
@@ -35,11 +35,6 @@ resource "azurerm_resource_group_cost_management_view" "example" {
       name        = "totalCost"
       column_name = "Cost"
     }
-
-    totalCost {
-      name     = "Cost"
-      function = "Sum"
-    }
   }
 }
 ```

--- a/website/docs/r/subscription_cost_management_view.html.markdown
+++ b/website/docs/r/subscription_cost_management_view.html.markdown
@@ -31,11 +31,6 @@ resource "azurerm_subscription_cost_management_view" "example" {
       name        = "totalCost"
       column_name = "Cost"
     }
-
-    totalCost {
-      name     = "Cost"
-      function = "Sum"
-    }
   }
 }
 ```


### PR DESCRIPTION
The totalCost is never defined in these two resources. So we can delete it directly from doc example. This is related [PR](https://github.com/hashicorp/terraform-provider-azurerm/pull/21317).