### PR TITLE
Allow for setting client ID / secret through files

### DIFF
--- a/.github/workflows/provider-test.yaml
+++ b/.github/workflows/provider-test.yaml
@@ -53,6 +53,12 @@ jobs:
       - name: Set OIDC Token File Path
         run: echo "${ARM_OIDC_TOKEN}" >"${RUNNER_TEMP}/oidc-token.jwt" && echo "ARM_OIDC_TOKEN_FILE_PATH=${RUNNER_TEMP}/oidc-token.jwt" >>${GITHUB_ENV}
 
+      - name: Set Client ID Path
+        run: echo "${{ secrets.ARM_CLIENT_ID }}" >"${RUNNER_TEMP}/client-id" && echo "ARM_CLIENT_ID_PATH=${RUNNER_TEMP}/client-id" >>${GITHUB_ENV}
+
+      - name: Set Client Secret Path
+        run: echo "${{ secrets.ARM_CLIENT_SECRET }}" >"${RUNNER_TEMP}/client-secret" && echo "ARM_CLIENT_SECRET_PATH=${RUNNER_TEMP}/client-secret" >>${GITHUB_ENV}
+
       - name: Run provider tests
         run: make testacc TEST=./internal/provider TESTARGS="-run '^TestAcc'"
         env:
@@ -65,6 +71,14 @@ jobs:
 
       - name: Clean Up OIDC Token File Path
         run: rm -f "${RUNNER_TEMP}/oidc-token.jwt"
+        if: always()
+
+      - name: Clean Up Client ID Path
+        run: rm -f "${RUNNER_TEMP}/client-id"
+        if: always()
+
+      - name: Clean Up Client Secret Path
+        run: rm -f "${RUNNER_TEMP}/client-secret"
         if: always()
 
       - name: Add waiting-response on fail

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -178,11 +178,11 @@ func azureProvider(supportLegacyTestSuite bool) *schema.Provider {
 				Description: "The Client ID which should be used.",
 			},
 
