### PR TITLE
`azurerm_spring_cloud_gateway_route_config` -  `filters` and `predicates` will be omitted when not specified

### DIFF
--- a/internal/services/springcloud/spring_cloud_gateway_route_config_resource.go
+++ b/internal/services/springcloud/spring_cloud_gateway_route_config_resource.go
@@ -215,14 +215,23 @@ func resourceSpringCloudGatewayRouteConfigCreateUpdate(d *pluginsdk.ResourceData
 	gatewayRouteConfigResource := appplatform.GatewayRouteConfigResource{
 		Properties: &appplatform.GatewayRouteConfigProperties{
 			AppResourceID: utils.String(d.Get("spring_cloud_app_id").(string)),
-			Filters:       utils.ExpandStringSlice(d.Get("filters").(*pluginsdk.Set).List()),
-			Predicates:    utils.ExpandStringSlice(d.Get("predicates").(*pluginsdk.Set).List()),
 			Protocol:      appplatform.GatewayRouteConfigProtocol(d.Get("protocol").(string)),
 			Routes:        expandGatewayRouteConfigGatewayAPIRouteArray(d.Get("route").(*pluginsdk.Set).List()),
 			SsoEnabled:    utils.Bool(d.Get("sso_validation_enabled").(bool)),
 			OpenAPI:       expandGatewayRouteConfigOpenApi(d.Get("open_api").([]interface{})),
 		},
 	}
+
+	filters := utils.ExpandStringSlice(d.Get("filters").(*pluginsdk.Set).List())
+	if len(*filters) > 0 {
+		gatewayRouteConfigResource.Properties.Filters = filters
+	}
+
+	predicates := utils.ExpandStringSlice(d.Get("predicates").(*pluginsdk.Set).List())
+	if len(*predicates) > 0 {
+		gatewayRouteConfigResource.Properties.Predicates = predicates
+	}
+
 	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.SpringName, id.GatewayName, id.RouteConfigName, gatewayRouteConfigResource)
 	if err != nil {
 		return fmt.Errorf("creating/updating %s: %+v", id, err)

--- a/internal/services/springcloud/spring_cloud_gateway_route_config_resource.go
+++ b/internal/services/springcloud/spring_cloud_gateway_route_config_resource.go
@@ -222,14 +222,14 @@ func resourceSpringCloudGatewayRouteConfigCreateUpdate(d *pluginsdk.ResourceData
 		},
 	}
 
-	filters := utils.ExpandStringSlice(d.Get("filters").(*pluginsdk.Set).List())
-	if len(*filters) > 0 {
-		gatewayRouteConfigResource.Properties.Filters = filters
+	filters := d.Get("filters").(*pluginsdk.Set).List()
+	if len(filters) > 0 {
+		gatewayRouteConfigResource.Properties.Filters = utils.ExpandStringSlice(filters)
 	}
 
-	predicates := utils.ExpandStringSlice(d.Get("predicates").(*pluginsdk.Set).List())
-	if len(*predicates) > 0 {
-		gatewayRouteConfigResource.Properties.Predicates = predicates
+	predicates := d.Get("predicates").(*pluginsdk.Set).List()
+	if len(predicates) > 0 {
+		gatewayRouteConfigResource.Properties.Predicates = utils.ExpandStringSlice(predicates)
 	}
 
 	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.SpringName, id.GatewayName, id.RouteConfigName, gatewayRouteConfigResource)


### PR DESCRIPTION
azurerm_spring_cloud_gateway_route_config when Filters or Predicates are not populated on the root of the route config and empty array of filters and predicates was being created resulting in routing being filtered out.

This changes only populates the filters or predicates properties if they are provided. See this issue for more details

https://github.com/hashicorp/terraform-provider-azurerm/issues/21617