### PR TITLE
`azurerm_kubernetes_cluster` - `maintenance_window_*` added

### DIFF
--- a/internal/services/containers/kubernetes_cluster_other_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_other_resource_test.go
@@ -2254,12 +2254,12 @@ resource "azurerm_kubernetes_cluster" "test" {
     start_date  = "2023-11-26"
 
     not_allowed {
-      end   = "2023-11-30"
-      start = "2023-11-26"
+      end   = "2023-11-30T00:00:00Z"
+      start = "2023-11-26T00:00:00Z"
     }
     not_allowed {
-      end   = "2023-12-30"
-      start = "2023-12-26"
+      end   = "2023-12-30T00:00:00Z"
+      start = "2023-12-26T00:00:00Z"
     }
   }
 }

--- a/internal/services/containers/kubernetes_cluster_other_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_other_resource_test.go
@@ -2251,7 +2251,7 @@ resource "azurerm_kubernetes_cluster" "test" {
     week_index  = "First"
     start_time  = "07:00"
     utc_offset  = "+01:00"
-    start_date  = "2023-11-26"
+    start_date  = "2023-11-26T00:00:00Z"
 
     not_allowed {
       end   = "2023-11-30T00:00:00Z"
@@ -2304,8 +2304,16 @@ resource "azurerm_kubernetes_cluster" "test" {
       hours = [1, 2]
     }
     allowed {
-      day   = "Sunday"
+      day   = "Thursday"
       hours = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23]
+    }
+    allowed {
+      day   = "Friday"
+      hours = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23]
+    }
+    allowed {
+      day   = "Saterday"
+      hours = [10, 11, 12, 13, 14, 15, 16]
     }
   }
 }
@@ -2344,15 +2352,15 @@ resource "azurerm_kubernetes_cluster" "test" {
     day_of_month = 5
     start_time   = "07:00"
     utc_offset   = "+01:00"
-    start_date   = "2023-11-26"
+    start_date   = "2023-11-26T00:00:00Z"
 
     not_allowed {
-      end   = "2023-11-30"
-      start = "2023-11-26"
+      end   = "2023-11-30T00:00:00Z"
+      start = "2023-11-26T00:00:00Z"
     }
     not_allowed {
-      end   = "2023-12-30"
-      start = "2023-12-26"
+      end   = "2023-12-30T00:00:00Z"
+      start = "2023-12-26T00:00:00Z"
     }
   }
 }

--- a/internal/services/containers/kubernetes_cluster_other_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_other_resource_test.go
@@ -2312,7 +2312,7 @@ resource "azurerm_kubernetes_cluster" "test" {
       hours = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23]
     }
     allowed {
-      day   = "Saterday"
+      day   = "Saturday"
       hours = [10, 11, 12, 13, 14, 15, 16]
     }
   }