-			"client_id_path": {
+			"client_id_file_path": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("ARM_CLIENT_ID_PATH", ""),
-				Description: "Path to a file containing the Client ID which should be used.",
+				DefaultFunc: schema.EnvDefaultFunc("ARM_CLIENT_ID_FILE_PATH", ""),
+				Description: "The path to a file containing the Client ID which should be used.",
 			},
 
 			"tenant_id": {
@@ -245,10 +245,10 @@ func azureProvider(supportLegacyTestSuite bool) *schema.Provider {
 				Description: "The Client Secret which should be used. For use When authenticating as a Service Principal using a Client Secret.",
 			},
 
-			"client_secret_path": {
+			"client_secret_file_path": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("ARM_CLIENT_SECRET_PATH", ""),
+				DefaultFunc: schema.EnvDefaultFunc("ARM_CLIENT_SECRET_FILE_PATH", ""),
 				Description: "The path to a file containing the Client Secret which should be used. For use When authenticating as a Service Principal using a Client Secret.",
 			},
 
@@ -392,7 +392,7 @@ func providerConfigure(p *schema.Provider) schema.ConfigureContextFunc {
 			return nil, diag.FromErr(err)
 		}
 
-		clientID, err := getClientID(d)
+		clientId, err := getClientId(d)
 		if err != nil {
 			return nil, diag.FromErr(err)
 		}
@@ -420,7 +420,7 @@ func providerConfigure(p *schema.Provider) schema.ConfigureContextFunc {
 
 		authConfig := &auth.Credentials{
 			Environment:        *env,
-			ClientID:           *clientID,
+			ClientID:           *clientId,
 			TenantID:           d.Get("tenant_id").(string),
 			AuxiliaryTenantIDs: auxTenants,
 
@@ -529,32 +529,32 @@ func getOidcToken(d *schema.ResourceData) (*string, error) {
 	return &idToken, nil
 }
 
-func getClientID(d *schema.ResourceData) (*string, error) {
-	clientID := strings.TrimSpace(d.Get("client_id").(string))
+func getClientId(d *schema.ResourceData) (*string, error) {
+	clientId := strings.TrimSpace(d.Get("client_id").(string))
 
-	if path := d.Get("client_id_path").(string); path != "" {
-		fileClientIDRaw, err := os.ReadFile(path)
+	if path := d.Get("client_id_file_path").(string); path != "" {
+		fileClientIdRaw, err := os.ReadFile(path)
 
 		if err != nil {
-			return nil, fmt.Errorf("reading Client Secret from file %q: %v", path, err)
+			return nil, fmt.Errorf("reading Client ID from file %q: %v", path, err)
 		}
 
-		fileClientID := strings.TrimSpace(string(fileClientIDRaw))
+		fileClientId := strings.TrimSpace(string(fileClientIdRaw))
 
-		if clientID != "" && clientID != fileClientID {
+		if clientId != "" && clientId != fileClientId {
 			return nil, fmt.Errorf("mismatch between supplied Client ID and supplied Client ID file contents - please either remove one or ensure they match")
 		}
 
-		clientID = fileClientID
+		clientId = fileClientId
 	}
 
-	return &clientID, nil
+	return &clientId, nil
 }
 
 func getClientSecret(d *schema.ResourceData) (*string, error) {
 	clientSecret := strings.TrimSpace(d.Get("client_secret").(string))
 
-	if path := d.Get("client_secret_path").(string); path != "" {
+	if path := d.Get("client_secret_file_path").(string); path != "" {
 		fileSecretRaw, err := os.ReadFile(path)
 
 		if err != nil {

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -232,8 +232,8 @@ func TestAccProvider_clientSecretAuth(t *testing.T) {
 
 	// Ensure we are running using the expected env-vars
 	// t.SetEnv does automatic cleanup / resets the values after the test
-	t.Setenv("ARM_CLIENT_ID_PATH", "")
-	t.Setenv("ARM_CLIENT_SECRET_PATH", "")
+	t.Setenv("ARM_CLIENT_ID_FILE_PATH", "")
+	t.Setenv("ARM_CLIENT_SECRET_FILE_PATH", "")
 
 	logging.SetOutput(t)
 
@@ -249,7 +249,7 @@ func TestAccProvider_clientSecretAuth(t *testing.T) {
 			t.Fatalf("configuring environment %q: %v", envName, err)
 		}
 
-		clientID, err := getClientID(d)
+		clientId, err := getClientId(d)
 		if err != nil {
 			return nil, diag.FromErr(err)
 		}
@@ -262,7 +262,7 @@ func TestAccProvider_clientSecretAuth(t *testing.T) {
 		authConfig := &auth.Credentials{
 			Environment:                           *env,
 			TenantID:                              d.Get("tenant_id").(string),
-			ClientID:                              *clientID,
+			ClientID:                              *clientId,
 			EnableAuthenticatingUsingClientSecret: true,
 			ClientSecret:                          *clientSecret,
 		}
@@ -282,15 +282,15 @@ func TestAccProvider_clientSecretAuth(t *testing.T) {
 	}
 }
 
-func TestAccProvider_clientSecretAuth_fileBased(t *testing.T) {
+func TestAccProvider_clientSecretAuthFromFiles(t *testing.T) {
 	if os.Getenv("TF_ACC") == "" {
 		t.Skip("TF_ACC not set")
 	}
-	if os.Getenv("ARM_CLIENT_ID_PATH") == "" {
-		t.Skip("ARM_CLIENT_ID_PATH not set")
+	if os.Getenv("ARM_CLIENT_ID_FILE_PATH") == "" {
+		t.Skip("ARM_CLIENT_ID_FILE_PATH not set")
 	}
-	if os.Getenv("ARM_CLIENT_SECRET_PATH") == "" {
-		t.Skip("ARM_CLIENT_SECRET_PATH not set")
+	if os.Getenv("ARM_CLIENT_SECRET_FILE_PATH") == "" {
+		t.Skip("ARM_CLIENT_SECRET_FILE_PATH not set")
 	}
 
 	// Ensure we are running using the expected env-vars
@@ -312,7 +312,7 @@ func TestAccProvider_clientSecretAuth_fileBased(t *testing.T) {
 			t.Fatalf("configuring environment %q: %v", envName, err)
 		}
 
-		clientID, err := getClientID(d)
+		clientId, err := getClientId(d)
 		if err != nil {
 			return nil, diag.FromErr(err)
 		}
@@ -325,7 +325,7 @@ func TestAccProvider_clientSecretAuth_fileBased(t *testing.T) {
 		authConfig := &auth.Credentials{
 			Environment:                           *env,
 			TenantID:                              d.Get("tenant_id").(string),
-			ClientID:                              *clientID,
+			ClientID:                              *clientId,
 			EnableAuthenticatingUsingClientSecret: true,
 			ClientSecret:                          *clientSecret,
 		}

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -220,6 +220,11 @@ func TestAccProvider_clientCertificateAuth(t *testing.T) {
 }
 
 func TestAccProvider_clientSecretAuth(t *testing.T) {
+	t.Run("fromEnvironment", testAccProvider_clientSecretAuthFromEnvironment)
+	t.Run("fromFiles", testAccProvider_clientSecretAuthFromFiles)
+}
+
+func testAccProvider_clientSecretAuthFromEnvironment(t *testing.T) {
 	if os.Getenv("TF_ACC") == "" {
 		t.Skip("TF_ACC not set")
 	}
@@ -282,7 +287,7 @@ func TestAccProvider_clientSecretAuth(t *testing.T) {
 	}
 }
 
-func TestAccProvider_clientSecretAuthFromFiles(t *testing.T) {
+func testAccProvider_clientSecretAuthFromFiles(t *testing.T) {
 	if os.Getenv("TF_ACC") == "" {
 		t.Skip("TF_ACC not set")
 	}

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -223,11 +223,11 @@ func TestAccProvider_clientSecretAuth(t *testing.T) {
 	if os.Getenv("TF_ACC") == "" {
 		t.Skip("TF_ACC not set")
 	}
-	if os.Getenv("ARM_CLIENT_ID") == "" {
-		t.Skip("ARM_CLIENT_ID not set")
+	if os.Getenv("ARM_CLIENT_ID") == "" && os.Getenv("ARM_CLIENT_ID_PATH") == "" {
+		t.Skip("ARM_CLIENT_ID or ARM_CLIENT_ID_PATH not set")
 	}
-	if os.Getenv("ARM_CLIENT_SECRET") == "" {
-		t.Skip("ARM_CLIENT_SECRET not set")
+	if os.Getenv("ARM_CLIENT_SECRET") == "" && os.Getenv("ARM_CLIENT_SECRET_PATH") == "" {
+		t.Skip("ARM_CLIENT_SECRET or ARM_CLIENT_SECRET_PATH not set")
 	}
 
 	logging.SetOutput(t)
@@ -244,12 +244,22 @@ func TestAccProvider_clientSecretAuth(t *testing.T) {
 			t.Fatalf("configuring environment %q: %v", envName, err)
 		}
 
+		clientID, err := getClientID(d)
+		if err != nil {
+			return nil, diag.FromErr(err)
+		}
+
+		clientSecret, err := getClientSecret(d)
+		if err != nil {
+			return nil, diag.FromErr(err)
+		}
+
 		authConfig := &auth.Credentials{
 			Environment:                           *env,
 			TenantID:                              d.Get("tenant_id").(string),
-			ClientID:                              d.Get("client_id").(string),
+			ClientID:                              *clientID,
 			EnableAuthenticatingUsingClientSecret: true,
-			ClientSecret:                          d.Get("client_secret").(string),
+			ClientSecret:                          *clientSecret,
 		}
 
 		return buildClient(ctx, provider, d, authConfig)


### PR DESCRIPTION
Adds the ability to specify a path to the client ID and client secret in place of supplying their values directly in the provider.