### PR TITLE
Doc: `azurerm_user_assigned_identity` example pass tf validate

### DIFF
--- a/website/docs/r/user_assigned_identity.html.markdown
+++ b/website/docs/r/user_assigned_identity.html.markdown
@@ -15,6 +15,11 @@ Manages a User Assigned Identity.
 ## Example Usage
 
 ```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "example"
+  location = "West Europe"
+}
+
 resource "azurerm_user_assigned_identity" "example" {
   location            = azurerm_resource_group.example.location
   name                = "example"


### PR DESCRIPTION
We are doing some document example fix up internally to make sure the HCL snippet in the document can at least pass `tf validate`. This PR is to fix for the `authorization` service.