### PR TITLE
Usability: Improve error messages for resource IDs with non-canonical casing

### DIFF
--- a/helpers/azure/resourceid.go
+++ b/helpers/azure/resourceid.go
@@ -156,6 +156,16 @@ func ParseAzureResourceIDWithoutSubscription(id string) (*ResourceID, error) {
 func (id *ResourceID) PopSegment(name string) (string, error) {
 	val, ok := id.Path[name]
 	if !ok {
+
+		// There are sometimes casing issues with path segments, check for case insensitive
+		// matches during error conditions to create more user-friendly errors for those
+		// importing resources
+		for key := range id.Path {
+			if strings.EqualFold(key, name) {
+				return "", fmt.Errorf("ID contained `%s` element, expected `%s`", key, name)
+			}
+		}
+
 		return "", fmt.Errorf("ID was missing the `%s` element", name)
 	}
 

--- a/helpers/azure/resourceid_test.go
+++ b/helpers/azure/resourceid_test.go
@@ -267,3 +267,52 @@ func TestParseAzureResourceIDWithoutSubscription(t *testing.T) {
 		}
 	}
 }
+
+func TestResourceIDPopSegment(t *testing.T) {
+	testCases := []struct {
+		key               string
+		id                string
+		expectError       bool
+		expectedErrorText string
+	}{
+		{
+			"ruleSets",
+			"/subscriptions/11111111-1111-1111-1111-111111111111/resourcegroups/example-resources/providers/Microsoft.Cdn/profiles/profile1/ruleSets/ruleset1/rules/rule1",
+			false,
+			"",
+		},
+		{
+			"ruleSets",
+			"/subscriptions/11111111-1111-1111-1111-111111111111/resourcegroups/example-resources/providers/Microsoft.Cdn/profiles/profile1",
+			true,
+			"ID was missing the `ruleSets` element",
+		},
+		{
+			"ruleSets",
+			"/subscriptions/11111111-1111-1111-1111-111111111111/resourcegroups/example-resources/providers/Microsoft.Cdn/profiles/profile1/rulesets/ruleset1/rules/rule1",
+			true,
+			"ID contained `rulesets` element, expected `ruleSets`",
+		},
+	}
+
+	for _, test := range testCases {
+		t.Logf("[DEBUG] Testing %q", test.id)
+
+		parsed, parse_err := azure.ParseAzureResourceID(test.id)
+		if parse_err != nil {
+			t.Fatalf("Unexpected error: %s", parse_err)
+		}
+		_, err := parsed.PopSegment(test.key)
+
+		if test.expectError && err != nil {
+			if err.Error() != test.expectedErrorText {
+				t.Fatalf("Unexpected error text: '%s' should be '%s'", err, test.expectedErrorText)
+			} else {
+				continue
+			}
+		}
+		if err != nil {
+			t.Fatalf("Unexpected error: %s", err)
+		}
+	}
+}


### PR DESCRIPTION
The Azure APIs and portal are not entirely consistent with casing in resource IDs. This is noted in ParseAzureResourceID where `resourcegroups` are special-cased to work around inconsistency. This behaviour can cause confusion when importing resources, as the error message `ID was missing the 'ruleSet' element` (for example) appears non-sensical if the user doesn't notice the capitalisation difference. This is exacerbated by the `az` cli returning the ID as provided when provided to show subcommands, meaning you can copy/paste an ID from the command-line output (or certain places in the portal) and be told it's missing a component.

This change does not alter the parsing behaviour, the case sensitivity of path segments is still maintained. It does, however, add an additional check to the error case of popping a segment from the path. If the path does not have a segment of that name, this change will iterate over the path segments and validate if any are a case-insensitive match. If so, this provides a more diagnostic error message.

I believe this is an appropriate efficiency trade-off of computer versus human time, the error case will be hit relatively infrequently, and resource IDs are generally a small number of segments. The impact on increased computation needed should be outweighed by allowing users to navigate this confusing error case more easily.

As this impacts only error messaging, I don't believe any acceptance tests are particularly relevant.