### PR TITLE
`azurerm_consumption_budget_subscription` - update validation for `name`

### DIFF
--- a/internal/services/consumption/consumption_budget_subscription_resource.go
+++ b/internal/services/consumption/consumption_budget_subscription_resource.go
@@ -5,8 +5,8 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/consumption/2019-10-01/budgets"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/consumption/migration"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/consumption/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 )
 
 type SubscriptionConsumptionBudget struct {
@@ -25,7 +25,7 @@ func (r SubscriptionConsumptionBudget) Arguments() map[string]*pluginsdk.Schema 
 			Type:         pluginsdk.TypeString,
 			Required:     true,
 			ForceNew:     true,
-			ValidateFunc: validation.StringIsNotWhiteSpace,
+			ValidateFunc: validate.ConsumptionBudgetName(),
 		},
 		"subscription_id": {
 			Type:         pluginsdk.TypeString,

--- a/internal/services/consumption/validate/name.go
+++ b/internal/services/consumption/validate/name.go
@@ -10,6 +10,6 @@ import (
 func ConsumptionBudgetName() pluginsdk.SchemaValidateFunc {
 	return validation.StringMatch(
 		regexp.MustCompile("^[-_a-zA-Z0-9]{1,63}$"),
-		"The consumption budget name can contain only letters, numbers, underscores, and hyphens. The consumption budget name be between 6 and 63 characters long.",
+		"The consumption budget name can contain only letters, numbers, underscores, and hyphens. The consumption budget name be between 1 and 63 characters long.",
 	)
 }


### PR DESCRIPTION
fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/21808

![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/19754191/733c94fc-2225-4539-ab0a-ed41d73cfbc8)
