### PR TITLE
`d/azurerm_images` - fix `tags_filter`

### DIFF
--- a/internal/services/compute/images_data_source.go
+++ b/internal/services/compute/images_data_source.go
@@ -181,12 +181,14 @@ func filterToImagesMatchingTags(input []images.Image, filterTags map[string]stri
 	output := make([]images.Image, 0)
 
 	for _, item := range input {
-		tagsMatch := false
-		if item.Tags != nil {
+		tagsMatch := true
+		if item.Tags == nil {
+			tagsMatch = false
+		} else {
 			for tagKey, tagValue := range filterTags {
 				otherVal, exists := (*item.Tags)[tagKey]
-				if exists && tagValue == otherVal {
-					tagsMatch = true
+				if !exists || tagValue != otherVal {
+					tagsMatch = false
 					break
 				}
 			}

--- a/internal/services/compute/images_data_source_test.go
+++ b/internal/services/compute/images_data_source_test.go
@@ -18,20 +18,16 @@ func TestAccDataSourceAzureRMImages_basic(t *testing.T) {
 	data.DataSourceTest(t, []acceptance.TestStep{
 		{
 			// need to create a vm and then reference it in the image creation
-			Config: ImageResource{}.setupUnmanagedDisks(data, "LRS"),
+			Config: ImageResource{}.setupUnmanagedDisks(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				data.CheckWithClientForResource(ImageResource{}.virtualMachineExists, "azurerm_virtual_machine.testsource"),
 				data.CheckWithClientForResource(ImageResource{}.generalizeVirtualMachine(data), "azurerm_virtual_machine.testsource"),
 			),
 		},
 		{
-			Config: ImageResource{}.standaloneImageProvision(data, "LRS", ""),
-			Check:  acceptance.ComposeTestCheckFunc(),
-		},
-		{
-			Config: r.basic(data, "LRS"),
+			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).Key("images.#").HasValue("1"),
+				check.That(data.ResourceName).Key("images.#").HasValue("2"),
 				check.That(data.ResourceName).Key("images.0.os_disk.0.os_type").HasValue("Linux"),
 			),
 		},
@@ -45,18 +41,14 @@ func TestAccDataSourceAzureRMImages_tagsFilterError(t *testing.T) {
 	data.DataSourceTest(t, []acceptance.TestStep{
 		{
 			// need to create a vm and then reference it in the image creation
-			Config: ImageResource{}.setupUnmanagedDisks(data, "LRS"),
+			Config: ImageResource{}.setupUnmanagedDisks(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				data.CheckWithClientForResource(ImageResource{}.virtualMachineExists, "azurerm_virtual_machine.testsource"),
 				data.CheckWithClientForResource(ImageResource{}.generalizeVirtualMachine(data), "azurerm_virtual_machine.testsource"),
 			),
 		},
 		{
-			Config: ImageResource{}.standaloneImageProvision(data, "LRS", ""),
-			Check:  acceptance.ComposeTestCheckFunc(),
-		},
-		{
-			Config:      r.tagsFilterError(data, "LRS"),
+			Config:      r.tagsFilterError(data),
 			ExpectError: regexp.MustCompile("no images were found that match the specified tags"),
 		},
 	})
@@ -69,18 +61,14 @@ func TestAccDataSourceAzureRMImages_tagsFilter(t *testing.T) {
 	data.DataSourceTest(t, []acceptance.TestStep{
 		{
 			// need to create a vm and then reference it in the image creation
-			Config: ImageResource{}.setupUnmanagedDisks(data, "LRS"),
+			Config: ImageResource{}.setupUnmanagedDisks(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				data.CheckWithClientForResource(ImageResource{}.virtualMachineExists, "azurerm_virtual_machine.testsource"),
 				data.CheckWithClientForResource(ImageResource{}.generalizeVirtualMachine(data), "azurerm_virtual_machine.testsource"),
 			),
 		},
 		{
-			Config: ImageResource{}.standaloneImageProvision(data, "LRS", ""),
-			Check:  acceptance.ComposeTestCheckFunc(),
-		},
-		{
-			Config: r.tagsFilter(data, "LRS"),
+			Config: r.tagsFilter(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("images.#").HasValue("1"),
 			),
@@ -88,17 +76,17 @@ func TestAccDataSourceAzureRMImages_tagsFilter(t *testing.T) {
 	})
 }
 
-func (ImagesDataSource) basic(data acceptance.TestData, storageType string) string {
+func (r ImagesDataSource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
 data "azurerm_images" "test" {
   resource_group_name = azurerm_image.test.resource_group_name
 }
-`, ImageResource{}.standaloneImageProvision(data, storageType, ""))
+`, r.template(data))
 }
 
-func (ImagesDataSource) tagsFilterError(data acceptance.TestData, storageType string) string {
+func (r ImagesDataSource) tagsFilterError(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -106,12 +94,13 @@ data "azurerm_images" "test" {
   resource_group_name = azurerm_image.test.resource_group_name
   tags_filter = {
     environment = "error"
+    cost-center = "Ops"
   }
 }
-`, ImageResource{}.standaloneImageProvision(data, storageType, ""))
+`, r.template(data))
 }
 
-func (ImagesDataSource) tagsFilter(data acceptance.TestData, storageType string) string {
+func (r ImagesDataSource) tagsFilter(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -119,7 +108,49 @@ data "azurerm_images" "test" {
   resource_group_name = azurerm_image.test.resource_group_name
   tags_filter = {
     environment = "Dev"
+    cost-center = "Ops"
   }
 }
-`, ImageResource{}.standaloneImageProvision(data, storageType, ""))
+`, r.template(data))
+}
+
+func (ImagesDataSource) template(data acceptance.TestData) string {
+	template := ImageResource{}.setupUnmanagedDisks(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_image" "test" {
+  name                = "accteste"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  os_disk {
+    os_type  = "Linux"
+    os_state = "Generalized"
+    blob_uri = "${azurerm_storage_account.test.primary_blob_endpoint}${azurerm_storage_container.test.name}/myosdisk1.vhd"
+    size_gb  = 30
+    caching  = "None"
+  }
+
+  tags = {
+    environment = "Dev"
+    cost-center = "Ops"
+    foo         = "bar"
+  }
+}
+
+resource "azurerm_image" "test2" {
+  name                = "accteste2"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  os_disk {
+    os_type  = "Linux"
+    os_state = "Generalized"
+    blob_uri = "${azurerm_storage_account.test.primary_blob_endpoint}${azurerm_storage_container.test.name}/myosdisk1.vhd"
+    size_gb  = 30
+    caching  = "None"
+  }
+}
+`, template)
 }

--- a/internal/services/compute/shared_image_version_resource_test.go
+++ b/internal/services/compute/shared_image_version_resource_test.go
@@ -289,11 +289,11 @@ func (SharedImageVersionResource) revokeSnapshot(ctx context.Context, client *cl
 
 // nolint: unparam
 func (SharedImageVersionResource) setup(data acceptance.TestData) string {
-	return ImageResource{}.setupUnmanagedDisks(data, "LRS")
+	return ImageResource{}.setupUnmanagedDisks(data)
 }
 
 func (SharedImageVersionResource) provision(data acceptance.TestData) string {
-	template := ImageResource{}.standaloneImageProvision(data, "LRS", "")
+	template := ImageResource{}.standaloneImageProvision(data, "")
 	return fmt.Sprintf(`
 %s
 

--- a/internal/services/compute/shared_image_versions_data_source.go
+++ b/internal/services/compute/shared_image_versions_data_source.go
@@ -154,6 +154,7 @@ func flattenSharedImageVersions(input []compute.GalleryImageVersion, filterTags 
 				// If the tags don't match, return false
 				if imageVersion.Tags[k] == nil || *v != *imageVersion.Tags[k] {
 					found = false
+					break
 				}
 			}
 		}


### PR DESCRIPTION
Fix #21742
- fix is referencing `shared_image_versions_data_source.go`
- also adding `break` to `shared_image_versions_data_source.go` to speed up a little bit
- updating test cases of both data sources. Now there will be two images created, one with 3 tags and the other with no tag. and data sources of tagsFilter have two tags, so that it can test multiple tags match and no tags match
- test templates `setupUnmanagedDisks` and `standaloneImageProvision` always accepts `LRS` as `storageAccountType` parameter which causes a golint issue, so removing this parameter