### PR TITLE
`azurerm_monitor_action_group` - fix method to check exactly one of `event_hub_id` or (`event_hub_namespace`, `event_hub_name`) must be set in `event_hub_receiver`

### DIFF
--- a/internal/services/monitor/monitor_action_group_resource.go
+++ b/internal/services/monitor/monitor_action_group_resource.go
@@ -526,9 +526,8 @@ func resourceMonitorActionGroupCreateUpdate(d *pluginsdk.ResourceData, meta inte
 	logicAppReceiversRaw := d.Get("logic_app_receiver").([]interface{})
 	azureFunctionReceiversRaw := d.Get("azure_function_receiver").([]interface{})
 	armRoleReceiversRaw := d.Get("arm_role_receiver").([]interface{})
-	eventHubReceiversRaw := d.Get("event_hub_receiver").([]interface{})
 
-	expandedEventHubReceiver, err := expandMonitorActionGroupEventHubReceiver(tenantId, subscriptionId, eventHubReceiversRaw)
+	expandedEventHubReceiver, err := expandMonitorActionGroupEventHubReceiver(tenantId, subscriptionId, d)
 	if err != nil {
 		return err
 	}
@@ -842,23 +841,41 @@ func expandMonitorActionGroupRoleReceiver(v []interface{}) *[]actiongroupsapis.A
 	return &receivers
 }
 
-func expandMonitorActionGroupEventHubReceiver(tenantId string, subscriptionId string, v []interface{}) (*[]actiongroupsapis.EventHubReceiver, error) {
+func expandMonitorActionGroupEventHubReceiver(tenantId string, subscriptionId string, d *pluginsdk.ResourceData) (*[]actiongroupsapis.EventHubReceiver, error) {
 	receivers := make([]actiongroupsapis.EventHubReceiver, 0)
-	for _, receiverValue := range v {
+	eventHubReceiver := d.Get("event_hub_receiver").([]interface{})
+	for i, receiverValue := range eventHubReceiver {
 		val := receiverValue.(map[string]interface{})
 
 		eventHubNameSpace, eventHubName, subId := val["event_hub_namespace"].(string), val["event_hub_name"].(string), val["subscription_id"].(string)
+
 		if !features.FourPointOhBeta() {
-			eventHubIdRaw := val["event_hub_id"].(string)
-			if eventHubNameSpace == "" && eventHubName == "" && subId == "" && eventHubIdRaw != "" {
-				eventHubId, err := eventhubs.ParseEventhubID(eventHubIdRaw)
+			eventHubReceiverRaw := d.GetRawConfig().AsValueMap()["event_hub_receiver"].AsValueSlice()[i].AsValueMap()
+			eventHubIdRaw := eventHubReceiverRaw["event_hub_id"]
+
+			hasSetId := !eventHubIdRaw.IsNull()
+			hasSetName := !eventHubReceiverRaw["event_hub_name"].IsNull()
+			hasSetNamespace := !eventHubReceiverRaw["event_hub_namespace"].IsNull()
+			hasSetSubscriptionId := !eventHubReceiverRaw["subscription_id"].IsNull()
+
+			if hasSetName != hasSetNamespace {
+				return nil, fmt.Errorf("in event_hub_receiver, event_hub_name and event_hub_namespace must be set together")
+			}
+
+			if hasSetId == hasSetName {
+				return nil, fmt.Errorf("in event_hub_receiver, exactly one of event_hub_id or (event_hub_namespace, event_hub_name) must be set")
+			}
+
+			if hasSetId && hasSetSubscriptionId {
+				return nil, fmt.Errorf("in event_hub_receiver, event_hub_id and subscription_id cannot be set together")
+			}
+
+			if hasSetId {
+				eventHubId, err := eventhubs.ParseEventhubID(eventHubIdRaw.AsString())
 				if err != nil {
 					return nil, err
 				}
 				eventHubNameSpace, eventHubName, subId = eventHubId.NamespaceName, eventHubId.EventhubName, eventHubId.SubscriptionId
-			}
-			if eventHubNameSpace == "" || eventHubName == "" {
-				return nil, fmt.Errorf("in event_hub_receiver, exactly one of event_hub_id or (event_hub_namespace, event_hub_name) must be set")
 			}
 		}
 
@@ -868,16 +885,19 @@ func expandMonitorActionGroupEventHubReceiver(tenantId string, subscriptionId st
 			Name:                 val["name"].(string),
 			UseCommonAlertSchema: utils.Bool(val["use_common_alert_schema"].(bool)),
 		}
+
 		if v := val["tenant_id"].(string); v != "" {
 			receiver.TenantId = utils.String(v)
 		} else {
 			receiver.TenantId = utils.String(tenantId)
 		}
+
 		if subId != "" {
 			receiver.SubscriptionId = subId
 		} else {
 			receiver.SubscriptionId = subscriptionId
 		}
+
 		receivers = append(receivers, receiver)
 	}
 	return &receivers, nil

--- a/internal/services/monitor/monitor_action_group_resource.go
+++ b/internal/services/monitor/monitor_action_group_resource.go
@@ -849,13 +849,15 @@ func expandMonitorActionGroupEventHubReceiver(tenantId string, subscriptionId st
 
 		eventHubNameSpace, eventHubName, subId := val["event_hub_namespace"].(string), val["event_hub_name"].(string), val["subscription_id"].(string)
 		if !features.FourPointOhBeta() {
-			if eventHubNameSpace == "" && eventHubName == "" && subId == "" && val["event_hub_id"].(string) != "" {
-				eventHubId, err := eventhubs.ParseEventhubID(*utils.String(val["event_hub_id"].(string)))
+			eventHubIdRaw := val["event_hub_id"].(string)
+			if eventHubNameSpace == "" && eventHubName == "" && subId == "" && eventHubIdRaw != "" {
+				eventHubId, err := eventhubs.ParseEventhubID(eventHubIdRaw)
 				if err != nil {
 					return nil, err
 				}
 				eventHubNameSpace, eventHubName, subId = eventHubId.NamespaceName, eventHubId.EventhubName, eventHubId.SubscriptionId
-			} else if val["event_hub_id"].(string) != "" || eventHubNameSpace == "" || eventHubName == "" {
+			}
+			if eventHubNameSpace == "" || eventHubName == "" {
 				return nil, fmt.Errorf("in event_hub_receiver, exactly one of event_hub_id or (event_hub_namespace, event_hub_name) must be set")
 			}
 		}


### PR DESCRIPTION
In #17335 the `event_hub_id` is deprecated in favor of `event_hub_namespace`, `event_hub_name`, all of the 3 field is marked as optional and computed. But there is bug to check the `exactly one of` of these properties. This PR uses the `d.GetRawConfig()` to check the `exactly one of`.

test:
```
TF_ACC=1 go test -v ./internal/services/monitor -parallel 20 -test.run=TestAccMonitorActionGroup_event -timeout 1440m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccMonitorActionGroup_eventHubReceiver
=== PAUSE TestAccMonitorActionGroup_eventHubReceiver
=== CONT  TestAccMonitorActionGroup_eventHubReceiver
--- PASS: TestAccMonitorActionGroup_eventHubReceiver (283.59s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/monitor       283.629s
```

resolves #20146