### PR TITLE
`azurerm_api_management` - fix `triple_des_ciphers_enabled` setting wrong value

### DIFF
--- a/internal/services/apimanagement/api_management_resource.go
+++ b/internal/services/apimanagement/api_management_resource.go
@@ -39,7 +39,7 @@ var (
 	apimFrontendProtocolSsl3                 = "Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Protocols.Ssl30"
 	apimFrontendProtocolTls10                = "Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Protocols.Tls10"
 	apimFrontendProtocolTls11                = "Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Protocols.Tls11"
-	apimTripleDesCiphers                     = "Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Ciphers.TLS_RSA_WITH_3DES_EDE_CBC_SHA"
+	apimTripleDesCiphers                     = "Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Ciphers.TripleDes168"
 	apimHttp2Protocol                        = "Microsoft.WindowsAzure.ApiManagement.Gateway.Protocols.Server.Http2"
 	apimTlsEcdheEcdsaWithAes256CbcShaCiphers = "Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Ciphers.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA"
 	apimTlsEcdheEcdsaWithAes128CbcShaCiphers = "Microsoft.WindowsAzure.ApiManagement.Gateway.Security.Ciphers.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA"


### PR DESCRIPTION
Per [doc](https://learn.microsoft.com/en-us/troubleshoot/windows-server/windows-security/restrict-cryptographic-algorithms-protocols-schannel#schannelciphers-subkey), disabling `Triple DES 168` effectively disallows the following values:

- SSL_RSA_WITH_3DES_EDE_CBC_SHA
- SSL_DHE_DSS_WITH_3DES_EDE_CBC_SHA
- TLS_RSA_WITH_3DES_EDE_CBC_SHA
- TLS_DHE_DSS_WITH_3DES_EDE_CBC_SHA

This means the `Triple DES 168` represents 4 settings, while currently, Terraform only uses one of them to represent the other three. This issue was introduced by [PR #17554](https://github.com/hashicorp/terraform-provider-azurerm/pull/17554) (fix issue #17553 ). For issue #17553, I just tested that if using Terraform Provider v3.12 with `triple_des_ciphers_enabled`  set to `false`, `
TLS_RSA_WITH_3DES_EDE_CBC_SHA (Triple DES)` is disabled in the Azure portal as shown below, the symptom in issue #17553  is gone. So I assume that issue #17553 is an API issue rather than a Terraform issue. So I submitted this PR to revert PR #17554.

![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/39109137/6af0a5d7-395c-4957-a3aa-ea8dc1e7f63d)