@@ -2346,7 +2346,7 @@ resource "azurerm_kubernetes_cluster" "test" {
   }
   maintenance_window_node_os {
     frequency = "AbsoluteMonthly"
-    interval  = 2
+    interval  = 1
     duration  = 9
 
     day_of_month = 5

--- a/internal/services/containers/kubernetes_cluster_other_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_other_resource_test.go
@@ -2022,9 +2022,9 @@ resource "azurerm_kubernetes_cluster" "test" {
   maintenance_window_auto_upgrade {
     frequency   = "Weekly"
     interval    = 1
-		day_of_week = "Monday"
-		start_time  = "07:00"
-		utc_offset  = "+01:00"
+    day_of_week = "Monday"
+    start_time  = "07:00"
+    utc_offset  = "+01:00"
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)

--- a/internal/services/containers/kubernetes_cluster_other_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_other_resource_test.go
@@ -2020,10 +2020,11 @@ resource "azurerm_kubernetes_cluster" "test" {
     type = "SystemAssigned"
   }
   maintenance_window_auto_upgrade {
-    allowed {
-      day   = "Monday"
-      hours = [1, 2]
-    }
+    frequency   = "Weekly"
+    interval    = 1
+		day_of_week = "Monday"
+		start_time  = "07:00"
+		utc_offset  = "+01:00"
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -2406,34 +2406,54 @@ func resourceKubernetesClusterUpdate(d *pluginsdk.ResourceData, meta interface{}
 
 	if d.HasChange("maintenance_window") {
 		client := meta.(*clients.Client).Containers.MaintenanceConfigurationsClient
-		parameters := maintenanceconfigurations.MaintenanceConfiguration{
-			Properties: expandKubernetesClusterMaintenanceConfigurationDefault(d.Get("maintenance_window").([]interface{})),
-		}
+		maintenanceWindowProperties := expandKubernetesClusterMaintenanceConfigurationDefault(d.Get("maintenance_window").([]interface{}))
 		maintenanceId := maintenanceconfigurations.NewMaintenanceConfigurationID(id.SubscriptionId, id.ResourceGroupName, id.ManagedClusterName, "default")
-		if _, err := client.CreateOrUpdate(ctx, maintenanceId, parameters); err != nil {
-			return fmt.Errorf("creating/updating Maintenance Configuration for Managed Kubernetes Cluster (%q): %+v", id, err)
+		if maintenanceWindowProperties != nil {
+			parameters := maintenanceconfigurations.MaintenanceConfiguration{
+				Properties: maintenanceWindowProperties,
+			}
+			if _, err := client.CreateOrUpdate(ctx, maintenanceId, parameters); err != nil {
+				return fmt.Errorf("creating/updating Maintenance Configuration for Managed Kubernetes Cluster (%q): %+v", id, err)
+			}
+		} else {
+			if _, err := client.Delete(ctx, maintenanceId); err != nil {
+				return fmt.Errorf("deleting Maintenance Configuration for Managed Kubernetes Cluster (%q): %+v", id, err)
+			}
 		}
 	}
 
 	if d.HasChange("maintenance_window_auto_upgrade") {
 		client := meta.(*clients.Client).Containers.MaintenanceConfigurationsClient
-		parameters := maintenanceconfigurations.MaintenanceConfiguration{
-			Properties: expandKubernetesClusterMaintenanceConfiguration(d.Get("maintenance_window_auto_upgrade").([]interface{})),
-		}
+		maintenanceWindowProperties := expandKubernetesClusterMaintenanceConfiguration(d.Get("maintenance_window_auto_upgrade").([]interface{}))
 		maintenanceId := maintenanceconfigurations.NewMaintenanceConfigurationID(id.SubscriptionId, id.ResourceGroupName, id.ManagedClusterName, "aksManagedAutoUpgradeSchedule")
-		if _, err := client.CreateOrUpdate(ctx, maintenanceId, parameters); err != nil {
-			return fmt.Errorf("creating/updating aksManagedAutoUpgradeSchedule Maintenance Configuration for Managed Kubernetes Cluster (%q): %+v", id, err)
+		if maintenanceWindowProperties != nil {
+			parameters := maintenanceconfigurations.MaintenanceConfiguration{
+				Properties: maintenanceWindowProperties,
+			}
+			if _, err := client.CreateOrUpdate(ctx, maintenanceId, parameters); err != nil {
+				return fmt.Errorf("creating/updating aksManagedAutoUpgradeSchedule Maintenance Configuration for Managed Kubernetes Cluster (%q): %+v", id, err)
+			}
+		} else {
+			if _, err := client.Delete(ctx, maintenanceId); err != nil {
+				return fmt.Errorf("deleting aksManagedAutoUpgradeSchedule Maintenance Configuration for Managed Kubernetes Cluster (%q): %+v", id, err)
+			}
 		}
 	}
 
 	if d.HasChange("maintenance_window_node_os") {
 		client := meta.(*clients.Client).Containers.MaintenanceConfigurationsClient
-		parameters := maintenanceconfigurations.MaintenanceConfiguration{
-			Properties: expandKubernetesClusterMaintenanceConfiguration(d.Get("maintenance_window_auto_upgrade").([]interface{})),
-		}
 		maintenanceId := maintenanceconfigurations.NewMaintenanceConfigurationID(id.SubscriptionId, id.ResourceGroupName, id.ManagedClusterName, "aksManagedNodeOSUpgradeSchedule")
+		maintenanceWindowProperties := expandKubernetesClusterMaintenanceConfiguration(d.Get("maintenance_window_node_os").([]interface{}))
+		if maintenanceWindowProperties != nil {
+			parameters := maintenanceconfigurations.MaintenanceConfiguration{
+			Properties: maintenanceWindowProperties,
+		}
 		if _, err := client.CreateOrUpdate(ctx, maintenanceId, parameters); err != nil {
 			return fmt.Errorf("creating/updating aksManagedNodeOSUpgradeSchedule Maintenance Configuration for Managed Kubernetes Cluster (%q): %+v", id, err)
+		}
+	} else {
+		if _, err := client.Delete(ctx, maintenanceId); err != nil {
+			return fmt.Errorf("deleting aksManagedNodeOSUpgradeSchedule Maintenance Configuration for Managed Kubernetes Cluster (%q): %+v", id, err)
 		}
 	}
 

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -3986,6 +3986,11 @@ func flattenKubernetesClusterMaintenanceConfigurationSchedule(input maintenancec
 	if input.Daily != nil {
 		frequency = "Daily"
 		interval = input.Daily.IntervalDays
+
+		return map[string]interface{}{
+			"frequency": frequency,
+			"interval":  interval,
+		}
 	}
 
 	dayOfWeek := ""
@@ -3993,6 +3998,12 @@ func flattenKubernetesClusterMaintenanceConfigurationSchedule(input maintenancec
 		frequency = "Weekly"
 		interval = input.Weekly.IntervalWeeks
 		dayOfWeek = string(input.Weekly.DayOfWeek)
+
+		return map[string]interface{}{
+			"frequency":   frequency,
+			"interval":    interval,
+			"day_of_week": dayOfWeek,
+		}
 	}
 
 	dayOfMonth := int64(0)
@@ -4000,6 +4011,12 @@ func flattenKubernetesClusterMaintenanceConfigurationSchedule(input maintenancec
 		frequency = "AbsoluteMonthly"
 		interval = input.AbsoluteMonthly.IntervalMonths
 		dayOfMonth = input.AbsoluteMonthly.DayOfMonth
+
+		return map[string]interface{}{
+			"frequency":    frequency,
+			"interval":     interval,
+			"day_of_month": dayOfMonth,
+		}
 	}
 
 	weekIndex := ""
@@ -4008,15 +4025,16 @@ func flattenKubernetesClusterMaintenanceConfigurationSchedule(input maintenancec
 		interval = input.RelativeMonthly.IntervalMonths
 		dayOfWeek = string(input.RelativeMonthly.DayOfWeek)
 		weekIndex = string(input.RelativeMonthly.WeekIndex)
+
+		return map[string]interface{}{
+			"frequency":   frequency,
+			"interval":    interval,
+			"day_of_week": dayOfWeek,
+			"week_index":  weekIndex,
+		}
 	}
 
-	return map[string]interface{}{
-		"frequency":    frequency,
-		"day_of_week":  dayOfWeek,
-		"week_index":   weekIndex,
-		"interval":     interval,
-		"day_of_month": dayOfMonth,
-	}
+	return map[string]interface{}{}
 }
 
 func flattenKubernetesClusterMaintenanceConfigurationDefault(input *maintenanceconfigurations.MaintenanceConfigurationProperties) interface{} {

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -756,18 +756,30 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 						},
 
 						"day_of_week": {
-							Type:     pluginsdk.TypeInt,
+							Type:     pluginsdk.TypeString,
+							Optional: true,
+							ValidateFunc: validation.StringInSlice(
+								maintenanceconfigurations.PossibleValuesForWeekDay(),
+								false),
+						},
+
+						"duration": {
+							Type:     pluginsdk.TypeString,
 							Optional: true,
 						},
 
 						"week_index": {
-							Type:     pluginsdk.TypeInt,
+							Type:     pluginsdk.TypeString,
 							Optional: true,
+							ValidateFunc: validation.StringInSlice(
+								maintenanceconfigurations.PossibleValuesForType(),
+								false),
 						},
 
 						"day_of_month": {
-							Type:     pluginsdk.TypeInt,
-							Optional: true,
+							Type:         pluginsdk.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IntBetween(0, 31),
 						},
 
 						"start_date": {
@@ -786,9 +798,8 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 						},
 
 						"not_allowed": {
-							Type:         pluginsdk.TypeSet,
-							Optional:     true,
-							AtLeastOneOf: []string{"maintenance_window_auto_upgrade.0.allowed", "maintenance_window_auto_upgrade.0.not_allowed"},
+							Type:     pluginsdk.TypeSet,
+							Optional: true,
 							Elem: &pluginsdk.Resource{
 								Schema: map[string]*pluginsdk.Schema{
 									"end": {
@@ -834,18 +845,30 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 						},
 
 						"day_of_week": {
-							Type:     pluginsdk.TypeInt,
+							Type:     pluginsdk.TypeString,
+							Optional: true,
+							ValidateFunc: validation.StringInSlice(
+								maintenanceconfigurations.PossibleValuesForWeekDay(),
+								false),
+						},
+
+						"duration": {
+							Type:     pluginsdk.TypeString,
 							Optional: true,
 						},
 
 						"week_index": {
-							Type:     pluginsdk.TypeInt,
+							Type:     pluginsdk.TypeString,
 							Optional: true,
+							ValidateFunc: validation.StringInSlice(
+								maintenanceconfigurations.PossibleValuesForType(),
+								false),
 						},
 
 						"day_of_month": {
-							Type:     pluginsdk.TypeInt,
-							Optional: true,
+							Type:         pluginsdk.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IntBetween(0, 31),
 						},
 
 						"start_date": {
@@ -864,9 +887,8 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 						},
 
 						"not_allowed": {
-							Type:         pluginsdk.TypeSet,
-							Optional:     true,
-							AtLeastOneOf: []string{"maintenance_window_auto_upgrade.0.allowed", "maintenance_window_auto_upgrade.0.not_allowed"},
+							Type:     pluginsdk.TypeSet,
+							Optional: true,
 							Elem: &pluginsdk.Resource{
 								Schema: map[string]*pluginsdk.Schema{
 									"end": {

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -1787,7 +1787,7 @@ func resourceKubernetesClusterCreate(d *pluginsdk.ResourceData, meta interface{}
 	if maintenanceConfigRaw, ok := d.GetOk("maintenance_window_node_os"); ok {
 		client := meta.(*clients.Client).Containers.MaintenanceConfigurationsClient
 		parameters := maintenanceconfigurations.MaintenanceConfiguration{
-			Properties: expandKubernetesClusterMaintenanceConfigurationDefault(maintenanceConfigRaw.([]interface{})),
+			Properties: expandKubernetesClusterMaintenanceConfiguration(maintenanceConfigRaw.([]interface{})),
 		}
 		maintenanceId := maintenanceconfigurations.NewMaintenanceConfigurationID(id.SubscriptionId, id.ResourceGroupName, id.ManagedClusterName, "aksManagedNodeOSUpgradeSchedule")
 		if _, err := client.CreateOrUpdate(ctx, maintenanceId, parameters); err != nil {

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -765,7 +765,7 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 
 						"duration": {
 							Type:         pluginsdk.TypeInt,
-							Optional:     true,
+							Required:     true,
 							ValidateFunc: validation.IntBetween(4, 24),
 						},
 
@@ -855,7 +855,7 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 
 						"duration": {
 							Type:         pluginsdk.TypeInt,
-							Optional:     true,
+							Required:     true,
 							ValidateFunc: validation.IntBetween(4, 24),
 						},
 

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -2446,14 +2446,15 @@ func resourceKubernetesClusterUpdate(d *pluginsdk.ResourceData, meta interface{}
 		maintenanceWindowProperties := expandKubernetesClusterMaintenanceConfiguration(d.Get("maintenance_window_node_os").([]interface{}))
 		if maintenanceWindowProperties != nil {
 			parameters := maintenanceconfigurations.MaintenanceConfiguration{
-			Properties: maintenanceWindowProperties,
-		}
-		if _, err := client.CreateOrUpdate(ctx, maintenanceId, parameters); err != nil {
-			return fmt.Errorf("creating/updating aksManagedNodeOSUpgradeSchedule Maintenance Configuration for Managed Kubernetes Cluster (%q): %+v", id, err)
-		}
-	} else {
-		if _, err := client.Delete(ctx, maintenanceId); err != nil {
-			return fmt.Errorf("deleting aksManagedNodeOSUpgradeSchedule Maintenance Configuration for Managed Kubernetes Cluster (%q): %+v", id, err)
+				Properties: maintenanceWindowProperties,
+			}
+			if _, err := client.CreateOrUpdate(ctx, maintenanceId, parameters); err != nil {
+				return fmt.Errorf("creating/updating aksManagedNodeOSUpgradeSchedule Maintenance Configuration for Managed Kubernetes Cluster (%q): %+v", id, err)
+			}
+		} else {
+			if _, err := client.Delete(ctx, maintenanceId); err != nil {
+				return fmt.Errorf("deleting aksManagedNodeOSUpgradeSchedule Maintenance Configuration for Managed Kubernetes Cluster (%q): %+v", id, err)
+			}
 		}
 	}
 

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -786,6 +786,7 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 						"start_date": {
 							Type:     pluginsdk.TypeString,
 							Optional: true,
+							Computed: true,
 						},
 
 						"start_time": {
@@ -876,6 +877,7 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 						"start_date": {
 							Type:     pluginsdk.TypeString,
 							Optional: true,
+							Computed: true,
 						},
 
 						"start_time": {

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -1776,7 +1776,7 @@ func resourceKubernetesClusterCreate(d *pluginsdk.ResourceData, meta interface{}
 	if maintenanceConfigRaw, ok := d.GetOk("maintenance_window_auto_upgrade"); ok {
 		client := meta.(*clients.Client).Containers.MaintenanceConfigurationsClient
 		parameters := maintenanceconfigurations.MaintenanceConfiguration{
-			Properties: expandKubernetesClusterMaintenanceConfigurationDefault(maintenanceConfigRaw.([]interface{})),
+			Properties: expandKubernetesClusterMaintenanceConfiguration(maintenanceConfigRaw.([]interface{})),
 		}
 		maintenanceId := maintenanceconfigurations.NewMaintenanceConfigurationID(id.SubscriptionId, id.ResourceGroupName, id.ManagedClusterName, "aksManagedAutoUpgradeSchedule")
 		if _, err := client.CreateOrUpdate(ctx, maintenanceId, parameters); err != nil {

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -853,7 +853,7 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 						},
 
 						"duration": {
-							Type:     pluginsdk.TypeString,
+							Type:     pluginsdk.TypeInt,
 							Optional: true,
 						},
 

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -764,7 +764,7 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 						},
 
 						"duration": {
-							Type:     pluginsdk.TypeString,
+							Type:     pluginsdk.TypeInt,
 							Optional: true,
 						},
 

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -2416,7 +2416,7 @@ func resourceKubernetesClusterUpdate(d *pluginsdk.ResourceData, meta interface{}
 	if d.HasChange("maintenance_window_auto_upgrade") {
 		client := meta.(*clients.Client).Containers.MaintenanceConfigurationsClient
 		parameters := maintenanceconfigurations.MaintenanceConfiguration{
-			Properties: expandKubernetesClusterMaintenanceConfiguration(d.Get("maintenance_window").([]interface{})),
+			Properties: expandKubernetesClusterMaintenanceConfiguration(d.Get("maintenance_window_auto_upgrade").([]interface{})),
 		}
 		maintenanceId := maintenanceconfigurations.NewMaintenanceConfigurationID(id.SubscriptionId, id.ResourceGroupName, id.ManagedClusterName, "aksManagedAutoUpgradeSchedule")
 		if _, err := client.CreateOrUpdate(ctx, maintenanceId, parameters); err != nil {
@@ -2427,7 +2427,7 @@ func resourceKubernetesClusterUpdate(d *pluginsdk.ResourceData, meta interface{}
 	if d.HasChange("maintenance_window_node_os") {
 		client := meta.(*clients.Client).Containers.MaintenanceConfigurationsClient
 		parameters := maintenanceconfigurations.MaintenanceConfiguration{
-			Properties: expandKubernetesClusterMaintenanceConfiguration(d.Get("maintenance_window").([]interface{})),
+			Properties: expandKubernetesClusterMaintenanceConfiguration(d.Get("maintenance_window_auto_upgrade").([]interface{})),
 		}
 		maintenanceId := maintenanceconfigurations.NewMaintenanceConfigurationID(id.SubscriptionId, id.ResourceGroupName, id.ManagedClusterName, "aksManagedNodeOSUpgradeSchedule")
 		if _, err := client.CreateOrUpdate(ctx, maintenanceId, parameters); err != nil {

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -1786,7 +1786,7 @@ func resourceKubernetesClusterCreate(d *pluginsdk.ResourceData, meta interface{}
 		}
 		maintenanceId := maintenanceconfigurations.NewMaintenanceConfigurationID(id.SubscriptionId, id.ResourceGroupName, id.ManagedClusterName, "aksManagedAutoUpgradeSchedule")
 		if _, err := client.CreateOrUpdate(ctx, maintenanceId, parameters); err != nil {
-			return fmt.Errorf("creating/updating aksManagedAutoUpgradeSchedule maintenance config for %s: %+v", id, err)
+			return fmt.Errorf("creating/updating auto upgrade schedule maintenance config for %s: %+v", id, err)
 		}
 	}
 
@@ -1797,7 +1797,7 @@ func resourceKubernetesClusterCreate(d *pluginsdk.ResourceData, meta interface{}
 		}
 		maintenanceId := maintenanceconfigurations.NewMaintenanceConfigurationID(id.SubscriptionId, id.ResourceGroupName, id.ManagedClusterName, "aksManagedNodeOSUpgradeSchedule")
 		if _, err := client.CreateOrUpdate(ctx, maintenanceId, parameters); err != nil {
-			return fmt.Errorf("creating/updating aksManagedNodeOSUpgradeSchedule maintenance config for %s: %+v", id, err)
+			return fmt.Errorf("creating/updating node os upgrade schedule maintenance config for %s: %+v", id, err)
 		}
 	}
 
@@ -2417,7 +2417,7 @@ func resourceKubernetesClusterUpdate(d *pluginsdk.ResourceData, meta interface{}
 			}
 		} else {
 			if _, err := client.Delete(ctx, maintenanceId); err != nil {
-				return fmt.Errorf("deleting Maintenance Configuration for Managed Kubernetes Cluster (%q): %+v", id, err)
+				return fmt.Errorf("deleting Maintenance Configuration for %s: %+v", id, err)
 			}
 		}
 	}
@@ -2431,11 +2431,11 @@ func resourceKubernetesClusterUpdate(d *pluginsdk.ResourceData, meta interface{}
 				Properties: maintenanceWindowProperties,
 			}
 			if _, err := client.CreateOrUpdate(ctx, maintenanceId, parameters); err != nil {
-				return fmt.Errorf("creating/updating aksManagedAutoUpgradeSchedule Maintenance Configuration for Managed Kubernetes Cluster (%q): %+v", id, err)
+				return fmt.Errorf("creating/updating Auto Upgrade Schedule Maintenance Configuration for %s: %+v", id, err)
 			}
 		} else {
 			if _, err := client.Delete(ctx, maintenanceId); err != nil {
-				return fmt.Errorf("deleting aksManagedAutoUpgradeSchedule Maintenance Configuration for Managed Kubernetes Cluster (%q): %+v", id, err)
+				return fmt.Errorf("deleting Auto Upgrade Schedule Maintenance Configuration for %s: %+v", id, err)
 			}
 		}
 	}
@@ -2449,11 +2449,11 @@ func resourceKubernetesClusterUpdate(d *pluginsdk.ResourceData, meta interface{}
 				Properties: maintenanceWindowProperties,
 			}
 			if _, err := client.CreateOrUpdate(ctx, maintenanceId, parameters); err != nil {
-				return fmt.Errorf("creating/updating aksManagedNodeOSUpgradeSchedule Maintenance Configuration for Managed Kubernetes Cluster (%q): %+v", id, err)
+				return fmt.Errorf("creating/updating Node OS Upgrade Schedule Maintenance Configuration for %s: %+v", id, err)
 			}
 		} else {
 			if _, err := client.Delete(ctx, maintenanceId); err != nil {
-				return fmt.Errorf("deleting aksManagedNodeOSUpgradeSchedule Maintenance Configuration for Managed Kubernetes Cluster (%q): %+v", id, err)
+				return fmt.Errorf("deleting Node OS Upgrade Schedule Maintenance Configuration for %s: %+v", id, err)
 			}
 		}
 	}

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -764,8 +764,9 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 						},
 
 						"duration": {
-							Type:     pluginsdk.TypeInt,
-							Optional: true,
+							Type:         pluginsdk.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IntBetween(4, 24),
 						},
 
 						"week_index": {
@@ -853,8 +854,9 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 						},
 
 						"duration": {
-							Type:     pluginsdk.TypeInt,
-							Optional: true,
+							Type:         pluginsdk.TypeInt,
+							Optional:     true,
+							ValidateFunc: validation.IntBetween(4, 24),
 						},
 
 						"week_index": {
@@ -3906,7 +3908,7 @@ func expandKubernetesClusterMaintenanceConfiguration(input []interface{}) *maint
 		},
 	}
 
-	if duration := value["duration"]; duration != nil {
+	if duration := value["duration"]; duration != nil && duration.(int) != 0 {
 		output.MaintenanceWindow.DurationHours = int64(duration.(int))
 	}
 

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -3972,17 +3972,22 @@ func flattenKubernetesClusterMaintenanceConfiguration(input *maintenanceconfigur
 		utcOfset = *input.UtcOffset
 	}
 
-	results = append(results, map[string]interface{}{
+	windowResults := map[string]interface{}{
 		"not_allowed": flattenKubernetesClusterMaintenanceConfigurationDateSpans(input.NotAllowedDates),
 		"duration":    int(input.DurationHours),
 		"start_date":  startDate,
 		"start_time":  input.StartTime,
 		"utc_offset":  utcOfset,
-	}, flattenKubernetesClusterMaintenanceConfigurationSchedule(input.Schedule))
-	return results
+	}
+
+	for k, v := range flattenKubernetesClusterMaintenanceConfigurationSchedule(input.Schedule) {
+		windowResults[k] = v
+	}
+
+	return append(results, windowResults)
 }
 
-func flattenKubernetesClusterMaintenanceConfigurationSchedule(input maintenanceconfigurations.Schedule) interface{} {
+func flattenKubernetesClusterMaintenanceConfigurationSchedule(input maintenanceconfigurations.Schedule) map[string]interface{} {
 	frequency := ""
 	interval := int64(0)
 	if input.Daily != nil {

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -3999,19 +3999,19 @@ func flattenKubernetesClusterMaintenanceConfiguration(input *maintenanceconfigur
 		utcOfset = *input.UtcOffset
 	}
 
-	windowResults := map[string]interface{}{
+	windowProperties := map[string]interface{}{
 		"not_allowed": flattenKubernetesClusterMaintenanceConfigurationDateSpans(input.NotAllowedDates),
 		"duration":    int(input.DurationHours),
 		"start_date":  startDate,
 		"start_time":  input.StartTime,
 		"utc_offset":  utcOfset,
 	}
-
+	// Add flattened schedule properties
 	for k, v := range flattenKubernetesClusterMaintenanceConfigurationSchedule(input.Schedule) {
-		windowResults[k] = v
+		windowProperties[k] = v
 	}
 
-	return append(results, windowResults)
+	return append(results, windowProperties)
 }
 
 func flattenKubernetesClusterMaintenanceConfigurationSchedule(input maintenanceconfigurations.Schedule) map[string]interface{} {

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -3974,7 +3974,7 @@ func flattenKubernetesClusterMaintenanceConfiguration(input *maintenanceconfigur
 
 	results = append(results, map[string]interface{}{
 		"not_allowed": flattenKubernetesClusterMaintenanceConfigurationDateSpans(input.NotAllowedDates),
-		"duration":    input.DurationHours,
+		"duration":    int(input.DurationHours),
 		"start_date":  startDate,
 		"start_time":  input.StartTime,
 		"utc_offset":  utcOfset,
@@ -3988,11 +3988,6 @@ func flattenKubernetesClusterMaintenanceConfigurationSchedule(input maintenancec
 	if input.Daily != nil {
 		frequency = "Daily"
 		interval = input.Daily.IntervalDays
-
-		return map[string]interface{}{
-			"frequency": frequency,
-			"interval":  interval,
-		}
 	}
 
 	dayOfWeek := ""
@@ -4000,25 +3995,13 @@ func flattenKubernetesClusterMaintenanceConfigurationSchedule(input maintenancec
 		frequency = "Weekly"
 		interval = input.Weekly.IntervalWeeks
 		dayOfWeek = string(input.Weekly.DayOfWeek)
-
-		return map[string]interface{}{
-			"frequency":   frequency,
-			"interval":    interval,
-			"day_of_week": dayOfWeek,
-		}
 	}
 
-	dayOfMonth := int64(0)
+	dayOfMonth := 0
 	if input.AbsoluteMonthly != nil {
 		frequency = "AbsoluteMonthly"
 		interval = input.AbsoluteMonthly.IntervalMonths
-		dayOfMonth = input.AbsoluteMonthly.DayOfMonth
-
-		return map[string]interface{}{
-			"frequency":    frequency,
-			"interval":     interval,
-			"day_of_month": dayOfMonth,
-		}
+		dayOfMonth = int(input.AbsoluteMonthly.DayOfMonth)
 	}
 
 	weekIndex := ""
@@ -4027,16 +4010,15 @@ func flattenKubernetesClusterMaintenanceConfigurationSchedule(input maintenancec
 		interval = input.RelativeMonthly.IntervalMonths
 		dayOfWeek = string(input.RelativeMonthly.DayOfWeek)
 		weekIndex = string(input.RelativeMonthly.WeekIndex)
-
-		return map[string]interface{}{
-			"frequency":   frequency,
-			"interval":    interval,
-			"day_of_week": dayOfWeek,
-			"week_index":  weekIndex,
-		}
 	}
 
-	return map[string]interface{}{}
+	return map[string]interface{}{
+		"frequency":    frequency,
+		"interval":     interval,
+		"day_of_week":  dayOfWeek,
+		"week_index":   weekIndex,
+		"day_of_month": dayOfMonth,
+	}
 }
 
 func flattenKubernetesClusterMaintenanceConfigurationDefault(input *maintenanceconfigurations.MaintenanceConfigurationProperties) interface{} {

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -745,7 +745,7 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 							Required: true,
 							ValidateFunc: validation.StringInSlice([]string{
 								"Weekly",
-								"Monthly",
+								"RelativeMonthly",
 								"AbsoluteMonthly",
 							}, false),
 						},
@@ -822,7 +822,7 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 							Required: true,
 							ValidateFunc: validation.StringInSlice([]string{
 								"Weekly",
-								"Monthly",
+								"RelativeMonthly",
 								"AbsoluteMonthly",
 								"Daily",
 							}, false),

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -141,6 +141,10 @@ In addition, one of either `identity` or `service_principal` blocks must be spec
 
 * `maintenance_window` - (Optional) A `maintenance_window` block as defined below.
 
+* `maintenance_window_auto_upgrade` - (Optional) A `maintenance_window_auto_upgrade` block as defined below.
+
+* `maintenance_window_node_os` - (Optional) A `maintenance_window_node_os` block as defined below.
+
 * `microsoft_defender` - (Optional) A `microsoft_defender` block as defined below.
 
 * `monitor_metrics` - (Optional) Specifies a Prometheus add-on profile for the Kubernetes Cluster. A `monitor_metrics` block as defined below.
@@ -567,6 +571,51 @@ A `linux_profile` block supports the following:
 A `maintenance_window` block supports the following:
 
 * `allowed` - (Optional) One or more `allowed` blocks as defined below.
+
+* `not_allowed` - (Optional) One or more `not_allowed` block as defined below.
+
+---
+
+A `maintenance_window_auto_upgrade` block supports the following:
+
+* `frequency` - (Required) Frequency of maintenance. Possible options are `Weekly`, `AbsoluteMonthly` and `RelativeMonthly`.
+
+* `interval` - (Required) The interval for maintenance runs. Depending on the frequency this interval is week or month based.
+
+* `duration` - (Required) The duration of the window for maintenance to run in hours.
+
+* `day_of_week` - (Optional) The day of the week for the maintenance run. Options are `Monday`, `Tuesday`, `Wednesday`, `Thurday`, `Friday`, `Saterday` and `Sunday`. Required in combination with weekly frequency.
+
+* `week_index` - (Optional) The week in the month used for the maintenance run. Options are `First`, `Second`, `Third`, `Fourth`, and `Last`.
+ Required in combination with relative monthly frequency.
+
+* `start_time` - (Optional) The time for maintenance to begin, based on the timezone determined by `utc_offset`. Format is `HH:mm`.
+
+* `utc_offset` - (Optional) Used to determine the timezone for cluster maintenance.
+
+* `start_date` - (Optional) The date on which the maintenance window begins to take effect. 
+
+* `not_allowed` - (Optional) One or more `not_allowed` block as defined below.
+
+---
+
+A `maintenance_window_node_os` block supports the following:
+
+* `frequency` - (Required) Frequency of maintenance. Possible options are `Daily`, `Weekly`, `AbsoluteMonthly` and `RelativeMonthly`.
+
+* `interval` - (Required) The interval for maintenance runs. Depending on the frequency this interval is week or month based.
+
+* `duration` - (Required) The duration of the window for maintenance to run in hours.
+
+* `day_of_week` - (Optional) The day of the week for the maintenance run. Options are `Monday`, `Tuesday`, `Wednesday`, `Thurday`, `Friday`, `Saterday` and `Sunday`. Required in combination with weekly frequency.
+
+* `week_index` - (Optional) The week in the month used for the maintenance run. Options are `First`, `Second`, `Third`, `Fourth`, and `Last`.
+
+* `start_time` - (Optional) The time for maintenance to begin, based on the timezone determined by `utc_offset`. Format is `HH:mm`.
+
+* `utc_offset` - (Optional) Used to determine the timezone for cluster maintenance.
+
+* `start_date` - (Optional) The date on which the maintenance window begins to take effect. 
 
 * `not_allowed` - (Optional) One or more `not_allowed` block as defined below.
 

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -584,7 +584,7 @@ A `maintenance_window_auto_upgrade` block supports the following:
 
 * `duration` - (Required) The duration of the window for maintenance to run in hours.
 
-* `day_of_week` - (Optional) The day of the week for the maintenance run. Options are `Monday`, `Tuesday`, `Wednesday`, `Thurday`, `Friday`, `Saterday` and `Sunday`. Required in combination with weekly frequency.
+* `day_of_week` - (Optional) The day of the week for the maintenance run. Options are `Monday`, `Tuesday`, `Wednesday`, `Thurday`, `Friday`, `Saturday` and `Sunday`. Required in combination with weekly frequency.
 
 * `week_index` - (Optional) The week in the month used for the maintenance run. Options are `First`, `Second`, `Third`, `Fourth`, and `Last`.
  Required in combination with relative monthly frequency.
@@ -607,7 +607,7 @@ A `maintenance_window_node_os` block supports the following:
 
 * `duration` - (Required) The duration of the window for maintenance to run in hours.
 
-* `day_of_week` - (Optional) The day of the week for the maintenance run. Options are `Monday`, `Tuesday`, `Wednesday`, `Thurday`, `Friday`, `Saterday` and `Sunday`. Required in combination with weekly frequency.
+* `day_of_week` - (Optional) The day of the week for the maintenance run. Options are `Monday`, `Tuesday`, `Wednesday`, `Thurday`, `Friday`, `Saturday` and `Sunday`. Required in combination with weekly frequency.
 
 * `week_index` - (Optional) The week in the month used for the maintenance run. Options are `First`, `Second`, `Third`, `Fourth`, and `Last`.
 


### PR DESCRIPTION
Fixes #21722

## TODO
- [x] (Extra) Acceptance Tests 
- [x] Decide on the `Considerations` (especially 2 and 3)
- [x] Docs

## Considerations

### 1 or multiple blocks:
```hcl
resource "azurerm_kubernetes_cluster" "example" {
  ...
  // option 1:
  maintenance_window {
    type = "default"
    ...
  }
  
  // option 2:
  // default
  maintenance_window {
    ...
  }
  // autoUpgrade
  maintenance_window_auto_upgrade {
    ...
  }
  // nodeOs
  maintenance_window_node_os {
    ...
  }
}
```

The default maintenance window type (the "legacy" type, according to the docs) has a different model compared to the other two types. Supporting these 2 different models in one block type is a bit messy from a user perspective, as we cannot validate it as extensively as when we differentiate (option 2). Option 1 will result in a bit more confusion and questions, option 2 is more clear and directing.

In the new maintenance window type there are multiple frequencies possible (Daily, Weekly, AbsoluteMonthly and RelativeMonthly), which in itself are already adding a lot of parameters and confusion. That adds up to the before mentioned preference for option 2.

This means that I've chosen option 2 for now 🙈

### Frequency schedules as separate blocks vs flat structure

```hcl
resource "azurerm_kubernetes_cluster" "test" {
  ...
  // option 1 (implemented)
  maintenance_window_node_os {
    frequency = "AbsoluteMonthly"
    interval  = 1
    duration  = 9

    day_of_month = 5
    start_time   = "07:00"
    utc_offset   = "+01:00"
    start_date   = "2023-11-26T00:00:00Z"

    not_allowed {
      end   = "2023-11-30T00:00:00Z"
      start = "2023-11-26T00:00:00Z"
    }
  }

  // option 2  (more like `azurerm_monitor_alert_processing_rule_suppression`)
  maintenance_window_node_os {
    // frequency options, only 1 allowed at a time
    daily {
      interval = 1
    }
    weekly {
      interval    = 1
      day_of_week = "Monday"
    }
    relative_monthly {
      interval    = 1    
      day_of_week = "Monday"
      week_index  = "First"
    }
    absolute_monthly {
      interval     = 1
      day_of_month = 5
    }

    duration   = 9
    start_time = "07:00"
    utc_offset = "+01:00"
    start_date = "2023-11-26T00:00:00Z"

    not_allowed {
      end   = "2023-11-30T00:00:00Z"
      start = "2023-11-26T00:00:00Z"
    }
  }
}
```

I'd prefer option 2, as is makes validation better and mimics the API more closely.

### Date, time: what are the standards?
We do have standards for date time, but what to use in case of date and time? I feel like it is a bit mixed across the provider? I've modeled dates now as datetime, but that doesn't sound like a great solution in the long run
