### PR TITLE
Allow colon character in APIM API Path validation

### DIFF
--- a/internal/services/apimanagement/validate/api_management.go
+++ b/internal/services/apimanagement/validate/api_management.go
@@ -73,7 +73,7 @@ func ApiManagementApiName(v interface{}, k string) (ws []string, es []error) {
 func ApiManagementApiPath(v interface{}, k string) (ws []string, es []error) {
 	value := v.(string)
 
-	if matched := regexp.MustCompile(`^(?:|[\w.][\w-/.]{0,398}[\w-])$`).Match([]byte(value)); !matched {
+	if matched := regexp.MustCompile(`^(?:|[\w.][\w-/.:]{0,398}[\w-])$`).Match([]byte(value)); !matched {
 		es = append(es, fmt.Errorf("%q may only be up to 400 characters in length, not start or end with `/` and only contain valid url characters", k))
 	}
 	return ws, es

--- a/internal/services/apimanagement/validate/api_management_test.go
+++ b/internal/services/apimanagement/validate/api_management_test.go
@@ -131,6 +131,10 @@ func TestAzureRMApiManagementApiPath_validation(t *testing.T) {
 			ErrCount: 0,
 		},
 		{
+			Value:    "api1:sub",
+			ErrCount: 0,
+		},
+		{
 			Value:    s.Repeat("x", 401),
 			ErrCount: 1,
 		},


### PR DESCRIPTION
This is to fix https://github.com/hashicorp/terraform-provider-azurerm/issues/21807 bug in validation code which will now allow a colon (:) character in apim api path. 

Path Example: services/ab:outbound-test
Service URL Example:  https://test.com/services/ab:outbound-test

