### PR TITLE
`authentication` - remove incorrect description for `backend` from msi authentication doc

### DIFF
--- a/website/docs/guides/managed_service_identity.html.markdown
+++ b/website/docs/guides/managed_service_identity.html.markdown
@@ -133,36 +133,6 @@ provider "azurerm" {
 }
 ```
 
-If you intend to configure a remote backend in the provider block, put `use_msi` outside of the backend block:
-
-```hcl
-# We strongly recommend using the required_providers block to set the
-# Azure Provider source and version being used
-terraform {
-  required_providers {
-    azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "=3.0.0"
-    }
-  }
-}
-
-# Configure the Microsoft Azure Provider
-provider "azurerm" {
-  features {}
-
-  use_msi = true
-
-  backend "azurerm" {
-    storage_account_name = "abcd1234"
-    container_name       = "tfstate"
-    key                  = "prod.terraform.tfstate"
-    subscription_id      = "00000000-0000-0000-0000-000000000000"
-    tenant_id            = "00000000-0000-0000-0000-000000000000"
-  }
-}
-```
-
 More information on [the fields supported in the provider block can be found here](../index.html#argument-reference).
 
 <!-- it's not clear to me that we even need this info; it seems like this is the sort of thing you'd know about if you needed it.


### PR DESCRIPTION
fix https://github.com/hashicorp/terraform-provider-azurerm/issues/21724
According to [the document](https://developer.hashicorp.com/terraform/language/settings/backends/azurerm#example-configuration), `backend "azurerm"` is defined in `terraform` block and `use_msi` is defined in `backend "azurerm"` block. The original description should be removed.