### PR TITLE
`azurerm_cosmosdb_account` - fix  for upstream Microsoft API updating `identity` and `default_identity` at the same time silently fails issue

### DIFF
--- a/internal/services/cosmos/cosmosdb_account_resource.go
+++ b/internal/services/cosmos/cosmosdb_account_resource.go
@@ -1192,11 +1192,7 @@ func resourceCosmosDbAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) 
 			log.Printf("[INFO] [SKIP] AzureRM Cosmos DB Account: Updating 'Locations' [NO CHANGE]")
 		}
 
-		// Identity and Default Identity...
-		log.Print("\r\n\r\n\r\n\r\n\r\n\r\n\r\nXXXX-XX-XXTXX:XX:XX.XXX-XXXX [INFO]  provider.terraform-provider-azurerm:   *********************************************************************")
-		log.Print("  ******************************* START *******************************")
-		log.Print("  *********************************************************************")
-
+		// Update Identity and Default Identity...
 		if d.HasChange("identity") {
 			expandedIdentity, err := expandAccountIdentity(d.Get("identity").([]interface{}))
 			if err != nil {
@@ -1240,8 +1236,8 @@ func resourceCosmosDbAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) 
 			log.Printf("[INFO] [SKIP] AzureRM Cosmos DB Account: Updating 'Identity' [NO CHANGE]")
 		}
 
-		// NOTE: updateDefaultIdentity now has a default value of 'FirstPartyIdentity'... This value now gets triggered if the default value
-		//       does not match the value in Azure...
+		// NOTE: updateDefaultIdentity now has a default value of 'FirstPartyIdentity'... This value now gets
+		//       triggered if the default value does not match the value in Azure...
 		if updateDefaultIdentity {
 			// This will now return the default of 'FirstPartyIdentity' if it
 			// is not set in the config, which is correct.
@@ -1262,10 +1258,6 @@ func resourceCosmosDbAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) 
 				return fmt.Errorf("updating 'default_identity_type' %q: %+v", id, err)
 			}
 		}
-
-		log.Print("  *******************************************************************")
-		log.Print("  ******************************* END *******************************")
-		log.Print("  *******************************************************************\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\nXXXX-XX-XXTXX:XX:XX.XXX-XXXX [INFO]  provider.terraform-provider-azurerm: ")
 
 		d.SetId(id.ID())
 	}

--- a/internal/services/cosmos/cosmosdb_account_resource.go
+++ b/internal/services/cosmos/cosmosdb_account_resource.go
@@ -978,6 +978,7 @@ func resourceCosmosDbAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) 
 
 		publicNetworkAccess := props.PublicNetworkAccess
 		if d.HasChange("public_network_access_enabled") {
+			publicNetworkAccess = documentdb.PublicNetworkAccessEnabled
 			if enabled := d.Get("public_network_access_enabled").(bool); !enabled {
 				publicNetworkAccess = documentdb.PublicNetworkAccessDisabled
 			}
@@ -986,6 +987,7 @@ func resourceCosmosDbAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) 
 
 		networkByPass := props.NetworkACLBypass
 		if d.HasChange("network_acl_bypass_for_azure_services") {
+			networkByPass = documentdb.NetworkACLBypassNone
 			if d.Get("network_acl_bypass_for_azure_services").(bool) {
 				networkByPass = documentdb.NetworkACLBypassAzureServices
 			}

--- a/internal/services/cosmos/cosmosdb_account_resource.go
+++ b/internal/services/cosmos/cosmosdb_account_resource.go
@@ -1002,7 +1002,7 @@ func resourceCosmosDbAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) 
 		// 'Identity' field is included in the update call with the 'DefaultIdentity' it will silently fail
 		// per the bug noted above (e.g. Azure Bug #2209567).
 		//
-		// In the update scenario where the end-user would like to update thier 'Identity' and thier 'DefaultIdentity'
+		// In the update scenario where the end-user would like to update their 'Identity' and their 'DefaultIdentity'
 		// fields at the same time both of these operations need to happen atomically in separate PUT/PATCH calls
 		// to the service else you will hit the bug mentioned above. You need to update the 'Identity' field
 		// first then update the 'DefaultIdentity' in totally different PUT/PATCH calls where you have to drop

--- a/internal/services/cosmos/cosmosdb_account_resource.go
+++ b/internal/services/cosmos/cosmosdb_account_resource.go
@@ -1072,6 +1072,10 @@ func resourceCosmosDbAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) 
 			updateDefaultIdentity = true
 		}
 
