### PR TITLE
Docs: add the usage link for `coordinator_storage_quota_in_mb` of `azurerm_cosmosdb_postgresql_cluster`

### DIFF
--- a/website/docs/r/cosmosdb_postgresql_cluster.html.markdown
+++ b/website/docs/r/cosmosdb_postgresql_cluster.html.markdown
@@ -43,6 +43,8 @@ The following arguments are supported:
 
 * `coordinator_storage_quota_in_mb` - (Required) The coordinator storage allowed for the Azure Cosmos DB for PostgreSQL Cluster. Possible values are `32768`, `65536`, `131072`, `262144`, `524288`, `1048576`, `2097152`, `4194304`, `8388608` and `16777216`.
 
+-> **NOTE:** For more information, please see the [product documentation](https://learn.microsoft.com/en-us/azure/cosmos-db/postgresql/resources-compute)
+
 * `coordinator_vcore_count` - (Required) The coordinator vCore count for the Azure Cosmos DB for PostgreSQL Cluster. Possible values are `1`, `2`, `4`, `8`, `16`, `32`, `64` and `96`.
 
 * `node_count` - (Required) The worker node count of the Azure Cosmos DB for PostgreSQL Cluster. Possible value is between `0` and `20` except `1`.

--- a/website/docs/r/cosmosdb_postgresql_cluster.html.markdown
+++ b/website/docs/r/cosmosdb_postgresql_cluster.html.markdown
@@ -43,7 +43,7 @@ The following arguments are supported:
 
 * `coordinator_storage_quota_in_mb` - (Required) The coordinator storage allowed for the Azure Cosmos DB for PostgreSQL Cluster. Possible values are `32768`, `65536`, `131072`, `262144`, `524288`, `1048576`, `2097152`, `4194304`, `8388608` and `16777216`.
 
--> **NOTE:** For more information, please see the [product documentation](https://learn.microsoft.com/azure/cosmos-db/postgresql/resources-compute)
+-> **NOTE:** More information on [the types of compute resources available for CosmosDB can be found in the product documentation](https://learn.microsoft.com/azure/cosmos-db/postgresql/resources-compute)
 
 * `coordinator_vcore_count` - (Required) The coordinator vCore count for the Azure Cosmos DB for PostgreSQL Cluster. Possible values are `1`, `2`, `4`, `8`, `16`, `32`, `64` and `96`.
 

--- a/website/docs/r/cosmosdb_postgresql_cluster.html.markdown
+++ b/website/docs/r/cosmosdb_postgresql_cluster.html.markdown
@@ -43,7 +43,7 @@ The following arguments are supported:
 
 * `coordinator_storage_quota_in_mb` - (Required) The coordinator storage allowed for the Azure Cosmos DB for PostgreSQL Cluster. Possible values are `32768`, `65536`, `131072`, `262144`, `524288`, `1048576`, `2097152`, `4194304`, `8388608` and `16777216`.
 
--> **NOTE:** For more information, please see the [product documentation](https://learn.microsoft.com/en-us/azure/cosmos-db/postgresql/resources-compute)
+-> **NOTE:** For more information, please see the [product documentation](https://learn.microsoft.com/azure/cosmos-db/postgresql/resources-compute)
 
 * `coordinator_vcore_count` - (Required) The coordinator vCore count for the Azure Cosmos DB for PostgreSQL Cluster. Possible values are `1`, `2`, `4`, `8`, `16`, `32`, `64` and `96`.
 


### PR DESCRIPTION
fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/21761