### PR TITLE
dependencies: updating to `v0.20230511.1094507` of `github.com/hashicorp/go-azure-sdk`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.1.2
 	github.com/hashicorp/go-azure-helpers v0.56.0
-	github.com/hashicorp/go-azure-sdk v0.20230510.1131358
+	github.com/hashicorp/go-azure-sdk v0.20230511.1094507
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/go-version v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -141,8 +141,8 @@ github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brv
 github.com/hashicorp/go-azure-helpers v0.12.0/go.mod h1:Zc3v4DNeX6PDdy7NljlYpnrdac1++qNW0I4U+ofGwpg=
 github.com/hashicorp/go-azure-helpers v0.56.0 h1:KxDXISHwWe4PKEz6FSSPG8vCXNrFGsCcCn/AI94ccig=
 github.com/hashicorp/go-azure-helpers v0.56.0/go.mod h1:MbnCV9jPmlkbdH7VsoBK8IbCHvo3pLWRbRvq+F6u9sI=
-github.com/hashicorp/go-azure-sdk v0.20230510.1131358 h1:LOpLWt/uCAfvU4gl45tEKbl/qb/xmSzOhcE88Uj3BSk=
-github.com/hashicorp/go-azure-sdk v0.20230510.1131358/go.mod h1:x2r7/U5MKlTHUO6/hFHRNO03qkRLBYyeQOuEUHkZmEg=
+github.com/hashicorp/go-azure-sdk v0.20230511.1094507 h1:uvmyrTZAHXtHzwkuHtjD889OyH3c4ul1IuPiegm/uag=
+github.com/hashicorp/go-azure-sdk v0.20230511.1094507/go.mod h1:x2r7/U5MKlTHUO6/hFHRNO03qkRLBYyeQOuEUHkZmEg=
 github.com/hashicorp/go-checkpoint v0.5.0 h1:MFYpPZCnQqQTE18jFwSII6eUQrD/oxMFp3mlgcqk5mU=
 github.com/hashicorp/go-checkpoint v0.5.0/go.mod h1:7nfLNL10NsxqO4iWuW6tWW0HjZuDrwkBuEQsVcpCOgg=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/aad/2021-05-01/domainservices/id_domainservice.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/aad/2021-05-01/domainservices/id_domainservice.go
@@ -40,15 +40,15 @@ func ParseDomainServiceID(input string) (*DomainServiceId, error) {
 	id := DomainServiceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DomainServiceName, ok = parsed.Parsed["domainServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'domainServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "domainServiceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseDomainServiceIDInsensitively(input string) (*DomainServiceId, error) {
 	id := DomainServiceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DomainServiceName, ok = parsed.Parsed["domainServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'domainServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "domainServiceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/aadb2c/2021-04-01-preview/tenants/id_b2cdirectory.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/aadb2c/2021-04-01-preview/tenants/id_b2cdirectory.go
@@ -40,15 +40,15 @@ func ParseB2CDirectoryID(input string) (*B2CDirectoryId, error) {
 	id := B2CDirectoryId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroup, ok = parsed.Parsed["resourceGroup"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroup' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroup", *parsed)
 	}
 
 	if id.DirectoryName, ok = parsed.Parsed["directoryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'directoryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "directoryName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseB2CDirectoryIDInsensitively(input string) (*B2CDirectoryId, error) {
 	id := B2CDirectoryId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroup, ok = parsed.Parsed["resourceGroup"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroup' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroup", *parsed)
 	}
 
 	if id.DirectoryName, ok = parsed.Parsed["directoryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'directoryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "directoryName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/advisor/2020-01-01/getrecommendations/id_scopedrecommendation.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/advisor/2020-01-01/getrecommendations/id_scopedrecommendation.go
@@ -38,11 +38,11 @@ func ParseScopedRecommendationID(input string) (*ScopedRecommendationId, error) 
 	id := ScopedRecommendationId{}
 
 	if id.ResourceUri, ok = parsed.Parsed["resourceUri"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceUri' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceUri", *parsed)
 	}
 
 	if id.RecommendationId, ok = parsed.Parsed["recommendationId"]; !ok {
-		return nil, fmt.Errorf("the segment 'recommendationId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "recommendationId", *parsed)
 	}
 
 	return &id, nil
@@ -61,11 +61,11 @@ func ParseScopedRecommendationIDInsensitively(input string) (*ScopedRecommendati
 	id := ScopedRecommendationId{}
 
 	if id.ResourceUri, ok = parsed.Parsed["resourceUri"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceUri' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceUri", *parsed)
 	}
 
 	if id.RecommendationId, ok = parsed.Parsed["recommendationId"]; !ok {
-		return nil, fmt.Errorf("the segment 'recommendationId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "recommendationId", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/alertsmanagement/2021-08-08/alertprocessingrules/id_actionrule.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/alertsmanagement/2021-08-08/alertprocessingrules/id_actionrule.go
@@ -40,15 +40,15 @@ func ParseActionRuleID(input string) (*ActionRuleId, error) {
 	id := ActionRuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ActionRuleName, ok = parsed.Parsed["actionRuleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'actionRuleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "actionRuleName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseActionRuleIDInsensitively(input string) (*ActionRuleId, error) {
 	id := ActionRuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ActionRuleName, ok = parsed.Parsed["actionRuleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'actionRuleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "actionRuleName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/analysisservices/2017-08-01/servers/id_location.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/analysisservices/2017-08-01/servers/id_location.go
@@ -38,11 +38,11 @@ func ParseLocationID(input string) (*LocationId, error) {
 	id := LocationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.LocationName, ok = parsed.Parsed["locationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'locationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "locationName", *parsed)
 	}
 
 	return &id, nil
@@ -61,11 +61,11 @@ func ParseLocationIDInsensitively(input string) (*LocationId, error) {
 	id := LocationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.LocationName, ok = parsed.Parsed["locationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'locationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "locationName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/analysisservices/2017-08-01/servers/id_server.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/analysisservices/2017-08-01/servers/id_server.go
@@ -40,15 +40,15 @@ func ParseServerID(input string) (*ServerId, error) {
 	id := ServerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServerName, ok = parsed.Parsed["serverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseServerIDInsensitively(input string) (*ServerId, error) {
 	id := ServerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServerName, ok = parsed.Parsed["serverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2021-08-01/schema/id_schema.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2021-08-01/schema/id_schema.go
@@ -42,19 +42,19 @@ func ParseSchemaID(input string) (*SchemaId, error) {
 	id := SchemaId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServiceName, ok = parsed.Parsed["serviceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'serviceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serviceName", *parsed)
 	}
 
 	if id.SchemaId, ok = parsed.Parsed["schemaId"]; !ok {
-		return nil, fmt.Errorf("the segment 'schemaId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "schemaId", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseSchemaIDInsensitively(input string) (*SchemaId, error) {
 	id := SchemaId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServiceName, ok = parsed.Parsed["serviceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'serviceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serviceName", *parsed)
 	}
 
 	if id.SchemaId, ok = parsed.Parsed["schemaId"]; !ok {
-		return nil, fmt.Errorf("the segment 'schemaId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "schemaId", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2021-08-01/schema/id_service.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2021-08-01/schema/id_service.go
@@ -40,15 +40,15 @@ func ParseServiceID(input string) (*ServiceId, error) {
 	id := ServiceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServiceName, ok = parsed.Parsed["serviceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'serviceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serviceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseServiceIDInsensitively(input string) (*ServiceId, error) {
 	id := ServiceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServiceName, ok = parsed.Parsed["serviceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'serviceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serviceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/appconfiguration/2023-03-01/configurationstores/id_configurationstore.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/appconfiguration/2023-03-01/configurationstores/id_configurationstore.go
@@ -40,15 +40,15 @@ func ParseConfigurationStoreID(input string) (*ConfigurationStoreId, error) {
 	id := ConfigurationStoreId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ConfigurationStoreName, ok = parsed.Parsed["configurationStoreName"]; !ok {
-		return nil, fmt.Errorf("the segment 'configurationStoreName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "configurationStoreName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseConfigurationStoreIDInsensitively(input string) (*ConfigurationStoreId
 	id := ConfigurationStoreId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ConfigurationStoreName, ok = parsed.Parsed["configurationStoreName"]; !ok {
-		return nil, fmt.Errorf("the segment 'configurationStoreName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "configurationStoreName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/appconfiguration/2023-03-01/deletedconfigurationstores/id_deletedconfigurationstore.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/appconfiguration/2023-03-01/deletedconfigurationstores/id_deletedconfigurationstore.go
@@ -40,15 +40,15 @@ func ParseDeletedConfigurationStoreID(input string) (*DeletedConfigurationStoreI
 	id := DeletedConfigurationStoreId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.LocationName, ok = parsed.Parsed["locationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'locationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "locationName", *parsed)
 	}
 
 	if id.DeletedConfigurationStoreName, ok = parsed.Parsed["deletedConfigurationStoreName"]; !ok {
-		return nil, fmt.Errorf("the segment 'deletedConfigurationStoreName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "deletedConfigurationStoreName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseDeletedConfigurationStoreIDInsensitively(input string) (*DeletedConfig
 	id := DeletedConfigurationStoreId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.LocationName, ok = parsed.Parsed["locationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'locationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "locationName", *parsed)
 	}
 
 	if id.DeletedConfigurationStoreName, ok = parsed.Parsed["deletedConfigurationStoreName"]; !ok {
-		return nil, fmt.Errorf("the segment 'deletedConfigurationStoreName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "deletedConfigurationStoreName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2020-11-20/workbooktemplatesapis/id_workbooktemplate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2020-11-20/workbooktemplatesapis/id_workbooktemplate.go
@@ -40,15 +40,15 @@ func ParseWorkbookTemplateID(input string) (*WorkbookTemplateId, error) {
 	id := WorkbookTemplateId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkbookTemplateName, ok = parsed.Parsed["workbookTemplateName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workbookTemplateName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workbookTemplateName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseWorkbookTemplateIDInsensitively(input string) (*WorkbookTemplateId, er
 	id := WorkbookTemplateId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkbookTemplateName, ok = parsed.Parsed["workbookTemplateName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workbookTemplateName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workbookTemplateName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-04-01/workbooksapis/id_revision.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-04-01/workbooksapis/id_revision.go
@@ -42,19 +42,19 @@ func ParseRevisionID(input string) (*RevisionId, error) {
 	id := RevisionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkbookName, ok = parsed.Parsed["workbookName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workbookName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workbookName", *parsed)
 	}
 
 	if id.RevisionId, ok = parsed.Parsed["revisionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'revisionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "revisionId", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseRevisionIDInsensitively(input string) (*RevisionId, error) {
 	id := RevisionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkbookName, ok = parsed.Parsed["workbookName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workbookName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workbookName", *parsed)
 	}
 
 	if id.RevisionId, ok = parsed.Parsed["revisionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'revisionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "revisionId", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-04-01/workbooksapis/id_workbook.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-04-01/workbooksapis/id_workbook.go
@@ -40,15 +40,15 @@ func ParseWorkbookID(input string) (*WorkbookId, error) {
 	id := WorkbookId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkbookName, ok = parsed.Parsed["workbookName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workbookName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workbookName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseWorkbookIDInsensitively(input string) (*WorkbookId, error) {
 	id := WorkbookId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkbookName, ok = parsed.Parsed["workbookName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workbookName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workbookName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-06-15/webtestsapis/id_component.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-06-15/webtestsapis/id_component.go
@@ -40,15 +40,15 @@ func ParseComponentID(input string) (*ComponentId, error) {
 	id := ComponentId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ComponentName, ok = parsed.Parsed["componentName"]; !ok {
-		return nil, fmt.Errorf("the segment 'componentName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "componentName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseComponentIDInsensitively(input string) (*ComponentId, error) {
 	id := ComponentId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ComponentName, ok = parsed.Parsed["componentName"]; !ok {
-		return nil, fmt.Errorf("the segment 'componentName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "componentName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-06-15/webtestsapis/id_webtest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/applicationinsights/2022-06-15/webtestsapis/id_webtest.go
@@ -40,15 +40,15 @@ func ParseWebTestID(input string) (*WebTestId, error) {
 	id := WebTestId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WebTestName, ok = parsed.Parsed["webTestName"]; !ok {
-		return nil, fmt.Errorf("the segment 'webTestName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "webTestName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseWebTestIDInsensitively(input string) (*WebTestId, error) {
 	id := WebTestId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WebTestName, ok = parsed.Parsed["webTestName"]; !ok {
-		return nil, fmt.Errorf("the segment 'webTestName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "webTestName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/attestation/2020-10-01/attestationproviders/id_attestationproviders.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/attestation/2020-10-01/attestationproviders/id_attestationproviders.go
@@ -40,15 +40,15 @@ func ParseAttestationProvidersID(input string) (*AttestationProvidersId, error) 
 	id := AttestationProvidersId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AttestationProviderName, ok = parsed.Parsed["attestationProviderName"]; !ok {
-		return nil, fmt.Errorf("the segment 'attestationProviderName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "attestationProviderName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseAttestationProvidersIDInsensitively(input string) (*AttestationProvide
 	id := AttestationProvidersId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AttestationProviderName, ok = parsed.Parsed["attestationProviderName"]; !ok {
-		return nil, fmt.Errorf("the segment 'attestationProviderName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "attestationProviderName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/attestation/2020-10-01/attestationproviders/id_location.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/attestation/2020-10-01/attestationproviders/id_location.go
@@ -38,11 +38,11 @@ func ParseLocationID(input string) (*LocationId, error) {
 	id := LocationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.LocationName, ok = parsed.Parsed["locationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'locationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "locationName", *parsed)
 	}
 
 	return &id, nil
@@ -61,11 +61,11 @@ func ParseLocationIDInsensitively(input string) (*LocationId, error) {
 	id := LocationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.LocationName, ok = parsed.Parsed["locationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'locationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "locationName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2015-10-31/webhook/id_automationaccount.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2015-10-31/webhook/id_automationaccount.go
@@ -40,15 +40,15 @@ func ParseAutomationAccountID(input string) (*AutomationAccountId, error) {
 	id := AutomationAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseAutomationAccountIDInsensitively(input string) (*AutomationAccountId, 
 	id := AutomationAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2015-10-31/webhook/id_webhook.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2015-10-31/webhook/id_webhook.go
@@ -42,19 +42,19 @@ func ParseWebHookID(input string) (*WebHookId, error) {
 	id := WebHookId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	if id.WebHookName, ok = parsed.Parsed["webHookName"]; !ok {
-		return nil, fmt.Errorf("the segment 'webHookName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "webHookName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseWebHookIDInsensitively(input string) (*WebHookId, error) {
 	id := WebHookId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	if id.WebHookName, ok = parsed.Parsed["webHookName"]; !ok {
-		return nil, fmt.Errorf("the segment 'webHookName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "webHookName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2019-06-01/dscconfiguration/id_automationaccount.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2019-06-01/dscconfiguration/id_automationaccount.go
@@ -40,15 +40,15 @@ func ParseAutomationAccountID(input string) (*AutomationAccountId, error) {
 	id := AutomationAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseAutomationAccountIDInsensitively(input string) (*AutomationAccountId, 
 	id := AutomationAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2019-06-01/dscconfiguration/id_configuration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2019-06-01/dscconfiguration/id_configuration.go
@@ -42,19 +42,19 @@ func ParseConfigurationID(input string) (*ConfigurationId, error) {
 	id := ConfigurationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	if id.ConfigurationName, ok = parsed.Parsed["configurationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'configurationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "configurationName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseConfigurationIDInsensitively(input string) (*ConfigurationId, error) {
 	id := ConfigurationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	if id.ConfigurationName, ok = parsed.Parsed["configurationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'configurationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "configurationName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2019-06-01/runbook/id_automationaccount.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2019-06-01/runbook/id_automationaccount.go
@@ -40,15 +40,15 @@ func ParseAutomationAccountID(input string) (*AutomationAccountId, error) {
 	id := AutomationAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseAutomationAccountIDInsensitively(input string) (*AutomationAccountId, 
 	id := AutomationAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2019-06-01/runbook/id_runbook.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2019-06-01/runbook/id_runbook.go
@@ -42,19 +42,19 @@ func ParseRunbookID(input string) (*RunbookId, error) {
 	id := RunbookId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	if id.RunbookName, ok = parsed.Parsed["runbookName"]; !ok {
-		return nil, fmt.Errorf("the segment 'runbookName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "runbookName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseRunbookIDInsensitively(input string) (*RunbookId, error) {
 	id := RunbookId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	if id.RunbookName, ok = parsed.Parsed["runbookName"]; !ok {
-		return nil, fmt.Errorf("the segment 'runbookName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "runbookName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2019-06-01/softwareupdateconfiguration/id_automationaccount.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2019-06-01/softwareupdateconfiguration/id_automationaccount.go
@@ -40,15 +40,15 @@ func ParseAutomationAccountID(input string) (*AutomationAccountId, error) {
 	id := AutomationAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseAutomationAccountIDInsensitively(input string) (*AutomationAccountId, 
 	id := AutomationAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2019-06-01/softwareupdateconfiguration/id_softwareupdateconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2019-06-01/softwareupdateconfiguration/id_softwareupdateconfiguration.go
@@ -42,19 +42,19 @@ func ParseSoftwareUpdateConfigurationID(input string) (*SoftwareUpdateConfigurat
 	id := SoftwareUpdateConfigurationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	if id.SoftwareUpdateConfigurationName, ok = parsed.Parsed["softwareUpdateConfigurationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'softwareUpdateConfigurationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "softwareUpdateConfigurationName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseSoftwareUpdateConfigurationIDInsensitively(input string) (*SoftwareUpd
 	id := SoftwareUpdateConfigurationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	if id.SoftwareUpdateConfigurationName, ok = parsed.Parsed["softwareUpdateConfigurationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'softwareUpdateConfigurationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "softwareUpdateConfigurationName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2020-01-13-preview/certificate/id_automationaccount.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2020-01-13-preview/certificate/id_automationaccount.go
@@ -40,15 +40,15 @@ func ParseAutomationAccountID(input string) (*AutomationAccountId, error) {
 	id := AutomationAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseAutomationAccountIDInsensitively(input string) (*AutomationAccountId, 
 	id := AutomationAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2020-01-13-preview/certificate/id_certificate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2020-01-13-preview/certificate/id_certificate.go
@@ -42,19 +42,19 @@ func ParseCertificateID(input string) (*CertificateId, error) {
 	id := CertificateId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	if id.CertificateName, ok = parsed.Parsed["certificateName"]; !ok {
-		return nil, fmt.Errorf("the segment 'certificateName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "certificateName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseCertificateIDInsensitively(input string) (*CertificateId, error) {
 	id := CertificateId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	if id.CertificateName, ok = parsed.Parsed["certificateName"]; !ok {
-		return nil, fmt.Errorf("the segment 'certificateName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "certificateName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2020-01-13-preview/connection/id_automationaccount.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2020-01-13-preview/connection/id_automationaccount.go
@@ -40,15 +40,15 @@ func ParseAutomationAccountID(input string) (*AutomationAccountId, error) {
 	id := AutomationAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseAutomationAccountIDInsensitively(input string) (*AutomationAccountId, 
 	id := AutomationAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2020-01-13-preview/connection/id_connection.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2020-01-13-preview/connection/id_connection.go
@@ -42,19 +42,19 @@ func ParseConnectionID(input string) (*ConnectionId, error) {
 	id := ConnectionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	if id.ConnectionName, ok = parsed.Parsed["connectionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'connectionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "connectionName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseConnectionIDInsensitively(input string) (*ConnectionId, error) {
 	id := ConnectionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	if id.ConnectionName, ok = parsed.Parsed["connectionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'connectionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "connectionName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2020-01-13-preview/connectiontype/id_automationaccount.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2020-01-13-preview/connectiontype/id_automationaccount.go
@@ -40,15 +40,15 @@ func ParseAutomationAccountID(input string) (*AutomationAccountId, error) {
 	id := AutomationAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseAutomationAccountIDInsensitively(input string) (*AutomationAccountId, 
 	id := AutomationAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2020-01-13-preview/connectiontype/id_connectiontype.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2020-01-13-preview/connectiontype/id_connectiontype.go
@@ -42,19 +42,19 @@ func ParseConnectionTypeID(input string) (*ConnectionTypeId, error) {
 	id := ConnectionTypeId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	if id.ConnectionTypeName, ok = parsed.Parsed["connectionTypeName"]; !ok {
-		return nil, fmt.Errorf("the segment 'connectionTypeName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "connectionTypeName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseConnectionTypeIDInsensitively(input string) (*ConnectionTypeId, error)
 	id := ConnectionTypeId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	if id.ConnectionTypeName, ok = parsed.Parsed["connectionTypeName"]; !ok {
-		return nil, fmt.Errorf("the segment 'connectionTypeName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "connectionTypeName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2020-01-13-preview/credential/id_automationaccount.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2020-01-13-preview/credential/id_automationaccount.go
@@ -40,15 +40,15 @@ func ParseAutomationAccountID(input string) (*AutomationAccountId, error) {
 	id := AutomationAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseAutomationAccountIDInsensitively(input string) (*AutomationAccountId, 
 	id := AutomationAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2020-01-13-preview/credential/id_credential.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2020-01-13-preview/credential/id_credential.go
@@ -42,19 +42,19 @@ func ParseCredentialID(input string) (*CredentialId, error) {
 	id := CredentialId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	if id.CredentialName, ok = parsed.Parsed["credentialName"]; !ok {
-		return nil, fmt.Errorf("the segment 'credentialName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "credentialName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseCredentialIDInsensitively(input string) (*CredentialId, error) {
 	id := CredentialId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	if id.CredentialName, ok = parsed.Parsed["credentialName"]; !ok {
-		return nil, fmt.Errorf("the segment 'credentialName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "credentialName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2020-01-13-preview/dscnodeconfiguration/id_automationaccount.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2020-01-13-preview/dscnodeconfiguration/id_automationaccount.go
@@ -40,15 +40,15 @@ func ParseAutomationAccountID(input string) (*AutomationAccountId, error) {
 	id := AutomationAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseAutomationAccountIDInsensitively(input string) (*AutomationAccountId, 
 	id := AutomationAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2020-01-13-preview/dscnodeconfiguration/id_nodeconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2020-01-13-preview/dscnodeconfiguration/id_nodeconfiguration.go
@@ -42,19 +42,19 @@ func ParseNodeConfigurationID(input string) (*NodeConfigurationId, error) {
 	id := NodeConfigurationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	if id.NodeConfigurationName, ok = parsed.Parsed["nodeConfigurationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'nodeConfigurationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "nodeConfigurationName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseNodeConfigurationIDInsensitively(input string) (*NodeConfigurationId, 
 	id := NodeConfigurationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	if id.NodeConfigurationName, ok = parsed.Parsed["nodeConfigurationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'nodeConfigurationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "nodeConfigurationName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2020-01-13-preview/jobschedule/id_automationaccount.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2020-01-13-preview/jobschedule/id_automationaccount.go
@@ -40,15 +40,15 @@ func ParseAutomationAccountID(input string) (*AutomationAccountId, error) {
 	id := AutomationAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseAutomationAccountIDInsensitively(input string) (*AutomationAccountId, 
 	id := AutomationAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2020-01-13-preview/jobschedule/id_jobschedule.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2020-01-13-preview/jobschedule/id_jobschedule.go
@@ -42,19 +42,19 @@ func ParseJobScheduleID(input string) (*JobScheduleId, error) {
 	id := JobScheduleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	if id.JobScheduleId, ok = parsed.Parsed["jobScheduleId"]; !ok {
-		return nil, fmt.Errorf("the segment 'jobScheduleId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "jobScheduleId", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseJobScheduleIDInsensitively(input string) (*JobScheduleId, error) {
 	id := JobScheduleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	if id.JobScheduleId, ok = parsed.Parsed["jobScheduleId"]; !ok {
-		return nil, fmt.Errorf("the segment 'jobScheduleId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "jobScheduleId", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2020-01-13-preview/module/id_automationaccount.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2020-01-13-preview/module/id_automationaccount.go
@@ -40,15 +40,15 @@ func ParseAutomationAccountID(input string) (*AutomationAccountId, error) {
 	id := AutomationAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseAutomationAccountIDInsensitively(input string) (*AutomationAccountId, 
 	id := AutomationAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2020-01-13-preview/module/id_module.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2020-01-13-preview/module/id_module.go
@@ -42,19 +42,19 @@ func ParseModuleID(input string) (*ModuleId, error) {
 	id := ModuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	if id.ModuleName, ok = parsed.Parsed["moduleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'moduleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "moduleName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseModuleIDInsensitively(input string) (*ModuleId, error) {
 	id := ModuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	if id.ModuleName, ok = parsed.Parsed["moduleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'moduleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "moduleName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2020-01-13-preview/schedule/id_automationaccount.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2020-01-13-preview/schedule/id_automationaccount.go
@@ -40,15 +40,15 @@ func ParseAutomationAccountID(input string) (*AutomationAccountId, error) {
 	id := AutomationAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseAutomationAccountIDInsensitively(input string) (*AutomationAccountId, 
 	id := AutomationAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2020-01-13-preview/schedule/id_schedule.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2020-01-13-preview/schedule/id_schedule.go
@@ -42,19 +42,19 @@ func ParseScheduleID(input string) (*ScheduleId, error) {
 	id := ScheduleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	if id.ScheduleName, ok = parsed.Parsed["scheduleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'scheduleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "scheduleName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseScheduleIDInsensitively(input string) (*ScheduleId, error) {
 	id := ScheduleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	if id.ScheduleName, ok = parsed.Parsed["scheduleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'scheduleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "scheduleName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2020-01-13-preview/sourcecontrol/id_automationaccount.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2020-01-13-preview/sourcecontrol/id_automationaccount.go
@@ -40,15 +40,15 @@ func ParseAutomationAccountID(input string) (*AutomationAccountId, error) {
 	id := AutomationAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseAutomationAccountIDInsensitively(input string) (*AutomationAccountId, 
 	id := AutomationAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2020-01-13-preview/sourcecontrol/id_sourcecontrol.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2020-01-13-preview/sourcecontrol/id_sourcecontrol.go
@@ -42,19 +42,19 @@ func ParseSourceControlID(input string) (*SourceControlId, error) {
 	id := SourceControlId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	if id.SourceControlName, ok = parsed.Parsed["sourceControlName"]; !ok {
-		return nil, fmt.Errorf("the segment 'sourceControlName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "sourceControlName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseSourceControlIDInsensitively(input string) (*SourceControlId, error) {
 	id := SourceControlId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	if id.SourceControlName, ok = parsed.Parsed["sourceControlName"]; !ok {
-		return nil, fmt.Errorf("the segment 'sourceControlName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "sourceControlName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2020-01-13-preview/variable/id_automationaccount.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2020-01-13-preview/variable/id_automationaccount.go
@@ -40,15 +40,15 @@ func ParseAutomationAccountID(input string) (*AutomationAccountId, error) {
 	id := AutomationAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseAutomationAccountIDInsensitively(input string) (*AutomationAccountId, 
 	id := AutomationAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2020-01-13-preview/variable/id_variable.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2020-01-13-preview/variable/id_variable.go
@@ -42,19 +42,19 @@ func ParseVariableID(input string) (*VariableId, error) {
 	id := VariableId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	if id.VariableName, ok = parsed.Parsed["variableName"]; !ok {
-		return nil, fmt.Errorf("the segment 'variableName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "variableName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseVariableIDInsensitively(input string) (*VariableId, error) {
 	id := VariableId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	if id.VariableName, ok = parsed.Parsed["variableName"]; !ok {
-		return nil, fmt.Errorf("the segment 'variableName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "variableName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2020-01-13-preview/watcher/id_automationaccount.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2020-01-13-preview/watcher/id_automationaccount.go
@@ -40,15 +40,15 @@ func ParseAutomationAccountID(input string) (*AutomationAccountId, error) {
 	id := AutomationAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseAutomationAccountIDInsensitively(input string) (*AutomationAccountId, 
 	id := AutomationAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2020-01-13-preview/watcher/id_watcher.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2020-01-13-preview/watcher/id_watcher.go
@@ -42,19 +42,19 @@ func ParseWatcherID(input string) (*WatcherId, error) {
 	id := WatcherId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	if id.WatcherName, ok = parsed.Parsed["watcherName"]; !ok {
-		return nil, fmt.Errorf("the segment 'watcherName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "watcherName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseWatcherIDInsensitively(input string) (*WatcherId, error) {
 	id := WatcherId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	if id.WatcherName, ok = parsed.Parsed["watcherName"]; !ok {
-		return nil, fmt.Errorf("the segment 'watcherName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "watcherName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2021-06-22/automationaccount/id_automationaccount.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2021-06-22/automationaccount/id_automationaccount.go
@@ -40,15 +40,15 @@ func ParseAutomationAccountID(input string) (*AutomationAccountId, error) {
 	id := AutomationAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseAutomationAccountIDInsensitively(input string) (*AutomationAccountId, 
 	id := AutomationAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2021-06-22/hybridrunbookworker/id_hybridrunbookworker.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2021-06-22/hybridrunbookworker/id_hybridrunbookworker.go
@@ -44,23 +44,23 @@ func ParseHybridRunbookWorkerID(input string) (*HybridRunbookWorkerId, error) {
 	id := HybridRunbookWorkerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	if id.HybridRunbookWorkerGroupName, ok = parsed.Parsed["hybridRunbookWorkerGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'hybridRunbookWorkerGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "hybridRunbookWorkerGroupName", *parsed)
 	}
 
 	if id.HybridRunbookWorkerId, ok = parsed.Parsed["hybridRunbookWorkerId"]; !ok {
-		return nil, fmt.Errorf("the segment 'hybridRunbookWorkerId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "hybridRunbookWorkerId", *parsed)
 	}
 
 	return &id, nil
@@ -79,23 +79,23 @@ func ParseHybridRunbookWorkerIDInsensitively(input string) (*HybridRunbookWorker
 	id := HybridRunbookWorkerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	if id.HybridRunbookWorkerGroupName, ok = parsed.Parsed["hybridRunbookWorkerGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'hybridRunbookWorkerGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "hybridRunbookWorkerGroupName", *parsed)
 	}
 
 	if id.HybridRunbookWorkerId, ok = parsed.Parsed["hybridRunbookWorkerId"]; !ok {
-		return nil, fmt.Errorf("the segment 'hybridRunbookWorkerId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "hybridRunbookWorkerId", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2021-06-22/hybridrunbookworker/id_hybridrunbookworkergroup.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2021-06-22/hybridrunbookworker/id_hybridrunbookworkergroup.go
@@ -42,19 +42,19 @@ func ParseHybridRunbookWorkerGroupID(input string) (*HybridRunbookWorkerGroupId,
 	id := HybridRunbookWorkerGroupId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	if id.HybridRunbookWorkerGroupName, ok = parsed.Parsed["hybridRunbookWorkerGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'hybridRunbookWorkerGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "hybridRunbookWorkerGroupName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseHybridRunbookWorkerGroupIDInsensitively(input string) (*HybridRunbookW
 	id := HybridRunbookWorkerGroupId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	if id.HybridRunbookWorkerGroupName, ok = parsed.Parsed["hybridRunbookWorkerGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'hybridRunbookWorkerGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "hybridRunbookWorkerGroupName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2021-06-22/hybridrunbookworkergroup/id_automationaccount.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2021-06-22/hybridrunbookworkergroup/id_automationaccount.go
@@ -40,15 +40,15 @@ func ParseAutomationAccountID(input string) (*AutomationAccountId, error) {
 	id := AutomationAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseAutomationAccountIDInsensitively(input string) (*AutomationAccountId, 
 	id := AutomationAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2021-06-22/hybridrunbookworkergroup/id_hybridrunbookworkergroup.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/automation/2021-06-22/hybridrunbookworkergroup/id_hybridrunbookworkergroup.go
@@ -42,19 +42,19 @@ func ParseHybridRunbookWorkerGroupID(input string) (*HybridRunbookWorkerGroupId,
 	id := HybridRunbookWorkerGroupId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	if id.HybridRunbookWorkerGroupName, ok = parsed.Parsed["hybridRunbookWorkerGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'hybridRunbookWorkerGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "hybridRunbookWorkerGroupName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseHybridRunbookWorkerGroupIDInsensitively(input string) (*HybridRunbookW
 	id := HybridRunbookWorkerGroupId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutomationAccountName, ok = parsed.Parsed["automationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationAccountName", *parsed)
 	}
 
 	if id.HybridRunbookWorkerGroupName, ok = parsed.Parsed["hybridRunbookWorkerGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'hybridRunbookWorkerGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "hybridRunbookWorkerGroupName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/azurestackhci/2022-12-01/arcsettings/id_arcsetting.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/azurestackhci/2022-12-01/arcsettings/id_arcsetting.go
@@ -42,19 +42,19 @@ func ParseArcSettingID(input string) (*ArcSettingId, error) {
 	id := ArcSettingId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	if id.ArcSettingName, ok = parsed.Parsed["arcSettingName"]; !ok {
-		return nil, fmt.Errorf("the segment 'arcSettingName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "arcSettingName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseArcSettingIDInsensitively(input string) (*ArcSettingId, error) {
 	id := ArcSettingId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	if id.ArcSettingName, ok = parsed.Parsed["arcSettingName"]; !ok {
-		return nil, fmt.Errorf("the segment 'arcSettingName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "arcSettingName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/azurestackhci/2022-12-01/arcsettings/id_cluster.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/azurestackhci/2022-12-01/arcsettings/id_cluster.go
@@ -40,15 +40,15 @@ func ParseClusterID(input string) (*ClusterId, error) {
 	id := ClusterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseClusterIDInsensitively(input string) (*ClusterId, error) {
 	id := ClusterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/azurestackhci/2022-12-01/cluster/id_cluster.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/azurestackhci/2022-12-01/cluster/id_cluster.go
@@ -40,15 +40,15 @@ func ParseClusterID(input string) (*ClusterId, error) {
 	id := ClusterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseClusterIDInsensitively(input string) (*ClusterId, error) {
 	id := ClusterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/azurestackhci/2022-12-01/clusters/id_cluster.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/azurestackhci/2022-12-01/clusters/id_cluster.go
@@ -40,15 +40,15 @@ func ParseClusterID(input string) (*ClusterId, error) {
 	id := ClusterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseClusterIDInsensitively(input string) (*ClusterId, error) {
 	id := ClusterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/azurestackhci/2022-12-01/extensions/id_arcsetting.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/azurestackhci/2022-12-01/extensions/id_arcsetting.go
@@ -42,19 +42,19 @@ func ParseArcSettingID(input string) (*ArcSettingId, error) {
 	id := ArcSettingId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	if id.ArcSettingName, ok = parsed.Parsed["arcSettingName"]; !ok {
-		return nil, fmt.Errorf("the segment 'arcSettingName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "arcSettingName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseArcSettingIDInsensitively(input string) (*ArcSettingId, error) {
 	id := ArcSettingId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	if id.ArcSettingName, ok = parsed.Parsed["arcSettingName"]; !ok {
-		return nil, fmt.Errorf("the segment 'arcSettingName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "arcSettingName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/azurestackhci/2022-12-01/extensions/id_extension.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/azurestackhci/2022-12-01/extensions/id_extension.go
@@ -44,23 +44,23 @@ func ParseExtensionID(input string) (*ExtensionId, error) {
 	id := ExtensionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	if id.ArcSettingName, ok = parsed.Parsed["arcSettingName"]; !ok {
-		return nil, fmt.Errorf("the segment 'arcSettingName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "arcSettingName", *parsed)
 	}
 
 	if id.ExtensionName, ok = parsed.Parsed["extensionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'extensionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "extensionName", *parsed)
 	}
 
 	return &id, nil
@@ -79,23 +79,23 @@ func ParseExtensionIDInsensitively(input string) (*ExtensionId, error) {
 	id := ExtensionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	if id.ArcSettingName, ok = parsed.Parsed["arcSettingName"]; !ok {
-		return nil, fmt.Errorf("the segment 'arcSettingName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "arcSettingName", *parsed)
 	}
 
 	if id.ExtensionName, ok = parsed.Parsed["extensionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'extensionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "extensionName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/azurestackhci/2022-12-01/offers/id_cluster.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/azurestackhci/2022-12-01/offers/id_cluster.go
@@ -40,15 +40,15 @@ func ParseClusterID(input string) (*ClusterId, error) {
 	id := ClusterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseClusterIDInsensitively(input string) (*ClusterId, error) {
 	id := ClusterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/azurestackhci/2022-12-01/offers/id_offer.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/azurestackhci/2022-12-01/offers/id_offer.go
@@ -44,23 +44,23 @@ func ParseOfferID(input string) (*OfferId, error) {
 	id := OfferId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	if id.PublisherName, ok = parsed.Parsed["publisherName"]; !ok {
-		return nil, fmt.Errorf("the segment 'publisherName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "publisherName", *parsed)
 	}
 
 	if id.OfferName, ok = parsed.Parsed["offerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'offerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "offerName", *parsed)
 	}
 
 	return &id, nil
@@ -79,23 +79,23 @@ func ParseOfferIDInsensitively(input string) (*OfferId, error) {
 	id := OfferId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	if id.PublisherName, ok = parsed.Parsed["publisherName"]; !ok {
-		return nil, fmt.Errorf("the segment 'publisherName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "publisherName", *parsed)
 	}
 
 	if id.OfferName, ok = parsed.Parsed["offerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'offerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "offerName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/azurestackhci/2022-12-01/offers/id_publisher.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/azurestackhci/2022-12-01/offers/id_publisher.go
@@ -42,19 +42,19 @@ func ParsePublisherID(input string) (*PublisherId, error) {
 	id := PublisherId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	if id.PublisherName, ok = parsed.Parsed["publisherName"]; !ok {
-		return nil, fmt.Errorf("the segment 'publisherName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "publisherName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParsePublisherIDInsensitively(input string) (*PublisherId, error) {
 	id := PublisherId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	if id.PublisherName, ok = parsed.Parsed["publisherName"]; !ok {
-		return nil, fmt.Errorf("the segment 'publisherName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "publisherName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/azurestackhci/2022-12-01/publishers/id_cluster.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/azurestackhci/2022-12-01/publishers/id_cluster.go
@@ -40,15 +40,15 @@ func ParseClusterID(input string) (*ClusterId, error) {
 	id := ClusterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseClusterIDInsensitively(input string) (*ClusterId, error) {
 	id := ClusterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/azurestackhci/2022-12-01/publishers/id_publisher.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/azurestackhci/2022-12-01/publishers/id_publisher.go
@@ -42,19 +42,19 @@ func ParsePublisherID(input string) (*PublisherId, error) {
 	id := PublisherId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	if id.PublisherName, ok = parsed.Parsed["publisherName"]; !ok {
-		return nil, fmt.Errorf("the segment 'publisherName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "publisherName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParsePublisherIDInsensitively(input string) (*PublisherId, error) {
 	id := PublisherId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	if id.PublisherName, ok = parsed.Parsed["publisherName"]; !ok {
-		return nil, fmt.Errorf("the segment 'publisherName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "publisherName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/azurestackhci/2022-12-01/skuses/id_offer.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/azurestackhci/2022-12-01/skuses/id_offer.go
@@ -44,23 +44,23 @@ func ParseOfferID(input string) (*OfferId, error) {
 	id := OfferId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	if id.PublisherName, ok = parsed.Parsed["publisherName"]; !ok {
-		return nil, fmt.Errorf("the segment 'publisherName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "publisherName", *parsed)
 	}
 
 	if id.OfferName, ok = parsed.Parsed["offerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'offerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "offerName", *parsed)
 	}
 
 	return &id, nil
@@ -79,23 +79,23 @@ func ParseOfferIDInsensitively(input string) (*OfferId, error) {
 	id := OfferId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	if id.PublisherName, ok = parsed.Parsed["publisherName"]; !ok {
-		return nil, fmt.Errorf("the segment 'publisherName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "publisherName", *parsed)
 	}
 
 	if id.OfferName, ok = parsed.Parsed["offerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'offerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "offerName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/azurestackhci/2022-12-01/skuses/id_sku.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/azurestackhci/2022-12-01/skuses/id_sku.go
@@ -46,27 +46,27 @@ func ParseSkuID(input string) (*SkuId, error) {
 	id := SkuId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	if id.PublisherName, ok = parsed.Parsed["publisherName"]; !ok {
-		return nil, fmt.Errorf("the segment 'publisherName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "publisherName", *parsed)
 	}
 
 	if id.OfferName, ok = parsed.Parsed["offerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'offerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "offerName", *parsed)
 	}
 
 	if id.SkuName, ok = parsed.Parsed["skuName"]; !ok {
-		return nil, fmt.Errorf("the segment 'skuName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "skuName", *parsed)
 	}
 
 	return &id, nil
@@ -85,27 +85,27 @@ func ParseSkuIDInsensitively(input string) (*SkuId, error) {
 	id := SkuId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	if id.PublisherName, ok = parsed.Parsed["publisherName"]; !ok {
-		return nil, fmt.Errorf("the segment 'publisherName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "publisherName", *parsed)
 	}
 
 	if id.OfferName, ok = parsed.Parsed["offerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'offerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "offerName", *parsed)
 	}
 
 	if id.SkuName, ok = parsed.Parsed["skuName"]; !ok {
-		return nil, fmt.Errorf("the segment 'skuName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "skuName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/azurestackhci/2022-12-01/updateruns/id_update.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/azurestackhci/2022-12-01/updateruns/id_update.go
@@ -42,19 +42,19 @@ func ParseUpdateID(input string) (*UpdateId, error) {
 	id := UpdateId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	if id.UpdateName, ok = parsed.Parsed["updateName"]; !ok {
-		return nil, fmt.Errorf("the segment 'updateName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "updateName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseUpdateIDInsensitively(input string) (*UpdateId, error) {
 	id := UpdateId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	if id.UpdateName, ok = parsed.Parsed["updateName"]; !ok {
-		return nil, fmt.Errorf("the segment 'updateName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "updateName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/azurestackhci/2022-12-01/updateruns/id_updaterun.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/azurestackhci/2022-12-01/updateruns/id_updaterun.go
@@ -44,23 +44,23 @@ func ParseUpdateRunID(input string) (*UpdateRunId, error) {
 	id := UpdateRunId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	if id.UpdateName, ok = parsed.Parsed["updateName"]; !ok {
-		return nil, fmt.Errorf("the segment 'updateName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "updateName", *parsed)
 	}
 
 	if id.UpdateRunName, ok = parsed.Parsed["updateRunName"]; !ok {
-		return nil, fmt.Errorf("the segment 'updateRunName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "updateRunName", *parsed)
 	}
 
 	return &id, nil
@@ -79,23 +79,23 @@ func ParseUpdateRunIDInsensitively(input string) (*UpdateRunId, error) {
 	id := UpdateRunId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	if id.UpdateName, ok = parsed.Parsed["updateName"]; !ok {
-		return nil, fmt.Errorf("the segment 'updateName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "updateName", *parsed)
 	}
 
 	if id.UpdateRunName, ok = parsed.Parsed["updateRunName"]; !ok {
-		return nil, fmt.Errorf("the segment 'updateRunName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "updateRunName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/azurestackhci/2022-12-01/updates/id_cluster.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/azurestackhci/2022-12-01/updates/id_cluster.go
@@ -40,15 +40,15 @@ func ParseClusterID(input string) (*ClusterId, error) {
 	id := ClusterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseClusterIDInsensitively(input string) (*ClusterId, error) {
 	id := ClusterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/azurestackhci/2022-12-01/updates/id_update.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/azurestackhci/2022-12-01/updates/id_update.go
@@ -42,19 +42,19 @@ func ParseUpdateID(input string) (*UpdateId, error) {
 	id := UpdateId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	if id.UpdateName, ok = parsed.Parsed["updateName"]; !ok {
-		return nil, fmt.Errorf("the segment 'updateName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "updateName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseUpdateIDInsensitively(input string) (*UpdateId, error) {
 	id := UpdateId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	if id.UpdateName, ok = parsed.Parsed["updateName"]; !ok {
-		return nil, fmt.Errorf("the segment 'updateName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "updateName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/azurestackhci/2022-12-01/updatesummaries/id_cluster.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/azurestackhci/2022-12-01/updatesummaries/id_cluster.go
@@ -40,15 +40,15 @@ func ParseClusterID(input string) (*ClusterId, error) {
 	id := ClusterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseClusterIDInsensitively(input string) (*ClusterId, error) {
 	id := ClusterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/batch/2022-01-01/application/id_application.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/batch/2022-01-01/application/id_application.go
@@ -42,19 +42,19 @@ func ParseApplicationID(input string) (*ApplicationId, error) {
 	id := ApplicationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.BatchAccountName, ok = parsed.Parsed["batchAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'batchAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "batchAccountName", *parsed)
 	}
 
 	if id.ApplicationName, ok = parsed.Parsed["applicationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'applicationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "applicationName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseApplicationIDInsensitively(input string) (*ApplicationId, error) {
 	id := ApplicationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.BatchAccountName, ok = parsed.Parsed["batchAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'batchAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "batchAccountName", *parsed)
 	}
 
 	if id.ApplicationName, ok = parsed.Parsed["applicationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'applicationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "applicationName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/batch/2022-01-01/application/id_batchaccount.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/batch/2022-01-01/application/id_batchaccount.go
@@ -40,15 +40,15 @@ func ParseBatchAccountID(input string) (*BatchAccountId, error) {
 	id := BatchAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.BatchAccountName, ok = parsed.Parsed["batchAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'batchAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "batchAccountName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseBatchAccountIDInsensitively(input string) (*BatchAccountId, error) {
 	id := BatchAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.BatchAccountName, ok = parsed.Parsed["batchAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'batchAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "batchAccountName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/batch/2022-01-01/batchaccount/id_batchaccount.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/batch/2022-01-01/batchaccount/id_batchaccount.go
@@ -40,15 +40,15 @@ func ParseBatchAccountID(input string) (*BatchAccountId, error) {
 	id := BatchAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.BatchAccountName, ok = parsed.Parsed["batchAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'batchAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "batchAccountName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseBatchAccountIDInsensitively(input string) (*BatchAccountId, error) {
 	id := BatchAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.BatchAccountName, ok = parsed.Parsed["batchAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'batchAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "batchAccountName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/batch/2022-01-01/certificate/id_batchaccount.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/batch/2022-01-01/certificate/id_batchaccount.go
@@ -40,15 +40,15 @@ func ParseBatchAccountID(input string) (*BatchAccountId, error) {
 	id := BatchAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.BatchAccountName, ok = parsed.Parsed["batchAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'batchAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "batchAccountName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseBatchAccountIDInsensitively(input string) (*BatchAccountId, error) {
 	id := BatchAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.BatchAccountName, ok = parsed.Parsed["batchAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'batchAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "batchAccountName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/batch/2022-01-01/certificate/id_certificate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/batch/2022-01-01/certificate/id_certificate.go
@@ -42,19 +42,19 @@ func ParseCertificateID(input string) (*CertificateId, error) {
 	id := CertificateId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.BatchAccountName, ok = parsed.Parsed["batchAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'batchAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "batchAccountName", *parsed)
 	}
 
 	if id.CertificateName, ok = parsed.Parsed["certificateName"]; !ok {
-		return nil, fmt.Errorf("the segment 'certificateName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "certificateName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseCertificateIDInsensitively(input string) (*CertificateId, error) {
 	id := CertificateId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.BatchAccountName, ok = parsed.Parsed["batchAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'batchAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "batchAccountName", *parsed)
 	}
 
 	if id.CertificateName, ok = parsed.Parsed["certificateName"]; !ok {
-		return nil, fmt.Errorf("the segment 'certificateName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "certificateName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/batch/2022-01-01/pool/id_batchaccount.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/batch/2022-01-01/pool/id_batchaccount.go
@@ -40,15 +40,15 @@ func ParseBatchAccountID(input string) (*BatchAccountId, error) {
 	id := BatchAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.BatchAccountName, ok = parsed.Parsed["batchAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'batchAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "batchAccountName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseBatchAccountIDInsensitively(input string) (*BatchAccountId, error) {
 	id := BatchAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.BatchAccountName, ok = parsed.Parsed["batchAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'batchAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "batchAccountName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/batch/2022-01-01/pool/id_pool.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/batch/2022-01-01/pool/id_pool.go
@@ -42,19 +42,19 @@ func ParsePoolID(input string) (*PoolId, error) {
 	id := PoolId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.BatchAccountName, ok = parsed.Parsed["batchAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'batchAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "batchAccountName", *parsed)
 	}
 
 	if id.PoolName, ok = parsed.Parsed["poolName"]; !ok {
-		return nil, fmt.Errorf("the segment 'poolName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "poolName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParsePoolIDInsensitively(input string) (*PoolId, error) {
 	id := PoolId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.BatchAccountName, ok = parsed.Parsed["batchAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'batchAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "batchAccountName", *parsed)
 	}
 
 	if id.PoolName, ok = parsed.Parsed["poolName"]; !ok {
-		return nil, fmt.Errorf("the segment 'poolName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "poolName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2022-10-01/cognitiveservicesaccounts/id_account.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2022-10-01/cognitiveservicesaccounts/id_account.go
@@ -40,15 +40,15 @@ func ParseAccountID(input string) (*AccountId, error) {
 	id := AccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AccountName, ok = parsed.Parsed["accountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'accountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "accountName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseAccountIDInsensitively(input string) (*AccountId, error) {
 	id := AccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AccountName, ok = parsed.Parsed["accountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'accountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "accountName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2022-10-01/cognitiveservicesaccounts/id_deletedaccount.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2022-10-01/cognitiveservicesaccounts/id_deletedaccount.go
@@ -42,19 +42,19 @@ func ParseDeletedAccountID(input string) (*DeletedAccountId, error) {
 	id := DeletedAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.LocationName, ok = parsed.Parsed["locationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'locationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "locationName", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DeletedAccountName, ok = parsed.Parsed["deletedAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'deletedAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "deletedAccountName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseDeletedAccountIDInsensitively(input string) (*DeletedAccountId, error)
 	id := DeletedAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.LocationName, ok = parsed.Parsed["locationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'locationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "locationName", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DeletedAccountName, ok = parsed.Parsed["deletedAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'deletedAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "deletedAccountName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2022-10-01/cognitiveservicesaccounts/id_location.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2022-10-01/cognitiveservicesaccounts/id_location.go
@@ -38,11 +38,11 @@ func ParseLocationID(input string) (*LocationId, error) {
 	id := LocationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.LocationName, ok = parsed.Parsed["locationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'locationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "locationName", *parsed)
 	}
 
 	return &id, nil
@@ -61,11 +61,11 @@ func ParseLocationIDInsensitively(input string) (*LocationId, error) {
 	id := LocationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.LocationName, ok = parsed.Parsed["locationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'locationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "locationName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2022-10-01/deployments/id_account.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2022-10-01/deployments/id_account.go
@@ -40,15 +40,15 @@ func ParseAccountID(input string) (*AccountId, error) {
 	id := AccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AccountName, ok = parsed.Parsed["accountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'accountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "accountName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseAccountIDInsensitively(input string) (*AccountId, error) {
 	id := AccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AccountName, ok = parsed.Parsed["accountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'accountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "accountName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2022-10-01/deployments/id_deployment.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2022-10-01/deployments/id_deployment.go
@@ -42,19 +42,19 @@ func ParseDeploymentID(input string) (*DeploymentId, error) {
 	id := DeploymentId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AccountName, ok = parsed.Parsed["accountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'accountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "accountName", *parsed)
 	}
 
 	if id.DeploymentName, ok = parsed.Parsed["deploymentName"]; !ok {
-		return nil, fmt.Errorf("the segment 'deploymentName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "deploymentName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseDeploymentIDInsensitively(input string) (*DeploymentId, error) {
 	id := DeploymentId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AccountName, ok = parsed.Parsed["accountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'accountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "accountName", *parsed)
 	}
 
 	if id.DeploymentName, ok = parsed.Parsed["deploymentName"]; !ok {
-		return nil, fmt.Errorf("the segment 'deploymentName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "deploymentName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/communication/2023-03-31/communicationservices/id_communicationservice.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/communication/2023-03-31/communicationservices/id_communicationservice.go
@@ -40,15 +40,15 @@ func ParseCommunicationServiceID(input string) (*CommunicationServiceId, error) 
 	id := CommunicationServiceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.CommunicationServiceName, ok = parsed.Parsed["communicationServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'communicationServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "communicationServiceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseCommunicationServiceIDInsensitively(input string) (*CommunicationServi
 	id := CommunicationServiceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.CommunicationServiceName, ok = parsed.Parsed["communicationServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'communicationServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "communicationServiceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/communication/2023-03-31/emailservices/id_emailservice.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/communication/2023-03-31/emailservices/id_emailservice.go
@@ -40,15 +40,15 @@ func ParseEmailServiceID(input string) (*EmailServiceId, error) {
 	id := EmailServiceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.EmailServiceName, ok = parsed.Parsed["emailServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'emailServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "emailServiceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseEmailServiceIDInsensitively(input string) (*EmailServiceId, error) {
 	id := EmailServiceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.EmailServiceName, ok = parsed.Parsed["emailServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'emailServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "emailServiceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-07-01/galleries/id_gallery.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-07-01/galleries/id_gallery.go
@@ -40,15 +40,15 @@ func ParseGalleryID(input string) (*GalleryId, error) {
 	id := GalleryId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.GalleryName, ok = parsed.Parsed["galleryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'galleryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "galleryName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseGalleryIDInsensitively(input string) (*GalleryId, error) {
 	id := GalleryId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.GalleryName, ok = parsed.Parsed["galleryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'galleryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "galleryName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-07-01/galleryapplications/id_application.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-07-01/galleryapplications/id_application.go
@@ -42,19 +42,19 @@ func ParseApplicationID(input string) (*ApplicationId, error) {
 	id := ApplicationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.GalleryName, ok = parsed.Parsed["galleryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'galleryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "galleryName", *parsed)
 	}
 
 	if id.ApplicationName, ok = parsed.Parsed["applicationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'applicationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "applicationName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseApplicationIDInsensitively(input string) (*ApplicationId, error) {
 	id := ApplicationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.GalleryName, ok = parsed.Parsed["galleryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'galleryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "galleryName", *parsed)
 	}
 
 	if id.ApplicationName, ok = parsed.Parsed["applicationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'applicationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "applicationName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-07-01/galleryapplications/id_gallery.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-07-01/galleryapplications/id_gallery.go
@@ -40,15 +40,15 @@ func ParseGalleryID(input string) (*GalleryId, error) {
 	id := GalleryId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.GalleryName, ok = parsed.Parsed["galleryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'galleryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "galleryName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseGalleryIDInsensitively(input string) (*GalleryId, error) {
 	id := GalleryId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.GalleryName, ok = parsed.Parsed["galleryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'galleryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "galleryName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-07-01/galleryapplicationversions/id_application.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-07-01/galleryapplicationversions/id_application.go
@@ -42,19 +42,19 @@ func ParseApplicationID(input string) (*ApplicationId, error) {
 	id := ApplicationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.GalleryName, ok = parsed.Parsed["galleryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'galleryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "galleryName", *parsed)
 	}
 
 	if id.ApplicationName, ok = parsed.Parsed["applicationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'applicationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "applicationName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseApplicationIDInsensitively(input string) (*ApplicationId, error) {
 	id := ApplicationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.GalleryName, ok = parsed.Parsed["galleryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'galleryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "galleryName", *parsed)
 	}
 
 	if id.ApplicationName, ok = parsed.Parsed["applicationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'applicationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "applicationName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-07-01/galleryapplicationversions/id_applicationversion.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-07-01/galleryapplicationversions/id_applicationversion.go
@@ -44,23 +44,23 @@ func ParseApplicationVersionID(input string) (*ApplicationVersionId, error) {
 	id := ApplicationVersionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.GalleryName, ok = parsed.Parsed["galleryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'galleryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "galleryName", *parsed)
 	}
 
 	if id.ApplicationName, ok = parsed.Parsed["applicationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'applicationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "applicationName", *parsed)
 	}
 
 	if id.VersionName, ok = parsed.Parsed["versionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'versionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "versionName", *parsed)
 	}
 
 	return &id, nil
@@ -79,23 +79,23 @@ func ParseApplicationVersionIDInsensitively(input string) (*ApplicationVersionId
 	id := ApplicationVersionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.GalleryName, ok = parsed.Parsed["galleryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'galleryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "galleryName", *parsed)
 	}
 
 	if id.ApplicationName, ok = parsed.Parsed["applicationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'applicationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "applicationName", *parsed)
 	}
 
 	if id.VersionName, ok = parsed.Parsed["versionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'versionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "versionName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-11-01/availabilitysets/id_availabilityset.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-11-01/availabilitysets/id_availabilityset.go
@@ -40,15 +40,15 @@ func ParseAvailabilitySetID(input string) (*AvailabilitySetId, error) {
 	id := AvailabilitySetId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AvailabilitySetName, ok = parsed.Parsed["availabilitySetName"]; !ok {
-		return nil, fmt.Errorf("the segment 'availabilitySetName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "availabilitySetName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseAvailabilitySetIDInsensitively(input string) (*AvailabilitySetId, erro
 	id := AvailabilitySetId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AvailabilitySetName, ok = parsed.Parsed["availabilitySetName"]; !ok {
-		return nil, fmt.Errorf("the segment 'availabilitySetName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "availabilitySetName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-11-01/dedicatedhostgroups/id_hostgroup.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-11-01/dedicatedhostgroups/id_hostgroup.go
@@ -40,15 +40,15 @@ func ParseHostGroupID(input string) (*HostGroupId, error) {
 	id := HostGroupId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.HostGroupName, ok = parsed.Parsed["hostGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'hostGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "hostGroupName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseHostGroupIDInsensitively(input string) (*HostGroupId, error) {
 	id := HostGroupId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.HostGroupName, ok = parsed.Parsed["hostGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'hostGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "hostGroupName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-11-01/dedicatedhosts/id_host.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-11-01/dedicatedhosts/id_host.go
@@ -42,19 +42,19 @@ func ParseHostID(input string) (*HostId, error) {
 	id := HostId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.HostGroupName, ok = parsed.Parsed["hostGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'hostGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "hostGroupName", *parsed)
 	}
 
 	if id.HostName, ok = parsed.Parsed["hostName"]; !ok {
-		return nil, fmt.Errorf("the segment 'hostName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "hostName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseHostIDInsensitively(input string) (*HostId, error) {
 	id := HostId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.HostGroupName, ok = parsed.Parsed["hostGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'hostGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "hostGroupName", *parsed)
 	}
 
 	if id.HostName, ok = parsed.Parsed["hostName"]; !ok {
-		return nil, fmt.Errorf("the segment 'hostName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "hostName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-11-01/sshpublickeys/id_sshpublickey.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-11-01/sshpublickeys/id_sshpublickey.go
@@ -40,15 +40,15 @@ func ParseSshPublicKeyID(input string) (*SshPublicKeyId, error) {
 	id := SshPublicKeyId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.SshPublicKeyName, ok = parsed.Parsed["sshPublicKeyName"]; !ok {
-		return nil, fmt.Errorf("the segment 'sshPublicKeyName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "sshPublicKeyName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseSshPublicKeyIDInsensitively(input string) (*SshPublicKeyId, error) {
 	id := SshPublicKeyId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.SshPublicKeyName, ok = parsed.Parsed["sshPublicKeyName"]; !ok {
-		return nil, fmt.Errorf("the segment 'sshPublicKeyName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "sshPublicKeyName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-11-01/virtualmachines/id_location.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-11-01/virtualmachines/id_location.go
@@ -38,11 +38,11 @@ func ParseLocationID(input string) (*LocationId, error) {
 	id := LocationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.LocationName, ok = parsed.Parsed["locationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'locationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "locationName", *parsed)
 	}
 
 	return &id, nil
@@ -61,11 +61,11 @@ func ParseLocationIDInsensitively(input string) (*LocationId, error) {
 	id := LocationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.LocationName, ok = parsed.Parsed["locationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'locationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "locationName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-11-01/virtualmachines/id_virtualmachine.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2021-11-01/virtualmachines/id_virtualmachine.go
@@ -40,15 +40,15 @@ func ParseVirtualMachineID(input string) (*VirtualMachineId, error) {
 	id := VirtualMachineId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VirtualMachineName, ok = parsed.Parsed["virtualMachineName"]; !ok {
-		return nil, fmt.Errorf("the segment 'virtualMachineName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "virtualMachineName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseVirtualMachineIDInsensitively(input string) (*VirtualMachineId, error)
 	id := VirtualMachineId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VirtualMachineName, ok = parsed.Parsed["virtualMachineName"]; !ok {
-		return nil, fmt.Errorf("the segment 'virtualMachineName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "virtualMachineName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-01/capacityreservationgroups/id_capacityreservationgroup.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-01/capacityreservationgroups/id_capacityreservationgroup.go
@@ -40,15 +40,15 @@ func ParseCapacityReservationGroupID(input string) (*CapacityReservationGroupId,
 	id := CapacityReservationGroupId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.CapacityReservationGroupName, ok = parsed.Parsed["capacityReservationGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'capacityReservationGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "capacityReservationGroupName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseCapacityReservationGroupIDInsensitively(input string) (*CapacityReserv
 	id := CapacityReservationGroupId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.CapacityReservationGroupName, ok = parsed.Parsed["capacityReservationGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'capacityReservationGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "capacityReservationGroupName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-01/capacityreservations/id_capacityreservation.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-01/capacityreservations/id_capacityreservation.go
@@ -42,19 +42,19 @@ func ParseCapacityReservationID(input string) (*CapacityReservationId, error) {
 	id := CapacityReservationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.CapacityReservationGroupName, ok = parsed.Parsed["capacityReservationGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'capacityReservationGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "capacityReservationGroupName", *parsed)
 	}
 
 	if id.CapacityReservationName, ok = parsed.Parsed["capacityReservationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'capacityReservationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "capacityReservationName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseCapacityReservationIDInsensitively(input string) (*CapacityReservation
 	id := CapacityReservationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.CapacityReservationGroupName, ok = parsed.Parsed["capacityReservationGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'capacityReservationGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "capacityReservationGroupName", *parsed)
 	}
 
 	if id.CapacityReservationName, ok = parsed.Parsed["capacityReservationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'capacityReservationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "capacityReservationName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-01/images/id_image.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-01/images/id_image.go
@@ -40,15 +40,15 @@ func ParseImageID(input string) (*ImageId, error) {
 	id := ImageId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ImageName, ok = parsed.Parsed["imageName"]; !ok {
-		return nil, fmt.Errorf("the segment 'imageName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "imageName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseImageIDInsensitively(input string) (*ImageId, error) {
 	id := ImageId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ImageName, ok = parsed.Parsed["imageName"]; !ok {
-		return nil, fmt.Errorf("the segment 'imageName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "imageName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-01/proximityplacementgroups/id_proximityplacementgroup.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-01/proximityplacementgroups/id_proximityplacementgroup.go
@@ -40,15 +40,15 @@ func ParseProximityPlacementGroupID(input string) (*ProximityPlacementGroupId, e
 	id := ProximityPlacementGroupId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ProximityPlacementGroupName, ok = parsed.Parsed["proximityPlacementGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'proximityPlacementGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "proximityPlacementGroupName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseProximityPlacementGroupIDInsensitively(input string) (*ProximityPlacem
 	id := ProximityPlacementGroupId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ProximityPlacementGroupName, ok = parsed.Parsed["proximityPlacementGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'proximityPlacementGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "proximityPlacementGroupName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-02/diskaccesses/id_diskaccess.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-02/diskaccesses/id_diskaccess.go
@@ -40,15 +40,15 @@ func ParseDiskAccessID(input string) (*DiskAccessId, error) {
 	id := DiskAccessId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DiskAccessName, ok = parsed.Parsed["diskAccessName"]; !ok {
-		return nil, fmt.Errorf("the segment 'diskAccessName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "diskAccessName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseDiskAccessIDInsensitively(input string) (*DiskAccessId, error) {
 	id := DiskAccessId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DiskAccessName, ok = parsed.Parsed["diskAccessName"]; !ok {
-		return nil, fmt.Errorf("the segment 'diskAccessName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "diskAccessName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-02/diskaccesses/id_privateendpointconnection.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-02/diskaccesses/id_privateendpointconnection.go
@@ -42,19 +42,19 @@ func ParsePrivateEndpointConnectionID(input string) (*PrivateEndpointConnectionI
 	id := PrivateEndpointConnectionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DiskAccessName, ok = parsed.Parsed["diskAccessName"]; !ok {
-		return nil, fmt.Errorf("the segment 'diskAccessName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "diskAccessName", *parsed)
 	}
 
 	if id.PrivateEndpointConnectionName, ok = parsed.Parsed["privateEndpointConnectionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'privateEndpointConnectionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "privateEndpointConnectionName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParsePrivateEndpointConnectionIDInsensitively(input string) (*PrivateEndpoi
 	id := PrivateEndpointConnectionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DiskAccessName, ok = parsed.Parsed["diskAccessName"]; !ok {
-		return nil, fmt.Errorf("the segment 'diskAccessName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "diskAccessName", *parsed)
 	}
 
 	if id.PrivateEndpointConnectionName, ok = parsed.Parsed["privateEndpointConnectionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'privateEndpointConnectionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "privateEndpointConnectionName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-02/diskencryptionsets/id_diskencryptionset.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-02/diskencryptionsets/id_diskencryptionset.go
@@ -40,15 +40,15 @@ func ParseDiskEncryptionSetID(input string) (*DiskEncryptionSetId, error) {
 	id := DiskEncryptionSetId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DiskEncryptionSetName, ok = parsed.Parsed["diskEncryptionSetName"]; !ok {
-		return nil, fmt.Errorf("the segment 'diskEncryptionSetName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "diskEncryptionSetName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseDiskEncryptionSetIDInsensitively(input string) (*DiskEncryptionSetId, 
 	id := DiskEncryptionSetId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DiskEncryptionSetName, ok = parsed.Parsed["diskEncryptionSetName"]; !ok {
-		return nil, fmt.Errorf("the segment 'diskEncryptionSetName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "diskEncryptionSetName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-02/disks/id_disk.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-02/disks/id_disk.go
@@ -40,15 +40,15 @@ func ParseDiskID(input string) (*DiskId, error) {
 	id := DiskId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DiskName, ok = parsed.Parsed["diskName"]; !ok {
-		return nil, fmt.Errorf("the segment 'diskName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "diskName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseDiskIDInsensitively(input string) (*DiskId, error) {
 	id := DiskId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DiskName, ok = parsed.Parsed["diskName"]; !ok {
-		return nil, fmt.Errorf("the segment 'diskName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "diskName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-02/snapshots/id_snapshot.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-02/snapshots/id_snapshot.go
@@ -40,15 +40,15 @@ func ParseSnapshotID(input string) (*SnapshotId, error) {
 	id := SnapshotId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.SnapshotName, ok = parsed.Parsed["snapshotName"]; !ok {
-		return nil, fmt.Errorf("the segment 'snapshotName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "snapshotName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseSnapshotIDInsensitively(input string) (*SnapshotId, error) {
 	id := SnapshotId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.SnapshotName, ok = parsed.Parsed["snapshotName"]; !ok {
-		return nil, fmt.Errorf("the segment 'snapshotName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "snapshotName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confidentialledger/2022-05-13/confidentialledger/id_ledger.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/confidentialledger/2022-05-13/confidentialledger/id_ledger.go
@@ -40,15 +40,15 @@ func ParseLedgerID(input string) (*LedgerId, error) {
 	id := LedgerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.LedgerName, ok = parsed.Parsed["ledgerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'ledgerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "ledgerName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseLedgerIDInsensitively(input string) (*LedgerId, error) {
 	id := LedgerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.LedgerName, ok = parsed.Parsed["ledgerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'ledgerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "ledgerName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/consumption/2019-10-01/budgets/id_scopedbudget.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/consumption/2019-10-01/budgets/id_scopedbudget.go
@@ -38,11 +38,11 @@ func ParseScopedBudgetID(input string) (*ScopedBudgetId, error) {
 	id := ScopedBudgetId{}
 
 	if id.Scope, ok = parsed.Parsed["scope"]; !ok {
-		return nil, fmt.Errorf("the segment 'scope' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "scope", *parsed)
 	}
 
 	if id.BudgetName, ok = parsed.Parsed["budgetName"]; !ok {
-		return nil, fmt.Errorf("the segment 'budgetName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "budgetName", *parsed)
 	}
 
 	return &id, nil
@@ -61,11 +61,11 @@ func ParseScopedBudgetIDInsensitively(input string) (*ScopedBudgetId, error) {
 	id := ScopedBudgetId{}
 
 	if id.Scope, ok = parsed.Parsed["scope"]; !ok {
-		return nil, fmt.Errorf("the segment 'scope' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "scope", *parsed)
 	}
 
 	if id.BudgetName, ok = parsed.Parsed["budgetName"]; !ok {
-		return nil, fmt.Errorf("the segment 'budgetName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "budgetName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2022-03-01/certificates/id_certificate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2022-03-01/certificates/id_certificate.go
@@ -42,19 +42,19 @@ func ParseCertificateID(input string) (*CertificateId, error) {
 	id := CertificateId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ManagedEnvironmentName, ok = parsed.Parsed["managedEnvironmentName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedEnvironmentName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedEnvironmentName", *parsed)
 	}
 
 	if id.CertificateName, ok = parsed.Parsed["certificateName"]; !ok {
-		return nil, fmt.Errorf("the segment 'certificateName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "certificateName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseCertificateIDInsensitively(input string) (*CertificateId, error) {
 	id := CertificateId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ManagedEnvironmentName, ok = parsed.Parsed["managedEnvironmentName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedEnvironmentName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedEnvironmentName", *parsed)
 	}
 
 	if id.CertificateName, ok = parsed.Parsed["certificateName"]; !ok {
-		return nil, fmt.Errorf("the segment 'certificateName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "certificateName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2022-03-01/certificates/id_managedenvironment.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2022-03-01/certificates/id_managedenvironment.go
@@ -40,15 +40,15 @@ func ParseManagedEnvironmentID(input string) (*ManagedEnvironmentId, error) {
 	id := ManagedEnvironmentId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ManagedEnvironmentName, ok = parsed.Parsed["managedEnvironmentName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedEnvironmentName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedEnvironmentName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseManagedEnvironmentIDInsensitively(input string) (*ManagedEnvironmentId
 	id := ManagedEnvironmentId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ManagedEnvironmentName, ok = parsed.Parsed["managedEnvironmentName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedEnvironmentName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedEnvironmentName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2022-03-01/containerapps/id_containerapp.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2022-03-01/containerapps/id_containerapp.go
@@ -40,15 +40,15 @@ func ParseContainerAppID(input string) (*ContainerAppId, error) {
 	id := ContainerAppId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ContainerAppName, ok = parsed.Parsed["containerAppName"]; !ok {
-		return nil, fmt.Errorf("the segment 'containerAppName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "containerAppName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseContainerAppIDInsensitively(input string) (*ContainerAppId, error) {
 	id := ContainerAppId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ContainerAppName, ok = parsed.Parsed["containerAppName"]; !ok {
-		return nil, fmt.Errorf("the segment 'containerAppName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "containerAppName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2022-03-01/containerappsrevisions/id_containerapp.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2022-03-01/containerappsrevisions/id_containerapp.go
@@ -40,15 +40,15 @@ func ParseContainerAppID(input string) (*ContainerAppId, error) {
 	id := ContainerAppId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ContainerAppName, ok = parsed.Parsed["containerAppName"]; !ok {
-		return nil, fmt.Errorf("the segment 'containerAppName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "containerAppName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseContainerAppIDInsensitively(input string) (*ContainerAppId, error) {
 	id := ContainerAppId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ContainerAppName, ok = parsed.Parsed["containerAppName"]; !ok {
-		return nil, fmt.Errorf("the segment 'containerAppName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "containerAppName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2022-03-01/containerappsrevisions/id_revision.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2022-03-01/containerappsrevisions/id_revision.go
@@ -42,19 +42,19 @@ func ParseRevisionID(input string) (*RevisionId, error) {
 	id := RevisionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ContainerAppName, ok = parsed.Parsed["containerAppName"]; !ok {
-		return nil, fmt.Errorf("the segment 'containerAppName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "containerAppName", *parsed)
 	}
 
 	if id.RevisionName, ok = parsed.Parsed["revisionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'revisionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "revisionName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseRevisionIDInsensitively(input string) (*RevisionId, error) {
 	id := RevisionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ContainerAppName, ok = parsed.Parsed["containerAppName"]; !ok {
-		return nil, fmt.Errorf("the segment 'containerAppName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "containerAppName", *parsed)
 	}
 
 	if id.RevisionName, ok = parsed.Parsed["revisionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'revisionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "revisionName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2022-03-01/daprcomponents/id_daprcomponent.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2022-03-01/daprcomponents/id_daprcomponent.go
@@ -42,19 +42,19 @@ func ParseDaprComponentID(input string) (*DaprComponentId, error) {
 	id := DaprComponentId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ManagedEnvironmentName, ok = parsed.Parsed["managedEnvironmentName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedEnvironmentName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedEnvironmentName", *parsed)
 	}
 
 	if id.DaprComponentName, ok = parsed.Parsed["daprComponentName"]; !ok {
-		return nil, fmt.Errorf("the segment 'daprComponentName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "daprComponentName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseDaprComponentIDInsensitively(input string) (*DaprComponentId, error) {
 	id := DaprComponentId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ManagedEnvironmentName, ok = parsed.Parsed["managedEnvironmentName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedEnvironmentName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedEnvironmentName", *parsed)
 	}
 
 	if id.DaprComponentName, ok = parsed.Parsed["daprComponentName"]; !ok {
-		return nil, fmt.Errorf("the segment 'daprComponentName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "daprComponentName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2022-03-01/daprcomponents/id_managedenvironment.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2022-03-01/daprcomponents/id_managedenvironment.go
@@ -40,15 +40,15 @@ func ParseManagedEnvironmentID(input string) (*ManagedEnvironmentId, error) {
 	id := ManagedEnvironmentId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ManagedEnvironmentName, ok = parsed.Parsed["managedEnvironmentName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedEnvironmentName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedEnvironmentName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseManagedEnvironmentIDInsensitively(input string) (*ManagedEnvironmentId
 	id := ManagedEnvironmentId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ManagedEnvironmentName, ok = parsed.Parsed["managedEnvironmentName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedEnvironmentName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedEnvironmentName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2022-03-01/managedenvironments/id_certificate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2022-03-01/managedenvironments/id_certificate.go
@@ -42,19 +42,19 @@ func ParseCertificateID(input string) (*CertificateId, error) {
 	id := CertificateId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ManagedEnvironmentName, ok = parsed.Parsed["managedEnvironmentName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedEnvironmentName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedEnvironmentName", *parsed)
 	}
 
 	if id.CertificateName, ok = parsed.Parsed["certificateName"]; !ok {
-		return nil, fmt.Errorf("the segment 'certificateName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "certificateName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseCertificateIDInsensitively(input string) (*CertificateId, error) {
 	id := CertificateId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ManagedEnvironmentName, ok = parsed.Parsed["managedEnvironmentName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedEnvironmentName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedEnvironmentName", *parsed)
 	}
 
 	if id.CertificateName, ok = parsed.Parsed["certificateName"]; !ok {
-		return nil, fmt.Errorf("the segment 'certificateName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "certificateName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2022-03-01/managedenvironments/id_managedenvironment.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2022-03-01/managedenvironments/id_managedenvironment.go
@@ -40,15 +40,15 @@ func ParseManagedEnvironmentID(input string) (*ManagedEnvironmentId, error) {
 	id := ManagedEnvironmentId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ManagedEnvironmentName, ok = parsed.Parsed["managedEnvironmentName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedEnvironmentName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedEnvironmentName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseManagedEnvironmentIDInsensitively(input string) (*ManagedEnvironmentId
 	id := ManagedEnvironmentId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ManagedEnvironmentName, ok = parsed.Parsed["managedEnvironmentName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedEnvironmentName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedEnvironmentName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2022-03-01/managedenvironmentsstorages/id_managedenvironment.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2022-03-01/managedenvironmentsstorages/id_managedenvironment.go
@@ -40,15 +40,15 @@ func ParseManagedEnvironmentID(input string) (*ManagedEnvironmentId, error) {
 	id := ManagedEnvironmentId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ManagedEnvironmentName, ok = parsed.Parsed["managedEnvironmentName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedEnvironmentName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedEnvironmentName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseManagedEnvironmentIDInsensitively(input string) (*ManagedEnvironmentId
 	id := ManagedEnvironmentId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ManagedEnvironmentName, ok = parsed.Parsed["managedEnvironmentName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedEnvironmentName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedEnvironmentName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2022-03-01/managedenvironmentsstorages/id_storage.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2022-03-01/managedenvironmentsstorages/id_storage.go
@@ -42,19 +42,19 @@ func ParseStorageID(input string) (*StorageId, error) {
 	id := StorageId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ManagedEnvironmentName, ok = parsed.Parsed["managedEnvironmentName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedEnvironmentName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedEnvironmentName", *parsed)
 	}
 
 	if id.StorageName, ok = parsed.Parsed["storageName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseStorageIDInsensitively(input string) (*StorageId, error) {
 	id := StorageId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ManagedEnvironmentName, ok = parsed.Parsed["managedEnvironmentName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedEnvironmentName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedEnvironmentName", *parsed)
 	}
 
 	if id.StorageName, ok = parsed.Parsed["storageName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerinstance/2021-10-01/containerinstance/id_container.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerinstance/2021-10-01/containerinstance/id_container.go
@@ -42,19 +42,19 @@ func ParseContainerID(input string) (*ContainerId, error) {
 	id := ContainerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ContainerGroupName, ok = parsed.Parsed["containerGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'containerGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "containerGroupName", *parsed)
 	}
 
 	if id.ContainerName, ok = parsed.Parsed["containerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'containerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "containerName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseContainerIDInsensitively(input string) (*ContainerId, error) {
 	id := ContainerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ContainerGroupName, ok = parsed.Parsed["containerGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'containerGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "containerGroupName", *parsed)
 	}
 
 	if id.ContainerName, ok = parsed.Parsed["containerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'containerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "containerName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerinstance/2021-10-01/containerinstance/id_containergroup.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerinstance/2021-10-01/containerinstance/id_containergroup.go
@@ -40,15 +40,15 @@ func ParseContainerGroupID(input string) (*ContainerGroupId, error) {
 	id := ContainerGroupId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ContainerGroupName, ok = parsed.Parsed["containerGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'containerGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "containerGroupName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseContainerGroupIDInsensitively(input string) (*ContainerGroupId, error)
 	id := ContainerGroupId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ContainerGroupName, ok = parsed.Parsed["containerGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'containerGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "containerGroupName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerinstance/2021-10-01/containerinstance/id_location.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerinstance/2021-10-01/containerinstance/id_location.go
@@ -38,11 +38,11 @@ func ParseLocationID(input string) (*LocationId, error) {
 	id := LocationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.LocationName, ok = parsed.Parsed["locationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'locationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "locationName", *parsed)
 	}
 
 	return &id, nil
@@ -61,11 +61,11 @@ func ParseLocationIDInsensitively(input string) (*LocationId, error) {
 	id := LocationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.LocationName, ok = parsed.Parsed["locationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'locationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "locationName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerinstance/2021-10-01/containerinstance/id_subnet.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerinstance/2021-10-01/containerinstance/id_subnet.go
@@ -42,19 +42,19 @@ func ParseSubnetID(input string) (*SubnetId, error) {
 	id := SubnetId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VirtualNetworkName, ok = parsed.Parsed["virtualNetworkName"]; !ok {
-		return nil, fmt.Errorf("the segment 'virtualNetworkName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "virtualNetworkName", *parsed)
 	}
 
 	if id.SubnetName, ok = parsed.Parsed["subnetName"]; !ok {
-		return nil, fmt.Errorf("the segment 'subnetName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subnetName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseSubnetIDInsensitively(input string) (*SubnetId, error) {
 	id := SubnetId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VirtualNetworkName, ok = parsed.Parsed["virtualNetworkName"]; !ok {
-		return nil, fmt.Errorf("the segment 'virtualNetworkName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "virtualNetworkName", *parsed)
 	}
 
 	if id.SubnetName, ok = parsed.Parsed["subnetName"]; !ok {
-		return nil, fmt.Errorf("the segment 'subnetName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subnetName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2019-06-01-preview/agentpools/id_agentpool.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2019-06-01-preview/agentpools/id_agentpool.go
@@ -42,19 +42,19 @@ func ParseAgentPoolID(input string) (*AgentPoolId, error) {
 	id := AgentPoolId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RegistryName, ok = parsed.Parsed["registryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'registryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "registryName", *parsed)
 	}
 
 	if id.AgentPoolName, ok = parsed.Parsed["agentPoolName"]; !ok {
-		return nil, fmt.Errorf("the segment 'agentPoolName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "agentPoolName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseAgentPoolIDInsensitively(input string) (*AgentPoolId, error) {
 	id := AgentPoolId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RegistryName, ok = parsed.Parsed["registryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'registryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "registryName", *parsed)
 	}
 
 	if id.AgentPoolName, ok = parsed.Parsed["agentPoolName"]; !ok {
-		return nil, fmt.Errorf("the segment 'agentPoolName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "agentPoolName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2019-06-01-preview/agentpools/id_registry.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2019-06-01-preview/agentpools/id_registry.go
@@ -40,15 +40,15 @@ func ParseRegistryID(input string) (*RegistryId, error) {
 	id := RegistryId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RegistryName, ok = parsed.Parsed["registryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'registryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "registryName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseRegistryIDInsensitively(input string) (*RegistryId, error) {
 	id := RegistryId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RegistryName, ok = parsed.Parsed["registryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'registryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "registryName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2019-06-01-preview/registries/id_registry.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2019-06-01-preview/registries/id_registry.go
@@ -40,15 +40,15 @@ func ParseRegistryID(input string) (*RegistryId, error) {
 	id := RegistryId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RegistryName, ok = parsed.Parsed["registryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'registryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "registryName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseRegistryIDInsensitively(input string) (*RegistryId, error) {
 	id := RegistryId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RegistryName, ok = parsed.Parsed["registryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'registryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "registryName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2019-06-01-preview/runs/id_registry.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2019-06-01-preview/runs/id_registry.go
@@ -40,15 +40,15 @@ func ParseRegistryID(input string) (*RegistryId, error) {
 	id := RegistryId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RegistryName, ok = parsed.Parsed["registryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'registryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "registryName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseRegistryIDInsensitively(input string) (*RegistryId, error) {
 	id := RegistryId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RegistryName, ok = parsed.Parsed["registryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'registryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "registryName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2019-06-01-preview/runs/id_run.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2019-06-01-preview/runs/id_run.go
@@ -42,19 +42,19 @@ func ParseRunID(input string) (*RunId, error) {
 	id := RunId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RegistryName, ok = parsed.Parsed["registryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'registryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "registryName", *parsed)
 	}
 
 	if id.RunId, ok = parsed.Parsed["runId"]; !ok {
-		return nil, fmt.Errorf("the segment 'runId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "runId", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseRunIDInsensitively(input string) (*RunId, error) {
 	id := RunId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RegistryName, ok = parsed.Parsed["registryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'registryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "registryName", *parsed)
 	}
 
 	if id.RunId, ok = parsed.Parsed["runId"]; !ok {
-		return nil, fmt.Errorf("the segment 'runId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "runId", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2019-06-01-preview/taskruns/id_registry.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2019-06-01-preview/taskruns/id_registry.go
@@ -40,15 +40,15 @@ func ParseRegistryID(input string) (*RegistryId, error) {
 	id := RegistryId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RegistryName, ok = parsed.Parsed["registryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'registryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "registryName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseRegistryIDInsensitively(input string) (*RegistryId, error) {
 	id := RegistryId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RegistryName, ok = parsed.Parsed["registryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'registryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "registryName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2019-06-01-preview/taskruns/id_taskrun.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2019-06-01-preview/taskruns/id_taskrun.go
@@ -42,19 +42,19 @@ func ParseTaskRunID(input string) (*TaskRunId, error) {
 	id := TaskRunId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RegistryName, ok = parsed.Parsed["registryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'registryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "registryName", *parsed)
 	}
 
 	if id.TaskRunName, ok = parsed.Parsed["taskRunName"]; !ok {
-		return nil, fmt.Errorf("the segment 'taskRunName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "taskRunName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseTaskRunIDInsensitively(input string) (*TaskRunId, error) {
 	id := TaskRunId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RegistryName, ok = parsed.Parsed["registryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'registryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "registryName", *parsed)
 	}
 
 	if id.TaskRunName, ok = parsed.Parsed["taskRunName"]; !ok {
-		return nil, fmt.Errorf("the segment 'taskRunName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "taskRunName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2019-06-01-preview/tasks/id_registry.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2019-06-01-preview/tasks/id_registry.go
@@ -40,15 +40,15 @@ func ParseRegistryID(input string) (*RegistryId, error) {
 	id := RegistryId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RegistryName, ok = parsed.Parsed["registryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'registryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "registryName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseRegistryIDInsensitively(input string) (*RegistryId, error) {
 	id := RegistryId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RegistryName, ok = parsed.Parsed["registryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'registryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "registryName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2019-06-01-preview/tasks/id_task.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2019-06-01-preview/tasks/id_task.go
@@ -42,19 +42,19 @@ func ParseTaskID(input string) (*TaskId, error) {
 	id := TaskId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RegistryName, ok = parsed.Parsed["registryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'registryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "registryName", *parsed)
 	}
 
 	if id.TaskName, ok = parsed.Parsed["taskName"]; !ok {
-		return nil, fmt.Errorf("the segment 'taskName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "taskName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseTaskIDInsensitively(input string) (*TaskId, error) {
 	id := TaskId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RegistryName, ok = parsed.Parsed["registryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'registryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "registryName", *parsed)
 	}
 
 	if id.TaskName, ok = parsed.Parsed["taskName"]; !ok {
-		return nil, fmt.Errorf("the segment 'taskName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "taskName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2021-08-01-preview/connectedregistries/id_connectedregistry.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2021-08-01-preview/connectedregistries/id_connectedregistry.go
@@ -42,19 +42,19 @@ func ParseConnectedRegistryID(input string) (*ConnectedRegistryId, error) {
 	id := ConnectedRegistryId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RegistryName, ok = parsed.Parsed["registryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'registryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "registryName", *parsed)
 	}
 
 	if id.ConnectedRegistryName, ok = parsed.Parsed["connectedRegistryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'connectedRegistryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "connectedRegistryName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseConnectedRegistryIDInsensitively(input string) (*ConnectedRegistryId, 
 	id := ConnectedRegistryId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RegistryName, ok = parsed.Parsed["registryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'registryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "registryName", *parsed)
 	}
 
 	if id.ConnectedRegistryName, ok = parsed.Parsed["connectedRegistryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'connectedRegistryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "connectedRegistryName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2021-08-01-preview/connectedregistries/id_registry.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2021-08-01-preview/connectedregistries/id_registry.go
@@ -40,15 +40,15 @@ func ParseRegistryID(input string) (*RegistryId, error) {
 	id := RegistryId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RegistryName, ok = parsed.Parsed["registryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'registryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "registryName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseRegistryIDInsensitively(input string) (*RegistryId, error) {
 	id := RegistryId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RegistryName, ok = parsed.Parsed["registryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'registryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "registryName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2021-08-01-preview/exportpipelines/id_exportpipeline.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2021-08-01-preview/exportpipelines/id_exportpipeline.go
@@ -42,19 +42,19 @@ func ParseExportPipelineID(input string) (*ExportPipelineId, error) {
 	id := ExportPipelineId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RegistryName, ok = parsed.Parsed["registryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'registryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "registryName", *parsed)
 	}
 
 	if id.ExportPipelineName, ok = parsed.Parsed["exportPipelineName"]; !ok {
-		return nil, fmt.Errorf("the segment 'exportPipelineName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "exportPipelineName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseExportPipelineIDInsensitively(input string) (*ExportPipelineId, error)
 	id := ExportPipelineId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RegistryName, ok = parsed.Parsed["registryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'registryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "registryName", *parsed)
 	}
 
 	if id.ExportPipelineName, ok = parsed.Parsed["exportPipelineName"]; !ok {
-		return nil, fmt.Errorf("the segment 'exportPipelineName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "exportPipelineName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2021-08-01-preview/exportpipelines/id_registry.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2021-08-01-preview/exportpipelines/id_registry.go
@@ -40,15 +40,15 @@ func ParseRegistryID(input string) (*RegistryId, error) {
 	id := RegistryId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RegistryName, ok = parsed.Parsed["registryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'registryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "registryName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseRegistryIDInsensitively(input string) (*RegistryId, error) {
 	id := RegistryId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RegistryName, ok = parsed.Parsed["registryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'registryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "registryName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2021-08-01-preview/importpipelines/id_importpipeline.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2021-08-01-preview/importpipelines/id_importpipeline.go
@@ -42,19 +42,19 @@ func ParseImportPipelineID(input string) (*ImportPipelineId, error) {
 	id := ImportPipelineId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RegistryName, ok = parsed.Parsed["registryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'registryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "registryName", *parsed)
 	}
 
 	if id.ImportPipelineName, ok = parsed.Parsed["importPipelineName"]; !ok {
-		return nil, fmt.Errorf("the segment 'importPipelineName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "importPipelineName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseImportPipelineIDInsensitively(input string) (*ImportPipelineId, error)
 	id := ImportPipelineId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RegistryName, ok = parsed.Parsed["registryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'registryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "registryName", *parsed)
 	}
 
 	if id.ImportPipelineName, ok = parsed.Parsed["importPipelineName"]; !ok {
-		return nil, fmt.Errorf("the segment 'importPipelineName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "importPipelineName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2021-08-01-preview/importpipelines/id_registry.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2021-08-01-preview/importpipelines/id_registry.go
@@ -40,15 +40,15 @@ func ParseRegistryID(input string) (*RegistryId, error) {
 	id := RegistryId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RegistryName, ok = parsed.Parsed["registryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'registryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "registryName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseRegistryIDInsensitively(input string) (*RegistryId, error) {
 	id := RegistryId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RegistryName, ok = parsed.Parsed["registryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'registryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "registryName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2021-08-01-preview/pipelineruns/id_pipelinerun.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2021-08-01-preview/pipelineruns/id_pipelinerun.go
@@ -42,19 +42,19 @@ func ParsePipelineRunID(input string) (*PipelineRunId, error) {
 	id := PipelineRunId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RegistryName, ok = parsed.Parsed["registryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'registryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "registryName", *parsed)
 	}
 
 	if id.PipelineRunName, ok = parsed.Parsed["pipelineRunName"]; !ok {
-		return nil, fmt.Errorf("the segment 'pipelineRunName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "pipelineRunName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParsePipelineRunIDInsensitively(input string) (*PipelineRunId, error) {
 	id := PipelineRunId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RegistryName, ok = parsed.Parsed["registryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'registryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "registryName", *parsed)
 	}
 
 	if id.PipelineRunName, ok = parsed.Parsed["pipelineRunName"]; !ok {
-		return nil, fmt.Errorf("the segment 'pipelineRunName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "pipelineRunName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2021-08-01-preview/pipelineruns/id_registry.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2021-08-01-preview/pipelineruns/id_registry.go
@@ -40,15 +40,15 @@ func ParseRegistryID(input string) (*RegistryId, error) {
 	id := RegistryId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RegistryName, ok = parsed.Parsed["registryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'registryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "registryName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseRegistryIDInsensitively(input string) (*RegistryId, error) {
 	id := RegistryId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RegistryName, ok = parsed.Parsed["registryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'registryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "registryName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2021-08-01-preview/privateendpointconnections/id_privateendpointconnection.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2021-08-01-preview/privateendpointconnections/id_privateendpointconnection.go
@@ -42,19 +42,19 @@ func ParsePrivateEndpointConnectionID(input string) (*PrivateEndpointConnectionI
 	id := PrivateEndpointConnectionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RegistryName, ok = parsed.Parsed["registryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'registryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "registryName", *parsed)
 	}
 
 	if id.PrivateEndpointConnectionName, ok = parsed.Parsed["privateEndpointConnectionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'privateEndpointConnectionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "privateEndpointConnectionName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParsePrivateEndpointConnectionIDInsensitively(input string) (*PrivateEndpoi
 	id := PrivateEndpointConnectionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RegistryName, ok = parsed.Parsed["registryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'registryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "registryName", *parsed)
 	}
 
 	if id.PrivateEndpointConnectionName, ok = parsed.Parsed["privateEndpointConnectionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'privateEndpointConnectionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "privateEndpointConnectionName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2021-08-01-preview/privateendpointconnections/id_registry.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2021-08-01-preview/privateendpointconnections/id_registry.go
@@ -40,15 +40,15 @@ func ParseRegistryID(input string) (*RegistryId, error) {
 	id := RegistryId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RegistryName, ok = parsed.Parsed["registryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'registryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "registryName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseRegistryIDInsensitively(input string) (*RegistryId, error) {
 	id := RegistryId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RegistryName, ok = parsed.Parsed["registryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'registryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "registryName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2021-08-01-preview/registries/id_registry.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2021-08-01-preview/registries/id_registry.go
@@ -40,15 +40,15 @@ func ParseRegistryID(input string) (*RegistryId, error) {
 	id := RegistryId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RegistryName, ok = parsed.Parsed["registryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'registryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "registryName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseRegistryIDInsensitively(input string) (*RegistryId, error) {
 	id := RegistryId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RegistryName, ok = parsed.Parsed["registryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'registryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "registryName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2021-08-01-preview/replications/id_registry.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2021-08-01-preview/replications/id_registry.go
@@ -40,15 +40,15 @@ func ParseRegistryID(input string) (*RegistryId, error) {
 	id := RegistryId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RegistryName, ok = parsed.Parsed["registryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'registryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "registryName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseRegistryIDInsensitively(input string) (*RegistryId, error) {
 	id := RegistryId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RegistryName, ok = parsed.Parsed["registryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'registryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "registryName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2021-08-01-preview/replications/id_replication.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2021-08-01-preview/replications/id_replication.go
@@ -42,19 +42,19 @@ func ParseReplicationID(input string) (*ReplicationId, error) {
 	id := ReplicationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RegistryName, ok = parsed.Parsed["registryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'registryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "registryName", *parsed)
 	}
 
 	if id.ReplicationName, ok = parsed.Parsed["replicationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'replicationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "replicationName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseReplicationIDInsensitively(input string) (*ReplicationId, error) {
 	id := ReplicationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RegistryName, ok = parsed.Parsed["registryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'registryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "registryName", *parsed)
 	}
 
 	if id.ReplicationName, ok = parsed.Parsed["replicationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'replicationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "replicationName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2021-08-01-preview/scopemaps/id_registry.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2021-08-01-preview/scopemaps/id_registry.go
@@ -40,15 +40,15 @@ func ParseRegistryID(input string) (*RegistryId, error) {
 	id := RegistryId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RegistryName, ok = parsed.Parsed["registryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'registryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "registryName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseRegistryIDInsensitively(input string) (*RegistryId, error) {
 	id := RegistryId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RegistryName, ok = parsed.Parsed["registryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'registryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "registryName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2021-08-01-preview/scopemaps/id_scopemap.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2021-08-01-preview/scopemaps/id_scopemap.go
@@ -42,19 +42,19 @@ func ParseScopeMapID(input string) (*ScopeMapId, error) {
 	id := ScopeMapId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RegistryName, ok = parsed.Parsed["registryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'registryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "registryName", *parsed)
 	}
 
 	if id.ScopeMapName, ok = parsed.Parsed["scopeMapName"]; !ok {
-		return nil, fmt.Errorf("the segment 'scopeMapName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "scopeMapName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseScopeMapIDInsensitively(input string) (*ScopeMapId, error) {
 	id := ScopeMapId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RegistryName, ok = parsed.Parsed["registryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'registryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "registryName", *parsed)
 	}
 
 	if id.ScopeMapName, ok = parsed.Parsed["scopeMapName"]; !ok {
-		return nil, fmt.Errorf("the segment 'scopeMapName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "scopeMapName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2021-08-01-preview/tokens/id_registry.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2021-08-01-preview/tokens/id_registry.go
@@ -40,15 +40,15 @@ func ParseRegistryID(input string) (*RegistryId, error) {
 	id := RegistryId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RegistryName, ok = parsed.Parsed["registryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'registryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "registryName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseRegistryIDInsensitively(input string) (*RegistryId, error) {
 	id := RegistryId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RegistryName, ok = parsed.Parsed["registryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'registryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "registryName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2021-08-01-preview/tokens/id_token.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2021-08-01-preview/tokens/id_token.go
@@ -42,19 +42,19 @@ func ParseTokenID(input string) (*TokenId, error) {
 	id := TokenId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RegistryName, ok = parsed.Parsed["registryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'registryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "registryName", *parsed)
 	}
 
 	if id.TokenName, ok = parsed.Parsed["tokenName"]; !ok {
-		return nil, fmt.Errorf("the segment 'tokenName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "tokenName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseTokenIDInsensitively(input string) (*TokenId, error) {
 	id := TokenId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RegistryName, ok = parsed.Parsed["registryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'registryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "registryName", *parsed)
 	}
 
 	if id.TokenName, ok = parsed.Parsed["tokenName"]; !ok {
-		return nil, fmt.Errorf("the segment 'tokenName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "tokenName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2021-08-01-preview/webhooks/id_registry.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2021-08-01-preview/webhooks/id_registry.go
@@ -40,15 +40,15 @@ func ParseRegistryID(input string) (*RegistryId, error) {
 	id := RegistryId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RegistryName, ok = parsed.Parsed["registryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'registryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "registryName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseRegistryIDInsensitively(input string) (*RegistryId, error) {
 	id := RegistryId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RegistryName, ok = parsed.Parsed["registryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'registryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "registryName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2021-08-01-preview/webhooks/id_webhook.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2021-08-01-preview/webhooks/id_webhook.go
@@ -42,19 +42,19 @@ func ParseWebHookID(input string) (*WebHookId, error) {
 	id := WebHookId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RegistryName, ok = parsed.Parsed["registryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'registryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "registryName", *parsed)
 	}
 
 	if id.WebHookName, ok = parsed.Parsed["webHookName"]; !ok {
-		return nil, fmt.Errorf("the segment 'webHookName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "webHookName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseWebHookIDInsensitively(input string) (*WebHookId, error) {
 	id := WebHookId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RegistryName, ok = parsed.Parsed["registryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'registryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "registryName", *parsed)
 	}
 
 	if id.WebHookName, ok = parsed.Parsed["webHookName"]; !ok {
-		return nil, fmt.Errorf("the segment 'webHookName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "webHookName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2019-08-01/containerservices/id_location.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2019-08-01/containerservices/id_location.go
@@ -38,11 +38,11 @@ func ParseLocationID(input string) (*LocationId, error) {
 	id := LocationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.LocationName, ok = parsed.Parsed["locationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'locationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "locationName", *parsed)
 	}
 
 	return &id, nil
@@ -61,11 +61,11 @@ func ParseLocationIDInsensitively(input string) (*LocationId, error) {
 	id := LocationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.LocationName, ok = parsed.Parsed["locationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'locationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "locationName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/agentpools/id_agentpool.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/agentpools/id_agentpool.go
@@ -42,19 +42,19 @@ func ParseAgentPoolID(input string) (*AgentPoolId, error) {
 	id := AgentPoolId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ManagedClusterName, ok = parsed.Parsed["managedClusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedClusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedClusterName", *parsed)
 	}
 
 	if id.AgentPoolName, ok = parsed.Parsed["agentPoolName"]; !ok {
-		return nil, fmt.Errorf("the segment 'agentPoolName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "agentPoolName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseAgentPoolIDInsensitively(input string) (*AgentPoolId, error) {
 	id := AgentPoolId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ManagedClusterName, ok = parsed.Parsed["managedClusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedClusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedClusterName", *parsed)
 	}
 
 	if id.AgentPoolName, ok = parsed.Parsed["agentPoolName"]; !ok {
-		return nil, fmt.Errorf("the segment 'agentPoolName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "agentPoolName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/agentpools/id_managedcluster.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/agentpools/id_managedcluster.go
@@ -40,15 +40,15 @@ func ParseManagedClusterID(input string) (*ManagedClusterId, error) {
 	id := ManagedClusterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ManagedClusterName, ok = parsed.Parsed["managedClusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedClusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedClusterName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseManagedClusterIDInsensitively(input string) (*ManagedClusterId, error)
 	id := ManagedClusterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ManagedClusterName, ok = parsed.Parsed["managedClusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedClusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedClusterName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/fleetmembers/id_fleet.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/fleetmembers/id_fleet.go
@@ -40,15 +40,15 @@ func ParseFleetID(input string) (*FleetId, error) {
 	id := FleetId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.FleetName, ok = parsed.Parsed["fleetName"]; !ok {
-		return nil, fmt.Errorf("the segment 'fleetName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "fleetName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseFleetIDInsensitively(input string) (*FleetId, error) {
 	id := FleetId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.FleetName, ok = parsed.Parsed["fleetName"]; !ok {
-		return nil, fmt.Errorf("the segment 'fleetName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "fleetName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/fleetmembers/id_member.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/fleetmembers/id_member.go
@@ -42,19 +42,19 @@ func ParseMemberID(input string) (*MemberId, error) {
 	id := MemberId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.FleetName, ok = parsed.Parsed["fleetName"]; !ok {
-		return nil, fmt.Errorf("the segment 'fleetName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "fleetName", *parsed)
 	}
 
 	if id.MemberName, ok = parsed.Parsed["memberName"]; !ok {
-		return nil, fmt.Errorf("the segment 'memberName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "memberName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseMemberIDInsensitively(input string) (*MemberId, error) {
 	id := MemberId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.FleetName, ok = parsed.Parsed["fleetName"]; !ok {
-		return nil, fmt.Errorf("the segment 'fleetName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "fleetName", *parsed)
 	}
 
 	if id.MemberName, ok = parsed.Parsed["memberName"]; !ok {
-		return nil, fmt.Errorf("the segment 'memberName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "memberName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/fleets/id_fleet.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/fleets/id_fleet.go
@@ -40,15 +40,15 @@ func ParseFleetID(input string) (*FleetId, error) {
 	id := FleetId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.FleetName, ok = parsed.Parsed["fleetName"]; !ok {
-		return nil, fmt.Errorf("the segment 'fleetName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "fleetName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseFleetIDInsensitively(input string) (*FleetId, error) {
 	id := FleetId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.FleetName, ok = parsed.Parsed["fleetName"]; !ok {
-		return nil, fmt.Errorf("the segment 'fleetName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "fleetName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/maintenanceconfigurations/id_maintenanceconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/maintenanceconfigurations/id_maintenanceconfiguration.go
@@ -42,19 +42,19 @@ func ParseMaintenanceConfigurationID(input string) (*MaintenanceConfigurationId,
 	id := MaintenanceConfigurationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ManagedClusterName, ok = parsed.Parsed["managedClusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedClusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedClusterName", *parsed)
 	}
 
 	if id.MaintenanceConfigurationName, ok = parsed.Parsed["maintenanceConfigurationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'maintenanceConfigurationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "maintenanceConfigurationName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseMaintenanceConfigurationIDInsensitively(input string) (*MaintenanceCon
 	id := MaintenanceConfigurationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ManagedClusterName, ok = parsed.Parsed["managedClusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedClusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedClusterName", *parsed)
 	}
 
 	if id.MaintenanceConfigurationName, ok = parsed.Parsed["maintenanceConfigurationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'maintenanceConfigurationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "maintenanceConfigurationName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/maintenanceconfigurations/id_managedcluster.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/maintenanceconfigurations/id_managedcluster.go
@@ -40,15 +40,15 @@ func ParseManagedClusterID(input string) (*ManagedClusterId, error) {
 	id := ManagedClusterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ManagedClusterName, ok = parsed.Parsed["managedClusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedClusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedClusterName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseManagedClusterIDInsensitively(input string) (*ManagedClusterId, error)
 	id := ManagedClusterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ManagedClusterName, ok = parsed.Parsed["managedClusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedClusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedClusterName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/managedclusters/id_accessprofile.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/managedclusters/id_accessprofile.go
@@ -42,19 +42,19 @@ func ParseAccessProfileID(input string) (*AccessProfileId, error) {
 	id := AccessProfileId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ManagedClusterName, ok = parsed.Parsed["managedClusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedClusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedClusterName", *parsed)
 	}
 
 	if id.AccessProfileName, ok = parsed.Parsed["accessProfileName"]; !ok {
-		return nil, fmt.Errorf("the segment 'accessProfileName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "accessProfileName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseAccessProfileIDInsensitively(input string) (*AccessProfileId, error) {
 	id := AccessProfileId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ManagedClusterName, ok = parsed.Parsed["managedClusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedClusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedClusterName", *parsed)
 	}
 
 	if id.AccessProfileName, ok = parsed.Parsed["accessProfileName"]; !ok {
-		return nil, fmt.Errorf("the segment 'accessProfileName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "accessProfileName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/managedclusters/id_commandresult.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/managedclusters/id_commandresult.go
@@ -42,19 +42,19 @@ func ParseCommandResultID(input string) (*CommandResultId, error) {
 	id := CommandResultId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ManagedClusterName, ok = parsed.Parsed["managedClusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedClusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedClusterName", *parsed)
 	}
 
 	if id.CommandId, ok = parsed.Parsed["commandId"]; !ok {
-		return nil, fmt.Errorf("the segment 'commandId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "commandId", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseCommandResultIDInsensitively(input string) (*CommandResultId, error) {
 	id := CommandResultId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ManagedClusterName, ok = parsed.Parsed["managedClusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedClusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedClusterName", *parsed)
 	}
 
 	if id.CommandId, ok = parsed.Parsed["commandId"]; !ok {
-		return nil, fmt.Errorf("the segment 'commandId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "commandId", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/managedclusters/id_location.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/managedclusters/id_location.go
@@ -38,11 +38,11 @@ func ParseLocationID(input string) (*LocationId, error) {
 	id := LocationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.LocationName, ok = parsed.Parsed["locationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'locationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "locationName", *parsed)
 	}
 
 	return &id, nil
@@ -61,11 +61,11 @@ func ParseLocationIDInsensitively(input string) (*LocationId, error) {
 	id := LocationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.LocationName, ok = parsed.Parsed["locationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'locationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "locationName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/managedclusters/id_managedcluster.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/managedclusters/id_managedcluster.go
@@ -40,15 +40,15 @@ func ParseManagedClusterID(input string) (*ManagedClusterId, error) {
 	id := ManagedClusterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ManagedClusterName, ok = parsed.Parsed["managedClusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedClusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedClusterName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseManagedClusterIDInsensitively(input string) (*ManagedClusterId, error)
 	id := ManagedClusterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ManagedClusterName, ok = parsed.Parsed["managedClusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedClusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedClusterName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/managedclustersnapshots/id_managedclustersnapshot.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/managedclustersnapshots/id_managedclustersnapshot.go
@@ -40,15 +40,15 @@ func ParseManagedClusterSnapshotID(input string) (*ManagedClusterSnapshotId, err
 	id := ManagedClusterSnapshotId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ManagedClusterSnapshotName, ok = parsed.Parsed["managedClusterSnapshotName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedClusterSnapshotName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedClusterSnapshotName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseManagedClusterSnapshotIDInsensitively(input string) (*ManagedClusterSn
 	id := ManagedClusterSnapshotId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ManagedClusterSnapshotName, ok = parsed.Parsed["managedClusterSnapshotName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedClusterSnapshotName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedClusterSnapshotName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/privateendpointconnections/id_managedcluster.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/privateendpointconnections/id_managedcluster.go
@@ -40,15 +40,15 @@ func ParseManagedClusterID(input string) (*ManagedClusterId, error) {
 	id := ManagedClusterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ManagedClusterName, ok = parsed.Parsed["managedClusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedClusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedClusterName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseManagedClusterIDInsensitively(input string) (*ManagedClusterId, error)
 	id := ManagedClusterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ManagedClusterName, ok = parsed.Parsed["managedClusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedClusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedClusterName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/privateendpointconnections/id_privateendpointconnection.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/privateendpointconnections/id_privateendpointconnection.go
@@ -42,19 +42,19 @@ func ParsePrivateEndpointConnectionID(input string) (*PrivateEndpointConnectionI
 	id := PrivateEndpointConnectionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ManagedClusterName, ok = parsed.Parsed["managedClusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedClusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedClusterName", *parsed)
 	}
 
 	if id.PrivateEndpointConnectionName, ok = parsed.Parsed["privateEndpointConnectionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'privateEndpointConnectionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "privateEndpointConnectionName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParsePrivateEndpointConnectionIDInsensitively(input string) (*PrivateEndpoi
 	id := PrivateEndpointConnectionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ManagedClusterName, ok = parsed.Parsed["managedClusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedClusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedClusterName", *parsed)
 	}
 
 	if id.PrivateEndpointConnectionName, ok = parsed.Parsed["privateEndpointConnectionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'privateEndpointConnectionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "privateEndpointConnectionName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/privatelinkresources/id_managedcluster.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/privatelinkresources/id_managedcluster.go
@@ -40,15 +40,15 @@ func ParseManagedClusterID(input string) (*ManagedClusterId, error) {
 	id := ManagedClusterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ManagedClusterName, ok = parsed.Parsed["managedClusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedClusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedClusterName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseManagedClusterIDInsensitively(input string) (*ManagedClusterId, error)
 	id := ManagedClusterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ManagedClusterName, ok = parsed.Parsed["managedClusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedClusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedClusterName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/resolveprivatelinkserviceid/id_managedcluster.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/resolveprivatelinkserviceid/id_managedcluster.go
@@ -40,15 +40,15 @@ func ParseManagedClusterID(input string) (*ManagedClusterId, error) {
 	id := ManagedClusterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ManagedClusterName, ok = parsed.Parsed["managedClusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedClusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedClusterName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseManagedClusterIDInsensitively(input string) (*ManagedClusterId, error)
 	id := ManagedClusterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ManagedClusterName, ok = parsed.Parsed["managedClusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedClusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedClusterName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/snapshots/id_snapshot.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/snapshots/id_snapshot.go
@@ -40,15 +40,15 @@ func ParseSnapshotID(input string) (*SnapshotId, error) {
 	id := SnapshotId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.SnapshotName, ok = parsed.Parsed["snapshotName"]; !ok {
-		return nil, fmt.Errorf("the segment 'snapshotName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "snapshotName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseSnapshotIDInsensitively(input string) (*SnapshotId, error) {
 	id := SnapshotId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.SnapshotName, ok = parsed.Parsed["snapshotName"]; !ok {
-		return nil, fmt.Errorf("the segment 'snapshotName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "snapshotName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/trustedaccess/id_location.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/trustedaccess/id_location.go
@@ -38,11 +38,11 @@ func ParseLocationID(input string) (*LocationId, error) {
 	id := LocationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.LocationName, ok = parsed.Parsed["locationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'locationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "locationName", *parsed)
 	}
 
 	return &id, nil
@@ -61,11 +61,11 @@ func ParseLocationIDInsensitively(input string) (*LocationId, error) {
 	id := LocationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.LocationName, ok = parsed.Parsed["locationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'locationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "locationName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/trustedaccess/id_managedcluster.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/trustedaccess/id_managedcluster.go
@@ -40,15 +40,15 @@ func ParseManagedClusterID(input string) (*ManagedClusterId, error) {
 	id := ManagedClusterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ManagedClusterName, ok = parsed.Parsed["managedClusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedClusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedClusterName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseManagedClusterIDInsensitively(input string) (*ManagedClusterId, error)
 	id := ManagedClusterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ManagedClusterName, ok = parsed.Parsed["managedClusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedClusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedClusterName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/trustedaccess/id_trustedaccessrolebinding.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-preview/trustedaccess/id_trustedaccessrolebinding.go
@@ -42,19 +42,19 @@ func ParseTrustedAccessRoleBindingID(input string) (*TrustedAccessRoleBindingId,
 	id := TrustedAccessRoleBindingId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ManagedClusterName, ok = parsed.Parsed["managedClusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedClusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedClusterName", *parsed)
 	}
 
 	if id.TrustedAccessRoleBindingName, ok = parsed.Parsed["trustedAccessRoleBindingName"]; !ok {
-		return nil, fmt.Errorf("the segment 'trustedAccessRoleBindingName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "trustedAccessRoleBindingName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseTrustedAccessRoleBindingIDInsensitively(input string) (*TrustedAccessR
 	id := TrustedAccessRoleBindingId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ManagedClusterName, ok = parsed.Parsed["managedClusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedClusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedClusterName", *parsed)
 	}
 
 	if id.TrustedAccessRoleBindingName, ok = parsed.Parsed["trustedAccessRoleBindingName"]; !ok {
-		return nil, fmt.Errorf("the segment 'trustedAccessRoleBindingName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "trustedAccessRoleBindingName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/agentpools/id_agentpool.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/agentpools/id_agentpool.go
@@ -42,19 +42,19 @@ func ParseAgentPoolID(input string) (*AgentPoolId, error) {
 	id := AgentPoolId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ManagedClusterName, ok = parsed.Parsed["managedClusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedClusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedClusterName", *parsed)
 	}
 
 	if id.AgentPoolName, ok = parsed.Parsed["agentPoolName"]; !ok {
-		return nil, fmt.Errorf("the segment 'agentPoolName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "agentPoolName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseAgentPoolIDInsensitively(input string) (*AgentPoolId, error) {
 	id := AgentPoolId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ManagedClusterName, ok = parsed.Parsed["managedClusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedClusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedClusterName", *parsed)
 	}
 
 	if id.AgentPoolName, ok = parsed.Parsed["agentPoolName"]; !ok {
-		return nil, fmt.Errorf("the segment 'agentPoolName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "agentPoolName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/agentpools/id_managedcluster.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/agentpools/id_managedcluster.go
@@ -40,15 +40,15 @@ func ParseManagedClusterID(input string) (*ManagedClusterId, error) {
 	id := ManagedClusterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ManagedClusterName, ok = parsed.Parsed["managedClusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedClusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedClusterName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseManagedClusterIDInsensitively(input string) (*ManagedClusterId, error)
 	id := ManagedClusterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ManagedClusterName, ok = parsed.Parsed["managedClusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedClusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedClusterName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/maintenanceconfigurations/id_maintenanceconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/maintenanceconfigurations/id_maintenanceconfiguration.go
@@ -42,19 +42,19 @@ func ParseMaintenanceConfigurationID(input string) (*MaintenanceConfigurationId,
 	id := MaintenanceConfigurationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ManagedClusterName, ok = parsed.Parsed["managedClusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedClusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedClusterName", *parsed)
 	}
 
 	if id.MaintenanceConfigurationName, ok = parsed.Parsed["maintenanceConfigurationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'maintenanceConfigurationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "maintenanceConfigurationName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseMaintenanceConfigurationIDInsensitively(input string) (*MaintenanceCon
 	id := MaintenanceConfigurationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ManagedClusterName, ok = parsed.Parsed["managedClusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedClusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedClusterName", *parsed)
 	}
 
 	if id.MaintenanceConfigurationName, ok = parsed.Parsed["maintenanceConfigurationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'maintenanceConfigurationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "maintenanceConfigurationName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/maintenanceconfigurations/id_managedcluster.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/maintenanceconfigurations/id_managedcluster.go
@@ -40,15 +40,15 @@ func ParseManagedClusterID(input string) (*ManagedClusterId, error) {
 	id := ManagedClusterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ManagedClusterName, ok = parsed.Parsed["managedClusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedClusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedClusterName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseManagedClusterIDInsensitively(input string) (*ManagedClusterId, error)
 	id := ManagedClusterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ManagedClusterName, ok = parsed.Parsed["managedClusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedClusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedClusterName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/managedclusters/id_accessprofile.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/managedclusters/id_accessprofile.go
@@ -42,19 +42,19 @@ func ParseAccessProfileID(input string) (*AccessProfileId, error) {
 	id := AccessProfileId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ManagedClusterName, ok = parsed.Parsed["managedClusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedClusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedClusterName", *parsed)
 	}
 
 	if id.AccessProfileName, ok = parsed.Parsed["accessProfileName"]; !ok {
-		return nil, fmt.Errorf("the segment 'accessProfileName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "accessProfileName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseAccessProfileIDInsensitively(input string) (*AccessProfileId, error) {
 	id := AccessProfileId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ManagedClusterName, ok = parsed.Parsed["managedClusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedClusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedClusterName", *parsed)
 	}
 
 	if id.AccessProfileName, ok = parsed.Parsed["accessProfileName"]; !ok {
-		return nil, fmt.Errorf("the segment 'accessProfileName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "accessProfileName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/managedclusters/id_commandresult.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/managedclusters/id_commandresult.go
@@ -42,19 +42,19 @@ func ParseCommandResultID(input string) (*CommandResultId, error) {
 	id := CommandResultId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ManagedClusterName, ok = parsed.Parsed["managedClusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedClusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedClusterName", *parsed)
 	}
 
 	if id.CommandId, ok = parsed.Parsed["commandId"]; !ok {
-		return nil, fmt.Errorf("the segment 'commandId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "commandId", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseCommandResultIDInsensitively(input string) (*CommandResultId, error) {
 	id := CommandResultId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ManagedClusterName, ok = parsed.Parsed["managedClusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedClusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedClusterName", *parsed)
 	}
 
 	if id.CommandId, ok = parsed.Parsed["commandId"]; !ok {
-		return nil, fmt.Errorf("the segment 'commandId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "commandId", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/managedclusters/id_location.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/managedclusters/id_location.go
@@ -38,11 +38,11 @@ func ParseLocationID(input string) (*LocationId, error) {
 	id := LocationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.LocationName, ok = parsed.Parsed["locationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'locationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "locationName", *parsed)
 	}
 
 	return &id, nil
@@ -61,11 +61,11 @@ func ParseLocationIDInsensitively(input string) (*LocationId, error) {
 	id := LocationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.LocationName, ok = parsed.Parsed["locationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'locationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "locationName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/managedclusters/id_managedcluster.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/managedclusters/id_managedcluster.go
@@ -40,15 +40,15 @@ func ParseManagedClusterID(input string) (*ManagedClusterId, error) {
 	id := ManagedClusterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ManagedClusterName, ok = parsed.Parsed["managedClusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedClusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedClusterName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseManagedClusterIDInsensitively(input string) (*ManagedClusterId, error)
 	id := ManagedClusterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ManagedClusterName, ok = parsed.Parsed["managedClusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedClusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedClusterName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/snapshots/id_snapshot.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/snapshots/id_snapshot.go
@@ -40,15 +40,15 @@ func ParseSnapshotID(input string) (*SnapshotId, error) {
 	id := SnapshotId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.SnapshotName, ok = parsed.Parsed["snapshotName"]; !ok {
-		return nil, fmt.Errorf("the segment 'snapshotName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "snapshotName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseSnapshotIDInsensitively(input string) (*SnapshotId, error) {
 	id := SnapshotId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.SnapshotName, ok = parsed.Parsed["snapshotName"]; !ok {
-		return nil, fmt.Errorf("the segment 'snapshotName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "snapshotName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-05-15/cosmosdb/id_cassandrakeyspace.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-05-15/cosmosdb/id_cassandrakeyspace.go
@@ -42,19 +42,19 @@ func ParseCassandraKeyspaceID(input string) (*CassandraKeyspaceId, error) {
 	id := CassandraKeyspaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DatabaseAccountName, ok = parsed.Parsed["databaseAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseAccountName", *parsed)
 	}
 
 	if id.CassandraKeyspaceName, ok = parsed.Parsed["cassandraKeyspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'cassandraKeyspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "cassandraKeyspaceName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseCassandraKeyspaceIDInsensitively(input string) (*CassandraKeyspaceId, 
 	id := CassandraKeyspaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DatabaseAccountName, ok = parsed.Parsed["databaseAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseAccountName", *parsed)
 	}
 
 	if id.CassandraKeyspaceName, ok = parsed.Parsed["cassandraKeyspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'cassandraKeyspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "cassandraKeyspaceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-05-15/cosmosdb/id_cassandrakeyspacetable.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-05-15/cosmosdb/id_cassandrakeyspacetable.go
@@ -44,23 +44,23 @@ func ParseCassandraKeyspaceTableID(input string) (*CassandraKeyspaceTableId, err
 	id := CassandraKeyspaceTableId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DatabaseAccountName, ok = parsed.Parsed["databaseAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseAccountName", *parsed)
 	}
 
 	if id.CassandraKeyspaceName, ok = parsed.Parsed["cassandraKeyspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'cassandraKeyspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "cassandraKeyspaceName", *parsed)
 	}
 
 	if id.TableName, ok = parsed.Parsed["tableName"]; !ok {
-		return nil, fmt.Errorf("the segment 'tableName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "tableName", *parsed)
 	}
 
 	return &id, nil
@@ -79,23 +79,23 @@ func ParseCassandraKeyspaceTableIDInsensitively(input string) (*CassandraKeyspac
 	id := CassandraKeyspaceTableId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DatabaseAccountName, ok = parsed.Parsed["databaseAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseAccountName", *parsed)
 	}
 
 	if id.CassandraKeyspaceName, ok = parsed.Parsed["cassandraKeyspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'cassandraKeyspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "cassandraKeyspaceName", *parsed)
 	}
 
 	if id.TableName, ok = parsed.Parsed["tableName"]; !ok {
-		return nil, fmt.Errorf("the segment 'tableName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "tableName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-05-15/cosmosdb/id_collection.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-05-15/cosmosdb/id_collection.go
@@ -44,23 +44,23 @@ func ParseCollectionID(input string) (*CollectionId, error) {
 	id := CollectionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DatabaseAccountName, ok = parsed.Parsed["databaseAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseAccountName", *parsed)
 	}
 
 	if id.DatabaseName, ok = parsed.Parsed["databaseName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseName", *parsed)
 	}
 
 	if id.CollectionName, ok = parsed.Parsed["collectionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'collectionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "collectionName", *parsed)
 	}
 
 	return &id, nil
@@ -79,23 +79,23 @@ func ParseCollectionIDInsensitively(input string) (*CollectionId, error) {
 	id := CollectionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DatabaseAccountName, ok = parsed.Parsed["databaseAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseAccountName", *parsed)
 	}
 
 	if id.DatabaseName, ok = parsed.Parsed["databaseName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseName", *parsed)
 	}
 
 	if id.CollectionName, ok = parsed.Parsed["collectionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'collectionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "collectionName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-05-15/cosmosdb/id_collectionpartitionkeyrangeid.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-05-15/cosmosdb/id_collectionpartitionkeyrangeid.go
@@ -48,31 +48,31 @@ func ParseCollectionPartitionKeyRangeIdID(input string) (*CollectionPartitionKey
 	id := CollectionPartitionKeyRangeIdId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DatabaseAccountName, ok = parsed.Parsed["databaseAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseAccountName", *parsed)
 	}
 
 	if id.RegionName, ok = parsed.Parsed["regionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'regionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "regionName", *parsed)
 	}
 
 	if id.DatabaseName, ok = parsed.Parsed["databaseName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseName", *parsed)
 	}
 
 	if id.CollectionName, ok = parsed.Parsed["collectionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'collectionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "collectionName", *parsed)
 	}
 
 	if id.PartitionKeyRangeId, ok = parsed.Parsed["partitionKeyRangeId"]; !ok {
-		return nil, fmt.Errorf("the segment 'partitionKeyRangeId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "partitionKeyRangeId", *parsed)
 	}
 
 	return &id, nil
@@ -91,31 +91,31 @@ func ParseCollectionPartitionKeyRangeIdIDInsensitively(input string) (*Collectio
 	id := CollectionPartitionKeyRangeIdId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DatabaseAccountName, ok = parsed.Parsed["databaseAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseAccountName", *parsed)
 	}
 
 	if id.RegionName, ok = parsed.Parsed["regionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'regionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "regionName", *parsed)
 	}
 
 	if id.DatabaseName, ok = parsed.Parsed["databaseName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseName", *parsed)
 	}
 
 	if id.CollectionName, ok = parsed.Parsed["collectionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'collectionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "collectionName", *parsed)
 	}
 
 	if id.PartitionKeyRangeId, ok = parsed.Parsed["partitionKeyRangeId"]; !ok {
-		return nil, fmt.Errorf("the segment 'partitionKeyRangeId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "partitionKeyRangeId", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-05-15/cosmosdb/id_container.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-05-15/cosmosdb/id_container.go
@@ -44,23 +44,23 @@ func ParseContainerID(input string) (*ContainerId, error) {
 	id := ContainerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DatabaseAccountName, ok = parsed.Parsed["databaseAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseAccountName", *parsed)
 	}
 
 	if id.SqlDatabaseName, ok = parsed.Parsed["sqlDatabaseName"]; !ok {
-		return nil, fmt.Errorf("the segment 'sqlDatabaseName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "sqlDatabaseName", *parsed)
 	}
 
 	if id.ContainerName, ok = parsed.Parsed["containerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'containerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "containerName", *parsed)
 	}
 
 	return &id, nil
@@ -79,23 +79,23 @@ func ParseContainerIDInsensitively(input string) (*ContainerId, error) {
 	id := ContainerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DatabaseAccountName, ok = parsed.Parsed["databaseAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseAccountName", *parsed)
 	}
 
 	if id.SqlDatabaseName, ok = parsed.Parsed["sqlDatabaseName"]; !ok {
-		return nil, fmt.Errorf("the segment 'sqlDatabaseName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "sqlDatabaseName", *parsed)
 	}
 
 	if id.ContainerName, ok = parsed.Parsed["containerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'containerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "containerName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-05-15/cosmosdb/id_database.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-05-15/cosmosdb/id_database.go
@@ -42,19 +42,19 @@ func ParseDatabaseID(input string) (*DatabaseId, error) {
 	id := DatabaseId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DatabaseAccountName, ok = parsed.Parsed["databaseAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseAccountName", *parsed)
 	}
 
 	if id.DatabaseName, ok = parsed.Parsed["databaseName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseDatabaseIDInsensitively(input string) (*DatabaseId, error) {
 	id := DatabaseId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DatabaseAccountName, ok = parsed.Parsed["databaseAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseAccountName", *parsed)
 	}
 
 	if id.DatabaseName, ok = parsed.Parsed["databaseName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-05-15/cosmosdb/id_databaseaccount.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-05-15/cosmosdb/id_databaseaccount.go
@@ -40,15 +40,15 @@ func ParseDatabaseAccountID(input string) (*DatabaseAccountId, error) {
 	id := DatabaseAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DatabaseAccountName, ok = parsed.Parsed["databaseAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseAccountName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseDatabaseAccountIDInsensitively(input string) (*DatabaseAccountId, erro
 	id := DatabaseAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DatabaseAccountName, ok = parsed.Parsed["databaseAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseAccountName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-05-15/cosmosdb/id_databaseaccountname.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-05-15/cosmosdb/id_databaseaccountname.go
@@ -36,7 +36,7 @@ func ParseDatabaseAccountNameID(input string) (*DatabaseAccountNameId, error) {
 	id := DatabaseAccountNameId{}
 
 	if id.DatabaseAccountName, ok = parsed.Parsed["databaseAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseAccountName", *parsed)
 	}
 
 	return &id, nil
@@ -55,7 +55,7 @@ func ParseDatabaseAccountNameIDInsensitively(input string) (*DatabaseAccountName
 	id := DatabaseAccountNameId{}
 
 	if id.DatabaseAccountName, ok = parsed.Parsed["databaseAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseAccountName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-05-15/cosmosdb/id_databasecollection.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-05-15/cosmosdb/id_databasecollection.go
@@ -46,27 +46,27 @@ func ParseDatabaseCollectionID(input string) (*DatabaseCollectionId, error) {
 	id := DatabaseCollectionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DatabaseAccountName, ok = parsed.Parsed["databaseAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseAccountName", *parsed)
 	}
 
 	if id.RegionName, ok = parsed.Parsed["regionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'regionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "regionName", *parsed)
 	}
 
 	if id.DatabaseName, ok = parsed.Parsed["databaseName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseName", *parsed)
 	}
 
 	if id.CollectionName, ok = parsed.Parsed["collectionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'collectionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "collectionName", *parsed)
 	}
 
 	return &id, nil
@@ -85,27 +85,27 @@ func ParseDatabaseCollectionIDInsensitively(input string) (*DatabaseCollectionId
 	id := DatabaseCollectionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DatabaseAccountName, ok = parsed.Parsed["databaseAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseAccountName", *parsed)
 	}
 
 	if id.RegionName, ok = parsed.Parsed["regionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'regionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "regionName", *parsed)
 	}
 
 	if id.DatabaseName, ok = parsed.Parsed["databaseName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseName", *parsed)
 	}
 
 	if id.CollectionName, ok = parsed.Parsed["collectionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'collectionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "collectionName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-05-15/cosmosdb/id_graph.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-05-15/cosmosdb/id_graph.go
@@ -44,23 +44,23 @@ func ParseGraphID(input string) (*GraphId, error) {
 	id := GraphId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DatabaseAccountName, ok = parsed.Parsed["databaseAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseAccountName", *parsed)
 	}
 
 	if id.GremlinDatabaseName, ok = parsed.Parsed["gremlinDatabaseName"]; !ok {
-		return nil, fmt.Errorf("the segment 'gremlinDatabaseName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "gremlinDatabaseName", *parsed)
 	}
 
 	if id.GraphName, ok = parsed.Parsed["graphName"]; !ok {
-		return nil, fmt.Errorf("the segment 'graphName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "graphName", *parsed)
 	}
 
 	return &id, nil
@@ -79,23 +79,23 @@ func ParseGraphIDInsensitively(input string) (*GraphId, error) {
 	id := GraphId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DatabaseAccountName, ok = parsed.Parsed["databaseAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseAccountName", *parsed)
 	}
 
 	if id.GremlinDatabaseName, ok = parsed.Parsed["gremlinDatabaseName"]; !ok {
-		return nil, fmt.Errorf("the segment 'gremlinDatabaseName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "gremlinDatabaseName", *parsed)
 	}
 
 	if id.GraphName, ok = parsed.Parsed["graphName"]; !ok {
-		return nil, fmt.Errorf("the segment 'graphName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "graphName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-05-15/cosmosdb/id_gremlindatabase.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-05-15/cosmosdb/id_gremlindatabase.go
@@ -42,19 +42,19 @@ func ParseGremlinDatabaseID(input string) (*GremlinDatabaseId, error) {
 	id := GremlinDatabaseId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DatabaseAccountName, ok = parsed.Parsed["databaseAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseAccountName", *parsed)
 	}
 
 	if id.GremlinDatabaseName, ok = parsed.Parsed["gremlinDatabaseName"]; !ok {
-		return nil, fmt.Errorf("the segment 'gremlinDatabaseName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "gremlinDatabaseName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseGremlinDatabaseIDInsensitively(input string) (*GremlinDatabaseId, erro
 	id := GremlinDatabaseId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DatabaseAccountName, ok = parsed.Parsed["databaseAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseAccountName", *parsed)
 	}
 
 	if id.GremlinDatabaseName, ok = parsed.Parsed["gremlinDatabaseName"]; !ok {
-		return nil, fmt.Errorf("the segment 'gremlinDatabaseName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "gremlinDatabaseName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-05-15/cosmosdb/id_location.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-05-15/cosmosdb/id_location.go
@@ -38,11 +38,11 @@ func ParseLocationID(input string) (*LocationId, error) {
 	id := LocationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.LocationName, ok = parsed.Parsed["locationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'locationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "locationName", *parsed)
 	}
 
 	return &id, nil
@@ -61,11 +61,11 @@ func ParseLocationIDInsensitively(input string) (*LocationId, error) {
 	id := LocationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.LocationName, ok = parsed.Parsed["locationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'locationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "locationName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-05-15/cosmosdb/id_mongodbdatabase.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-05-15/cosmosdb/id_mongodbdatabase.go
@@ -42,19 +42,19 @@ func ParseMongodbDatabaseID(input string) (*MongodbDatabaseId, error) {
 	id := MongodbDatabaseId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DatabaseAccountName, ok = parsed.Parsed["databaseAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseAccountName", *parsed)
 	}
 
 	if id.MongodbDatabaseName, ok = parsed.Parsed["mongodbDatabaseName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mongodbDatabaseName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mongodbDatabaseName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseMongodbDatabaseIDInsensitively(input string) (*MongodbDatabaseId, erro
 	id := MongodbDatabaseId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DatabaseAccountName, ok = parsed.Parsed["databaseAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseAccountName", *parsed)
 	}
 
 	if id.MongodbDatabaseName, ok = parsed.Parsed["mongodbDatabaseName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mongodbDatabaseName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mongodbDatabaseName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-05-15/cosmosdb/id_mongodbdatabasecollection.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-05-15/cosmosdb/id_mongodbdatabasecollection.go
@@ -44,23 +44,23 @@ func ParseMongodbDatabaseCollectionID(input string) (*MongodbDatabaseCollectionI
 	id := MongodbDatabaseCollectionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DatabaseAccountName, ok = parsed.Parsed["databaseAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseAccountName", *parsed)
 	}
 
 	if id.MongodbDatabaseName, ok = parsed.Parsed["mongodbDatabaseName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mongodbDatabaseName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mongodbDatabaseName", *parsed)
 	}
 
 	if id.CollectionName, ok = parsed.Parsed["collectionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'collectionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "collectionName", *parsed)
 	}
 
 	return &id, nil
@@ -79,23 +79,23 @@ func ParseMongodbDatabaseCollectionIDInsensitively(input string) (*MongodbDataba
 	id := MongodbDatabaseCollectionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DatabaseAccountName, ok = parsed.Parsed["databaseAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseAccountName", *parsed)
 	}
 
 	if id.MongodbDatabaseName, ok = parsed.Parsed["mongodbDatabaseName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mongodbDatabaseName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mongodbDatabaseName", *parsed)
 	}
 
 	if id.CollectionName, ok = parsed.Parsed["collectionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'collectionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "collectionName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-05-15/cosmosdb/id_partitionkeyrangeid.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-05-15/cosmosdb/id_partitionkeyrangeid.go
@@ -46,27 +46,27 @@ func ParsePartitionKeyRangeIdID(input string) (*PartitionKeyRangeIdId, error) {
 	id := PartitionKeyRangeIdId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DatabaseAccountName, ok = parsed.Parsed["databaseAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseAccountName", *parsed)
 	}
 
 	if id.DatabaseName, ok = parsed.Parsed["databaseName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseName", *parsed)
 	}
 
 	if id.CollectionName, ok = parsed.Parsed["collectionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'collectionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "collectionName", *parsed)
 	}
 
 	if id.PartitionKeyRangeId, ok = parsed.Parsed["partitionKeyRangeId"]; !ok {
-		return nil, fmt.Errorf("the segment 'partitionKeyRangeId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "partitionKeyRangeId", *parsed)
 	}
 
 	return &id, nil
@@ -85,27 +85,27 @@ func ParsePartitionKeyRangeIdIDInsensitively(input string) (*PartitionKeyRangeId
 	id := PartitionKeyRangeIdId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DatabaseAccountName, ok = parsed.Parsed["databaseAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseAccountName", *parsed)
 	}
 
 	if id.DatabaseName, ok = parsed.Parsed["databaseName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseName", *parsed)
 	}
 
 	if id.CollectionName, ok = parsed.Parsed["collectionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'collectionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "collectionName", *parsed)
 	}
 
 	if id.PartitionKeyRangeId, ok = parsed.Parsed["partitionKeyRangeId"]; !ok {
-		return nil, fmt.Errorf("the segment 'partitionKeyRangeId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "partitionKeyRangeId", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-05-15/cosmosdb/id_region.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-05-15/cosmosdb/id_region.go
@@ -42,19 +42,19 @@ func ParseRegionID(input string) (*RegionId, error) {
 	id := RegionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DatabaseAccountName, ok = parsed.Parsed["databaseAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseAccountName", *parsed)
 	}
 
 	if id.RegionName, ok = parsed.Parsed["regionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'regionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "regionName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseRegionIDInsensitively(input string) (*RegionId, error) {
 	id := RegionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DatabaseAccountName, ok = parsed.Parsed["databaseAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseAccountName", *parsed)
 	}
 
 	if id.RegionName, ok = parsed.Parsed["regionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'regionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "regionName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-05-15/cosmosdb/id_sourceregiontargetregion.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-05-15/cosmosdb/id_sourceregiontargetregion.go
@@ -44,23 +44,23 @@ func ParseSourceRegionTargetRegionID(input string) (*SourceRegionTargetRegionId,
 	id := SourceRegionTargetRegionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DatabaseAccountName, ok = parsed.Parsed["databaseAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseAccountName", *parsed)
 	}
 
 	if id.SourceRegionName, ok = parsed.Parsed["sourceRegionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'sourceRegionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "sourceRegionName", *parsed)
 	}
 
 	if id.TargetRegionName, ok = parsed.Parsed["targetRegionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'targetRegionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "targetRegionName", *parsed)
 	}
 
 	return &id, nil
@@ -79,23 +79,23 @@ func ParseSourceRegionTargetRegionIDInsensitively(input string) (*SourceRegionTa
 	id := SourceRegionTargetRegionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DatabaseAccountName, ok = parsed.Parsed["databaseAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseAccountName", *parsed)
 	}
 
 	if id.SourceRegionName, ok = parsed.Parsed["sourceRegionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'sourceRegionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "sourceRegionName", *parsed)
 	}
 
 	if id.TargetRegionName, ok = parsed.Parsed["targetRegionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'targetRegionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "targetRegionName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-05-15/cosmosdb/id_sqldatabase.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-05-15/cosmosdb/id_sqldatabase.go
@@ -42,19 +42,19 @@ func ParseSqlDatabaseID(input string) (*SqlDatabaseId, error) {
 	id := SqlDatabaseId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DatabaseAccountName, ok = parsed.Parsed["databaseAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseAccountName", *parsed)
 	}
 
 	if id.SqlDatabaseName, ok = parsed.Parsed["sqlDatabaseName"]; !ok {
-		return nil, fmt.Errorf("the segment 'sqlDatabaseName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "sqlDatabaseName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseSqlDatabaseIDInsensitively(input string) (*SqlDatabaseId, error) {
 	id := SqlDatabaseId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DatabaseAccountName, ok = parsed.Parsed["databaseAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseAccountName", *parsed)
 	}
 
 	if id.SqlDatabaseName, ok = parsed.Parsed["sqlDatabaseName"]; !ok {
-		return nil, fmt.Errorf("the segment 'sqlDatabaseName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "sqlDatabaseName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-05-15/cosmosdb/id_storedprocedure.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-05-15/cosmosdb/id_storedprocedure.go
@@ -46,27 +46,27 @@ func ParseStoredProcedureID(input string) (*StoredProcedureId, error) {
 	id := StoredProcedureId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DatabaseAccountName, ok = parsed.Parsed["databaseAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseAccountName", *parsed)
 	}
 
 	if id.SqlDatabaseName, ok = parsed.Parsed["sqlDatabaseName"]; !ok {
-		return nil, fmt.Errorf("the segment 'sqlDatabaseName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "sqlDatabaseName", *parsed)
 	}
 
 	if id.ContainerName, ok = parsed.Parsed["containerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'containerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "containerName", *parsed)
 	}
 
 	if id.StoredProcedureName, ok = parsed.Parsed["storedProcedureName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storedProcedureName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storedProcedureName", *parsed)
 	}
 
 	return &id, nil
@@ -85,27 +85,27 @@ func ParseStoredProcedureIDInsensitively(input string) (*StoredProcedureId, erro
 	id := StoredProcedureId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DatabaseAccountName, ok = parsed.Parsed["databaseAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseAccountName", *parsed)
 	}
 
 	if id.SqlDatabaseName, ok = parsed.Parsed["sqlDatabaseName"]; !ok {
-		return nil, fmt.Errorf("the segment 'sqlDatabaseName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "sqlDatabaseName", *parsed)
 	}
 
 	if id.ContainerName, ok = parsed.Parsed["containerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'containerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "containerName", *parsed)
 	}
 
 	if id.StoredProcedureName, ok = parsed.Parsed["storedProcedureName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storedProcedureName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storedProcedureName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-05-15/cosmosdb/id_table.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-05-15/cosmosdb/id_table.go
@@ -42,19 +42,19 @@ func ParseTableID(input string) (*TableId, error) {
 	id := TableId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DatabaseAccountName, ok = parsed.Parsed["databaseAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseAccountName", *parsed)
 	}
 
 	if id.TableName, ok = parsed.Parsed["tableName"]; !ok {
-		return nil, fmt.Errorf("the segment 'tableName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "tableName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseTableIDInsensitively(input string) (*TableId, error) {
 	id := TableId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DatabaseAccountName, ok = parsed.Parsed["databaseAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseAccountName", *parsed)
 	}
 
 	if id.TableName, ok = parsed.Parsed["tableName"]; !ok {
-		return nil, fmt.Errorf("the segment 'tableName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "tableName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-05-15/cosmosdb/id_targetregion.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-05-15/cosmosdb/id_targetregion.go
@@ -42,19 +42,19 @@ func ParseTargetRegionID(input string) (*TargetRegionId, error) {
 	id := TargetRegionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DatabaseAccountName, ok = parsed.Parsed["databaseAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseAccountName", *parsed)
 	}
 
 	if id.TargetRegionName, ok = parsed.Parsed["targetRegionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'targetRegionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "targetRegionName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseTargetRegionIDInsensitively(input string) (*TargetRegionId, error) {
 	id := TargetRegionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DatabaseAccountName, ok = parsed.Parsed["databaseAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseAccountName", *parsed)
 	}
 
 	if id.TargetRegionName, ok = parsed.Parsed["targetRegionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'targetRegionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "targetRegionName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-05-15/cosmosdb/id_trigger.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-05-15/cosmosdb/id_trigger.go
@@ -46,27 +46,27 @@ func ParseTriggerID(input string) (*TriggerId, error) {
 	id := TriggerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DatabaseAccountName, ok = parsed.Parsed["databaseAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseAccountName", *parsed)
 	}
 
 	if id.SqlDatabaseName, ok = parsed.Parsed["sqlDatabaseName"]; !ok {
-		return nil, fmt.Errorf("the segment 'sqlDatabaseName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "sqlDatabaseName", *parsed)
 	}
 
 	if id.ContainerName, ok = parsed.Parsed["containerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'containerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "containerName", *parsed)
 	}
 
 	if id.TriggerName, ok = parsed.Parsed["triggerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'triggerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "triggerName", *parsed)
 	}
 
 	return &id, nil
@@ -85,27 +85,27 @@ func ParseTriggerIDInsensitively(input string) (*TriggerId, error) {
 	id := TriggerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DatabaseAccountName, ok = parsed.Parsed["databaseAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseAccountName", *parsed)
 	}
 
 	if id.SqlDatabaseName, ok = parsed.Parsed["sqlDatabaseName"]; !ok {
-		return nil, fmt.Errorf("the segment 'sqlDatabaseName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "sqlDatabaseName", *parsed)
 	}
 
 	if id.ContainerName, ok = parsed.Parsed["containerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'containerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "containerName", *parsed)
 	}
 
 	if id.TriggerName, ok = parsed.Parsed["triggerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'triggerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "triggerName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-05-15/cosmosdb/id_userdefinedfunction.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-05-15/cosmosdb/id_userdefinedfunction.go
@@ -46,27 +46,27 @@ func ParseUserDefinedFunctionID(input string) (*UserDefinedFunctionId, error) {
 	id := UserDefinedFunctionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DatabaseAccountName, ok = parsed.Parsed["databaseAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseAccountName", *parsed)
 	}
 
 	if id.SqlDatabaseName, ok = parsed.Parsed["sqlDatabaseName"]; !ok {
-		return nil, fmt.Errorf("the segment 'sqlDatabaseName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "sqlDatabaseName", *parsed)
 	}
 
 	if id.ContainerName, ok = parsed.Parsed["containerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'containerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "containerName", *parsed)
 	}
 
 	if id.UserDefinedFunctionName, ok = parsed.Parsed["userDefinedFunctionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'userDefinedFunctionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "userDefinedFunctionName", *parsed)
 	}
 
 	return &id, nil
@@ -85,27 +85,27 @@ func ParseUserDefinedFunctionIDInsensitively(input string) (*UserDefinedFunction
 	id := UserDefinedFunctionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DatabaseAccountName, ok = parsed.Parsed["databaseAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseAccountName", *parsed)
 	}
 
 	if id.SqlDatabaseName, ok = parsed.Parsed["sqlDatabaseName"]; !ok {
-		return nil, fmt.Errorf("the segment 'sqlDatabaseName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "sqlDatabaseName", *parsed)
 	}
 
 	if id.ContainerName, ok = parsed.Parsed["containerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'containerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "containerName", *parsed)
 	}
 
 	if id.UserDefinedFunctionName, ok = parsed.Parsed["userDefinedFunctionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'userDefinedFunctionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "userDefinedFunctionName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-05-15/managedcassandras/id_cassandracluster.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-05-15/managedcassandras/id_cassandracluster.go
@@ -40,15 +40,15 @@ func ParseCassandraClusterID(input string) (*CassandraClusterId, error) {
 	id := CassandraClusterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.CassandraClusterName, ok = parsed.Parsed["cassandraClusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'cassandraClusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "cassandraClusterName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseCassandraClusterIDInsensitively(input string) (*CassandraClusterId, er
 	id := CassandraClusterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.CassandraClusterName, ok = parsed.Parsed["cassandraClusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'cassandraClusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "cassandraClusterName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-05-15/managedcassandras/id_datacenter.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-05-15/managedcassandras/id_datacenter.go
@@ -42,19 +42,19 @@ func ParseDataCenterID(input string) (*DataCenterId, error) {
 	id := DataCenterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.CassandraClusterName, ok = parsed.Parsed["cassandraClusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'cassandraClusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "cassandraClusterName", *parsed)
 	}
 
 	if id.DataCenterName, ok = parsed.Parsed["dataCenterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'dataCenterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "dataCenterName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseDataCenterIDInsensitively(input string) (*DataCenterId, error) {
 	id := DataCenterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.CassandraClusterName, ok = parsed.Parsed["cassandraClusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'cassandraClusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "cassandraClusterName", *parsed)
 	}
 
 	if id.DataCenterName, ok = parsed.Parsed["dataCenterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'dataCenterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "dataCenterName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-05-15/sqldedicatedgateway/id_service.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-05-15/sqldedicatedgateway/id_service.go
@@ -42,19 +42,19 @@ func ParseServiceID(input string) (*ServiceId, error) {
 	id := ServiceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DatabaseAccountName, ok = parsed.Parsed["databaseAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseAccountName", *parsed)
 	}
 
 	if id.ServiceName, ok = parsed.Parsed["serviceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'serviceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serviceName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseServiceIDInsensitively(input string) (*ServiceId, error) {
 	id := ServiceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DatabaseAccountName, ok = parsed.Parsed["databaseAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseAccountName", *parsed)
 	}
 
 	if id.ServiceName, ok = parsed.Parsed["serviceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'serviceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serviceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/costmanagement/2021-10-01/exports/id_scopedexport.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/costmanagement/2021-10-01/exports/id_scopedexport.go
@@ -38,11 +38,11 @@ func ParseScopedExportID(input string) (*ScopedExportId, error) {
 	id := ScopedExportId{}
 
 	if id.Scope, ok = parsed.Parsed["scope"]; !ok {
-		return nil, fmt.Errorf("the segment 'scope' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "scope", *parsed)
 	}
 
 	if id.ExportName, ok = parsed.Parsed["exportName"]; !ok {
-		return nil, fmt.Errorf("the segment 'exportName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "exportName", *parsed)
 	}
 
 	return &id, nil
@@ -61,11 +61,11 @@ func ParseScopedExportIDInsensitively(input string) (*ScopedExportId, error) {
 	id := ScopedExportId{}
 
 	if id.Scope, ok = parsed.Parsed["scope"]; !ok {
-		return nil, fmt.Errorf("the segment 'scope' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "scope", *parsed)
 	}
 
 	if id.ExportName, ok = parsed.Parsed["exportName"]; !ok {
-		return nil, fmt.Errorf("the segment 'exportName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "exportName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/costmanagement/2022-06-01-preview/scheduledactions/id_scheduledaction.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/costmanagement/2022-06-01-preview/scheduledactions/id_scheduledaction.go
@@ -36,7 +36,7 @@ func ParseScheduledActionID(input string) (*ScheduledActionId, error) {
 	id := ScheduledActionId{}
 
 	if id.ScheduledActionName, ok = parsed.Parsed["scheduledActionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'scheduledActionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "scheduledActionName", *parsed)
 	}
 
 	return &id, nil
@@ -55,7 +55,7 @@ func ParseScheduledActionIDInsensitively(input string) (*ScheduledActionId, erro
 	id := ScheduledActionId{}
 
 	if id.ScheduledActionName, ok = parsed.Parsed["scheduledActionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'scheduledActionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "scheduledActionName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/costmanagement/2022-06-01-preview/scheduledactions/id_scopedscheduledaction.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/costmanagement/2022-06-01-preview/scheduledactions/id_scopedscheduledaction.go
@@ -38,11 +38,11 @@ func ParseScopedScheduledActionID(input string) (*ScopedScheduledActionId, error
 	id := ScopedScheduledActionId{}
 
 	if id.Scope, ok = parsed.Parsed["scope"]; !ok {
-		return nil, fmt.Errorf("the segment 'scope' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "scope", *parsed)
 	}
 
 	if id.ScheduledActionName, ok = parsed.Parsed["scheduledActionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'scheduledActionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "scheduledActionName", *parsed)
 	}
 
 	return &id, nil
@@ -61,11 +61,11 @@ func ParseScopedScheduledActionIDInsensitively(input string) (*ScopedScheduledAc
 	id := ScopedScheduledActionId{}
 
 	if id.Scope, ok = parsed.Parsed["scope"]; !ok {
-		return nil, fmt.Errorf("the segment 'scope' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "scope", *parsed)
 	}
 
 	if id.ScheduledActionName, ok = parsed.Parsed["scheduledActionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'scheduledActionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "scheduledActionName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/costmanagement/2022-10-01/scheduledactions/id_scheduledaction.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/costmanagement/2022-10-01/scheduledactions/id_scheduledaction.go
@@ -36,7 +36,7 @@ func ParseScheduledActionID(input string) (*ScheduledActionId, error) {
 	id := ScheduledActionId{}
 
 	if id.ScheduledActionName, ok = parsed.Parsed["scheduledActionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'scheduledActionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "scheduledActionName", *parsed)
 	}
 
 	return &id, nil
@@ -55,7 +55,7 @@ func ParseScheduledActionIDInsensitively(input string) (*ScheduledActionId, erro
 	id := ScheduledActionId{}
 
 	if id.ScheduledActionName, ok = parsed.Parsed["scheduledActionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'scheduledActionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "scheduledActionName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/costmanagement/2022-10-01/scheduledactions/id_scopedscheduledaction.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/costmanagement/2022-10-01/scheduledactions/id_scopedscheduledaction.go
@@ -38,11 +38,11 @@ func ParseScopedScheduledActionID(input string) (*ScopedScheduledActionId, error
 	id := ScopedScheduledActionId{}
 
 	if id.Scope, ok = parsed.Parsed["scope"]; !ok {
-		return nil, fmt.Errorf("the segment 'scope' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "scope", *parsed)
 	}
 
 	if id.ScheduledActionName, ok = parsed.Parsed["scheduledActionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'scheduledActionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "scheduledActionName", *parsed)
 	}
 
 	return &id, nil
@@ -61,11 +61,11 @@ func ParseScopedScheduledActionIDInsensitively(input string) (*ScopedScheduledAc
 	id := ScopedScheduledActionId{}
 
 	if id.Scope, ok = parsed.Parsed["scope"]; !ok {
-		return nil, fmt.Errorf("the segment 'scope' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "scope", *parsed)
 	}
 
 	if id.ScheduledActionName, ok = parsed.Parsed["scheduledActionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'scheduledActionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "scheduledActionName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/costmanagement/2022-10-01/views/id_scopedview.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/costmanagement/2022-10-01/views/id_scopedview.go
@@ -38,11 +38,11 @@ func ParseScopedViewID(input string) (*ScopedViewId, error) {
 	id := ScopedViewId{}
 
 	if id.Scope, ok = parsed.Parsed["scope"]; !ok {
-		return nil, fmt.Errorf("the segment 'scope' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "scope", *parsed)
 	}
 
 	if id.ViewName, ok = parsed.Parsed["viewName"]; !ok {
-		return nil, fmt.Errorf("the segment 'viewName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "viewName", *parsed)
 	}
 
 	return &id, nil
@@ -61,11 +61,11 @@ func ParseScopedViewIDInsensitively(input string) (*ScopedViewId, error) {
 	id := ScopedViewId{}
 
 	if id.Scope, ok = parsed.Parsed["scope"]; !ok {
-		return nil, fmt.Errorf("the segment 'scope' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "scope", *parsed)
 	}
 
 	if id.ViewName, ok = parsed.Parsed["viewName"]; !ok {
-		return nil, fmt.Errorf("the segment 'viewName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "viewName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/costmanagement/2022-10-01/views/id_view.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/costmanagement/2022-10-01/views/id_view.go
@@ -36,7 +36,7 @@ func ParseViewID(input string) (*ViewId, error) {
 	id := ViewId{}
 
 	if id.ViewName, ok = parsed.Parsed["viewName"]; !ok {
-		return nil, fmt.Errorf("the segment 'viewName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "viewName", *parsed)
 	}
 
 	return &id, nil
@@ -55,7 +55,7 @@ func ParseViewIDInsensitively(input string) (*ViewId, error) {
 	id := ViewId{}
 
 	if id.ViewName, ok = parsed.Parsed["viewName"]; !ok {
-		return nil, fmt.Errorf("the segment 'viewName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "viewName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/customproviders/2018-09-01-preview/customresourceprovider/id_resourceprovider.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/customproviders/2018-09-01-preview/customresourceprovider/id_resourceprovider.go
@@ -40,15 +40,15 @@ func ParseResourceProviderID(input string) (*ResourceProviderId, error) {
 	id := ResourceProviderId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ResourceProviderName, ok = parsed.Parsed["resourceProviderName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceProviderName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceProviderName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseResourceProviderIDInsensitively(input string) (*ResourceProviderId, er
 	id := ResourceProviderId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ResourceProviderName, ok = parsed.Parsed["resourceProviderName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceProviderName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceProviderName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dashboard/2022-08-01/grafanaresource/id_grafana.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dashboard/2022-08-01/grafanaresource/id_grafana.go
@@ -40,15 +40,15 @@ func ParseGrafanaID(input string) (*GrafanaId, error) {
 	id := GrafanaId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.GrafanaName, ok = parsed.Parsed["grafanaName"]; !ok {
-		return nil, fmt.Errorf("the segment 'grafanaName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "grafanaName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseGrafanaIDInsensitively(input string) (*GrafanaId, error) {
 	id := GrafanaId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.GrafanaName, ok = parsed.Parsed["grafanaName"]; !ok {
-		return nil, fmt.Errorf("the segment 'grafanaName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "grafanaName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/databoxedge/2022-03-01/devices/id_databoxedgedevice.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/databoxedge/2022-03-01/devices/id_databoxedgedevice.go
@@ -40,15 +40,15 @@ func ParseDataBoxEdgeDeviceID(input string) (*DataBoxEdgeDeviceId, error) {
 	id := DataBoxEdgeDeviceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DataBoxEdgeDeviceName, ok = parsed.Parsed["dataBoxEdgeDeviceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'dataBoxEdgeDeviceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "dataBoxEdgeDeviceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseDataBoxEdgeDeviceIDInsensitively(input string) (*DataBoxEdgeDeviceId, 
 	id := DataBoxEdgeDeviceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DataBoxEdgeDeviceName, ok = parsed.Parsed["dataBoxEdgeDeviceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'dataBoxEdgeDeviceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "dataBoxEdgeDeviceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/databoxedge/2022-03-01/orders/id_databoxedgedevice.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/databoxedge/2022-03-01/orders/id_databoxedgedevice.go
@@ -40,15 +40,15 @@ func ParseDataBoxEdgeDeviceID(input string) (*DataBoxEdgeDeviceId, error) {
 	id := DataBoxEdgeDeviceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DataBoxEdgeDeviceName, ok = parsed.Parsed["dataBoxEdgeDeviceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'dataBoxEdgeDeviceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "dataBoxEdgeDeviceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseDataBoxEdgeDeviceIDInsensitively(input string) (*DataBoxEdgeDeviceId, 
 	id := DataBoxEdgeDeviceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DataBoxEdgeDeviceName, ok = parsed.Parsed["dataBoxEdgeDeviceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'dataBoxEdgeDeviceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "dataBoxEdgeDeviceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/databricks/2022-04-01-preview/workspaces/id_workspace.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/databricks/2022-04-01-preview/workspaces/id_workspace.go
@@ -40,15 +40,15 @@ func ParseWorkspaceID(input string) (*WorkspaceId, error) {
 	id := WorkspaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseWorkspaceIDInsensitively(input string) (*WorkspaceId, error) {
 	id := WorkspaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/databricks/2022-10-01-preview/accessconnector/id_accessconnector.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/databricks/2022-10-01-preview/accessconnector/id_accessconnector.go
@@ -40,15 +40,15 @@ func ParseAccessConnectorID(input string) (*AccessConnectorId, error) {
 	id := AccessConnectorId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AccessConnectorName, ok = parsed.Parsed["accessConnectorName"]; !ok {
-		return nil, fmt.Errorf("the segment 'accessConnectorName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "accessConnectorName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseAccessConnectorIDInsensitively(input string) (*AccessConnectorId, erro
 	id := AccessConnectorId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AccessConnectorName, ok = parsed.Parsed["accessConnectorName"]; !ok {
-		return nil, fmt.Errorf("the segment 'accessConnectorName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "accessConnectorName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/databricks/2023-02-01/vnetpeering/id_virtualnetworkpeering.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/databricks/2023-02-01/vnetpeering/id_virtualnetworkpeering.go
@@ -42,19 +42,19 @@ func ParseVirtualNetworkPeeringID(input string) (*VirtualNetworkPeeringId, error
 	id := VirtualNetworkPeeringId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	if id.VirtualNetworkPeeringName, ok = parsed.Parsed["virtualNetworkPeeringName"]; !ok {
-		return nil, fmt.Errorf("the segment 'virtualNetworkPeeringName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "virtualNetworkPeeringName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseVirtualNetworkPeeringIDInsensitively(input string) (*VirtualNetworkPee
 	id := VirtualNetworkPeeringId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	if id.VirtualNetworkPeeringName, ok = parsed.Parsed["virtualNetworkPeeringName"]; !ok {
-		return nil, fmt.Errorf("the segment 'virtualNetworkPeeringName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "virtualNetworkPeeringName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/databricks/2023-02-01/vnetpeering/id_workspace.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/databricks/2023-02-01/vnetpeering/id_workspace.go
@@ -40,15 +40,15 @@ func ParseWorkspaceID(input string) (*WorkspaceId, error) {
 	id := WorkspaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseWorkspaceIDInsensitively(input string) (*WorkspaceId, error) {
 	id := WorkspaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/databricks/2023-02-01/workspaces/id_workspace.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/databricks/2023-02-01/workspaces/id_workspace.go
@@ -40,15 +40,15 @@ func ParseWorkspaceID(input string) (*WorkspaceId, error) {
 	id := WorkspaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseWorkspaceIDInsensitively(input string) (*WorkspaceId, error) {
 	id := WorkspaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datadog/2021-03-01/apikey/id_monitor.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datadog/2021-03-01/apikey/id_monitor.go
@@ -40,15 +40,15 @@ func ParseMonitorID(input string) (*MonitorId, error) {
 	id := MonitorId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MonitorName, ok = parsed.Parsed["monitorName"]; !ok {
-		return nil, fmt.Errorf("the segment 'monitorName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "monitorName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseMonitorIDInsensitively(input string) (*MonitorId, error) {
 	id := MonitorId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MonitorName, ok = parsed.Parsed["monitorName"]; !ok {
-		return nil, fmt.Errorf("the segment 'monitorName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "monitorName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datadog/2021-03-01/hosts/id_monitor.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datadog/2021-03-01/hosts/id_monitor.go
@@ -40,15 +40,15 @@ func ParseMonitorID(input string) (*MonitorId, error) {
 	id := MonitorId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MonitorName, ok = parsed.Parsed["monitorName"]; !ok {
-		return nil, fmt.Errorf("the segment 'monitorName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "monitorName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseMonitorIDInsensitively(input string) (*MonitorId, error) {
 	id := MonitorId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MonitorName, ok = parsed.Parsed["monitorName"]; !ok {
-		return nil, fmt.Errorf("the segment 'monitorName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "monitorName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datadog/2021-03-01/linkedresources/id_monitor.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datadog/2021-03-01/linkedresources/id_monitor.go
@@ -40,15 +40,15 @@ func ParseMonitorID(input string) (*MonitorId, error) {
 	id := MonitorId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MonitorName, ok = parsed.Parsed["monitorName"]; !ok {
-		return nil, fmt.Errorf("the segment 'monitorName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "monitorName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseMonitorIDInsensitively(input string) (*MonitorId, error) {
 	id := MonitorId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MonitorName, ok = parsed.Parsed["monitorName"]; !ok {
-		return nil, fmt.Errorf("the segment 'monitorName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "monitorName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datadog/2021-03-01/monitoredresources/id_monitor.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datadog/2021-03-01/monitoredresources/id_monitor.go
@@ -40,15 +40,15 @@ func ParseMonitorID(input string) (*MonitorId, error) {
 	id := MonitorId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MonitorName, ok = parsed.Parsed["monitorName"]; !ok {
-		return nil, fmt.Errorf("the segment 'monitorName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "monitorName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseMonitorIDInsensitively(input string) (*MonitorId, error) {
 	id := MonitorId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MonitorName, ok = parsed.Parsed["monitorName"]; !ok {
-		return nil, fmt.Errorf("the segment 'monitorName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "monitorName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datadog/2021-03-01/monitorsresource/id_monitor.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datadog/2021-03-01/monitorsresource/id_monitor.go
@@ -40,15 +40,15 @@ func ParseMonitorID(input string) (*MonitorId, error) {
 	id := MonitorId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MonitorName, ok = parsed.Parsed["monitorName"]; !ok {
-		return nil, fmt.Errorf("the segment 'monitorName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "monitorName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseMonitorIDInsensitively(input string) (*MonitorId, error) {
 	id := MonitorId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MonitorName, ok = parsed.Parsed["monitorName"]; !ok {
-		return nil, fmt.Errorf("the segment 'monitorName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "monitorName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datadog/2021-03-01/refreshsetpasswordlink/id_monitor.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datadog/2021-03-01/refreshsetpasswordlink/id_monitor.go
@@ -40,15 +40,15 @@ func ParseMonitorID(input string) (*MonitorId, error) {
 	id := MonitorId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MonitorName, ok = parsed.Parsed["monitorName"]; !ok {
-		return nil, fmt.Errorf("the segment 'monitorName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "monitorName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseMonitorIDInsensitively(input string) (*MonitorId, error) {
 	id := MonitorId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MonitorName, ok = parsed.Parsed["monitorName"]; !ok {
-		return nil, fmt.Errorf("the segment 'monitorName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "monitorName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datadog/2021-03-01/rules/id_monitor.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datadog/2021-03-01/rules/id_monitor.go
@@ -40,15 +40,15 @@ func ParseMonitorID(input string) (*MonitorId, error) {
 	id := MonitorId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MonitorName, ok = parsed.Parsed["monitorName"]; !ok {
-		return nil, fmt.Errorf("the segment 'monitorName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "monitorName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseMonitorIDInsensitively(input string) (*MonitorId, error) {
 	id := MonitorId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MonitorName, ok = parsed.Parsed["monitorName"]; !ok {
-		return nil, fmt.Errorf("the segment 'monitorName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "monitorName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datadog/2021-03-01/rules/id_tagrule.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datadog/2021-03-01/rules/id_tagrule.go
@@ -42,19 +42,19 @@ func ParseTagRuleID(input string) (*TagRuleId, error) {
 	id := TagRuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MonitorName, ok = parsed.Parsed["monitorName"]; !ok {
-		return nil, fmt.Errorf("the segment 'monitorName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "monitorName", *parsed)
 	}
 
 	if id.TagRuleName, ok = parsed.Parsed["tagRuleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'tagRuleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "tagRuleName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseTagRuleIDInsensitively(input string) (*TagRuleId, error) {
 	id := TagRuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MonitorName, ok = parsed.Parsed["monitorName"]; !ok {
-		return nil, fmt.Errorf("the segment 'monitorName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "monitorName", *parsed)
 	}
 
 	if id.TagRuleName, ok = parsed.Parsed["tagRuleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'tagRuleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "tagRuleName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datadog/2021-03-01/singlesignon/id_monitor.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datadog/2021-03-01/singlesignon/id_monitor.go
@@ -40,15 +40,15 @@ func ParseMonitorID(input string) (*MonitorId, error) {
 	id := MonitorId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MonitorName, ok = parsed.Parsed["monitorName"]; !ok {
-		return nil, fmt.Errorf("the segment 'monitorName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "monitorName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseMonitorIDInsensitively(input string) (*MonitorId, error) {
 	id := MonitorId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MonitorName, ok = parsed.Parsed["monitorName"]; !ok {
-		return nil, fmt.Errorf("the segment 'monitorName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "monitorName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datadog/2021-03-01/singlesignon/id_singlesignonconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datadog/2021-03-01/singlesignon/id_singlesignonconfiguration.go
@@ -42,19 +42,19 @@ func ParseSingleSignOnConfigurationID(input string) (*SingleSignOnConfigurationI
 	id := SingleSignOnConfigurationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MonitorName, ok = parsed.Parsed["monitorName"]; !ok {
-		return nil, fmt.Errorf("the segment 'monitorName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "monitorName", *parsed)
 	}
 
 	if id.SingleSignOnConfigurationName, ok = parsed.Parsed["singleSignOnConfigurationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'singleSignOnConfigurationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "singleSignOnConfigurationName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseSingleSignOnConfigurationIDInsensitively(input string) (*SingleSignOnC
 	id := SingleSignOnConfigurationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MonitorName, ok = parsed.Parsed["monitorName"]; !ok {
-		return nil, fmt.Errorf("the segment 'monitorName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "monitorName", *parsed)
 	}
 
 	if id.SingleSignOnConfigurationName, ok = parsed.Parsed["singleSignOnConfigurationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'singleSignOnConfigurationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "singleSignOnConfigurationName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datamigration/2018-04-19/projectresource/id_project.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datamigration/2018-04-19/projectresource/id_project.go
@@ -42,19 +42,19 @@ func ParseProjectID(input string) (*ProjectId, error) {
 	id := ProjectId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServiceName, ok = parsed.Parsed["serviceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'serviceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serviceName", *parsed)
 	}
 
 	if id.ProjectName, ok = parsed.Parsed["projectName"]; !ok {
-		return nil, fmt.Errorf("the segment 'projectName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "projectName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseProjectIDInsensitively(input string) (*ProjectId, error) {
 	id := ProjectId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServiceName, ok = parsed.Parsed["serviceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'serviceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serviceName", *parsed)
 	}
 
 	if id.ProjectName, ok = parsed.Parsed["projectName"]; !ok {
-		return nil, fmt.Errorf("the segment 'projectName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "projectName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datamigration/2018-04-19/projectresource/id_service.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datamigration/2018-04-19/projectresource/id_service.go
@@ -40,15 +40,15 @@ func ParseServiceID(input string) (*ServiceId, error) {
 	id := ServiceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServiceName, ok = parsed.Parsed["serviceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'serviceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serviceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseServiceIDInsensitively(input string) (*ServiceId, error) {
 	id := ServiceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServiceName, ok = parsed.Parsed["serviceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'serviceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serviceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datamigration/2018-04-19/serviceresource/id_project.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datamigration/2018-04-19/serviceresource/id_project.go
@@ -42,19 +42,19 @@ func ParseProjectID(input string) (*ProjectId, error) {
 	id := ProjectId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServiceName, ok = parsed.Parsed["serviceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'serviceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serviceName", *parsed)
 	}
 
 	if id.ProjectName, ok = parsed.Parsed["projectName"]; !ok {
-		return nil, fmt.Errorf("the segment 'projectName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "projectName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseProjectIDInsensitively(input string) (*ProjectId, error) {
 	id := ProjectId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServiceName, ok = parsed.Parsed["serviceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'serviceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serviceName", *parsed)
 	}
 
 	if id.ProjectName, ok = parsed.Parsed["projectName"]; !ok {
-		return nil, fmt.Errorf("the segment 'projectName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "projectName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datamigration/2018-04-19/serviceresource/id_resourcegroup.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datamigration/2018-04-19/serviceresource/id_resourcegroup.go
@@ -38,11 +38,11 @@ func ParseResourceGroupID(input string) (*ResourceGroupId, error) {
 	id := ResourceGroupId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	return &id, nil
@@ -61,11 +61,11 @@ func ParseResourceGroupIDInsensitively(input string) (*ResourceGroupId, error) {
 	id := ResourceGroupId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datamigration/2018-04-19/serviceresource/id_service.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datamigration/2018-04-19/serviceresource/id_service.go
@@ -40,15 +40,15 @@ func ParseServiceID(input string) (*ServiceId, error) {
 	id := ServiceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServiceName, ok = parsed.Parsed["serviceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'serviceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serviceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseServiceIDInsensitively(input string) (*ServiceId, error) {
 	id := ServiceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServiceName, ok = parsed.Parsed["serviceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'serviceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serviceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dataprotection/2022-04-01/backupinstances/id_backupinstance.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dataprotection/2022-04-01/backupinstances/id_backupinstance.go
@@ -42,19 +42,19 @@ func ParseBackupInstanceID(input string) (*BackupInstanceId, error) {
 	id := BackupInstanceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.BackupVaultName, ok = parsed.Parsed["backupVaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'backupVaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "backupVaultName", *parsed)
 	}
 
 	if id.BackupInstanceName, ok = parsed.Parsed["backupInstanceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'backupInstanceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "backupInstanceName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseBackupInstanceIDInsensitively(input string) (*BackupInstanceId, error)
 	id := BackupInstanceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.BackupVaultName, ok = parsed.Parsed["backupVaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'backupVaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "backupVaultName", *parsed)
 	}
 
 	if id.BackupInstanceName, ok = parsed.Parsed["backupInstanceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'backupInstanceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "backupInstanceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dataprotection/2022-04-01/backupinstances/id_backupvault.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dataprotection/2022-04-01/backupinstances/id_backupvault.go
@@ -40,15 +40,15 @@ func ParseBackupVaultID(input string) (*BackupVaultId, error) {
 	id := BackupVaultId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.BackupVaultName, ok = parsed.Parsed["backupVaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'backupVaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "backupVaultName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseBackupVaultIDInsensitively(input string) (*BackupVaultId, error) {
 	id := BackupVaultId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.BackupVaultName, ok = parsed.Parsed["backupVaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'backupVaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "backupVaultName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dataprotection/2022-04-01/backuppolicies/id_backuppolicy.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dataprotection/2022-04-01/backuppolicies/id_backuppolicy.go
@@ -42,19 +42,19 @@ func ParseBackupPolicyID(input string) (*BackupPolicyId, error) {
 	id := BackupPolicyId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.BackupVaultName, ok = parsed.Parsed["backupVaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'backupVaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "backupVaultName", *parsed)
 	}
 
 	if id.BackupPolicyName, ok = parsed.Parsed["backupPolicyName"]; !ok {
-		return nil, fmt.Errorf("the segment 'backupPolicyName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "backupPolicyName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseBackupPolicyIDInsensitively(input string) (*BackupPolicyId, error) {
 	id := BackupPolicyId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.BackupVaultName, ok = parsed.Parsed["backupVaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'backupVaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "backupVaultName", *parsed)
 	}
 
 	if id.BackupPolicyName, ok = parsed.Parsed["backupPolicyName"]; !ok {
-		return nil, fmt.Errorf("the segment 'backupPolicyName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "backupPolicyName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dataprotection/2022-04-01/backuppolicies/id_backupvault.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dataprotection/2022-04-01/backuppolicies/id_backupvault.go
@@ -40,15 +40,15 @@ func ParseBackupVaultID(input string) (*BackupVaultId, error) {
 	id := BackupVaultId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.BackupVaultName, ok = parsed.Parsed["backupVaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'backupVaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "backupVaultName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseBackupVaultIDInsensitively(input string) (*BackupVaultId, error) {
 	id := BackupVaultId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.BackupVaultName, ok = parsed.Parsed["backupVaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'backupVaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "backupVaultName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dataprotection/2022-04-01/backupvaults/id_backupvault.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dataprotection/2022-04-01/backupvaults/id_backupvault.go
@@ -40,15 +40,15 @@ func ParseBackupVaultID(input string) (*BackupVaultId, error) {
 	id := BackupVaultId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.BackupVaultName, ok = parsed.Parsed["backupVaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'backupVaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "backupVaultName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseBackupVaultIDInsensitively(input string) (*BackupVaultId, error) {
 	id := BackupVaultId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.BackupVaultName, ok = parsed.Parsed["backupVaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'backupVaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "backupVaultName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dataprotection/2022-04-01/backupvaults/id_providerlocation.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dataprotection/2022-04-01/backupvaults/id_providerlocation.go
@@ -40,15 +40,15 @@ func ParseProviderLocationID(input string) (*ProviderLocationId, error) {
 	id := ProviderLocationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.LocationName, ok = parsed.Parsed["locationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'locationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "locationName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseProviderLocationIDInsensitively(input string) (*ProviderLocationId, er
 	id := ProviderLocationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.LocationName, ok = parsed.Parsed["locationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'locationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "locationName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dataprotection/2022-04-01/resourceguards/id_deleteprotecteditemrequest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dataprotection/2022-04-01/resourceguards/id_deleteprotecteditemrequest.go
@@ -42,19 +42,19 @@ func ParseDeleteProtectedItemRequestID(input string) (*DeleteProtectedItemReques
 	id := DeleteProtectedItemRequestId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ResourceGuardName, ok = parsed.Parsed["resourceGuardName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGuardName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGuardName", *parsed)
 	}
 
 	if id.DeleteProtectedItemRequestName, ok = parsed.Parsed["deleteProtectedItemRequestName"]; !ok {
-		return nil, fmt.Errorf("the segment 'deleteProtectedItemRequestName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "deleteProtectedItemRequestName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseDeleteProtectedItemRequestIDInsensitively(input string) (*DeleteProtec
 	id := DeleteProtectedItemRequestId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ResourceGuardName, ok = parsed.Parsed["resourceGuardName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGuardName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGuardName", *parsed)
 	}
 
 	if id.DeleteProtectedItemRequestName, ok = parsed.Parsed["deleteProtectedItemRequestName"]; !ok {
-		return nil, fmt.Errorf("the segment 'deleteProtectedItemRequestName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "deleteProtectedItemRequestName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dataprotection/2022-04-01/resourceguards/id_deleteresourceguardproxyrequest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dataprotection/2022-04-01/resourceguards/id_deleteresourceguardproxyrequest.go
@@ -42,19 +42,19 @@ func ParseDeleteResourceGuardProxyRequestID(input string) (*DeleteResourceGuardP
 	id := DeleteResourceGuardProxyRequestId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ResourceGuardName, ok = parsed.Parsed["resourceGuardName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGuardName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGuardName", *parsed)
 	}
 
 	if id.DeleteResourceGuardProxyRequestName, ok = parsed.Parsed["deleteResourceGuardProxyRequestName"]; !ok {
-		return nil, fmt.Errorf("the segment 'deleteResourceGuardProxyRequestName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "deleteResourceGuardProxyRequestName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseDeleteResourceGuardProxyRequestIDInsensitively(input string) (*DeleteR
 	id := DeleteResourceGuardProxyRequestId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ResourceGuardName, ok = parsed.Parsed["resourceGuardName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGuardName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGuardName", *parsed)
 	}
 
 	if id.DeleteResourceGuardProxyRequestName, ok = parsed.Parsed["deleteResourceGuardProxyRequestName"]; !ok {
-		return nil, fmt.Errorf("the segment 'deleteResourceGuardProxyRequestName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "deleteResourceGuardProxyRequestName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dataprotection/2022-04-01/resourceguards/id_disablesoftdeleterequest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dataprotection/2022-04-01/resourceguards/id_disablesoftdeleterequest.go
@@ -42,19 +42,19 @@ func ParseDisableSoftDeleteRequestID(input string) (*DisableSoftDeleteRequestId,
 	id := DisableSoftDeleteRequestId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ResourceGuardName, ok = parsed.Parsed["resourceGuardName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGuardName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGuardName", *parsed)
 	}
 
 	if id.DisableSoftDeleteRequestName, ok = parsed.Parsed["disableSoftDeleteRequestName"]; !ok {
-		return nil, fmt.Errorf("the segment 'disableSoftDeleteRequestName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "disableSoftDeleteRequestName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseDisableSoftDeleteRequestIDInsensitively(input string) (*DisableSoftDel
 	id := DisableSoftDeleteRequestId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ResourceGuardName, ok = parsed.Parsed["resourceGuardName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGuardName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGuardName", *parsed)
 	}
 
 	if id.DisableSoftDeleteRequestName, ok = parsed.Parsed["disableSoftDeleteRequestName"]; !ok {
-		return nil, fmt.Errorf("the segment 'disableSoftDeleteRequestName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "disableSoftDeleteRequestName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dataprotection/2022-04-01/resourceguards/id_getbackupsecuritypinrequest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dataprotection/2022-04-01/resourceguards/id_getbackupsecuritypinrequest.go
@@ -42,19 +42,19 @@ func ParseGetBackupSecurityPINRequestID(input string) (*GetBackupSecurityPINRequ
 	id := GetBackupSecurityPINRequestId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ResourceGuardName, ok = parsed.Parsed["resourceGuardName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGuardName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGuardName", *parsed)
 	}
 
 	if id.GetBackupSecurityPINRequestName, ok = parsed.Parsed["getBackupSecurityPINRequestName"]; !ok {
-		return nil, fmt.Errorf("the segment 'getBackupSecurityPINRequestName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "getBackupSecurityPINRequestName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseGetBackupSecurityPINRequestIDInsensitively(input string) (*GetBackupSe
 	id := GetBackupSecurityPINRequestId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ResourceGuardName, ok = parsed.Parsed["resourceGuardName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGuardName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGuardName", *parsed)
 	}
 
 	if id.GetBackupSecurityPINRequestName, ok = parsed.Parsed["getBackupSecurityPINRequestName"]; !ok {
-		return nil, fmt.Errorf("the segment 'getBackupSecurityPINRequestName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "getBackupSecurityPINRequestName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dataprotection/2022-04-01/resourceguards/id_resourceguard.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dataprotection/2022-04-01/resourceguards/id_resourceguard.go
@@ -40,15 +40,15 @@ func ParseResourceGuardID(input string) (*ResourceGuardId, error) {
 	id := ResourceGuardId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ResourceGuardName, ok = parsed.Parsed["resourceGuardName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGuardName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGuardName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseResourceGuardIDInsensitively(input string) (*ResourceGuardId, error) {
 	id := ResourceGuardId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ResourceGuardName, ok = parsed.Parsed["resourceGuardName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGuardName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGuardName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dataprotection/2022-04-01/resourceguards/id_updateprotecteditemrequest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dataprotection/2022-04-01/resourceguards/id_updateprotecteditemrequest.go
@@ -42,19 +42,19 @@ func ParseUpdateProtectedItemRequestID(input string) (*UpdateProtectedItemReques
 	id := UpdateProtectedItemRequestId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ResourceGuardName, ok = parsed.Parsed["resourceGuardName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGuardName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGuardName", *parsed)
 	}
 
 	if id.UpdateProtectedItemRequestName, ok = parsed.Parsed["updateProtectedItemRequestName"]; !ok {
-		return nil, fmt.Errorf("the segment 'updateProtectedItemRequestName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "updateProtectedItemRequestName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseUpdateProtectedItemRequestIDInsensitively(input string) (*UpdateProtec
 	id := UpdateProtectedItemRequestId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ResourceGuardName, ok = parsed.Parsed["resourceGuardName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGuardName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGuardName", *parsed)
 	}
 
 	if id.UpdateProtectedItemRequestName, ok = parsed.Parsed["updateProtectedItemRequestName"]; !ok {
-		return nil, fmt.Errorf("the segment 'updateProtectedItemRequestName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "updateProtectedItemRequestName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dataprotection/2022-04-01/resourceguards/id_updateprotectionpolicyrequest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dataprotection/2022-04-01/resourceguards/id_updateprotectionpolicyrequest.go
@@ -42,19 +42,19 @@ func ParseUpdateProtectionPolicyRequestID(input string) (*UpdateProtectionPolicy
 	id := UpdateProtectionPolicyRequestId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ResourceGuardName, ok = parsed.Parsed["resourceGuardName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGuardName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGuardName", *parsed)
 	}
 
 	if id.UpdateProtectionPolicyRequestName, ok = parsed.Parsed["updateProtectionPolicyRequestName"]; !ok {
-		return nil, fmt.Errorf("the segment 'updateProtectionPolicyRequestName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "updateProtectionPolicyRequestName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseUpdateProtectionPolicyRequestIDInsensitively(input string) (*UpdatePro
 	id := UpdateProtectionPolicyRequestId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ResourceGuardName, ok = parsed.Parsed["resourceGuardName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGuardName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGuardName", *parsed)
 	}
 
 	if id.UpdateProtectionPolicyRequestName, ok = parsed.Parsed["updateProtectionPolicyRequestName"]; !ok {
-		return nil, fmt.Errorf("the segment 'updateProtectionPolicyRequestName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "updateProtectionPolicyRequestName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datashare/2019-11-01/account/id_account.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datashare/2019-11-01/account/id_account.go
@@ -40,15 +40,15 @@ func ParseAccountID(input string) (*AccountId, error) {
 	id := AccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AccountName, ok = parsed.Parsed["accountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'accountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "accountName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseAccountIDInsensitively(input string) (*AccountId, error) {
 	id := AccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AccountName, ok = parsed.Parsed["accountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'accountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "accountName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datashare/2019-11-01/dataset/id_dataset.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datashare/2019-11-01/dataset/id_dataset.go
@@ -44,23 +44,23 @@ func ParseDataSetID(input string) (*DataSetId, error) {
 	id := DataSetId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AccountName, ok = parsed.Parsed["accountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'accountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "accountName", *parsed)
 	}
 
 	if id.ShareName, ok = parsed.Parsed["shareName"]; !ok {
-		return nil, fmt.Errorf("the segment 'shareName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "shareName", *parsed)
 	}
 
 	if id.DataSetName, ok = parsed.Parsed["dataSetName"]; !ok {
-		return nil, fmt.Errorf("the segment 'dataSetName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "dataSetName", *parsed)
 	}
 
 	return &id, nil
@@ -79,23 +79,23 @@ func ParseDataSetIDInsensitively(input string) (*DataSetId, error) {
 	id := DataSetId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AccountName, ok = parsed.Parsed["accountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'accountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "accountName", *parsed)
 	}
 
 	if id.ShareName, ok = parsed.Parsed["shareName"]; !ok {
-		return nil, fmt.Errorf("the segment 'shareName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "shareName", *parsed)
 	}
 
 	if id.DataSetName, ok = parsed.Parsed["dataSetName"]; !ok {
-		return nil, fmt.Errorf("the segment 'dataSetName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "dataSetName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datashare/2019-11-01/dataset/id_share.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datashare/2019-11-01/dataset/id_share.go
@@ -42,19 +42,19 @@ func ParseShareID(input string) (*ShareId, error) {
 	id := ShareId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AccountName, ok = parsed.Parsed["accountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'accountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "accountName", *parsed)
 	}
 
 	if id.ShareName, ok = parsed.Parsed["shareName"]; !ok {
-		return nil, fmt.Errorf("the segment 'shareName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "shareName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseShareIDInsensitively(input string) (*ShareId, error) {
 	id := ShareId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AccountName, ok = parsed.Parsed["accountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'accountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "accountName", *parsed)
 	}
 
 	if id.ShareName, ok = parsed.Parsed["shareName"]; !ok {
-		return nil, fmt.Errorf("the segment 'shareName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "shareName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datashare/2019-11-01/share/id_account.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datashare/2019-11-01/share/id_account.go
@@ -40,15 +40,15 @@ func ParseAccountID(input string) (*AccountId, error) {
 	id := AccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AccountName, ok = parsed.Parsed["accountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'accountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "accountName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseAccountIDInsensitively(input string) (*AccountId, error) {
 	id := AccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AccountName, ok = parsed.Parsed["accountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'accountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "accountName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datashare/2019-11-01/share/id_providersharesubscription.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datashare/2019-11-01/share/id_providersharesubscription.go
@@ -44,23 +44,23 @@ func ParseProviderShareSubscriptionID(input string) (*ProviderShareSubscriptionI
 	id := ProviderShareSubscriptionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AccountName, ok = parsed.Parsed["accountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'accountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "accountName", *parsed)
 	}
 
 	if id.ShareName, ok = parsed.Parsed["shareName"]; !ok {
-		return nil, fmt.Errorf("the segment 'shareName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "shareName", *parsed)
 	}
 
 	if id.ProviderShareSubscriptionId, ok = parsed.Parsed["providerShareSubscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'providerShareSubscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "providerShareSubscriptionId", *parsed)
 	}
 
 	return &id, nil
@@ -79,23 +79,23 @@ func ParseProviderShareSubscriptionIDInsensitively(input string) (*ProviderShare
 	id := ProviderShareSubscriptionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AccountName, ok = parsed.Parsed["accountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'accountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "accountName", *parsed)
 	}
 
 	if id.ShareName, ok = parsed.Parsed["shareName"]; !ok {
-		return nil, fmt.Errorf("the segment 'shareName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "shareName", *parsed)
 	}
 
 	if id.ProviderShareSubscriptionId, ok = parsed.Parsed["providerShareSubscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'providerShareSubscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "providerShareSubscriptionId", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datashare/2019-11-01/share/id_share.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datashare/2019-11-01/share/id_share.go
@@ -42,19 +42,19 @@ func ParseShareID(input string) (*ShareId, error) {
 	id := ShareId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AccountName, ok = parsed.Parsed["accountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'accountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "accountName", *parsed)
 	}
 
 	if id.ShareName, ok = parsed.Parsed["shareName"]; !ok {
-		return nil, fmt.Errorf("the segment 'shareName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "shareName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseShareIDInsensitively(input string) (*ShareId, error) {
 	id := ShareId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AccountName, ok = parsed.Parsed["accountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'accountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "accountName", *parsed)
 	}
 
 	if id.ShareName, ok = parsed.Parsed["shareName"]; !ok {
-		return nil, fmt.Errorf("the segment 'shareName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "shareName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datashare/2019-11-01/synchronizationsetting/id_share.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datashare/2019-11-01/synchronizationsetting/id_share.go
@@ -42,19 +42,19 @@ func ParseShareID(input string) (*ShareId, error) {
 	id := ShareId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AccountName, ok = parsed.Parsed["accountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'accountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "accountName", *parsed)
 	}
 
 	if id.ShareName, ok = parsed.Parsed["shareName"]; !ok {
-		return nil, fmt.Errorf("the segment 'shareName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "shareName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseShareIDInsensitively(input string) (*ShareId, error) {
 	id := ShareId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AccountName, ok = parsed.Parsed["accountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'accountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "accountName", *parsed)
 	}
 
 	if id.ShareName, ok = parsed.Parsed["shareName"]; !ok {
-		return nil, fmt.Errorf("the segment 'shareName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "shareName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datashare/2019-11-01/synchronizationsetting/id_synchronizationsetting.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datashare/2019-11-01/synchronizationsetting/id_synchronizationsetting.go
@@ -44,23 +44,23 @@ func ParseSynchronizationSettingID(input string) (*SynchronizationSettingId, err
 	id := SynchronizationSettingId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AccountName, ok = parsed.Parsed["accountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'accountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "accountName", *parsed)
 	}
 
 	if id.ShareName, ok = parsed.Parsed["shareName"]; !ok {
-		return nil, fmt.Errorf("the segment 'shareName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "shareName", *parsed)
 	}
 
 	if id.SynchronizationSettingName, ok = parsed.Parsed["synchronizationSettingName"]; !ok {
-		return nil, fmt.Errorf("the segment 'synchronizationSettingName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "synchronizationSettingName", *parsed)
 	}
 
 	return &id, nil
@@ -79,23 +79,23 @@ func ParseSynchronizationSettingIDInsensitively(input string) (*SynchronizationS
 	id := SynchronizationSettingId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AccountName, ok = parsed.Parsed["accountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'accountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "accountName", *parsed)
 	}
 
 	if id.ShareName, ok = parsed.Parsed["shareName"]; !ok {
-		return nil, fmt.Errorf("the segment 'shareName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "shareName", *parsed)
 	}
 
 	if id.SynchronizationSettingName, ok = parsed.Parsed["synchronizationSettingName"]; !ok {
-		return nil, fmt.Errorf("the segment 'synchronizationSettingName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "synchronizationSettingName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2021-09-03-preview/applicationgroup/id_applicationgroup.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2021-09-03-preview/applicationgroup/id_applicationgroup.go
@@ -40,15 +40,15 @@ func ParseApplicationGroupID(input string) (*ApplicationGroupId, error) {
 	id := ApplicationGroupId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ApplicationGroupName, ok = parsed.Parsed["applicationGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'applicationGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "applicationGroupName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseApplicationGroupIDInsensitively(input string) (*ApplicationGroupId, er
 	id := ApplicationGroupId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ApplicationGroupName, ok = parsed.Parsed["applicationGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'applicationGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "applicationGroupName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2021-09-03-preview/hostpool/id_hostpool.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2021-09-03-preview/hostpool/id_hostpool.go
@@ -40,15 +40,15 @@ func ParseHostPoolID(input string) (*HostPoolId, error) {
 	id := HostPoolId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.HostPoolName, ok = parsed.Parsed["hostPoolName"]; !ok {
-		return nil, fmt.Errorf("the segment 'hostPoolName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "hostPoolName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseHostPoolIDInsensitively(input string) (*HostPoolId, error) {
 	id := HostPoolId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.HostPoolName, ok = parsed.Parsed["hostPoolName"]; !ok {
-		return nil, fmt.Errorf("the segment 'hostPoolName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "hostPoolName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2021-09-03-preview/workspace/id_workspace.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2021-09-03-preview/workspace/id_workspace.go
@@ -40,15 +40,15 @@ func ParseWorkspaceID(input string) (*WorkspaceId, error) {
 	id := WorkspaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseWorkspaceIDInsensitively(input string) (*WorkspaceId, error) {
 	id := WorkspaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/application/id_application.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/application/id_application.go
@@ -42,19 +42,19 @@ func ParseApplicationID(input string) (*ApplicationId, error) {
 	id := ApplicationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ApplicationGroupName, ok = parsed.Parsed["applicationGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'applicationGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "applicationGroupName", *parsed)
 	}
 
 	if id.ApplicationName, ok = parsed.Parsed["applicationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'applicationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "applicationName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseApplicationIDInsensitively(input string) (*ApplicationId, error) {
 	id := ApplicationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ApplicationGroupName, ok = parsed.Parsed["applicationGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'applicationGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "applicationGroupName", *parsed)
 	}
 
 	if id.ApplicationName, ok = parsed.Parsed["applicationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'applicationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "applicationName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/application/id_applicationgroup.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/application/id_applicationgroup.go
@@ -40,15 +40,15 @@ func ParseApplicationGroupID(input string) (*ApplicationGroupId, error) {
 	id := ApplicationGroupId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ApplicationGroupName, ok = parsed.Parsed["applicationGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'applicationGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "applicationGroupName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseApplicationGroupIDInsensitively(input string) (*ApplicationGroupId, er
 	id := ApplicationGroupId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ApplicationGroupName, ok = parsed.Parsed["applicationGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'applicationGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "applicationGroupName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/applicationgroup/id_applicationgroup.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/applicationgroup/id_applicationgroup.go
@@ -40,15 +40,15 @@ func ParseApplicationGroupID(input string) (*ApplicationGroupId, error) {
 	id := ApplicationGroupId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ApplicationGroupName, ok = parsed.Parsed["applicationGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'applicationGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "applicationGroupName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseApplicationGroupIDInsensitively(input string) (*ApplicationGroupId, er
 	id := ApplicationGroupId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ApplicationGroupName, ok = parsed.Parsed["applicationGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'applicationGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "applicationGroupName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/desktop/id_applicationgroup.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/desktop/id_applicationgroup.go
@@ -40,15 +40,15 @@ func ParseApplicationGroupID(input string) (*ApplicationGroupId, error) {
 	id := ApplicationGroupId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ApplicationGroupName, ok = parsed.Parsed["applicationGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'applicationGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "applicationGroupName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseApplicationGroupIDInsensitively(input string) (*ApplicationGroupId, er
 	id := ApplicationGroupId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ApplicationGroupName, ok = parsed.Parsed["applicationGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'applicationGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "applicationGroupName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/desktop/id_desktop.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/desktop/id_desktop.go
@@ -42,19 +42,19 @@ func ParseDesktopID(input string) (*DesktopId, error) {
 	id := DesktopId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ApplicationGroupName, ok = parsed.Parsed["applicationGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'applicationGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "applicationGroupName", *parsed)
 	}
 
 	if id.DesktopName, ok = parsed.Parsed["desktopName"]; !ok {
-		return nil, fmt.Errorf("the segment 'desktopName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "desktopName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseDesktopIDInsensitively(input string) (*DesktopId, error) {
 	id := DesktopId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ApplicationGroupName, ok = parsed.Parsed["applicationGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'applicationGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "applicationGroupName", *parsed)
 	}
 
 	if id.DesktopName, ok = parsed.Parsed["desktopName"]; !ok {
-		return nil, fmt.Errorf("the segment 'desktopName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "desktopName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/hostpool/id_hostpool.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/hostpool/id_hostpool.go
@@ -40,15 +40,15 @@ func ParseHostPoolID(input string) (*HostPoolId, error) {
 	id := HostPoolId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.HostPoolName, ok = parsed.Parsed["hostPoolName"]; !ok {
-		return nil, fmt.Errorf("the segment 'hostPoolName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "hostPoolName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseHostPoolIDInsensitively(input string) (*HostPoolId, error) {
 	id := HostPoolId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.HostPoolName, ok = parsed.Parsed["hostPoolName"]; !ok {
-		return nil, fmt.Errorf("the segment 'hostPoolName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "hostPoolName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/scalingplan/id_hostpool.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/scalingplan/id_hostpool.go
@@ -40,15 +40,15 @@ func ParseHostPoolID(input string) (*HostPoolId, error) {
 	id := HostPoolId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.HostPoolName, ok = parsed.Parsed["hostPoolName"]; !ok {
-		return nil, fmt.Errorf("the segment 'hostPoolName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "hostPoolName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseHostPoolIDInsensitively(input string) (*HostPoolId, error) {
 	id := HostPoolId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.HostPoolName, ok = parsed.Parsed["hostPoolName"]; !ok {
-		return nil, fmt.Errorf("the segment 'hostPoolName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "hostPoolName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/scalingplan/id_scalingplan.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/scalingplan/id_scalingplan.go
@@ -40,15 +40,15 @@ func ParseScalingPlanID(input string) (*ScalingPlanId, error) {
 	id := ScalingPlanId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ScalingPlanName, ok = parsed.Parsed["scalingPlanName"]; !ok {
-		return nil, fmt.Errorf("the segment 'scalingPlanName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "scalingPlanName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseScalingPlanIDInsensitively(input string) (*ScalingPlanId, error) {
 	id := ScalingPlanId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ScalingPlanName, ok = parsed.Parsed["scalingPlanName"]; !ok {
-		return nil, fmt.Errorf("the segment 'scalingPlanName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "scalingPlanName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/sessionhost/id_hostpool.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/sessionhost/id_hostpool.go
@@ -40,15 +40,15 @@ func ParseHostPoolID(input string) (*HostPoolId, error) {
 	id := HostPoolId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.HostPoolName, ok = parsed.Parsed["hostPoolName"]; !ok {
-		return nil, fmt.Errorf("the segment 'hostPoolName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "hostPoolName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseHostPoolIDInsensitively(input string) (*HostPoolId, error) {
 	id := HostPoolId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.HostPoolName, ok = parsed.Parsed["hostPoolName"]; !ok {
-		return nil, fmt.Errorf("the segment 'hostPoolName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "hostPoolName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/sessionhost/id_sessionhost.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/sessionhost/id_sessionhost.go
@@ -42,19 +42,19 @@ func ParseSessionHostID(input string) (*SessionHostId, error) {
 	id := SessionHostId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.HostPoolName, ok = parsed.Parsed["hostPoolName"]; !ok {
-		return nil, fmt.Errorf("the segment 'hostPoolName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "hostPoolName", *parsed)
 	}
 
 	if id.SessionHostName, ok = parsed.Parsed["sessionHostName"]; !ok {
-		return nil, fmt.Errorf("the segment 'sessionHostName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "sessionHostName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseSessionHostIDInsensitively(input string) (*SessionHostId, error) {
 	id := SessionHostId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.HostPoolName, ok = parsed.Parsed["hostPoolName"]; !ok {
-		return nil, fmt.Errorf("the segment 'hostPoolName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "hostPoolName", *parsed)
 	}
 
 	if id.SessionHostName, ok = parsed.Parsed["sessionHostName"]; !ok {
-		return nil, fmt.Errorf("the segment 'sessionHostName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "sessionHostName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/workspace/id_workspace.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/desktopvirtualization/2022-02-10-preview/workspace/id_workspace.go
@@ -40,15 +40,15 @@ func ParseWorkspaceID(input string) (*WorkspaceId, error) {
 	id := WorkspaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseWorkspaceIDInsensitively(input string) (*WorkspaceId, error) {
 	id := WorkspaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceprovisioningservices/2022-02-05/dpscertificate/id_certificate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceprovisioningservices/2022-02-05/dpscertificate/id_certificate.go
@@ -42,19 +42,19 @@ func ParseCertificateID(input string) (*CertificateId, error) {
 	id := CertificateId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ProvisioningServiceName, ok = parsed.Parsed["provisioningServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'provisioningServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "provisioningServiceName", *parsed)
 	}
 
 	if id.CertificateName, ok = parsed.Parsed["certificateName"]; !ok {
-		return nil, fmt.Errorf("the segment 'certificateName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "certificateName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseCertificateIDInsensitively(input string) (*CertificateId, error) {
 	id := CertificateId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ProvisioningServiceName, ok = parsed.Parsed["provisioningServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'provisioningServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "provisioningServiceName", *parsed)
 	}
 
 	if id.CertificateName, ok = parsed.Parsed["certificateName"]; !ok {
-		return nil, fmt.Errorf("the segment 'certificateName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "certificateName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceprovisioningservices/2022-02-05/iotdpsresource/id_key.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceprovisioningservices/2022-02-05/iotdpsresource/id_key.go
@@ -42,19 +42,19 @@ func ParseKeyID(input string) (*KeyId, error) {
 	id := KeyId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ProvisioningServiceName, ok = parsed.Parsed["provisioningServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'provisioningServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "provisioningServiceName", *parsed)
 	}
 
 	if id.KeyName, ok = parsed.Parsed["keyName"]; !ok {
-		return nil, fmt.Errorf("the segment 'keyName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "keyName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseKeyIDInsensitively(input string) (*KeyId, error) {
 	id := KeyId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ProvisioningServiceName, ok = parsed.Parsed["provisioningServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'provisioningServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "provisioningServiceName", *parsed)
 	}
 
 	if id.KeyName, ok = parsed.Parsed["keyName"]; !ok {
-		return nil, fmt.Errorf("the segment 'keyName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "keyName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceprovisioningservices/2022-02-05/iotdpsresource/id_privateendpointconnection.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceprovisioningservices/2022-02-05/iotdpsresource/id_privateendpointconnection.go
@@ -42,19 +42,19 @@ func ParsePrivateEndpointConnectionID(input string) (*PrivateEndpointConnectionI
 	id := PrivateEndpointConnectionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ProvisioningServiceName, ok = parsed.Parsed["provisioningServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'provisioningServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "provisioningServiceName", *parsed)
 	}
 
 	if id.PrivateEndpointConnectionName, ok = parsed.Parsed["privateEndpointConnectionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'privateEndpointConnectionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "privateEndpointConnectionName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParsePrivateEndpointConnectionIDInsensitively(input string) (*PrivateEndpoi
 	id := PrivateEndpointConnectionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ProvisioningServiceName, ok = parsed.Parsed["provisioningServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'provisioningServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "provisioningServiceName", *parsed)
 	}
 
 	if id.PrivateEndpointConnectionName, ok = parsed.Parsed["privateEndpointConnectionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'privateEndpointConnectionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "privateEndpointConnectionName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceprovisioningservices/2022-02-05/iotdpsresource/id_privatelinkresource.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceprovisioningservices/2022-02-05/iotdpsresource/id_privatelinkresource.go
@@ -42,19 +42,19 @@ func ParsePrivateLinkResourceID(input string) (*PrivateLinkResourceId, error) {
 	id := PrivateLinkResourceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ProvisioningServiceName, ok = parsed.Parsed["provisioningServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'provisioningServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "provisioningServiceName", *parsed)
 	}
 
 	if id.GroupId, ok = parsed.Parsed["groupId"]; !ok {
-		return nil, fmt.Errorf("the segment 'groupId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "groupId", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParsePrivateLinkResourceIDInsensitively(input string) (*PrivateLinkResource
 	id := PrivateLinkResourceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ProvisioningServiceName, ok = parsed.Parsed["provisioningServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'provisioningServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "provisioningServiceName", *parsed)
 	}
 
 	if id.GroupId, ok = parsed.Parsed["groupId"]; !ok {
-		return nil, fmt.Errorf("the segment 'groupId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "groupId", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/id_account.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/id_account.go
@@ -40,15 +40,15 @@ func ParseAccountID(input string) (*AccountId, error) {
 	id := AccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AccountName, ok = parsed.Parsed["accountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'accountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "accountName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseAccountIDInsensitively(input string) (*AccountId, error) {
 	id := AccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AccountName, ok = parsed.Parsed["accountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'accountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "accountName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/id_instance.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/id_instance.go
@@ -42,19 +42,19 @@ func ParseInstanceID(input string) (*InstanceId, error) {
 	id := InstanceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AccountName, ok = parsed.Parsed["accountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'accountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "accountName", *parsed)
 	}
 
 	if id.InstanceName, ok = parsed.Parsed["instanceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'instanceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "instanceName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseInstanceIDInsensitively(input string) (*InstanceId, error) {
 	id := InstanceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AccountName, ok = parsed.Parsed["accountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'accountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "accountName", *parsed)
 	}
 
 	if id.InstanceName, ok = parsed.Parsed["instanceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'instanceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "instanceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/id_privateendpointconnectionproxy.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/deviceupdate/2022-10-01/deviceupdates/id_privateendpointconnectionproxy.go
@@ -42,19 +42,19 @@ func ParsePrivateEndpointConnectionProxyID(input string) (*PrivateEndpointConnec
 	id := PrivateEndpointConnectionProxyId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AccountName, ok = parsed.Parsed["accountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'accountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "accountName", *parsed)
 	}
 
 	if id.PrivateEndpointConnectionProxyId, ok = parsed.Parsed["privateEndpointConnectionProxyId"]; !ok {
-		return nil, fmt.Errorf("the segment 'privateEndpointConnectionProxyId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "privateEndpointConnectionProxyId", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParsePrivateEndpointConnectionProxyIDInsensitively(input string) (*PrivateE
 	id := PrivateEndpointConnectionProxyId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AccountName, ok = parsed.Parsed["accountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'accountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "accountName", *parsed)
 	}
 
 	if id.PrivateEndpointConnectionProxyId, ok = parsed.Parsed["privateEndpointConnectionProxyId"]; !ok {
-		return nil, fmt.Errorf("the segment 'privateEndpointConnectionProxyId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "privateEndpointConnectionProxyId", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/devtestlab/2018-09-15/globalschedules/id_schedule.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/devtestlab/2018-09-15/globalschedules/id_schedule.go
@@ -40,15 +40,15 @@ func ParseScheduleID(input string) (*ScheduleId, error) {
 	id := ScheduleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ScheduleName, ok = parsed.Parsed["scheduleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'scheduleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "scheduleName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseScheduleIDInsensitively(input string) (*ScheduleId, error) {
 	id := ScheduleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ScheduleName, ok = parsed.Parsed["scheduleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'scheduleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "scheduleName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/devtestlab/2018-09-15/labs/id_lab.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/devtestlab/2018-09-15/labs/id_lab.go
@@ -40,15 +40,15 @@ func ParseLabID(input string) (*LabId, error) {
 	id := LabId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.LabName, ok = parsed.Parsed["labName"]; !ok {
-		return nil, fmt.Errorf("the segment 'labName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "labName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseLabIDInsensitively(input string) (*LabId, error) {
 	id := LabId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.LabName, ok = parsed.Parsed["labName"]; !ok {
-		return nil, fmt.Errorf("the segment 'labName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "labName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/devtestlab/2018-09-15/policies/id_policy.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/devtestlab/2018-09-15/policies/id_policy.go
@@ -44,23 +44,23 @@ func ParsePolicyID(input string) (*PolicyId, error) {
 	id := PolicyId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.LabName, ok = parsed.Parsed["labName"]; !ok {
-		return nil, fmt.Errorf("the segment 'labName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "labName", *parsed)
 	}
 
 	if id.PolicySetName, ok = parsed.Parsed["policySetName"]; !ok {
-		return nil, fmt.Errorf("the segment 'policySetName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "policySetName", *parsed)
 	}
 
 	if id.PolicyName, ok = parsed.Parsed["policyName"]; !ok {
-		return nil, fmt.Errorf("the segment 'policyName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "policyName", *parsed)
 	}
 
 	return &id, nil
@@ -79,23 +79,23 @@ func ParsePolicyIDInsensitively(input string) (*PolicyId, error) {
 	id := PolicyId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.LabName, ok = parsed.Parsed["labName"]; !ok {
-		return nil, fmt.Errorf("the segment 'labName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "labName", *parsed)
 	}
 
 	if id.PolicySetName, ok = parsed.Parsed["policySetName"]; !ok {
-		return nil, fmt.Errorf("the segment 'policySetName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "policySetName", *parsed)
 	}
 
 	if id.PolicyName, ok = parsed.Parsed["policyName"]; !ok {
-		return nil, fmt.Errorf("the segment 'policyName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "policyName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/devtestlab/2018-09-15/policies/id_policyset.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/devtestlab/2018-09-15/policies/id_policyset.go
@@ -42,19 +42,19 @@ func ParsePolicySetID(input string) (*PolicySetId, error) {
 	id := PolicySetId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.LabName, ok = parsed.Parsed["labName"]; !ok {
-		return nil, fmt.Errorf("the segment 'labName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "labName", *parsed)
 	}
 
 	if id.PolicySetName, ok = parsed.Parsed["policySetName"]; !ok {
-		return nil, fmt.Errorf("the segment 'policySetName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "policySetName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParsePolicySetIDInsensitively(input string) (*PolicySetId, error) {
 	id := PolicySetId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.LabName, ok = parsed.Parsed["labName"]; !ok {
-		return nil, fmt.Errorf("the segment 'labName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "labName", *parsed)
 	}
 
 	if id.PolicySetName, ok = parsed.Parsed["policySetName"]; !ok {
-		return nil, fmt.Errorf("the segment 'policySetName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "policySetName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/devtestlab/2018-09-15/schedules/id_lab.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/devtestlab/2018-09-15/schedules/id_lab.go
@@ -40,15 +40,15 @@ func ParseLabID(input string) (*LabId, error) {
 	id := LabId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.LabName, ok = parsed.Parsed["labName"]; !ok {
-		return nil, fmt.Errorf("the segment 'labName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "labName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseLabIDInsensitively(input string) (*LabId, error) {
 	id := LabId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.LabName, ok = parsed.Parsed["labName"]; !ok {
-		return nil, fmt.Errorf("the segment 'labName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "labName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/devtestlab/2018-09-15/schedules/id_labschedule.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/devtestlab/2018-09-15/schedules/id_labschedule.go
@@ -42,19 +42,19 @@ func ParseLabScheduleID(input string) (*LabScheduleId, error) {
 	id := LabScheduleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.LabName, ok = parsed.Parsed["labName"]; !ok {
-		return nil, fmt.Errorf("the segment 'labName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "labName", *parsed)
 	}
 
 	if id.ScheduleName, ok = parsed.Parsed["scheduleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'scheduleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "scheduleName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseLabScheduleIDInsensitively(input string) (*LabScheduleId, error) {
 	id := LabScheduleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.LabName, ok = parsed.Parsed["labName"]; !ok {
-		return nil, fmt.Errorf("the segment 'labName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "labName", *parsed)
 	}
 
 	if id.ScheduleName, ok = parsed.Parsed["scheduleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'scheduleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "scheduleName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/devtestlab/2018-09-15/virtualmachines/id_lab.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/devtestlab/2018-09-15/virtualmachines/id_lab.go
@@ -40,15 +40,15 @@ func ParseLabID(input string) (*LabId, error) {
 	id := LabId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.LabName, ok = parsed.Parsed["labName"]; !ok {
-		return nil, fmt.Errorf("the segment 'labName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "labName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseLabIDInsensitively(input string) (*LabId, error) {
 	id := LabId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.LabName, ok = parsed.Parsed["labName"]; !ok {
-		return nil, fmt.Errorf("the segment 'labName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "labName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/devtestlab/2018-09-15/virtualmachines/id_virtualmachine.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/devtestlab/2018-09-15/virtualmachines/id_virtualmachine.go
@@ -42,19 +42,19 @@ func ParseVirtualMachineID(input string) (*VirtualMachineId, error) {
 	id := VirtualMachineId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.LabName, ok = parsed.Parsed["labName"]; !ok {
-		return nil, fmt.Errorf("the segment 'labName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "labName", *parsed)
 	}
 
 	if id.VirtualMachineName, ok = parsed.Parsed["virtualMachineName"]; !ok {
-		return nil, fmt.Errorf("the segment 'virtualMachineName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "virtualMachineName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseVirtualMachineIDInsensitively(input string) (*VirtualMachineId, error)
 	id := VirtualMachineId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.LabName, ok = parsed.Parsed["labName"]; !ok {
-		return nil, fmt.Errorf("the segment 'labName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "labName", *parsed)
 	}
 
 	if id.VirtualMachineName, ok = parsed.Parsed["virtualMachineName"]; !ok {
-		return nil, fmt.Errorf("the segment 'virtualMachineName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "virtualMachineName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/devtestlab/2018-09-15/virtualnetworks/id_lab.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/devtestlab/2018-09-15/virtualnetworks/id_lab.go
@@ -40,15 +40,15 @@ func ParseLabID(input string) (*LabId, error) {
 	id := LabId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.LabName, ok = parsed.Parsed["labName"]; !ok {
-		return nil, fmt.Errorf("the segment 'labName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "labName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseLabIDInsensitively(input string) (*LabId, error) {
 	id := LabId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.LabName, ok = parsed.Parsed["labName"]; !ok {
-		return nil, fmt.Errorf("the segment 'labName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "labName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/devtestlab/2018-09-15/virtualnetworks/id_virtualnetwork.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/devtestlab/2018-09-15/virtualnetworks/id_virtualnetwork.go
@@ -42,19 +42,19 @@ func ParseVirtualNetworkID(input string) (*VirtualNetworkId, error) {
 	id := VirtualNetworkId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.LabName, ok = parsed.Parsed["labName"]; !ok {
-		return nil, fmt.Errorf("the segment 'labName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "labName", *parsed)
 	}
 
 	if id.VirtualNetworkName, ok = parsed.Parsed["virtualNetworkName"]; !ok {
-		return nil, fmt.Errorf("the segment 'virtualNetworkName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "virtualNetworkName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseVirtualNetworkIDInsensitively(input string) (*VirtualNetworkId, error)
 	id := VirtualNetworkId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.LabName, ok = parsed.Parsed["labName"]; !ok {
-		return nil, fmt.Errorf("the segment 'labName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "labName", *parsed)
 	}
 
 	if id.VirtualNetworkName, ok = parsed.Parsed["virtualNetworkName"]; !ok {
-		return nil, fmt.Errorf("the segment 'virtualNetworkName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "virtualNetworkName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/digitaltwins/2020-12-01/digitaltwinsinstance/id_digitaltwinsinstance.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/digitaltwins/2020-12-01/digitaltwinsinstance/id_digitaltwinsinstance.go
@@ -40,15 +40,15 @@ func ParseDigitalTwinsInstanceID(input string) (*DigitalTwinsInstanceId, error) 
 	id := DigitalTwinsInstanceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DigitalTwinsInstanceName, ok = parsed.Parsed["digitalTwinsInstanceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'digitalTwinsInstanceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "digitalTwinsInstanceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseDigitalTwinsInstanceIDInsensitively(input string) (*DigitalTwinsInstan
 	id := DigitalTwinsInstanceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DigitalTwinsInstanceName, ok = parsed.Parsed["digitalTwinsInstanceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'digitalTwinsInstanceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "digitalTwinsInstanceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/digitaltwins/2020-12-01/endpoints/id_digitaltwinsinstance.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/digitaltwins/2020-12-01/endpoints/id_digitaltwinsinstance.go
@@ -40,15 +40,15 @@ func ParseDigitalTwinsInstanceID(input string) (*DigitalTwinsInstanceId, error) 
 	id := DigitalTwinsInstanceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DigitalTwinsInstanceName, ok = parsed.Parsed["digitalTwinsInstanceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'digitalTwinsInstanceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "digitalTwinsInstanceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseDigitalTwinsInstanceIDInsensitively(input string) (*DigitalTwinsInstan
 	id := DigitalTwinsInstanceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DigitalTwinsInstanceName, ok = parsed.Parsed["digitalTwinsInstanceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'digitalTwinsInstanceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "digitalTwinsInstanceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/digitaltwins/2020-12-01/endpoints/id_endpoint.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/digitaltwins/2020-12-01/endpoints/id_endpoint.go
@@ -42,19 +42,19 @@ func ParseEndpointID(input string) (*EndpointId, error) {
 	id := EndpointId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DigitalTwinsInstanceName, ok = parsed.Parsed["digitalTwinsInstanceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'digitalTwinsInstanceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "digitalTwinsInstanceName", *parsed)
 	}
 
 	if id.EndpointName, ok = parsed.Parsed["endpointName"]; !ok {
-		return nil, fmt.Errorf("the segment 'endpointName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "endpointName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseEndpointIDInsensitively(input string) (*EndpointId, error) {
 	id := EndpointId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DigitalTwinsInstanceName, ok = parsed.Parsed["digitalTwinsInstanceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'digitalTwinsInstanceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "digitalTwinsInstanceName", *parsed)
 	}
 
 	if id.EndpointName, ok = parsed.Parsed["endpointName"]; !ok {
-		return nil, fmt.Errorf("the segment 'endpointName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "endpointName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/digitaltwins/2022-10-31/timeseriesdatabaseconnections/id_digitaltwinsinstance.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/digitaltwins/2022-10-31/timeseriesdatabaseconnections/id_digitaltwinsinstance.go
@@ -40,15 +40,15 @@ func ParseDigitalTwinsInstanceID(input string) (*DigitalTwinsInstanceId, error) 
 	id := DigitalTwinsInstanceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DigitalTwinsInstanceName, ok = parsed.Parsed["digitalTwinsInstanceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'digitalTwinsInstanceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "digitalTwinsInstanceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseDigitalTwinsInstanceIDInsensitively(input string) (*DigitalTwinsInstan
 	id := DigitalTwinsInstanceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DigitalTwinsInstanceName, ok = parsed.Parsed["digitalTwinsInstanceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'digitalTwinsInstanceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "digitalTwinsInstanceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/digitaltwins/2022-10-31/timeseriesdatabaseconnections/id_timeseriesdatabaseconnection.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/digitaltwins/2022-10-31/timeseriesdatabaseconnections/id_timeseriesdatabaseconnection.go
@@ -42,19 +42,19 @@ func ParseTimeSeriesDatabaseConnectionID(input string) (*TimeSeriesDatabaseConne
 	id := TimeSeriesDatabaseConnectionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DigitalTwinsInstanceName, ok = parsed.Parsed["digitalTwinsInstanceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'digitalTwinsInstanceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "digitalTwinsInstanceName", *parsed)
 	}
 
 	if id.TimeSeriesDatabaseConnectionName, ok = parsed.Parsed["timeSeriesDatabaseConnectionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'timeSeriesDatabaseConnectionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "timeSeriesDatabaseConnectionName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseTimeSeriesDatabaseConnectionIDInsensitively(input string) (*TimeSeries
 	id := TimeSeriesDatabaseConnectionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DigitalTwinsInstanceName, ok = parsed.Parsed["digitalTwinsInstanceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'digitalTwinsInstanceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "digitalTwinsInstanceName", *parsed)
 	}
 
 	if id.TimeSeriesDatabaseConnectionName, ok = parsed.Parsed["timeSeriesDatabaseConnectionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'timeSeriesDatabaseConnectionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "timeSeriesDatabaseConnectionName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dns/2018-05-01/recordsets/id_dnszone.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dns/2018-05-01/recordsets/id_dnszone.go
@@ -40,15 +40,15 @@ func ParseDnsZoneID(input string) (*DnsZoneId, error) {
 	id := DnsZoneId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DnsZoneName, ok = parsed.Parsed["dnsZoneName"]; !ok {
-		return nil, fmt.Errorf("the segment 'dnsZoneName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "dnsZoneName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseDnsZoneIDInsensitively(input string) (*DnsZoneId, error) {
 	id := DnsZoneId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DnsZoneName, ok = parsed.Parsed["dnsZoneName"]; !ok {
-		return nil, fmt.Errorf("the segment 'dnsZoneName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "dnsZoneName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dns/2018-05-01/recordsets/id_recordtype.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dns/2018-05-01/recordsets/id_recordtype.go
@@ -44,20 +44,20 @@ func ParseRecordTypeID(input string) (*RecordTypeId, error) {
 	id := RecordTypeId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DnsZoneName, ok = parsed.Parsed["dnsZoneName"]; !ok {
-		return nil, fmt.Errorf("the segment 'dnsZoneName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "dnsZoneName", *parsed)
 	}
 
 	if v, ok := parsed.Parsed["recordType"]; true {
 		if !ok {
-			return nil, fmt.Errorf("the segment 'recordType' was not found in the resource id %q", input)
+			return nil, resourceids.NewSegmentNotSpecifiedError(id, "recordType", *parsed)
 		}
 
 		recordType, err := parseRecordType(v)
@@ -68,7 +68,7 @@ func ParseRecordTypeID(input string) (*RecordTypeId, error) {
 	}
 
 	if id.RelativeRecordSetName, ok = parsed.Parsed["relativeRecordSetName"]; !ok {
-		return nil, fmt.Errorf("the segment 'relativeRecordSetName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "relativeRecordSetName", *parsed)
 	}
 
 	return &id, nil
@@ -87,20 +87,20 @@ func ParseRecordTypeIDInsensitively(input string) (*RecordTypeId, error) {
 	id := RecordTypeId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DnsZoneName, ok = parsed.Parsed["dnsZoneName"]; !ok {
-		return nil, fmt.Errorf("the segment 'dnsZoneName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "dnsZoneName", *parsed)
 	}
 
 	if v, ok := parsed.Parsed["recordType"]; true {
 		if !ok {
-			return nil, fmt.Errorf("the segment 'recordType' was not found in the resource id %q", input)
+			return nil, resourceids.NewSegmentNotSpecifiedError(id, "recordType", *parsed)
 		}
 
 		recordType, err := parseRecordType(v)
@@ -111,7 +111,7 @@ func ParseRecordTypeIDInsensitively(input string) (*RecordTypeId, error) {
 	}
 
 	if id.RelativeRecordSetName, ok = parsed.Parsed["relativeRecordSetName"]; !ok {
-		return nil, fmt.Errorf("the segment 'relativeRecordSetName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "relativeRecordSetName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dns/2018-05-01/recordsets/id_zone.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dns/2018-05-01/recordsets/id_zone.go
@@ -42,20 +42,20 @@ func ParseZoneID(input string) (*ZoneId, error) {
 	id := ZoneId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DnsZoneName, ok = parsed.Parsed["dnsZoneName"]; !ok {
-		return nil, fmt.Errorf("the segment 'dnsZoneName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "dnsZoneName", *parsed)
 	}
 
 	if v, ok := parsed.Parsed["recordType"]; true {
 		if !ok {
-			return nil, fmt.Errorf("the segment 'recordType' was not found in the resource id %q", input)
+			return nil, resourceids.NewSegmentNotSpecifiedError(id, "recordType", *parsed)
 		}
 
 		recordType, err := parseRecordType(v)
@@ -81,20 +81,20 @@ func ParseZoneIDInsensitively(input string) (*ZoneId, error) {
 	id := ZoneId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DnsZoneName, ok = parsed.Parsed["dnsZoneName"]; !ok {
-		return nil, fmt.Errorf("the segment 'dnsZoneName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "dnsZoneName", *parsed)
 	}
 
 	if v, ok := parsed.Parsed["recordType"]; true {
 		if !ok {
-			return nil, fmt.Errorf("the segment 'recordType' was not found in the resource id %q", input)
+			return nil, resourceids.NewSegmentNotSpecifiedError(id, "recordType", *parsed)
 		}
 
 		recordType, err := parseRecordType(v)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dns/2018-05-01/zones/id_dnszone.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dns/2018-05-01/zones/id_dnszone.go
@@ -40,15 +40,15 @@ func ParseDnsZoneID(input string) (*DnsZoneId, error) {
 	id := DnsZoneId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DnsZoneName, ok = parsed.Parsed["dnsZoneName"]; !ok {
-		return nil, fmt.Errorf("the segment 'dnsZoneName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "dnsZoneName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseDnsZoneIDInsensitively(input string) (*DnsZoneId, error) {
 	id := DnsZoneId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DnsZoneName, ok = parsed.Parsed["dnsZoneName"]; !ok {
-		return nil, fmt.Errorf("the segment 'dnsZoneName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "dnsZoneName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dnsresolver/2022-07-01/dnsforwardingrulesets/id_dnsforwardingruleset.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dnsresolver/2022-07-01/dnsforwardingrulesets/id_dnsforwardingruleset.go
@@ -40,15 +40,15 @@ func ParseDnsForwardingRulesetID(input string) (*DnsForwardingRulesetId, error) 
 	id := DnsForwardingRulesetId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DnsForwardingRulesetName, ok = parsed.Parsed["dnsForwardingRulesetName"]; !ok {
-		return nil, fmt.Errorf("the segment 'dnsForwardingRulesetName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "dnsForwardingRulesetName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseDnsForwardingRulesetIDInsensitively(input string) (*DnsForwardingRules
 	id := DnsForwardingRulesetId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DnsForwardingRulesetName, ok = parsed.Parsed["dnsForwardingRulesetName"]; !ok {
-		return nil, fmt.Errorf("the segment 'dnsForwardingRulesetName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "dnsForwardingRulesetName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dnsresolver/2022-07-01/dnsforwardingrulesets/id_virtualnetwork.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dnsresolver/2022-07-01/dnsforwardingrulesets/id_virtualnetwork.go
@@ -40,15 +40,15 @@ func ParseVirtualNetworkID(input string) (*VirtualNetworkId, error) {
 	id := VirtualNetworkId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VirtualNetworkName, ok = parsed.Parsed["virtualNetworkName"]; !ok {
-		return nil, fmt.Errorf("the segment 'virtualNetworkName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "virtualNetworkName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseVirtualNetworkIDInsensitively(input string) (*VirtualNetworkId, error)
 	id := VirtualNetworkId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VirtualNetworkName, ok = parsed.Parsed["virtualNetworkName"]; !ok {
-		return nil, fmt.Errorf("the segment 'virtualNetworkName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "virtualNetworkName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dnsresolver/2022-07-01/dnsresolvers/id_dnsresolver.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dnsresolver/2022-07-01/dnsresolvers/id_dnsresolver.go
@@ -40,15 +40,15 @@ func ParseDnsResolverID(input string) (*DnsResolverId, error) {
 	id := DnsResolverId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DnsResolverName, ok = parsed.Parsed["dnsResolverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'dnsResolverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "dnsResolverName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseDnsResolverIDInsensitively(input string) (*DnsResolverId, error) {
 	id := DnsResolverId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DnsResolverName, ok = parsed.Parsed["dnsResolverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'dnsResolverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "dnsResolverName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dnsresolver/2022-07-01/dnsresolvers/id_virtualnetwork.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dnsresolver/2022-07-01/dnsresolvers/id_virtualnetwork.go
@@ -40,15 +40,15 @@ func ParseVirtualNetworkID(input string) (*VirtualNetworkId, error) {
 	id := VirtualNetworkId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VirtualNetworkName, ok = parsed.Parsed["virtualNetworkName"]; !ok {
-		return nil, fmt.Errorf("the segment 'virtualNetworkName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "virtualNetworkName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseVirtualNetworkIDInsensitively(input string) (*VirtualNetworkId, error)
 	id := VirtualNetworkId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VirtualNetworkName, ok = parsed.Parsed["virtualNetworkName"]; !ok {
-		return nil, fmt.Errorf("the segment 'virtualNetworkName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "virtualNetworkName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dnsresolver/2022-07-01/forwardingrules/id_dnsforwardingruleset.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dnsresolver/2022-07-01/forwardingrules/id_dnsforwardingruleset.go
@@ -40,15 +40,15 @@ func ParseDnsForwardingRulesetID(input string) (*DnsForwardingRulesetId, error) 
 	id := DnsForwardingRulesetId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DnsForwardingRulesetName, ok = parsed.Parsed["dnsForwardingRulesetName"]; !ok {
-		return nil, fmt.Errorf("the segment 'dnsForwardingRulesetName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "dnsForwardingRulesetName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseDnsForwardingRulesetIDInsensitively(input string) (*DnsForwardingRules
 	id := DnsForwardingRulesetId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DnsForwardingRulesetName, ok = parsed.Parsed["dnsForwardingRulesetName"]; !ok {
-		return nil, fmt.Errorf("the segment 'dnsForwardingRulesetName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "dnsForwardingRulesetName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dnsresolver/2022-07-01/forwardingrules/id_forwardingrule.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dnsresolver/2022-07-01/forwardingrules/id_forwardingrule.go
@@ -42,19 +42,19 @@ func ParseForwardingRuleID(input string) (*ForwardingRuleId, error) {
 	id := ForwardingRuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DnsForwardingRulesetName, ok = parsed.Parsed["dnsForwardingRulesetName"]; !ok {
-		return nil, fmt.Errorf("the segment 'dnsForwardingRulesetName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "dnsForwardingRulesetName", *parsed)
 	}
 
 	if id.ForwardingRuleName, ok = parsed.Parsed["forwardingRuleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'forwardingRuleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "forwardingRuleName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseForwardingRuleIDInsensitively(input string) (*ForwardingRuleId, error)
 	id := ForwardingRuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DnsForwardingRulesetName, ok = parsed.Parsed["dnsForwardingRulesetName"]; !ok {
-		return nil, fmt.Errorf("the segment 'dnsForwardingRulesetName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "dnsForwardingRulesetName", *parsed)
 	}
 
 	if id.ForwardingRuleName, ok = parsed.Parsed["forwardingRuleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'forwardingRuleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "forwardingRuleName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dnsresolver/2022-07-01/inboundendpoints/id_dnsresolver.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dnsresolver/2022-07-01/inboundendpoints/id_dnsresolver.go
@@ -40,15 +40,15 @@ func ParseDnsResolverID(input string) (*DnsResolverId, error) {
 	id := DnsResolverId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DnsResolverName, ok = parsed.Parsed["dnsResolverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'dnsResolverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "dnsResolverName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseDnsResolverIDInsensitively(input string) (*DnsResolverId, error) {
 	id := DnsResolverId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DnsResolverName, ok = parsed.Parsed["dnsResolverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'dnsResolverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "dnsResolverName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dnsresolver/2022-07-01/inboundendpoints/id_inboundendpoint.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dnsresolver/2022-07-01/inboundendpoints/id_inboundendpoint.go
@@ -42,19 +42,19 @@ func ParseInboundEndpointID(input string) (*InboundEndpointId, error) {
 	id := InboundEndpointId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DnsResolverName, ok = parsed.Parsed["dnsResolverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'dnsResolverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "dnsResolverName", *parsed)
 	}
 
 	if id.InboundEndpointName, ok = parsed.Parsed["inboundEndpointName"]; !ok {
-		return nil, fmt.Errorf("the segment 'inboundEndpointName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "inboundEndpointName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseInboundEndpointIDInsensitively(input string) (*InboundEndpointId, erro
 	id := InboundEndpointId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DnsResolverName, ok = parsed.Parsed["dnsResolverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'dnsResolverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "dnsResolverName", *parsed)
 	}
 
 	if id.InboundEndpointName, ok = parsed.Parsed["inboundEndpointName"]; !ok {
-		return nil, fmt.Errorf("the segment 'inboundEndpointName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "inboundEndpointName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dnsresolver/2022-07-01/outboundendpoints/id_dnsresolver.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dnsresolver/2022-07-01/outboundendpoints/id_dnsresolver.go
@@ -40,15 +40,15 @@ func ParseDnsResolverID(input string) (*DnsResolverId, error) {
 	id := DnsResolverId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DnsResolverName, ok = parsed.Parsed["dnsResolverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'dnsResolverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "dnsResolverName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseDnsResolverIDInsensitively(input string) (*DnsResolverId, error) {
 	id := DnsResolverId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DnsResolverName, ok = parsed.Parsed["dnsResolverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'dnsResolverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "dnsResolverName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dnsresolver/2022-07-01/outboundendpoints/id_outboundendpoint.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dnsresolver/2022-07-01/outboundendpoints/id_outboundendpoint.go
@@ -42,19 +42,19 @@ func ParseOutboundEndpointID(input string) (*OutboundEndpointId, error) {
 	id := OutboundEndpointId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DnsResolverName, ok = parsed.Parsed["dnsResolverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'dnsResolverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "dnsResolverName", *parsed)
 	}
 
 	if id.OutboundEndpointName, ok = parsed.Parsed["outboundEndpointName"]; !ok {
-		return nil, fmt.Errorf("the segment 'outboundEndpointName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "outboundEndpointName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseOutboundEndpointIDInsensitively(input string) (*OutboundEndpointId, er
 	id := OutboundEndpointId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DnsResolverName, ok = parsed.Parsed["dnsResolverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'dnsResolverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "dnsResolverName", *parsed)
 	}
 
 	if id.OutboundEndpointName, ok = parsed.Parsed["outboundEndpointName"]; !ok {
-		return nil, fmt.Errorf("the segment 'outboundEndpointName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "outboundEndpointName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dnsresolver/2022-07-01/virtualnetworklinks/id_dnsforwardingruleset.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dnsresolver/2022-07-01/virtualnetworklinks/id_dnsforwardingruleset.go
@@ -40,15 +40,15 @@ func ParseDnsForwardingRulesetID(input string) (*DnsForwardingRulesetId, error) 
 	id := DnsForwardingRulesetId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DnsForwardingRulesetName, ok = parsed.Parsed["dnsForwardingRulesetName"]; !ok {
-		return nil, fmt.Errorf("the segment 'dnsForwardingRulesetName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "dnsForwardingRulesetName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseDnsForwardingRulesetIDInsensitively(input string) (*DnsForwardingRules
 	id := DnsForwardingRulesetId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DnsForwardingRulesetName, ok = parsed.Parsed["dnsForwardingRulesetName"]; !ok {
-		return nil, fmt.Errorf("the segment 'dnsForwardingRulesetName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "dnsForwardingRulesetName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dnsresolver/2022-07-01/virtualnetworklinks/id_virtualnetworklink.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dnsresolver/2022-07-01/virtualnetworklinks/id_virtualnetworklink.go
@@ -42,19 +42,19 @@ func ParseVirtualNetworkLinkID(input string) (*VirtualNetworkLinkId, error) {
 	id := VirtualNetworkLinkId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DnsForwardingRulesetName, ok = parsed.Parsed["dnsForwardingRulesetName"]; !ok {
-		return nil, fmt.Errorf("the segment 'dnsForwardingRulesetName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "dnsForwardingRulesetName", *parsed)
 	}
 
 	if id.VirtualNetworkLinkName, ok = parsed.Parsed["virtualNetworkLinkName"]; !ok {
-		return nil, fmt.Errorf("the segment 'virtualNetworkLinkName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "virtualNetworkLinkName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseVirtualNetworkLinkIDInsensitively(input string) (*VirtualNetworkLinkId
 	id := VirtualNetworkLinkId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DnsForwardingRulesetName, ok = parsed.Parsed["dnsForwardingRulesetName"]; !ok {
-		return nil, fmt.Errorf("the segment 'dnsForwardingRulesetName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "dnsForwardingRulesetName", *parsed)
 	}
 
 	if id.VirtualNetworkLinkName, ok = parsed.Parsed["virtualNetworkLinkName"]; !ok {
-		return nil, fmt.Errorf("the segment 'virtualNetworkLinkName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "virtualNetworkLinkName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/elastic/2020-07-01/monitorsresource/id_monitor.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/elastic/2020-07-01/monitorsresource/id_monitor.go
@@ -40,15 +40,15 @@ func ParseMonitorID(input string) (*MonitorId, error) {
 	id := MonitorId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MonitorName, ok = parsed.Parsed["monitorName"]; !ok {
-		return nil, fmt.Errorf("the segment 'monitorName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "monitorName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseMonitorIDInsensitively(input string) (*MonitorId, error) {
 	id := MonitorId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MonitorName, ok = parsed.Parsed["monitorName"]; !ok {
-		return nil, fmt.Errorf("the segment 'monitorName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "monitorName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/elastic/2020-07-01/rules/id_monitor.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/elastic/2020-07-01/rules/id_monitor.go
@@ -40,15 +40,15 @@ func ParseMonitorID(input string) (*MonitorId, error) {
 	id := MonitorId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MonitorName, ok = parsed.Parsed["monitorName"]; !ok {
-		return nil, fmt.Errorf("the segment 'monitorName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "monitorName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseMonitorIDInsensitively(input string) (*MonitorId, error) {
 	id := MonitorId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MonitorName, ok = parsed.Parsed["monitorName"]; !ok {
-		return nil, fmt.Errorf("the segment 'monitorName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "monitorName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/elastic/2020-07-01/rules/id_tagrule.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/elastic/2020-07-01/rules/id_tagrule.go
@@ -42,19 +42,19 @@ func ParseTagRuleID(input string) (*TagRuleId, error) {
 	id := TagRuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MonitorName, ok = parsed.Parsed["monitorName"]; !ok {
-		return nil, fmt.Errorf("the segment 'monitorName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "monitorName", *parsed)
 	}
 
 	if id.TagRuleName, ok = parsed.Parsed["tagRuleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'tagRuleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "tagRuleName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseTagRuleIDInsensitively(input string) (*TagRuleId, error) {
 	id := TagRuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MonitorName, ok = parsed.Parsed["monitorName"]; !ok {
-		return nil, fmt.Errorf("the segment 'monitorName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "monitorName", *parsed)
 	}
 
 	if id.TagRuleName, ok = parsed.Parsed["tagRuleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'tagRuleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "tagRuleName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2021-11-01/authorizationruleseventhubs/id_eventhub.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2021-11-01/authorizationruleseventhubs/id_eventhub.go
@@ -42,19 +42,19 @@ func ParseEventhubID(input string) (*EventhubId, error) {
 	id := EventhubId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	if id.EventhubName, ok = parsed.Parsed["eventhubName"]; !ok {
-		return nil, fmt.Errorf("the segment 'eventhubName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "eventhubName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseEventhubIDInsensitively(input string) (*EventhubId, error) {
 	id := EventhubId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	if id.EventhubName, ok = parsed.Parsed["eventhubName"]; !ok {
-		return nil, fmt.Errorf("the segment 'eventhubName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "eventhubName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2021-11-01/authorizationruleseventhubs/id_eventhubauthorizationrule.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2021-11-01/authorizationruleseventhubs/id_eventhubauthorizationrule.go
@@ -44,23 +44,23 @@ func ParseEventhubAuthorizationRuleID(input string) (*EventhubAuthorizationRuleI
 	id := EventhubAuthorizationRuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	if id.EventhubName, ok = parsed.Parsed["eventhubName"]; !ok {
-		return nil, fmt.Errorf("the segment 'eventhubName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "eventhubName", *parsed)
 	}
 
 	if id.AuthorizationRuleName, ok = parsed.Parsed["authorizationRuleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'authorizationRuleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "authorizationRuleName", *parsed)
 	}
 
 	return &id, nil
@@ -79,23 +79,23 @@ func ParseEventhubAuthorizationRuleIDInsensitively(input string) (*EventhubAutho
 	id := EventhubAuthorizationRuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	if id.EventhubName, ok = parsed.Parsed["eventhubName"]; !ok {
-		return nil, fmt.Errorf("the segment 'eventhubName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "eventhubName", *parsed)
 	}
 
 	if id.AuthorizationRuleName, ok = parsed.Parsed["authorizationRuleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'authorizationRuleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "authorizationRuleName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2021-11-01/authorizationrulesnamespaces/id_authorizationrule.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2021-11-01/authorizationrulesnamespaces/id_authorizationrule.go
@@ -42,19 +42,19 @@ func ParseAuthorizationRuleID(input string) (*AuthorizationRuleId, error) {
 	id := AuthorizationRuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	if id.AuthorizationRuleName, ok = parsed.Parsed["authorizationRuleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'authorizationRuleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "authorizationRuleName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseAuthorizationRuleIDInsensitively(input string) (*AuthorizationRuleId, 
 	id := AuthorizationRuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	if id.AuthorizationRuleName, ok = parsed.Parsed["authorizationRuleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'authorizationRuleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "authorizationRuleName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2021-11-01/authorizationrulesnamespaces/id_namespace.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2021-11-01/authorizationrulesnamespaces/id_namespace.go
@@ -40,15 +40,15 @@ func ParseNamespaceID(input string) (*NamespaceId, error) {
 	id := NamespaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseNamespaceIDInsensitively(input string) (*NamespaceId, error) {
 	id := NamespaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2021-11-01/checknameavailabilitydisasterrecoveryconfigs/id_namespace.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2021-11-01/checknameavailabilitydisasterrecoveryconfigs/id_namespace.go
@@ -40,15 +40,15 @@ func ParseNamespaceID(input string) (*NamespaceId, error) {
 	id := NamespaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseNamespaceIDInsensitively(input string) (*NamespaceId, error) {
 	id := NamespaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2021-11-01/consumergroups/id_consumergroup.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2021-11-01/consumergroups/id_consumergroup.go
@@ -44,23 +44,23 @@ func ParseConsumerGroupID(input string) (*ConsumerGroupId, error) {
 	id := ConsumerGroupId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	if id.EventhubName, ok = parsed.Parsed["eventhubName"]; !ok {
-		return nil, fmt.Errorf("the segment 'eventhubName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "eventhubName", *parsed)
 	}
 
 	if id.ConsumerGroupName, ok = parsed.Parsed["consumerGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'consumerGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "consumerGroupName", *parsed)
 	}
 
 	return &id, nil
@@ -79,23 +79,23 @@ func ParseConsumerGroupIDInsensitively(input string) (*ConsumerGroupId, error) {
 	id := ConsumerGroupId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	if id.EventhubName, ok = parsed.Parsed["eventhubName"]; !ok {
-		return nil, fmt.Errorf("the segment 'eventhubName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "eventhubName", *parsed)
 	}
 
 	if id.ConsumerGroupName, ok = parsed.Parsed["consumerGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'consumerGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "consumerGroupName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2021-11-01/consumergroups/id_eventhub.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2021-11-01/consumergroups/id_eventhub.go
@@ -42,19 +42,19 @@ func ParseEventhubID(input string) (*EventhubId, error) {
 	id := EventhubId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	if id.EventhubName, ok = parsed.Parsed["eventhubName"]; !ok {
-		return nil, fmt.Errorf("the segment 'eventhubName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "eventhubName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseEventhubIDInsensitively(input string) (*EventhubId, error) {
 	id := EventhubId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	if id.EventhubName, ok = parsed.Parsed["eventhubName"]; !ok {
-		return nil, fmt.Errorf("the segment 'eventhubName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "eventhubName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2021-11-01/disasterrecoveryconfigs/id_disasterrecoveryconfig.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2021-11-01/disasterrecoveryconfigs/id_disasterrecoveryconfig.go
@@ -42,19 +42,19 @@ func ParseDisasterRecoveryConfigID(input string) (*DisasterRecoveryConfigId, err
 	id := DisasterRecoveryConfigId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	if id.DisasterRecoveryConfigName, ok = parsed.Parsed["disasterRecoveryConfigName"]; !ok {
-		return nil, fmt.Errorf("the segment 'disasterRecoveryConfigName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "disasterRecoveryConfigName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseDisasterRecoveryConfigIDInsensitively(input string) (*DisasterRecovery
 	id := DisasterRecoveryConfigId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	if id.DisasterRecoveryConfigName, ok = parsed.Parsed["disasterRecoveryConfigName"]; !ok {
-		return nil, fmt.Errorf("the segment 'disasterRecoveryConfigName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "disasterRecoveryConfigName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2021-11-01/disasterrecoveryconfigs/id_namespace.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2021-11-01/disasterrecoveryconfigs/id_namespace.go
@@ -40,15 +40,15 @@ func ParseNamespaceID(input string) (*NamespaceId, error) {
 	id := NamespaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseNamespaceIDInsensitively(input string) (*NamespaceId, error) {
 	id := NamespaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2021-11-01/eventhubs/id_eventhub.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2021-11-01/eventhubs/id_eventhub.go
@@ -42,19 +42,19 @@ func ParseEventhubID(input string) (*EventhubId, error) {
 	id := EventhubId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	if id.EventhubName, ok = parsed.Parsed["eventhubName"]; !ok {
-		return nil, fmt.Errorf("the segment 'eventhubName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "eventhubName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseEventhubIDInsensitively(input string) (*EventhubId, error) {
 	id := EventhubId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	if id.EventhubName, ok = parsed.Parsed["eventhubName"]; !ok {
-		return nil, fmt.Errorf("the segment 'eventhubName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "eventhubName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2021-11-01/eventhubs/id_eventhubauthorizationrule.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2021-11-01/eventhubs/id_eventhubauthorizationrule.go
@@ -44,23 +44,23 @@ func ParseEventhubAuthorizationRuleID(input string) (*EventhubAuthorizationRuleI
 	id := EventhubAuthorizationRuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	if id.EventhubName, ok = parsed.Parsed["eventhubName"]; !ok {
-		return nil, fmt.Errorf("the segment 'eventhubName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "eventhubName", *parsed)
 	}
 
 	if id.AuthorizationRuleName, ok = parsed.Parsed["authorizationRuleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'authorizationRuleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "authorizationRuleName", *parsed)
 	}
 
 	return &id, nil
@@ -79,23 +79,23 @@ func ParseEventhubAuthorizationRuleIDInsensitively(input string) (*EventhubAutho
 	id := EventhubAuthorizationRuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	if id.EventhubName, ok = parsed.Parsed["eventhubName"]; !ok {
-		return nil, fmt.Errorf("the segment 'eventhubName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "eventhubName", *parsed)
 	}
 
 	if id.AuthorizationRuleName, ok = parsed.Parsed["authorizationRuleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'authorizationRuleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "authorizationRuleName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2021-11-01/eventhubs/id_namespace.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2021-11-01/eventhubs/id_namespace.go
@@ -40,15 +40,15 @@ func ParseNamespaceID(input string) (*NamespaceId, error) {
 	id := NamespaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseNamespaceIDInsensitively(input string) (*NamespaceId, error) {
 	id := NamespaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2021-11-01/eventhubsclusters/id_cluster.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2021-11-01/eventhubsclusters/id_cluster.go
@@ -40,15 +40,15 @@ func ParseClusterID(input string) (*ClusterId, error) {
 	id := ClusterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseClusterIDInsensitively(input string) (*ClusterId, error) {
 	id := ClusterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2021-11-01/namespaces/id_namespace.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2021-11-01/namespaces/id_namespace.go
@@ -40,15 +40,15 @@ func ParseNamespaceID(input string) (*NamespaceId, error) {
 	id := NamespaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseNamespaceIDInsensitively(input string) (*NamespaceId, error) {
 	id := NamespaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2021-11-01/networkrulesets/id_namespace.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2021-11-01/networkrulesets/id_namespace.go
@@ -40,15 +40,15 @@ func ParseNamespaceID(input string) (*NamespaceId, error) {
 	id := NamespaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseNamespaceIDInsensitively(input string) (*NamespaceId, error) {
 	id := NamespaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2021-11-01/schemaregistry/id_namespace.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2021-11-01/schemaregistry/id_namespace.go
@@ -40,15 +40,15 @@ func ParseNamespaceID(input string) (*NamespaceId, error) {
 	id := NamespaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseNamespaceIDInsensitively(input string) (*NamespaceId, error) {
 	id := NamespaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2021-11-01/schemaregistry/id_schemagroup.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2021-11-01/schemaregistry/id_schemagroup.go
@@ -42,19 +42,19 @@ func ParseSchemaGroupID(input string) (*SchemaGroupId, error) {
 	id := SchemaGroupId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	if id.SchemaGroupName, ok = parsed.Parsed["schemaGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'schemaGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "schemaGroupName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseSchemaGroupIDInsensitively(input string) (*SchemaGroupId, error) {
 	id := SchemaGroupId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	if id.SchemaGroupName, ok = parsed.Parsed["schemaGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'schemaGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "schemaGroupName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2022-01-01-preview/namespaces/id_namespace.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventhub/2022-01-01-preview/namespaces/id_namespace.go
@@ -40,15 +40,15 @@ func ParseNamespaceID(input string) (*NamespaceId, error) {
 	id := NamespaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseNamespaceIDInsensitively(input string) (*NamespaceId, error) {
 	id := NamespaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/fluidrelay/2022-05-26/fluidrelaycontainers/id_fluidrelaycontainer.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/fluidrelay/2022-05-26/fluidrelaycontainers/id_fluidrelaycontainer.go
@@ -42,19 +42,19 @@ func ParseFluidRelayContainerID(input string) (*FluidRelayContainerId, error) {
 	id := FluidRelayContainerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroup, ok = parsed.Parsed["resourceGroup"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroup' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroup", *parsed)
 	}
 
 	if id.FluidRelayServerName, ok = parsed.Parsed["fluidRelayServerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'fluidRelayServerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "fluidRelayServerName", *parsed)
 	}
 
 	if id.FluidRelayContainerName, ok = parsed.Parsed["fluidRelayContainerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'fluidRelayContainerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "fluidRelayContainerName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseFluidRelayContainerIDInsensitively(input string) (*FluidRelayContainer
 	id := FluidRelayContainerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroup, ok = parsed.Parsed["resourceGroup"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroup' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroup", *parsed)
 	}
 
 	if id.FluidRelayServerName, ok = parsed.Parsed["fluidRelayServerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'fluidRelayServerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "fluidRelayServerName", *parsed)
 	}
 
 	if id.FluidRelayContainerName, ok = parsed.Parsed["fluidRelayContainerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'fluidRelayContainerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "fluidRelayContainerName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/fluidrelay/2022-05-26/fluidrelaycontainers/id_fluidrelayserver.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/fluidrelay/2022-05-26/fluidrelaycontainers/id_fluidrelayserver.go
@@ -40,15 +40,15 @@ func ParseFluidRelayServerID(input string) (*FluidRelayServerId, error) {
 	id := FluidRelayServerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroup, ok = parsed.Parsed["resourceGroup"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroup' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroup", *parsed)
 	}
 
 	if id.FluidRelayServerName, ok = parsed.Parsed["fluidRelayServerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'fluidRelayServerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "fluidRelayServerName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseFluidRelayServerIDInsensitively(input string) (*FluidRelayServerId, er
 	id := FluidRelayServerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroup, ok = parsed.Parsed["resourceGroup"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroup' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroup", *parsed)
 	}
 
 	if id.FluidRelayServerName, ok = parsed.Parsed["fluidRelayServerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'fluidRelayServerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "fluidRelayServerName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/fluidrelay/2022-05-26/fluidrelayservers/id_fluidrelayserver.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/fluidrelay/2022-05-26/fluidrelayservers/id_fluidrelayserver.go
@@ -40,15 +40,15 @@ func ParseFluidRelayServerID(input string) (*FluidRelayServerId, error) {
 	id := FluidRelayServerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroup, ok = parsed.Parsed["resourceGroup"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroup' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroup", *parsed)
 	}
 
 	if id.FluidRelayServerName, ok = parsed.Parsed["fluidRelayServerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'fluidRelayServerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "fluidRelayServerName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseFluidRelayServerIDInsensitively(input string) (*FluidRelayServerId, er
 	id := FluidRelayServerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroup, ok = parsed.Parsed["resourceGroup"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroup' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroup", *parsed)
 	}
 
 	if id.FluidRelayServerName, ok = parsed.Parsed["fluidRelayServerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'fluidRelayServerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "fluidRelayServerName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2020-04-01/webapplicationfirewallpolicies/id_frontdoorwebapplicationfirewallpolicy.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2020-04-01/webapplicationfirewallpolicies/id_frontdoorwebapplicationfirewallpolicy.go
@@ -40,15 +40,15 @@ func ParseFrontDoorWebApplicationFirewallPolicyID(input string) (*FrontDoorWebAp
 	id := FrontDoorWebApplicationFirewallPolicyId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.FrontDoorWebApplicationFirewallPolicyName, ok = parsed.Parsed["frontDoorWebApplicationFirewallPolicyName"]; !ok {
-		return nil, fmt.Errorf("the segment 'frontDoorWebApplicationFirewallPolicyName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "frontDoorWebApplicationFirewallPolicyName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseFrontDoorWebApplicationFirewallPolicyIDInsensitively(input string) (*F
 	id := FrontDoorWebApplicationFirewallPolicyId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.FrontDoorWebApplicationFirewallPolicyName, ok = parsed.Parsed["frontDoorWebApplicationFirewallPolicyName"]; !ok {
-		return nil, fmt.Errorf("the segment 'frontDoorWebApplicationFirewallPolicyName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "frontDoorWebApplicationFirewallPolicyName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2020-05-01/frontdoors/id_frontdoor.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2020-05-01/frontdoors/id_frontdoor.go
@@ -40,15 +40,15 @@ func ParseFrontDoorID(input string) (*FrontDoorId, error) {
 	id := FrontDoorId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.FrontDoorName, ok = parsed.Parsed["frontDoorName"]; !ok {
-		return nil, fmt.Errorf("the segment 'frontDoorName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "frontDoorName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseFrontDoorIDInsensitively(input string) (*FrontDoorId, error) {
 	id := FrontDoorId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.FrontDoorName, ok = parsed.Parsed["frontDoorName"]; !ok {
-		return nil, fmt.Errorf("the segment 'frontDoorName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "frontDoorName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2020-05-01/frontdoors/id_frontendendpoint.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2020-05-01/frontdoors/id_frontendendpoint.go
@@ -42,19 +42,19 @@ func ParseFrontendEndpointID(input string) (*FrontendEndpointId, error) {
 	id := FrontendEndpointId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.FrontDoorName, ok = parsed.Parsed["frontDoorName"]; !ok {
-		return nil, fmt.Errorf("the segment 'frontDoorName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "frontDoorName", *parsed)
 	}
 
 	if id.FrontendEndpointName, ok = parsed.Parsed["frontendEndpointName"]; !ok {
-		return nil, fmt.Errorf("the segment 'frontendEndpointName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "frontendEndpointName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseFrontendEndpointIDInsensitively(input string) (*FrontendEndpointId, er
 	id := FrontendEndpointId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.FrontDoorName, ok = parsed.Parsed["frontDoorName"]; !ok {
-		return nil, fmt.Errorf("the segment 'frontDoorName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "frontDoorName", *parsed)
 	}
 
 	if id.FrontendEndpointName, ok = parsed.Parsed["frontendEndpointName"]; !ok {
-		return nil, fmt.Errorf("the segment 'frontendEndpointName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "frontendEndpointName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2020-05-01/frontdoors/id_rulesengine.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2020-05-01/frontdoors/id_rulesengine.go
@@ -42,19 +42,19 @@ func ParseRulesEngineID(input string) (*RulesEngineId, error) {
 	id := RulesEngineId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.FrontDoorName, ok = parsed.Parsed["frontDoorName"]; !ok {
-		return nil, fmt.Errorf("the segment 'frontDoorName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "frontDoorName", *parsed)
 	}
 
 	if id.RulesEngineName, ok = parsed.Parsed["rulesEngineName"]; !ok {
-		return nil, fmt.Errorf("the segment 'rulesEngineName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "rulesEngineName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseRulesEngineIDInsensitively(input string) (*RulesEngineId, error) {
 	id := RulesEngineId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.FrontDoorName, ok = parsed.Parsed["frontDoorName"]; !ok {
-		return nil, fmt.Errorf("the segment 'frontDoorName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "frontDoorName", *parsed)
 	}
 
 	if id.RulesEngineName, ok = parsed.Parsed["rulesEngineName"]; !ok {
-		return nil, fmt.Errorf("the segment 'rulesEngineName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "rulesEngineName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hardwaresecuritymodules/2021-11-30/dedicatedhsms/id_dedicatedhsm.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hardwaresecuritymodules/2021-11-30/dedicatedhsms/id_dedicatedhsm.go
@@ -40,15 +40,15 @@ func ParseDedicatedHSMID(input string) (*DedicatedHSMId, error) {
 	id := DedicatedHSMId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DedicatedHSMName, ok = parsed.Parsed["dedicatedHSMName"]; !ok {
-		return nil, fmt.Errorf("the segment 'dedicatedHSMName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "dedicatedHSMName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseDedicatedHSMIDInsensitively(input string) (*DedicatedHSMId, error) {
 	id := DedicatedHSMId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DedicatedHSMName, ok = parsed.Parsed["dedicatedHSMName"]; !ok {
-		return nil, fmt.Errorf("the segment 'dedicatedHSMName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "dedicatedHSMName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/healthbot/2022-08-08/healthbots/id_healthbot.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/healthbot/2022-08-08/healthbots/id_healthbot.go
@@ -40,15 +40,15 @@ func ParseHealthBotID(input string) (*HealthBotId, error) {
 	id := HealthBotId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.HealthBotName, ok = parsed.Parsed["healthBotName"]; !ok {
-		return nil, fmt.Errorf("the segment 'healthBotName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "healthBotName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseHealthBotIDInsensitively(input string) (*HealthBotId, error) {
 	id := HealthBotId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.HealthBotName, ok = parsed.Parsed["healthBotName"]; !ok {
-		return nil, fmt.Errorf("the segment 'healthBotName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "healthBotName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/healthcareapis/2022-12-01/dicomservices/id_dicomservice.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/healthcareapis/2022-12-01/dicomservices/id_dicomservice.go
@@ -42,19 +42,19 @@ func ParseDicomServiceID(input string) (*DicomServiceId, error) {
 	id := DicomServiceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	if id.DicomServiceName, ok = parsed.Parsed["dicomServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'dicomServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "dicomServiceName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseDicomServiceIDInsensitively(input string) (*DicomServiceId, error) {
 	id := DicomServiceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	if id.DicomServiceName, ok = parsed.Parsed["dicomServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'dicomServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "dicomServiceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/healthcareapis/2022-12-01/dicomservices/id_workspace.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/healthcareapis/2022-12-01/dicomservices/id_workspace.go
@@ -40,15 +40,15 @@ func ParseWorkspaceID(input string) (*WorkspaceId, error) {
 	id := WorkspaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseWorkspaceIDInsensitively(input string) (*WorkspaceId, error) {
 	id := WorkspaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/healthcareapis/2022-12-01/fhirservices/id_fhirservice.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/healthcareapis/2022-12-01/fhirservices/id_fhirservice.go
@@ -42,19 +42,19 @@ func ParseFhirServiceID(input string) (*FhirServiceId, error) {
 	id := FhirServiceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	if id.FhirServiceName, ok = parsed.Parsed["fhirServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'fhirServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "fhirServiceName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseFhirServiceIDInsensitively(input string) (*FhirServiceId, error) {
 	id := FhirServiceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	if id.FhirServiceName, ok = parsed.Parsed["fhirServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'fhirServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "fhirServiceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/healthcareapis/2022-12-01/fhirservices/id_workspace.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/healthcareapis/2022-12-01/fhirservices/id_workspace.go
@@ -40,15 +40,15 @@ func ParseWorkspaceID(input string) (*WorkspaceId, error) {
 	id := WorkspaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseWorkspaceIDInsensitively(input string) (*WorkspaceId, error) {
 	id := WorkspaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/healthcareapis/2022-12-01/iotconnectors/id_fhirdestination.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/healthcareapis/2022-12-01/iotconnectors/id_fhirdestination.go
@@ -44,23 +44,23 @@ func ParseFhirDestinationID(input string) (*FhirDestinationId, error) {
 	id := FhirDestinationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	if id.IotConnectorName, ok = parsed.Parsed["iotConnectorName"]; !ok {
-		return nil, fmt.Errorf("the segment 'iotConnectorName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "iotConnectorName", *parsed)
 	}
 
 	if id.FhirDestinationName, ok = parsed.Parsed["fhirDestinationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'fhirDestinationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "fhirDestinationName", *parsed)
 	}
 
 	return &id, nil
@@ -79,23 +79,23 @@ func ParseFhirDestinationIDInsensitively(input string) (*FhirDestinationId, erro
 	id := FhirDestinationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	if id.IotConnectorName, ok = parsed.Parsed["iotConnectorName"]; !ok {
-		return nil, fmt.Errorf("the segment 'iotConnectorName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "iotConnectorName", *parsed)
 	}
 
 	if id.FhirDestinationName, ok = parsed.Parsed["fhirDestinationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'fhirDestinationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "fhirDestinationName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/healthcareapis/2022-12-01/iotconnectors/id_iotconnector.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/healthcareapis/2022-12-01/iotconnectors/id_iotconnector.go
@@ -42,19 +42,19 @@ func ParseIotConnectorID(input string) (*IotConnectorId, error) {
 	id := IotConnectorId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	if id.IotConnectorName, ok = parsed.Parsed["iotConnectorName"]; !ok {
-		return nil, fmt.Errorf("the segment 'iotConnectorName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "iotConnectorName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseIotConnectorIDInsensitively(input string) (*IotConnectorId, error) {
 	id := IotConnectorId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	if id.IotConnectorName, ok = parsed.Parsed["iotConnectorName"]; !ok {
-		return nil, fmt.Errorf("the segment 'iotConnectorName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "iotConnectorName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/healthcareapis/2022-12-01/iotconnectors/id_workspace.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/healthcareapis/2022-12-01/iotconnectors/id_workspace.go
@@ -40,15 +40,15 @@ func ParseWorkspaceID(input string) (*WorkspaceId, error) {
 	id := WorkspaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseWorkspaceIDInsensitively(input string) (*WorkspaceId, error) {
 	id := WorkspaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/healthcareapis/2022-12-01/resource/id_service.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/healthcareapis/2022-12-01/resource/id_service.go
@@ -40,15 +40,15 @@ func ParseServiceID(input string) (*ServiceId, error) {
 	id := ServiceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServiceName, ok = parsed.Parsed["serviceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'serviceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serviceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseServiceIDInsensitively(input string) (*ServiceId, error) {
 	id := ServiceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServiceName, ok = parsed.Parsed["serviceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'serviceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serviceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/healthcareapis/2022-12-01/workspaces/id_workspace.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/healthcareapis/2022-12-01/workspaces/id_workspace.go
@@ -40,15 +40,15 @@ func ParseWorkspaceID(input string) (*WorkspaceId, error) {
 	id := WorkspaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseWorkspaceIDInsensitively(input string) (*WorkspaceId, error) {
 	id := WorkspaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/machineextensions/id_extension.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/machineextensions/id_extension.go
@@ -42,19 +42,19 @@ func ParseExtensionID(input string) (*ExtensionId, error) {
 	id := ExtensionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MachineName, ok = parsed.Parsed["machineName"]; !ok {
-		return nil, fmt.Errorf("the segment 'machineName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "machineName", *parsed)
 	}
 
 	if id.ExtensionName, ok = parsed.Parsed["extensionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'extensionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "extensionName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseExtensionIDInsensitively(input string) (*ExtensionId, error) {
 	id := ExtensionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MachineName, ok = parsed.Parsed["machineName"]; !ok {
-		return nil, fmt.Errorf("the segment 'machineName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "machineName", *parsed)
 	}
 
 	if id.ExtensionName, ok = parsed.Parsed["extensionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'extensionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "extensionName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/machineextensions/id_machine.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/machineextensions/id_machine.go
@@ -40,15 +40,15 @@ func ParseMachineID(input string) (*MachineId, error) {
 	id := MachineId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MachineName, ok = parsed.Parsed["machineName"]; !ok {
-		return nil, fmt.Errorf("the segment 'machineName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "machineName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseMachineIDInsensitively(input string) (*MachineId, error) {
 	id := MachineId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MachineName, ok = parsed.Parsed["machineName"]; !ok {
-		return nil, fmt.Errorf("the segment 'machineName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "machineName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/machines/id_machine.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/machines/id_machine.go
@@ -40,15 +40,15 @@ func ParseMachineID(input string) (*MachineId, error) {
 	id := MachineId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MachineName, ok = parsed.Parsed["machineName"]; !ok {
-		return nil, fmt.Errorf("the segment 'machineName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "machineName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseMachineIDInsensitively(input string) (*MachineId, error) {
 	id := MachineId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MachineName, ok = parsed.Parsed["machineName"]; !ok {
-		return nil, fmt.Errorf("the segment 'machineName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "machineName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/privateendpointconnections/id_privateendpointconnection.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/privateendpointconnections/id_privateendpointconnection.go
@@ -42,19 +42,19 @@ func ParsePrivateEndpointConnectionID(input string) (*PrivateEndpointConnectionI
 	id := PrivateEndpointConnectionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.PrivateLinkScopeName, ok = parsed.Parsed["privateLinkScopeName"]; !ok {
-		return nil, fmt.Errorf("the segment 'privateLinkScopeName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "privateLinkScopeName", *parsed)
 	}
 
 	if id.PrivateEndpointConnectionName, ok = parsed.Parsed["privateEndpointConnectionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'privateEndpointConnectionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "privateEndpointConnectionName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParsePrivateEndpointConnectionIDInsensitively(input string) (*PrivateEndpoi
 	id := PrivateEndpointConnectionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.PrivateLinkScopeName, ok = parsed.Parsed["privateLinkScopeName"]; !ok {
-		return nil, fmt.Errorf("the segment 'privateLinkScopeName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "privateLinkScopeName", *parsed)
 	}
 
 	if id.PrivateEndpointConnectionName, ok = parsed.Parsed["privateEndpointConnectionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'privateEndpointConnectionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "privateEndpointConnectionName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/privateendpointconnections/id_providerprivatelinkscope.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/privateendpointconnections/id_providerprivatelinkscope.go
@@ -40,15 +40,15 @@ func ParseProviderPrivateLinkScopeID(input string) (*ProviderPrivateLinkScopeId,
 	id := ProviderPrivateLinkScopeId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.PrivateLinkScopeName, ok = parsed.Parsed["privateLinkScopeName"]; !ok {
-		return nil, fmt.Errorf("the segment 'privateLinkScopeName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "privateLinkScopeName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseProviderPrivateLinkScopeIDInsensitively(input string) (*ProviderPrivat
 	id := ProviderPrivateLinkScopeId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.PrivateLinkScopeName, ok = parsed.Parsed["privateLinkScopeName"]; !ok {
-		return nil, fmt.Errorf("the segment 'privateLinkScopeName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "privateLinkScopeName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hybridkubernetes/2021-10-01/connectedclusters/id_connectedcluster.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hybridkubernetes/2021-10-01/connectedclusters/id_connectedcluster.go
@@ -40,15 +40,15 @@ func ParseConnectedClusterID(input string) (*ConnectedClusterId, error) {
 	id := ConnectedClusterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ConnectedClusterName, ok = parsed.Parsed["connectedClusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'connectedClusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "connectedClusterName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseConnectedClusterIDInsensitively(input string) (*ConnectedClusterId, er
 	id := ConnectedClusterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ConnectedClusterName, ok = parsed.Parsed["connectedClusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'connectedClusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "connectedClusterName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2015-04-01/autoscalesettings/id_autoscalesetting.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2015-04-01/autoscalesettings/id_autoscalesetting.go
@@ -40,15 +40,15 @@ func ParseAutoScaleSettingID(input string) (*AutoScaleSettingId, error) {
 	id := AutoScaleSettingId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutoScaleSettingName, ok = parsed.Parsed["autoScaleSettingName"]; !ok {
-		return nil, fmt.Errorf("the segment 'autoScaleSettingName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "autoScaleSettingName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseAutoScaleSettingIDInsensitively(input string) (*AutoScaleSettingId, er
 	id := AutoScaleSettingId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AutoScaleSettingName, ok = parsed.Parsed["autoScaleSettingName"]; !ok {
-		return nil, fmt.Errorf("the segment 'autoScaleSettingName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "autoScaleSettingName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2016-03-01/logprofiles/id_logprofile.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2016-03-01/logprofiles/id_logprofile.go
@@ -38,11 +38,11 @@ func ParseLogProfileID(input string) (*LogProfileId, error) {
 	id := LogProfileId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.LogProfileName, ok = parsed.Parsed["logProfileName"]; !ok {
-		return nil, fmt.Errorf("the segment 'logProfileName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "logProfileName", *parsed)
 	}
 
 	return &id, nil
@@ -61,11 +61,11 @@ func ParseLogProfileIDInsensitively(input string) (*LogProfileId, error) {
 	id := LogProfileId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.LogProfileName, ok = parsed.Parsed["logProfileName"]; !ok {
-		return nil, fmt.Errorf("the segment 'logProfileName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "logProfileName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2018-03-01/metricalerts/id_metricalert.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2018-03-01/metricalerts/id_metricalert.go
@@ -40,15 +40,15 @@ func ParseMetricAlertID(input string) (*MetricAlertId, error) {
 	id := MetricAlertId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MetricAlertName, ok = parsed.Parsed["metricAlertName"]; !ok {
-		return nil, fmt.Errorf("the segment 'metricAlertName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "metricAlertName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseMetricAlertIDInsensitively(input string) (*MetricAlertId, error) {
 	id := MetricAlertId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MetricAlertName, ok = parsed.Parsed["metricAlertName"]; !ok {
-		return nil, fmt.Errorf("the segment 'metricAlertName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "metricAlertName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2018-04-16/scheduledqueryrules/id_scheduledqueryrule.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2018-04-16/scheduledqueryrules/id_scheduledqueryrule.go
@@ -40,15 +40,15 @@ func ParseScheduledQueryRuleID(input string) (*ScheduledQueryRuleId, error) {
 	id := ScheduledQueryRuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ScheduledQueryRuleName, ok = parsed.Parsed["scheduledQueryRuleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'scheduledQueryRuleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "scheduledQueryRuleName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseScheduledQueryRuleIDInsensitively(input string) (*ScheduledQueryRuleId
 	id := ScheduledQueryRuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ScheduledQueryRuleName, ok = parsed.Parsed["scheduledQueryRuleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'scheduledQueryRuleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "scheduledQueryRuleName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2019-10-17-preview/privatelinkscopedresources/id_privatelinkscope.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2019-10-17-preview/privatelinkscopedresources/id_privatelinkscope.go
@@ -40,15 +40,15 @@ func ParsePrivateLinkScopeID(input string) (*PrivateLinkScopeId, error) {
 	id := PrivateLinkScopeId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.PrivateLinkScopeName, ok = parsed.Parsed["privateLinkScopeName"]; !ok {
-		return nil, fmt.Errorf("the segment 'privateLinkScopeName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "privateLinkScopeName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParsePrivateLinkScopeIDInsensitively(input string) (*PrivateLinkScopeId, er
 	id := PrivateLinkScopeId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.PrivateLinkScopeName, ok = parsed.Parsed["privateLinkScopeName"]; !ok {
-		return nil, fmt.Errorf("the segment 'privateLinkScopeName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "privateLinkScopeName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2019-10-17-preview/privatelinkscopedresources/id_scopedresource.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2019-10-17-preview/privatelinkscopedresources/id_scopedresource.go
@@ -42,19 +42,19 @@ func ParseScopedResourceID(input string) (*ScopedResourceId, error) {
 	id := ScopedResourceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.PrivateLinkScopeName, ok = parsed.Parsed["privateLinkScopeName"]; !ok {
-		return nil, fmt.Errorf("the segment 'privateLinkScopeName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "privateLinkScopeName", *parsed)
 	}
 
 	if id.ScopedResourceName, ok = parsed.Parsed["scopedResourceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'scopedResourceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "scopedResourceName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseScopedResourceIDInsensitively(input string) (*ScopedResourceId, error)
 	id := ScopedResourceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.PrivateLinkScopeName, ok = parsed.Parsed["privateLinkScopeName"]; !ok {
-		return nil, fmt.Errorf("the segment 'privateLinkScopeName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "privateLinkScopeName", *parsed)
 	}
 
 	if id.ScopedResourceName, ok = parsed.Parsed["scopedResourceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'scopedResourceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "scopedResourceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2019-10-17-preview/privatelinkscopesapis/id_privatelinkscope.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2019-10-17-preview/privatelinkscopesapis/id_privatelinkscope.go
@@ -40,15 +40,15 @@ func ParsePrivateLinkScopeID(input string) (*PrivateLinkScopeId, error) {
 	id := PrivateLinkScopeId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.PrivateLinkScopeName, ok = parsed.Parsed["privateLinkScopeName"]; !ok {
-		return nil, fmt.Errorf("the segment 'privateLinkScopeName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "privateLinkScopeName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParsePrivateLinkScopeIDInsensitively(input string) (*PrivateLinkScopeId, er
 	id := PrivateLinkScopeId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.PrivateLinkScopeName, ok = parsed.Parsed["privateLinkScopeName"]; !ok {
-		return nil, fmt.Errorf("the segment 'privateLinkScopeName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "privateLinkScopeName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2020-10-01/activitylogalertsapis/id_activitylogalert.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2020-10-01/activitylogalertsapis/id_activitylogalert.go
@@ -40,15 +40,15 @@ func ParseActivityLogAlertID(input string) (*ActivityLogAlertId, error) {
 	id := ActivityLogAlertId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ActivityLogAlertName, ok = parsed.Parsed["activityLogAlertName"]; !ok {
-		return nil, fmt.Errorf("the segment 'activityLogAlertName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "activityLogAlertName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseActivityLogAlertIDInsensitively(input string) (*ActivityLogAlertId, er
 	id := ActivityLogAlertId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ActivityLogAlertName, ok = parsed.Parsed["activityLogAlertName"]; !ok {
-		return nil, fmt.Errorf("the segment 'activityLogAlertName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "activityLogAlertName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2021-05-01-preview/diagnosticsettings/id_scopeddiagnosticsetting.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2021-05-01-preview/diagnosticsettings/id_scopeddiagnosticsetting.go
@@ -38,11 +38,11 @@ func ParseScopedDiagnosticSettingID(input string) (*ScopedDiagnosticSettingId, e
 	id := ScopedDiagnosticSettingId{}
 
 	if id.ResourceUri, ok = parsed.Parsed["resourceUri"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceUri' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceUri", *parsed)
 	}
 
 	if id.DiagnosticSettingName, ok = parsed.Parsed["diagnosticSettingName"]; !ok {
-		return nil, fmt.Errorf("the segment 'diagnosticSettingName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "diagnosticSettingName", *parsed)
 	}
 
 	return &id, nil
@@ -61,11 +61,11 @@ func ParseScopedDiagnosticSettingIDInsensitively(input string) (*ScopedDiagnosti
 	id := ScopedDiagnosticSettingId{}
 
 	if id.ResourceUri, ok = parsed.Parsed["resourceUri"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceUri' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceUri", *parsed)
 	}
 
 	if id.DiagnosticSettingName, ok = parsed.Parsed["diagnosticSettingName"]; !ok {
-		return nil, fmt.Errorf("the segment 'diagnosticSettingName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "diagnosticSettingName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2021-05-01-preview/diagnosticsettingscategories/id_scopeddiagnosticsettingscategory.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2021-05-01-preview/diagnosticsettingscategories/id_scopeddiagnosticsettingscategory.go
@@ -38,11 +38,11 @@ func ParseScopedDiagnosticSettingsCategoryID(input string) (*ScopedDiagnosticSet
 	id := ScopedDiagnosticSettingsCategoryId{}
 
 	if id.ResourceUri, ok = parsed.Parsed["resourceUri"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceUri' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceUri", *parsed)
 	}
 
 	if id.DiagnosticSettingsCategoryName, ok = parsed.Parsed["diagnosticSettingsCategoryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'diagnosticSettingsCategoryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "diagnosticSettingsCategoryName", *parsed)
 	}
 
 	return &id, nil
@@ -61,11 +61,11 @@ func ParseScopedDiagnosticSettingsCategoryIDInsensitively(input string) (*Scoped
 	id := ScopedDiagnosticSettingsCategoryId{}
 
 	if id.ResourceUri, ok = parsed.Parsed["resourceUri"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceUri' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceUri", *parsed)
 	}
 
 	if id.DiagnosticSettingsCategoryName, ok = parsed.Parsed["diagnosticSettingsCategoryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'diagnosticSettingsCategoryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "diagnosticSettingsCategoryName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2021-08-01/scheduledqueryrules/id_scheduledqueryrule.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2021-08-01/scheduledqueryrules/id_scheduledqueryrule.go
@@ -40,15 +40,15 @@ func ParseScheduledQueryRuleID(input string) (*ScheduledQueryRuleId, error) {
 	id := ScheduledQueryRuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ScheduledQueryRuleName, ok = parsed.Parsed["scheduledQueryRuleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'scheduledQueryRuleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "scheduledQueryRuleName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseScheduledQueryRuleIDInsensitively(input string) (*ScheduledQueryRuleId
 	id := ScheduledQueryRuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ScheduledQueryRuleName, ok = parsed.Parsed["scheduledQueryRuleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'scheduledQueryRuleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "scheduledQueryRuleName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2021-09-01/actiongroupsapis/id_actiongroup.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2021-09-01/actiongroupsapis/id_actiongroup.go
@@ -40,15 +40,15 @@ func ParseActionGroupID(input string) (*ActionGroupId, error) {
 	id := ActionGroupId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ActionGroupName, ok = parsed.Parsed["actionGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'actionGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "actionGroupName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseActionGroupIDInsensitively(input string) (*ActionGroupId, error) {
 	id := ActionGroupId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ActionGroupName, ok = parsed.Parsed["actionGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'actionGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "actionGroupName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2021-09-01/actiongroupsapis/id_actiongroupnotificationstatus.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2021-09-01/actiongroupsapis/id_actiongroupnotificationstatus.go
@@ -42,19 +42,19 @@ func ParseActionGroupNotificationStatusID(input string) (*ActionGroupNotificatio
 	id := ActionGroupNotificationStatusId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ActionGroupName, ok = parsed.Parsed["actionGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'actionGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "actionGroupName", *parsed)
 	}
 
 	if id.NotificationId, ok = parsed.Parsed["notificationId"]; !ok {
-		return nil, fmt.Errorf("the segment 'notificationId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "notificationId", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseActionGroupNotificationStatusIDInsensitively(input string) (*ActionGro
 	id := ActionGroupNotificationStatusId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ActionGroupName, ok = parsed.Parsed["actionGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'actionGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "actionGroupName", *parsed)
 	}
 
 	if id.NotificationId, ok = parsed.Parsed["notificationId"]; !ok {
-		return nil, fmt.Errorf("the segment 'notificationId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "notificationId", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2021-09-01/actiongroupsapis/id_notificationstatus.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2021-09-01/actiongroupsapis/id_notificationstatus.go
@@ -38,11 +38,11 @@ func ParseNotificationStatusID(input string) (*NotificationStatusId, error) {
 	id := NotificationStatusId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.NotificationId, ok = parsed.Parsed["notificationId"]; !ok {
-		return nil, fmt.Errorf("the segment 'notificationId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "notificationId", *parsed)
 	}
 
 	return &id, nil
@@ -61,11 +61,11 @@ func ParseNotificationStatusIDInsensitively(input string) (*NotificationStatusId
 	id := NotificationStatusId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.NotificationId, ok = parsed.Parsed["notificationId"]; !ok {
-		return nil, fmt.Errorf("the segment 'notificationId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "notificationId", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2021-09-01/actiongroupsapis/id_providernotificationstatus.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2021-09-01/actiongroupsapis/id_providernotificationstatus.go
@@ -40,15 +40,15 @@ func ParseProviderNotificationStatusID(input string) (*ProviderNotificationStatu
 	id := ProviderNotificationStatusId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NotificationId, ok = parsed.Parsed["notificationId"]; !ok {
-		return nil, fmt.Errorf("the segment 'notificationId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "notificationId", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseProviderNotificationStatusIDInsensitively(input string) (*ProviderNoti
 	id := ProviderNotificationStatusId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NotificationId, ok = parsed.Parsed["notificationId"]; !ok {
-		return nil, fmt.Errorf("the segment 'notificationId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "notificationId", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2022-06-01/datacollectionendpoints/id_datacollectionendpoint.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2022-06-01/datacollectionendpoints/id_datacollectionendpoint.go
@@ -40,15 +40,15 @@ func ParseDataCollectionEndpointID(input string) (*DataCollectionEndpointId, err
 	id := DataCollectionEndpointId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DataCollectionEndpointName, ok = parsed.Parsed["dataCollectionEndpointName"]; !ok {
-		return nil, fmt.Errorf("the segment 'dataCollectionEndpointName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "dataCollectionEndpointName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseDataCollectionEndpointIDInsensitively(input string) (*DataCollectionEn
 	id := DataCollectionEndpointId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DataCollectionEndpointName, ok = parsed.Parsed["dataCollectionEndpointName"]; !ok {
-		return nil, fmt.Errorf("the segment 'dataCollectionEndpointName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "dataCollectionEndpointName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2022-06-01/datacollectionruleassociations/id_datacollectionendpoint.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2022-06-01/datacollectionruleassociations/id_datacollectionendpoint.go
@@ -40,15 +40,15 @@ func ParseDataCollectionEndpointID(input string) (*DataCollectionEndpointId, err
 	id := DataCollectionEndpointId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DataCollectionEndpointName, ok = parsed.Parsed["dataCollectionEndpointName"]; !ok {
-		return nil, fmt.Errorf("the segment 'dataCollectionEndpointName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "dataCollectionEndpointName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseDataCollectionEndpointIDInsensitively(input string) (*DataCollectionEn
 	id := DataCollectionEndpointId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DataCollectionEndpointName, ok = parsed.Parsed["dataCollectionEndpointName"]; !ok {
-		return nil, fmt.Errorf("the segment 'dataCollectionEndpointName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "dataCollectionEndpointName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2022-06-01/datacollectionruleassociations/id_datacollectionrule.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2022-06-01/datacollectionruleassociations/id_datacollectionrule.go
@@ -40,15 +40,15 @@ func ParseDataCollectionRuleID(input string) (*DataCollectionRuleId, error) {
 	id := DataCollectionRuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DataCollectionRuleName, ok = parsed.Parsed["dataCollectionRuleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'dataCollectionRuleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "dataCollectionRuleName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseDataCollectionRuleIDInsensitively(input string) (*DataCollectionRuleId
 	id := DataCollectionRuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DataCollectionRuleName, ok = parsed.Parsed["dataCollectionRuleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'dataCollectionRuleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "dataCollectionRuleName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2022-06-01/datacollectionruleassociations/id_scopeddatacollectionruleassociation.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2022-06-01/datacollectionruleassociations/id_scopeddatacollectionruleassociation.go
@@ -38,11 +38,11 @@ func ParseScopedDataCollectionRuleAssociationID(input string) (*ScopedDataCollec
 	id := ScopedDataCollectionRuleAssociationId{}
 
 	if id.ResourceUri, ok = parsed.Parsed["resourceUri"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceUri' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceUri", *parsed)
 	}
 
 	if id.DataCollectionRuleAssociationName, ok = parsed.Parsed["dataCollectionRuleAssociationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'dataCollectionRuleAssociationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "dataCollectionRuleAssociationName", *parsed)
 	}
 
 	return &id, nil
@@ -61,11 +61,11 @@ func ParseScopedDataCollectionRuleAssociationIDInsensitively(input string) (*Sco
 	id := ScopedDataCollectionRuleAssociationId{}
 
 	if id.ResourceUri, ok = parsed.Parsed["resourceUri"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceUri' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceUri", *parsed)
 	}
 
 	if id.DataCollectionRuleAssociationName, ok = parsed.Parsed["dataCollectionRuleAssociationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'dataCollectionRuleAssociationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "dataCollectionRuleAssociationName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2022-06-01/datacollectionrules/id_datacollectionrule.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2022-06-01/datacollectionrules/id_datacollectionrule.go
@@ -40,15 +40,15 @@ func ParseDataCollectionRuleID(input string) (*DataCollectionRuleId, error) {
 	id := DataCollectionRuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DataCollectionRuleName, ok = parsed.Parsed["dataCollectionRuleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'dataCollectionRuleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "dataCollectionRuleName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseDataCollectionRuleIDInsensitively(input string) (*DataCollectionRuleId
 	id := DataCollectionRuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DataCollectionRuleName, ok = parsed.Parsed["dataCollectionRuleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'dataCollectionRuleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "dataCollectionRuleName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2023-04-03/azuremonitorworkspaces/id_account.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2023-04-03/azuremonitorworkspaces/id_account.go
@@ -40,15 +40,15 @@ func ParseAccountID(input string) (*AccountId, error) {
 	id := AccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AccountName, ok = parsed.Parsed["accountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'accountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "accountName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseAccountIDInsensitively(input string) (*AccountId, error) {
 	id := AccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AccountName, ok = parsed.Parsed["accountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'accountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "accountName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/iotcentral/2021-11-01-preview/apps/id_iotapp.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/iotcentral/2021-11-01-preview/apps/id_iotapp.go
@@ -40,15 +40,15 @@ func ParseIotAppID(input string) (*IotAppId, error) {
 	id := IotAppId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.IotAppName, ok = parsed.Parsed["iotAppName"]; !ok {
-		return nil, fmt.Errorf("the segment 'iotAppName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "iotAppName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseIotAppIDInsensitively(input string) (*IotAppId, error) {
 	id := IotAppId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.IotAppName, ok = parsed.Parsed["iotAppName"]; !ok {
-		return nil, fmt.Errorf("the segment 'iotAppName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "iotAppName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2021-10-01/managedhsms/id_deletedmanagedhsm.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2021-10-01/managedhsms/id_deletedmanagedhsm.go
@@ -40,15 +40,15 @@ func ParseDeletedManagedHSMID(input string) (*DeletedManagedHSMId, error) {
 	id := DeletedManagedHSMId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.LocationName, ok = parsed.Parsed["locationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'locationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "locationName", *parsed)
 	}
 
 	if id.DeletedManagedHSMName, ok = parsed.Parsed["deletedManagedHSMName"]; !ok {
-		return nil, fmt.Errorf("the segment 'deletedManagedHSMName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "deletedManagedHSMName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseDeletedManagedHSMIDInsensitively(input string) (*DeletedManagedHSMId, 
 	id := DeletedManagedHSMId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.LocationName, ok = parsed.Parsed["locationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'locationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "locationName", *parsed)
 	}
 
 	if id.DeletedManagedHSMName, ok = parsed.Parsed["deletedManagedHSMName"]; !ok {
-		return nil, fmt.Errorf("the segment 'deletedManagedHSMName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "deletedManagedHSMName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2021-10-01/managedhsms/id_managedhsm.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2021-10-01/managedhsms/id_managedhsm.go
@@ -40,15 +40,15 @@ func ParseManagedHSMID(input string) (*ManagedHSMId, error) {
 	id := ManagedHSMId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ManagedHSMName, ok = parsed.Parsed["managedHSMName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedHSMName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedHSMName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseManagedHSMIDInsensitively(input string) (*ManagedHSMId, error) {
 	id := ManagedHSMId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ManagedHSMName, ok = parsed.Parsed["managedHSMName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedHSMName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedHSMName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2021-10-01/vaults/id_deletedvault.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2021-10-01/vaults/id_deletedvault.go
@@ -40,15 +40,15 @@ func ParseDeletedVaultID(input string) (*DeletedVaultId, error) {
 	id := DeletedVaultId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.LocationName, ok = parsed.Parsed["locationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'locationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "locationName", *parsed)
 	}
 
 	if id.DeletedVaultName, ok = parsed.Parsed["deletedVaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'deletedVaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "deletedVaultName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseDeletedVaultIDInsensitively(input string) (*DeletedVaultId, error) {
 	id := DeletedVaultId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.LocationName, ok = parsed.Parsed["locationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'locationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "locationName", *parsed)
 	}
 
 	if id.DeletedVaultName, ok = parsed.Parsed["deletedVaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'deletedVaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "deletedVaultName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2021-10-01/vaults/id_operationkind.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2021-10-01/vaults/id_operationkind.go
@@ -42,20 +42,20 @@ func ParseOperationKindID(input string) (*OperationKindId, error) {
 	id := OperationKindId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "vaultName", *parsed)
 	}
 
 	if v, ok := parsed.Parsed["operationKind"]; true {
 		if !ok {
-			return nil, fmt.Errorf("the segment 'operationKind' was not found in the resource id %q", input)
+			return nil, resourceids.NewSegmentNotSpecifiedError(id, "operationKind", *parsed)
 		}
 
 		operationKind, err := parseAccessPolicyUpdateKind(v)
@@ -81,20 +81,20 @@ func ParseOperationKindIDInsensitively(input string) (*OperationKindId, error) {
 	id := OperationKindId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "vaultName", *parsed)
 	}
 
 	if v, ok := parsed.Parsed["operationKind"]; true {
 		if !ok {
-			return nil, fmt.Errorf("the segment 'operationKind' was not found in the resource id %q", input)
+			return nil, resourceids.NewSegmentNotSpecifiedError(id, "operationKind", *parsed)
 		}
 
 		operationKind, err := parseAccessPolicyUpdateKind(v)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2022-11-01/extensions/id_extension.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2022-11-01/extensions/id_extension.go
@@ -46,27 +46,27 @@ func ParseExtensionID(input string) (*ExtensionId, error) {
 	id := ExtensionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ProviderName, ok = parsed.Parsed["providerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'providerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "providerName", *parsed)
 	}
 
 	if id.ClusterResourceName, ok = parsed.Parsed["clusterResourceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterResourceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterResourceName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	if id.ExtensionName, ok = parsed.Parsed["extensionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'extensionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "extensionName", *parsed)
 	}
 
 	return &id, nil
@@ -85,27 +85,27 @@ func ParseExtensionIDInsensitively(input string) (*ExtensionId, error) {
 	id := ExtensionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ProviderName, ok = parsed.Parsed["providerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'providerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "providerName", *parsed)
 	}
 
 	if id.ClusterResourceName, ok = parsed.Parsed["clusterResourceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterResourceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterResourceName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	if id.ExtensionName, ok = parsed.Parsed["extensionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'extensionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "extensionName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2022-11-01/extensions/id_provider.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2022-11-01/extensions/id_provider.go
@@ -44,23 +44,23 @@ func ParseProviderID(input string) (*ProviderId, error) {
 	id := ProviderId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ProviderName, ok = parsed.Parsed["providerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'providerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "providerName", *parsed)
 	}
 
 	if id.ClusterResourceName, ok = parsed.Parsed["clusterResourceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterResourceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterResourceName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	return &id, nil
@@ -79,23 +79,23 @@ func ParseProviderIDInsensitively(input string) (*ProviderId, error) {
 	id := ProviderId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ProviderName, ok = parsed.Parsed["providerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'providerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "providerName", *parsed)
 	}
 
 	if id.ClusterResourceName, ok = parsed.Parsed["clusterResourceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterResourceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterResourceName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2022-02-01/attacheddatabaseconfigurations/id_attacheddatabaseconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2022-02-01/attacheddatabaseconfigurations/id_attacheddatabaseconfiguration.go
@@ -42,19 +42,19 @@ func ParseAttachedDatabaseConfigurationID(input string) (*AttachedDatabaseConfig
 	id := AttachedDatabaseConfigurationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	if id.AttachedDatabaseConfigurationName, ok = parsed.Parsed["attachedDatabaseConfigurationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'attachedDatabaseConfigurationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "attachedDatabaseConfigurationName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseAttachedDatabaseConfigurationIDInsensitively(input string) (*AttachedD
 	id := AttachedDatabaseConfigurationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	if id.AttachedDatabaseConfigurationName, ok = parsed.Parsed["attachedDatabaseConfigurationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'attachedDatabaseConfigurationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "attachedDatabaseConfigurationName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2022-02-01/attacheddatabaseconfigurations/id_cluster.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2022-02-01/attacheddatabaseconfigurations/id_cluster.go
@@ -40,15 +40,15 @@ func ParseClusterID(input string) (*ClusterId, error) {
 	id := ClusterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseClusterIDInsensitively(input string) (*ClusterId, error) {
 	id := ClusterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2022-02-01/clusterprincipalassignments/id_cluster.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2022-02-01/clusterprincipalassignments/id_cluster.go
@@ -40,15 +40,15 @@ func ParseClusterID(input string) (*ClusterId, error) {
 	id := ClusterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseClusterIDInsensitively(input string) (*ClusterId, error) {
 	id := ClusterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2022-02-01/clusterprincipalassignments/id_principalassignment.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2022-02-01/clusterprincipalassignments/id_principalassignment.go
@@ -42,19 +42,19 @@ func ParsePrincipalAssignmentID(input string) (*PrincipalAssignmentId, error) {
 	id := PrincipalAssignmentId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	if id.PrincipalAssignmentName, ok = parsed.Parsed["principalAssignmentName"]; !ok {
-		return nil, fmt.Errorf("the segment 'principalAssignmentName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "principalAssignmentName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParsePrincipalAssignmentIDInsensitively(input string) (*PrincipalAssignment
 	id := PrincipalAssignmentId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	if id.PrincipalAssignmentName, ok = parsed.Parsed["principalAssignmentName"]; !ok {
-		return nil, fmt.Errorf("the segment 'principalAssignmentName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "principalAssignmentName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2022-02-01/clusters/id_cluster.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2022-02-01/clusters/id_cluster.go
@@ -40,15 +40,15 @@ func ParseClusterID(input string) (*ClusterId, error) {
 	id := ClusterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseClusterIDInsensitively(input string) (*ClusterId, error) {
 	id := ClusterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2022-02-01/clusters/id_location.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2022-02-01/clusters/id_location.go
@@ -38,11 +38,11 @@ func ParseLocationID(input string) (*LocationId, error) {
 	id := LocationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.LocationName, ok = parsed.Parsed["locationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'locationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "locationName", *parsed)
 	}
 
 	return &id, nil
@@ -61,11 +61,11 @@ func ParseLocationIDInsensitively(input string) (*LocationId, error) {
 	id := LocationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.LocationName, ok = parsed.Parsed["locationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'locationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "locationName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2022-02-01/databaseprincipalassignments/id_database.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2022-02-01/databaseprincipalassignments/id_database.go
@@ -42,19 +42,19 @@ func ParseDatabaseID(input string) (*DatabaseId, error) {
 	id := DatabaseId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	if id.DatabaseName, ok = parsed.Parsed["databaseName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseDatabaseIDInsensitively(input string) (*DatabaseId, error) {
 	id := DatabaseId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	if id.DatabaseName, ok = parsed.Parsed["databaseName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2022-02-01/databaseprincipalassignments/id_databaseprincipalassignment.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2022-02-01/databaseprincipalassignments/id_databaseprincipalassignment.go
@@ -44,23 +44,23 @@ func ParseDatabasePrincipalAssignmentID(input string) (*DatabasePrincipalAssignm
 	id := DatabasePrincipalAssignmentId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	if id.DatabaseName, ok = parsed.Parsed["databaseName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseName", *parsed)
 	}
 
 	if id.PrincipalAssignmentName, ok = parsed.Parsed["principalAssignmentName"]; !ok {
-		return nil, fmt.Errorf("the segment 'principalAssignmentName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "principalAssignmentName", *parsed)
 	}
 
 	return &id, nil
@@ -79,23 +79,23 @@ func ParseDatabasePrincipalAssignmentIDInsensitively(input string) (*DatabasePri
 	id := DatabasePrincipalAssignmentId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	if id.DatabaseName, ok = parsed.Parsed["databaseName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseName", *parsed)
 	}
 
 	if id.PrincipalAssignmentName, ok = parsed.Parsed["principalAssignmentName"]; !ok {
-		return nil, fmt.Errorf("the segment 'principalAssignmentName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "principalAssignmentName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2022-02-01/databases/id_cluster.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2022-02-01/databases/id_cluster.go
@@ -40,15 +40,15 @@ func ParseClusterID(input string) (*ClusterId, error) {
 	id := ClusterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseClusterIDInsensitively(input string) (*ClusterId, error) {
 	id := ClusterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2022-02-01/databases/id_database.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2022-02-01/databases/id_database.go
@@ -42,19 +42,19 @@ func ParseDatabaseID(input string) (*DatabaseId, error) {
 	id := DatabaseId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	if id.DatabaseName, ok = parsed.Parsed["databaseName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseDatabaseIDInsensitively(input string) (*DatabaseId, error) {
 	id := DatabaseId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	if id.DatabaseName, ok = parsed.Parsed["databaseName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2022-02-01/dataconnections/id_database.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2022-02-01/dataconnections/id_database.go
@@ -42,19 +42,19 @@ func ParseDatabaseID(input string) (*DatabaseId, error) {
 	id := DatabaseId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	if id.DatabaseName, ok = parsed.Parsed["databaseName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseDatabaseIDInsensitively(input string) (*DatabaseId, error) {
 	id := DatabaseId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	if id.DatabaseName, ok = parsed.Parsed["databaseName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2022-02-01/dataconnections/id_dataconnection.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2022-02-01/dataconnections/id_dataconnection.go
@@ -44,23 +44,23 @@ func ParseDataConnectionID(input string) (*DataConnectionId, error) {
 	id := DataConnectionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	if id.DatabaseName, ok = parsed.Parsed["databaseName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseName", *parsed)
 	}
 
 	if id.DataConnectionName, ok = parsed.Parsed["dataConnectionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'dataConnectionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "dataConnectionName", *parsed)
 	}
 
 	return &id, nil
@@ -79,23 +79,23 @@ func ParseDataConnectionIDInsensitively(input string) (*DataConnectionId, error)
 	id := DataConnectionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	if id.DatabaseName, ok = parsed.Parsed["databaseName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseName", *parsed)
 	}
 
 	if id.DataConnectionName, ok = parsed.Parsed["dataConnectionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'dataConnectionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "dataConnectionName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2022-02-01/managedprivateendpoints/id_cluster.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2022-02-01/managedprivateendpoints/id_cluster.go
@@ -40,15 +40,15 @@ func ParseClusterID(input string) (*ClusterId, error) {
 	id := ClusterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseClusterIDInsensitively(input string) (*ClusterId, error) {
 	id := ClusterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2022-02-01/managedprivateendpoints/id_managedprivateendpoint.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2022-02-01/managedprivateendpoints/id_managedprivateendpoint.go
@@ -42,19 +42,19 @@ func ParseManagedPrivateEndpointID(input string) (*ManagedPrivateEndpointId, err
 	id := ManagedPrivateEndpointId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	if id.ManagedPrivateEndpointName, ok = parsed.Parsed["managedPrivateEndpointName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedPrivateEndpointName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedPrivateEndpointName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseManagedPrivateEndpointIDInsensitively(input string) (*ManagedPrivateEn
 	id := ManagedPrivateEndpointId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	if id.ManagedPrivateEndpointName, ok = parsed.Parsed["managedPrivateEndpointName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedPrivateEndpointName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedPrivateEndpointName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2022-02-01/scripts/id_database.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2022-02-01/scripts/id_database.go
@@ -42,19 +42,19 @@ func ParseDatabaseID(input string) (*DatabaseId, error) {
 	id := DatabaseId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	if id.DatabaseName, ok = parsed.Parsed["databaseName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseDatabaseIDInsensitively(input string) (*DatabaseId, error) {
 	id := DatabaseId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	if id.DatabaseName, ok = parsed.Parsed["databaseName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2022-02-01/scripts/id_script.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2022-02-01/scripts/id_script.go
@@ -44,23 +44,23 @@ func ParseScriptID(input string) (*ScriptId, error) {
 	id := ScriptId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	if id.DatabaseName, ok = parsed.Parsed["databaseName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseName", *parsed)
 	}
 
 	if id.ScriptName, ok = parsed.Parsed["scriptName"]; !ok {
-		return nil, fmt.Errorf("the segment 'scriptName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "scriptName", *parsed)
 	}
 
 	return &id, nil
@@ -79,23 +79,23 @@ func ParseScriptIDInsensitively(input string) (*ScriptId, error) {
 	id := ScriptId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	if id.DatabaseName, ok = parsed.Parsed["databaseName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseName", *parsed)
 	}
 
 	if id.ScriptName, ok = parsed.Parsed["scriptName"]; !ok {
-		return nil, fmt.Errorf("the segment 'scriptName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "scriptName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2022-07-07/clusters/id_cluster.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2022-07-07/clusters/id_cluster.go
@@ -40,15 +40,15 @@ func ParseClusterID(input string) (*ClusterId, error) {
 	id := ClusterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseClusterIDInsensitively(input string) (*ClusterId, error) {
 	id := ClusterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2022-07-07/clusters/id_location.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2022-07-07/clusters/id_location.go
@@ -38,11 +38,11 @@ func ParseLocationID(input string) (*LocationId, error) {
 	id := LocationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.LocationName, ok = parsed.Parsed["locationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'locationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "locationName", *parsed)
 	}
 
 	return &id, nil
@@ -61,11 +61,11 @@ func ParseLocationIDInsensitively(input string) (*LocationId, error) {
 	id := LocationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.LocationName, ok = parsed.Parsed["locationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'locationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "locationName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/labservices/2022-08-01/lab/id_lab.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/labservices/2022-08-01/lab/id_lab.go
@@ -40,15 +40,15 @@ func ParseLabID(input string) (*LabId, error) {
 	id := LabId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.LabName, ok = parsed.Parsed["labName"]; !ok {
-		return nil, fmt.Errorf("the segment 'labName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "labName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseLabIDInsensitively(input string) (*LabId, error) {
 	id := LabId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.LabName, ok = parsed.Parsed["labName"]; !ok {
-		return nil, fmt.Errorf("the segment 'labName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "labName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/labservices/2022-08-01/labplan/id_labplan.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/labservices/2022-08-01/labplan/id_labplan.go
@@ -40,15 +40,15 @@ func ParseLabPlanID(input string) (*LabPlanId, error) {
 	id := LabPlanId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.LabPlanName, ok = parsed.Parsed["labPlanName"]; !ok {
-		return nil, fmt.Errorf("the segment 'labPlanName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "labPlanName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseLabPlanIDInsensitively(input string) (*LabPlanId, error) {
 	id := LabPlanId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.LabPlanName, ok = parsed.Parsed["labPlanName"]; !ok {
-		return nil, fmt.Errorf("the segment 'labPlanName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "labPlanName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/labservices/2022-08-01/schedule/id_lab.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/labservices/2022-08-01/schedule/id_lab.go
@@ -40,15 +40,15 @@ func ParseLabID(input string) (*LabId, error) {
 	id := LabId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.LabName, ok = parsed.Parsed["labName"]; !ok {
-		return nil, fmt.Errorf("the segment 'labName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "labName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseLabIDInsensitively(input string) (*LabId, error) {
 	id := LabId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.LabName, ok = parsed.Parsed["labName"]; !ok {
-		return nil, fmt.Errorf("the segment 'labName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "labName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/labservices/2022-08-01/schedule/id_schedule.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/labservices/2022-08-01/schedule/id_schedule.go
@@ -42,19 +42,19 @@ func ParseScheduleID(input string) (*ScheduleId, error) {
 	id := ScheduleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.LabName, ok = parsed.Parsed["labName"]; !ok {
-		return nil, fmt.Errorf("the segment 'labName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "labName", *parsed)
 	}
 
 	if id.ScheduleName, ok = parsed.Parsed["scheduleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'scheduleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "scheduleName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseScheduleIDInsensitively(input string) (*ScheduleId, error) {
 	id := ScheduleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.LabName, ok = parsed.Parsed["labName"]; !ok {
-		return nil, fmt.Errorf("the segment 'labName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "labName", *parsed)
 	}
 
 	if id.ScheduleName, ok = parsed.Parsed["scheduleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'scheduleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "scheduleName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/labservices/2022-08-01/user/id_lab.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/labservices/2022-08-01/user/id_lab.go
@@ -40,15 +40,15 @@ func ParseLabID(input string) (*LabId, error) {
 	id := LabId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.LabName, ok = parsed.Parsed["labName"]; !ok {
-		return nil, fmt.Errorf("the segment 'labName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "labName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseLabIDInsensitively(input string) (*LabId, error) {
 	id := LabId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.LabName, ok = parsed.Parsed["labName"]; !ok {
-		return nil, fmt.Errorf("the segment 'labName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "labName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/labservices/2022-08-01/user/id_user.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/labservices/2022-08-01/user/id_user.go
@@ -42,19 +42,19 @@ func ParseUserID(input string) (*UserId, error) {
 	id := UserId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.LabName, ok = parsed.Parsed["labName"]; !ok {
-		return nil, fmt.Errorf("the segment 'labName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "labName", *parsed)
 	}
 
 	if id.UserName, ok = parsed.Parsed["userName"]; !ok {
-		return nil, fmt.Errorf("the segment 'userName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "userName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseUserIDInsensitively(input string) (*UserId, error) {
 	id := UserId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.LabName, ok = parsed.Parsed["labName"]; !ok {
-		return nil, fmt.Errorf("the segment 'labName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "labName", *parsed)
 	}
 
 	if id.UserName, ok = parsed.Parsed["userName"]; !ok {
-		return nil, fmt.Errorf("the segment 'userName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "userName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/loadtestservice/2021-12-01-preview/loadtests/id_loadtest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/loadtestservice/2021-12-01-preview/loadtests/id_loadtest.go
@@ -40,15 +40,15 @@ func ParseLoadTestID(input string) (*LoadTestId, error) {
 	id := LoadTestId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.LoadTestName, ok = parsed.Parsed["loadTestName"]; !ok {
-		return nil, fmt.Errorf("the segment 'loadTestName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "loadTestName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseLoadTestIDInsensitively(input string) (*LoadTestId, error) {
 	id := LoadTestId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.LoadTestName, ok = parsed.Parsed["loadTestName"]; !ok {
-		return nil, fmt.Errorf("the segment 'loadTestName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "loadTestName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/integrationaccountagreements/id_agreement.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/integrationaccountagreements/id_agreement.go
@@ -42,19 +42,19 @@ func ParseAgreementID(input string) (*AgreementId, error) {
 	id := AgreementId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.IntegrationAccountName, ok = parsed.Parsed["integrationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'integrationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "integrationAccountName", *parsed)
 	}
 
 	if id.AgreementName, ok = parsed.Parsed["agreementName"]; !ok {
-		return nil, fmt.Errorf("the segment 'agreementName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "agreementName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseAgreementIDInsensitively(input string) (*AgreementId, error) {
 	id := AgreementId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.IntegrationAccountName, ok = parsed.Parsed["integrationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'integrationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "integrationAccountName", *parsed)
 	}
 
 	if id.AgreementName, ok = parsed.Parsed["agreementName"]; !ok {
-		return nil, fmt.Errorf("the segment 'agreementName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "agreementName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/integrationaccountagreements/id_integrationaccount.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/integrationaccountagreements/id_integrationaccount.go
@@ -40,15 +40,15 @@ func ParseIntegrationAccountID(input string) (*IntegrationAccountId, error) {
 	id := IntegrationAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.IntegrationAccountName, ok = parsed.Parsed["integrationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'integrationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "integrationAccountName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseIntegrationAccountIDInsensitively(input string) (*IntegrationAccountId
 	id := IntegrationAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.IntegrationAccountName, ok = parsed.Parsed["integrationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'integrationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "integrationAccountName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/integrationaccountassemblies/id_assembly.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/integrationaccountassemblies/id_assembly.go
@@ -42,19 +42,19 @@ func ParseAssemblyID(input string) (*AssemblyId, error) {
 	id := AssemblyId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.IntegrationAccountName, ok = parsed.Parsed["integrationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'integrationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "integrationAccountName", *parsed)
 	}
 
 	if id.AssemblyName, ok = parsed.Parsed["assemblyName"]; !ok {
-		return nil, fmt.Errorf("the segment 'assemblyName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "assemblyName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseAssemblyIDInsensitively(input string) (*AssemblyId, error) {
 	id := AssemblyId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.IntegrationAccountName, ok = parsed.Parsed["integrationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'integrationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "integrationAccountName", *parsed)
 	}
 
 	if id.AssemblyName, ok = parsed.Parsed["assemblyName"]; !ok {
-		return nil, fmt.Errorf("the segment 'assemblyName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "assemblyName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/integrationaccountassemblies/id_integrationaccount.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/integrationaccountassemblies/id_integrationaccount.go
@@ -40,15 +40,15 @@ func ParseIntegrationAccountID(input string) (*IntegrationAccountId, error) {
 	id := IntegrationAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.IntegrationAccountName, ok = parsed.Parsed["integrationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'integrationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "integrationAccountName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseIntegrationAccountIDInsensitively(input string) (*IntegrationAccountId
 	id := IntegrationAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.IntegrationAccountName, ok = parsed.Parsed["integrationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'integrationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "integrationAccountName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/integrationaccountbatchconfigurations/id_batchconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/integrationaccountbatchconfigurations/id_batchconfiguration.go
@@ -42,19 +42,19 @@ func ParseBatchConfigurationID(input string) (*BatchConfigurationId, error) {
 	id := BatchConfigurationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.IntegrationAccountName, ok = parsed.Parsed["integrationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'integrationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "integrationAccountName", *parsed)
 	}
 
 	if id.BatchConfigurationName, ok = parsed.Parsed["batchConfigurationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'batchConfigurationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "batchConfigurationName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseBatchConfigurationIDInsensitively(input string) (*BatchConfigurationId
 	id := BatchConfigurationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.IntegrationAccountName, ok = parsed.Parsed["integrationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'integrationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "integrationAccountName", *parsed)
 	}
 
 	if id.BatchConfigurationName, ok = parsed.Parsed["batchConfigurationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'batchConfigurationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "batchConfigurationName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/integrationaccountbatchconfigurations/id_integrationaccount.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/integrationaccountbatchconfigurations/id_integrationaccount.go
@@ -40,15 +40,15 @@ func ParseIntegrationAccountID(input string) (*IntegrationAccountId, error) {
 	id := IntegrationAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.IntegrationAccountName, ok = parsed.Parsed["integrationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'integrationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "integrationAccountName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseIntegrationAccountIDInsensitively(input string) (*IntegrationAccountId
 	id := IntegrationAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.IntegrationAccountName, ok = parsed.Parsed["integrationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'integrationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "integrationAccountName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/integrationaccountcertificates/id_certificate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/integrationaccountcertificates/id_certificate.go
@@ -42,19 +42,19 @@ func ParseCertificateID(input string) (*CertificateId, error) {
 	id := CertificateId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.IntegrationAccountName, ok = parsed.Parsed["integrationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'integrationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "integrationAccountName", *parsed)
 	}
 
 	if id.CertificateName, ok = parsed.Parsed["certificateName"]; !ok {
-		return nil, fmt.Errorf("the segment 'certificateName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "certificateName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseCertificateIDInsensitively(input string) (*CertificateId, error) {
 	id := CertificateId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.IntegrationAccountName, ok = parsed.Parsed["integrationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'integrationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "integrationAccountName", *parsed)
 	}
 
 	if id.CertificateName, ok = parsed.Parsed["certificateName"]; !ok {
-		return nil, fmt.Errorf("the segment 'certificateName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "certificateName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/integrationaccountcertificates/id_integrationaccount.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/integrationaccountcertificates/id_integrationaccount.go
@@ -40,15 +40,15 @@ func ParseIntegrationAccountID(input string) (*IntegrationAccountId, error) {
 	id := IntegrationAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.IntegrationAccountName, ok = parsed.Parsed["integrationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'integrationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "integrationAccountName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseIntegrationAccountIDInsensitively(input string) (*IntegrationAccountId
 	id := IntegrationAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.IntegrationAccountName, ok = parsed.Parsed["integrationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'integrationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "integrationAccountName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/integrationaccountmaps/id_integrationaccount.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/integrationaccountmaps/id_integrationaccount.go
@@ -40,15 +40,15 @@ func ParseIntegrationAccountID(input string) (*IntegrationAccountId, error) {
 	id := IntegrationAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.IntegrationAccountName, ok = parsed.Parsed["integrationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'integrationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "integrationAccountName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseIntegrationAccountIDInsensitively(input string) (*IntegrationAccountId
 	id := IntegrationAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.IntegrationAccountName, ok = parsed.Parsed["integrationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'integrationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "integrationAccountName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/integrationaccountmaps/id_map.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/integrationaccountmaps/id_map.go
@@ -42,19 +42,19 @@ func ParseMapID(input string) (*MapId, error) {
 	id := MapId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.IntegrationAccountName, ok = parsed.Parsed["integrationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'integrationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "integrationAccountName", *parsed)
 	}
 
 	if id.MapName, ok = parsed.Parsed["mapName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mapName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mapName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseMapIDInsensitively(input string) (*MapId, error) {
 	id := MapId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.IntegrationAccountName, ok = parsed.Parsed["integrationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'integrationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "integrationAccountName", *parsed)
 	}
 
 	if id.MapName, ok = parsed.Parsed["mapName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mapName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mapName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/integrationaccountpartners/id_integrationaccount.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/integrationaccountpartners/id_integrationaccount.go
@@ -40,15 +40,15 @@ func ParseIntegrationAccountID(input string) (*IntegrationAccountId, error) {
 	id := IntegrationAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.IntegrationAccountName, ok = parsed.Parsed["integrationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'integrationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "integrationAccountName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseIntegrationAccountIDInsensitively(input string) (*IntegrationAccountId
 	id := IntegrationAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.IntegrationAccountName, ok = parsed.Parsed["integrationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'integrationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "integrationAccountName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/integrationaccountpartners/id_partner.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/integrationaccountpartners/id_partner.go
@@ -42,19 +42,19 @@ func ParsePartnerID(input string) (*PartnerId, error) {
 	id := PartnerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.IntegrationAccountName, ok = parsed.Parsed["integrationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'integrationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "integrationAccountName", *parsed)
 	}
 
 	if id.PartnerName, ok = parsed.Parsed["partnerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'partnerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "partnerName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParsePartnerIDInsensitively(input string) (*PartnerId, error) {
 	id := PartnerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.IntegrationAccountName, ok = parsed.Parsed["integrationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'integrationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "integrationAccountName", *parsed)
 	}
 
 	if id.PartnerName, ok = parsed.Parsed["partnerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'partnerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "partnerName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/integrationaccounts/id_integrationaccount.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/integrationaccounts/id_integrationaccount.go
@@ -40,15 +40,15 @@ func ParseIntegrationAccountID(input string) (*IntegrationAccountId, error) {
 	id := IntegrationAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.IntegrationAccountName, ok = parsed.Parsed["integrationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'integrationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "integrationAccountName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseIntegrationAccountIDInsensitively(input string) (*IntegrationAccountId
 	id := IntegrationAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.IntegrationAccountName, ok = parsed.Parsed["integrationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'integrationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "integrationAccountName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/integrationaccountschemas/id_integrationaccount.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/integrationaccountschemas/id_integrationaccount.go
@@ -40,15 +40,15 @@ func ParseIntegrationAccountID(input string) (*IntegrationAccountId, error) {
 	id := IntegrationAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.IntegrationAccountName, ok = parsed.Parsed["integrationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'integrationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "integrationAccountName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseIntegrationAccountIDInsensitively(input string) (*IntegrationAccountId
 	id := IntegrationAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.IntegrationAccountName, ok = parsed.Parsed["integrationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'integrationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "integrationAccountName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/integrationaccountschemas/id_schema.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/integrationaccountschemas/id_schema.go
@@ -42,19 +42,19 @@ func ParseSchemaID(input string) (*SchemaId, error) {
 	id := SchemaId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.IntegrationAccountName, ok = parsed.Parsed["integrationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'integrationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "integrationAccountName", *parsed)
 	}
 
 	if id.SchemaName, ok = parsed.Parsed["schemaName"]; !ok {
-		return nil, fmt.Errorf("the segment 'schemaName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "schemaName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseSchemaIDInsensitively(input string) (*SchemaId, error) {
 	id := SchemaId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.IntegrationAccountName, ok = parsed.Parsed["integrationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'integrationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "integrationAccountName", *parsed)
 	}
 
 	if id.SchemaName, ok = parsed.Parsed["schemaName"]; !ok {
-		return nil, fmt.Errorf("the segment 'schemaName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "schemaName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/integrationaccountsessions/id_integrationaccount.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/integrationaccountsessions/id_integrationaccount.go
@@ -40,15 +40,15 @@ func ParseIntegrationAccountID(input string) (*IntegrationAccountId, error) {
 	id := IntegrationAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.IntegrationAccountName, ok = parsed.Parsed["integrationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'integrationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "integrationAccountName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseIntegrationAccountIDInsensitively(input string) (*IntegrationAccountId
 	id := IntegrationAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.IntegrationAccountName, ok = parsed.Parsed["integrationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'integrationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "integrationAccountName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/integrationaccountsessions/id_session.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/integrationaccountsessions/id_session.go
@@ -42,19 +42,19 @@ func ParseSessionID(input string) (*SessionId, error) {
 	id := SessionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.IntegrationAccountName, ok = parsed.Parsed["integrationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'integrationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "integrationAccountName", *parsed)
 	}
 
 	if id.SessionName, ok = parsed.Parsed["sessionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'sessionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "sessionName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseSessionIDInsensitively(input string) (*SessionId, error) {
 	id := SessionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.IntegrationAccountName, ok = parsed.Parsed["integrationAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'integrationAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "integrationAccountName", *parsed)
 	}
 
 	if id.SessionName, ok = parsed.Parsed["sessionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'sessionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "sessionName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/integrationserviceenvironments/id_integrationserviceenvironment.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/integrationserviceenvironments/id_integrationserviceenvironment.go
@@ -40,15 +40,15 @@ func ParseIntegrationServiceEnvironmentID(input string) (*IntegrationServiceEnvi
 	id := IntegrationServiceEnvironmentId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroup, ok = parsed.Parsed["resourceGroup"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroup' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroup", *parsed)
 	}
 
 	if id.IntegrationServiceEnvironmentName, ok = parsed.Parsed["integrationServiceEnvironmentName"]; !ok {
-		return nil, fmt.Errorf("the segment 'integrationServiceEnvironmentName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "integrationServiceEnvironmentName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseIntegrationServiceEnvironmentIDInsensitively(input string) (*Integrati
 	id := IntegrationServiceEnvironmentId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroup, ok = parsed.Parsed["resourceGroup"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroup' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroup", *parsed)
 	}
 
 	if id.IntegrationServiceEnvironmentName, ok = parsed.Parsed["integrationServiceEnvironmentName"]; !ok {
-		return nil, fmt.Errorf("the segment 'integrationServiceEnvironmentName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "integrationServiceEnvironmentName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/workflowrunactions/id_action.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/workflowrunactions/id_action.go
@@ -44,23 +44,23 @@ func ParseActionID(input string) (*ActionId, error) {
 	id := ActionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkflowName, ok = parsed.Parsed["workflowName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workflowName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workflowName", *parsed)
 	}
 
 	if id.RunName, ok = parsed.Parsed["runName"]; !ok {
-		return nil, fmt.Errorf("the segment 'runName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "runName", *parsed)
 	}
 
 	if id.ActionName, ok = parsed.Parsed["actionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'actionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "actionName", *parsed)
 	}
 
 	return &id, nil
@@ -79,23 +79,23 @@ func ParseActionIDInsensitively(input string) (*ActionId, error) {
 	id := ActionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkflowName, ok = parsed.Parsed["workflowName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workflowName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workflowName", *parsed)
 	}
 
 	if id.RunName, ok = parsed.Parsed["runName"]; !ok {
-		return nil, fmt.Errorf("the segment 'runName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "runName", *parsed)
 	}
 
 	if id.ActionName, ok = parsed.Parsed["actionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'actionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "actionName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/workflowrunactions/id_repetition.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/workflowrunactions/id_repetition.go
@@ -46,27 +46,27 @@ func ParseRepetitionID(input string) (*RepetitionId, error) {
 	id := RepetitionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkflowName, ok = parsed.Parsed["workflowName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workflowName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workflowName", *parsed)
 	}
 
 	if id.RunName, ok = parsed.Parsed["runName"]; !ok {
-		return nil, fmt.Errorf("the segment 'runName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "runName", *parsed)
 	}
 
 	if id.ActionName, ok = parsed.Parsed["actionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'actionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "actionName", *parsed)
 	}
 
 	if id.RepetitionName, ok = parsed.Parsed["repetitionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'repetitionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "repetitionName", *parsed)
 	}
 
 	return &id, nil
@@ -85,27 +85,27 @@ func ParseRepetitionIDInsensitively(input string) (*RepetitionId, error) {
 	id := RepetitionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkflowName, ok = parsed.Parsed["workflowName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workflowName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workflowName", *parsed)
 	}
 
 	if id.RunName, ok = parsed.Parsed["runName"]; !ok {
-		return nil, fmt.Errorf("the segment 'runName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "runName", *parsed)
 	}
 
 	if id.ActionName, ok = parsed.Parsed["actionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'actionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "actionName", *parsed)
 	}
 
 	if id.RepetitionName, ok = parsed.Parsed["repetitionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'repetitionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "repetitionName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/workflowrunactions/id_repetitionrequesthistory.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/workflowrunactions/id_repetitionrequesthistory.go
@@ -48,31 +48,31 @@ func ParseRepetitionRequestHistoryID(input string) (*RepetitionRequestHistoryId,
 	id := RepetitionRequestHistoryId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkflowName, ok = parsed.Parsed["workflowName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workflowName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workflowName", *parsed)
 	}
 
 	if id.RunName, ok = parsed.Parsed["runName"]; !ok {
-		return nil, fmt.Errorf("the segment 'runName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "runName", *parsed)
 	}
 
 	if id.ActionName, ok = parsed.Parsed["actionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'actionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "actionName", *parsed)
 	}
 
 	if id.RepetitionName, ok = parsed.Parsed["repetitionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'repetitionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "repetitionName", *parsed)
 	}
 
 	if id.RequestHistoryName, ok = parsed.Parsed["requestHistoryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'requestHistoryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "requestHistoryName", *parsed)
 	}
 
 	return &id, nil
@@ -91,31 +91,31 @@ func ParseRepetitionRequestHistoryIDInsensitively(input string) (*RepetitionRequ
 	id := RepetitionRequestHistoryId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkflowName, ok = parsed.Parsed["workflowName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workflowName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workflowName", *parsed)
 	}
 
 	if id.RunName, ok = parsed.Parsed["runName"]; !ok {
-		return nil, fmt.Errorf("the segment 'runName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "runName", *parsed)
 	}
 
 	if id.ActionName, ok = parsed.Parsed["actionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'actionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "actionName", *parsed)
 	}
 
 	if id.RepetitionName, ok = parsed.Parsed["repetitionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'repetitionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "repetitionName", *parsed)
 	}
 
 	if id.RequestHistoryName, ok = parsed.Parsed["requestHistoryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'requestHistoryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "requestHistoryName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/workflowrunactions/id_requesthistory.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/workflowrunactions/id_requesthistory.go
@@ -46,27 +46,27 @@ func ParseRequestHistoryID(input string) (*RequestHistoryId, error) {
 	id := RequestHistoryId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkflowName, ok = parsed.Parsed["workflowName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workflowName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workflowName", *parsed)
 	}
 
 	if id.RunName, ok = parsed.Parsed["runName"]; !ok {
-		return nil, fmt.Errorf("the segment 'runName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "runName", *parsed)
 	}
 
 	if id.ActionName, ok = parsed.Parsed["actionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'actionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "actionName", *parsed)
 	}
 
 	if id.RequestHistoryName, ok = parsed.Parsed["requestHistoryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'requestHistoryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "requestHistoryName", *parsed)
 	}
 
 	return &id, nil
@@ -85,27 +85,27 @@ func ParseRequestHistoryIDInsensitively(input string) (*RequestHistoryId, error)
 	id := RequestHistoryId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkflowName, ok = parsed.Parsed["workflowName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workflowName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workflowName", *parsed)
 	}
 
 	if id.RunName, ok = parsed.Parsed["runName"]; !ok {
-		return nil, fmt.Errorf("the segment 'runName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "runName", *parsed)
 	}
 
 	if id.ActionName, ok = parsed.Parsed["actionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'actionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "actionName", *parsed)
 	}
 
 	if id.RequestHistoryName, ok = parsed.Parsed["requestHistoryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'requestHistoryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "requestHistoryName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/workflowrunactions/id_run.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/workflowrunactions/id_run.go
@@ -42,19 +42,19 @@ func ParseRunID(input string) (*RunId, error) {
 	id := RunId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkflowName, ok = parsed.Parsed["workflowName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workflowName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workflowName", *parsed)
 	}
 
 	if id.RunName, ok = parsed.Parsed["runName"]; !ok {
-		return nil, fmt.Errorf("the segment 'runName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "runName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseRunIDInsensitively(input string) (*RunId, error) {
 	id := RunId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkflowName, ok = parsed.Parsed["workflowName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workflowName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workflowName", *parsed)
 	}
 
 	if id.RunName, ok = parsed.Parsed["runName"]; !ok {
-		return nil, fmt.Errorf("the segment 'runName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "runName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/workflowrunactions/id_scoperepetition.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/workflowrunactions/id_scoperepetition.go
@@ -46,27 +46,27 @@ func ParseScopeRepetitionID(input string) (*ScopeRepetitionId, error) {
 	id := ScopeRepetitionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkflowName, ok = parsed.Parsed["workflowName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workflowName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workflowName", *parsed)
 	}
 
 	if id.RunName, ok = parsed.Parsed["runName"]; !ok {
-		return nil, fmt.Errorf("the segment 'runName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "runName", *parsed)
 	}
 
 	if id.ActionName, ok = parsed.Parsed["actionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'actionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "actionName", *parsed)
 	}
 
 	if id.ScopeRepetitionName, ok = parsed.Parsed["scopeRepetitionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'scopeRepetitionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "scopeRepetitionName", *parsed)
 	}
 
 	return &id, nil
@@ -85,27 +85,27 @@ func ParseScopeRepetitionIDInsensitively(input string) (*ScopeRepetitionId, erro
 	id := ScopeRepetitionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkflowName, ok = parsed.Parsed["workflowName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workflowName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workflowName", *parsed)
 	}
 
 	if id.RunName, ok = parsed.Parsed["runName"]; !ok {
-		return nil, fmt.Errorf("the segment 'runName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "runName", *parsed)
 	}
 
 	if id.ActionName, ok = parsed.Parsed["actionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'actionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "actionName", *parsed)
 	}
 
 	if id.ScopeRepetitionName, ok = parsed.Parsed["scopeRepetitionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'scopeRepetitionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "scopeRepetitionName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/workflows/id_locationworkflow.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/workflows/id_locationworkflow.go
@@ -42,19 +42,19 @@ func ParseLocationWorkflowID(input string) (*LocationWorkflowId, error) {
 	id := LocationWorkflowId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.LocationName, ok = parsed.Parsed["locationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'locationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "locationName", *parsed)
 	}
 
 	if id.WorkflowName, ok = parsed.Parsed["workflowName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workflowName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workflowName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseLocationWorkflowIDInsensitively(input string) (*LocationWorkflowId, er
 	id := LocationWorkflowId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.LocationName, ok = parsed.Parsed["locationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'locationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "locationName", *parsed)
 	}
 
 	if id.WorkflowName, ok = parsed.Parsed["workflowName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workflowName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workflowName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/workflows/id_workflow.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/workflows/id_workflow.go
@@ -40,15 +40,15 @@ func ParseWorkflowID(input string) (*WorkflowId, error) {
 	id := WorkflowId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkflowName, ok = parsed.Parsed["workflowName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workflowName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workflowName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseWorkflowIDInsensitively(input string) (*WorkflowId, error) {
 	id := WorkflowId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkflowName, ok = parsed.Parsed["workflowName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workflowName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workflowName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/workflowtriggers/id_trigger.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/workflowtriggers/id_trigger.go
@@ -42,19 +42,19 @@ func ParseTriggerID(input string) (*TriggerId, error) {
 	id := TriggerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkflowName, ok = parsed.Parsed["workflowName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workflowName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workflowName", *parsed)
 	}
 
 	if id.TriggerName, ok = parsed.Parsed["triggerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'triggerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "triggerName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseTriggerIDInsensitively(input string) (*TriggerId, error) {
 	id := TriggerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkflowName, ok = parsed.Parsed["workflowName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workflowName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workflowName", *parsed)
 	}
 
 	if id.TriggerName, ok = parsed.Parsed["triggerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'triggerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "triggerName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/workflowtriggers/id_versiontrigger.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/workflowtriggers/id_versiontrigger.go
@@ -44,23 +44,23 @@ func ParseVersionTriggerID(input string) (*VersionTriggerId, error) {
 	id := VersionTriggerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkflowName, ok = parsed.Parsed["workflowName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workflowName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workflowName", *parsed)
 	}
 
 	if id.VersionId, ok = parsed.Parsed["versionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'versionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "versionId", *parsed)
 	}
 
 	if id.TriggerName, ok = parsed.Parsed["triggerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'triggerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "triggerName", *parsed)
 	}
 
 	return &id, nil
@@ -79,23 +79,23 @@ func ParseVersionTriggerIDInsensitively(input string) (*VersionTriggerId, error)
 	id := VersionTriggerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkflowName, ok = parsed.Parsed["workflowName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workflowName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workflowName", *parsed)
 	}
 
 	if id.VersionId, ok = parsed.Parsed["versionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'versionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "versionId", *parsed)
 	}
 
 	if id.TriggerName, ok = parsed.Parsed["triggerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'triggerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "triggerName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/workflowtriggers/id_workflow.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logic/2019-05-01/workflowtriggers/id_workflow.go
@@ -40,15 +40,15 @@ func ParseWorkflowID(input string) (*WorkflowId, error) {
 	id := WorkflowId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkflowName, ok = parsed.Parsed["workflowName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workflowName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workflowName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseWorkflowIDInsensitively(input string) (*WorkflowId, error) {
 	id := WorkflowId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkflowName, ok = parsed.Parsed["workflowName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workflowName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workflowName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logz/2020-10-01/monitors/id_monitor.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logz/2020-10-01/monitors/id_monitor.go
@@ -40,15 +40,15 @@ func ParseMonitorID(input string) (*MonitorId, error) {
 	id := MonitorId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MonitorName, ok = parsed.Parsed["monitorName"]; !ok {
-		return nil, fmt.Errorf("the segment 'monitorName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "monitorName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseMonitorIDInsensitively(input string) (*MonitorId, error) {
 	id := MonitorId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MonitorName, ok = parsed.Parsed["monitorName"]; !ok {
-		return nil, fmt.Errorf("the segment 'monitorName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "monitorName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logz/2020-10-01/subaccount/id_account.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logz/2020-10-01/subaccount/id_account.go
@@ -42,19 +42,19 @@ func ParseAccountID(input string) (*AccountId, error) {
 	id := AccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MonitorName, ok = parsed.Parsed["monitorName"]; !ok {
-		return nil, fmt.Errorf("the segment 'monitorName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "monitorName", *parsed)
 	}
 
 	if id.AccountName, ok = parsed.Parsed["accountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'accountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "accountName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseAccountIDInsensitively(input string) (*AccountId, error) {
 	id := AccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MonitorName, ok = parsed.Parsed["monitorName"]; !ok {
-		return nil, fmt.Errorf("the segment 'monitorName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "monitorName", *parsed)
 	}
 
 	if id.AccountName, ok = parsed.Parsed["accountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'accountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "accountName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logz/2020-10-01/subaccount/id_monitor.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logz/2020-10-01/subaccount/id_monitor.go
@@ -40,15 +40,15 @@ func ParseMonitorID(input string) (*MonitorId, error) {
 	id := MonitorId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MonitorName, ok = parsed.Parsed["monitorName"]; !ok {
-		return nil, fmt.Errorf("the segment 'monitorName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "monitorName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseMonitorIDInsensitively(input string) (*MonitorId, error) {
 	id := MonitorId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MonitorName, ok = parsed.Parsed["monitorName"]; !ok {
-		return nil, fmt.Errorf("the segment 'monitorName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "monitorName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logz/2020-10-01/tagrules/id_account.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logz/2020-10-01/tagrules/id_account.go
@@ -42,19 +42,19 @@ func ParseAccountID(input string) (*AccountId, error) {
 	id := AccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MonitorName, ok = parsed.Parsed["monitorName"]; !ok {
-		return nil, fmt.Errorf("the segment 'monitorName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "monitorName", *parsed)
 	}
 
 	if id.AccountName, ok = parsed.Parsed["accountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'accountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "accountName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseAccountIDInsensitively(input string) (*AccountId, error) {
 	id := AccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MonitorName, ok = parsed.Parsed["monitorName"]; !ok {
-		return nil, fmt.Errorf("the segment 'monitorName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "monitorName", *parsed)
 	}
 
 	if id.AccountName, ok = parsed.Parsed["accountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'accountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "accountName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logz/2020-10-01/tagrules/id_accounttagrule.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logz/2020-10-01/tagrules/id_accounttagrule.go
@@ -44,23 +44,23 @@ func ParseAccountTagRuleID(input string) (*AccountTagRuleId, error) {
 	id := AccountTagRuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MonitorName, ok = parsed.Parsed["monitorName"]; !ok {
-		return nil, fmt.Errorf("the segment 'monitorName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "monitorName", *parsed)
 	}
 
 	if id.AccountName, ok = parsed.Parsed["accountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'accountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "accountName", *parsed)
 	}
 
 	if id.TagRuleName, ok = parsed.Parsed["tagRuleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'tagRuleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "tagRuleName", *parsed)
 	}
 
 	return &id, nil
@@ -79,23 +79,23 @@ func ParseAccountTagRuleIDInsensitively(input string) (*AccountTagRuleId, error)
 	id := AccountTagRuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MonitorName, ok = parsed.Parsed["monitorName"]; !ok {
-		return nil, fmt.Errorf("the segment 'monitorName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "monitorName", *parsed)
 	}
 
 	if id.AccountName, ok = parsed.Parsed["accountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'accountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "accountName", *parsed)
 	}
 
 	if id.TagRuleName, ok = parsed.Parsed["tagRuleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'tagRuleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "tagRuleName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logz/2020-10-01/tagrules/id_monitor.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logz/2020-10-01/tagrules/id_monitor.go
@@ -40,15 +40,15 @@ func ParseMonitorID(input string) (*MonitorId, error) {
 	id := MonitorId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MonitorName, ok = parsed.Parsed["monitorName"]; !ok {
-		return nil, fmt.Errorf("the segment 'monitorName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "monitorName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseMonitorIDInsensitively(input string) (*MonitorId, error) {
 	id := MonitorId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MonitorName, ok = parsed.Parsed["monitorName"]; !ok {
-		return nil, fmt.Errorf("the segment 'monitorName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "monitorName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logz/2020-10-01/tagrules/id_tagrule.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/logz/2020-10-01/tagrules/id_tagrule.go
@@ -42,19 +42,19 @@ func ParseTagRuleID(input string) (*TagRuleId, error) {
 	id := TagRuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MonitorName, ok = parsed.Parsed["monitorName"]; !ok {
-		return nil, fmt.Errorf("the segment 'monitorName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "monitorName", *parsed)
 	}
 
 	if id.TagRuleName, ok = parsed.Parsed["tagRuleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'tagRuleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "tagRuleName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseTagRuleIDInsensitively(input string) (*TagRuleId, error) {
 	id := TagRuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MonitorName, ok = parsed.Parsed["monitorName"]; !ok {
-		return nil, fmt.Errorf("the segment 'monitorName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "monitorName", *parsed)
 	}
 
 	if id.TagRuleName, ok = parsed.Parsed["tagRuleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'tagRuleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "tagRuleName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2022-05-01/datastore/id_datastore.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2022-05-01/datastore/id_datastore.go
@@ -42,19 +42,19 @@ func ParseDataStoreID(input string) (*DataStoreId, error) {
 	id := DataStoreId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	if id.DataStoreName, ok = parsed.Parsed["dataStoreName"]; !ok {
-		return nil, fmt.Errorf("the segment 'dataStoreName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "dataStoreName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseDataStoreIDInsensitively(input string) (*DataStoreId, error) {
 	id := DataStoreId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	if id.DataStoreName, ok = parsed.Parsed["dataStoreName"]; !ok {
-		return nil, fmt.Errorf("the segment 'dataStoreName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "dataStoreName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2022-05-01/datastore/id_workspace.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2022-05-01/datastore/id_workspace.go
@@ -40,15 +40,15 @@ func ParseWorkspaceID(input string) (*WorkspaceId, error) {
 	id := WorkspaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseWorkspaceIDInsensitively(input string) (*WorkspaceId, error) {
 	id := WorkspaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2022-05-01/machinelearningcomputes/id_compute.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2022-05-01/machinelearningcomputes/id_compute.go
@@ -42,19 +42,19 @@ func ParseComputeID(input string) (*ComputeId, error) {
 	id := ComputeId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	if id.ComputeName, ok = parsed.Parsed["computeName"]; !ok {
-		return nil, fmt.Errorf("the segment 'computeName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "computeName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseComputeIDInsensitively(input string) (*ComputeId, error) {
 	id := ComputeId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	if id.ComputeName, ok = parsed.Parsed["computeName"]; !ok {
-		return nil, fmt.Errorf("the segment 'computeName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "computeName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2022-05-01/machinelearningcomputes/id_workspace.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2022-05-01/machinelearningcomputes/id_workspace.go
@@ -40,15 +40,15 @@ func ParseWorkspaceID(input string) (*WorkspaceId, error) {
 	id := WorkspaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseWorkspaceIDInsensitively(input string) (*WorkspaceId, error) {
 	id := WorkspaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2022-05-01/workspaces/id_workspace.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2022-05-01/workspaces/id_workspace.go
@@ -40,15 +40,15 @@ func ParseWorkspaceID(input string) (*WorkspaceId, error) {
 	id := WorkspaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseWorkspaceIDInsensitively(input string) (*WorkspaceId, error) {
 	id := WorkspaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/maintenance/2022-07-01-preview/configurationassignments/id_configurationassignment.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/maintenance/2022-07-01-preview/configurationassignments/id_configurationassignment.go
@@ -46,27 +46,27 @@ func ParseConfigurationAssignmentID(input string) (*ConfigurationAssignmentId, e
 	id := ConfigurationAssignmentId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ProviderName, ok = parsed.Parsed["providerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'providerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "providerName", *parsed)
 	}
 
 	if id.ResourceType, ok = parsed.Parsed["resourceType"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceType' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceType", *parsed)
 	}
 
 	if id.ResourceName, ok = parsed.Parsed["resourceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceName", *parsed)
 	}
 
 	if id.ConfigurationAssignmentName, ok = parsed.Parsed["configurationAssignmentName"]; !ok {
-		return nil, fmt.Errorf("the segment 'configurationAssignmentName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "configurationAssignmentName", *parsed)
 	}
 
 	return &id, nil
@@ -85,27 +85,27 @@ func ParseConfigurationAssignmentIDInsensitively(input string) (*ConfigurationAs
 	id := ConfigurationAssignmentId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ProviderName, ok = parsed.Parsed["providerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'providerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "providerName", *parsed)
 	}
 
 	if id.ResourceType, ok = parsed.Parsed["resourceType"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceType' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceType", *parsed)
 	}
 
 	if id.ResourceName, ok = parsed.Parsed["resourceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceName", *parsed)
 	}
 
 	if id.ConfigurationAssignmentName, ok = parsed.Parsed["configurationAssignmentName"]; !ok {
-		return nil, fmt.Errorf("the segment 'configurationAssignmentName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "configurationAssignmentName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/maintenance/2022-07-01-preview/configurationassignments/id_provider.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/maintenance/2022-07-01-preview/configurationassignments/id_provider.go
@@ -44,23 +44,23 @@ func ParseProviderID(input string) (*ProviderId, error) {
 	id := ProviderId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ProviderName, ok = parsed.Parsed["providerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'providerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "providerName", *parsed)
 	}
 
 	if id.ResourceType, ok = parsed.Parsed["resourceType"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceType' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceType", *parsed)
 	}
 
 	if id.ResourceName, ok = parsed.Parsed["resourceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceName", *parsed)
 	}
 
 	return &id, nil
@@ -79,23 +79,23 @@ func ParseProviderIDInsensitively(input string) (*ProviderId, error) {
 	id := ProviderId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ProviderName, ok = parsed.Parsed["providerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'providerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "providerName", *parsed)
 	}
 
 	if id.ResourceType, ok = parsed.Parsed["resourceType"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceType' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceType", *parsed)
 	}
 
 	if id.ResourceName, ok = parsed.Parsed["resourceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/maintenance/2022-07-01-preview/configurationassignments/id_providers2configurationassignment.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/maintenance/2022-07-01-preview/configurationassignments/id_providers2configurationassignment.go
@@ -50,35 +50,35 @@ func ParseProviders2ConfigurationAssignmentID(input string) (*Providers2Configur
 	id := Providers2ConfigurationAssignmentId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ProviderName, ok = parsed.Parsed["providerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'providerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "providerName", *parsed)
 	}
 
 	if id.ResourceParentType, ok = parsed.Parsed["resourceParentType"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceParentType' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceParentType", *parsed)
 	}
 
 	if id.ResourceParentName, ok = parsed.Parsed["resourceParentName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceParentName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceParentName", *parsed)
 	}
 
 	if id.ResourceType, ok = parsed.Parsed["resourceType"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceType' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceType", *parsed)
 	}
 
 	if id.ResourceName, ok = parsed.Parsed["resourceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceName", *parsed)
 	}
 
 	if id.ConfigurationAssignmentName, ok = parsed.Parsed["configurationAssignmentName"]; !ok {
-		return nil, fmt.Errorf("the segment 'configurationAssignmentName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "configurationAssignmentName", *parsed)
 	}
 
 	return &id, nil
@@ -97,35 +97,35 @@ func ParseProviders2ConfigurationAssignmentIDInsensitively(input string) (*Provi
 	id := Providers2ConfigurationAssignmentId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ProviderName, ok = parsed.Parsed["providerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'providerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "providerName", *parsed)
 	}
 
 	if id.ResourceParentType, ok = parsed.Parsed["resourceParentType"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceParentType' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceParentType", *parsed)
 	}
 
 	if id.ResourceParentName, ok = parsed.Parsed["resourceParentName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceParentName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceParentName", *parsed)
 	}
 
 	if id.ResourceType, ok = parsed.Parsed["resourceType"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceType' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceType", *parsed)
 	}
 
 	if id.ResourceName, ok = parsed.Parsed["resourceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceName", *parsed)
 	}
 
 	if id.ConfigurationAssignmentName, ok = parsed.Parsed["configurationAssignmentName"]; !ok {
-		return nil, fmt.Errorf("the segment 'configurationAssignmentName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "configurationAssignmentName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/maintenance/2022-07-01-preview/configurationassignments/id_resourcegroupprovider.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/maintenance/2022-07-01-preview/configurationassignments/id_resourcegroupprovider.go
@@ -48,31 +48,31 @@ func ParseResourceGroupProviderID(input string) (*ResourceGroupProviderId, error
 	id := ResourceGroupProviderId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ProviderName, ok = parsed.Parsed["providerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'providerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "providerName", *parsed)
 	}
 
 	if id.ResourceParentType, ok = parsed.Parsed["resourceParentType"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceParentType' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceParentType", *parsed)
 	}
 
 	if id.ResourceParentName, ok = parsed.Parsed["resourceParentName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceParentName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceParentName", *parsed)
 	}
 
 	if id.ResourceType, ok = parsed.Parsed["resourceType"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceType' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceType", *parsed)
 	}
 
 	if id.ResourceName, ok = parsed.Parsed["resourceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceName", *parsed)
 	}
 
 	return &id, nil
@@ -91,31 +91,31 @@ func ParseResourceGroupProviderIDInsensitively(input string) (*ResourceGroupProv
 	id := ResourceGroupProviderId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ProviderName, ok = parsed.Parsed["providerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'providerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "providerName", *parsed)
 	}
 
 	if id.ResourceParentType, ok = parsed.Parsed["resourceParentType"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceParentType' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceParentType", *parsed)
 	}
 
 	if id.ResourceParentName, ok = parsed.Parsed["resourceParentName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceParentName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceParentName", *parsed)
 	}
 
 	if id.ResourceType, ok = parsed.Parsed["resourceType"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceType' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceType", *parsed)
 	}
 
 	if id.ResourceName, ok = parsed.Parsed["resourceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/maintenance/2022-07-01-preview/maintenanceconfigurations/id_maintenanceconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/maintenance/2022-07-01-preview/maintenanceconfigurations/id_maintenanceconfiguration.go
@@ -40,15 +40,15 @@ func ParseMaintenanceConfigurationID(input string) (*MaintenanceConfigurationId,
 	id := MaintenanceConfigurationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MaintenanceConfigurationName, ok = parsed.Parsed["maintenanceConfigurationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'maintenanceConfigurationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "maintenanceConfigurationName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseMaintenanceConfigurationIDInsensitively(input string) (*MaintenanceCon
 	id := MaintenanceConfigurationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MaintenanceConfigurationName, ok = parsed.Parsed["maintenanceConfigurationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'maintenanceConfigurationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "maintenanceConfigurationName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/maintenance/2022-07-01-preview/publicmaintenanceconfigurations/id_publicmaintenanceconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/maintenance/2022-07-01-preview/publicmaintenanceconfigurations/id_publicmaintenanceconfiguration.go
@@ -38,11 +38,11 @@ func ParsePublicMaintenanceConfigurationID(input string) (*PublicMaintenanceConf
 	id := PublicMaintenanceConfigurationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.PublicMaintenanceConfigurationName, ok = parsed.Parsed["publicMaintenanceConfigurationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'publicMaintenanceConfigurationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "publicMaintenanceConfigurationName", *parsed)
 	}
 
 	return &id, nil
@@ -61,11 +61,11 @@ func ParsePublicMaintenanceConfigurationIDInsensitively(input string) (*PublicMa
 	id := PublicMaintenanceConfigurationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.PublicMaintenanceConfigurationName, ok = parsed.Parsed["publicMaintenanceConfigurationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'publicMaintenanceConfigurationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "publicMaintenanceConfigurationName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/managedidentity/2022-01-31-preview/managedidentities/id_federatedidentitycredential.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/managedidentity/2022-01-31-preview/managedidentities/id_federatedidentitycredential.go
@@ -42,19 +42,19 @@ func ParseFederatedIdentityCredentialID(input string) (*FederatedIdentityCredent
 	id := FederatedIdentityCredentialId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.UserAssignedIdentityName, ok = parsed.Parsed["userAssignedIdentityName"]; !ok {
-		return nil, fmt.Errorf("the segment 'userAssignedIdentityName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "userAssignedIdentityName", *parsed)
 	}
 
 	if id.FederatedIdentityCredentialName, ok = parsed.Parsed["federatedIdentityCredentialName"]; !ok {
-		return nil, fmt.Errorf("the segment 'federatedIdentityCredentialName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "federatedIdentityCredentialName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseFederatedIdentityCredentialIDInsensitively(input string) (*FederatedId
 	id := FederatedIdentityCredentialId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.UserAssignedIdentityName, ok = parsed.Parsed["userAssignedIdentityName"]; !ok {
-		return nil, fmt.Errorf("the segment 'userAssignedIdentityName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "userAssignedIdentityName", *parsed)
 	}
 
 	if id.FederatedIdentityCredentialName, ok = parsed.Parsed["federatedIdentityCredentialName"]; !ok {
-		return nil, fmt.Errorf("the segment 'federatedIdentityCredentialName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "federatedIdentityCredentialName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/managedservices/2019-06-01/registrationassignments/id_scopedregistrationassignment.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/managedservices/2019-06-01/registrationassignments/id_scopedregistrationassignment.go
@@ -38,11 +38,11 @@ func ParseScopedRegistrationAssignmentID(input string) (*ScopedRegistrationAssig
 	id := ScopedRegistrationAssignmentId{}
 
 	if id.Scope, ok = parsed.Parsed["scope"]; !ok {
-		return nil, fmt.Errorf("the segment 'scope' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "scope", *parsed)
 	}
 
 	if id.RegistrationAssignmentId, ok = parsed.Parsed["registrationAssignmentId"]; !ok {
-		return nil, fmt.Errorf("the segment 'registrationAssignmentId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "registrationAssignmentId", *parsed)
 	}
 
 	return &id, nil
@@ -61,11 +61,11 @@ func ParseScopedRegistrationAssignmentIDInsensitively(input string) (*ScopedRegi
 	id := ScopedRegistrationAssignmentId{}
 
 	if id.Scope, ok = parsed.Parsed["scope"]; !ok {
-		return nil, fmt.Errorf("the segment 'scope' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "scope", *parsed)
 	}
 
 	if id.RegistrationAssignmentId, ok = parsed.Parsed["registrationAssignmentId"]; !ok {
-		return nil, fmt.Errorf("the segment 'registrationAssignmentId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "registrationAssignmentId", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/managedservices/2022-10-01/registrationdefinitions/id_scopedregistrationdefinition.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/managedservices/2022-10-01/registrationdefinitions/id_scopedregistrationdefinition.go
@@ -38,11 +38,11 @@ func ParseScopedRegistrationDefinitionID(input string) (*ScopedRegistrationDefin
 	id := ScopedRegistrationDefinitionId{}
 
 	if id.Scope, ok = parsed.Parsed["scope"]; !ok {
-		return nil, fmt.Errorf("the segment 'scope' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "scope", *parsed)
 	}
 
 	if id.RegistrationDefinitionId, ok = parsed.Parsed["registrationDefinitionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'registrationDefinitionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "registrationDefinitionId", *parsed)
 	}
 
 	return &id, nil
@@ -61,11 +61,11 @@ func ParseScopedRegistrationDefinitionIDInsensitively(input string) (*ScopedRegi
 	id := ScopedRegistrationDefinitionId{}
 
 	if id.Scope, ok = parsed.Parsed["scope"]; !ok {
-		return nil, fmt.Errorf("the segment 'scope' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "scope", *parsed)
 	}
 
 	if id.RegistrationDefinitionId, ok = parsed.Parsed["registrationDefinitionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'registrationDefinitionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "registrationDefinitionId", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/maps/2021-02-01/accounts/id_account.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/maps/2021-02-01/accounts/id_account.go
@@ -40,15 +40,15 @@ func ParseAccountID(input string) (*AccountId, error) {
 	id := AccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AccountName, ok = parsed.Parsed["accountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'accountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "accountName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseAccountIDInsensitively(input string) (*AccountId, error) {
 	id := AccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AccountName, ok = parsed.Parsed["accountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'accountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "accountName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/maps/2021-02-01/creators/id_account.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/maps/2021-02-01/creators/id_account.go
@@ -40,15 +40,15 @@ func ParseAccountID(input string) (*AccountId, error) {
 	id := AccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AccountName, ok = parsed.Parsed["accountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'accountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "accountName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseAccountIDInsensitively(input string) (*AccountId, error) {
 	id := AccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AccountName, ok = parsed.Parsed["accountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'accountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "accountName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/maps/2021-02-01/creators/id_creator.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/maps/2021-02-01/creators/id_creator.go
@@ -42,19 +42,19 @@ func ParseCreatorID(input string) (*CreatorId, error) {
 	id := CreatorId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AccountName, ok = parsed.Parsed["accountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'accountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "accountName", *parsed)
 	}
 
 	if id.CreatorName, ok = parsed.Parsed["creatorName"]; !ok {
-		return nil, fmt.Errorf("the segment 'creatorName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "creatorName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseCreatorIDInsensitively(input string) (*CreatorId, error) {
 	id := CreatorId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AccountName, ok = parsed.Parsed["accountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'accountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "accountName", *parsed)
 	}
 
 	if id.CreatorName, ok = parsed.Parsed["creatorName"]; !ok {
-		return nil, fmt.Errorf("the segment 'creatorName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "creatorName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mariadb/2018-06-01/configurations/id_configuration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mariadb/2018-06-01/configurations/id_configuration.go
@@ -42,19 +42,19 @@ func ParseConfigurationID(input string) (*ConfigurationId, error) {
 	id := ConfigurationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServerName, ok = parsed.Parsed["serverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverName", *parsed)
 	}
 
 	if id.ConfigurationName, ok = parsed.Parsed["configurationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'configurationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "configurationName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseConfigurationIDInsensitively(input string) (*ConfigurationId, error) {
 	id := ConfigurationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServerName, ok = parsed.Parsed["serverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverName", *parsed)
 	}
 
 	if id.ConfigurationName, ok = parsed.Parsed["configurationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'configurationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "configurationName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mariadb/2018-06-01/configurations/id_server.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mariadb/2018-06-01/configurations/id_server.go
@@ -40,15 +40,15 @@ func ParseServerID(input string) (*ServerId, error) {
 	id := ServerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServerName, ok = parsed.Parsed["serverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseServerIDInsensitively(input string) (*ServerId, error) {
 	id := ServerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServerName, ok = parsed.Parsed["serverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mariadb/2018-06-01/databases/id_database.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mariadb/2018-06-01/databases/id_database.go
@@ -42,19 +42,19 @@ func ParseDatabaseID(input string) (*DatabaseId, error) {
 	id := DatabaseId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServerName, ok = parsed.Parsed["serverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverName", *parsed)
 	}
 
 	if id.DatabaseName, ok = parsed.Parsed["databaseName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseDatabaseIDInsensitively(input string) (*DatabaseId, error) {
 	id := DatabaseId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServerName, ok = parsed.Parsed["serverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverName", *parsed)
 	}
 
 	if id.DatabaseName, ok = parsed.Parsed["databaseName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mariadb/2018-06-01/databases/id_server.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mariadb/2018-06-01/databases/id_server.go
@@ -40,15 +40,15 @@ func ParseServerID(input string) (*ServerId, error) {
 	id := ServerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServerName, ok = parsed.Parsed["serverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseServerIDInsensitively(input string) (*ServerId, error) {
 	id := ServerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServerName, ok = parsed.Parsed["serverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mariadb/2018-06-01/firewallrules/id_firewallrule.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mariadb/2018-06-01/firewallrules/id_firewallrule.go
@@ -42,19 +42,19 @@ func ParseFirewallRuleID(input string) (*FirewallRuleId, error) {
 	id := FirewallRuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServerName, ok = parsed.Parsed["serverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverName", *parsed)
 	}
 
 	if id.FirewallRuleName, ok = parsed.Parsed["firewallRuleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'firewallRuleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "firewallRuleName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseFirewallRuleIDInsensitively(input string) (*FirewallRuleId, error) {
 	id := FirewallRuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServerName, ok = parsed.Parsed["serverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverName", *parsed)
 	}
 
 	if id.FirewallRuleName, ok = parsed.Parsed["firewallRuleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'firewallRuleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "firewallRuleName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mariadb/2018-06-01/firewallrules/id_server.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mariadb/2018-06-01/firewallrules/id_server.go
@@ -40,15 +40,15 @@ func ParseServerID(input string) (*ServerId, error) {
 	id := ServerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServerName, ok = parsed.Parsed["serverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseServerIDInsensitively(input string) (*ServerId, error) {
 	id := ServerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServerName, ok = parsed.Parsed["serverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mariadb/2018-06-01/servers/id_server.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mariadb/2018-06-01/servers/id_server.go
@@ -40,15 +40,15 @@ func ParseServerID(input string) (*ServerId, error) {
 	id := ServerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServerName, ok = parsed.Parsed["serverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseServerIDInsensitively(input string) (*ServerId, error) {
 	id := ServerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServerName, ok = parsed.Parsed["serverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mariadb/2018-06-01/virtualnetworkrules/id_server.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mariadb/2018-06-01/virtualnetworkrules/id_server.go
@@ -40,15 +40,15 @@ func ParseServerID(input string) (*ServerId, error) {
 	id := ServerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServerName, ok = parsed.Parsed["serverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseServerIDInsensitively(input string) (*ServerId, error) {
 	id := ServerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServerName, ok = parsed.Parsed["serverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mariadb/2018-06-01/virtualnetworkrules/id_virtualnetworkrule.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mariadb/2018-06-01/virtualnetworkrules/id_virtualnetworkrule.go
@@ -42,19 +42,19 @@ func ParseVirtualNetworkRuleID(input string) (*VirtualNetworkRuleId, error) {
 	id := VirtualNetworkRuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServerName, ok = parsed.Parsed["serverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverName", *parsed)
 	}
 
 	if id.VirtualNetworkRuleName, ok = parsed.Parsed["virtualNetworkRuleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'virtualNetworkRuleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "virtualNetworkRuleName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseVirtualNetworkRuleIDInsensitively(input string) (*VirtualNetworkRuleId
 	id := VirtualNetworkRuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServerName, ok = parsed.Parsed["serverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverName", *parsed)
 	}
 
 	if id.VirtualNetworkRuleName, ok = parsed.Parsed["virtualNetworkRuleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'virtualNetworkRuleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "virtualNetworkRuleName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/accountfilters/id_accountfilter.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/accountfilters/id_accountfilter.go
@@ -42,19 +42,19 @@ func ParseAccountFilterID(input string) (*AccountFilterId, error) {
 	id := AccountFilterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	if id.AccountFilterName, ok = parsed.Parsed["accountFilterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'accountFilterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "accountFilterName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseAccountFilterIDInsensitively(input string) (*AccountFilterId, error) {
 	id := AccountFilterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	if id.AccountFilterName, ok = parsed.Parsed["accountFilterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'accountFilterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "accountFilterName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/accountfilters/id_mediaservice.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/accountfilters/id_mediaservice.go
@@ -40,15 +40,15 @@ func ParseMediaServiceID(input string) (*MediaServiceId, error) {
 	id := MediaServiceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseMediaServiceIDInsensitively(input string) (*MediaServiceId, error) {
 	id := MediaServiceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/accounts/id_location.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/accounts/id_location.go
@@ -38,11 +38,11 @@ func ParseLocationID(input string) (*LocationId, error) {
 	id := LocationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.LocationName, ok = parsed.Parsed["locationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'locationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "locationName", *parsed)
 	}
 
 	return &id, nil
@@ -61,11 +61,11 @@ func ParseLocationIDInsensitively(input string) (*LocationId, error) {
 	id := LocationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.LocationName, ok = parsed.Parsed["locationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'locationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "locationName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/accounts/id_mediaservice.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/accounts/id_mediaservice.go
@@ -40,15 +40,15 @@ func ParseMediaServiceID(input string) (*MediaServiceId, error) {
 	id := MediaServiceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseMediaServiceIDInsensitively(input string) (*MediaServiceId, error) {
 	id := MediaServiceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/accounts/id_mediaservicesoperationresult.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/accounts/id_mediaservicesoperationresult.go
@@ -40,15 +40,15 @@ func ParseMediaServicesOperationResultID(input string) (*MediaServicesOperationR
 	id := MediaServicesOperationResultId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.LocationName, ok = parsed.Parsed["locationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'locationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "locationName", *parsed)
 	}
 
 	if id.OperationId, ok = parsed.Parsed["operationId"]; !ok {
-		return nil, fmt.Errorf("the segment 'operationId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "operationId", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseMediaServicesOperationResultIDInsensitively(input string) (*MediaServi
 	id := MediaServicesOperationResultId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.LocationName, ok = parsed.Parsed["locationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'locationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "locationName", *parsed)
 	}
 
 	if id.OperationId, ok = parsed.Parsed["operationId"]; !ok {
-		return nil, fmt.Errorf("the segment 'operationId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "operationId", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/accounts/id_mediaservicesoperationstatus.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/accounts/id_mediaservicesoperationstatus.go
@@ -40,15 +40,15 @@ func ParseMediaServicesOperationStatusID(input string) (*MediaServicesOperationS
 	id := MediaServicesOperationStatusId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.LocationName, ok = parsed.Parsed["locationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'locationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "locationName", *parsed)
 	}
 
 	if id.OperationId, ok = parsed.Parsed["operationId"]; !ok {
-		return nil, fmt.Errorf("the segment 'operationId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "operationId", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseMediaServicesOperationStatusIDInsensitively(input string) (*MediaServi
 	id := MediaServicesOperationStatusId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.LocationName, ok = parsed.Parsed["locationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'locationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "locationName", *parsed)
 	}
 
 	if id.OperationId, ok = parsed.Parsed["operationId"]; !ok {
-		return nil, fmt.Errorf("the segment 'operationId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "operationId", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/accounts/id_privateendpointconnection.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/accounts/id_privateendpointconnection.go
@@ -42,19 +42,19 @@ func ParsePrivateEndpointConnectionID(input string) (*PrivateEndpointConnectionI
 	id := PrivateEndpointConnectionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	if id.PrivateEndpointConnectionName, ok = parsed.Parsed["privateEndpointConnectionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'privateEndpointConnectionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "privateEndpointConnectionName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParsePrivateEndpointConnectionIDInsensitively(input string) (*PrivateEndpoi
 	id := PrivateEndpointConnectionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	if id.PrivateEndpointConnectionName, ok = parsed.Parsed["privateEndpointConnectionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'privateEndpointConnectionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "privateEndpointConnectionName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/accounts/id_privatelinkresource.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/accounts/id_privatelinkresource.go
@@ -42,19 +42,19 @@ func ParsePrivateLinkResourceID(input string) (*PrivateLinkResourceId, error) {
 	id := PrivateLinkResourceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	if id.PrivateLinkResourceName, ok = parsed.Parsed["privateLinkResourceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'privateLinkResourceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "privateLinkResourceName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParsePrivateLinkResourceIDInsensitively(input string) (*PrivateLinkResource
 	id := PrivateLinkResourceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	if id.PrivateLinkResourceName, ok = parsed.Parsed["privateLinkResourceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'privateLinkResourceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "privateLinkResourceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/assetsandassetfilters/id_asset.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/assetsandassetfilters/id_asset.go
@@ -42,19 +42,19 @@ func ParseAssetID(input string) (*AssetId, error) {
 	id := AssetId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	if id.AssetName, ok = parsed.Parsed["assetName"]; !ok {
-		return nil, fmt.Errorf("the segment 'assetName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "assetName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseAssetIDInsensitively(input string) (*AssetId, error) {
 	id := AssetId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	if id.AssetName, ok = parsed.Parsed["assetName"]; !ok {
-		return nil, fmt.Errorf("the segment 'assetName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "assetName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/assetsandassetfilters/id_assetfilter.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/assetsandassetfilters/id_assetfilter.go
@@ -44,23 +44,23 @@ func ParseAssetFilterID(input string) (*AssetFilterId, error) {
 	id := AssetFilterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	if id.AssetName, ok = parsed.Parsed["assetName"]; !ok {
-		return nil, fmt.Errorf("the segment 'assetName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "assetName", *parsed)
 	}
 
 	if id.AssetFilterName, ok = parsed.Parsed["assetFilterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'assetFilterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "assetFilterName", *parsed)
 	}
 
 	return &id, nil
@@ -79,23 +79,23 @@ func ParseAssetFilterIDInsensitively(input string) (*AssetFilterId, error) {
 	id := AssetFilterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	if id.AssetName, ok = parsed.Parsed["assetName"]; !ok {
-		return nil, fmt.Errorf("the segment 'assetName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "assetName", *parsed)
 	}
 
 	if id.AssetFilterName, ok = parsed.Parsed["assetFilterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'assetFilterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "assetFilterName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/assetsandassetfilters/id_mediaservice.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/assetsandassetfilters/id_mediaservice.go
@@ -40,15 +40,15 @@ func ParseMediaServiceID(input string) (*MediaServiceId, error) {
 	id := MediaServiceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseMediaServiceIDInsensitively(input string) (*MediaServiceId, error) {
 	id := MediaServiceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/assetsandassetfilters/id_track.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/assetsandassetfilters/id_track.go
@@ -44,23 +44,23 @@ func ParseTrackID(input string) (*TrackId, error) {
 	id := TrackId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	if id.AssetName, ok = parsed.Parsed["assetName"]; !ok {
-		return nil, fmt.Errorf("the segment 'assetName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "assetName", *parsed)
 	}
 
 	if id.TrackName, ok = parsed.Parsed["trackName"]; !ok {
-		return nil, fmt.Errorf("the segment 'trackName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "trackName", *parsed)
 	}
 
 	return &id, nil
@@ -79,23 +79,23 @@ func ParseTrackIDInsensitively(input string) (*TrackId, error) {
 	id := TrackId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	if id.AssetName, ok = parsed.Parsed["assetName"]; !ok {
-		return nil, fmt.Errorf("the segment 'assetName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "assetName", *parsed)
 	}
 
 	if id.TrackName, ok = parsed.Parsed["trackName"]; !ok {
-		return nil, fmt.Errorf("the segment 'trackName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "trackName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/contentkeypolicies/id_contentkeypolicy.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/contentkeypolicies/id_contentkeypolicy.go
@@ -42,19 +42,19 @@ func ParseContentKeyPolicyID(input string) (*ContentKeyPolicyId, error) {
 	id := ContentKeyPolicyId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	if id.ContentKeyPolicyName, ok = parsed.Parsed["contentKeyPolicyName"]; !ok {
-		return nil, fmt.Errorf("the segment 'contentKeyPolicyName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "contentKeyPolicyName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseContentKeyPolicyIDInsensitively(input string) (*ContentKeyPolicyId, er
 	id := ContentKeyPolicyId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	if id.ContentKeyPolicyName, ok = parsed.Parsed["contentKeyPolicyName"]; !ok {
-		return nil, fmt.Errorf("the segment 'contentKeyPolicyName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "contentKeyPolicyName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/contentkeypolicies/id_mediaservice.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/contentkeypolicies/id_mediaservice.go
@@ -40,15 +40,15 @@ func ParseMediaServiceID(input string) (*MediaServiceId, error) {
 	id := MediaServiceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseMediaServiceIDInsensitively(input string) (*MediaServiceId, error) {
 	id := MediaServiceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/encodings/id_job.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/encodings/id_job.go
@@ -44,23 +44,23 @@ func ParseJobID(input string) (*JobId, error) {
 	id := JobId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	if id.TransformName, ok = parsed.Parsed["transformName"]; !ok {
-		return nil, fmt.Errorf("the segment 'transformName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "transformName", *parsed)
 	}
 
 	if id.JobName, ok = parsed.Parsed["jobName"]; !ok {
-		return nil, fmt.Errorf("the segment 'jobName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "jobName", *parsed)
 	}
 
 	return &id, nil
@@ -79,23 +79,23 @@ func ParseJobIDInsensitively(input string) (*JobId, error) {
 	id := JobId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	if id.TransformName, ok = parsed.Parsed["transformName"]; !ok {
-		return nil, fmt.Errorf("the segment 'transformName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "transformName", *parsed)
 	}
 
 	if id.JobName, ok = parsed.Parsed["jobName"]; !ok {
-		return nil, fmt.Errorf("the segment 'jobName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "jobName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/encodings/id_mediaservice.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/encodings/id_mediaservice.go
@@ -40,15 +40,15 @@ func ParseMediaServiceID(input string) (*MediaServiceId, error) {
 	id := MediaServiceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseMediaServiceIDInsensitively(input string) (*MediaServiceId, error) {
 	id := MediaServiceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/encodings/id_transform.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/encodings/id_transform.go
@@ -42,19 +42,19 @@ func ParseTransformID(input string) (*TransformId, error) {
 	id := TransformId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	if id.TransformName, ok = parsed.Parsed["transformName"]; !ok {
-		return nil, fmt.Errorf("the segment 'transformName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "transformName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseTransformIDInsensitively(input string) (*TransformId, error) {
 	id := TransformId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	if id.TransformName, ok = parsed.Parsed["transformName"]; !ok {
-		return nil, fmt.Errorf("the segment 'transformName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "transformName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/liveevents/id_liveevent.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/liveevents/id_liveevent.go
@@ -42,19 +42,19 @@ func ParseLiveEventID(input string) (*LiveEventId, error) {
 	id := LiveEventId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	if id.LiveEventName, ok = parsed.Parsed["liveEventName"]; !ok {
-		return nil, fmt.Errorf("the segment 'liveEventName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "liveEventName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseLiveEventIDInsensitively(input string) (*LiveEventId, error) {
 	id := LiveEventId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	if id.LiveEventName, ok = parsed.Parsed["liveEventName"]; !ok {
-		return nil, fmt.Errorf("the segment 'liveEventName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "liveEventName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/liveevents/id_mediaservice.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/liveevents/id_mediaservice.go
@@ -40,15 +40,15 @@ func ParseMediaServiceID(input string) (*MediaServiceId, error) {
 	id := MediaServiceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseMediaServiceIDInsensitively(input string) (*MediaServiceId, error) {
 	id := MediaServiceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/liveoutputs/id_liveevent.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/liveoutputs/id_liveevent.go
@@ -42,19 +42,19 @@ func ParseLiveEventID(input string) (*LiveEventId, error) {
 	id := LiveEventId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	if id.LiveEventName, ok = parsed.Parsed["liveEventName"]; !ok {
-		return nil, fmt.Errorf("the segment 'liveEventName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "liveEventName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseLiveEventIDInsensitively(input string) (*LiveEventId, error) {
 	id := LiveEventId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	if id.LiveEventName, ok = parsed.Parsed["liveEventName"]; !ok {
-		return nil, fmt.Errorf("the segment 'liveEventName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "liveEventName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/liveoutputs/id_liveoutput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/liveoutputs/id_liveoutput.go
@@ -44,23 +44,23 @@ func ParseLiveOutputID(input string) (*LiveOutputId, error) {
 	id := LiveOutputId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	if id.LiveEventName, ok = parsed.Parsed["liveEventName"]; !ok {
-		return nil, fmt.Errorf("the segment 'liveEventName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "liveEventName", *parsed)
 	}
 
 	if id.LiveOutputName, ok = parsed.Parsed["liveOutputName"]; !ok {
-		return nil, fmt.Errorf("the segment 'liveOutputName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "liveOutputName", *parsed)
 	}
 
 	return &id, nil
@@ -79,23 +79,23 @@ func ParseLiveOutputIDInsensitively(input string) (*LiveOutputId, error) {
 	id := LiveOutputId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	if id.LiveEventName, ok = parsed.Parsed["liveEventName"]; !ok {
-		return nil, fmt.Errorf("the segment 'liveEventName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "liveEventName", *parsed)
 	}
 
 	if id.LiveOutputName, ok = parsed.Parsed["liveOutputName"]; !ok {
-		return nil, fmt.Errorf("the segment 'liveOutputName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "liveOutputName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/streamingendpoints/id_mediaservice.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/streamingendpoints/id_mediaservice.go
@@ -40,15 +40,15 @@ func ParseMediaServiceID(input string) (*MediaServiceId, error) {
 	id := MediaServiceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseMediaServiceIDInsensitively(input string) (*MediaServiceId, error) {
 	id := MediaServiceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/streamingendpoints/id_streamingendpoint.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/streamingendpoints/id_streamingendpoint.go
@@ -42,19 +42,19 @@ func ParseStreamingEndpointID(input string) (*StreamingEndpointId, error) {
 	id := StreamingEndpointId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	if id.StreamingEndpointName, ok = parsed.Parsed["streamingEndpointName"]; !ok {
-		return nil, fmt.Errorf("the segment 'streamingEndpointName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "streamingEndpointName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseStreamingEndpointIDInsensitively(input string) (*StreamingEndpointId, 
 	id := StreamingEndpointId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	if id.StreamingEndpointName, ok = parsed.Parsed["streamingEndpointName"]; !ok {
-		return nil, fmt.Errorf("the segment 'streamingEndpointName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "streamingEndpointName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/streamingpoliciesandstreaminglocators/id_mediaservice.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/streamingpoliciesandstreaminglocators/id_mediaservice.go
@@ -40,15 +40,15 @@ func ParseMediaServiceID(input string) (*MediaServiceId, error) {
 	id := MediaServiceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseMediaServiceIDInsensitively(input string) (*MediaServiceId, error) {
 	id := MediaServiceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/streamingpoliciesandstreaminglocators/id_streaminglocator.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/streamingpoliciesandstreaminglocators/id_streaminglocator.go
@@ -42,19 +42,19 @@ func ParseStreamingLocatorID(input string) (*StreamingLocatorId, error) {
 	id := StreamingLocatorId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	if id.StreamingLocatorName, ok = parsed.Parsed["streamingLocatorName"]; !ok {
-		return nil, fmt.Errorf("the segment 'streamingLocatorName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "streamingLocatorName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseStreamingLocatorIDInsensitively(input string) (*StreamingLocatorId, er
 	id := StreamingLocatorId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	if id.StreamingLocatorName, ok = parsed.Parsed["streamingLocatorName"]; !ok {
-		return nil, fmt.Errorf("the segment 'streamingLocatorName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "streamingLocatorName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/streamingpoliciesandstreaminglocators/id_streamingpolicy.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/streamingpoliciesandstreaminglocators/id_streamingpolicy.go
@@ -42,19 +42,19 @@ func ParseStreamingPolicyID(input string) (*StreamingPolicyId, error) {
 	id := StreamingPolicyId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	if id.StreamingPolicyName, ok = parsed.Parsed["streamingPolicyName"]; !ok {
-		return nil, fmt.Errorf("the segment 'streamingPolicyName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "streamingPolicyName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseStreamingPolicyIDInsensitively(input string) (*StreamingPolicyId, erro
 	id := StreamingPolicyId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	if id.StreamingPolicyName, ok = parsed.Parsed["streamingPolicyName"]; !ok {
-		return nil, fmt.Errorf("the segment 'streamingPolicyName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "streamingPolicyName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-07-01/encodings/id_job.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-07-01/encodings/id_job.go
@@ -44,23 +44,23 @@ func ParseJobID(input string) (*JobId, error) {
 	id := JobId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	if id.TransformName, ok = parsed.Parsed["transformName"]; !ok {
-		return nil, fmt.Errorf("the segment 'transformName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "transformName", *parsed)
 	}
 
 	if id.JobName, ok = parsed.Parsed["jobName"]; !ok {
-		return nil, fmt.Errorf("the segment 'jobName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "jobName", *parsed)
 	}
 
 	return &id, nil
@@ -79,23 +79,23 @@ func ParseJobIDInsensitively(input string) (*JobId, error) {
 	id := JobId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	if id.TransformName, ok = parsed.Parsed["transformName"]; !ok {
-		return nil, fmt.Errorf("the segment 'transformName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "transformName", *parsed)
 	}
 
 	if id.JobName, ok = parsed.Parsed["jobName"]; !ok {
-		return nil, fmt.Errorf("the segment 'jobName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "jobName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-07-01/encodings/id_mediaservice.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-07-01/encodings/id_mediaservice.go
@@ -40,15 +40,15 @@ func ParseMediaServiceID(input string) (*MediaServiceId, error) {
 	id := MediaServiceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseMediaServiceIDInsensitively(input string) (*MediaServiceId, error) {
 	id := MediaServiceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-07-01/encodings/id_transform.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-07-01/encodings/id_transform.go
@@ -42,19 +42,19 @@ func ParseTransformID(input string) (*TransformId, error) {
 	id := TransformId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	if id.TransformName, ok = parsed.Parsed["transformName"]; !ok {
-		return nil, fmt.Errorf("the segment 'transformName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "transformName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseTransformIDInsensitively(input string) (*TransformId, error) {
 	id := TransformId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	if id.TransformName, ok = parsed.Parsed["transformName"]; !ok {
-		return nil, fmt.Errorf("the segment 'transformName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "transformName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-08-01/accountfilters/id_accountfilter.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-08-01/accountfilters/id_accountfilter.go
@@ -42,19 +42,19 @@ func ParseAccountFilterID(input string) (*AccountFilterId, error) {
 	id := AccountFilterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	if id.AccountFilterName, ok = parsed.Parsed["accountFilterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'accountFilterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "accountFilterName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseAccountFilterIDInsensitively(input string) (*AccountFilterId, error) {
 	id := AccountFilterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	if id.AccountFilterName, ok = parsed.Parsed["accountFilterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'accountFilterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "accountFilterName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-08-01/accountfilters/id_mediaservice.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-08-01/accountfilters/id_mediaservice.go
@@ -40,15 +40,15 @@ func ParseMediaServiceID(input string) (*MediaServiceId, error) {
 	id := MediaServiceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseMediaServiceIDInsensitively(input string) (*MediaServiceId, error) {
 	id := MediaServiceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-08-01/assetsandassetfilters/id_asset.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-08-01/assetsandassetfilters/id_asset.go
@@ -42,19 +42,19 @@ func ParseAssetID(input string) (*AssetId, error) {
 	id := AssetId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	if id.AssetName, ok = parsed.Parsed["assetName"]; !ok {
-		return nil, fmt.Errorf("the segment 'assetName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "assetName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseAssetIDInsensitively(input string) (*AssetId, error) {
 	id := AssetId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	if id.AssetName, ok = parsed.Parsed["assetName"]; !ok {
-		return nil, fmt.Errorf("the segment 'assetName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "assetName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-08-01/assetsandassetfilters/id_assetfilter.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-08-01/assetsandassetfilters/id_assetfilter.go
@@ -44,23 +44,23 @@ func ParseAssetFilterID(input string) (*AssetFilterId, error) {
 	id := AssetFilterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	if id.AssetName, ok = parsed.Parsed["assetName"]; !ok {
-		return nil, fmt.Errorf("the segment 'assetName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "assetName", *parsed)
 	}
 
 	if id.AssetFilterName, ok = parsed.Parsed["assetFilterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'assetFilterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "assetFilterName", *parsed)
 	}
 
 	return &id, nil
@@ -79,23 +79,23 @@ func ParseAssetFilterIDInsensitively(input string) (*AssetFilterId, error) {
 	id := AssetFilterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	if id.AssetName, ok = parsed.Parsed["assetName"]; !ok {
-		return nil, fmt.Errorf("the segment 'assetName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "assetName", *parsed)
 	}
 
 	if id.AssetFilterName, ok = parsed.Parsed["assetFilterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'assetFilterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "assetFilterName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-08-01/assetsandassetfilters/id_mediaservice.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-08-01/assetsandassetfilters/id_mediaservice.go
@@ -40,15 +40,15 @@ func ParseMediaServiceID(input string) (*MediaServiceId, error) {
 	id := MediaServiceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseMediaServiceIDInsensitively(input string) (*MediaServiceId, error) {
 	id := MediaServiceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-08-01/assetsandassetfilters/id_track.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-08-01/assetsandassetfilters/id_track.go
@@ -44,23 +44,23 @@ func ParseTrackID(input string) (*TrackId, error) {
 	id := TrackId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	if id.AssetName, ok = parsed.Parsed["assetName"]; !ok {
-		return nil, fmt.Errorf("the segment 'assetName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "assetName", *parsed)
 	}
 
 	if id.TrackName, ok = parsed.Parsed["trackName"]; !ok {
-		return nil, fmt.Errorf("the segment 'trackName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "trackName", *parsed)
 	}
 
 	return &id, nil
@@ -79,23 +79,23 @@ func ParseTrackIDInsensitively(input string) (*TrackId, error) {
 	id := TrackId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	if id.AssetName, ok = parsed.Parsed["assetName"]; !ok {
-		return nil, fmt.Errorf("the segment 'assetName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "assetName", *parsed)
 	}
 
 	if id.TrackName, ok = parsed.Parsed["trackName"]; !ok {
-		return nil, fmt.Errorf("the segment 'trackName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "trackName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-08-01/contentkeypolicies/id_contentkeypolicy.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-08-01/contentkeypolicies/id_contentkeypolicy.go
@@ -42,19 +42,19 @@ func ParseContentKeyPolicyID(input string) (*ContentKeyPolicyId, error) {
 	id := ContentKeyPolicyId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	if id.ContentKeyPolicyName, ok = parsed.Parsed["contentKeyPolicyName"]; !ok {
-		return nil, fmt.Errorf("the segment 'contentKeyPolicyName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "contentKeyPolicyName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseContentKeyPolicyIDInsensitively(input string) (*ContentKeyPolicyId, er
 	id := ContentKeyPolicyId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	if id.ContentKeyPolicyName, ok = parsed.Parsed["contentKeyPolicyName"]; !ok {
-		return nil, fmt.Errorf("the segment 'contentKeyPolicyName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "contentKeyPolicyName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-08-01/contentkeypolicies/id_mediaservice.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-08-01/contentkeypolicies/id_mediaservice.go
@@ -40,15 +40,15 @@ func ParseMediaServiceID(input string) (*MediaServiceId, error) {
 	id := MediaServiceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseMediaServiceIDInsensitively(input string) (*MediaServiceId, error) {
 	id := MediaServiceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-08-01/liveevents/id_liveevent.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-08-01/liveevents/id_liveevent.go
@@ -42,19 +42,19 @@ func ParseLiveEventID(input string) (*LiveEventId, error) {
 	id := LiveEventId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	if id.LiveEventName, ok = parsed.Parsed["liveEventName"]; !ok {
-		return nil, fmt.Errorf("the segment 'liveEventName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "liveEventName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseLiveEventIDInsensitively(input string) (*LiveEventId, error) {
 	id := LiveEventId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	if id.LiveEventName, ok = parsed.Parsed["liveEventName"]; !ok {
-		return nil, fmt.Errorf("the segment 'liveEventName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "liveEventName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-08-01/liveevents/id_liveeventoperation.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-08-01/liveevents/id_liveeventoperation.go
@@ -42,19 +42,19 @@ func ParseLiveEventOperationID(input string) (*LiveEventOperationId, error) {
 	id := LiveEventOperationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	if id.OperationId, ok = parsed.Parsed["operationId"]; !ok {
-		return nil, fmt.Errorf("the segment 'operationId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "operationId", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseLiveEventOperationIDInsensitively(input string) (*LiveEventOperationId
 	id := LiveEventOperationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	if id.OperationId, ok = parsed.Parsed["operationId"]; !ok {
-		return nil, fmt.Errorf("the segment 'operationId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "operationId", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-08-01/liveevents/id_mediaservice.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-08-01/liveevents/id_mediaservice.go
@@ -40,15 +40,15 @@ func ParseMediaServiceID(input string) (*MediaServiceId, error) {
 	id := MediaServiceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseMediaServiceIDInsensitively(input string) (*MediaServiceId, error) {
 	id := MediaServiceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-08-01/liveevents/id_operationlocation.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-08-01/liveevents/id_operationlocation.go
@@ -44,23 +44,23 @@ func ParseOperationLocationID(input string) (*OperationLocationId, error) {
 	id := OperationLocationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	if id.LiveEventName, ok = parsed.Parsed["liveEventName"]; !ok {
-		return nil, fmt.Errorf("the segment 'liveEventName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "liveEventName", *parsed)
 	}
 
 	if id.OperationId, ok = parsed.Parsed["operationId"]; !ok {
-		return nil, fmt.Errorf("the segment 'operationId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "operationId", *parsed)
 	}
 
 	return &id, nil
@@ -79,23 +79,23 @@ func ParseOperationLocationIDInsensitively(input string) (*OperationLocationId, 
 	id := OperationLocationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	if id.LiveEventName, ok = parsed.Parsed["liveEventName"]; !ok {
-		return nil, fmt.Errorf("the segment 'liveEventName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "liveEventName", *parsed)
 	}
 
 	if id.OperationId, ok = parsed.Parsed["operationId"]; !ok {
-		return nil, fmt.Errorf("the segment 'operationId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "operationId", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-08-01/liveoutputs/id_liveevent.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-08-01/liveoutputs/id_liveevent.go
@@ -42,19 +42,19 @@ func ParseLiveEventID(input string) (*LiveEventId, error) {
 	id := LiveEventId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	if id.LiveEventName, ok = parsed.Parsed["liveEventName"]; !ok {
-		return nil, fmt.Errorf("the segment 'liveEventName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "liveEventName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseLiveEventIDInsensitively(input string) (*LiveEventId, error) {
 	id := LiveEventId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	if id.LiveEventName, ok = parsed.Parsed["liveEventName"]; !ok {
-		return nil, fmt.Errorf("the segment 'liveEventName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "liveEventName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-08-01/liveoutputs/id_liveoutput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-08-01/liveoutputs/id_liveoutput.go
@@ -44,23 +44,23 @@ func ParseLiveOutputID(input string) (*LiveOutputId, error) {
 	id := LiveOutputId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	if id.LiveEventName, ok = parsed.Parsed["liveEventName"]; !ok {
-		return nil, fmt.Errorf("the segment 'liveEventName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "liveEventName", *parsed)
 	}
 
 	if id.LiveOutputName, ok = parsed.Parsed["liveOutputName"]; !ok {
-		return nil, fmt.Errorf("the segment 'liveOutputName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "liveOutputName", *parsed)
 	}
 
 	return &id, nil
@@ -79,23 +79,23 @@ func ParseLiveOutputIDInsensitively(input string) (*LiveOutputId, error) {
 	id := LiveOutputId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	if id.LiveEventName, ok = parsed.Parsed["liveEventName"]; !ok {
-		return nil, fmt.Errorf("the segment 'liveEventName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "liveEventName", *parsed)
 	}
 
 	if id.LiveOutputName, ok = parsed.Parsed["liveOutputName"]; !ok {
-		return nil, fmt.Errorf("the segment 'liveOutputName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "liveOutputName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-08-01/liveoutputs/id_liveoutputoperation.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-08-01/liveoutputs/id_liveoutputoperation.go
@@ -42,19 +42,19 @@ func ParseLiveOutputOperationID(input string) (*LiveOutputOperationId, error) {
 	id := LiveOutputOperationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	if id.OperationId, ok = parsed.Parsed["operationId"]; !ok {
-		return nil, fmt.Errorf("the segment 'operationId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "operationId", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseLiveOutputOperationIDInsensitively(input string) (*LiveOutputOperation
 	id := LiveOutputOperationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	if id.OperationId, ok = parsed.Parsed["operationId"]; !ok {
-		return nil, fmt.Errorf("the segment 'operationId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "operationId", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-08-01/liveoutputs/id_liveoutputoperationlocation.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-08-01/liveoutputs/id_liveoutputoperationlocation.go
@@ -46,27 +46,27 @@ func ParseLiveOutputOperationLocationID(input string) (*LiveOutputOperationLocat
 	id := LiveOutputOperationLocationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	if id.LiveEventName, ok = parsed.Parsed["liveEventName"]; !ok {
-		return nil, fmt.Errorf("the segment 'liveEventName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "liveEventName", *parsed)
 	}
 
 	if id.LiveOutputName, ok = parsed.Parsed["liveOutputName"]; !ok {
-		return nil, fmt.Errorf("the segment 'liveOutputName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "liveOutputName", *parsed)
 	}
 
 	if id.OperationId, ok = parsed.Parsed["operationId"]; !ok {
-		return nil, fmt.Errorf("the segment 'operationId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "operationId", *parsed)
 	}
 
 	return &id, nil
@@ -85,27 +85,27 @@ func ParseLiveOutputOperationLocationIDInsensitively(input string) (*LiveOutputO
 	id := LiveOutputOperationLocationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	if id.LiveEventName, ok = parsed.Parsed["liveEventName"]; !ok {
-		return nil, fmt.Errorf("the segment 'liveEventName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "liveEventName", *parsed)
 	}
 
 	if id.LiveOutputName, ok = parsed.Parsed["liveOutputName"]; !ok {
-		return nil, fmt.Errorf("the segment 'liveOutputName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "liveOutputName", *parsed)
 	}
 
 	if id.OperationId, ok = parsed.Parsed["operationId"]; !ok {
-		return nil, fmt.Errorf("the segment 'operationId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "operationId", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-08-01/streamingendpoints/id_mediaservice.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-08-01/streamingendpoints/id_mediaservice.go
@@ -40,15 +40,15 @@ func ParseMediaServiceID(input string) (*MediaServiceId, error) {
 	id := MediaServiceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseMediaServiceIDInsensitively(input string) (*MediaServiceId, error) {
 	id := MediaServiceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-08-01/streamingendpoints/id_streamingendpoint.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-08-01/streamingendpoints/id_streamingendpoint.go
@@ -42,19 +42,19 @@ func ParseStreamingEndpointID(input string) (*StreamingEndpointId, error) {
 	id := StreamingEndpointId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	if id.StreamingEndpointName, ok = parsed.Parsed["streamingEndpointName"]; !ok {
-		return nil, fmt.Errorf("the segment 'streamingEndpointName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "streamingEndpointName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseStreamingEndpointIDInsensitively(input string) (*StreamingEndpointId, 
 	id := StreamingEndpointId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	if id.StreamingEndpointName, ok = parsed.Parsed["streamingEndpointName"]; !ok {
-		return nil, fmt.Errorf("the segment 'streamingEndpointName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "streamingEndpointName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-08-01/streamingendpoints/id_streamingendpointoperation.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-08-01/streamingendpoints/id_streamingendpointoperation.go
@@ -42,19 +42,19 @@ func ParseStreamingEndpointOperationID(input string) (*StreamingEndpointOperatio
 	id := StreamingEndpointOperationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	if id.OperationId, ok = parsed.Parsed["operationId"]; !ok {
-		return nil, fmt.Errorf("the segment 'operationId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "operationId", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseStreamingEndpointOperationIDInsensitively(input string) (*StreamingEnd
 	id := StreamingEndpointOperationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	if id.OperationId, ok = parsed.Parsed["operationId"]; !ok {
-		return nil, fmt.Errorf("the segment 'operationId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "operationId", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-08-01/streamingendpoints/id_streamingendpointoperationlocation.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-08-01/streamingendpoints/id_streamingendpointoperationlocation.go
@@ -44,23 +44,23 @@ func ParseStreamingEndpointOperationLocationID(input string) (*StreamingEndpoint
 	id := StreamingEndpointOperationLocationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	if id.StreamingEndpointName, ok = parsed.Parsed["streamingEndpointName"]; !ok {
-		return nil, fmt.Errorf("the segment 'streamingEndpointName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "streamingEndpointName", *parsed)
 	}
 
 	if id.OperationId, ok = parsed.Parsed["operationId"]; !ok {
-		return nil, fmt.Errorf("the segment 'operationId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "operationId", *parsed)
 	}
 
 	return &id, nil
@@ -79,23 +79,23 @@ func ParseStreamingEndpointOperationLocationIDInsensitively(input string) (*Stre
 	id := StreamingEndpointOperationLocationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	if id.StreamingEndpointName, ok = parsed.Parsed["streamingEndpointName"]; !ok {
-		return nil, fmt.Errorf("the segment 'streamingEndpointName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "streamingEndpointName", *parsed)
 	}
 
 	if id.OperationId, ok = parsed.Parsed["operationId"]; !ok {
-		return nil, fmt.Errorf("the segment 'operationId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "operationId", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-08-01/streamingpoliciesandstreaminglocators/id_mediaservice.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-08-01/streamingpoliciesandstreaminglocators/id_mediaservice.go
@@ -40,15 +40,15 @@ func ParseMediaServiceID(input string) (*MediaServiceId, error) {
 	id := MediaServiceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseMediaServiceIDInsensitively(input string) (*MediaServiceId, error) {
 	id := MediaServiceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-08-01/streamingpoliciesandstreaminglocators/id_streaminglocator.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-08-01/streamingpoliciesandstreaminglocators/id_streaminglocator.go
@@ -42,19 +42,19 @@ func ParseStreamingLocatorID(input string) (*StreamingLocatorId, error) {
 	id := StreamingLocatorId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	if id.StreamingLocatorName, ok = parsed.Parsed["streamingLocatorName"]; !ok {
-		return nil, fmt.Errorf("the segment 'streamingLocatorName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "streamingLocatorName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseStreamingLocatorIDInsensitively(input string) (*StreamingLocatorId, er
 	id := StreamingLocatorId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	if id.StreamingLocatorName, ok = parsed.Parsed["streamingLocatorName"]; !ok {
-		return nil, fmt.Errorf("the segment 'streamingLocatorName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "streamingLocatorName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-08-01/streamingpoliciesandstreaminglocators/id_streamingpolicy.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-08-01/streamingpoliciesandstreaminglocators/id_streamingpolicy.go
@@ -42,19 +42,19 @@ func ParseStreamingPolicyID(input string) (*StreamingPolicyId, error) {
 	id := StreamingPolicyId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	if id.StreamingPolicyName, ok = parsed.Parsed["streamingPolicyName"]; !ok {
-		return nil, fmt.Errorf("the segment 'streamingPolicyName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "streamingPolicyName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseStreamingPolicyIDInsensitively(input string) (*StreamingPolicyId, erro
 	id := StreamingPolicyId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MediaServiceName, ok = parsed.Parsed["mediaServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mediaServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mediaServiceName", *parsed)
 	}
 
 	if id.StreamingPolicyName, ok = parsed.Parsed["streamingPolicyName"]; !ok {
-		return nil, fmt.Errorf("the segment 'streamingPolicyName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "streamingPolicyName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mixedreality/2021-01-01/resource/id_remoterenderingaccount.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mixedreality/2021-01-01/resource/id_remoterenderingaccount.go
@@ -40,15 +40,15 @@ func ParseRemoteRenderingAccountID(input string) (*RemoteRenderingAccountId, err
 	id := RemoteRenderingAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RemoteRenderingAccountName, ok = parsed.Parsed["remoteRenderingAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'remoteRenderingAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "remoteRenderingAccountName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseRemoteRenderingAccountIDInsensitively(input string) (*RemoteRenderingA
 	id := RemoteRenderingAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RemoteRenderingAccountName, ok = parsed.Parsed["remoteRenderingAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'remoteRenderingAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "remoteRenderingAccountName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mixedreality/2021-01-01/resource/id_spatialanchorsaccount.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mixedreality/2021-01-01/resource/id_spatialanchorsaccount.go
@@ -40,15 +40,15 @@ func ParseSpatialAnchorsAccountID(input string) (*SpatialAnchorsAccountId, error
 	id := SpatialAnchorsAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.SpatialAnchorsAccountName, ok = parsed.Parsed["spatialAnchorsAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'spatialAnchorsAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "spatialAnchorsAccountName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseSpatialAnchorsAccountIDInsensitively(input string) (*SpatialAnchorsAcc
 	id := SpatialAnchorsAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.SpatialAnchorsAccountName, ok = parsed.Parsed["spatialAnchorsAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'spatialAnchorsAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "spatialAnchorsAccountName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/datanetwork/id_datanetwork.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/datanetwork/id_datanetwork.go
@@ -42,19 +42,19 @@ func ParseDataNetworkID(input string) (*DataNetworkId, error) {
 	id := DataNetworkId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MobileNetworkName, ok = parsed.Parsed["mobileNetworkName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mobileNetworkName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mobileNetworkName", *parsed)
 	}
 
 	if id.DataNetworkName, ok = parsed.Parsed["dataNetworkName"]; !ok {
-		return nil, fmt.Errorf("the segment 'dataNetworkName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "dataNetworkName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseDataNetworkIDInsensitively(input string) (*DataNetworkId, error) {
 	id := DataNetworkId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MobileNetworkName, ok = parsed.Parsed["mobileNetworkName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mobileNetworkName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mobileNetworkName", *parsed)
 	}
 
 	if id.DataNetworkName, ok = parsed.Parsed["dataNetworkName"]; !ok {
-		return nil, fmt.Errorf("the segment 'dataNetworkName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "dataNetworkName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/mobilenetwork/id_mobilenetwork.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/mobilenetwork/id_mobilenetwork.go
@@ -40,15 +40,15 @@ func ParseMobileNetworkID(input string) (*MobileNetworkId, error) {
 	id := MobileNetworkId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MobileNetworkName, ok = parsed.Parsed["mobileNetworkName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mobileNetworkName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mobileNetworkName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseMobileNetworkIDInsensitively(input string) (*MobileNetworkId, error) {
 	id := MobileNetworkId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MobileNetworkName, ok = parsed.Parsed["mobileNetworkName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mobileNetworkName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mobileNetworkName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/service/id_service.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/service/id_service.go
@@ -42,19 +42,19 @@ func ParseServiceID(input string) (*ServiceId, error) {
 	id := ServiceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MobileNetworkName, ok = parsed.Parsed["mobileNetworkName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mobileNetworkName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mobileNetworkName", *parsed)
 	}
 
 	if id.ServiceName, ok = parsed.Parsed["serviceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'serviceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serviceName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseServiceIDInsensitively(input string) (*ServiceId, error) {
 	id := ServiceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MobileNetworkName, ok = parsed.Parsed["mobileNetworkName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mobileNetworkName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mobileNetworkName", *parsed)
 	}
 
 	if id.ServiceName, ok = parsed.Parsed["serviceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'serviceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serviceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/simgroup/id_simgroup.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/simgroup/id_simgroup.go
@@ -40,15 +40,15 @@ func ParseSimGroupID(input string) (*SimGroupId, error) {
 	id := SimGroupId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.SimGroupName, ok = parsed.Parsed["simGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'simGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "simGroupName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseSimGroupIDInsensitively(input string) (*SimGroupId, error) {
 	id := SimGroupId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.SimGroupName, ok = parsed.Parsed["simGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'simGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "simGroupName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/simpolicy/id_simpolicy.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/simpolicy/id_simpolicy.go
@@ -42,19 +42,19 @@ func ParseSimPolicyID(input string) (*SimPolicyId, error) {
 	id := SimPolicyId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MobileNetworkName, ok = parsed.Parsed["mobileNetworkName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mobileNetworkName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mobileNetworkName", *parsed)
 	}
 
 	if id.SimPolicyName, ok = parsed.Parsed["simPolicyName"]; !ok {
-		return nil, fmt.Errorf("the segment 'simPolicyName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "simPolicyName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseSimPolicyIDInsensitively(input string) (*SimPolicyId, error) {
 	id := SimPolicyId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MobileNetworkName, ok = parsed.Parsed["mobileNetworkName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mobileNetworkName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mobileNetworkName", *parsed)
 	}
 
 	if id.SimPolicyName, ok = parsed.Parsed["simPolicyName"]; !ok {
-		return nil, fmt.Errorf("the segment 'simPolicyName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "simPolicyName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/site/id_site.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/site/id_site.go
@@ -42,19 +42,19 @@ func ParseSiteID(input string) (*SiteId, error) {
 	id := SiteId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MobileNetworkName, ok = parsed.Parsed["mobileNetworkName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mobileNetworkName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mobileNetworkName", *parsed)
 	}
 
 	if id.SiteName, ok = parsed.Parsed["siteName"]; !ok {
-		return nil, fmt.Errorf("the segment 'siteName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "siteName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseSiteIDInsensitively(input string) (*SiteId, error) {
 	id := SiteId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MobileNetworkName, ok = parsed.Parsed["mobileNetworkName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mobileNetworkName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mobileNetworkName", *parsed)
 	}
 
 	if id.SiteName, ok = parsed.Parsed["siteName"]; !ok {
-		return nil, fmt.Errorf("the segment 'siteName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "siteName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/slice/id_slice.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mobilenetwork/2022-11-01/slice/id_slice.go
@@ -42,19 +42,19 @@ func ParseSliceID(input string) (*SliceId, error) {
 	id := SliceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MobileNetworkName, ok = parsed.Parsed["mobileNetworkName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mobileNetworkName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mobileNetworkName", *parsed)
 	}
 
 	if id.SliceName, ok = parsed.Parsed["sliceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'sliceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "sliceName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseSliceIDInsensitively(input string) (*SliceId, error) {
 	id := SliceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.MobileNetworkName, ok = parsed.Parsed["mobileNetworkName"]; !ok {
-		return nil, fmt.Errorf("the segment 'mobileNetworkName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "mobileNetworkName", *parsed)
 	}
 
 	if id.SliceName, ok = parsed.Parsed["sliceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'sliceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "sliceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mysql/2021-05-01/serverfailover/id_flexibleserver.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mysql/2021-05-01/serverfailover/id_flexibleserver.go
@@ -40,15 +40,15 @@ func ParseFlexibleServerID(input string) (*FlexibleServerId, error) {
 	id := FlexibleServerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.FlexibleServerName, ok = parsed.Parsed["flexibleServerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'flexibleServerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "flexibleServerName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseFlexibleServerIDInsensitively(input string) (*FlexibleServerId, error)
 	id := FlexibleServerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.FlexibleServerName, ok = parsed.Parsed["flexibleServerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'flexibleServerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "flexibleServerName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mysql/2021-05-01/servers/id_flexibleserver.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mysql/2021-05-01/servers/id_flexibleserver.go
@@ -40,15 +40,15 @@ func ParseFlexibleServerID(input string) (*FlexibleServerId, error) {
 	id := FlexibleServerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.FlexibleServerName, ok = parsed.Parsed["flexibleServerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'flexibleServerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "flexibleServerName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseFlexibleServerIDInsensitively(input string) (*FlexibleServerId, error)
 	id := FlexibleServerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.FlexibleServerName, ok = parsed.Parsed["flexibleServerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'flexibleServerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "flexibleServerName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/netapp/2022-05-01/capacitypools/id_capacitypool.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/netapp/2022-05-01/capacitypools/id_capacitypool.go
@@ -42,19 +42,19 @@ func ParseCapacityPoolID(input string) (*CapacityPoolId, error) {
 	id := CapacityPoolId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NetAppAccountName, ok = parsed.Parsed["netAppAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'netAppAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "netAppAccountName", *parsed)
 	}
 
 	if id.CapacityPoolName, ok = parsed.Parsed["capacityPoolName"]; !ok {
-		return nil, fmt.Errorf("the segment 'capacityPoolName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "capacityPoolName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseCapacityPoolIDInsensitively(input string) (*CapacityPoolId, error) {
 	id := CapacityPoolId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NetAppAccountName, ok = parsed.Parsed["netAppAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'netAppAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "netAppAccountName", *parsed)
 	}
 
 	if id.CapacityPoolName, ok = parsed.Parsed["capacityPoolName"]; !ok {
-		return nil, fmt.Errorf("the segment 'capacityPoolName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "capacityPoolName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/netapp/2022-05-01/capacitypools/id_netappaccount.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/netapp/2022-05-01/capacitypools/id_netappaccount.go
@@ -40,15 +40,15 @@ func ParseNetAppAccountID(input string) (*NetAppAccountId, error) {
 	id := NetAppAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NetAppAccountName, ok = parsed.Parsed["netAppAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'netAppAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "netAppAccountName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseNetAppAccountIDInsensitively(input string) (*NetAppAccountId, error) {
 	id := NetAppAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NetAppAccountName, ok = parsed.Parsed["netAppAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'netAppAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "netAppAccountName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/netapp/2022-05-01/netappaccounts/id_netappaccount.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/netapp/2022-05-01/netappaccounts/id_netappaccount.go
@@ -40,15 +40,15 @@ func ParseNetAppAccountID(input string) (*NetAppAccountId, error) {
 	id := NetAppAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NetAppAccountName, ok = parsed.Parsed["netAppAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'netAppAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "netAppAccountName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseNetAppAccountIDInsensitively(input string) (*NetAppAccountId, error) {
 	id := NetAppAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NetAppAccountName, ok = parsed.Parsed["netAppAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'netAppAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "netAppAccountName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/netapp/2022-05-01/snapshotpolicy/id_netappaccount.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/netapp/2022-05-01/snapshotpolicy/id_netappaccount.go
@@ -40,15 +40,15 @@ func ParseNetAppAccountID(input string) (*NetAppAccountId, error) {
 	id := NetAppAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NetAppAccountName, ok = parsed.Parsed["netAppAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'netAppAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "netAppAccountName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseNetAppAccountIDInsensitively(input string) (*NetAppAccountId, error) {
 	id := NetAppAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NetAppAccountName, ok = parsed.Parsed["netAppAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'netAppAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "netAppAccountName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/netapp/2022-05-01/snapshotpolicy/id_snapshotpolicy.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/netapp/2022-05-01/snapshotpolicy/id_snapshotpolicy.go
@@ -42,19 +42,19 @@ func ParseSnapshotPolicyID(input string) (*SnapshotPolicyId, error) {
 	id := SnapshotPolicyId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NetAppAccountName, ok = parsed.Parsed["netAppAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'netAppAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "netAppAccountName", *parsed)
 	}
 
 	if id.SnapshotPolicyName, ok = parsed.Parsed["snapshotPolicyName"]; !ok {
-		return nil, fmt.Errorf("the segment 'snapshotPolicyName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "snapshotPolicyName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseSnapshotPolicyIDInsensitively(input string) (*SnapshotPolicyId, error)
 	id := SnapshotPolicyId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NetAppAccountName, ok = parsed.Parsed["netAppAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'netAppAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "netAppAccountName", *parsed)
 	}
 
 	if id.SnapshotPolicyName, ok = parsed.Parsed["snapshotPolicyName"]; !ok {
-		return nil, fmt.Errorf("the segment 'snapshotPolicyName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "snapshotPolicyName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/netapp/2022-05-01/snapshots/id_snapshot.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/netapp/2022-05-01/snapshots/id_snapshot.go
@@ -46,27 +46,27 @@ func ParseSnapshotID(input string) (*SnapshotId, error) {
 	id := SnapshotId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NetAppAccountName, ok = parsed.Parsed["netAppAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'netAppAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "netAppAccountName", *parsed)
 	}
 
 	if id.CapacityPoolName, ok = parsed.Parsed["capacityPoolName"]; !ok {
-		return nil, fmt.Errorf("the segment 'capacityPoolName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "capacityPoolName", *parsed)
 	}
 
 	if id.VolumeName, ok = parsed.Parsed["volumeName"]; !ok {
-		return nil, fmt.Errorf("the segment 'volumeName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "volumeName", *parsed)
 	}
 
 	if id.SnapshotName, ok = parsed.Parsed["snapshotName"]; !ok {
-		return nil, fmt.Errorf("the segment 'snapshotName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "snapshotName", *parsed)
 	}
 
 	return &id, nil
@@ -85,27 +85,27 @@ func ParseSnapshotIDInsensitively(input string) (*SnapshotId, error) {
 	id := SnapshotId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NetAppAccountName, ok = parsed.Parsed["netAppAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'netAppAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "netAppAccountName", *parsed)
 	}
 
 	if id.CapacityPoolName, ok = parsed.Parsed["capacityPoolName"]; !ok {
-		return nil, fmt.Errorf("the segment 'capacityPoolName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "capacityPoolName", *parsed)
 	}
 
 	if id.VolumeName, ok = parsed.Parsed["volumeName"]; !ok {
-		return nil, fmt.Errorf("the segment 'volumeName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "volumeName", *parsed)
 	}
 
 	if id.SnapshotName, ok = parsed.Parsed["snapshotName"]; !ok {
-		return nil, fmt.Errorf("the segment 'snapshotName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "snapshotName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/netapp/2022-05-01/snapshots/id_volume.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/netapp/2022-05-01/snapshots/id_volume.go
@@ -44,23 +44,23 @@ func ParseVolumeID(input string) (*VolumeId, error) {
 	id := VolumeId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NetAppAccountName, ok = parsed.Parsed["netAppAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'netAppAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "netAppAccountName", *parsed)
 	}
 
 	if id.CapacityPoolName, ok = parsed.Parsed["capacityPoolName"]; !ok {
-		return nil, fmt.Errorf("the segment 'capacityPoolName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "capacityPoolName", *parsed)
 	}
 
 	if id.VolumeName, ok = parsed.Parsed["volumeName"]; !ok {
-		return nil, fmt.Errorf("the segment 'volumeName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "volumeName", *parsed)
 	}
 
 	return &id, nil
@@ -79,23 +79,23 @@ func ParseVolumeIDInsensitively(input string) (*VolumeId, error) {
 	id := VolumeId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NetAppAccountName, ok = parsed.Parsed["netAppAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'netAppAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "netAppAccountName", *parsed)
 	}
 
 	if id.CapacityPoolName, ok = parsed.Parsed["capacityPoolName"]; !ok {
-		return nil, fmt.Errorf("the segment 'capacityPoolName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "capacityPoolName", *parsed)
 	}
 
 	if id.VolumeName, ok = parsed.Parsed["volumeName"]; !ok {
-		return nil, fmt.Errorf("the segment 'volumeName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "volumeName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/netapp/2022-05-01/volumegroups/id_netappaccount.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/netapp/2022-05-01/volumegroups/id_netappaccount.go
@@ -40,15 +40,15 @@ func ParseNetAppAccountID(input string) (*NetAppAccountId, error) {
 	id := NetAppAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NetAppAccountName, ok = parsed.Parsed["netAppAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'netAppAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "netAppAccountName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseNetAppAccountIDInsensitively(input string) (*NetAppAccountId, error) {
 	id := NetAppAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NetAppAccountName, ok = parsed.Parsed["netAppAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'netAppAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "netAppAccountName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/netapp/2022-05-01/volumegroups/id_volumegroup.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/netapp/2022-05-01/volumegroups/id_volumegroup.go
@@ -42,19 +42,19 @@ func ParseVolumeGroupID(input string) (*VolumeGroupId, error) {
 	id := VolumeGroupId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NetAppAccountName, ok = parsed.Parsed["netAppAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'netAppAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "netAppAccountName", *parsed)
 	}
 
 	if id.VolumeGroupName, ok = parsed.Parsed["volumeGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'volumeGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "volumeGroupName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseVolumeGroupIDInsensitively(input string) (*VolumeGroupId, error) {
 	id := VolumeGroupId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NetAppAccountName, ok = parsed.Parsed["netAppAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'netAppAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "netAppAccountName", *parsed)
 	}
 
 	if id.VolumeGroupName, ok = parsed.Parsed["volumeGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'volumeGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "volumeGroupName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/netapp/2022-05-01/volumes/id_capacitypool.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/netapp/2022-05-01/volumes/id_capacitypool.go
@@ -42,19 +42,19 @@ func ParseCapacityPoolID(input string) (*CapacityPoolId, error) {
 	id := CapacityPoolId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NetAppAccountName, ok = parsed.Parsed["netAppAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'netAppAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "netAppAccountName", *parsed)
 	}
 
 	if id.CapacityPoolName, ok = parsed.Parsed["capacityPoolName"]; !ok {
-		return nil, fmt.Errorf("the segment 'capacityPoolName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "capacityPoolName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseCapacityPoolIDInsensitively(input string) (*CapacityPoolId, error) {
 	id := CapacityPoolId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NetAppAccountName, ok = parsed.Parsed["netAppAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'netAppAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "netAppAccountName", *parsed)
 	}
 
 	if id.CapacityPoolName, ok = parsed.Parsed["capacityPoolName"]; !ok {
-		return nil, fmt.Errorf("the segment 'capacityPoolName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "capacityPoolName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/netapp/2022-05-01/volumes/id_volume.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/netapp/2022-05-01/volumes/id_volume.go
@@ -44,23 +44,23 @@ func ParseVolumeID(input string) (*VolumeId, error) {
 	id := VolumeId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NetAppAccountName, ok = parsed.Parsed["netAppAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'netAppAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "netAppAccountName", *parsed)
 	}
 
 	if id.CapacityPoolName, ok = parsed.Parsed["capacityPoolName"]; !ok {
-		return nil, fmt.Errorf("the segment 'capacityPoolName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "capacityPoolName", *parsed)
 	}
 
 	if id.VolumeName, ok = parsed.Parsed["volumeName"]; !ok {
-		return nil, fmt.Errorf("the segment 'volumeName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "volumeName", *parsed)
 	}
 
 	return &id, nil
@@ -79,23 +79,23 @@ func ParseVolumeIDInsensitively(input string) (*VolumeId, error) {
 	id := VolumeId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NetAppAccountName, ok = parsed.Parsed["netAppAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'netAppAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "netAppAccountName", *parsed)
 	}
 
 	if id.CapacityPoolName, ok = parsed.Parsed["capacityPoolName"]; !ok {
-		return nil, fmt.Errorf("the segment 'capacityPoolName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "capacityPoolName", *parsed)
 	}
 
 	if id.VolumeName, ok = parsed.Parsed["volumeName"]; !ok {
-		return nil, fmt.Errorf("the segment 'volumeName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "volumeName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/netapp/2022-05-01/volumesreplication/id_volume.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/netapp/2022-05-01/volumesreplication/id_volume.go
@@ -44,23 +44,23 @@ func ParseVolumeID(input string) (*VolumeId, error) {
 	id := VolumeId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NetAppAccountName, ok = parsed.Parsed["netAppAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'netAppAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "netAppAccountName", *parsed)
 	}
 
 	if id.CapacityPoolName, ok = parsed.Parsed["capacityPoolName"]; !ok {
-		return nil, fmt.Errorf("the segment 'capacityPoolName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "capacityPoolName", *parsed)
 	}
 
 	if id.VolumeName, ok = parsed.Parsed["volumeName"]; !ok {
-		return nil, fmt.Errorf("the segment 'volumeName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "volumeName", *parsed)
 	}
 
 	return &id, nil
@@ -79,23 +79,23 @@ func ParseVolumeIDInsensitively(input string) (*VolumeId, error) {
 	id := VolumeId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NetAppAccountName, ok = parsed.Parsed["netAppAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'netAppAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "netAppAccountName", *parsed)
 	}
 
 	if id.CapacityPoolName, ok = parsed.Parsed["capacityPoolName"]; !ok {
-		return nil, fmt.Errorf("the segment 'capacityPoolName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "capacityPoolName", *parsed)
 	}
 
 	if id.VolumeName, ok = parsed.Parsed["volumeName"]; !ok {
-		return nil, fmt.Errorf("the segment 'volumeName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "volumeName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2022-09-01/networkmanagers/id_networkmanager.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2022-09-01/networkmanagers/id_networkmanager.go
@@ -40,15 +40,15 @@ func ParseNetworkManagerID(input string) (*NetworkManagerId, error) {
 	id := NetworkManagerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NetworkManagerName, ok = parsed.Parsed["networkManagerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'networkManagerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "networkManagerName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseNetworkManagerIDInsensitively(input string) (*NetworkManagerId, error)
 	id := NetworkManagerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NetworkManagerName, ok = parsed.Parsed["networkManagerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'networkManagerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "networkManagerName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/nginx/2022-08-01/nginxcertificate/id_certificate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/nginx/2022-08-01/nginxcertificate/id_certificate.go
@@ -42,19 +42,19 @@ func ParseCertificateID(input string) (*CertificateId, error) {
 	id := CertificateId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NginxDeploymentName, ok = parsed.Parsed["nginxDeploymentName"]; !ok {
-		return nil, fmt.Errorf("the segment 'nginxDeploymentName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "nginxDeploymentName", *parsed)
 	}
 
 	if id.CertificateName, ok = parsed.Parsed["certificateName"]; !ok {
-		return nil, fmt.Errorf("the segment 'certificateName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "certificateName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseCertificateIDInsensitively(input string) (*CertificateId, error) {
 	id := CertificateId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NginxDeploymentName, ok = parsed.Parsed["nginxDeploymentName"]; !ok {
-		return nil, fmt.Errorf("the segment 'nginxDeploymentName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "nginxDeploymentName", *parsed)
 	}
 
 	if id.CertificateName, ok = parsed.Parsed["certificateName"]; !ok {
-		return nil, fmt.Errorf("the segment 'certificateName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "certificateName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/nginx/2022-08-01/nginxcertificate/id_nginxdeployment.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/nginx/2022-08-01/nginxcertificate/id_nginxdeployment.go
@@ -40,15 +40,15 @@ func ParseNginxDeploymentID(input string) (*NginxDeploymentId, error) {
 	id := NginxDeploymentId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NginxDeploymentName, ok = parsed.Parsed["nginxDeploymentName"]; !ok {
-		return nil, fmt.Errorf("the segment 'nginxDeploymentName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "nginxDeploymentName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseNginxDeploymentIDInsensitively(input string) (*NginxDeploymentId, erro
 	id := NginxDeploymentId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NginxDeploymentName, ok = parsed.Parsed["nginxDeploymentName"]; !ok {
-		return nil, fmt.Errorf("the segment 'nginxDeploymentName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "nginxDeploymentName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/nginx/2022-08-01/nginxconfiguration/id_configuration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/nginx/2022-08-01/nginxconfiguration/id_configuration.go
@@ -42,19 +42,19 @@ func ParseConfigurationID(input string) (*ConfigurationId, error) {
 	id := ConfigurationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NginxDeploymentName, ok = parsed.Parsed["nginxDeploymentName"]; !ok {
-		return nil, fmt.Errorf("the segment 'nginxDeploymentName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "nginxDeploymentName", *parsed)
 	}
 
 	if id.ConfigurationName, ok = parsed.Parsed["configurationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'configurationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "configurationName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseConfigurationIDInsensitively(input string) (*ConfigurationId, error) {
 	id := ConfigurationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NginxDeploymentName, ok = parsed.Parsed["nginxDeploymentName"]; !ok {
-		return nil, fmt.Errorf("the segment 'nginxDeploymentName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "nginxDeploymentName", *parsed)
 	}
 
 	if id.ConfigurationName, ok = parsed.Parsed["configurationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'configurationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "configurationName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/nginx/2022-08-01/nginxconfiguration/id_nginxdeployment.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/nginx/2022-08-01/nginxconfiguration/id_nginxdeployment.go
@@ -40,15 +40,15 @@ func ParseNginxDeploymentID(input string) (*NginxDeploymentId, error) {
 	id := NginxDeploymentId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NginxDeploymentName, ok = parsed.Parsed["nginxDeploymentName"]; !ok {
-		return nil, fmt.Errorf("the segment 'nginxDeploymentName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "nginxDeploymentName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseNginxDeploymentIDInsensitively(input string) (*NginxDeploymentId, erro
 	id := NginxDeploymentId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NginxDeploymentName, ok = parsed.Parsed["nginxDeploymentName"]; !ok {
-		return nil, fmt.Errorf("the segment 'nginxDeploymentName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "nginxDeploymentName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/nginx/2022-08-01/nginxdeployment/id_nginxdeployment.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/nginx/2022-08-01/nginxdeployment/id_nginxdeployment.go
@@ -40,15 +40,15 @@ func ParseNginxDeploymentID(input string) (*NginxDeploymentId, error) {
 	id := NginxDeploymentId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NginxDeploymentName, ok = parsed.Parsed["nginxDeploymentName"]; !ok {
-		return nil, fmt.Errorf("the segment 'nginxDeploymentName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "nginxDeploymentName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseNginxDeploymentIDInsensitively(input string) (*NginxDeploymentId, erro
 	id := NginxDeploymentId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NginxDeploymentName, ok = parsed.Parsed["nginxDeploymentName"]; !ok {
-		return nil, fmt.Errorf("the segment 'nginxDeploymentName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "nginxDeploymentName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/notificationhubs/2017-04-01/namespaces/id_authorizationrule.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/notificationhubs/2017-04-01/namespaces/id_authorizationrule.go
@@ -42,19 +42,19 @@ func ParseAuthorizationRuleID(input string) (*AuthorizationRuleId, error) {
 	id := AuthorizationRuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	if id.AuthorizationRuleName, ok = parsed.Parsed["authorizationRuleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'authorizationRuleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "authorizationRuleName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseAuthorizationRuleIDInsensitively(input string) (*AuthorizationRuleId, 
 	id := AuthorizationRuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	if id.AuthorizationRuleName, ok = parsed.Parsed["authorizationRuleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'authorizationRuleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "authorizationRuleName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/notificationhubs/2017-04-01/namespaces/id_namespace.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/notificationhubs/2017-04-01/namespaces/id_namespace.go
@@ -40,15 +40,15 @@ func ParseNamespaceID(input string) (*NamespaceId, error) {
 	id := NamespaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseNamespaceIDInsensitively(input string) (*NamespaceId, error) {
 	id := NamespaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/notificationhubs/2017-04-01/notificationhubs/id_namespace.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/notificationhubs/2017-04-01/notificationhubs/id_namespace.go
@@ -40,15 +40,15 @@ func ParseNamespaceID(input string) (*NamespaceId, error) {
 	id := NamespaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseNamespaceIDInsensitively(input string) (*NamespaceId, error) {
 	id := NamespaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/notificationhubs/2017-04-01/notificationhubs/id_notificationhub.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/notificationhubs/2017-04-01/notificationhubs/id_notificationhub.go
@@ -42,19 +42,19 @@ func ParseNotificationHubID(input string) (*NotificationHubId, error) {
 	id := NotificationHubId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	if id.NotificationHubName, ok = parsed.Parsed["notificationHubName"]; !ok {
-		return nil, fmt.Errorf("the segment 'notificationHubName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "notificationHubName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseNotificationHubIDInsensitively(input string) (*NotificationHubId, erro
 	id := NotificationHubId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	if id.NotificationHubName, ok = parsed.Parsed["notificationHubName"]; !ok {
-		return nil, fmt.Errorf("the segment 'notificationHubName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "notificationHubName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/notificationhubs/2017-04-01/notificationhubs/id_notificationhubauthorizationrule.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/notificationhubs/2017-04-01/notificationhubs/id_notificationhubauthorizationrule.go
@@ -44,23 +44,23 @@ func ParseNotificationHubAuthorizationRuleID(input string) (*NotificationHubAuth
 	id := NotificationHubAuthorizationRuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	if id.NotificationHubName, ok = parsed.Parsed["notificationHubName"]; !ok {
-		return nil, fmt.Errorf("the segment 'notificationHubName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "notificationHubName", *parsed)
 	}
 
 	if id.AuthorizationRuleName, ok = parsed.Parsed["authorizationRuleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'authorizationRuleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "authorizationRuleName", *parsed)
 	}
 
 	return &id, nil
@@ -79,23 +79,23 @@ func ParseNotificationHubAuthorizationRuleIDInsensitively(input string) (*Notifi
 	id := NotificationHubAuthorizationRuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	if id.NotificationHubName, ok = parsed.Parsed["notificationHubName"]; !ok {
-		return nil, fmt.Errorf("the segment 'notificationHubName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "notificationHubName", *parsed)
 	}
 
 	if id.AuthorizationRuleName, ok = parsed.Parsed["authorizationRuleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'authorizationRuleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "authorizationRuleName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2019-09-01/querypackqueries/id_query.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2019-09-01/querypackqueries/id_query.go
@@ -42,19 +42,19 @@ func ParseQueryID(input string) (*QueryId, error) {
 	id := QueryId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.QueryPackName, ok = parsed.Parsed["queryPackName"]; !ok {
-		return nil, fmt.Errorf("the segment 'queryPackName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "queryPackName", *parsed)
 	}
 
 	if id.QueryName, ok = parsed.Parsed["queryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'queryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "queryName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseQueryIDInsensitively(input string) (*QueryId, error) {
 	id := QueryId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.QueryPackName, ok = parsed.Parsed["queryPackName"]; !ok {
-		return nil, fmt.Errorf("the segment 'queryPackName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "queryPackName", *parsed)
 	}
 
 	if id.QueryName, ok = parsed.Parsed["queryName"]; !ok {
-		return nil, fmt.Errorf("the segment 'queryName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "queryName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2019-09-01/querypackqueries/id_querypack.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2019-09-01/querypackqueries/id_querypack.go
@@ -40,15 +40,15 @@ func ParseQueryPackID(input string) (*QueryPackId, error) {
 	id := QueryPackId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.QueryPackName, ok = parsed.Parsed["queryPackName"]; !ok {
-		return nil, fmt.Errorf("the segment 'queryPackName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "queryPackName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseQueryPackIDInsensitively(input string) (*QueryPackId, error) {
 	id := QueryPackId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.QueryPackName, ok = parsed.Parsed["queryPackName"]; !ok {
-		return nil, fmt.Errorf("the segment 'queryPackName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "queryPackName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2019-09-01/querypacks/id_querypack.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2019-09-01/querypacks/id_querypack.go
@@ -40,15 +40,15 @@ func ParseQueryPackID(input string) (*QueryPackId, error) {
 	id := QueryPackId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.QueryPackName, ok = parsed.Parsed["queryPackName"]; !ok {
-		return nil, fmt.Errorf("the segment 'queryPackName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "queryPackName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseQueryPackIDInsensitively(input string) (*QueryPackId, error) {
 	id := QueryPackId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.QueryPackName, ok = parsed.Parsed["queryPackName"]; !ok {
-		return nil, fmt.Errorf("the segment 'queryPackName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "queryPackName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/clusters/id_cluster.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/clusters/id_cluster.go
@@ -40,15 +40,15 @@ func ParseClusterID(input string) (*ClusterId, error) {
 	id := ClusterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseClusterIDInsensitively(input string) (*ClusterId, error) {
 	id := ClusterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/dataexport/id_dataexport.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/dataexport/id_dataexport.go
@@ -42,19 +42,19 @@ func ParseDataExportID(input string) (*DataExportId, error) {
 	id := DataExportId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	if id.DataExportName, ok = parsed.Parsed["dataExportName"]; !ok {
-		return nil, fmt.Errorf("the segment 'dataExportName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "dataExportName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseDataExportIDInsensitively(input string) (*DataExportId, error) {
 	id := DataExportId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	if id.DataExportName, ok = parsed.Parsed["dataExportName"]; !ok {
-		return nil, fmt.Errorf("the segment 'dataExportName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "dataExportName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/dataexport/id_workspace.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/dataexport/id_workspace.go
@@ -40,15 +40,15 @@ func ParseWorkspaceID(input string) (*WorkspaceId, error) {
 	id := WorkspaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseWorkspaceIDInsensitively(input string) (*WorkspaceId, error) {
 	id := WorkspaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/datasources/id_datasource.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/datasources/id_datasource.go
@@ -42,19 +42,19 @@ func ParseDataSourceID(input string) (*DataSourceId, error) {
 	id := DataSourceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	if id.DataSourceName, ok = parsed.Parsed["dataSourceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'dataSourceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "dataSourceName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseDataSourceIDInsensitively(input string) (*DataSourceId, error) {
 	id := DataSourceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	if id.DataSourceName, ok = parsed.Parsed["dataSourceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'dataSourceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "dataSourceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/datasources/id_workspace.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/datasources/id_workspace.go
@@ -40,15 +40,15 @@ func ParseWorkspaceID(input string) (*WorkspaceId, error) {
 	id := WorkspaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseWorkspaceIDInsensitively(input string) (*WorkspaceId, error) {
 	id := WorkspaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/linkedservices/id_linkedservice.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/linkedservices/id_linkedservice.go
@@ -42,19 +42,19 @@ func ParseLinkedServiceID(input string) (*LinkedServiceId, error) {
 	id := LinkedServiceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	if id.LinkedServiceName, ok = parsed.Parsed["linkedServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'linkedServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "linkedServiceName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseLinkedServiceIDInsensitively(input string) (*LinkedServiceId, error) {
 	id := LinkedServiceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	if id.LinkedServiceName, ok = parsed.Parsed["linkedServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'linkedServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "linkedServiceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/linkedservices/id_workspace.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/linkedservices/id_workspace.go
@@ -40,15 +40,15 @@ func ParseWorkspaceID(input string) (*WorkspaceId, error) {
 	id := WorkspaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseWorkspaceIDInsensitively(input string) (*WorkspaceId, error) {
 	id := WorkspaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/linkedstorageaccounts/id_datasourcetype.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/linkedstorageaccounts/id_datasourcetype.go
@@ -42,20 +42,20 @@ func ParseDataSourceTypeID(input string) (*DataSourceTypeId, error) {
 	id := DataSourceTypeId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	if v, ok := parsed.Parsed["dataSourceType"]; true {
 		if !ok {
-			return nil, fmt.Errorf("the segment 'dataSourceType' was not found in the resource id %q", input)
+			return nil, resourceids.NewSegmentNotSpecifiedError(id, "dataSourceType", *parsed)
 		}
 
 		dataSourceType, err := parseDataSourceType(v)
@@ -81,20 +81,20 @@ func ParseDataSourceTypeIDInsensitively(input string) (*DataSourceTypeId, error)
 	id := DataSourceTypeId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	if v, ok := parsed.Parsed["dataSourceType"]; true {
 		if !ok {
-			return nil, fmt.Errorf("the segment 'dataSourceType' was not found in the resource id %q", input)
+			return nil, resourceids.NewSegmentNotSpecifiedError(id, "dataSourceType", *parsed)
 		}
 
 		dataSourceType, err := parseDataSourceType(v)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/linkedstorageaccounts/id_workspace.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/linkedstorageaccounts/id_workspace.go
@@ -40,15 +40,15 @@ func ParseWorkspaceID(input string) (*WorkspaceId, error) {
 	id := WorkspaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseWorkspaceIDInsensitively(input string) (*WorkspaceId, error) {
 	id := WorkspaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/savedsearches/id_savedsearch.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/savedsearches/id_savedsearch.go
@@ -42,19 +42,19 @@ func ParseSavedSearchID(input string) (*SavedSearchId, error) {
 	id := SavedSearchId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	if id.SavedSearchId, ok = parsed.Parsed["savedSearchId"]; !ok {
-		return nil, fmt.Errorf("the segment 'savedSearchId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "savedSearchId", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseSavedSearchIDInsensitively(input string) (*SavedSearchId, error) {
 	id := SavedSearchId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	if id.SavedSearchId, ok = parsed.Parsed["savedSearchId"]; !ok {
-		return nil, fmt.Errorf("the segment 'savedSearchId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "savedSearchId", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/savedsearches/id_workspace.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/savedsearches/id_workspace.go
@@ -40,15 +40,15 @@ func ParseWorkspaceID(input string) (*WorkspaceId, error) {
 	id := WorkspaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseWorkspaceIDInsensitively(input string) (*WorkspaceId, error) {
 	id := WorkspaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/storageinsights/id_storageinsightconfig.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/storageinsights/id_storageinsightconfig.go
@@ -42,19 +42,19 @@ func ParseStorageInsightConfigID(input string) (*StorageInsightConfigId, error) 
 	id := StorageInsightConfigId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	if id.StorageInsightConfigName, ok = parsed.Parsed["storageInsightConfigName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageInsightConfigName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageInsightConfigName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseStorageInsightConfigIDInsensitively(input string) (*StorageInsightConf
 	id := StorageInsightConfigId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	if id.StorageInsightConfigName, ok = parsed.Parsed["storageInsightConfigName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageInsightConfigName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageInsightConfigName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/storageinsights/id_workspace.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/storageinsights/id_workspace.go
@@ -40,15 +40,15 @@ func ParseWorkspaceID(input string) (*WorkspaceId, error) {
 	id := WorkspaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseWorkspaceIDInsensitively(input string) (*WorkspaceId, error) {
 	id := WorkspaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/workspaces/id_gateway.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/workspaces/id_gateway.go
@@ -42,19 +42,19 @@ func ParseGatewayID(input string) (*GatewayId, error) {
 	id := GatewayId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	if id.GatewayId, ok = parsed.Parsed["gatewayId"]; !ok {
-		return nil, fmt.Errorf("the segment 'gatewayId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "gatewayId", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseGatewayIDInsensitively(input string) (*GatewayId, error) {
 	id := GatewayId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	if id.GatewayId, ok = parsed.Parsed["gatewayId"]; !ok {
-		return nil, fmt.Errorf("the segment 'gatewayId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "gatewayId", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/workspaces/id_intelligencepack.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/workspaces/id_intelligencepack.go
@@ -42,19 +42,19 @@ func ParseIntelligencePackID(input string) (*IntelligencePackId, error) {
 	id := IntelligencePackId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	if id.IntelligencePackName, ok = parsed.Parsed["intelligencePackName"]; !ok {
-		return nil, fmt.Errorf("the segment 'intelligencePackName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "intelligencePackName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseIntelligencePackIDInsensitively(input string) (*IntelligencePackId, er
 	id := IntelligencePackId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	if id.IntelligencePackName, ok = parsed.Parsed["intelligencePackName"]; !ok {
-		return nil, fmt.Errorf("the segment 'intelligencePackName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "intelligencePackName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/workspaces/id_operation.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/workspaces/id_operation.go
@@ -42,19 +42,19 @@ func ParseOperationID(input string) (*OperationId, error) {
 	id := OperationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	if id.PurgeId, ok = parsed.Parsed["purgeId"]; !ok {
-		return nil, fmt.Errorf("the segment 'purgeId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "purgeId", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseOperationIDInsensitively(input string) (*OperationId, error) {
 	id := OperationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	if id.PurgeId, ok = parsed.Parsed["purgeId"]; !ok {
-		return nil, fmt.Errorf("the segment 'purgeId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "purgeId", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/workspaces/id_workspace.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/workspaces/id_workspace.go
@@ -40,15 +40,15 @@ func ParseWorkspaceID(input string) (*WorkspaceId, error) {
 	id := WorkspaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseWorkspaceIDInsensitively(input string) (*WorkspaceId, error) {
 	id := WorkspaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/workspaces/id_workspace.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/workspaces/id_workspace.go
@@ -40,15 +40,15 @@ func ParseWorkspaceID(input string) (*WorkspaceId, error) {
 	id := WorkspaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseWorkspaceIDInsensitively(input string) (*WorkspaceId, error) {
 	id := WorkspaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationsmanagement/2015-11-01-preview/solution/id_solution.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/operationsmanagement/2015-11-01-preview/solution/id_solution.go
@@ -40,15 +40,15 @@ func ParseSolutionID(input string) (*SolutionId, error) {
 	id := SolutionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.SolutionName, ok = parsed.Parsed["solutionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'solutionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "solutionName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseSolutionIDInsensitively(input string) (*SolutionId, error) {
 	id := SolutionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.SolutionName, ok = parsed.Parsed["solutionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'solutionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "solutionName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/orbital/2022-11-01/contact/id_contact.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/orbital/2022-11-01/contact/id_contact.go
@@ -42,19 +42,19 @@ func ParseContactID(input string) (*ContactId, error) {
 	id := ContactId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.SpacecraftName, ok = parsed.Parsed["spacecraftName"]; !ok {
-		return nil, fmt.Errorf("the segment 'spacecraftName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "spacecraftName", *parsed)
 	}
 
 	if id.ContactName, ok = parsed.Parsed["contactName"]; !ok {
-		return nil, fmt.Errorf("the segment 'contactName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "contactName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseContactIDInsensitively(input string) (*ContactId, error) {
 	id := ContactId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.SpacecraftName, ok = parsed.Parsed["spacecraftName"]; !ok {
-		return nil, fmt.Errorf("the segment 'spacecraftName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "spacecraftName", *parsed)
 	}
 
 	if id.ContactName, ok = parsed.Parsed["contactName"]; !ok {
-		return nil, fmt.Errorf("the segment 'contactName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "contactName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/orbital/2022-11-01/contact/id_spacecraft.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/orbital/2022-11-01/contact/id_spacecraft.go
@@ -40,15 +40,15 @@ func ParseSpacecraftID(input string) (*SpacecraftId, error) {
 	id := SpacecraftId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.SpacecraftName, ok = parsed.Parsed["spacecraftName"]; !ok {
-		return nil, fmt.Errorf("the segment 'spacecraftName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "spacecraftName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseSpacecraftIDInsensitively(input string) (*SpacecraftId, error) {
 	id := SpacecraftId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.SpacecraftName, ok = parsed.Parsed["spacecraftName"]; !ok {
-		return nil, fmt.Errorf("the segment 'spacecraftName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "spacecraftName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/orbital/2022-11-01/contactprofile/id_contactprofile.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/orbital/2022-11-01/contactprofile/id_contactprofile.go
@@ -40,15 +40,15 @@ func ParseContactProfileID(input string) (*ContactProfileId, error) {
 	id := ContactProfileId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ContactProfileName, ok = parsed.Parsed["contactProfileName"]; !ok {
-		return nil, fmt.Errorf("the segment 'contactProfileName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "contactProfileName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseContactProfileIDInsensitively(input string) (*ContactProfileId, error)
 	id := ContactProfileId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ContactProfileName, ok = parsed.Parsed["contactProfileName"]; !ok {
-		return nil, fmt.Errorf("the segment 'contactProfileName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "contactProfileName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/orbital/2022-11-01/spacecraft/id_spacecraft.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/orbital/2022-11-01/spacecraft/id_spacecraft.go
@@ -40,15 +40,15 @@ func ParseSpacecraftID(input string) (*SpacecraftId, error) {
 	id := SpacecraftId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.SpacecraftName, ok = parsed.Parsed["spacecraftName"]; !ok {
-		return nil, fmt.Errorf("the segment 'spacecraftName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "spacecraftName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseSpacecraftIDInsensitively(input string) (*SpacecraftId, error) {
 	id := SpacecraftId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.SpacecraftName, ok = parsed.Parsed["spacecraftName"]; !ok {
-		return nil, fmt.Errorf("the segment 'spacecraftName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "spacecraftName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/policyinsights/2021-10-01/remediations/id_managementgroup.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/policyinsights/2021-10-01/remediations/id_managementgroup.go
@@ -36,7 +36,7 @@ func ParseManagementGroupID(input string) (*ManagementGroupId, error) {
 	id := ManagementGroupId{}
 
 	if id.ManagementGroupId, ok = parsed.Parsed["managementGroupId"]; !ok {
-		return nil, fmt.Errorf("the segment 'managementGroupId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managementGroupId", *parsed)
 	}
 
 	return &id, nil
@@ -55,7 +55,7 @@ func ParseManagementGroupIDInsensitively(input string) (*ManagementGroupId, erro
 	id := ManagementGroupId{}
 
 	if id.ManagementGroupId, ok = parsed.Parsed["managementGroupId"]; !ok {
-		return nil, fmt.Errorf("the segment 'managementGroupId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managementGroupId", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/policyinsights/2021-10-01/remediations/id_providerremediation.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/policyinsights/2021-10-01/remediations/id_providerremediation.go
@@ -40,15 +40,15 @@ func ParseProviderRemediationID(input string) (*ProviderRemediationId, error) {
 	id := ProviderRemediationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RemediationName, ok = parsed.Parsed["remediationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'remediationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "remediationName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseProviderRemediationIDInsensitively(input string) (*ProviderRemediation
 	id := ProviderRemediationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RemediationName, ok = parsed.Parsed["remediationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'remediationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "remediationName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/policyinsights/2021-10-01/remediations/id_providers2remediation.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/policyinsights/2021-10-01/remediations/id_providers2remediation.go
@@ -38,11 +38,11 @@ func ParseProviders2RemediationID(input string) (*Providers2RemediationId, error
 	id := Providers2RemediationId{}
 
 	if id.ManagementGroupId, ok = parsed.Parsed["managementGroupId"]; !ok {
-		return nil, fmt.Errorf("the segment 'managementGroupId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managementGroupId", *parsed)
 	}
 
 	if id.RemediationName, ok = parsed.Parsed["remediationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'remediationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "remediationName", *parsed)
 	}
 
 	return &id, nil
@@ -61,11 +61,11 @@ func ParseProviders2RemediationIDInsensitively(input string) (*Providers2Remedia
 	id := Providers2RemediationId{}
 
 	if id.ManagementGroupId, ok = parsed.Parsed["managementGroupId"]; !ok {
-		return nil, fmt.Errorf("the segment 'managementGroupId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managementGroupId", *parsed)
 	}
 
 	if id.RemediationName, ok = parsed.Parsed["remediationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'remediationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "remediationName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/policyinsights/2021-10-01/remediations/id_remediation.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/policyinsights/2021-10-01/remediations/id_remediation.go
@@ -38,11 +38,11 @@ func ParseRemediationID(input string) (*RemediationId, error) {
 	id := RemediationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.RemediationName, ok = parsed.Parsed["remediationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'remediationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "remediationName", *parsed)
 	}
 
 	return &id, nil
@@ -61,11 +61,11 @@ func ParseRemediationIDInsensitively(input string) (*RemediationId, error) {
 	id := RemediationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.RemediationName, ok = parsed.Parsed["remediationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'remediationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "remediationName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/policyinsights/2021-10-01/remediations/id_scopedremediation.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/policyinsights/2021-10-01/remediations/id_scopedremediation.go
@@ -38,11 +38,11 @@ func ParseScopedRemediationID(input string) (*ScopedRemediationId, error) {
 	id := ScopedRemediationId{}
 
 	if id.ResourceId, ok = parsed.Parsed["resourceId"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceId", *parsed)
 	}
 
 	if id.RemediationName, ok = parsed.Parsed["remediationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'remediationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "remediationName", *parsed)
 	}
 
 	return &id, nil
@@ -61,11 +61,11 @@ func ParseScopedRemediationIDInsensitively(input string) (*ScopedRemediationId, 
 	id := ScopedRemediationId{}
 
 	if id.ResourceId, ok = parsed.Parsed["resourceId"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceId", *parsed)
 	}
 
 	if id.RemediationName, ok = parsed.Parsed["remediationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'remediationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "remediationName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/portal/2019-01-01-preview/dashboard/id_dashboard.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/portal/2019-01-01-preview/dashboard/id_dashboard.go
@@ -40,15 +40,15 @@ func ParseDashboardID(input string) (*DashboardId, error) {
 	id := DashboardId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DashboardName, ok = parsed.Parsed["dashboardName"]; !ok {
-		return nil, fmt.Errorf("the segment 'dashboardName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "dashboardName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseDashboardIDInsensitively(input string) (*DashboardId, error) {
 	id := DashboardId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DashboardName, ok = parsed.Parsed["dashboardName"]; !ok {
-		return nil, fmt.Errorf("the segment 'dashboardName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "dashboardName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2017-12-01/configurations/id_configuration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2017-12-01/configurations/id_configuration.go
@@ -42,19 +42,19 @@ func ParseConfigurationID(input string) (*ConfigurationId, error) {
 	id := ConfigurationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServerName, ok = parsed.Parsed["serverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverName", *parsed)
 	}
 
 	if id.ConfigurationName, ok = parsed.Parsed["configurationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'configurationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "configurationName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseConfigurationIDInsensitively(input string) (*ConfigurationId, error) {
 	id := ConfigurationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServerName, ok = parsed.Parsed["serverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverName", *parsed)
 	}
 
 	if id.ConfigurationName, ok = parsed.Parsed["configurationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'configurationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "configurationName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2017-12-01/configurations/id_server.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2017-12-01/configurations/id_server.go
@@ -40,15 +40,15 @@ func ParseServerID(input string) (*ServerId, error) {
 	id := ServerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServerName, ok = parsed.Parsed["serverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseServerIDInsensitively(input string) (*ServerId, error) {
 	id := ServerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServerName, ok = parsed.Parsed["serverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2017-12-01/databases/id_database.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2017-12-01/databases/id_database.go
@@ -42,19 +42,19 @@ func ParseDatabaseID(input string) (*DatabaseId, error) {
 	id := DatabaseId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServerName, ok = parsed.Parsed["serverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverName", *parsed)
 	}
 
 	if id.DatabaseName, ok = parsed.Parsed["databaseName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseDatabaseIDInsensitively(input string) (*DatabaseId, error) {
 	id := DatabaseId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServerName, ok = parsed.Parsed["serverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverName", *parsed)
 	}
 
 	if id.DatabaseName, ok = parsed.Parsed["databaseName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2017-12-01/databases/id_server.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2017-12-01/databases/id_server.go
@@ -40,15 +40,15 @@ func ParseServerID(input string) (*ServerId, error) {
 	id := ServerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServerName, ok = parsed.Parsed["serverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseServerIDInsensitively(input string) (*ServerId, error) {
 	id := ServerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServerName, ok = parsed.Parsed["serverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2017-12-01/firewallrules/id_firewallrule.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2017-12-01/firewallrules/id_firewallrule.go
@@ -42,19 +42,19 @@ func ParseFirewallRuleID(input string) (*FirewallRuleId, error) {
 	id := FirewallRuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServerName, ok = parsed.Parsed["serverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverName", *parsed)
 	}
 
 	if id.FirewallRuleName, ok = parsed.Parsed["firewallRuleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'firewallRuleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "firewallRuleName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseFirewallRuleIDInsensitively(input string) (*FirewallRuleId, error) {
 	id := FirewallRuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServerName, ok = parsed.Parsed["serverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverName", *parsed)
 	}
 
 	if id.FirewallRuleName, ok = parsed.Parsed["firewallRuleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'firewallRuleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "firewallRuleName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2017-12-01/firewallrules/id_server.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2017-12-01/firewallrules/id_server.go
@@ -40,15 +40,15 @@ func ParseServerID(input string) (*ServerId, error) {
 	id := ServerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServerName, ok = parsed.Parsed["serverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseServerIDInsensitively(input string) (*ServerId, error) {
 	id := ServerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServerName, ok = parsed.Parsed["serverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2017-12-01/replicas/id_server.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2017-12-01/replicas/id_server.go
@@ -40,15 +40,15 @@ func ParseServerID(input string) (*ServerId, error) {
 	id := ServerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServerName, ok = parsed.Parsed["serverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseServerIDInsensitively(input string) (*ServerId, error) {
 	id := ServerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServerName, ok = parsed.Parsed["serverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2017-12-01/serveradministrators/id_server.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2017-12-01/serveradministrators/id_server.go
@@ -40,15 +40,15 @@ func ParseServerID(input string) (*ServerId, error) {
 	id := ServerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServerName, ok = parsed.Parsed["serverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseServerIDInsensitively(input string) (*ServerId, error) {
 	id := ServerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServerName, ok = parsed.Parsed["serverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2017-12-01/servers/id_server.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2017-12-01/servers/id_server.go
@@ -40,15 +40,15 @@ func ParseServerID(input string) (*ServerId, error) {
 	id := ServerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServerName, ok = parsed.Parsed["serverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseServerIDInsensitively(input string) (*ServerId, error) {
 	id := ServerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServerName, ok = parsed.Parsed["serverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2017-12-01/serversecurityalertpolicies/id_server.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2017-12-01/serversecurityalertpolicies/id_server.go
@@ -40,15 +40,15 @@ func ParseServerID(input string) (*ServerId, error) {
 	id := ServerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServerName, ok = parsed.Parsed["serverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseServerIDInsensitively(input string) (*ServerId, error) {
 	id := ServerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServerName, ok = parsed.Parsed["serverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2017-12-01/virtualnetworkrules/id_server.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2017-12-01/virtualnetworkrules/id_server.go
@@ -40,15 +40,15 @@ func ParseServerID(input string) (*ServerId, error) {
 	id := ServerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServerName, ok = parsed.Parsed["serverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseServerIDInsensitively(input string) (*ServerId, error) {
 	id := ServerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServerName, ok = parsed.Parsed["serverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2017-12-01/virtualnetworkrules/id_virtualnetworkrule.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2017-12-01/virtualnetworkrules/id_virtualnetworkrule.go
@@ -42,19 +42,19 @@ func ParseVirtualNetworkRuleID(input string) (*VirtualNetworkRuleId, error) {
 	id := VirtualNetworkRuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServerName, ok = parsed.Parsed["serverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverName", *parsed)
 	}
 
 	if id.VirtualNetworkRuleName, ok = parsed.Parsed["virtualNetworkRuleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'virtualNetworkRuleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "virtualNetworkRuleName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseVirtualNetworkRuleIDInsensitively(input string) (*VirtualNetworkRuleId
 	id := VirtualNetworkRuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServerName, ok = parsed.Parsed["serverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverName", *parsed)
 	}
 
 	if id.VirtualNetworkRuleName, ok = parsed.Parsed["virtualNetworkRuleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'virtualNetworkRuleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "virtualNetworkRuleName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2020-01-01/serverkeys/id_key.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2020-01-01/serverkeys/id_key.go
@@ -42,19 +42,19 @@ func ParseKeyID(input string) (*KeyId, error) {
 	id := KeyId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServerName, ok = parsed.Parsed["serverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverName", *parsed)
 	}
 
 	if id.KeyName, ok = parsed.Parsed["keyName"]; !ok {
-		return nil, fmt.Errorf("the segment 'keyName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "keyName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseKeyIDInsensitively(input string) (*KeyId, error) {
 	id := KeyId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServerName, ok = parsed.Parsed["serverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverName", *parsed)
 	}
 
 	if id.KeyName, ok = parsed.Parsed["keyName"]; !ok {
-		return nil, fmt.Errorf("the segment 'keyName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "keyName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2020-01-01/serverkeys/id_server.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2020-01-01/serverkeys/id_server.go
@@ -40,15 +40,15 @@ func ParseServerID(input string) (*ServerId, error) {
 	id := ServerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServerName, ok = parsed.Parsed["serverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseServerIDInsensitively(input string) (*ServerId, error) {
 	id := ServerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServerName, ok = parsed.Parsed["serverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2021-06-01/configurations/id_configuration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2021-06-01/configurations/id_configuration.go
@@ -42,19 +42,19 @@ func ParseConfigurationID(input string) (*ConfigurationId, error) {
 	id := ConfigurationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.FlexibleServerName, ok = parsed.Parsed["flexibleServerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'flexibleServerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "flexibleServerName", *parsed)
 	}
 
 	if id.ConfigurationName, ok = parsed.Parsed["configurationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'configurationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "configurationName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseConfigurationIDInsensitively(input string) (*ConfigurationId, error) {
 	id := ConfigurationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.FlexibleServerName, ok = parsed.Parsed["flexibleServerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'flexibleServerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "flexibleServerName", *parsed)
 	}
 
 	if id.ConfigurationName, ok = parsed.Parsed["configurationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'configurationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "configurationName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2021-06-01/configurations/id_flexibleserver.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2021-06-01/configurations/id_flexibleserver.go
@@ -40,15 +40,15 @@ func ParseFlexibleServerID(input string) (*FlexibleServerId, error) {
 	id := FlexibleServerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.FlexibleServerName, ok = parsed.Parsed["flexibleServerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'flexibleServerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "flexibleServerName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseFlexibleServerIDInsensitively(input string) (*FlexibleServerId, error)
 	id := FlexibleServerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.FlexibleServerName, ok = parsed.Parsed["flexibleServerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'flexibleServerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "flexibleServerName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2021-06-01/serverrestart/id_flexibleserver.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2021-06-01/serverrestart/id_flexibleserver.go
@@ -40,15 +40,15 @@ func ParseFlexibleServerID(input string) (*FlexibleServerId, error) {
 	id := FlexibleServerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.FlexibleServerName, ok = parsed.Parsed["flexibleServerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'flexibleServerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "flexibleServerName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseFlexibleServerIDInsensitively(input string) (*FlexibleServerId, error)
 	id := FlexibleServerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.FlexibleServerName, ok = parsed.Parsed["flexibleServerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'flexibleServerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "flexibleServerName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2022-12-01/administrators/id_administrator.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2022-12-01/administrators/id_administrator.go
@@ -42,19 +42,19 @@ func ParseAdministratorID(input string) (*AdministratorId, error) {
 	id := AdministratorId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.FlexibleServerName, ok = parsed.Parsed["flexibleServerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'flexibleServerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "flexibleServerName", *parsed)
 	}
 
 	if id.ObjectId, ok = parsed.Parsed["objectId"]; !ok {
-		return nil, fmt.Errorf("the segment 'objectId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "objectId", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseAdministratorIDInsensitively(input string) (*AdministratorId, error) {
 	id := AdministratorId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.FlexibleServerName, ok = parsed.Parsed["flexibleServerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'flexibleServerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "flexibleServerName", *parsed)
 	}
 
 	if id.ObjectId, ok = parsed.Parsed["objectId"]; !ok {
-		return nil, fmt.Errorf("the segment 'objectId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "objectId", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2022-12-01/administrators/id_flexibleserver.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2022-12-01/administrators/id_flexibleserver.go
@@ -40,15 +40,15 @@ func ParseFlexibleServerID(input string) (*FlexibleServerId, error) {
 	id := FlexibleServerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.FlexibleServerName, ok = parsed.Parsed["flexibleServerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'flexibleServerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "flexibleServerName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseFlexibleServerIDInsensitively(input string) (*FlexibleServerId, error)
 	id := FlexibleServerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.FlexibleServerName, ok = parsed.Parsed["flexibleServerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'flexibleServerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "flexibleServerName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2022-12-01/databases/id_database.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2022-12-01/databases/id_database.go
@@ -42,19 +42,19 @@ func ParseDatabaseID(input string) (*DatabaseId, error) {
 	id := DatabaseId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.FlexibleServerName, ok = parsed.Parsed["flexibleServerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'flexibleServerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "flexibleServerName", *parsed)
 	}
 
 	if id.DatabaseName, ok = parsed.Parsed["databaseName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseDatabaseIDInsensitively(input string) (*DatabaseId, error) {
 	id := DatabaseId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.FlexibleServerName, ok = parsed.Parsed["flexibleServerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'flexibleServerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "flexibleServerName", *parsed)
 	}
 
 	if id.DatabaseName, ok = parsed.Parsed["databaseName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2022-12-01/databases/id_flexibleserver.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2022-12-01/databases/id_flexibleserver.go
@@ -40,15 +40,15 @@ func ParseFlexibleServerID(input string) (*FlexibleServerId, error) {
 	id := FlexibleServerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.FlexibleServerName, ok = parsed.Parsed["flexibleServerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'flexibleServerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "flexibleServerName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseFlexibleServerIDInsensitively(input string) (*FlexibleServerId, error)
 	id := FlexibleServerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.FlexibleServerName, ok = parsed.Parsed["flexibleServerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'flexibleServerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "flexibleServerName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2022-12-01/firewallrules/id_firewallrule.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2022-12-01/firewallrules/id_firewallrule.go
@@ -42,19 +42,19 @@ func ParseFirewallRuleID(input string) (*FirewallRuleId, error) {
 	id := FirewallRuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.FlexibleServerName, ok = parsed.Parsed["flexibleServerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'flexibleServerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "flexibleServerName", *parsed)
 	}
 
 	if id.FirewallRuleName, ok = parsed.Parsed["firewallRuleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'firewallRuleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "firewallRuleName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseFirewallRuleIDInsensitively(input string) (*FirewallRuleId, error) {
 	id := FirewallRuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.FlexibleServerName, ok = parsed.Parsed["flexibleServerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'flexibleServerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "flexibleServerName", *parsed)
 	}
 
 	if id.FirewallRuleName, ok = parsed.Parsed["firewallRuleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'firewallRuleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "firewallRuleName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2022-12-01/firewallrules/id_flexibleserver.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2022-12-01/firewallrules/id_flexibleserver.go
@@ -40,15 +40,15 @@ func ParseFlexibleServerID(input string) (*FlexibleServerId, error) {
 	id := FlexibleServerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.FlexibleServerName, ok = parsed.Parsed["flexibleServerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'flexibleServerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "flexibleServerName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseFlexibleServerIDInsensitively(input string) (*FlexibleServerId, error)
 	id := FlexibleServerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.FlexibleServerName, ok = parsed.Parsed["flexibleServerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'flexibleServerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "flexibleServerName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2022-12-01/servers/id_flexibleserver.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2022-12-01/servers/id_flexibleserver.go
@@ -40,15 +40,15 @@ func ParseFlexibleServerID(input string) (*FlexibleServerId, error) {
 	id := FlexibleServerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.FlexibleServerName, ok = parsed.Parsed["flexibleServerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'flexibleServerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "flexibleServerName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseFlexibleServerIDInsensitively(input string) (*FlexibleServerId, error)
 	id := FlexibleServerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.FlexibleServerName, ok = parsed.Parsed["flexibleServerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'flexibleServerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "flexibleServerName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresqlhsc/2022-11-08/clusters/id_servergroupsv2.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresqlhsc/2022-11-08/clusters/id_servergroupsv2.go
@@ -40,15 +40,15 @@ func ParseServerGroupsv2ID(input string) (*ServerGroupsv2Id, error) {
 	id := ServerGroupsv2Id{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServerGroupsv2Name, ok = parsed.Parsed["serverGroupsv2Name"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverGroupsv2Name' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverGroupsv2Name", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseServerGroupsv2IDInsensitively(input string) (*ServerGroupsv2Id, error)
 	id := ServerGroupsv2Id{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServerGroupsv2Name, ok = parsed.Parsed["serverGroupsv2Name"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverGroupsv2Name' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverGroupsv2Name", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresqlhsc/2022-11-08/configurations/id_configuration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresqlhsc/2022-11-08/configurations/id_configuration.go
@@ -42,19 +42,19 @@ func ParseConfigurationID(input string) (*ConfigurationId, error) {
 	id := ConfigurationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServerGroupsv2Name, ok = parsed.Parsed["serverGroupsv2Name"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverGroupsv2Name' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverGroupsv2Name", *parsed)
 	}
 
 	if id.ConfigurationName, ok = parsed.Parsed["configurationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'configurationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "configurationName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseConfigurationIDInsensitively(input string) (*ConfigurationId, error) {
 	id := ConfigurationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServerGroupsv2Name, ok = parsed.Parsed["serverGroupsv2Name"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverGroupsv2Name' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverGroupsv2Name", *parsed)
 	}
 
 	if id.ConfigurationName, ok = parsed.Parsed["configurationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'configurationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "configurationName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresqlhsc/2022-11-08/configurations/id_coordinatorconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresqlhsc/2022-11-08/configurations/id_coordinatorconfiguration.go
@@ -42,19 +42,19 @@ func ParseCoordinatorConfigurationID(input string) (*CoordinatorConfigurationId,
 	id := CoordinatorConfigurationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServerGroupsv2Name, ok = parsed.Parsed["serverGroupsv2Name"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverGroupsv2Name' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverGroupsv2Name", *parsed)
 	}
 
 	if id.CoordinatorConfigurationName, ok = parsed.Parsed["coordinatorConfigurationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'coordinatorConfigurationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "coordinatorConfigurationName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseCoordinatorConfigurationIDInsensitively(input string) (*CoordinatorCon
 	id := CoordinatorConfigurationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServerGroupsv2Name, ok = parsed.Parsed["serverGroupsv2Name"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverGroupsv2Name' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverGroupsv2Name", *parsed)
 	}
 
 	if id.CoordinatorConfigurationName, ok = parsed.Parsed["coordinatorConfigurationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'coordinatorConfigurationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "coordinatorConfigurationName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresqlhsc/2022-11-08/configurations/id_nodeconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresqlhsc/2022-11-08/configurations/id_nodeconfiguration.go
@@ -42,19 +42,19 @@ func ParseNodeConfigurationID(input string) (*NodeConfigurationId, error) {
 	id := NodeConfigurationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServerGroupsv2Name, ok = parsed.Parsed["serverGroupsv2Name"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverGroupsv2Name' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverGroupsv2Name", *parsed)
 	}
 
 	if id.NodeConfigurationName, ok = parsed.Parsed["nodeConfigurationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'nodeConfigurationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "nodeConfigurationName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseNodeConfigurationIDInsensitively(input string) (*NodeConfigurationId, 
 	id := NodeConfigurationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServerGroupsv2Name, ok = parsed.Parsed["serverGroupsv2Name"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverGroupsv2Name' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverGroupsv2Name", *parsed)
 	}
 
 	if id.NodeConfigurationName, ok = parsed.Parsed["nodeConfigurationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'nodeConfigurationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "nodeConfigurationName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresqlhsc/2022-11-08/configurations/id_server.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresqlhsc/2022-11-08/configurations/id_server.go
@@ -42,19 +42,19 @@ func ParseServerID(input string) (*ServerId, error) {
 	id := ServerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServerGroupsv2Name, ok = parsed.Parsed["serverGroupsv2Name"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverGroupsv2Name' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverGroupsv2Name", *parsed)
 	}
 
 	if id.ServerName, ok = parsed.Parsed["serverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseServerIDInsensitively(input string) (*ServerId, error) {
 	id := ServerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServerGroupsv2Name, ok = parsed.Parsed["serverGroupsv2Name"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverGroupsv2Name' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverGroupsv2Name", *parsed)
 	}
 
 	if id.ServerName, ok = parsed.Parsed["serverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresqlhsc/2022-11-08/configurations/id_servergroupsv2.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresqlhsc/2022-11-08/configurations/id_servergroupsv2.go
@@ -40,15 +40,15 @@ func ParseServerGroupsv2ID(input string) (*ServerGroupsv2Id, error) {
 	id := ServerGroupsv2Id{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServerGroupsv2Name, ok = parsed.Parsed["serverGroupsv2Name"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverGroupsv2Name' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverGroupsv2Name", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseServerGroupsv2IDInsensitively(input string) (*ServerGroupsv2Id, error)
 	id := ServerGroupsv2Id{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServerGroupsv2Name, ok = parsed.Parsed["serverGroupsv2Name"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverGroupsv2Name' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverGroupsv2Name", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresqlhsc/2022-11-08/firewallrules/id_firewallrule.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresqlhsc/2022-11-08/firewallrules/id_firewallrule.go
@@ -42,19 +42,19 @@ func ParseFirewallRuleID(input string) (*FirewallRuleId, error) {
 	id := FirewallRuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServerGroupsv2Name, ok = parsed.Parsed["serverGroupsv2Name"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverGroupsv2Name' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverGroupsv2Name", *parsed)
 	}
 
 	if id.FirewallRuleName, ok = parsed.Parsed["firewallRuleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'firewallRuleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "firewallRuleName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseFirewallRuleIDInsensitively(input string) (*FirewallRuleId, error) {
 	id := FirewallRuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServerGroupsv2Name, ok = parsed.Parsed["serverGroupsv2Name"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverGroupsv2Name' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverGroupsv2Name", *parsed)
 	}
 
 	if id.FirewallRuleName, ok = parsed.Parsed["firewallRuleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'firewallRuleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "firewallRuleName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresqlhsc/2022-11-08/firewallrules/id_servergroupsv2.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresqlhsc/2022-11-08/firewallrules/id_servergroupsv2.go
@@ -40,15 +40,15 @@ func ParseServerGroupsv2ID(input string) (*ServerGroupsv2Id, error) {
 	id := ServerGroupsv2Id{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServerGroupsv2Name, ok = parsed.Parsed["serverGroupsv2Name"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverGroupsv2Name' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverGroupsv2Name", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseServerGroupsv2IDInsensitively(input string) (*ServerGroupsv2Id, error)
 	id := ServerGroupsv2Id{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServerGroupsv2Name, ok = parsed.Parsed["serverGroupsv2Name"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverGroupsv2Name' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverGroupsv2Name", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresqlhsc/2022-11-08/roles/id_role.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresqlhsc/2022-11-08/roles/id_role.go
@@ -42,19 +42,19 @@ func ParseRoleID(input string) (*RoleId, error) {
 	id := RoleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServerGroupsv2Name, ok = parsed.Parsed["serverGroupsv2Name"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverGroupsv2Name' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverGroupsv2Name", *parsed)
 	}
 
 	if id.RoleName, ok = parsed.Parsed["roleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'roleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "roleName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseRoleIDInsensitively(input string) (*RoleId, error) {
 	id := RoleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServerGroupsv2Name, ok = parsed.Parsed["serverGroupsv2Name"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverGroupsv2Name' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverGroupsv2Name", *parsed)
 	}
 
 	if id.RoleName, ok = parsed.Parsed["roleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'roleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "roleName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresqlhsc/2022-11-08/roles/id_servergroupsv2.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresqlhsc/2022-11-08/roles/id_servergroupsv2.go
@@ -40,15 +40,15 @@ func ParseServerGroupsv2ID(input string) (*ServerGroupsv2Id, error) {
 	id := ServerGroupsv2Id{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServerGroupsv2Name, ok = parsed.Parsed["serverGroupsv2Name"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverGroupsv2Name' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverGroupsv2Name", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseServerGroupsv2IDInsensitively(input string) (*ServerGroupsv2Id, error)
 	id := ServerGroupsv2Id{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ServerGroupsv2Name, ok = parsed.Parsed["serverGroupsv2Name"]; !ok {
-		return nil, fmt.Errorf("the segment 'serverGroupsv2Name' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "serverGroupsv2Name", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/powerbidedicated/2021-01-01/capacities/id_capacity.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/powerbidedicated/2021-01-01/capacities/id_capacity.go
@@ -40,15 +40,15 @@ func ParseCapacityID(input string) (*CapacityId, error) {
 	id := CapacityId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.CapacityName, ok = parsed.Parsed["capacityName"]; !ok {
-		return nil, fmt.Errorf("the segment 'capacityName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "capacityName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseCapacityIDInsensitively(input string) (*CapacityId, error) {
 	id := CapacityId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.CapacityName, ok = parsed.Parsed["capacityName"]; !ok {
-		return nil, fmt.Errorf("the segment 'capacityName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "capacityName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/powerbidedicated/2021-01-01/capacities/id_location.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/powerbidedicated/2021-01-01/capacities/id_location.go
@@ -38,11 +38,11 @@ func ParseLocationID(input string) (*LocationId, error) {
 	id := LocationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.LocationName, ok = parsed.Parsed["locationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'locationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "locationName", *parsed)
 	}
 
 	return &id, nil
@@ -61,11 +61,11 @@ func ParseLocationIDInsensitively(input string) (*LocationId, error) {
 	id := LocationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.LocationName, ok = parsed.Parsed["locationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'locationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "locationName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/privatedns/2018-09-01/privatezones/id_privatednszone.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/privatedns/2018-09-01/privatezones/id_privatednszone.go
@@ -40,15 +40,15 @@ func ParsePrivateDnsZoneID(input string) (*PrivateDnsZoneId, error) {
 	id := PrivateDnsZoneId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.PrivateDnsZoneName, ok = parsed.Parsed["privateDnsZoneName"]; !ok {
-		return nil, fmt.Errorf("the segment 'privateDnsZoneName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "privateDnsZoneName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParsePrivateDnsZoneIDInsensitively(input string) (*PrivateDnsZoneId, error)
 	id := PrivateDnsZoneId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.PrivateDnsZoneName, ok = parsed.Parsed["privateDnsZoneName"]; !ok {
-		return nil, fmt.Errorf("the segment 'privateDnsZoneName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "privateDnsZoneName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/privatedns/2018-09-01/recordsets/id_privatednszone.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/privatedns/2018-09-01/recordsets/id_privatednszone.go
@@ -40,15 +40,15 @@ func ParsePrivateDnsZoneID(input string) (*PrivateDnsZoneId, error) {
 	id := PrivateDnsZoneId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.PrivateDnsZoneName, ok = parsed.Parsed["privateDnsZoneName"]; !ok {
-		return nil, fmt.Errorf("the segment 'privateDnsZoneName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "privateDnsZoneName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParsePrivateDnsZoneIDInsensitively(input string) (*PrivateDnsZoneId, error)
 	id := PrivateDnsZoneId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.PrivateDnsZoneName, ok = parsed.Parsed["privateDnsZoneName"]; !ok {
-		return nil, fmt.Errorf("the segment 'privateDnsZoneName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "privateDnsZoneName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/privatedns/2018-09-01/recordsets/id_privatezone.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/privatedns/2018-09-01/recordsets/id_privatezone.go
@@ -42,20 +42,20 @@ func ParsePrivateZoneID(input string) (*PrivateZoneId, error) {
 	id := PrivateZoneId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.PrivateDnsZoneName, ok = parsed.Parsed["privateDnsZoneName"]; !ok {
-		return nil, fmt.Errorf("the segment 'privateDnsZoneName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "privateDnsZoneName", *parsed)
 	}
 
 	if v, ok := parsed.Parsed["recordType"]; true {
 		if !ok {
-			return nil, fmt.Errorf("the segment 'recordType' was not found in the resource id %q", input)
+			return nil, resourceids.NewSegmentNotSpecifiedError(id, "recordType", *parsed)
 		}
 
 		recordType, err := parseRecordType(v)
@@ -81,20 +81,20 @@ func ParsePrivateZoneIDInsensitively(input string) (*PrivateZoneId, error) {
 	id := PrivateZoneId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.PrivateDnsZoneName, ok = parsed.Parsed["privateDnsZoneName"]; !ok {
-		return nil, fmt.Errorf("the segment 'privateDnsZoneName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "privateDnsZoneName", *parsed)
 	}
 
 	if v, ok := parsed.Parsed["recordType"]; true {
 		if !ok {
-			return nil, fmt.Errorf("the segment 'recordType' was not found in the resource id %q", input)
+			return nil, resourceids.NewSegmentNotSpecifiedError(id, "recordType", *parsed)
 		}
 
 		recordType, err := parseRecordType(v)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/privatedns/2018-09-01/recordsets/id_recordtype.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/privatedns/2018-09-01/recordsets/id_recordtype.go
@@ -44,20 +44,20 @@ func ParseRecordTypeID(input string) (*RecordTypeId, error) {
 	id := RecordTypeId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.PrivateDnsZoneName, ok = parsed.Parsed["privateDnsZoneName"]; !ok {
-		return nil, fmt.Errorf("the segment 'privateDnsZoneName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "privateDnsZoneName", *parsed)
 	}
 
 	if v, ok := parsed.Parsed["recordType"]; true {
 		if !ok {
-			return nil, fmt.Errorf("the segment 'recordType' was not found in the resource id %q", input)
+			return nil, resourceids.NewSegmentNotSpecifiedError(id, "recordType", *parsed)
 		}
 
 		recordType, err := parseRecordType(v)
@@ -68,7 +68,7 @@ func ParseRecordTypeID(input string) (*RecordTypeId, error) {
 	}
 
 	if id.RelativeRecordSetName, ok = parsed.Parsed["relativeRecordSetName"]; !ok {
-		return nil, fmt.Errorf("the segment 'relativeRecordSetName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "relativeRecordSetName", *parsed)
 	}
 
 	return &id, nil
@@ -87,20 +87,20 @@ func ParseRecordTypeIDInsensitively(input string) (*RecordTypeId, error) {
 	id := RecordTypeId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.PrivateDnsZoneName, ok = parsed.Parsed["privateDnsZoneName"]; !ok {
-		return nil, fmt.Errorf("the segment 'privateDnsZoneName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "privateDnsZoneName", *parsed)
 	}
 
 	if v, ok := parsed.Parsed["recordType"]; true {
 		if !ok {
-			return nil, fmt.Errorf("the segment 'recordType' was not found in the resource id %q", input)
+			return nil, resourceids.NewSegmentNotSpecifiedError(id, "recordType", *parsed)
 		}
 
 		recordType, err := parseRecordType(v)
@@ -111,7 +111,7 @@ func ParseRecordTypeIDInsensitively(input string) (*RecordTypeId, error) {
 	}
 
 	if id.RelativeRecordSetName, ok = parsed.Parsed["relativeRecordSetName"]; !ok {
-		return nil, fmt.Errorf("the segment 'relativeRecordSetName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "relativeRecordSetName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/privatedns/2018-09-01/virtualnetworklinks/id_privatednszone.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/privatedns/2018-09-01/virtualnetworklinks/id_privatednszone.go
@@ -40,15 +40,15 @@ func ParsePrivateDnsZoneID(input string) (*PrivateDnsZoneId, error) {
 	id := PrivateDnsZoneId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.PrivateDnsZoneName, ok = parsed.Parsed["privateDnsZoneName"]; !ok {
-		return nil, fmt.Errorf("the segment 'privateDnsZoneName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "privateDnsZoneName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParsePrivateDnsZoneIDInsensitively(input string) (*PrivateDnsZoneId, error)
 	id := PrivateDnsZoneId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.PrivateDnsZoneName, ok = parsed.Parsed["privateDnsZoneName"]; !ok {
-		return nil, fmt.Errorf("the segment 'privateDnsZoneName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "privateDnsZoneName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/privatedns/2018-09-01/virtualnetworklinks/id_virtualnetworklink.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/privatedns/2018-09-01/virtualnetworklinks/id_virtualnetworklink.go
@@ -42,19 +42,19 @@ func ParseVirtualNetworkLinkID(input string) (*VirtualNetworkLinkId, error) {
 	id := VirtualNetworkLinkId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.PrivateDnsZoneName, ok = parsed.Parsed["privateDnsZoneName"]; !ok {
-		return nil, fmt.Errorf("the segment 'privateDnsZoneName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "privateDnsZoneName", *parsed)
 	}
 
 	if id.VirtualNetworkLinkName, ok = parsed.Parsed["virtualNetworkLinkName"]; !ok {
-		return nil, fmt.Errorf("the segment 'virtualNetworkLinkName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "virtualNetworkLinkName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseVirtualNetworkLinkIDInsensitively(input string) (*VirtualNetworkLinkId
 	id := VirtualNetworkLinkId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.PrivateDnsZoneName, ok = parsed.Parsed["privateDnsZoneName"]; !ok {
-		return nil, fmt.Errorf("the segment 'privateDnsZoneName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "privateDnsZoneName", *parsed)
 	}
 
 	if id.VirtualNetworkLinkName, ok = parsed.Parsed["virtualNetworkLinkName"]; !ok {
-		return nil, fmt.Errorf("the segment 'virtualNetworkLinkName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "virtualNetworkLinkName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/purview/2021-07-01/account/id_account.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/purview/2021-07-01/account/id_account.go
@@ -40,15 +40,15 @@ func ParseAccountID(input string) (*AccountId, error) {
 	id := AccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AccountName, ok = parsed.Parsed["accountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'accountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "accountName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseAccountIDInsensitively(input string) (*AccountId, error) {
 	id := AccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.AccountName, ok = parsed.Parsed["accountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'accountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "accountName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservices/2022-10-01/vaultcertificates/id_certificate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservices/2022-10-01/vaultcertificates/id_certificate.go
@@ -42,19 +42,19 @@ func ParseCertificateID(input string) (*CertificateId, error) {
 	id := CertificateId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "vaultName", *parsed)
 	}
 
 	if id.CertificateName, ok = parsed.Parsed["certificateName"]; !ok {
-		return nil, fmt.Errorf("the segment 'certificateName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "certificateName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseCertificateIDInsensitively(input string) (*CertificateId, error) {
 	id := CertificateId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "vaultName", *parsed)
 	}
 
 	if id.CertificateName, ok = parsed.Parsed["certificateName"]; !ok {
-		return nil, fmt.Errorf("the segment 'certificateName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "certificateName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservices/2022-10-01/vaults/id_vault.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservices/2022-10-01/vaults/id_vault.go
@@ -40,15 +40,15 @@ func ParseVaultID(input string) (*VaultId, error) {
 	id := VaultId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "vaultName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseVaultIDInsensitively(input string) (*VaultId, error) {
 	id := VaultId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "vaultName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2023-02-01/backupprotectableitems/id_vault.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2023-02-01/backupprotectableitems/id_vault.go
@@ -40,15 +40,15 @@ func ParseVaultID(input string) (*VaultId, error) {
 	id := VaultId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "vaultName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseVaultIDInsensitively(input string) (*VaultId, error) {
 	id := VaultId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "vaultName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2023-02-01/backupprotecteditems/id_vault.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2023-02-01/backupprotecteditems/id_vault.go
@@ -40,15 +40,15 @@ func ParseVaultID(input string) (*VaultId, error) {
 	id := VaultId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "vaultName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseVaultIDInsensitively(input string) (*VaultId, error) {
 	id := VaultId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "vaultName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2023-02-01/backupresourcestorageconfigsnoncrr/id_vault.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2023-02-01/backupresourcestorageconfigsnoncrr/id_vault.go
@@ -40,15 +40,15 @@ func ParseVaultID(input string) (*VaultId, error) {
 	id := VaultId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "vaultName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseVaultIDInsensitively(input string) (*VaultId, error) {
 	id := VaultId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "vaultName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2023-02-01/backupresourcevaultconfigs/id_vault.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2023-02-01/backupresourcevaultconfigs/id_vault.go
@@ -40,15 +40,15 @@ func ParseVaultID(input string) (*VaultId, error) {
 	id := VaultId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "vaultName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseVaultIDInsensitively(input string) (*VaultId, error) {
 	id := VaultId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "vaultName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2023-02-01/protecteditems/id_protecteditem.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2023-02-01/protecteditems/id_protecteditem.go
@@ -46,27 +46,27 @@ func ParseProtectedItemID(input string) (*ProtectedItemId, error) {
 	id := ProtectedItemId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "vaultName", *parsed)
 	}
 
 	if id.BackupFabricName, ok = parsed.Parsed["backupFabricName"]; !ok {
-		return nil, fmt.Errorf("the segment 'backupFabricName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "backupFabricName", *parsed)
 	}
 
 	if id.ProtectionContainerName, ok = parsed.Parsed["protectionContainerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'protectionContainerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "protectionContainerName", *parsed)
 	}
 
 	if id.ProtectedItemName, ok = parsed.Parsed["protectedItemName"]; !ok {
-		return nil, fmt.Errorf("the segment 'protectedItemName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "protectedItemName", *parsed)
 	}
 
 	return &id, nil
@@ -85,27 +85,27 @@ func ParseProtectedItemIDInsensitively(input string) (*ProtectedItemId, error) {
 	id := ProtectedItemId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "vaultName", *parsed)
 	}
 
 	if id.BackupFabricName, ok = parsed.Parsed["backupFabricName"]; !ok {
-		return nil, fmt.Errorf("the segment 'backupFabricName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "backupFabricName", *parsed)
 	}
 
 	if id.ProtectionContainerName, ok = parsed.Parsed["protectionContainerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'protectionContainerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "protectionContainerName", *parsed)
 	}
 
 	if id.ProtectedItemName, ok = parsed.Parsed["protectedItemName"]; !ok {
-		return nil, fmt.Errorf("the segment 'protectedItemName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "protectedItemName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2023-02-01/protectioncontainers/id_backupfabric.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2023-02-01/protectioncontainers/id_backupfabric.go
@@ -42,19 +42,19 @@ func ParseBackupFabricID(input string) (*BackupFabricId, error) {
 	id := BackupFabricId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "vaultName", *parsed)
 	}
 
 	if id.BackupFabricName, ok = parsed.Parsed["backupFabricName"]; !ok {
-		return nil, fmt.Errorf("the segment 'backupFabricName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "backupFabricName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseBackupFabricIDInsensitively(input string) (*BackupFabricId, error) {
 	id := BackupFabricId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "vaultName", *parsed)
 	}
 
 	if id.BackupFabricName, ok = parsed.Parsed["backupFabricName"]; !ok {
-		return nil, fmt.Errorf("the segment 'backupFabricName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "backupFabricName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2023-02-01/protectioncontainers/id_protectioncontainer.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2023-02-01/protectioncontainers/id_protectioncontainer.go
@@ -44,23 +44,23 @@ func ParseProtectionContainerID(input string) (*ProtectionContainerId, error) {
 	id := ProtectionContainerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "vaultName", *parsed)
 	}
 
 	if id.BackupFabricName, ok = parsed.Parsed["backupFabricName"]; !ok {
-		return nil, fmt.Errorf("the segment 'backupFabricName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "backupFabricName", *parsed)
 	}
 
 	if id.ProtectionContainerName, ok = parsed.Parsed["protectionContainerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'protectionContainerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "protectionContainerName", *parsed)
 	}
 
 	return &id, nil
@@ -79,23 +79,23 @@ func ParseProtectionContainerIDInsensitively(input string) (*ProtectionContainer
 	id := ProtectionContainerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "vaultName", *parsed)
 	}
 
 	if id.BackupFabricName, ok = parsed.Parsed["backupFabricName"]; !ok {
-		return nil, fmt.Errorf("the segment 'backupFabricName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "backupFabricName", *parsed)
 	}
 
 	if id.ProtectionContainerName, ok = parsed.Parsed["protectionContainerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'protectionContainerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "protectionContainerName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2023-02-01/protectionpolicies/id_backuppolicy.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2023-02-01/protectionpolicies/id_backuppolicy.go
@@ -42,19 +42,19 @@ func ParseBackupPolicyID(input string) (*BackupPolicyId, error) {
 	id := BackupPolicyId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "vaultName", *parsed)
 	}
 
 	if id.BackupPolicyName, ok = parsed.Parsed["backupPolicyName"]; !ok {
-		return nil, fmt.Errorf("the segment 'backupPolicyName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "backupPolicyName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseBackupPolicyIDInsensitively(input string) (*BackupPolicyId, error) {
 	id := BackupPolicyId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "vaultName", *parsed)
 	}
 
 	if id.BackupPolicyName, ok = parsed.Parsed["backupPolicyName"]; !ok {
-		return nil, fmt.Errorf("the segment 'backupPolicyName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "backupPolicyName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/id_replicationfabric.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/id_replicationfabric.go
@@ -42,19 +42,19 @@ func ParseReplicationFabricID(input string) (*ReplicationFabricId, error) {
 	id := ReplicationFabricId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "vaultName", *parsed)
 	}
 
 	if id.ReplicationFabricName, ok = parsed.Parsed["replicationFabricName"]; !ok {
-		return nil, fmt.Errorf("the segment 'replicationFabricName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "replicationFabricName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseReplicationFabricIDInsensitively(input string) (*ReplicationFabricId, 
 	id := ReplicationFabricId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "vaultName", *parsed)
 	}
 
 	if id.ReplicationFabricName, ok = parsed.Parsed["replicationFabricName"]; !ok {
-		return nil, fmt.Errorf("the segment 'replicationFabricName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "replicationFabricName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/id_vault.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/id_vault.go
@@ -40,15 +40,15 @@ func ParseVaultID(input string) (*VaultId, error) {
 	id := VaultId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "vaultName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseVaultIDInsensitively(input string) (*VaultId, error) {
 	id := VaultId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "vaultName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/id_replicationnetwork.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/id_replicationnetwork.go
@@ -44,23 +44,23 @@ func ParseReplicationNetworkID(input string) (*ReplicationNetworkId, error) {
 	id := ReplicationNetworkId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "vaultName", *parsed)
 	}
 
 	if id.ReplicationFabricName, ok = parsed.Parsed["replicationFabricName"]; !ok {
-		return nil, fmt.Errorf("the segment 'replicationFabricName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "replicationFabricName", *parsed)
 	}
 
 	if id.ReplicationNetworkName, ok = parsed.Parsed["replicationNetworkName"]; !ok {
-		return nil, fmt.Errorf("the segment 'replicationNetworkName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "replicationNetworkName", *parsed)
 	}
 
 	return &id, nil
@@ -79,23 +79,23 @@ func ParseReplicationNetworkIDInsensitively(input string) (*ReplicationNetworkId
 	id := ReplicationNetworkId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "vaultName", *parsed)
 	}
 
 	if id.ReplicationFabricName, ok = parsed.Parsed["replicationFabricName"]; !ok {
-		return nil, fmt.Errorf("the segment 'replicationFabricName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "replicationFabricName", *parsed)
 	}
 
 	if id.ReplicationNetworkName, ok = parsed.Parsed["replicationNetworkName"]; !ok {
-		return nil, fmt.Errorf("the segment 'replicationNetworkName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "replicationNetworkName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/id_replicationnetworkmapping.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/id_replicationnetworkmapping.go
@@ -46,27 +46,27 @@ func ParseReplicationNetworkMappingID(input string) (*ReplicationNetworkMappingI
 	id := ReplicationNetworkMappingId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "vaultName", *parsed)
 	}
 
 	if id.ReplicationFabricName, ok = parsed.Parsed["replicationFabricName"]; !ok {
-		return nil, fmt.Errorf("the segment 'replicationFabricName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "replicationFabricName", *parsed)
 	}
 
 	if id.ReplicationNetworkName, ok = parsed.Parsed["replicationNetworkName"]; !ok {
-		return nil, fmt.Errorf("the segment 'replicationNetworkName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "replicationNetworkName", *parsed)
 	}
 
 	if id.ReplicationNetworkMappingName, ok = parsed.Parsed["replicationNetworkMappingName"]; !ok {
-		return nil, fmt.Errorf("the segment 'replicationNetworkMappingName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "replicationNetworkMappingName", *parsed)
 	}
 
 	return &id, nil
@@ -85,27 +85,27 @@ func ParseReplicationNetworkMappingIDInsensitively(input string) (*ReplicationNe
 	id := ReplicationNetworkMappingId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "vaultName", *parsed)
 	}
 
 	if id.ReplicationFabricName, ok = parsed.Parsed["replicationFabricName"]; !ok {
-		return nil, fmt.Errorf("the segment 'replicationFabricName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "replicationFabricName", *parsed)
 	}
 
 	if id.ReplicationNetworkName, ok = parsed.Parsed["replicationNetworkName"]; !ok {
-		return nil, fmt.Errorf("the segment 'replicationNetworkName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "replicationNetworkName", *parsed)
 	}
 
 	if id.ReplicationNetworkMappingName, ok = parsed.Parsed["replicationNetworkMappingName"]; !ok {
-		return nil, fmt.Errorf("the segment 'replicationNetworkMappingName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "replicationNetworkMappingName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/id_vault.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/id_vault.go
@@ -40,15 +40,15 @@ func ParseVaultID(input string) (*VaultId, error) {
 	id := VaultId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "vaultName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseVaultIDInsensitively(input string) (*VaultId, error) {
 	id := VaultId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "vaultName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/id_replicationpolicy.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/id_replicationpolicy.go
@@ -42,19 +42,19 @@ func ParseReplicationPolicyID(input string) (*ReplicationPolicyId, error) {
 	id := ReplicationPolicyId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "vaultName", *parsed)
 	}
 
 	if id.ReplicationPolicyName, ok = parsed.Parsed["replicationPolicyName"]; !ok {
-		return nil, fmt.Errorf("the segment 'replicationPolicyName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "replicationPolicyName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseReplicationPolicyIDInsensitively(input string) (*ReplicationPolicyId, 
 	id := ReplicationPolicyId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "vaultName", *parsed)
 	}
 
 	if id.ReplicationPolicyName, ok = parsed.Parsed["replicationPolicyName"]; !ok {
-		return nil, fmt.Errorf("the segment 'replicationPolicyName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "replicationPolicyName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/id_vault.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/id_vault.go
@@ -40,15 +40,15 @@ func ParseVaultID(input string) (*VaultId, error) {
 	id := VaultId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "vaultName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseVaultIDInsensitively(input string) (*VaultId, error) {
 	id := VaultId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "vaultName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/id_replicationprotecteditem.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/id_replicationprotecteditem.go
@@ -46,27 +46,27 @@ func ParseReplicationProtectedItemID(input string) (*ReplicationProtectedItemId,
 	id := ReplicationProtectedItemId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "vaultName", *parsed)
 	}
 
 	if id.ReplicationFabricName, ok = parsed.Parsed["replicationFabricName"]; !ok {
-		return nil, fmt.Errorf("the segment 'replicationFabricName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "replicationFabricName", *parsed)
 	}
 
 	if id.ReplicationProtectionContainerName, ok = parsed.Parsed["replicationProtectionContainerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'replicationProtectionContainerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "replicationProtectionContainerName", *parsed)
 	}
 
 	if id.ReplicationProtectedItemName, ok = parsed.Parsed["replicationProtectedItemName"]; !ok {
-		return nil, fmt.Errorf("the segment 'replicationProtectedItemName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "replicationProtectedItemName", *parsed)
 	}
 
 	return &id, nil
@@ -85,27 +85,27 @@ func ParseReplicationProtectedItemIDInsensitively(input string) (*ReplicationPro
 	id := ReplicationProtectedItemId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "vaultName", *parsed)
 	}
 
 	if id.ReplicationFabricName, ok = parsed.Parsed["replicationFabricName"]; !ok {
-		return nil, fmt.Errorf("the segment 'replicationFabricName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "replicationFabricName", *parsed)
 	}
 
 	if id.ReplicationProtectionContainerName, ok = parsed.Parsed["replicationProtectionContainerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'replicationProtectionContainerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "replicationProtectionContainerName", *parsed)
 	}
 
 	if id.ReplicationProtectedItemName, ok = parsed.Parsed["replicationProtectedItemName"]; !ok {
-		return nil, fmt.Errorf("the segment 'replicationProtectedItemName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "replicationProtectedItemName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/id_replicationprotectioncontainer.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/id_replicationprotectioncontainer.go
@@ -44,23 +44,23 @@ func ParseReplicationProtectionContainerID(input string) (*ReplicationProtection
 	id := ReplicationProtectionContainerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "vaultName", *parsed)
 	}
 
 	if id.ReplicationFabricName, ok = parsed.Parsed["replicationFabricName"]; !ok {
-		return nil, fmt.Errorf("the segment 'replicationFabricName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "replicationFabricName", *parsed)
 	}
 
 	if id.ReplicationProtectionContainerName, ok = parsed.Parsed["replicationProtectionContainerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'replicationProtectionContainerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "replicationProtectionContainerName", *parsed)
 	}
 
 	return &id, nil
@@ -79,23 +79,23 @@ func ParseReplicationProtectionContainerIDInsensitively(input string) (*Replicat
 	id := ReplicationProtectionContainerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "vaultName", *parsed)
 	}
 
 	if id.ReplicationFabricName, ok = parsed.Parsed["replicationFabricName"]; !ok {
-		return nil, fmt.Errorf("the segment 'replicationFabricName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "replicationFabricName", *parsed)
 	}
 
 	if id.ReplicationProtectionContainerName, ok = parsed.Parsed["replicationProtectionContainerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'replicationProtectionContainerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "replicationProtectionContainerName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/id_vault.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/id_vault.go
@@ -40,15 +40,15 @@ func ParseVaultID(input string) (*VaultId, error) {
 	id := VaultId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "vaultName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseVaultIDInsensitively(input string) (*VaultId, error) {
 	id := VaultId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "vaultName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/id_replicationprotectioncontainer.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/id_replicationprotectioncontainer.go
@@ -44,23 +44,23 @@ func ParseReplicationProtectionContainerID(input string) (*ReplicationProtection
 	id := ReplicationProtectionContainerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "vaultName", *parsed)
 	}
 
 	if id.ReplicationFabricName, ok = parsed.Parsed["replicationFabricName"]; !ok {
-		return nil, fmt.Errorf("the segment 'replicationFabricName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "replicationFabricName", *parsed)
 	}
 
 	if id.ReplicationProtectionContainerName, ok = parsed.Parsed["replicationProtectionContainerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'replicationProtectionContainerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "replicationProtectionContainerName", *parsed)
 	}
 
 	return &id, nil
@@ -79,23 +79,23 @@ func ParseReplicationProtectionContainerIDInsensitively(input string) (*Replicat
 	id := ReplicationProtectionContainerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "vaultName", *parsed)
 	}
 
 	if id.ReplicationFabricName, ok = parsed.Parsed["replicationFabricName"]; !ok {
-		return nil, fmt.Errorf("the segment 'replicationFabricName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "replicationFabricName", *parsed)
 	}
 
 	if id.ReplicationProtectionContainerName, ok = parsed.Parsed["replicationProtectionContainerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'replicationProtectionContainerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "replicationProtectionContainerName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/id_replicationprotectioncontainermapping.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/id_replicationprotectioncontainermapping.go
@@ -46,27 +46,27 @@ func ParseReplicationProtectionContainerMappingID(input string) (*ReplicationPro
 	id := ReplicationProtectionContainerMappingId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "vaultName", *parsed)
 	}
 
 	if id.ReplicationFabricName, ok = parsed.Parsed["replicationFabricName"]; !ok {
-		return nil, fmt.Errorf("the segment 'replicationFabricName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "replicationFabricName", *parsed)
 	}
 
 	if id.ReplicationProtectionContainerName, ok = parsed.Parsed["replicationProtectionContainerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'replicationProtectionContainerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "replicationProtectionContainerName", *parsed)
 	}
 
 	if id.ReplicationProtectionContainerMappingName, ok = parsed.Parsed["replicationProtectionContainerMappingName"]; !ok {
-		return nil, fmt.Errorf("the segment 'replicationProtectionContainerMappingName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "replicationProtectionContainerMappingName", *parsed)
 	}
 
 	return &id, nil
@@ -85,27 +85,27 @@ func ParseReplicationProtectionContainerMappingIDInsensitively(input string) (*R
 	id := ReplicationProtectionContainerMappingId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "vaultName", *parsed)
 	}
 
 	if id.ReplicationFabricName, ok = parsed.Parsed["replicationFabricName"]; !ok {
-		return nil, fmt.Errorf("the segment 'replicationFabricName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "replicationFabricName", *parsed)
 	}
 
 	if id.ReplicationProtectionContainerName, ok = parsed.Parsed["replicationProtectionContainerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'replicationProtectionContainerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "replicationProtectionContainerName", *parsed)
 	}
 
 	if id.ReplicationProtectionContainerMappingName, ok = parsed.Parsed["replicationProtectionContainerMappingName"]; !ok {
-		return nil, fmt.Errorf("the segment 'replicationProtectionContainerMappingName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "replicationProtectionContainerMappingName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/id_vault.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/id_vault.go
@@ -40,15 +40,15 @@ func ParseVaultID(input string) (*VaultId, error) {
 	id := VaultId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "vaultName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseVaultIDInsensitively(input string) (*VaultId, error) {
 	id := VaultId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "vaultName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/id_replicationfabric.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/id_replicationfabric.go
@@ -42,19 +42,19 @@ func ParseReplicationFabricID(input string) (*ReplicationFabricId, error) {
 	id := ReplicationFabricId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "vaultName", *parsed)
 	}
 
 	if id.ReplicationFabricName, ok = parsed.Parsed["replicationFabricName"]; !ok {
-		return nil, fmt.Errorf("the segment 'replicationFabricName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "replicationFabricName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseReplicationFabricIDInsensitively(input string) (*ReplicationFabricId, 
 	id := ReplicationFabricId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "vaultName", *parsed)
 	}
 
 	if id.ReplicationFabricName, ok = parsed.Parsed["replicationFabricName"]; !ok {
-		return nil, fmt.Errorf("the segment 'replicationFabricName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "replicationFabricName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/id_replicationprotectioncontainer.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/id_replicationprotectioncontainer.go
@@ -44,23 +44,23 @@ func ParseReplicationProtectionContainerID(input string) (*ReplicationProtection
 	id := ReplicationProtectionContainerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "vaultName", *parsed)
 	}
 
 	if id.ReplicationFabricName, ok = parsed.Parsed["replicationFabricName"]; !ok {
-		return nil, fmt.Errorf("the segment 'replicationFabricName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "replicationFabricName", *parsed)
 	}
 
 	if id.ReplicationProtectionContainerName, ok = parsed.Parsed["replicationProtectionContainerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'replicationProtectionContainerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "replicationProtectionContainerName", *parsed)
 	}
 
 	return &id, nil
@@ -79,23 +79,23 @@ func ParseReplicationProtectionContainerIDInsensitively(input string) (*Replicat
 	id := ReplicationProtectionContainerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "vaultName", *parsed)
 	}
 
 	if id.ReplicationFabricName, ok = parsed.Parsed["replicationFabricName"]; !ok {
-		return nil, fmt.Errorf("the segment 'replicationFabricName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "replicationFabricName", *parsed)
 	}
 
 	if id.ReplicationProtectionContainerName, ok = parsed.Parsed["replicationProtectionContainerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'replicationProtectionContainerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "replicationProtectionContainerName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/id_vault.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/id_vault.go
@@ -40,15 +40,15 @@ func ParseVaultID(input string) (*VaultId, error) {
 	id := VaultId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "vaultName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseVaultIDInsensitively(input string) (*VaultId, error) {
 	id := VaultId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "vaultName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/id_replicationrecoveryplan.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/id_replicationrecoveryplan.go
@@ -42,19 +42,19 @@ func ParseReplicationRecoveryPlanID(input string) (*ReplicationRecoveryPlanId, e
 	id := ReplicationRecoveryPlanId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "vaultName", *parsed)
 	}
 
 	if id.ReplicationRecoveryPlanName, ok = parsed.Parsed["replicationRecoveryPlanName"]; !ok {
-		return nil, fmt.Errorf("the segment 'replicationRecoveryPlanName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "replicationRecoveryPlanName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseReplicationRecoveryPlanIDInsensitively(input string) (*ReplicationReco
 	id := ReplicationRecoveryPlanId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "vaultName", *parsed)
 	}
 
 	if id.ReplicationRecoveryPlanName, ok = parsed.Parsed["replicationRecoveryPlanName"]; !ok {
-		return nil, fmt.Errorf("the segment 'replicationRecoveryPlanName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "replicationRecoveryPlanName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/id_vault.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/id_vault.go
@@ -40,15 +40,15 @@ func ParseVaultID(input string) (*VaultId, error) {
 	id := VaultId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "vaultName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseVaultIDInsensitively(input string) (*VaultId, error) {
 	id := VaultId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "vaultName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryservicesproviders/id_replicationfabric.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryservicesproviders/id_replicationfabric.go
@@ -42,19 +42,19 @@ func ParseReplicationFabricID(input string) (*ReplicationFabricId, error) {
 	id := ReplicationFabricId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "vaultName", *parsed)
 	}
 
 	if id.ReplicationFabricName, ok = parsed.Parsed["replicationFabricName"]; !ok {
-		return nil, fmt.Errorf("the segment 'replicationFabricName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "replicationFabricName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseReplicationFabricIDInsensitively(input string) (*ReplicationFabricId, 
 	id := ReplicationFabricId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "vaultName", *parsed)
 	}
 
 	if id.ReplicationFabricName, ok = parsed.Parsed["replicationFabricName"]; !ok {
-		return nil, fmt.Errorf("the segment 'replicationFabricName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "replicationFabricName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryservicesproviders/id_replicationrecoveryservicesprovider.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryservicesproviders/id_replicationrecoveryservicesprovider.go
@@ -44,23 +44,23 @@ func ParseReplicationRecoveryServicesProviderID(input string) (*ReplicationRecov
 	id := ReplicationRecoveryServicesProviderId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "vaultName", *parsed)
 	}
 
 	if id.ReplicationFabricName, ok = parsed.Parsed["replicationFabricName"]; !ok {
-		return nil, fmt.Errorf("the segment 'replicationFabricName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "replicationFabricName", *parsed)
 	}
 
 	if id.ReplicationRecoveryServicesProviderName, ok = parsed.Parsed["replicationRecoveryServicesProviderName"]; !ok {
-		return nil, fmt.Errorf("the segment 'replicationRecoveryServicesProviderName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "replicationRecoveryServicesProviderName", *parsed)
 	}
 
 	return &id, nil
@@ -79,23 +79,23 @@ func ParseReplicationRecoveryServicesProviderIDInsensitively(input string) (*Rep
 	id := ReplicationRecoveryServicesProviderId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "vaultName", *parsed)
 	}
 
 	if id.ReplicationFabricName, ok = parsed.Parsed["replicationFabricName"]; !ok {
-		return nil, fmt.Errorf("the segment 'replicationFabricName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "replicationFabricName", *parsed)
 	}
 
 	if id.ReplicationRecoveryServicesProviderName, ok = parsed.Parsed["replicationRecoveryServicesProviderName"]; !ok {
-		return nil, fmt.Errorf("the segment 'replicationRecoveryServicesProviderName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "replicationRecoveryServicesProviderName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryservicesproviders/id_vault.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryservicesproviders/id_vault.go
@@ -40,15 +40,15 @@ func ParseVaultID(input string) (*VaultId, error) {
 	id := VaultId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "vaultName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseVaultIDInsensitively(input string) (*VaultId, error) {
 	id := VaultId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "vaultName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationvaultsetting/id_replicationvaultsetting.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationvaultsetting/id_replicationvaultsetting.go
@@ -42,19 +42,19 @@ func ParseReplicationVaultSettingID(input string) (*ReplicationVaultSettingId, e
 	id := ReplicationVaultSettingId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "vaultName", *parsed)
 	}
 
 	if id.ReplicationVaultSettingName, ok = parsed.Parsed["replicationVaultSettingName"]; !ok {
-		return nil, fmt.Errorf("the segment 'replicationVaultSettingName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "replicationVaultSettingName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseReplicationVaultSettingIDInsensitively(input string) (*ReplicationVaul
 	id := ReplicationVaultSettingId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "vaultName", *parsed)
 	}
 
 	if id.ReplicationVaultSettingName, ok = parsed.Parsed["replicationVaultSettingName"]; !ok {
-		return nil, fmt.Errorf("the segment 'replicationVaultSettingName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "replicationVaultSettingName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationvaultsetting/id_vault.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationvaultsetting/id_vault.go
@@ -40,15 +40,15 @@ func ParseVaultID(input string) (*VaultId, error) {
 	id := VaultId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "vaultName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseVaultIDInsensitively(input string) (*VaultId, error) {
 	id := VaultId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VaultName, ok = parsed.Parsed["vaultName"]; !ok {
-		return nil, fmt.Errorf("the segment 'vaultName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "vaultName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/redis/2022-06-01/firewallrules/id_firewallrule.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/redis/2022-06-01/firewallrules/id_firewallrule.go
@@ -42,19 +42,19 @@ func ParseFirewallRuleID(input string) (*FirewallRuleId, error) {
 	id := FirewallRuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RedisName, ok = parsed.Parsed["redisName"]; !ok {
-		return nil, fmt.Errorf("the segment 'redisName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "redisName", *parsed)
 	}
 
 	if id.FirewallRuleName, ok = parsed.Parsed["firewallRuleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'firewallRuleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "firewallRuleName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseFirewallRuleIDInsensitively(input string) (*FirewallRuleId, error) {
 	id := FirewallRuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RedisName, ok = parsed.Parsed["redisName"]; !ok {
-		return nil, fmt.Errorf("the segment 'redisName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "redisName", *parsed)
 	}
 
 	if id.FirewallRuleName, ok = parsed.Parsed["firewallRuleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'firewallRuleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "firewallRuleName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/redis/2022-06-01/firewallrules/id_redi.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/redis/2022-06-01/firewallrules/id_redi.go
@@ -40,15 +40,15 @@ func ParseRediID(input string) (*RediId, error) {
 	id := RediId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RedisName, ok = parsed.Parsed["redisName"]; !ok {
-		return nil, fmt.Errorf("the segment 'redisName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "redisName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseRediIDInsensitively(input string) (*RediId, error) {
 	id := RediId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RedisName, ok = parsed.Parsed["redisName"]; !ok {
-		return nil, fmt.Errorf("the segment 'redisName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "redisName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/redis/2022-06-01/patchschedules/id_redi.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/redis/2022-06-01/patchschedules/id_redi.go
@@ -40,15 +40,15 @@ func ParseRediID(input string) (*RediId, error) {
 	id := RediId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RedisName, ok = parsed.Parsed["redisName"]; !ok {
-		return nil, fmt.Errorf("the segment 'redisName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "redisName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseRediIDInsensitively(input string) (*RediId, error) {
 	id := RediId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RedisName, ok = parsed.Parsed["redisName"]; !ok {
-		return nil, fmt.Errorf("the segment 'redisName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "redisName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/redis/2022-06-01/privateendpointconnections/id_privateendpointconnection.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/redis/2022-06-01/privateendpointconnections/id_privateendpointconnection.go
@@ -42,19 +42,19 @@ func ParsePrivateEndpointConnectionID(input string) (*PrivateEndpointConnectionI
 	id := PrivateEndpointConnectionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RedisName, ok = parsed.Parsed["redisName"]; !ok {
-		return nil, fmt.Errorf("the segment 'redisName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "redisName", *parsed)
 	}
 
 	if id.PrivateEndpointConnectionName, ok = parsed.Parsed["privateEndpointConnectionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'privateEndpointConnectionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "privateEndpointConnectionName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParsePrivateEndpointConnectionIDInsensitively(input string) (*PrivateEndpoi
 	id := PrivateEndpointConnectionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RedisName, ok = parsed.Parsed["redisName"]; !ok {
-		return nil, fmt.Errorf("the segment 'redisName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "redisName", *parsed)
 	}
 
 	if id.PrivateEndpointConnectionName, ok = parsed.Parsed["privateEndpointConnectionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'privateEndpointConnectionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "privateEndpointConnectionName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/redis/2022-06-01/privateendpointconnections/id_redi.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/redis/2022-06-01/privateendpointconnections/id_redi.go
@@ -40,15 +40,15 @@ func ParseRediID(input string) (*RediId, error) {
 	id := RediId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RedisName, ok = parsed.Parsed["redisName"]; !ok {
-		return nil, fmt.Errorf("the segment 'redisName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "redisName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseRediIDInsensitively(input string) (*RediId, error) {
 	id := RediId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RedisName, ok = parsed.Parsed["redisName"]; !ok {
-		return nil, fmt.Errorf("the segment 'redisName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "redisName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/redis/2022-06-01/privatelinkresources/id_redi.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/redis/2022-06-01/privatelinkresources/id_redi.go
@@ -40,15 +40,15 @@ func ParseRediID(input string) (*RediId, error) {
 	id := RediId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RedisName, ok = parsed.Parsed["redisName"]; !ok {
-		return nil, fmt.Errorf("the segment 'redisName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "redisName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseRediIDInsensitively(input string) (*RediId, error) {
 	id := RediId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RedisName, ok = parsed.Parsed["redisName"]; !ok {
-		return nil, fmt.Errorf("the segment 'redisName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "redisName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/redis/2022-06-01/redis/id_firewallrule.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/redis/2022-06-01/redis/id_firewallrule.go
@@ -42,19 +42,19 @@ func ParseFirewallRuleID(input string) (*FirewallRuleId, error) {
 	id := FirewallRuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RedisName, ok = parsed.Parsed["redisName"]; !ok {
-		return nil, fmt.Errorf("the segment 'redisName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "redisName", *parsed)
 	}
 
 	if id.FirewallRuleName, ok = parsed.Parsed["firewallRuleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'firewallRuleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "firewallRuleName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseFirewallRuleIDInsensitively(input string) (*FirewallRuleId, error) {
 	id := FirewallRuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RedisName, ok = parsed.Parsed["redisName"]; !ok {
-		return nil, fmt.Errorf("the segment 'redisName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "redisName", *parsed)
 	}
 
 	if id.FirewallRuleName, ok = parsed.Parsed["firewallRuleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'firewallRuleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "firewallRuleName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/redis/2022-06-01/redis/id_linkedserver.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/redis/2022-06-01/redis/id_linkedserver.go
@@ -42,19 +42,19 @@ func ParseLinkedServerID(input string) (*LinkedServerId, error) {
 	id := LinkedServerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RedisName, ok = parsed.Parsed["redisName"]; !ok {
-		return nil, fmt.Errorf("the segment 'redisName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "redisName", *parsed)
 	}
 
 	if id.LinkedServerName, ok = parsed.Parsed["linkedServerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'linkedServerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "linkedServerName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseLinkedServerIDInsensitively(input string) (*LinkedServerId, error) {
 	id := LinkedServerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RedisName, ok = parsed.Parsed["redisName"]; !ok {
-		return nil, fmt.Errorf("the segment 'redisName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "redisName", *parsed)
 	}
 
 	if id.LinkedServerName, ok = parsed.Parsed["linkedServerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'linkedServerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "linkedServerName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/redis/2022-06-01/redis/id_redi.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/redis/2022-06-01/redis/id_redi.go
@@ -40,15 +40,15 @@ func ParseRediID(input string) (*RediId, error) {
 	id := RediId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RedisName, ok = parsed.Parsed["redisName"]; !ok {
-		return nil, fmt.Errorf("the segment 'redisName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "redisName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseRediIDInsensitively(input string) (*RediId, error) {
 	id := RediId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RedisName, ok = parsed.Parsed["redisName"]; !ok {
-		return nil, fmt.Errorf("the segment 'redisName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "redisName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/redisenterprise/2022-01-01/databases/id_database.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/redisenterprise/2022-01-01/databases/id_database.go
@@ -42,19 +42,19 @@ func ParseDatabaseID(input string) (*DatabaseId, error) {
 	id := DatabaseId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RedisEnterpriseName, ok = parsed.Parsed["redisEnterpriseName"]; !ok {
-		return nil, fmt.Errorf("the segment 'redisEnterpriseName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "redisEnterpriseName", *parsed)
 	}
 
 	if id.DatabaseName, ok = parsed.Parsed["databaseName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseDatabaseIDInsensitively(input string) (*DatabaseId, error) {
 	id := DatabaseId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RedisEnterpriseName, ok = parsed.Parsed["redisEnterpriseName"]; !ok {
-		return nil, fmt.Errorf("the segment 'redisEnterpriseName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "redisEnterpriseName", *parsed)
 	}
 
 	if id.DatabaseName, ok = parsed.Parsed["databaseName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/redisenterprise/2022-01-01/databases/id_redisenterprise.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/redisenterprise/2022-01-01/databases/id_redisenterprise.go
@@ -40,15 +40,15 @@ func ParseRedisEnterpriseID(input string) (*RedisEnterpriseId, error) {
 	id := RedisEnterpriseId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RedisEnterpriseName, ok = parsed.Parsed["redisEnterpriseName"]; !ok {
-		return nil, fmt.Errorf("the segment 'redisEnterpriseName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "redisEnterpriseName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseRedisEnterpriseIDInsensitively(input string) (*RedisEnterpriseId, erro
 	id := RedisEnterpriseId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RedisEnterpriseName, ok = parsed.Parsed["redisEnterpriseName"]; !ok {
-		return nil, fmt.Errorf("the segment 'redisEnterpriseName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "redisEnterpriseName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/redisenterprise/2022-01-01/redisenterprise/id_database.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/redisenterprise/2022-01-01/redisenterprise/id_database.go
@@ -42,19 +42,19 @@ func ParseDatabaseID(input string) (*DatabaseId, error) {
 	id := DatabaseId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RedisEnterpriseName, ok = parsed.Parsed["redisEnterpriseName"]; !ok {
-		return nil, fmt.Errorf("the segment 'redisEnterpriseName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "redisEnterpriseName", *parsed)
 	}
 
 	if id.DatabaseName, ok = parsed.Parsed["databaseName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseDatabaseIDInsensitively(input string) (*DatabaseId, error) {
 	id := DatabaseId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RedisEnterpriseName, ok = parsed.Parsed["redisEnterpriseName"]; !ok {
-		return nil, fmt.Errorf("the segment 'redisEnterpriseName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "redisEnterpriseName", *parsed)
 	}
 
 	if id.DatabaseName, ok = parsed.Parsed["databaseName"]; !ok {
-		return nil, fmt.Errorf("the segment 'databaseName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "databaseName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/redisenterprise/2022-01-01/redisenterprise/id_redisenterprise.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/redisenterprise/2022-01-01/redisenterprise/id_redisenterprise.go
@@ -40,15 +40,15 @@ func ParseRedisEnterpriseID(input string) (*RedisEnterpriseId, error) {
 	id := RedisEnterpriseId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RedisEnterpriseName, ok = parsed.Parsed["redisEnterpriseName"]; !ok {
-		return nil, fmt.Errorf("the segment 'redisEnterpriseName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "redisEnterpriseName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseRedisEnterpriseIDInsensitively(input string) (*RedisEnterpriseId, erro
 	id := RedisEnterpriseId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.RedisEnterpriseName, ok = parsed.Parsed["redisEnterpriseName"]; !ok {
-		return nil, fmt.Errorf("the segment 'redisEnterpriseName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "redisEnterpriseName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/relay/2017-04-01/hybridconnections/id_hybridconnection.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/relay/2017-04-01/hybridconnections/id_hybridconnection.go
@@ -42,19 +42,19 @@ func ParseHybridConnectionID(input string) (*HybridConnectionId, error) {
 	id := HybridConnectionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	if id.HybridConnectionName, ok = parsed.Parsed["hybridConnectionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'hybridConnectionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "hybridConnectionName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseHybridConnectionIDInsensitively(input string) (*HybridConnectionId, er
 	id := HybridConnectionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	if id.HybridConnectionName, ok = parsed.Parsed["hybridConnectionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'hybridConnectionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "hybridConnectionName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/relay/2017-04-01/hybridconnections/id_hybridconnectionauthorizationrule.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/relay/2017-04-01/hybridconnections/id_hybridconnectionauthorizationrule.go
@@ -44,23 +44,23 @@ func ParseHybridConnectionAuthorizationRuleID(input string) (*HybridConnectionAu
 	id := HybridConnectionAuthorizationRuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	if id.HybridConnectionName, ok = parsed.Parsed["hybridConnectionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'hybridConnectionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "hybridConnectionName", *parsed)
 	}
 
 	if id.AuthorizationRuleName, ok = parsed.Parsed["authorizationRuleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'authorizationRuleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "authorizationRuleName", *parsed)
 	}
 
 	return &id, nil
@@ -79,23 +79,23 @@ func ParseHybridConnectionAuthorizationRuleIDInsensitively(input string) (*Hybri
 	id := HybridConnectionAuthorizationRuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	if id.HybridConnectionName, ok = parsed.Parsed["hybridConnectionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'hybridConnectionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "hybridConnectionName", *parsed)
 	}
 
 	if id.AuthorizationRuleName, ok = parsed.Parsed["authorizationRuleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'authorizationRuleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "authorizationRuleName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/relay/2017-04-01/hybridconnections/id_namespace.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/relay/2017-04-01/hybridconnections/id_namespace.go
@@ -40,15 +40,15 @@ func ParseNamespaceID(input string) (*NamespaceId, error) {
 	id := NamespaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseNamespaceIDInsensitively(input string) (*NamespaceId, error) {
 	id := NamespaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/relay/2017-04-01/namespaces/id_authorizationrule.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/relay/2017-04-01/namespaces/id_authorizationrule.go
@@ -42,19 +42,19 @@ func ParseAuthorizationRuleID(input string) (*AuthorizationRuleId, error) {
 	id := AuthorizationRuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	if id.AuthorizationRuleName, ok = parsed.Parsed["authorizationRuleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'authorizationRuleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "authorizationRuleName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseAuthorizationRuleIDInsensitively(input string) (*AuthorizationRuleId, 
 	id := AuthorizationRuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	if id.AuthorizationRuleName, ok = parsed.Parsed["authorizationRuleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'authorizationRuleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "authorizationRuleName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/relay/2017-04-01/namespaces/id_namespace.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/relay/2017-04-01/namespaces/id_namespace.go
@@ -40,15 +40,15 @@ func ParseNamespaceID(input string) (*NamespaceId, error) {
 	id := NamespaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseNamespaceIDInsensitively(input string) (*NamespaceId, error) {
 	id := NamespaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2020-05-01/managementlocks/id_lock.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2020-05-01/managementlocks/id_lock.go
@@ -38,11 +38,11 @@ func ParseLockID(input string) (*LockId, error) {
 	id := LockId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.LockName, ok = parsed.Parsed["lockName"]; !ok {
-		return nil, fmt.Errorf("the segment 'lockName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "lockName", *parsed)
 	}
 
 	return &id, nil
@@ -61,11 +61,11 @@ func ParseLockIDInsensitively(input string) (*LockId, error) {
 	id := LockId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.LockName, ok = parsed.Parsed["lockName"]; !ok {
-		return nil, fmt.Errorf("the segment 'lockName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "lockName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2020-05-01/managementlocks/id_providerlock.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2020-05-01/managementlocks/id_providerlock.go
@@ -40,15 +40,15 @@ func ParseProviderLockID(input string) (*ProviderLockId, error) {
 	id := ProviderLockId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.LockName, ok = parsed.Parsed["lockName"]; !ok {
-		return nil, fmt.Errorf("the segment 'lockName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "lockName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseProviderLockIDInsensitively(input string) (*ProviderLockId, error) {
 	id := ProviderLockId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.LockName, ok = parsed.Parsed["lockName"]; !ok {
-		return nil, fmt.Errorf("the segment 'lockName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "lockName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2020-05-01/managementlocks/id_resource.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2020-05-01/managementlocks/id_resource.go
@@ -46,27 +46,27 @@ func ParseResourceID(input string) (*ResourceId, error) {
 	id := ResourceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ProviderName, ok = parsed.Parsed["providerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'providerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "providerName", *parsed)
 	}
 
 	if id.ParentResourcePath, ok = parsed.Parsed["parentResourcePath"]; !ok {
-		return nil, fmt.Errorf("the segment 'parentResourcePath' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "parentResourcePath", *parsed)
 	}
 
 	if id.ResourceType, ok = parsed.Parsed["resourceType"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceType' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceType", *parsed)
 	}
 
 	if id.ResourceName, ok = parsed.Parsed["resourceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceName", *parsed)
 	}
 
 	return &id, nil
@@ -85,27 +85,27 @@ func ParseResourceIDInsensitively(input string) (*ResourceId, error) {
 	id := ResourceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ProviderName, ok = parsed.Parsed["providerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'providerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "providerName", *parsed)
 	}
 
 	if id.ParentResourcePath, ok = parsed.Parsed["parentResourcePath"]; !ok {
-		return nil, fmt.Errorf("the segment 'parentResourcePath' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "parentResourcePath", *parsed)
 	}
 
 	if id.ResourceType, ok = parsed.Parsed["resourceType"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceType' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceType", *parsed)
 	}
 
 	if id.ResourceName, ok = parsed.Parsed["resourceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2020-05-01/managementlocks/id_resourcelock.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2020-05-01/managementlocks/id_resourcelock.go
@@ -48,31 +48,31 @@ func ParseResourceLockID(input string) (*ResourceLockId, error) {
 	id := ResourceLockId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ProviderName, ok = parsed.Parsed["providerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'providerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "providerName", *parsed)
 	}
 
 	if id.ParentResourcePath, ok = parsed.Parsed["parentResourcePath"]; !ok {
-		return nil, fmt.Errorf("the segment 'parentResourcePath' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "parentResourcePath", *parsed)
 	}
 
 	if id.ResourceType, ok = parsed.Parsed["resourceType"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceType' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceType", *parsed)
 	}
 
 	if id.ResourceName, ok = parsed.Parsed["resourceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceName", *parsed)
 	}
 
 	if id.LockName, ok = parsed.Parsed["lockName"]; !ok {
-		return nil, fmt.Errorf("the segment 'lockName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "lockName", *parsed)
 	}
 
 	return &id, nil
@@ -91,31 +91,31 @@ func ParseResourceLockIDInsensitively(input string) (*ResourceLockId, error) {
 	id := ResourceLockId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ProviderName, ok = parsed.Parsed["providerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'providerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "providerName", *parsed)
 	}
 
 	if id.ParentResourcePath, ok = parsed.Parsed["parentResourcePath"]; !ok {
-		return nil, fmt.Errorf("the segment 'parentResourcePath' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "parentResourcePath", *parsed)
 	}
 
 	if id.ResourceType, ok = parsed.Parsed["resourceType"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceType' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceType", *parsed)
 	}
 
 	if id.ResourceName, ok = parsed.Parsed["resourceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceName", *parsed)
 	}
 
 	if id.LockName, ok = parsed.Parsed["lockName"]; !ok {
-		return nil, fmt.Errorf("the segment 'lockName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "lockName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2020-05-01/managementlocks/id_scopedlock.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2020-05-01/managementlocks/id_scopedlock.go
@@ -38,11 +38,11 @@ func ParseScopedLockID(input string) (*ScopedLockId, error) {
 	id := ScopedLockId{}
 
 	if id.Scope, ok = parsed.Parsed["scope"]; !ok {
-		return nil, fmt.Errorf("the segment 'scope' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "scope", *parsed)
 	}
 
 	if id.LockName, ok = parsed.Parsed["lockName"]; !ok {
-		return nil, fmt.Errorf("the segment 'lockName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "lockName", *parsed)
 	}
 
 	return &id, nil
@@ -61,11 +61,11 @@ func ParseScopedLockIDInsensitively(input string) (*ScopedLockId, error) {
 	id := ScopedLockId{}
 
 	if id.Scope, ok = parsed.Parsed["scope"]; !ok {
-		return nil, fmt.Errorf("the segment 'scope' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "scope", *parsed)
 	}
 
 	if id.LockName, ok = parsed.Parsed["lockName"]; !ok {
-		return nil, fmt.Errorf("the segment 'lockName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "lockName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2020-10-01/deploymentscripts/id_deploymentscript.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2020-10-01/deploymentscripts/id_deploymentscript.go
@@ -40,15 +40,15 @@ func ParseDeploymentScriptID(input string) (*DeploymentScriptId, error) {
 	id := DeploymentScriptId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DeploymentScriptName, ok = parsed.Parsed["deploymentScriptName"]; !ok {
-		return nil, fmt.Errorf("the segment 'deploymentScriptName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "deploymentScriptName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseDeploymentScriptIDInsensitively(input string) (*DeploymentScriptId, er
 	id := DeploymentScriptId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DeploymentScriptName, ok = parsed.Parsed["deploymentScriptName"]; !ok {
-		return nil, fmt.Errorf("the segment 'deploymentScriptName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "deploymentScriptName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2022-06-01/policyassignments/id_policyassignmentid.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2022-06-01/policyassignments/id_policyassignmentid.go
@@ -36,7 +36,7 @@ func ParsePolicyAssignmentIdID(input string) (*PolicyAssignmentIdId, error) {
 	id := PolicyAssignmentIdId{}
 
 	if id.PolicyAssignmentId, ok = parsed.Parsed["policyAssignmentId"]; !ok {
-		return nil, fmt.Errorf("the segment 'policyAssignmentId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "policyAssignmentId", *parsed)
 	}
 
 	return &id, nil
@@ -55,7 +55,7 @@ func ParsePolicyAssignmentIdIDInsensitively(input string) (*PolicyAssignmentIdId
 	id := PolicyAssignmentIdId{}
 
 	if id.PolicyAssignmentId, ok = parsed.Parsed["policyAssignmentId"]; !ok {
-		return nil, fmt.Errorf("the segment 'policyAssignmentId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "policyAssignmentId", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2022-06-01/policyassignments/id_resource.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2022-06-01/policyassignments/id_resource.go
@@ -46,27 +46,27 @@ func ParseResourceID(input string) (*ResourceId, error) {
 	id := ResourceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ProviderName, ok = parsed.Parsed["providerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'providerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "providerName", *parsed)
 	}
 
 	if id.ParentResourcePath, ok = parsed.Parsed["parentResourcePath"]; !ok {
-		return nil, fmt.Errorf("the segment 'parentResourcePath' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "parentResourcePath", *parsed)
 	}
 
 	if id.ResourceType, ok = parsed.Parsed["resourceType"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceType' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceType", *parsed)
 	}
 
 	if id.ResourceName, ok = parsed.Parsed["resourceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceName", *parsed)
 	}
 
 	return &id, nil
@@ -85,27 +85,27 @@ func ParseResourceIDInsensitively(input string) (*ResourceId, error) {
 	id := ResourceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ProviderName, ok = parsed.Parsed["providerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'providerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "providerName", *parsed)
 	}
 
 	if id.ParentResourcePath, ok = parsed.Parsed["parentResourcePath"]; !ok {
-		return nil, fmt.Errorf("the segment 'parentResourcePath' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "parentResourcePath", *parsed)
 	}
 
 	if id.ResourceType, ok = parsed.Parsed["resourceType"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceType' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceType", *parsed)
 	}
 
 	if id.ResourceName, ok = parsed.Parsed["resourceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2022-06-01/policyassignments/id_scopedpolicyassignment.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2022-06-01/policyassignments/id_scopedpolicyassignment.go
@@ -38,11 +38,11 @@ func ParseScopedPolicyAssignmentID(input string) (*ScopedPolicyAssignmentId, err
 	id := ScopedPolicyAssignmentId{}
 
 	if id.Scope, ok = parsed.Parsed["scope"]; !ok {
-		return nil, fmt.Errorf("the segment 'scope' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "scope", *parsed)
 	}
 
 	if id.PolicyAssignmentName, ok = parsed.Parsed["policyAssignmentName"]; !ok {
-		return nil, fmt.Errorf("the segment 'policyAssignmentName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "policyAssignmentName", *parsed)
 	}
 
 	return &id, nil
@@ -61,11 +61,11 @@ func ParseScopedPolicyAssignmentIDInsensitively(input string) (*ScopedPolicyAssi
 	id := ScopedPolicyAssignmentId{}
 
 	if id.Scope, ok = parsed.Parsed["scope"]; !ok {
-		return nil, fmt.Errorf("the segment 'scope' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "scope", *parsed)
 	}
 
 	if id.PolicyAssignmentName, ok = parsed.Parsed["policyAssignmentName"]; !ok {
-		return nil, fmt.Errorf("the segment 'policyAssignmentName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "policyAssignmentName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2022-09-01/providers/id_provider.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2022-09-01/providers/id_provider.go
@@ -36,7 +36,7 @@ func ParseProviderID(input string) (*ProviderId, error) {
 	id := ProviderId{}
 
 	if id.ProviderName, ok = parsed.Parsed["providerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'providerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "providerName", *parsed)
 	}
 
 	return &id, nil
@@ -55,7 +55,7 @@ func ParseProviderIDInsensitively(input string) (*ProviderId, error) {
 	id := ProviderId{}
 
 	if id.ProviderName, ok = parsed.Parsed["providerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'providerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "providerName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2022-09-01/providers/id_providers2.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2022-09-01/providers/id_providers2.go
@@ -38,11 +38,11 @@ func ParseProviders2ID(input string) (*Providers2Id, error) {
 	id := Providers2Id{}
 
 	if id.GroupId, ok = parsed.Parsed["groupId"]; !ok {
-		return nil, fmt.Errorf("the segment 'groupId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "groupId", *parsed)
 	}
 
 	if id.ProviderName, ok = parsed.Parsed["providerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'providerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "providerName", *parsed)
 	}
 
 	return &id, nil
@@ -61,11 +61,11 @@ func ParseProviders2IDInsensitively(input string) (*Providers2Id, error) {
 	id := Providers2Id{}
 
 	if id.GroupId, ok = parsed.Parsed["groupId"]; !ok {
-		return nil, fmt.Errorf("the segment 'groupId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "groupId", *parsed)
 	}
 
 	if id.ProviderName, ok = parsed.Parsed["providerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'providerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "providerName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2022-09-01/providers/id_subscriptionprovider.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2022-09-01/providers/id_subscriptionprovider.go
@@ -38,11 +38,11 @@ func ParseSubscriptionProviderID(input string) (*SubscriptionProviderId, error) 
 	id := SubscriptionProviderId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ProviderName, ok = parsed.Parsed["providerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'providerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "providerName", *parsed)
 	}
 
 	return &id, nil
@@ -61,11 +61,11 @@ func ParseSubscriptionProviderIDInsensitively(input string) (*SubscriptionProvid
 	id := SubscriptionProviderId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ProviderName, ok = parsed.Parsed["providerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'providerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "providerName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/search/2022-09-01/adminkeys/id_keykind.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/search/2022-09-01/adminkeys/id_keykind.go
@@ -42,20 +42,20 @@ func ParseKeyKindID(input string) (*KeyKindId, error) {
 	id := KeyKindId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.SearchServiceName, ok = parsed.Parsed["searchServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'searchServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "searchServiceName", *parsed)
 	}
 
 	if v, ok := parsed.Parsed["keyKind"]; true {
 		if !ok {
-			return nil, fmt.Errorf("the segment 'keyKind' was not found in the resource id %q", input)
+			return nil, resourceids.NewSegmentNotSpecifiedError(id, "keyKind", *parsed)
 		}
 
 		keyKind, err := parseAdminKeyKind(v)
@@ -81,20 +81,20 @@ func ParseKeyKindIDInsensitively(input string) (*KeyKindId, error) {
 	id := KeyKindId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.SearchServiceName, ok = parsed.Parsed["searchServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'searchServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "searchServiceName", *parsed)
 	}
 
 	if v, ok := parsed.Parsed["keyKind"]; true {
 		if !ok {
-			return nil, fmt.Errorf("the segment 'keyKind' was not found in the resource id %q", input)
+			return nil, resourceids.NewSegmentNotSpecifiedError(id, "keyKind", *parsed)
 		}
 
 		keyKind, err := parseAdminKeyKind(v)

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/search/2022-09-01/adminkeys/id_searchservice.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/search/2022-09-01/adminkeys/id_searchservice.go
@@ -40,15 +40,15 @@ func ParseSearchServiceID(input string) (*SearchServiceId, error) {
 	id := SearchServiceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.SearchServiceName, ok = parsed.Parsed["searchServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'searchServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "searchServiceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseSearchServiceIDInsensitively(input string) (*SearchServiceId, error) {
 	id := SearchServiceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.SearchServiceName, ok = parsed.Parsed["searchServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'searchServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "searchServiceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/search/2022-09-01/querykeys/id_createquerykey.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/search/2022-09-01/querykeys/id_createquerykey.go
@@ -42,19 +42,19 @@ func ParseCreateQueryKeyID(input string) (*CreateQueryKeyId, error) {
 	id := CreateQueryKeyId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.SearchServiceName, ok = parsed.Parsed["searchServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'searchServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "searchServiceName", *parsed)
 	}
 
 	if id.CreateQueryKeyName, ok = parsed.Parsed["createQueryKeyName"]; !ok {
-		return nil, fmt.Errorf("the segment 'createQueryKeyName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "createQueryKeyName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseCreateQueryKeyIDInsensitively(input string) (*CreateQueryKeyId, error)
 	id := CreateQueryKeyId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.SearchServiceName, ok = parsed.Parsed["searchServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'searchServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "searchServiceName", *parsed)
 	}
 
 	if id.CreateQueryKeyName, ok = parsed.Parsed["createQueryKeyName"]; !ok {
-		return nil, fmt.Errorf("the segment 'createQueryKeyName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "createQueryKeyName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/search/2022-09-01/querykeys/id_deletequerykey.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/search/2022-09-01/querykeys/id_deletequerykey.go
@@ -42,19 +42,19 @@ func ParseDeleteQueryKeyID(input string) (*DeleteQueryKeyId, error) {
 	id := DeleteQueryKeyId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.SearchServiceName, ok = parsed.Parsed["searchServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'searchServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "searchServiceName", *parsed)
 	}
 
 	if id.DeleteQueryKeyName, ok = parsed.Parsed["deleteQueryKeyName"]; !ok {
-		return nil, fmt.Errorf("the segment 'deleteQueryKeyName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "deleteQueryKeyName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseDeleteQueryKeyIDInsensitively(input string) (*DeleteQueryKeyId, error)
 	id := DeleteQueryKeyId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.SearchServiceName, ok = parsed.Parsed["searchServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'searchServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "searchServiceName", *parsed)
 	}
 
 	if id.DeleteQueryKeyName, ok = parsed.Parsed["deleteQueryKeyName"]; !ok {
-		return nil, fmt.Errorf("the segment 'deleteQueryKeyName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "deleteQueryKeyName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/search/2022-09-01/querykeys/id_searchservice.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/search/2022-09-01/querykeys/id_searchservice.go
@@ -40,15 +40,15 @@ func ParseSearchServiceID(input string) (*SearchServiceId, error) {
 	id := SearchServiceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.SearchServiceName, ok = parsed.Parsed["searchServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'searchServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "searchServiceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseSearchServiceIDInsensitively(input string) (*SearchServiceId, error) {
 	id := SearchServiceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.SearchServiceName, ok = parsed.Parsed["searchServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'searchServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "searchServiceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/search/2022-09-01/services/id_searchservice.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/search/2022-09-01/services/id_searchservice.go
@@ -40,15 +40,15 @@ func ParseSearchServiceID(input string) (*SearchServiceId, error) {
 	id := SearchServiceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.SearchServiceName, ok = parsed.Parsed["searchServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'searchServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "searchServiceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseSearchServiceIDInsensitively(input string) (*SearchServiceId, error) {
 	id := SearchServiceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.SearchServiceName, ok = parsed.Parsed["searchServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'searchServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "searchServiceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/search/2022-09-01/sharedprivatelinkresources/id_searchservice.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/search/2022-09-01/sharedprivatelinkresources/id_searchservice.go
@@ -40,15 +40,15 @@ func ParseSearchServiceID(input string) (*SearchServiceId, error) {
 	id := SearchServiceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.SearchServiceName, ok = parsed.Parsed["searchServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'searchServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "searchServiceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseSearchServiceIDInsensitively(input string) (*SearchServiceId, error) {
 	id := SearchServiceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.SearchServiceName, ok = parsed.Parsed["searchServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'searchServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "searchServiceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/search/2022-09-01/sharedprivatelinkresources/id_sharedprivatelinkresource.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/search/2022-09-01/sharedprivatelinkresources/id_sharedprivatelinkresource.go
@@ -42,19 +42,19 @@ func ParseSharedPrivateLinkResourceID(input string) (*SharedPrivateLinkResourceI
 	id := SharedPrivateLinkResourceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.SearchServiceName, ok = parsed.Parsed["searchServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'searchServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "searchServiceName", *parsed)
 	}
 
 	if id.SharedPrivateLinkResourceName, ok = parsed.Parsed["sharedPrivateLinkResourceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'sharedPrivateLinkResourceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "sharedPrivateLinkResourceName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseSharedPrivateLinkResourceIDInsensitively(input string) (*SharedPrivate
 	id := SharedPrivateLinkResourceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.SearchServiceName, ok = parsed.Parsed["searchServiceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'searchServiceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "searchServiceName", *parsed)
 	}
 
 	if id.SharedPrivateLinkResourceName, ok = parsed.Parsed["sharedPrivateLinkResourceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'sharedPrivateLinkResourceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "sharedPrivateLinkResourceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2023-01-01/pricings/id_pricing.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2023-01-01/pricings/id_pricing.go
@@ -38,11 +38,11 @@ func ParsePricingID(input string) (*PricingId, error) {
 	id := PricingId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.PricingName, ok = parsed.Parsed["pricingName"]; !ok {
-		return nil, fmt.Errorf("the segment 'pricingName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "pricingName", *parsed)
 	}
 
 	return &id, nil
@@ -61,11 +61,11 @@ func ParsePricingIDInsensitively(input string) (*PricingId, error) {
 	id := PricingId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.PricingName, ok = parsed.Parsed["pricingName"]; !ok {
-		return nil, fmt.Errorf("the segment 'pricingName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "pricingName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/securityinsights/2022-10-01-preview/alertrules/id_alertrule.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/securityinsights/2022-10-01-preview/alertrules/id_alertrule.go
@@ -42,19 +42,19 @@ func ParseAlertRuleID(input string) (*AlertRuleId, error) {
 	id := AlertRuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	if id.RuleId, ok = parsed.Parsed["ruleId"]; !ok {
-		return nil, fmt.Errorf("the segment 'ruleId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "ruleId", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseAlertRuleIDInsensitively(input string) (*AlertRuleId, error) {
 	id := AlertRuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	if id.RuleId, ok = parsed.Parsed["ruleId"]; !ok {
-		return nil, fmt.Errorf("the segment 'ruleId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "ruleId", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/securityinsights/2022-10-01-preview/alertrules/id_workspace.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/securityinsights/2022-10-01-preview/alertrules/id_workspace.go
@@ -40,15 +40,15 @@ func ParseWorkspaceID(input string) (*WorkspaceId, error) {
 	id := WorkspaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseWorkspaceIDInsensitively(input string) (*WorkspaceId, error) {
 	id := WorkspaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/securityinsights/2022-10-01-preview/automationrules/id_automationrule.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/securityinsights/2022-10-01-preview/automationrules/id_automationrule.go
@@ -42,19 +42,19 @@ func ParseAutomationRuleID(input string) (*AutomationRuleId, error) {
 	id := AutomationRuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	if id.AutomationRuleId, ok = parsed.Parsed["automationRuleId"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationRuleId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationRuleId", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseAutomationRuleIDInsensitively(input string) (*AutomationRuleId, error)
 	id := AutomationRuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	if id.AutomationRuleId, ok = parsed.Parsed["automationRuleId"]; !ok {
-		return nil, fmt.Errorf("the segment 'automationRuleId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "automationRuleId", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/securityinsights/2022-10-01-preview/automationrules/id_workspace.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/securityinsights/2022-10-01-preview/automationrules/id_workspace.go
@@ -40,15 +40,15 @@ func ParseWorkspaceID(input string) (*WorkspaceId, error) {
 	id := WorkspaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseWorkspaceIDInsensitively(input string) (*WorkspaceId, error) {
 	id := WorkspaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/securityinsights/2022-10-01-preview/metadata/id_metadata.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/securityinsights/2022-10-01-preview/metadata/id_metadata.go
@@ -42,19 +42,19 @@ func ParseMetadataID(input string) (*MetadataId, error) {
 	id := MetadataId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	if id.MetadataName, ok = parsed.Parsed["metadataName"]; !ok {
-		return nil, fmt.Errorf("the segment 'metadataName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "metadataName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseMetadataIDInsensitively(input string) (*MetadataId, error) {
 	id := MetadataId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	if id.MetadataName, ok = parsed.Parsed["metadataName"]; !ok {
-		return nil, fmt.Errorf("the segment 'metadataName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "metadataName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/securityinsights/2022-10-01-preview/metadata/id_workspace.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/securityinsights/2022-10-01-preview/metadata/id_workspace.go
@@ -40,15 +40,15 @@ func ParseWorkspaceID(input string) (*WorkspaceId, error) {
 	id := WorkspaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseWorkspaceIDInsensitively(input string) (*WorkspaceId, error) {
 	id := WorkspaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/securityinsights/2022-11-01/sentinelonboardingstates/id_onboardingstate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/securityinsights/2022-11-01/sentinelonboardingstates/id_onboardingstate.go
@@ -42,19 +42,19 @@ func ParseOnboardingStateID(input string) (*OnboardingStateId, error) {
 	id := OnboardingStateId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	if id.OnboardingStateName, ok = parsed.Parsed["onboardingStateName"]; !ok {
-		return nil, fmt.Errorf("the segment 'onboardingStateName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "onboardingStateName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseOnboardingStateIDInsensitively(input string) (*OnboardingStateId, erro
 	id := OnboardingStateId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	if id.OnboardingStateName, ok = parsed.Parsed["onboardingStateName"]; !ok {
-		return nil, fmt.Errorf("the segment 'onboardingStateName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "onboardingStateName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/securityinsights/2022-11-01/sentinelonboardingstates/id_workspace.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/securityinsights/2022-11-01/sentinelonboardingstates/id_workspace.go
@@ -40,15 +40,15 @@ func ParseWorkspaceID(input string) (*WorkspaceId, error) {
 	id := WorkspaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseWorkspaceIDInsensitively(input string) (*WorkspaceId, error) {
 	id := WorkspaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WorkspaceName, ok = parsed.Parsed["workspaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'workspaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "workspaceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2021-06-01-preview/disasterrecoveryconfigs/id_authorizationrule.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2021-06-01-preview/disasterrecoveryconfigs/id_authorizationrule.go
@@ -42,19 +42,19 @@ func ParseAuthorizationRuleID(input string) (*AuthorizationRuleId, error) {
 	id := AuthorizationRuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	if id.AuthorizationRuleName, ok = parsed.Parsed["authorizationRuleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'authorizationRuleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "authorizationRuleName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseAuthorizationRuleIDInsensitively(input string) (*AuthorizationRuleId, 
 	id := AuthorizationRuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	if id.AuthorizationRuleName, ok = parsed.Parsed["authorizationRuleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'authorizationRuleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "authorizationRuleName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2021-06-01-preview/disasterrecoveryconfigs/id_disasterrecoveryconfig.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2021-06-01-preview/disasterrecoveryconfigs/id_disasterrecoveryconfig.go
@@ -42,19 +42,19 @@ func ParseDisasterRecoveryConfigID(input string) (*DisasterRecoveryConfigId, err
 	id := DisasterRecoveryConfigId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	if id.DisasterRecoveryConfigName, ok = parsed.Parsed["disasterRecoveryConfigName"]; !ok {
-		return nil, fmt.Errorf("the segment 'disasterRecoveryConfigName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "disasterRecoveryConfigName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseDisasterRecoveryConfigIDInsensitively(input string) (*DisasterRecovery
 	id := DisasterRecoveryConfigId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	if id.DisasterRecoveryConfigName, ok = parsed.Parsed["disasterRecoveryConfigName"]; !ok {
-		return nil, fmt.Errorf("the segment 'disasterRecoveryConfigName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "disasterRecoveryConfigName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2021-06-01-preview/disasterrecoveryconfigs/id_namespace.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2021-06-01-preview/disasterrecoveryconfigs/id_namespace.go
@@ -40,15 +40,15 @@ func ParseNamespaceID(input string) (*NamespaceId, error) {
 	id := NamespaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseNamespaceIDInsensitively(input string) (*NamespaceId, error) {
 	id := NamespaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2021-06-01-preview/namespacesauthorizationrule/id_authorizationrule.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2021-06-01-preview/namespacesauthorizationrule/id_authorizationrule.go
@@ -42,19 +42,19 @@ func ParseAuthorizationRuleID(input string) (*AuthorizationRuleId, error) {
 	id := AuthorizationRuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	if id.AuthorizationRuleName, ok = parsed.Parsed["authorizationRuleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'authorizationRuleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "authorizationRuleName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseAuthorizationRuleIDInsensitively(input string) (*AuthorizationRuleId, 
 	id := AuthorizationRuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	if id.AuthorizationRuleName, ok = parsed.Parsed["authorizationRuleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'authorizationRuleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "authorizationRuleName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2021-06-01-preview/namespacesauthorizationrule/id_namespace.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2021-06-01-preview/namespacesauthorizationrule/id_namespace.go
@@ -40,15 +40,15 @@ func ParseNamespaceID(input string) (*NamespaceId, error) {
 	id := NamespaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseNamespaceIDInsensitively(input string) (*NamespaceId, error) {
 	id := NamespaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2021-06-01-preview/queues/id_namespace.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2021-06-01-preview/queues/id_namespace.go
@@ -40,15 +40,15 @@ func ParseNamespaceID(input string) (*NamespaceId, error) {
 	id := NamespaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseNamespaceIDInsensitively(input string) (*NamespaceId, error) {
 	id := NamespaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2021-06-01-preview/queues/id_queue.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2021-06-01-preview/queues/id_queue.go
@@ -42,19 +42,19 @@ func ParseQueueID(input string) (*QueueId, error) {
 	id := QueueId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	if id.QueueName, ok = parsed.Parsed["queueName"]; !ok {
-		return nil, fmt.Errorf("the segment 'queueName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "queueName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseQueueIDInsensitively(input string) (*QueueId, error) {
 	id := QueueId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	if id.QueueName, ok = parsed.Parsed["queueName"]; !ok {
-		return nil, fmt.Errorf("the segment 'queueName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "queueName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2021-06-01-preview/queuesauthorizationrule/id_queue.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2021-06-01-preview/queuesauthorizationrule/id_queue.go
@@ -42,19 +42,19 @@ func ParseQueueID(input string) (*QueueId, error) {
 	id := QueueId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	if id.QueueName, ok = parsed.Parsed["queueName"]; !ok {
-		return nil, fmt.Errorf("the segment 'queueName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "queueName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseQueueIDInsensitively(input string) (*QueueId, error) {
 	id := QueueId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	if id.QueueName, ok = parsed.Parsed["queueName"]; !ok {
-		return nil, fmt.Errorf("the segment 'queueName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "queueName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2021-06-01-preview/queuesauthorizationrule/id_queueauthorizationrule.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2021-06-01-preview/queuesauthorizationrule/id_queueauthorizationrule.go
@@ -44,23 +44,23 @@ func ParseQueueAuthorizationRuleID(input string) (*QueueAuthorizationRuleId, err
 	id := QueueAuthorizationRuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	if id.QueueName, ok = parsed.Parsed["queueName"]; !ok {
-		return nil, fmt.Errorf("the segment 'queueName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "queueName", *parsed)
 	}
 
 	if id.AuthorizationRuleName, ok = parsed.Parsed["authorizationRuleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'authorizationRuleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "authorizationRuleName", *parsed)
 	}
 
 	return &id, nil
@@ -79,23 +79,23 @@ func ParseQueueAuthorizationRuleIDInsensitively(input string) (*QueueAuthorizati
 	id := QueueAuthorizationRuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	if id.QueueName, ok = parsed.Parsed["queueName"]; !ok {
-		return nil, fmt.Errorf("the segment 'queueName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "queueName", *parsed)
 	}
 
 	if id.AuthorizationRuleName, ok = parsed.Parsed["authorizationRuleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'authorizationRuleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "authorizationRuleName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2021-06-01-preview/rules/id_rule.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2021-06-01-preview/rules/id_rule.go
@@ -46,27 +46,27 @@ func ParseRuleID(input string) (*RuleId, error) {
 	id := RuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	if id.TopicName, ok = parsed.Parsed["topicName"]; !ok {
-		return nil, fmt.Errorf("the segment 'topicName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "topicName", *parsed)
 	}
 
 	if id.SubscriptionName, ok = parsed.Parsed["subscriptionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionName", *parsed)
 	}
 
 	if id.RuleName, ok = parsed.Parsed["ruleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'ruleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "ruleName", *parsed)
 	}
 
 	return &id, nil
@@ -85,27 +85,27 @@ func ParseRuleIDInsensitively(input string) (*RuleId, error) {
 	id := RuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	if id.TopicName, ok = parsed.Parsed["topicName"]; !ok {
-		return nil, fmt.Errorf("the segment 'topicName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "topicName", *parsed)
 	}
 
 	if id.SubscriptionName, ok = parsed.Parsed["subscriptionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionName", *parsed)
 	}
 
 	if id.RuleName, ok = parsed.Parsed["ruleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'ruleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "ruleName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2021-06-01-preview/rules/id_subscriptions2.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2021-06-01-preview/rules/id_subscriptions2.go
@@ -44,23 +44,23 @@ func ParseSubscriptions2ID(input string) (*Subscriptions2Id, error) {
 	id := Subscriptions2Id{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	if id.TopicName, ok = parsed.Parsed["topicName"]; !ok {
-		return nil, fmt.Errorf("the segment 'topicName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "topicName", *parsed)
 	}
 
 	if id.SubscriptionName, ok = parsed.Parsed["subscriptionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionName", *parsed)
 	}
 
 	return &id, nil
@@ -79,23 +79,23 @@ func ParseSubscriptions2IDInsensitively(input string) (*Subscriptions2Id, error)
 	id := Subscriptions2Id{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	if id.TopicName, ok = parsed.Parsed["topicName"]; !ok {
-		return nil, fmt.Errorf("the segment 'topicName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "topicName", *parsed)
 	}
 
 	if id.SubscriptionName, ok = parsed.Parsed["subscriptionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2021-06-01-preview/subscriptions/id_rule.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2021-06-01-preview/subscriptions/id_rule.go
@@ -46,27 +46,27 @@ func ParseRuleID(input string) (*RuleId, error) {
 	id := RuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	if id.TopicName, ok = parsed.Parsed["topicName"]; !ok {
-		return nil, fmt.Errorf("the segment 'topicName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "topicName", *parsed)
 	}
 
 	if id.SubscriptionName, ok = parsed.Parsed["subscriptionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionName", *parsed)
 	}
 
 	if id.RuleName, ok = parsed.Parsed["ruleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'ruleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "ruleName", *parsed)
 	}
 
 	return &id, nil
@@ -85,27 +85,27 @@ func ParseRuleIDInsensitively(input string) (*RuleId, error) {
 	id := RuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	if id.TopicName, ok = parsed.Parsed["topicName"]; !ok {
-		return nil, fmt.Errorf("the segment 'topicName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "topicName", *parsed)
 	}
 
 	if id.SubscriptionName, ok = parsed.Parsed["subscriptionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionName", *parsed)
 	}
 
 	if id.RuleName, ok = parsed.Parsed["ruleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'ruleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "ruleName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2021-06-01-preview/subscriptions/id_subscriptions2.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2021-06-01-preview/subscriptions/id_subscriptions2.go
@@ -44,23 +44,23 @@ func ParseSubscriptions2ID(input string) (*Subscriptions2Id, error) {
 	id := Subscriptions2Id{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	if id.TopicName, ok = parsed.Parsed["topicName"]; !ok {
-		return nil, fmt.Errorf("the segment 'topicName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "topicName", *parsed)
 	}
 
 	if id.SubscriptionName, ok = parsed.Parsed["subscriptionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionName", *parsed)
 	}
 
 	return &id, nil
@@ -79,23 +79,23 @@ func ParseSubscriptions2IDInsensitively(input string) (*Subscriptions2Id, error)
 	id := Subscriptions2Id{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	if id.TopicName, ok = parsed.Parsed["topicName"]; !ok {
-		return nil, fmt.Errorf("the segment 'topicName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "topicName", *parsed)
 	}
 
 	if id.SubscriptionName, ok = parsed.Parsed["subscriptionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2021-06-01-preview/subscriptions/id_topic.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2021-06-01-preview/subscriptions/id_topic.go
@@ -42,19 +42,19 @@ func ParseTopicID(input string) (*TopicId, error) {
 	id := TopicId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	if id.TopicName, ok = parsed.Parsed["topicName"]; !ok {
-		return nil, fmt.Errorf("the segment 'topicName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "topicName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseTopicIDInsensitively(input string) (*TopicId, error) {
 	id := TopicId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	if id.TopicName, ok = parsed.Parsed["topicName"]; !ok {
-		return nil, fmt.Errorf("the segment 'topicName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "topicName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2021-06-01-preview/topics/id_namespace.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2021-06-01-preview/topics/id_namespace.go
@@ -40,15 +40,15 @@ func ParseNamespaceID(input string) (*NamespaceId, error) {
 	id := NamespaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseNamespaceIDInsensitively(input string) (*NamespaceId, error) {
 	id := NamespaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2021-06-01-preview/topics/id_topic.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2021-06-01-preview/topics/id_topic.go
@@ -42,19 +42,19 @@ func ParseTopicID(input string) (*TopicId, error) {
 	id := TopicId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	if id.TopicName, ok = parsed.Parsed["topicName"]; !ok {
-		return nil, fmt.Errorf("the segment 'topicName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "topicName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseTopicIDInsensitively(input string) (*TopicId, error) {
 	id := TopicId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	if id.TopicName, ok = parsed.Parsed["topicName"]; !ok {
-		return nil, fmt.Errorf("the segment 'topicName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "topicName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2021-06-01-preview/topicsauthorizationrule/id_topic.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2021-06-01-preview/topicsauthorizationrule/id_topic.go
@@ -42,19 +42,19 @@ func ParseTopicID(input string) (*TopicId, error) {
 	id := TopicId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	if id.TopicName, ok = parsed.Parsed["topicName"]; !ok {
-		return nil, fmt.Errorf("the segment 'topicName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "topicName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseTopicIDInsensitively(input string) (*TopicId, error) {
 	id := TopicId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	if id.TopicName, ok = parsed.Parsed["topicName"]; !ok {
-		return nil, fmt.Errorf("the segment 'topicName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "topicName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2021-06-01-preview/topicsauthorizationrule/id_topicauthorizationrule.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2021-06-01-preview/topicsauthorizationrule/id_topicauthorizationrule.go
@@ -44,23 +44,23 @@ func ParseTopicAuthorizationRuleID(input string) (*TopicAuthorizationRuleId, err
 	id := TopicAuthorizationRuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	if id.TopicName, ok = parsed.Parsed["topicName"]; !ok {
-		return nil, fmt.Errorf("the segment 'topicName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "topicName", *parsed)
 	}
 
 	if id.AuthorizationRuleName, ok = parsed.Parsed["authorizationRuleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'authorizationRuleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "authorizationRuleName", *parsed)
 	}
 
 	return &id, nil
@@ -79,23 +79,23 @@ func ParseTopicAuthorizationRuleIDInsensitively(input string) (*TopicAuthorizati
 	id := TopicAuthorizationRuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	if id.TopicName, ok = parsed.Parsed["topicName"]; !ok {
-		return nil, fmt.Errorf("the segment 'topicName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "topicName", *parsed)
 	}
 
 	if id.AuthorizationRuleName, ok = parsed.Parsed["authorizationRuleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'authorizationRuleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "authorizationRuleName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2022-01-01-preview/namespaces/id_namespace.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2022-01-01-preview/namespaces/id_namespace.go
@@ -40,15 +40,15 @@ func ParseNamespaceID(input string) (*NamespaceId, error) {
 	id := NamespaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseNamespaceIDInsensitively(input string) (*NamespaceId, error) {
 	id := NamespaceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.NamespaceName, ok = parsed.Parsed["namespaceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'namespaceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "namespaceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicefabric/2021-06-01/cluster/id_cluster.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicefabric/2021-06-01/cluster/id_cluster.go
@@ -40,15 +40,15 @@ func ParseClusterID(input string) (*ClusterId, error) {
 	id := ClusterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseClusterIDInsensitively(input string) (*ClusterId, error) {
 	id := ClusterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicefabricmanagedcluster/2021-05-01/managedcluster/id_managedcluster.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicefabricmanagedcluster/2021-05-01/managedcluster/id_managedcluster.go
@@ -40,15 +40,15 @@ func ParseManagedClusterID(input string) (*ManagedClusterId, error) {
 	id := ManagedClusterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ManagedClusterName, ok = parsed.Parsed["managedClusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedClusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedClusterName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseManagedClusterIDInsensitively(input string) (*ManagedClusterId, error)
 	id := ManagedClusterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ManagedClusterName, ok = parsed.Parsed["managedClusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedClusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedClusterName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicefabricmanagedcluster/2021-05-01/nodetype/id_managedcluster.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicefabricmanagedcluster/2021-05-01/nodetype/id_managedcluster.go
@@ -40,15 +40,15 @@ func ParseManagedClusterID(input string) (*ManagedClusterId, error) {
 	id := ManagedClusterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ManagedClusterName, ok = parsed.Parsed["managedClusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedClusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedClusterName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseManagedClusterIDInsensitively(input string) (*ManagedClusterId, error)
 	id := ManagedClusterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ManagedClusterName, ok = parsed.Parsed["managedClusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedClusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedClusterName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicefabricmanagedcluster/2021-05-01/nodetype/id_nodetype.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicefabricmanagedcluster/2021-05-01/nodetype/id_nodetype.go
@@ -42,19 +42,19 @@ func ParseNodeTypeID(input string) (*NodeTypeId, error) {
 	id := NodeTypeId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ManagedClusterName, ok = parsed.Parsed["managedClusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedClusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedClusterName", *parsed)
 	}
 
 	if id.NodeTypeName, ok = parsed.Parsed["nodeTypeName"]; !ok {
-		return nil, fmt.Errorf("the segment 'nodeTypeName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "nodeTypeName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseNodeTypeIDInsensitively(input string) (*NodeTypeId, error) {
 	id := NodeTypeId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ManagedClusterName, ok = parsed.Parsed["managedClusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedClusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedClusterName", *parsed)
 	}
 
 	if id.NodeTypeName, ok = parsed.Parsed["nodeTypeName"]; !ok {
-		return nil, fmt.Errorf("the segment 'nodeTypeName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "nodeTypeName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicelinker/2022-05-01/links/id_scopedlinker.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicelinker/2022-05-01/links/id_scopedlinker.go
@@ -38,11 +38,11 @@ func ParseScopedLinkerID(input string) (*ScopedLinkerId, error) {
 	id := ScopedLinkerId{}
 
 	if id.ResourceUri, ok = parsed.Parsed["resourceUri"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceUri' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceUri", *parsed)
 	}
 
 	if id.LinkerName, ok = parsed.Parsed["linkerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'linkerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "linkerName", *parsed)
 	}
 
 	return &id, nil
@@ -61,11 +61,11 @@ func ParseScopedLinkerIDInsensitively(input string) (*ScopedLinkerId, error) {
 	id := ScopedLinkerId{}
 
 	if id.ResourceUri, ok = parsed.Parsed["resourceUri"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceUri' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceUri", *parsed)
 	}
 
 	if id.LinkerName, ok = parsed.Parsed["linkerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'linkerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "linkerName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicelinker/2022-05-01/servicelinker/id_scopedlinker.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicelinker/2022-05-01/servicelinker/id_scopedlinker.go
@@ -38,11 +38,11 @@ func ParseScopedLinkerID(input string) (*ScopedLinkerId, error) {
 	id := ScopedLinkerId{}
 
 	if id.ResourceUri, ok = parsed.Parsed["resourceUri"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceUri' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceUri", *parsed)
 	}
 
 	if id.LinkerName, ok = parsed.Parsed["linkerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'linkerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "linkerName", *parsed)
 	}
 
 	return &id, nil
@@ -61,11 +61,11 @@ func ParseScopedLinkerIDInsensitively(input string) (*ScopedLinkerId, error) {
 	id := ScopedLinkerId{}
 
 	if id.ResourceUri, ok = parsed.Parsed["resourceUri"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceUri' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceUri", *parsed)
 	}
 
 	if id.LinkerName, ok = parsed.Parsed["linkerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'linkerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "linkerName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/signalr/2023-02-01/signalr/id_customcertificate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/signalr/2023-02-01/signalr/id_customcertificate.go
@@ -42,19 +42,19 @@ func ParseCustomCertificateID(input string) (*CustomCertificateId, error) {
 	id := CustomCertificateId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.SignalRName, ok = parsed.Parsed["signalRName"]; !ok {
-		return nil, fmt.Errorf("the segment 'signalRName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "signalRName", *parsed)
 	}
 
 	if id.CustomCertificateName, ok = parsed.Parsed["customCertificateName"]; !ok {
-		return nil, fmt.Errorf("the segment 'customCertificateName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "customCertificateName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseCustomCertificateIDInsensitively(input string) (*CustomCertificateId, 
 	id := CustomCertificateId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.SignalRName, ok = parsed.Parsed["signalRName"]; !ok {
-		return nil, fmt.Errorf("the segment 'signalRName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "signalRName", *parsed)
 	}
 
 	if id.CustomCertificateName, ok = parsed.Parsed["customCertificateName"]; !ok {
-		return nil, fmt.Errorf("the segment 'customCertificateName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "customCertificateName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/signalr/2023-02-01/signalr/id_customdomain.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/signalr/2023-02-01/signalr/id_customdomain.go
@@ -42,19 +42,19 @@ func ParseCustomDomainID(input string) (*CustomDomainId, error) {
 	id := CustomDomainId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.SignalRName, ok = parsed.Parsed["signalRName"]; !ok {
-		return nil, fmt.Errorf("the segment 'signalRName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "signalRName", *parsed)
 	}
 
 	if id.CustomDomainName, ok = parsed.Parsed["customDomainName"]; !ok {
-		return nil, fmt.Errorf("the segment 'customDomainName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "customDomainName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseCustomDomainIDInsensitively(input string) (*CustomDomainId, error) {
 	id := CustomDomainId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.SignalRName, ok = parsed.Parsed["signalRName"]; !ok {
-		return nil, fmt.Errorf("the segment 'signalRName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "signalRName", *parsed)
 	}
 
 	if id.CustomDomainName, ok = parsed.Parsed["customDomainName"]; !ok {
-		return nil, fmt.Errorf("the segment 'customDomainName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "customDomainName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/signalr/2023-02-01/signalr/id_location.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/signalr/2023-02-01/signalr/id_location.go
@@ -38,11 +38,11 @@ func ParseLocationID(input string) (*LocationId, error) {
 	id := LocationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.LocationName, ok = parsed.Parsed["locationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'locationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "locationName", *parsed)
 	}
 
 	return &id, nil
@@ -61,11 +61,11 @@ func ParseLocationIDInsensitively(input string) (*LocationId, error) {
 	id := LocationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.LocationName, ok = parsed.Parsed["locationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'locationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "locationName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/signalr/2023-02-01/signalr/id_privateendpointconnection.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/signalr/2023-02-01/signalr/id_privateendpointconnection.go
@@ -42,19 +42,19 @@ func ParsePrivateEndpointConnectionID(input string) (*PrivateEndpointConnectionI
 	id := PrivateEndpointConnectionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.SignalRName, ok = parsed.Parsed["signalRName"]; !ok {
-		return nil, fmt.Errorf("the segment 'signalRName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "signalRName", *parsed)
 	}
 
 	if id.PrivateEndpointConnectionName, ok = parsed.Parsed["privateEndpointConnectionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'privateEndpointConnectionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "privateEndpointConnectionName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParsePrivateEndpointConnectionIDInsensitively(input string) (*PrivateEndpoi
 	id := PrivateEndpointConnectionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.SignalRName, ok = parsed.Parsed["signalRName"]; !ok {
-		return nil, fmt.Errorf("the segment 'signalRName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "signalRName", *parsed)
 	}
 
 	if id.PrivateEndpointConnectionName, ok = parsed.Parsed["privateEndpointConnectionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'privateEndpointConnectionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "privateEndpointConnectionName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/signalr/2023-02-01/signalr/id_sharedprivatelinkresource.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/signalr/2023-02-01/signalr/id_sharedprivatelinkresource.go
@@ -42,19 +42,19 @@ func ParseSharedPrivateLinkResourceID(input string) (*SharedPrivateLinkResourceI
 	id := SharedPrivateLinkResourceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.SignalRName, ok = parsed.Parsed["signalRName"]; !ok {
-		return nil, fmt.Errorf("the segment 'signalRName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "signalRName", *parsed)
 	}
 
 	if id.SharedPrivateLinkResourceName, ok = parsed.Parsed["sharedPrivateLinkResourceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'sharedPrivateLinkResourceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "sharedPrivateLinkResourceName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseSharedPrivateLinkResourceIDInsensitively(input string) (*SharedPrivate
 	id := SharedPrivateLinkResourceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.SignalRName, ok = parsed.Parsed["signalRName"]; !ok {
-		return nil, fmt.Errorf("the segment 'signalRName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "signalRName", *parsed)
 	}
 
 	if id.SharedPrivateLinkResourceName, ok = parsed.Parsed["sharedPrivateLinkResourceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'sharedPrivateLinkResourceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "sharedPrivateLinkResourceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/signalr/2023-02-01/signalr/id_signalr.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/signalr/2023-02-01/signalr/id_signalr.go
@@ -40,15 +40,15 @@ func ParseSignalRID(input string) (*SignalRId, error) {
 	id := SignalRId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.SignalRName, ok = parsed.Parsed["signalRName"]; !ok {
-		return nil, fmt.Errorf("the segment 'signalRName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "signalRName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseSignalRIDInsensitively(input string) (*SignalRId, error) {
 	id := SignalRId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.SignalRName, ok = parsed.Parsed["signalRName"]; !ok {
-		return nil, fmt.Errorf("the segment 'signalRName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "signalRName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/sqlvirtualmachine/2022-02-01/sqlvirtualmachines/id_sqlvirtualmachine.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/sqlvirtualmachine/2022-02-01/sqlvirtualmachines/id_sqlvirtualmachine.go
@@ -40,15 +40,15 @@ func ParseSqlVirtualMachineID(input string) (*SqlVirtualMachineId, error) {
 	id := SqlVirtualMachineId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.SqlVirtualMachineName, ok = parsed.Parsed["sqlVirtualMachineName"]; !ok {
-		return nil, fmt.Errorf("the segment 'sqlVirtualMachineName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "sqlVirtualMachineName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseSqlVirtualMachineIDInsensitively(input string) (*SqlVirtualMachineId, 
 	id := SqlVirtualMachineId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.SqlVirtualMachineName, ok = parsed.Parsed["sqlVirtualMachineName"]; !ok {
-		return nil, fmt.Errorf("the segment 'sqlVirtualMachineName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "sqlVirtualMachineName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/sqlvirtualmachine/2022-02-01/sqlvirtualmachines/id_sqlvirtualmachinegroup.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/sqlvirtualmachine/2022-02-01/sqlvirtualmachines/id_sqlvirtualmachinegroup.go
@@ -40,15 +40,15 @@ func ParseSqlVirtualMachineGroupID(input string) (*SqlVirtualMachineGroupId, err
 	id := SqlVirtualMachineGroupId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.SqlVirtualMachineGroupName, ok = parsed.Parsed["sqlVirtualMachineGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'sqlVirtualMachineGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "sqlVirtualMachineGroupName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseSqlVirtualMachineGroupIDInsensitively(input string) (*SqlVirtualMachin
 	id := SqlVirtualMachineGroupId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.SqlVirtualMachineGroupName, ok = parsed.Parsed["sqlVirtualMachineGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'sqlVirtualMachineGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "sqlVirtualMachineGroupName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2022-05-01/blobcontainers/id_container.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2022-05-01/blobcontainers/id_container.go
@@ -42,19 +42,19 @@ func ParseContainerID(input string) (*ContainerId, error) {
 	id := ContainerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StorageAccountName, ok = parsed.Parsed["storageAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageAccountName", *parsed)
 	}
 
 	if id.ContainerName, ok = parsed.Parsed["containerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'containerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "containerName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseContainerIDInsensitively(input string) (*ContainerId, error) {
 	id := ContainerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StorageAccountName, ok = parsed.Parsed["storageAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageAccountName", *parsed)
 	}
 
 	if id.ContainerName, ok = parsed.Parsed["containerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'containerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "containerName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2022-05-01/blobcontainers/id_storageaccount.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2022-05-01/blobcontainers/id_storageaccount.go
@@ -40,15 +40,15 @@ func ParseStorageAccountID(input string) (*StorageAccountId, error) {
 	id := StorageAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StorageAccountName, ok = parsed.Parsed["storageAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageAccountName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseStorageAccountIDInsensitively(input string) (*StorageAccountId, error)
 	id := StorageAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StorageAccountName, ok = parsed.Parsed["storageAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageAccountName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2022-05-01/blobinventorypolicies/id_storageaccount.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2022-05-01/blobinventorypolicies/id_storageaccount.go
@@ -40,15 +40,15 @@ func ParseStorageAccountID(input string) (*StorageAccountId, error) {
 	id := StorageAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StorageAccountName, ok = parsed.Parsed["storageAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageAccountName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseStorageAccountIDInsensitively(input string) (*StorageAccountId, error)
 	id := StorageAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StorageAccountName, ok = parsed.Parsed["storageAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageAccountName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2022-05-01/blobservice/id_storageaccount.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2022-05-01/blobservice/id_storageaccount.go
@@ -40,15 +40,15 @@ func ParseStorageAccountID(input string) (*StorageAccountId, error) {
 	id := StorageAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StorageAccountName, ok = parsed.Parsed["storageAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageAccountName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseStorageAccountIDInsensitively(input string) (*StorageAccountId, error)
 	id := StorageAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StorageAccountName, ok = parsed.Parsed["storageAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageAccountName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2022-05-01/deletedaccounts/id_deletedaccount.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2022-05-01/deletedaccounts/id_deletedaccount.go
@@ -40,15 +40,15 @@ func ParseDeletedAccountID(input string) (*DeletedAccountId, error) {
 	id := DeletedAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.LocationName, ok = parsed.Parsed["locationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'locationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "locationName", *parsed)
 	}
 
 	if id.DeletedAccountName, ok = parsed.Parsed["deletedAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'deletedAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "deletedAccountName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseDeletedAccountIDInsensitively(input string) (*DeletedAccountId, error)
 	id := DeletedAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.LocationName, ok = parsed.Parsed["locationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'locationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "locationName", *parsed)
 	}
 
 	if id.DeletedAccountName, ok = parsed.Parsed["deletedAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'deletedAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "deletedAccountName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2022-05-01/encryptionscopes/id_encryptionscope.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2022-05-01/encryptionscopes/id_encryptionscope.go
@@ -42,19 +42,19 @@ func ParseEncryptionScopeID(input string) (*EncryptionScopeId, error) {
 	id := EncryptionScopeId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StorageAccountName, ok = parsed.Parsed["storageAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageAccountName", *parsed)
 	}
 
 	if id.EncryptionScopeName, ok = parsed.Parsed["encryptionScopeName"]; !ok {
-		return nil, fmt.Errorf("the segment 'encryptionScopeName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "encryptionScopeName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseEncryptionScopeIDInsensitively(input string) (*EncryptionScopeId, erro
 	id := EncryptionScopeId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StorageAccountName, ok = parsed.Parsed["storageAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageAccountName", *parsed)
 	}
 
 	if id.EncryptionScopeName, ok = parsed.Parsed["encryptionScopeName"]; !ok {
-		return nil, fmt.Errorf("the segment 'encryptionScopeName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "encryptionScopeName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2022-05-01/encryptionscopes/id_storageaccount.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2022-05-01/encryptionscopes/id_storageaccount.go
@@ -40,15 +40,15 @@ func ParseStorageAccountID(input string) (*StorageAccountId, error) {
 	id := StorageAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StorageAccountName, ok = parsed.Parsed["storageAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageAccountName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseStorageAccountIDInsensitively(input string) (*StorageAccountId, error)
 	id := StorageAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StorageAccountName, ok = parsed.Parsed["storageAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageAccountName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2022-05-01/fileservice/id_storageaccount.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2022-05-01/fileservice/id_storageaccount.go
@@ -40,15 +40,15 @@ func ParseStorageAccountID(input string) (*StorageAccountId, error) {
 	id := StorageAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StorageAccountName, ok = parsed.Parsed["storageAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageAccountName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseStorageAccountIDInsensitively(input string) (*StorageAccountId, error)
 	id := StorageAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StorageAccountName, ok = parsed.Parsed["storageAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageAccountName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2022-05-01/fileshares/id_share.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2022-05-01/fileshares/id_share.go
@@ -42,19 +42,19 @@ func ParseShareID(input string) (*ShareId, error) {
 	id := ShareId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StorageAccountName, ok = parsed.Parsed["storageAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageAccountName", *parsed)
 	}
 
 	if id.ShareName, ok = parsed.Parsed["shareName"]; !ok {
-		return nil, fmt.Errorf("the segment 'shareName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "shareName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseShareIDInsensitively(input string) (*ShareId, error) {
 	id := ShareId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StorageAccountName, ok = parsed.Parsed["storageAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageAccountName", *parsed)
 	}
 
 	if id.ShareName, ok = parsed.Parsed["shareName"]; !ok {
-		return nil, fmt.Errorf("the segment 'shareName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "shareName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2022-05-01/fileshares/id_storageaccount.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2022-05-01/fileshares/id_storageaccount.go
@@ -40,15 +40,15 @@ func ParseStorageAccountID(input string) (*StorageAccountId, error) {
 	id := StorageAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StorageAccountName, ok = parsed.Parsed["storageAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageAccountName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseStorageAccountIDInsensitively(input string) (*StorageAccountId, error)
 	id := StorageAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StorageAccountName, ok = parsed.Parsed["storageAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageAccountName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2022-05-01/localusers/id_localuser.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2022-05-01/localusers/id_localuser.go
@@ -42,19 +42,19 @@ func ParseLocalUserID(input string) (*LocalUserId, error) {
 	id := LocalUserId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StorageAccountName, ok = parsed.Parsed["storageAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageAccountName", *parsed)
 	}
 
 	if id.LocalUserName, ok = parsed.Parsed["localUserName"]; !ok {
-		return nil, fmt.Errorf("the segment 'localUserName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "localUserName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseLocalUserIDInsensitively(input string) (*LocalUserId, error) {
 	id := LocalUserId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StorageAccountName, ok = parsed.Parsed["storageAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageAccountName", *parsed)
 	}
 
 	if id.LocalUserName, ok = parsed.Parsed["localUserName"]; !ok {
-		return nil, fmt.Errorf("the segment 'localUserName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "localUserName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2022-05-01/localusers/id_storageaccount.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2022-05-01/localusers/id_storageaccount.go
@@ -40,15 +40,15 @@ func ParseStorageAccountID(input string) (*StorageAccountId, error) {
 	id := StorageAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StorageAccountName, ok = parsed.Parsed["storageAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageAccountName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseStorageAccountIDInsensitively(input string) (*StorageAccountId, error)
 	id := StorageAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StorageAccountName, ok = parsed.Parsed["storageAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageAccountName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2022-05-01/managementpolicies/id_storageaccount.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2022-05-01/managementpolicies/id_storageaccount.go
@@ -40,15 +40,15 @@ func ParseStorageAccountID(input string) (*StorageAccountId, error) {
 	id := StorageAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StorageAccountName, ok = parsed.Parsed["storageAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageAccountName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseStorageAccountIDInsensitively(input string) (*StorageAccountId, error)
 	id := StorageAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StorageAccountName, ok = parsed.Parsed["storageAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageAccountName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2022-05-01/objectreplicationpolicies/id_objectreplicationpolicy.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2022-05-01/objectreplicationpolicies/id_objectreplicationpolicy.go
@@ -42,19 +42,19 @@ func ParseObjectReplicationPolicyID(input string) (*ObjectReplicationPolicyId, e
 	id := ObjectReplicationPolicyId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StorageAccountName, ok = parsed.Parsed["storageAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageAccountName", *parsed)
 	}
 
 	if id.ObjectReplicationPolicyId, ok = parsed.Parsed["objectReplicationPolicyId"]; !ok {
-		return nil, fmt.Errorf("the segment 'objectReplicationPolicyId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "objectReplicationPolicyId", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseObjectReplicationPolicyIDInsensitively(input string) (*ObjectReplicati
 	id := ObjectReplicationPolicyId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StorageAccountName, ok = parsed.Parsed["storageAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageAccountName", *parsed)
 	}
 
 	if id.ObjectReplicationPolicyId, ok = parsed.Parsed["objectReplicationPolicyId"]; !ok {
-		return nil, fmt.Errorf("the segment 'objectReplicationPolicyId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "objectReplicationPolicyId", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2022-05-01/objectreplicationpolicies/id_storageaccount.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2022-05-01/objectreplicationpolicies/id_storageaccount.go
@@ -40,15 +40,15 @@ func ParseStorageAccountID(input string) (*StorageAccountId, error) {
 	id := StorageAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StorageAccountName, ok = parsed.Parsed["storageAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageAccountName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseStorageAccountIDInsensitively(input string) (*StorageAccountId, error)
 	id := StorageAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StorageAccountName, ok = parsed.Parsed["storageAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageAccountName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2022-05-01/privateendpointconnections/id_privateendpointconnection.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2022-05-01/privateendpointconnections/id_privateendpointconnection.go
@@ -42,19 +42,19 @@ func ParsePrivateEndpointConnectionID(input string) (*PrivateEndpointConnectionI
 	id := PrivateEndpointConnectionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StorageAccountName, ok = parsed.Parsed["storageAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageAccountName", *parsed)
 	}
 
 	if id.PrivateEndpointConnectionName, ok = parsed.Parsed["privateEndpointConnectionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'privateEndpointConnectionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "privateEndpointConnectionName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParsePrivateEndpointConnectionIDInsensitively(input string) (*PrivateEndpoi
 	id := PrivateEndpointConnectionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StorageAccountName, ok = parsed.Parsed["storageAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageAccountName", *parsed)
 	}
 
 	if id.PrivateEndpointConnectionName, ok = parsed.Parsed["privateEndpointConnectionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'privateEndpointConnectionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "privateEndpointConnectionName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2022-05-01/privateendpointconnections/id_storageaccount.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2022-05-01/privateendpointconnections/id_storageaccount.go
@@ -40,15 +40,15 @@ func ParseStorageAccountID(input string) (*StorageAccountId, error) {
 	id := StorageAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StorageAccountName, ok = parsed.Parsed["storageAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageAccountName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseStorageAccountIDInsensitively(input string) (*StorageAccountId, error)
 	id := StorageAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StorageAccountName, ok = parsed.Parsed["storageAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageAccountName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2022-05-01/privatelinkresources/id_storageaccount.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2022-05-01/privatelinkresources/id_storageaccount.go
@@ -40,15 +40,15 @@ func ParseStorageAccountID(input string) (*StorageAccountId, error) {
 	id := StorageAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StorageAccountName, ok = parsed.Parsed["storageAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageAccountName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseStorageAccountIDInsensitively(input string) (*StorageAccountId, error)
 	id := StorageAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StorageAccountName, ok = parsed.Parsed["storageAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageAccountName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2022-05-01/queueservice/id_queue.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2022-05-01/queueservice/id_queue.go
@@ -42,19 +42,19 @@ func ParseQueueID(input string) (*QueueId, error) {
 	id := QueueId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StorageAccountName, ok = parsed.Parsed["storageAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageAccountName", *parsed)
 	}
 
 	if id.QueueName, ok = parsed.Parsed["queueName"]; !ok {
-		return nil, fmt.Errorf("the segment 'queueName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "queueName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseQueueIDInsensitively(input string) (*QueueId, error) {
 	id := QueueId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StorageAccountName, ok = parsed.Parsed["storageAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageAccountName", *parsed)
 	}
 
 	if id.QueueName, ok = parsed.Parsed["queueName"]; !ok {
-		return nil, fmt.Errorf("the segment 'queueName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "queueName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2022-05-01/queueservice/id_storageaccount.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2022-05-01/queueservice/id_storageaccount.go
@@ -40,15 +40,15 @@ func ParseStorageAccountID(input string) (*StorageAccountId, error) {
 	id := StorageAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StorageAccountName, ok = parsed.Parsed["storageAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageAccountName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseStorageAccountIDInsensitively(input string) (*StorageAccountId, error)
 	id := StorageAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StorageAccountName, ok = parsed.Parsed["storageAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageAccountName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2022-05-01/queueserviceproperties/id_storageaccount.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2022-05-01/queueserviceproperties/id_storageaccount.go
@@ -40,15 +40,15 @@ func ParseStorageAccountID(input string) (*StorageAccountId, error) {
 	id := StorageAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StorageAccountName, ok = parsed.Parsed["storageAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageAccountName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseStorageAccountIDInsensitively(input string) (*StorageAccountId, error)
 	id := StorageAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StorageAccountName, ok = parsed.Parsed["storageAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageAccountName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2022-05-01/storageaccounts/id_storageaccount.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2022-05-01/storageaccounts/id_storageaccount.go
@@ -40,15 +40,15 @@ func ParseStorageAccountID(input string) (*StorageAccountId, error) {
 	id := StorageAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StorageAccountName, ok = parsed.Parsed["storageAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageAccountName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseStorageAccountIDInsensitively(input string) (*StorageAccountId, error)
 	id := StorageAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StorageAccountName, ok = parsed.Parsed["storageAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageAccountName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2022-05-01/tableservice/id_storageaccount.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2022-05-01/tableservice/id_storageaccount.go
@@ -40,15 +40,15 @@ func ParseStorageAccountID(input string) (*StorageAccountId, error) {
 	id := StorageAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StorageAccountName, ok = parsed.Parsed["storageAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageAccountName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseStorageAccountIDInsensitively(input string) (*StorageAccountId, error)
 	id := StorageAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StorageAccountName, ok = parsed.Parsed["storageAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageAccountName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2022-05-01/tableservice/id_table.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2022-05-01/tableservice/id_table.go
@@ -42,19 +42,19 @@ func ParseTableID(input string) (*TableId, error) {
 	id := TableId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StorageAccountName, ok = parsed.Parsed["storageAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageAccountName", *parsed)
 	}
 
 	if id.TableName, ok = parsed.Parsed["tableName"]; !ok {
-		return nil, fmt.Errorf("the segment 'tableName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "tableName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseTableIDInsensitively(input string) (*TableId, error) {
 	id := TableId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StorageAccountName, ok = parsed.Parsed["storageAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageAccountName", *parsed)
 	}
 
 	if id.TableName, ok = parsed.Parsed["tableName"]; !ok {
-		return nil, fmt.Errorf("the segment 'tableName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "tableName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2022-05-01/tableserviceproperties/id_storageaccount.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storage/2022-05-01/tableserviceproperties/id_storageaccount.go
@@ -40,15 +40,15 @@ func ParseStorageAccountID(input string) (*StorageAccountId, error) {
 	id := StorageAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StorageAccountName, ok = parsed.Parsed["storageAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageAccountName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseStorageAccountIDInsensitively(input string) (*StorageAccountId, error)
 	id := StorageAccountId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StorageAccountName, ok = parsed.Parsed["storageAccountName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageAccountName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageAccountName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagecache/2023-01-01/caches/id_cache.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagecache/2023-01-01/caches/id_cache.go
@@ -40,15 +40,15 @@ func ParseCacheID(input string) (*CacheId, error) {
 	id := CacheId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.CacheName, ok = parsed.Parsed["cacheName"]; !ok {
-		return nil, fmt.Errorf("the segment 'cacheName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "cacheName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseCacheIDInsensitively(input string) (*CacheId, error) {
 	id := CacheId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.CacheName, ok = parsed.Parsed["cacheName"]; !ok {
-		return nil, fmt.Errorf("the segment 'cacheName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "cacheName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagecache/2023-01-01/storagetargets/id_cache.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagecache/2023-01-01/storagetargets/id_cache.go
@@ -40,15 +40,15 @@ func ParseCacheID(input string) (*CacheId, error) {
 	id := CacheId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.CacheName, ok = parsed.Parsed["cacheName"]; !ok {
-		return nil, fmt.Errorf("the segment 'cacheName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "cacheName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseCacheIDInsensitively(input string) (*CacheId, error) {
 	id := CacheId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.CacheName, ok = parsed.Parsed["cacheName"]; !ok {
-		return nil, fmt.Errorf("the segment 'cacheName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "cacheName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagecache/2023-01-01/storagetargets/id_storagetarget.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagecache/2023-01-01/storagetargets/id_storagetarget.go
@@ -42,19 +42,19 @@ func ParseStorageTargetID(input string) (*StorageTargetId, error) {
 	id := StorageTargetId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.CacheName, ok = parsed.Parsed["cacheName"]; !ok {
-		return nil, fmt.Errorf("the segment 'cacheName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "cacheName", *parsed)
 	}
 
 	if id.StorageTargetName, ok = parsed.Parsed["storageTargetName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageTargetName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageTargetName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseStorageTargetIDInsensitively(input string) (*StorageTargetId, error) {
 	id := StorageTargetId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.CacheName, ok = parsed.Parsed["cacheName"]; !ok {
-		return nil, fmt.Errorf("the segment 'cacheName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "cacheName", *parsed)
 	}
 
 	if id.StorageTargetName, ok = parsed.Parsed["storageTargetName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageTargetName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageTargetName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagemover/2023-03-01/agents/id_agent.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagemover/2023-03-01/agents/id_agent.go
@@ -42,19 +42,19 @@ func ParseAgentID(input string) (*AgentId, error) {
 	id := AgentId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StorageMoverName, ok = parsed.Parsed["storageMoverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageMoverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageMoverName", *parsed)
 	}
 
 	if id.AgentName, ok = parsed.Parsed["agentName"]; !ok {
-		return nil, fmt.Errorf("the segment 'agentName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "agentName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseAgentIDInsensitively(input string) (*AgentId, error) {
 	id := AgentId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StorageMoverName, ok = parsed.Parsed["storageMoverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageMoverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageMoverName", *parsed)
 	}
 
 	if id.AgentName, ok = parsed.Parsed["agentName"]; !ok {
-		return nil, fmt.Errorf("the segment 'agentName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "agentName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagemover/2023-03-01/agents/id_storagemover.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagemover/2023-03-01/agents/id_storagemover.go
@@ -40,15 +40,15 @@ func ParseStorageMoverID(input string) (*StorageMoverId, error) {
 	id := StorageMoverId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StorageMoverName, ok = parsed.Parsed["storageMoverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageMoverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageMoverName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseStorageMoverIDInsensitively(input string) (*StorageMoverId, error) {
 	id := StorageMoverId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StorageMoverName, ok = parsed.Parsed["storageMoverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageMoverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageMoverName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagemover/2023-03-01/endpoints/id_endpoint.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagemover/2023-03-01/endpoints/id_endpoint.go
@@ -42,19 +42,19 @@ func ParseEndpointID(input string) (*EndpointId, error) {
 	id := EndpointId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StorageMoverName, ok = parsed.Parsed["storageMoverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageMoverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageMoverName", *parsed)
 	}
 
 	if id.EndpointName, ok = parsed.Parsed["endpointName"]; !ok {
-		return nil, fmt.Errorf("the segment 'endpointName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "endpointName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseEndpointIDInsensitively(input string) (*EndpointId, error) {
 	id := EndpointId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StorageMoverName, ok = parsed.Parsed["storageMoverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageMoverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageMoverName", *parsed)
 	}
 
 	if id.EndpointName, ok = parsed.Parsed["endpointName"]; !ok {
-		return nil, fmt.Errorf("the segment 'endpointName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "endpointName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagemover/2023-03-01/endpoints/id_storagemover.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagemover/2023-03-01/endpoints/id_storagemover.go
@@ -40,15 +40,15 @@ func ParseStorageMoverID(input string) (*StorageMoverId, error) {
 	id := StorageMoverId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StorageMoverName, ok = parsed.Parsed["storageMoverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageMoverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageMoverName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseStorageMoverIDInsensitively(input string) (*StorageMoverId, error) {
 	id := StorageMoverId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StorageMoverName, ok = parsed.Parsed["storageMoverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageMoverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageMoverName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagemover/2023-03-01/jobdefinitions/id_jobdefinition.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagemover/2023-03-01/jobdefinitions/id_jobdefinition.go
@@ -44,23 +44,23 @@ func ParseJobDefinitionID(input string) (*JobDefinitionId, error) {
 	id := JobDefinitionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StorageMoverName, ok = parsed.Parsed["storageMoverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageMoverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageMoverName", *parsed)
 	}
 
 	if id.ProjectName, ok = parsed.Parsed["projectName"]; !ok {
-		return nil, fmt.Errorf("the segment 'projectName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "projectName", *parsed)
 	}
 
 	if id.JobDefinitionName, ok = parsed.Parsed["jobDefinitionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'jobDefinitionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "jobDefinitionName", *parsed)
 	}
 
 	return &id, nil
@@ -79,23 +79,23 @@ func ParseJobDefinitionIDInsensitively(input string) (*JobDefinitionId, error) {
 	id := JobDefinitionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StorageMoverName, ok = parsed.Parsed["storageMoverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageMoverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageMoverName", *parsed)
 	}
 
 	if id.ProjectName, ok = parsed.Parsed["projectName"]; !ok {
-		return nil, fmt.Errorf("the segment 'projectName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "projectName", *parsed)
 	}
 
 	if id.JobDefinitionName, ok = parsed.Parsed["jobDefinitionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'jobDefinitionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "jobDefinitionName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagemover/2023-03-01/jobdefinitions/id_project.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagemover/2023-03-01/jobdefinitions/id_project.go
@@ -42,19 +42,19 @@ func ParseProjectID(input string) (*ProjectId, error) {
 	id := ProjectId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StorageMoverName, ok = parsed.Parsed["storageMoverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageMoverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageMoverName", *parsed)
 	}
 
 	if id.ProjectName, ok = parsed.Parsed["projectName"]; !ok {
-		return nil, fmt.Errorf("the segment 'projectName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "projectName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseProjectIDInsensitively(input string) (*ProjectId, error) {
 	id := ProjectId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StorageMoverName, ok = parsed.Parsed["storageMoverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageMoverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageMoverName", *parsed)
 	}
 
 	if id.ProjectName, ok = parsed.Parsed["projectName"]; !ok {
-		return nil, fmt.Errorf("the segment 'projectName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "projectName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagemover/2023-03-01/projects/id_project.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagemover/2023-03-01/projects/id_project.go
@@ -42,19 +42,19 @@ func ParseProjectID(input string) (*ProjectId, error) {
 	id := ProjectId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StorageMoverName, ok = parsed.Parsed["storageMoverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageMoverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageMoverName", *parsed)
 	}
 
 	if id.ProjectName, ok = parsed.Parsed["projectName"]; !ok {
-		return nil, fmt.Errorf("the segment 'projectName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "projectName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseProjectIDInsensitively(input string) (*ProjectId, error) {
 	id := ProjectId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StorageMoverName, ok = parsed.Parsed["storageMoverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageMoverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageMoverName", *parsed)
 	}
 
 	if id.ProjectName, ok = parsed.Parsed["projectName"]; !ok {
-		return nil, fmt.Errorf("the segment 'projectName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "projectName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagemover/2023-03-01/projects/id_storagemover.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagemover/2023-03-01/projects/id_storagemover.go
@@ -40,15 +40,15 @@ func ParseStorageMoverID(input string) (*StorageMoverId, error) {
 	id := StorageMoverId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StorageMoverName, ok = parsed.Parsed["storageMoverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageMoverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageMoverName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseStorageMoverIDInsensitively(input string) (*StorageMoverId, error) {
 	id := StorageMoverId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StorageMoverName, ok = parsed.Parsed["storageMoverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageMoverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageMoverName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagemover/2023-03-01/storagemovers/id_storagemover.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagemover/2023-03-01/storagemovers/id_storagemover.go
@@ -40,15 +40,15 @@ func ParseStorageMoverID(input string) (*StorageMoverId, error) {
 	id := StorageMoverId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StorageMoverName, ok = parsed.Parsed["storageMoverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageMoverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageMoverName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseStorageMoverIDInsensitively(input string) (*StorageMoverId, error) {
 	id := StorageMoverId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StorageMoverName, ok = parsed.Parsed["storageMoverName"]; !ok {
-		return nil, fmt.Errorf("the segment 'storageMoverName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "storageMoverName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagepool/2021-08-01/diskpools/id_diskpool.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagepool/2021-08-01/diskpools/id_diskpool.go
@@ -40,15 +40,15 @@ func ParseDiskPoolID(input string) (*DiskPoolId, error) {
 	id := DiskPoolId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DiskPoolName, ok = parsed.Parsed["diskPoolName"]; !ok {
-		return nil, fmt.Errorf("the segment 'diskPoolName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "diskPoolName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseDiskPoolIDInsensitively(input string) (*DiskPoolId, error) {
 	id := DiskPoolId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DiskPoolName, ok = parsed.Parsed["diskPoolName"]; !ok {
-		return nil, fmt.Errorf("the segment 'diskPoolName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "diskPoolName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagepool/2021-08-01/iscsitargets/id_diskpool.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagepool/2021-08-01/iscsitargets/id_diskpool.go
@@ -40,15 +40,15 @@ func ParseDiskPoolID(input string) (*DiskPoolId, error) {
 	id := DiskPoolId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DiskPoolName, ok = parsed.Parsed["diskPoolName"]; !ok {
-		return nil, fmt.Errorf("the segment 'diskPoolName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "diskPoolName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseDiskPoolIDInsensitively(input string) (*DiskPoolId, error) {
 	id := DiskPoolId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DiskPoolName, ok = parsed.Parsed["diskPoolName"]; !ok {
-		return nil, fmt.Errorf("the segment 'diskPoolName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "diskPoolName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagepool/2021-08-01/iscsitargets/id_iscsitarget.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagepool/2021-08-01/iscsitargets/id_iscsitarget.go
@@ -42,19 +42,19 @@ func ParseIscsiTargetID(input string) (*IscsiTargetId, error) {
 	id := IscsiTargetId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DiskPoolName, ok = parsed.Parsed["diskPoolName"]; !ok {
-		return nil, fmt.Errorf("the segment 'diskPoolName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "diskPoolName", *parsed)
 	}
 
 	if id.IscsiTargetName, ok = parsed.Parsed["iscsiTargetName"]; !ok {
-		return nil, fmt.Errorf("the segment 'iscsiTargetName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "iscsiTargetName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseIscsiTargetIDInsensitively(input string) (*IscsiTargetId, error) {
 	id := IscsiTargetId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.DiskPoolName, ok = parsed.Parsed["diskPoolName"]; !ok {
-		return nil, fmt.Errorf("the segment 'diskPoolName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "diskPoolName", *parsed)
 	}
 
 	if id.IscsiTargetName, ok = parsed.Parsed["iscsiTargetName"]; !ok {
-		return nil, fmt.Errorf("the segment 'iscsiTargetName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "iscsiTargetName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/clusters/id_cluster.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/clusters/id_cluster.go
@@ -40,15 +40,15 @@ func ParseClusterID(input string) (*ClusterId, error) {
 	id := ClusterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseClusterIDInsensitively(input string) (*ClusterId, error) {
 	id := ClusterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/functions/id_function.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/functions/id_function.go
@@ -42,19 +42,19 @@ func ParseFunctionID(input string) (*FunctionId, error) {
 	id := FunctionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StreamingJobName, ok = parsed.Parsed["streamingJobName"]; !ok {
-		return nil, fmt.Errorf("the segment 'streamingJobName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "streamingJobName", *parsed)
 	}
 
 	if id.FunctionName, ok = parsed.Parsed["functionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'functionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "functionName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseFunctionIDInsensitively(input string) (*FunctionId, error) {
 	id := FunctionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StreamingJobName, ok = parsed.Parsed["streamingJobName"]; !ok {
-		return nil, fmt.Errorf("the segment 'streamingJobName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "streamingJobName", *parsed)
 	}
 
 	if id.FunctionName, ok = parsed.Parsed["functionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'functionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "functionName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/functions/id_streamingjob.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/functions/id_streamingjob.go
@@ -40,15 +40,15 @@ func ParseStreamingJobID(input string) (*StreamingJobId, error) {
 	id := StreamingJobId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StreamingJobName, ok = parsed.Parsed["streamingJobName"]; !ok {
-		return nil, fmt.Errorf("the segment 'streamingJobName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "streamingJobName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseStreamingJobIDInsensitively(input string) (*StreamingJobId, error) {
 	id := StreamingJobId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StreamingJobName, ok = parsed.Parsed["streamingJobName"]; !ok {
-		return nil, fmt.Errorf("the segment 'streamingJobName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "streamingJobName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/inputs/id_input.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/inputs/id_input.go
@@ -42,19 +42,19 @@ func ParseInputID(input string) (*InputId, error) {
 	id := InputId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StreamingJobName, ok = parsed.Parsed["streamingJobName"]; !ok {
-		return nil, fmt.Errorf("the segment 'streamingJobName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "streamingJobName", *parsed)
 	}
 
 	if id.InputName, ok = parsed.Parsed["inputName"]; !ok {
-		return nil, fmt.Errorf("the segment 'inputName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "inputName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseInputIDInsensitively(input string) (*InputId, error) {
 	id := InputId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StreamingJobName, ok = parsed.Parsed["streamingJobName"]; !ok {
-		return nil, fmt.Errorf("the segment 'streamingJobName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "streamingJobName", *parsed)
 	}
 
 	if id.InputName, ok = parsed.Parsed["inputName"]; !ok {
-		return nil, fmt.Errorf("the segment 'inputName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "inputName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/inputs/id_streamingjob.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/inputs/id_streamingjob.go
@@ -40,15 +40,15 @@ func ParseStreamingJobID(input string) (*StreamingJobId, error) {
 	id := StreamingJobId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StreamingJobName, ok = parsed.Parsed["streamingJobName"]; !ok {
-		return nil, fmt.Errorf("the segment 'streamingJobName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "streamingJobName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseStreamingJobIDInsensitively(input string) (*StreamingJobId, error) {
 	id := StreamingJobId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StreamingJobName, ok = parsed.Parsed["streamingJobName"]; !ok {
-		return nil, fmt.Errorf("the segment 'streamingJobName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "streamingJobName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/privateendpoints/id_cluster.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/privateendpoints/id_cluster.go
@@ -40,15 +40,15 @@ func ParseClusterID(input string) (*ClusterId, error) {
 	id := ClusterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseClusterIDInsensitively(input string) (*ClusterId, error) {
 	id := ClusterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/privateendpoints/id_privateendpoint.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/privateendpoints/id_privateendpoint.go
@@ -42,19 +42,19 @@ func ParsePrivateEndpointID(input string) (*PrivateEndpointId, error) {
 	id := PrivateEndpointId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	if id.PrivateEndpointName, ok = parsed.Parsed["privateEndpointName"]; !ok {
-		return nil, fmt.Errorf("the segment 'privateEndpointName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "privateEndpointName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParsePrivateEndpointIDInsensitively(input string) (*PrivateEndpointId, erro
 	id := PrivateEndpointId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	if id.PrivateEndpointName, ok = parsed.Parsed["privateEndpointName"]; !ok {
-		return nil, fmt.Errorf("the segment 'privateEndpointName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "privateEndpointName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/streamingjobs/id_streamingjob.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/streamingjobs/id_streamingjob.go
@@ -40,15 +40,15 @@ func ParseStreamingJobID(input string) (*StreamingJobId, error) {
 	id := StreamingJobId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StreamingJobName, ok = parsed.Parsed["streamingJobName"]; !ok {
-		return nil, fmt.Errorf("the segment 'streamingJobName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "streamingJobName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseStreamingJobIDInsensitively(input string) (*StreamingJobId, error) {
 	id := StreamingJobId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StreamingJobName, ok = parsed.Parsed["streamingJobName"]; !ok {
-		return nil, fmt.Errorf("the segment 'streamingJobName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "streamingJobName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/transformations/id_transformation.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/transformations/id_transformation.go
@@ -42,19 +42,19 @@ func ParseTransformationID(input string) (*TransformationId, error) {
 	id := TransformationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StreamingJobName, ok = parsed.Parsed["streamingJobName"]; !ok {
-		return nil, fmt.Errorf("the segment 'streamingJobName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "streamingJobName", *parsed)
 	}
 
 	if id.TransformationName, ok = parsed.Parsed["transformationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'transformationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "transformationName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseTransformationIDInsensitively(input string) (*TransformationId, error)
 	id := TransformationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StreamingJobName, ok = parsed.Parsed["streamingJobName"]; !ok {
-		return nil, fmt.Errorf("the segment 'streamingJobName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "streamingJobName", *parsed)
 	}
 
 	if id.TransformationName, ok = parsed.Parsed["transformationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'transformationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "transformationName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2021-10-01-preview/outputs/id_output.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2021-10-01-preview/outputs/id_output.go
@@ -42,19 +42,19 @@ func ParseOutputID(input string) (*OutputId, error) {
 	id := OutputId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StreamingJobName, ok = parsed.Parsed["streamingJobName"]; !ok {
-		return nil, fmt.Errorf("the segment 'streamingJobName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "streamingJobName", *parsed)
 	}
 
 	if id.OutputName, ok = parsed.Parsed["outputName"]; !ok {
-		return nil, fmt.Errorf("the segment 'outputName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "outputName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseOutputIDInsensitively(input string) (*OutputId, error) {
 	id := OutputId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StreamingJobName, ok = parsed.Parsed["streamingJobName"]; !ok {
-		return nil, fmt.Errorf("the segment 'streamingJobName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "streamingJobName", *parsed)
 	}
 
 	if id.OutputName, ok = parsed.Parsed["outputName"]; !ok {
-		return nil, fmt.Errorf("the segment 'outputName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "outputName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2021-10-01-preview/outputs/id_streamingjob.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2021-10-01-preview/outputs/id_streamingjob.go
@@ -40,15 +40,15 @@ func ParseStreamingJobID(input string) (*StreamingJobId, error) {
 	id := StreamingJobId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StreamingJobName, ok = parsed.Parsed["streamingJobName"]; !ok {
-		return nil, fmt.Errorf("the segment 'streamingJobName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "streamingJobName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseStreamingJobIDInsensitively(input string) (*StreamingJobId, error) {
 	id := StreamingJobId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.StreamingJobName, ok = parsed.Parsed["streamingJobName"]; !ok {
-		return nil, fmt.Errorf("the segment 'streamingJobName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "streamingJobName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/subscription/2021-10-01/subscriptions/id_alias.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/subscription/2021-10-01/subscriptions/id_alias.go
@@ -36,7 +36,7 @@ func ParseAliasID(input string) (*AliasId, error) {
 	id := AliasId{}
 
 	if id.AliasName, ok = parsed.Parsed["aliasName"]; !ok {
-		return nil, fmt.Errorf("the segment 'aliasName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "aliasName", *parsed)
 	}
 
 	return &id, nil
@@ -55,7 +55,7 @@ func ParseAliasIDInsensitively(input string) (*AliasId, error) {
 	id := AliasId{}
 
 	if id.AliasName, ok = parsed.Parsed["aliasName"]; !ok {
-		return nil, fmt.Errorf("the segment 'aliasName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "aliasName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/subscription/2021-10-01/subscriptions/id_billingaccount.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/subscription/2021-10-01/subscriptions/id_billingaccount.go
@@ -36,7 +36,7 @@ func ParseBillingAccountID(input string) (*BillingAccountId, error) {
 	id := BillingAccountId{}
 
 	if id.BillingAccountId, ok = parsed.Parsed["billingAccountId"]; !ok {
-		return nil, fmt.Errorf("the segment 'billingAccountId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "billingAccountId", *parsed)
 	}
 
 	return &id, nil
@@ -55,7 +55,7 @@ func ParseBillingAccountIDInsensitively(input string) (*BillingAccountId, error)
 	id := BillingAccountId{}
 
 	if id.BillingAccountId, ok = parsed.Parsed["billingAccountId"]; !ok {
-		return nil, fmt.Errorf("the segment 'billingAccountId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "billingAccountId", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/subscription/2021-10-01/subscriptions/id_providersubscription.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/subscription/2021-10-01/subscriptions/id_providersubscription.go
@@ -36,7 +36,7 @@ func ParseProviderSubscriptionID(input string) (*ProviderSubscriptionId, error) 
 	id := ProviderSubscriptionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	return &id, nil
@@ -55,7 +55,7 @@ func ParseProviderSubscriptionIDInsensitively(input string) (*ProviderSubscripti
 	id := ProviderSubscriptionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/timeseriesinsights/2020-05-15/accesspolicies/id_accesspolicy.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/timeseriesinsights/2020-05-15/accesspolicies/id_accesspolicy.go
@@ -42,19 +42,19 @@ func ParseAccessPolicyID(input string) (*AccessPolicyId, error) {
 	id := AccessPolicyId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.EnvironmentName, ok = parsed.Parsed["environmentName"]; !ok {
-		return nil, fmt.Errorf("the segment 'environmentName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "environmentName", *parsed)
 	}
 
 	if id.AccessPolicyName, ok = parsed.Parsed["accessPolicyName"]; !ok {
-		return nil, fmt.Errorf("the segment 'accessPolicyName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "accessPolicyName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseAccessPolicyIDInsensitively(input string) (*AccessPolicyId, error) {
 	id := AccessPolicyId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.EnvironmentName, ok = parsed.Parsed["environmentName"]; !ok {
-		return nil, fmt.Errorf("the segment 'environmentName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "environmentName", *parsed)
 	}
 
 	if id.AccessPolicyName, ok = parsed.Parsed["accessPolicyName"]; !ok {
-		return nil, fmt.Errorf("the segment 'accessPolicyName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "accessPolicyName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/timeseriesinsights/2020-05-15/accesspolicies/id_environment.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/timeseriesinsights/2020-05-15/accesspolicies/id_environment.go
@@ -40,15 +40,15 @@ func ParseEnvironmentID(input string) (*EnvironmentId, error) {
 	id := EnvironmentId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.EnvironmentName, ok = parsed.Parsed["environmentName"]; !ok {
-		return nil, fmt.Errorf("the segment 'environmentName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "environmentName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseEnvironmentIDInsensitively(input string) (*EnvironmentId, error) {
 	id := EnvironmentId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.EnvironmentName, ok = parsed.Parsed["environmentName"]; !ok {
-		return nil, fmt.Errorf("the segment 'environmentName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "environmentName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/timeseriesinsights/2020-05-15/environments/id_environment.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/timeseriesinsights/2020-05-15/environments/id_environment.go
@@ -40,15 +40,15 @@ func ParseEnvironmentID(input string) (*EnvironmentId, error) {
 	id := EnvironmentId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.EnvironmentName, ok = parsed.Parsed["environmentName"]; !ok {
-		return nil, fmt.Errorf("the segment 'environmentName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "environmentName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseEnvironmentIDInsensitively(input string) (*EnvironmentId, error) {
 	id := EnvironmentId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.EnvironmentName, ok = parsed.Parsed["environmentName"]; !ok {
-		return nil, fmt.Errorf("the segment 'environmentName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "environmentName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/timeseriesinsights/2020-05-15/eventsources/id_environment.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/timeseriesinsights/2020-05-15/eventsources/id_environment.go
@@ -40,15 +40,15 @@ func ParseEnvironmentID(input string) (*EnvironmentId, error) {
 	id := EnvironmentId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.EnvironmentName, ok = parsed.Parsed["environmentName"]; !ok {
-		return nil, fmt.Errorf("the segment 'environmentName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "environmentName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseEnvironmentIDInsensitively(input string) (*EnvironmentId, error) {
 	id := EnvironmentId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.EnvironmentName, ok = parsed.Parsed["environmentName"]; !ok {
-		return nil, fmt.Errorf("the segment 'environmentName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "environmentName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/timeseriesinsights/2020-05-15/eventsources/id_eventsource.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/timeseriesinsights/2020-05-15/eventsources/id_eventsource.go
@@ -42,19 +42,19 @@ func ParseEventSourceID(input string) (*EventSourceId, error) {
 	id := EventSourceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.EnvironmentName, ok = parsed.Parsed["environmentName"]; !ok {
-		return nil, fmt.Errorf("the segment 'environmentName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "environmentName", *parsed)
 	}
 
 	if id.EventSourceName, ok = parsed.Parsed["eventSourceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'eventSourceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "eventSourceName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseEventSourceIDInsensitively(input string) (*EventSourceId, error) {
 	id := EventSourceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.EnvironmentName, ok = parsed.Parsed["environmentName"]; !ok {
-		return nil, fmt.Errorf("the segment 'environmentName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "environmentName", *parsed)
 	}
 
 	if id.EventSourceName, ok = parsed.Parsed["eventSourceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'eventSourceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "eventSourceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/timeseriesinsights/2020-05-15/referencedatasets/id_environment.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/timeseriesinsights/2020-05-15/referencedatasets/id_environment.go
@@ -40,15 +40,15 @@ func ParseEnvironmentID(input string) (*EnvironmentId, error) {
 	id := EnvironmentId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.EnvironmentName, ok = parsed.Parsed["environmentName"]; !ok {
-		return nil, fmt.Errorf("the segment 'environmentName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "environmentName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseEnvironmentIDInsensitively(input string) (*EnvironmentId, error) {
 	id := EnvironmentId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.EnvironmentName, ok = parsed.Parsed["environmentName"]; !ok {
-		return nil, fmt.Errorf("the segment 'environmentName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "environmentName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/timeseriesinsights/2020-05-15/referencedatasets/id_referencedataset.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/timeseriesinsights/2020-05-15/referencedatasets/id_referencedataset.go
@@ -42,19 +42,19 @@ func ParseReferenceDataSetID(input string) (*ReferenceDataSetId, error) {
 	id := ReferenceDataSetId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.EnvironmentName, ok = parsed.Parsed["environmentName"]; !ok {
-		return nil, fmt.Errorf("the segment 'environmentName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "environmentName", *parsed)
 	}
 
 	if id.ReferenceDataSetName, ok = parsed.Parsed["referenceDataSetName"]; !ok {
-		return nil, fmt.Errorf("the segment 'referenceDataSetName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "referenceDataSetName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseReferenceDataSetIDInsensitively(input string) (*ReferenceDataSetId, er
 	id := ReferenceDataSetId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.EnvironmentName, ok = parsed.Parsed["environmentName"]; !ok {
-		return nil, fmt.Errorf("the segment 'environmentName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "environmentName", *parsed)
 	}
 
 	if id.ReferenceDataSetName, ok = parsed.Parsed["referenceDataSetName"]; !ok {
-		return nil, fmt.Errorf("the segment 'referenceDataSetName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "referenceDataSetName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/trafficmanager/2018-08-01/endpoints/id_endpointtype.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/trafficmanager/2018-08-01/endpoints/id_endpointtype.go
@@ -44,20 +44,20 @@ func ParseEndpointTypeID(input string) (*EndpointTypeId, error) {
 	id := EndpointTypeId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.TrafficManagerProfileName, ok = parsed.Parsed["trafficManagerProfileName"]; !ok {
-		return nil, fmt.Errorf("the segment 'trafficManagerProfileName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "trafficManagerProfileName", *parsed)
 	}
 
 	if v, ok := parsed.Parsed["endpointType"]; true {
 		if !ok {
-			return nil, fmt.Errorf("the segment 'endpointType' was not found in the resource id %q", input)
+			return nil, resourceids.NewSegmentNotSpecifiedError(id, "endpointType", *parsed)
 		}
 
 		endpointType, err := parseEndpointType(v)
@@ -68,7 +68,7 @@ func ParseEndpointTypeID(input string) (*EndpointTypeId, error) {
 	}
 
 	if id.EndpointName, ok = parsed.Parsed["endpointName"]; !ok {
-		return nil, fmt.Errorf("the segment 'endpointName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "endpointName", *parsed)
 	}
 
 	return &id, nil
@@ -87,20 +87,20 @@ func ParseEndpointTypeIDInsensitively(input string) (*EndpointTypeId, error) {
 	id := EndpointTypeId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.TrafficManagerProfileName, ok = parsed.Parsed["trafficManagerProfileName"]; !ok {
-		return nil, fmt.Errorf("the segment 'trafficManagerProfileName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "trafficManagerProfileName", *parsed)
 	}
 
 	if v, ok := parsed.Parsed["endpointType"]; true {
 		if !ok {
-			return nil, fmt.Errorf("the segment 'endpointType' was not found in the resource id %q", input)
+			return nil, resourceids.NewSegmentNotSpecifiedError(id, "endpointType", *parsed)
 		}
 
 		endpointType, err := parseEndpointType(v)
@@ -111,7 +111,7 @@ func ParseEndpointTypeIDInsensitively(input string) (*EndpointTypeId, error) {
 	}
 
 	if id.EndpointName, ok = parsed.Parsed["endpointName"]; !ok {
-		return nil, fmt.Errorf("the segment 'endpointName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "endpointName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/trafficmanager/2018-08-01/profiles/id_trafficmanagerprofile.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/trafficmanager/2018-08-01/profiles/id_trafficmanagerprofile.go
@@ -40,15 +40,15 @@ func ParseTrafficManagerProfileID(input string) (*TrafficManagerProfileId, error
 	id := TrafficManagerProfileId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.TrafficManagerProfileName, ok = parsed.Parsed["trafficManagerProfileName"]; !ok {
-		return nil, fmt.Errorf("the segment 'trafficManagerProfileName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "trafficManagerProfileName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseTrafficManagerProfileIDInsensitively(input string) (*TrafficManagerPro
 	id := TrafficManagerProfileId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.TrafficManagerProfileName, ok = parsed.Parsed["trafficManagerProfileName"]; !ok {
-		return nil, fmt.Errorf("the segment 'trafficManagerProfileName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "trafficManagerProfileName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/videoanalyzer/2021-05-01-preview/edgemodules/id_edgemodule.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/videoanalyzer/2021-05-01-preview/edgemodules/id_edgemodule.go
@@ -42,19 +42,19 @@ func ParseEdgeModuleID(input string) (*EdgeModuleId, error) {
 	id := EdgeModuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VideoAnalyzerName, ok = parsed.Parsed["videoAnalyzerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'videoAnalyzerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "videoAnalyzerName", *parsed)
 	}
 
 	if id.EdgeModuleName, ok = parsed.Parsed["edgeModuleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'edgeModuleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "edgeModuleName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseEdgeModuleIDInsensitively(input string) (*EdgeModuleId, error) {
 	id := EdgeModuleId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VideoAnalyzerName, ok = parsed.Parsed["videoAnalyzerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'videoAnalyzerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "videoAnalyzerName", *parsed)
 	}
 
 	if id.EdgeModuleName, ok = parsed.Parsed["edgeModuleName"]; !ok {
-		return nil, fmt.Errorf("the segment 'edgeModuleName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "edgeModuleName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/videoanalyzer/2021-05-01-preview/edgemodules/id_videoanalyzer.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/videoanalyzer/2021-05-01-preview/edgemodules/id_videoanalyzer.go
@@ -40,15 +40,15 @@ func ParseVideoAnalyzerID(input string) (*VideoAnalyzerId, error) {
 	id := VideoAnalyzerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VideoAnalyzerName, ok = parsed.Parsed["videoAnalyzerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'videoAnalyzerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "videoAnalyzerName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseVideoAnalyzerIDInsensitively(input string) (*VideoAnalyzerId, error) {
 	id := VideoAnalyzerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VideoAnalyzerName, ok = parsed.Parsed["videoAnalyzerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'videoAnalyzerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "videoAnalyzerName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/videoanalyzer/2021-05-01-preview/videoanalyzers/id_location.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/videoanalyzer/2021-05-01-preview/videoanalyzers/id_location.go
@@ -38,11 +38,11 @@ func ParseLocationID(input string) (*LocationId, error) {
 	id := LocationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.LocationName, ok = parsed.Parsed["locationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'locationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "locationName", *parsed)
 	}
 
 	return &id, nil
@@ -61,11 +61,11 @@ func ParseLocationIDInsensitively(input string) (*LocationId, error) {
 	id := LocationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.LocationName, ok = parsed.Parsed["locationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'locationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "locationName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/videoanalyzer/2021-05-01-preview/videoanalyzers/id_videoanalyzer.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/videoanalyzer/2021-05-01-preview/videoanalyzers/id_videoanalyzer.go
@@ -40,15 +40,15 @@ func ParseVideoAnalyzerID(input string) (*VideoAnalyzerId, error) {
 	id := VideoAnalyzerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VideoAnalyzerName, ok = parsed.Parsed["videoAnalyzerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'videoAnalyzerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "videoAnalyzerName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseVideoAnalyzerIDInsensitively(input string) (*VideoAnalyzerId, error) {
 	id := VideoAnalyzerId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.VideoAnalyzerName, ok = parsed.Parsed["videoAnalyzerName"]; !ok {
-		return nil, fmt.Errorf("the segment 'videoAnalyzerName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "videoAnalyzerName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/vmware/2022-05-01/authorizations/id_authorization.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/vmware/2022-05-01/authorizations/id_authorization.go
@@ -42,19 +42,19 @@ func ParseAuthorizationID(input string) (*AuthorizationId, error) {
 	id := AuthorizationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.PrivateCloudName, ok = parsed.Parsed["privateCloudName"]; !ok {
-		return nil, fmt.Errorf("the segment 'privateCloudName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "privateCloudName", *parsed)
 	}
 
 	if id.AuthorizationName, ok = parsed.Parsed["authorizationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'authorizationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "authorizationName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseAuthorizationIDInsensitively(input string) (*AuthorizationId, error) {
 	id := AuthorizationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.PrivateCloudName, ok = parsed.Parsed["privateCloudName"]; !ok {
-		return nil, fmt.Errorf("the segment 'privateCloudName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "privateCloudName", *parsed)
 	}
 
 	if id.AuthorizationName, ok = parsed.Parsed["authorizationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'authorizationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "authorizationName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/vmware/2022-05-01/authorizations/id_privatecloud.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/vmware/2022-05-01/authorizations/id_privatecloud.go
@@ -40,15 +40,15 @@ func ParsePrivateCloudID(input string) (*PrivateCloudId, error) {
 	id := PrivateCloudId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.PrivateCloudName, ok = parsed.Parsed["privateCloudName"]; !ok {
-		return nil, fmt.Errorf("the segment 'privateCloudName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "privateCloudName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParsePrivateCloudIDInsensitively(input string) (*PrivateCloudId, error) {
 	id := PrivateCloudId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.PrivateCloudName, ok = parsed.Parsed["privateCloudName"]; !ok {
-		return nil, fmt.Errorf("the segment 'privateCloudName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "privateCloudName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/vmware/2022-05-01/clusters/id_cluster.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/vmware/2022-05-01/clusters/id_cluster.go
@@ -42,19 +42,19 @@ func ParseClusterID(input string) (*ClusterId, error) {
 	id := ClusterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.PrivateCloudName, ok = parsed.Parsed["privateCloudName"]; !ok {
-		return nil, fmt.Errorf("the segment 'privateCloudName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "privateCloudName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseClusterIDInsensitively(input string) (*ClusterId, error) {
 	id := ClusterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.PrivateCloudName, ok = parsed.Parsed["privateCloudName"]; !ok {
-		return nil, fmt.Errorf("the segment 'privateCloudName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "privateCloudName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/vmware/2022-05-01/clusters/id_privatecloud.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/vmware/2022-05-01/clusters/id_privatecloud.go
@@ -40,15 +40,15 @@ func ParsePrivateCloudID(input string) (*PrivateCloudId, error) {
 	id := PrivateCloudId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.PrivateCloudName, ok = parsed.Parsed["privateCloudName"]; !ok {
-		return nil, fmt.Errorf("the segment 'privateCloudName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "privateCloudName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParsePrivateCloudIDInsensitively(input string) (*PrivateCloudId, error) {
 	id := PrivateCloudId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.PrivateCloudName, ok = parsed.Parsed["privateCloudName"]; !ok {
-		return nil, fmt.Errorf("the segment 'privateCloudName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "privateCloudName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/vmware/2022-05-01/datastores/id_cluster.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/vmware/2022-05-01/datastores/id_cluster.go
@@ -42,19 +42,19 @@ func ParseClusterID(input string) (*ClusterId, error) {
 	id := ClusterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.PrivateCloudName, ok = parsed.Parsed["privateCloudName"]; !ok {
-		return nil, fmt.Errorf("the segment 'privateCloudName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "privateCloudName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseClusterIDInsensitively(input string) (*ClusterId, error) {
 	id := ClusterId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.PrivateCloudName, ok = parsed.Parsed["privateCloudName"]; !ok {
-		return nil, fmt.Errorf("the segment 'privateCloudName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "privateCloudName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/vmware/2022-05-01/datastores/id_datastore.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/vmware/2022-05-01/datastores/id_datastore.go
@@ -44,23 +44,23 @@ func ParseDataStoreID(input string) (*DataStoreId, error) {
 	id := DataStoreId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.PrivateCloudName, ok = parsed.Parsed["privateCloudName"]; !ok {
-		return nil, fmt.Errorf("the segment 'privateCloudName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "privateCloudName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	if id.DataStoreName, ok = parsed.Parsed["dataStoreName"]; !ok {
-		return nil, fmt.Errorf("the segment 'dataStoreName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "dataStoreName", *parsed)
 	}
 
 	return &id, nil
@@ -79,23 +79,23 @@ func ParseDataStoreIDInsensitively(input string) (*DataStoreId, error) {
 	id := DataStoreId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.PrivateCloudName, ok = parsed.Parsed["privateCloudName"]; !ok {
-		return nil, fmt.Errorf("the segment 'privateCloudName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "privateCloudName", *parsed)
 	}
 
 	if id.ClusterName, ok = parsed.Parsed["clusterName"]; !ok {
-		return nil, fmt.Errorf("the segment 'clusterName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "clusterName", *parsed)
 	}
 
 	if id.DataStoreName, ok = parsed.Parsed["dataStoreName"]; !ok {
-		return nil, fmt.Errorf("the segment 'dataStoreName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "dataStoreName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/vmware/2022-05-01/privateclouds/id_privatecloud.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/vmware/2022-05-01/privateclouds/id_privatecloud.go
@@ -40,15 +40,15 @@ func ParsePrivateCloudID(input string) (*PrivateCloudId, error) {
 	id := PrivateCloudId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.PrivateCloudName, ok = parsed.Parsed["privateCloudName"]; !ok {
-		return nil, fmt.Errorf("the segment 'privateCloudName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "privateCloudName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParsePrivateCloudIDInsensitively(input string) (*PrivateCloudId, error) {
 	id := PrivateCloudId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.PrivateCloudName, ok = parsed.Parsed["privateCloudName"]; !ok {
-		return nil, fmt.Errorf("the segment 'privateCloudName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "privateCloudName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/voiceservices/2023-01-31/communicationsgateways/id_communicationsgateway.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/voiceservices/2023-01-31/communicationsgateways/id_communicationsgateway.go
@@ -40,15 +40,15 @@ func ParseCommunicationsGatewayID(input string) (*CommunicationsGatewayId, error
 	id := CommunicationsGatewayId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.CommunicationsGatewayName, ok = parsed.Parsed["communicationsGatewayName"]; !ok {
-		return nil, fmt.Errorf("the segment 'communicationsGatewayName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "communicationsGatewayName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseCommunicationsGatewayIDInsensitively(input string) (*CommunicationsGat
 	id := CommunicationsGatewayId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.CommunicationsGatewayName, ok = parsed.Parsed["communicationsGatewayName"]; !ok {
-		return nil, fmt.Errorf("the segment 'communicationsGatewayName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "communicationsGatewayName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/voiceservices/2023-01-31/testlines/id_communicationsgateway.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/voiceservices/2023-01-31/testlines/id_communicationsgateway.go
@@ -40,15 +40,15 @@ func ParseCommunicationsGatewayID(input string) (*CommunicationsGatewayId, error
 	id := CommunicationsGatewayId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.CommunicationsGatewayName, ok = parsed.Parsed["communicationsGatewayName"]; !ok {
-		return nil, fmt.Errorf("the segment 'communicationsGatewayName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "communicationsGatewayName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseCommunicationsGatewayIDInsensitively(input string) (*CommunicationsGat
 	id := CommunicationsGatewayId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.CommunicationsGatewayName, ok = parsed.Parsed["communicationsGatewayName"]; !ok {
-		return nil, fmt.Errorf("the segment 'communicationsGatewayName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "communicationsGatewayName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/voiceservices/2023-01-31/testlines/id_testline.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/voiceservices/2023-01-31/testlines/id_testline.go
@@ -42,19 +42,19 @@ func ParseTestLineID(input string) (*TestLineId, error) {
 	id := TestLineId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.CommunicationsGatewayName, ok = parsed.Parsed["communicationsGatewayName"]; !ok {
-		return nil, fmt.Errorf("the segment 'communicationsGatewayName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "communicationsGatewayName", *parsed)
 	}
 
 	if id.TestLineName, ok = parsed.Parsed["testLineName"]; !ok {
-		return nil, fmt.Errorf("the segment 'testLineName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "testLineName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseTestLineIDInsensitively(input string) (*TestLineId, error) {
 	id := TestLineId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.CommunicationsGatewayName, ok = parsed.Parsed["communicationsGatewayName"]; !ok {
-		return nil, fmt.Errorf("the segment 'communicationsGatewayName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "communicationsGatewayName", *parsed)
 	}
 
 	if id.TestLineName, ok = parsed.Parsed["testLineName"]; !ok {
-		return nil, fmt.Errorf("the segment 'testLineName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "testLineName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/web/2016-06-01/connections/id_connection.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/web/2016-06-01/connections/id_connection.go
@@ -40,15 +40,15 @@ func ParseConnectionID(input string) (*ConnectionId, error) {
 	id := ConnectionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ConnectionName, ok = parsed.Parsed["connectionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'connectionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "connectionName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseConnectionIDInsensitively(input string) (*ConnectionId, error) {
 	id := ConnectionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.ConnectionName, ok = parsed.Parsed["connectionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'connectionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "connectionName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/web/2016-06-01/managedapis/id_location.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/web/2016-06-01/managedapis/id_location.go
@@ -38,11 +38,11 @@ func ParseLocationID(input string) (*LocationId, error) {
 	id := LocationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.LocationName, ok = parsed.Parsed["locationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'locationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "locationName", *parsed)
 	}
 
 	return &id, nil
@@ -61,11 +61,11 @@ func ParseLocationIDInsensitively(input string) (*LocationId, error) {
 	id := LocationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.LocationName, ok = parsed.Parsed["locationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'locationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "locationName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/web/2016-06-01/managedapis/id_managedapi.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/web/2016-06-01/managedapis/id_managedapi.go
@@ -40,15 +40,15 @@ func ParseManagedApiID(input string) (*ManagedApiId, error) {
 	id := ManagedApiId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.LocationName, ok = parsed.Parsed["locationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'locationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "locationName", *parsed)
 	}
 
 	if id.ManagedApiName, ok = parsed.Parsed["managedApiName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedApiName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedApiName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseManagedApiIDInsensitively(input string) (*ManagedApiId, error) {
 	id := ManagedApiId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.LocationName, ok = parsed.Parsed["locationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'locationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "locationName", *parsed)
 	}
 
 	if id.ManagedApiName, ok = parsed.Parsed["managedApiName"]; !ok {
-		return nil, fmt.Errorf("the segment 'managedApiName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedApiName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/webpubsub/2023-02-01/webpubsub/id_customcertificate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/webpubsub/2023-02-01/webpubsub/id_customcertificate.go
@@ -42,19 +42,19 @@ func ParseCustomCertificateID(input string) (*CustomCertificateId, error) {
 	id := CustomCertificateId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WebPubSubName, ok = parsed.Parsed["webPubSubName"]; !ok {
-		return nil, fmt.Errorf("the segment 'webPubSubName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "webPubSubName", *parsed)
 	}
 
 	if id.CustomCertificateName, ok = parsed.Parsed["customCertificateName"]; !ok {
-		return nil, fmt.Errorf("the segment 'customCertificateName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "customCertificateName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseCustomCertificateIDInsensitively(input string) (*CustomCertificateId, 
 	id := CustomCertificateId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WebPubSubName, ok = parsed.Parsed["webPubSubName"]; !ok {
-		return nil, fmt.Errorf("the segment 'webPubSubName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "webPubSubName", *parsed)
 	}
 
 	if id.CustomCertificateName, ok = parsed.Parsed["customCertificateName"]; !ok {
-		return nil, fmt.Errorf("the segment 'customCertificateName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "customCertificateName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/webpubsub/2023-02-01/webpubsub/id_customdomain.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/webpubsub/2023-02-01/webpubsub/id_customdomain.go
@@ -42,19 +42,19 @@ func ParseCustomDomainID(input string) (*CustomDomainId, error) {
 	id := CustomDomainId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WebPubSubName, ok = parsed.Parsed["webPubSubName"]; !ok {
-		return nil, fmt.Errorf("the segment 'webPubSubName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "webPubSubName", *parsed)
 	}
 
 	if id.CustomDomainName, ok = parsed.Parsed["customDomainName"]; !ok {
-		return nil, fmt.Errorf("the segment 'customDomainName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "customDomainName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseCustomDomainIDInsensitively(input string) (*CustomDomainId, error) {
 	id := CustomDomainId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WebPubSubName, ok = parsed.Parsed["webPubSubName"]; !ok {
-		return nil, fmt.Errorf("the segment 'webPubSubName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "webPubSubName", *parsed)
 	}
 
 	if id.CustomDomainName, ok = parsed.Parsed["customDomainName"]; !ok {
-		return nil, fmt.Errorf("the segment 'customDomainName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "customDomainName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/webpubsub/2023-02-01/webpubsub/id_hub.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/webpubsub/2023-02-01/webpubsub/id_hub.go
@@ -42,19 +42,19 @@ func ParseHubID(input string) (*HubId, error) {
 	id := HubId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WebPubSubName, ok = parsed.Parsed["webPubSubName"]; !ok {
-		return nil, fmt.Errorf("the segment 'webPubSubName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "webPubSubName", *parsed)
 	}
 
 	if id.HubName, ok = parsed.Parsed["hubName"]; !ok {
-		return nil, fmt.Errorf("the segment 'hubName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "hubName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseHubIDInsensitively(input string) (*HubId, error) {
 	id := HubId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WebPubSubName, ok = parsed.Parsed["webPubSubName"]; !ok {
-		return nil, fmt.Errorf("the segment 'webPubSubName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "webPubSubName", *parsed)
 	}
 
 	if id.HubName, ok = parsed.Parsed["hubName"]; !ok {
-		return nil, fmt.Errorf("the segment 'hubName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "hubName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/webpubsub/2023-02-01/webpubsub/id_location.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/webpubsub/2023-02-01/webpubsub/id_location.go
@@ -38,11 +38,11 @@ func ParseLocationID(input string) (*LocationId, error) {
 	id := LocationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.LocationName, ok = parsed.Parsed["locationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'locationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "locationName", *parsed)
 	}
 
 	return &id, nil
@@ -61,11 +61,11 @@ func ParseLocationIDInsensitively(input string) (*LocationId, error) {
 	id := LocationId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.LocationName, ok = parsed.Parsed["locationName"]; !ok {
-		return nil, fmt.Errorf("the segment 'locationName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "locationName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/webpubsub/2023-02-01/webpubsub/id_privateendpointconnection.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/webpubsub/2023-02-01/webpubsub/id_privateendpointconnection.go
@@ -42,19 +42,19 @@ func ParsePrivateEndpointConnectionID(input string) (*PrivateEndpointConnectionI
 	id := PrivateEndpointConnectionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WebPubSubName, ok = parsed.Parsed["webPubSubName"]; !ok {
-		return nil, fmt.Errorf("the segment 'webPubSubName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "webPubSubName", *parsed)
 	}
 
 	if id.PrivateEndpointConnectionName, ok = parsed.Parsed["privateEndpointConnectionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'privateEndpointConnectionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "privateEndpointConnectionName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParsePrivateEndpointConnectionIDInsensitively(input string) (*PrivateEndpoi
 	id := PrivateEndpointConnectionId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WebPubSubName, ok = parsed.Parsed["webPubSubName"]; !ok {
-		return nil, fmt.Errorf("the segment 'webPubSubName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "webPubSubName", *parsed)
 	}
 
 	if id.PrivateEndpointConnectionName, ok = parsed.Parsed["privateEndpointConnectionName"]; !ok {
-		return nil, fmt.Errorf("the segment 'privateEndpointConnectionName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "privateEndpointConnectionName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/webpubsub/2023-02-01/webpubsub/id_sharedprivatelinkresource.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/webpubsub/2023-02-01/webpubsub/id_sharedprivatelinkresource.go
@@ -42,19 +42,19 @@ func ParseSharedPrivateLinkResourceID(input string) (*SharedPrivateLinkResourceI
 	id := SharedPrivateLinkResourceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WebPubSubName, ok = parsed.Parsed["webPubSubName"]; !ok {
-		return nil, fmt.Errorf("the segment 'webPubSubName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "webPubSubName", *parsed)
 	}
 
 	if id.SharedPrivateLinkResourceName, ok = parsed.Parsed["sharedPrivateLinkResourceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'sharedPrivateLinkResourceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "sharedPrivateLinkResourceName", *parsed)
 	}
 
 	return &id, nil
@@ -73,19 +73,19 @@ func ParseSharedPrivateLinkResourceIDInsensitively(input string) (*SharedPrivate
 	id := SharedPrivateLinkResourceId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WebPubSubName, ok = parsed.Parsed["webPubSubName"]; !ok {
-		return nil, fmt.Errorf("the segment 'webPubSubName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "webPubSubName", *parsed)
 	}
 
 	if id.SharedPrivateLinkResourceName, ok = parsed.Parsed["sharedPrivateLinkResourceName"]; !ok {
-		return nil, fmt.Errorf("the segment 'sharedPrivateLinkResourceName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "sharedPrivateLinkResourceName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/webpubsub/2023-02-01/webpubsub/id_webpubsub.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/webpubsub/2023-02-01/webpubsub/id_webpubsub.go
@@ -40,15 +40,15 @@ func ParseWebPubSubID(input string) (*WebPubSubId, error) {
 	id := WebPubSubId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WebPubSubName, ok = parsed.Parsed["webPubSubName"]; !ok {
-		return nil, fmt.Errorf("the segment 'webPubSubName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "webPubSubName", *parsed)
 	}
 
 	return &id, nil
@@ -67,15 +67,15 @@ func ParseWebPubSubIDInsensitively(input string) (*WebPubSubId, error) {
 	id := WebPubSubId{}
 
 	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
-		return nil, fmt.Errorf("the segment 'subscriptionId' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
 	}
 
 	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
-		return nil, fmt.Errorf("the segment 'resourceGroupName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
 	}
 
 	if id.WebPubSubName, ok = parsed.Parsed["webPubSubName"]; !ok {
-		return nil, fmt.Errorf("the segment 'webPubSubName' was not found in the resource id %q", input)
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "webPubSubName", *parsed)
 	}
 
 	return &id, nil

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -139,7 +139,7 @@ github.com/hashicorp/go-azure-helpers/resourcemanager/tags
 github.com/hashicorp/go-azure-helpers/resourcemanager/zones
 github.com/hashicorp/go-azure-helpers/sender
 github.com/hashicorp/go-azure-helpers/storage
-# github.com/hashicorp/go-azure-sdk v0.20230510.1131358
+# github.com/hashicorp/go-azure-sdk v0.20230511.1094507
 ## explicit; go 1.19
 github.com/hashicorp/go-azure-sdk/resource-manager/aad/2021-05-01/domainservices
 github.com/hashicorp/go-azure-sdk/resource-manager/aadb2c/2021-04-01-preview


### PR DESCRIPTION
This PR updates the generated Resource ID parsers to include the updated errors when segments don't match, as seen in #21725