### PR TITLE
Removing forcenew on the `kubernetes_cluster` `http_proxy_config` `no_proxy`

### DIFF
--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -434,7 +434,6 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 						"no_proxy": {
 							Type:     pluginsdk.TypeSet,
 							Optional: true,
-							ForceNew: true,
 							Elem: &schema.Schema{
 								Type: schema.TypeString,
 							},

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -852,7 +852,7 @@ A `http_proxy_config` block supports the following:
 
 * `https_proxy` - (Optional) The proxy address to be used when communicating over HTTPS. Changing this forces a new resource to be created.
 
-* `no_proxy` - (Optional) The list of domains that will not use the proxy for communication. Changing this forces a new resource to be created.
+* `no_proxy` - (Optional) The list of domains that will not use the proxy for communication.
 
 -> **Note:** If you specify the `default_node_pool.0.vnet_subnet_id`, be sure to include the Subnet CIDR in the `no_proxy` list.
 


### PR DESCRIPTION
The AKS API now supports updating existing nodes with a new no_proxy list.  https://learn.microsoft.com/en-us/azure/aks/http-proxy#updating-proxy-configurations