+		if props.AnalyticalStorageConfiguration != nil {
+			accountProps.AnalyticalStorageConfiguration.SchemaType = props.AnalyticalStorageConfiguration.SchemaType
+		}
+
 		if d.HasChange("analytical_storage") {
 			if v, ok := d.GetOk("analytical_storage"); ok {
 				accountProps.AnalyticalStorageConfiguration = expandCosmosDBAccountAnalyticalStorageConfiguration(v.([]interface{}))
@@ -1079,11 +1083,19 @@ func resourceCosmosDbAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) 
 			updateRequired = true
 		}
 
+		if props.Capacity != nil {
+			accountProps.Capacity = props.Capacity
+		}
+
 		if d.HasChange("capacity") {
 			if v, ok := d.GetOk("capacity"); ok {
 				accountProps.Capacity = expandCosmosDBAccountCapacity(v.([]interface{}))
 			}
 			updateRequired = true
+		}
+
+		if props.CreateMode != "" {
+			accountProps.CreateMode = props.CreateMode
 		}
 
 		var createMode string
@@ -1095,11 +1107,19 @@ func resourceCosmosDbAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) 
 			updateRequired = true
 		}
 
+		if props.RestoreParameters != nil {
+			accountProps.RestoreParameters = props.RestoreParameters
+		}
+
 		if d.HasChange("restore") {
 			if v, ok := d.GetOk("restore"); ok {
 				accountProps.RestoreParameters = expandCosmosdbAccountRestoreParameters(v.([]interface{}))
 			}
 			updateRequired = true
+		}
+
+		if props.KeyVaultKeyURI != nil {
+			accountProps.KeyVaultKeyURI = props.KeyVaultKeyURI
 		}
 
 		if d.HasChange("key_vault_key_id") {
@@ -1113,6 +1133,10 @@ func resourceCosmosDbAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) 
 			updateRequired = true
 		}
 
+		if props.APIProperties != nil {
+			accountProps.APIProperties = props.APIProperties
+		}
+
 		if d.HasChange("mongo_server_version") {
 			if v, ok := d.GetOk("mongo_server_version"); ok {
 				accountProps.APIProperties = &documentdb.APIProperties{
@@ -1120,6 +1144,10 @@ func resourceCosmosDbAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) 
 				}
 			}
 			updateRequired = true
+		}
+
+		if props.BackupPolicy != nil {
+			accountProps.BackupPolicy = props.BackupPolicy
 		}
 
 		if d.HasChange("backup") {

--- a/internal/services/cosmos/cosmosdb_account_resource.go
+++ b/internal/services/cosmos/cosmosdb_account_resource.go
@@ -985,6 +985,24 @@ func resourceCosmosDbAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) 
 			updateRequired = true
 		}
 
+		// NOTE: these fields are expanded directly into the
+		// 'documentdb.DatabaseAccountCreateUpdateParameters' below...
+		if d.HasChanges("consistency_policy") {
+			updateRequired = true
+		}
+
+		if d.HasChange("virtual_network_rule") {
+			updateRequired = true
+		}
+
+		if d.HasChange("cors_rule") {
+			updateRequired = true
+		}
+
+		if d.HasChange("access_key_metadata_writes_enabled") {
+			updateRequired = true
+		}
+
 		networkByPass := props.NetworkACLBypass
 		if d.HasChange("network_acl_bypass_for_azure_services") {
 			networkByPass = documentdb.NetworkACLBypassNone
@@ -994,9 +1012,7 @@ func resourceCosmosDbAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) 
 			updateRequired = true
 		}
 
-		// NOTE: for this field the expand is embedded directly into the
-		// 'documentdb.DatabaseAccountCreateUpdateParameters' below...
-		if d.HasChanges("consistency_policy") {
+		if d.HasChange("network_acl_bypass_ids") {
 			updateRequired = true
 		}
 

--- a/internal/services/cosmos/cosmosdb_account_resource.go
+++ b/internal/services/cosmos/cosmosdb_account_resource.go
@@ -994,6 +994,12 @@ func resourceCosmosDbAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) 
 			updateRequired = true
 		}
 
+		// NOTE: for this field the expand is embedded directly into the
+		// 'documentdb.DatabaseAccountCreateUpdateParameters' below...
+		if d.HasChanges("consistency_policy") {
+			updateRequired = true
+		}
+
 		// Incident : #383341730
 		// Azure Bug: #2209567 'Updating identities and default identity at the same time fails silently'
 		//

--- a/internal/services/cosmos/cosmosdb_account_resource.go
+++ b/internal/services/cosmos/cosmosdb_account_resource.go
@@ -1211,8 +1211,6 @@ func resourceCosmosDbAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) 
 				return fmt.Errorf("updating 'default_identity_type' %q: %+v", id, err)
 			}
 		}
-
-		d.SetId(id.ID())
 	}
 
 	return resourceCosmosDbAccountRead(d, meta)

--- a/internal/services/cosmos/cosmosdb_account_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_account_resource_test.go
@@ -2656,7 +2656,7 @@ resource "azurerm_cosmosdb_account" "test" {
   offer_type          = "Standard"
   kind                = "MongoDB"
 
-  default_identity_type = join("=", ["UserAssignedIdentity", join("=", ["UserAssignedIdentity", %[4]s])])
+  default_identity_type = join("=", ["UserAssignedIdentity", %[4]s])
 
   capabilities {
     name = "EnableMongo"

--- a/internal/services/cosmos/cosmosdb_account_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_account_resource_test.go
@@ -153,7 +153,7 @@ func TestAccCosmosDBAccount_updateDefaultIdentity(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
-			Config: r.defaultIdentity(data, documentdb.DatabaseAccountKindGlobalDocumentDB, `"FirstPartyIdentity"`, documentdb.DefaultConsistencyLevelEventual),
+			Config: r.defaultIdentity(data, documentdb.DatabaseAccountKindGlobalDocumentDB, "FirstPartyIdentity", documentdb.DefaultConsistencyLevelEventual),
 			Check: acceptance.ComposeAggregateTestCheckFunc(
 				checkAccCosmosDBAccount_basic(data, documentdb.DefaultConsistencyLevelEventual, 1),
 			),

--- a/internal/services/cosmos/cosmosdb_account_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_account_resource_test.go
@@ -153,14 +153,14 @@ func TestAccCosmosDBAccount_updateDefaultIdentity(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
-			Config: r.defaultIdentity(data, documentdb.DatabaseAccountKindGlobalDocumentDB, "FirstPartyIdentity", documentdb.DefaultConsistencyLevelEventual),
+			Config: r.defaultIdentity(data, documentdb.DatabaseAccountKindGlobalDocumentDB, `"FirstPartyIdentity"`, documentdb.DefaultConsistencyLevelEventual),
 			Check: acceptance.ComposeAggregateTestCheckFunc(
 				checkAccCosmosDBAccount_basic(data, documentdb.DefaultConsistencyLevelEventual, 1),
 			),
 		},
 		data.ImportStep(),
 		{
-			Config: r.updateDefaultIdentity(data, documentdb.DatabaseAccountKindGlobalDocumentDB, "SystemAssignedIdentity", documentdb.DefaultConsistencyLevelEventual),
+			Config: r.updateDefaultIdentity(data, documentdb.DatabaseAccountKindGlobalDocumentDB, `"SystemAssignedIdentity"`, documentdb.DefaultConsistencyLevelEventual),
 			Check: acceptance.ComposeAggregateTestCheckFunc(
 				checkAccCosmosDBAccount_basic(data, documentdb.DefaultConsistencyLevelEventual, 1),
 			),
@@ -3257,7 +3257,7 @@ resource "azurerm_cosmosdb_account" "test" {
   resource_group_name   = azurerm_resource_group.test.name
   offer_type            = "Standard"
   kind                  = "%s"
-  default_identity_type = "%s"
+  default_identity_type = %s
 
   identity {
     type = "SystemAssigned"
@@ -3298,7 +3298,7 @@ resource "azurerm_cosmosdb_account" "test" {
   resource_group_name   = azurerm_resource_group.test.name
   offer_type            = "Standard"
   kind                  = "%s"
-  default_identity_type = "%s"
+  default_identity_type = %s
 
   identity {
     type         = "%s"

--- a/internal/services/cosmos/cosmosdb_account_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_account_resource_test.go
@@ -2515,6 +2515,7 @@ resource "azurerm_key_vault" "test" {
       "Get",
       "Purge",
       "Update",
+      "GetRotationPolicy",
     ]
 
     secret_permissions = [
@@ -2536,6 +2537,7 @@ resource "azurerm_key_vault" "test" {
       "Update",
       "UnwrapKey",
       "WrapKey",
+      "GetRotationPolicy",
     ]
 
     secret_permissions = [

--- a/internal/services/cosmos/cosmosdb_account_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_account_resource_test.go
@@ -118,6 +118,42 @@ func TestAccCosmosDBAccount_keyVaultUri(t *testing.T) {
 	})
 }
 
+func TestAccCosmosDBAccount_customerManagedKeyWithIdentity(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_cosmosdb_account", "test")
+	r := CosmosDBAccountResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.keyVaultKeyUriWithSystemAssignedIdentity(data, documentdb.DatabaseAccountKindMongoDB, documentdb.DefaultConsistencyLevelStrong),
+			Check: acceptance.ComposeAggregateTestCheckFunc(
+				checkAccCosmosDBAccount_basic(data, documentdb.DefaultConsistencyLevelStrong, 1),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.keyVaultKeyUriWithSystemAssignedAndUserAssignedIdentity(data, documentdb.DatabaseAccountKindMongoDB, documentdb.DefaultConsistencyLevelStrong),
+			Check: acceptance.ComposeAggregateTestCheckFunc(
+				checkAccCosmosDBAccount_basic(data, documentdb.DefaultConsistencyLevelStrong, 1),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.keyVaultKeyUriWithUserAssignedIdentity(data, documentdb.DatabaseAccountKindMongoDB, documentdb.DefaultConsistencyLevelStrong),
+			Check: acceptance.ComposeAggregateTestCheckFunc(
+				checkAccCosmosDBAccount_basic(data, documentdb.DefaultConsistencyLevelStrong, 1),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.keyVaultKeyUriWithSystemAssignedIdentity(data, documentdb.DatabaseAccountKindMongoDB, documentdb.DefaultConsistencyLevelStrong),
+			Check: acceptance.ComposeAggregateTestCheckFunc(
+				checkAccCosmosDBAccount_basic(data, documentdb.DefaultConsistencyLevelStrong, 1),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccCosmosDBAccount_keyVaultUriUpdateConsistancy(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_cosmosdb_account", "test")
 	r := CosmosDBAccountResource{}
@@ -2583,6 +2619,462 @@ resource "azurerm_cosmosdb_account" "test" {
   geo_location {
     location          = azurerm_resource_group.test.location
     failover_priority = 0
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString, data.RandomInteger, string(kind), string(consistency))
+}
+
+func (CosmosDBAccountResource) keyVaultKeyUriWithSystemAssignedIdentity(data acceptance.TestData, kind documentdb.DatabaseAccountKind, consistency documentdb.DefaultConsistencyLevel) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy       = false
+      purge_soft_deleted_keys_on_destroy = false
+    }
+  }
+}
+
+provider "azuread" {}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-cosmos-%d"
+  location = "%s"
+}
+
+data "azurerm_client_config" "current" {}
+
+data "azuread_service_principal" "cosmosdb" {
+  display_name = "Azure Cosmos DB"
+}
+
+resource "azurerm_user_assigned_identity" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  name                = "acctest-user-example"
+}
+
+resource "azurerm_key_vault" "test" {
+  name                = "acctestkv-%s"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  tenant_id           = data.azurerm_client_config.current.tenant_id
+  sku_name            = "standard"
+
+  purge_protection_enabled   = true
+  soft_delete_retention_days = 7
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azurerm_client_config.current.object_id
+
+    key_permissions = [
+      "List",
+      "Create",
+      "Delete",
+      "Get",
+      "Purge",
+      "Update",
+      "GetRotationPolicy",
+    ]
+
+    secret_permissions = [
+      "Get",
+      "Delete",
+      "Set",
+    ]
+  }
+
+  access_policy {
+    tenant_id = azurerm_user_assigned_identity.test.tenant_id
+    object_id = azurerm_user_assigned_identity.test.principal_id
+
+    key_permissions = [
+      "List",
+      "Create",
+      "Delete",
+      "Get",
+      "Update",
+      "UnwrapKey",
+      "WrapKey",
+      "GetRotationPolicy",
+    ]
+
+    secret_permissions = [
+      "Get",
+      "Delete",
+      "Set",
+    ]
+  }
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azuread_service_principal.cosmosdb.id
+
+    key_permissions = [
+      "List",
+      "Create",
+      "Delete",
+      "Get",
+      "Update",
+      "UnwrapKey",
+      "WrapKey",
+      "GetRotationPolicy",
+    ]
+
+    secret_permissions = [
+      "Get",
+      "Delete",
+      "Set",
+    ]
+  }
+}
+
+resource "azurerm_key_vault_key" "test" {
+  name         = "key-%s"
+  key_vault_id = azurerm_key_vault.test.id
+  key_type     = "RSA"
+  key_size     = 2048
+
+  key_opts = [
+    "decrypt",
+    "encrypt",
+    "sign",
+    "unwrapKey",
+    "verify",
+    "wrapKey",
+  ]
+}
+
+resource "azurerm_cosmosdb_account" "test" {
+  name                = "acctest-ca-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  offer_type          = "Standard"
+  kind                = "%s"
+  key_vault_key_id    = azurerm_key_vault_key.test.versionless_id
+
+  capabilities {
+    name = "EnableMongo"
+  }
+
+  consistency_policy {
+    consistency_level = "%s"
+  }
+
+  geo_location {
+    location          = azurerm_resource_group.test.location
+    failover_priority = 0
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString, data.RandomInteger, string(kind), string(consistency))
+}
+
+func (CosmosDBAccountResource) keyVaultKeyUriWithSystemAssignedAndUserAssignedIdentity(data acceptance.TestData, kind documentdb.DatabaseAccountKind, consistency documentdb.DefaultConsistencyLevel) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy       = false
+      purge_soft_deleted_keys_on_destroy = false
+    }
+  }
+}
+
+provider "azuread" {}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-cosmos-%d"
+  location = "%s"
+}
+
+data "azurerm_client_config" "current" {}
+
+data "azuread_service_principal" "cosmosdb" {
+  display_name = "Azure Cosmos DB"
+}
+
+resource "azurerm_user_assigned_identity" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  name                = "acctest-user-example"
+}
+
+resource "azurerm_key_vault" "test" {
+  name                = "acctestkv-%s"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  tenant_id           = data.azurerm_client_config.current.tenant_id
+  sku_name            = "standard"
+
+  purge_protection_enabled   = true
+  soft_delete_retention_days = 7
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azurerm_client_config.current.object_id
+
+    key_permissions = [
+      "List",
+      "Create",
+      "Delete",
+      "Get",
+      "Purge",
+      "Update",
+      "GetRotationPolicy",
+    ]
+
+    secret_permissions = [
+      "Get",
+      "Delete",
+      "Set",
+    ]
+  }
+
+  access_policy {
+    tenant_id = azurerm_user_assigned_identity.test.tenant_id
+    object_id = azurerm_user_assigned_identity.test.principal_id
+
+    key_permissions = [
+      "List",
+      "Create",
+      "Delete",
+      "Get",
+      "Update",
+      "UnwrapKey",
+      "WrapKey",
+      "GetRotationPolicy",
+    ]
+
+    secret_permissions = [
+      "Get",
+      "Delete",
+      "Set",
+    ]
+  }
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azuread_service_principal.cosmosdb.id
+
+    key_permissions = [
+      "List",
+      "Create",
+      "Delete",
+      "Get",
+      "Update",
+      "UnwrapKey",
+      "WrapKey",
+      "GetRotationPolicy",
+    ]
+
+    secret_permissions = [
+      "Get",
+      "Delete",
+      "Set",
+    ]
+  }
+}
+
+resource "azurerm_key_vault_key" "test" {
+  name         = "key-%s"
+  key_vault_id = azurerm_key_vault.test.id
+  key_type     = "RSA"
+  key_size     = 2048
+
+  key_opts = [
+    "decrypt",
+    "encrypt",
+    "sign",
+    "unwrapKey",
+    "verify",
+    "wrapKey",
+  ]
+}
+
+resource "azurerm_cosmosdb_account" "test" {
+  name                = "acctest-ca-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  offer_type          = "Standard"
+  kind                = "%s"
+  key_vault_key_id    = azurerm_key_vault_key.test.versionless_id
+
+  capabilities {
+    name = "EnableMongo"
+  }
+
+  consistency_policy {
+    consistency_level = "%s"
+  }
+
+  geo_location {
+    location          = azurerm_resource_group.test.location
+    failover_priority = 0
+  }
+
+  identity {
+    type = "SystemAssigned, UserAssigned"
+    identity_ids = [
+      azurerm_user_assigned_identity.test.id
+    ]
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString, data.RandomInteger, string(kind), string(consistency))
+}
+
+func (CosmosDBAccountResource) keyVaultKeyUriWithUserAssignedIdentity(data acceptance.TestData, kind documentdb.DatabaseAccountKind, consistency documentdb.DefaultConsistencyLevel) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy       = false
+      purge_soft_deleted_keys_on_destroy = false
+    }
+  }
+}
+
+provider "azuread" {}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-cosmos-%d"
+  location = "%s"
+}
+
+data "azurerm_client_config" "current" {}
+
+data "azuread_service_principal" "cosmosdb" {
+  display_name = "Azure Cosmos DB"
+}
+
+resource "azurerm_user_assigned_identity" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  name                = "acctest-user-example"
+}
+
+resource "azurerm_key_vault" "test" {
+  name                = "acctestkv-%s"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  tenant_id           = data.azurerm_client_config.current.tenant_id
+  sku_name            = "standard"
+
+  purge_protection_enabled   = true
+  soft_delete_retention_days = 7
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azurerm_client_config.current.object_id
+
+    key_permissions = [
+      "List",
+      "Create",
+      "Delete",
+      "Get",
+      "Purge",
+      "Update",
+      "GetRotationPolicy",
+    ]
+
+    secret_permissions = [
+      "Get",
+      "Delete",
+      "Set",
+    ]
+  }
+
+  access_policy {
+    tenant_id = azurerm_user_assigned_identity.test.tenant_id
+    object_id = azurerm_user_assigned_identity.test.principal_id
+
+    key_permissions = [
+      "List",
+      "Create",
+      "Delete",
+      "Get",
+      "Update",
+      "UnwrapKey",
+      "WrapKey",
+      "GetRotationPolicy",
+    ]
+
+    secret_permissions = [
+      "Get",
+      "Delete",
+      "Set",
+    ]
+  }
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azuread_service_principal.cosmosdb.id
+
+    key_permissions = [
+      "List",
+      "Create",
+      "Delete",
+      "Get",
+      "Update",
+      "UnwrapKey",
+      "WrapKey",
+      "GetRotationPolicy",
+    ]
+
+    secret_permissions = [
+      "Get",
+      "Delete",
+      "Set",
+    ]
+  }
+}
+
+resource "azurerm_key_vault_key" "test" {
+  name         = "key-%s"
+  key_vault_id = azurerm_key_vault.test.id
+  key_type     = "RSA"
+  key_size     = 2048
+
+  key_opts = [
+    "decrypt",
+    "encrypt",
+    "sign",
+    "unwrapKey",
+    "verify",
+    "wrapKey",
+  ]
+}
+
+resource "azurerm_cosmosdb_account" "test" {
+  name                = "acctest-ca-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  offer_type          = "Standard"
+  kind                = "%s"
+  key_vault_key_id    = azurerm_key_vault_key.test.versionless_id
+
+  capabilities {
+    name = "EnableMongo"
+  }
+
+  consistency_policy {
+    consistency_level = "%s"
+  }
+
+  geo_location {
+    location          = azurerm_resource_group.test.location
+    failover_priority = 0
+  }
+
+  identity {
+    type = "UserAssigned"
+    identity_ids = [
+      azurerm_user_assigned_identity.test.id
+    ]
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString, data.RandomInteger, string(kind), string(consistency))

--- a/internal/services/cosmos/cosmosdb_account_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_account_resource_test.go
@@ -3294,9 +3294,9 @@ resource "azurerm_cosmosdb_account" "test" {
   default_identity_type = "%s"
 
   identity {
-     type         = "UserAssigned"
-     identity_ids = [azurerm_user_assigned_identity.test.id]
-  } 
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.test.id]
+  }
 
   consistency_policy {
     consistency_level = "%s"

--- a/website/docs/r/cosmosdb_account.html.markdown
+++ b/website/docs/r/cosmosdb_account.html.markdown
@@ -124,7 +124,7 @@ The following arguments are supported:
 
 ~> **NOTE:** `create_mode` only works when `backup.type` is `Continuous`.
 
-* `default_identity_type` - (Optional) The default identity for accessing Key Vault. Possible values are `FirstPartyIdentity`, `SystemAssignedIdentity` or `UserAssignedIdentity`.
+* `default_identity_type` - (Optional) The default identity for accessing Key Vault. Possible values are `FirstPartyIdentity`, `SystemAssignedIdentity` or `UserAssignedIdentity`. Defaults to `FirstPartyIdentity`.
 
 ~> **NOTE:** When `default_identity_type` is a `UserAssignedIdentity` it must include the User Assigned Identity ID in the following format: `UserAssignedIdentity=/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{userAssignedIdentityName}`.
 


### PR DESCRIPTION
## Fixes:
```
IcM       : #383341730
Azure Bug : #2209567 - Updating identities and default identity at the same time fails silently
```
This is a mess and a total nightmare due to the Azure Bug: 2209567, however I feel this is the best we can do within the provider to compensate for that issue.