### PR TITLE
`data` `azurerm_shared_image_version` - consider `excludeFromLatest` for `latest` version

### DIFF
--- a/internal/services/compute/shared_image_version_data_source.go
+++ b/internal/services/compute/shared_image_version_data_source.go
@@ -193,8 +193,11 @@ func obtainImage(client *compute.GalleryImageVersionsClient, ctx context.Context
 					return nil, fmt.Errorf("parsing version(s): %v", errs)
 				}
 			}
-			image := images[len(images)-1]
-			return &image, nil
+			for i := len(images) - 1; i >= 0; i-- {
+				if prop := images[i].GalleryImageVersionProperties; prop == nil || prop.PublishingProfile == nil || prop.PublishingProfile.ExcludeFromLatest == nil || !*prop.PublishingProfile.ExcludeFromLatest {
+					return &(images[i]), nil
+				}
+			}
 		}
 		return nil, notFoundError
 

--- a/internal/services/compute/shared_image_version_data_source.go
+++ b/internal/services/compute/shared_image_version_data_source.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/compute/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/compute/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
@@ -193,6 +194,12 @@ func obtainImage(client *compute.GalleryImageVersionsClient, ctx context.Context
 					return nil, fmt.Errorf("parsing version(s): %v", errs)
 				}
 			}
+
+			if !features.FourPointOhBeta() {
+				image := images[len(images)-1]
+				return &image, nil
+			}
+
 			for i := len(images) - 1; i >= 0; i-- {
 				if prop := images[i].GalleryImageVersionProperties; prop == nil || prop.PublishingProfile == nil || prop.PublishingProfile.ExcludeFromLatest == nil || !*prop.PublishingProfile.ExcludeFromLatest {
 					return &(images[i]), nil

--- a/internal/services/compute/shared_image_version_data_source_test.go
+++ b/internal/services/compute/shared_image_version_data_source_test.go
@@ -24,9 +24,6 @@ func TestAccDataSourceSharedImageVersion_basic(t *testing.T) {
 			),
 		},
 		{
-			Config: SharedImageVersionResource{}.imageVersion(data),
-		},
-		{
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("managed_image_id").Exists(),
@@ -51,11 +48,34 @@ func TestAccDataSourceSharedImageVersion_latest(t *testing.T) {
 			),
 		},
 		{
-			Config: r.additionalVersion(data),
+			Config: r.latest(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("name").HasValue("0.0.2"),
+				check.That(data.ResourceName).Key("managed_image_id").Exists(),
+				check.That(data.ResourceName).Key("target_region.#").HasValue("1"),
+				check.That(data.ResourceName).Key("target_region.0.storage_account_type").HasValue("Standard_LRS"),
+			),
+		},
+	})
+}
+
+func TestAccDataSourceSharedImageVersion_excludeFromLatest(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_shared_image_version", "test")
+	r := SharedImageVersionDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			// need to create a vm and then reference it in the image creation
+			Config: SharedImageVersionResource{}.setup(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				data.CheckWithClientForResource(ImageResource{}.virtualMachineExists, "azurerm_virtual_machine.testsource"),
+				data.CheckWithClientForResource(ImageResource{}.generalizeVirtualMachine(data), "azurerm_virtual_machine.testsource"),
+			),
 		},
 		{
-			Config: r.customName(data, "latest"),
+			Config: r.excludeFromLatest(data),
 			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("name").HasValue("0.0.1"),
 				check.That(data.ResourceName).Key("managed_image_id").Exists(),
 				check.That(data.ResourceName).Key("target_region.#").HasValue("1"),
 				check.That(data.ResourceName).Key("target_region.0.storage_account_type").HasValue("Standard_LRS"),
@@ -79,11 +99,34 @@ func TestAccDataSourceSharedImageVersion_recent(t *testing.T) {
 			),
 		},
 		{
-			Config: r.additionalVersion(data),
+			Config: r.recent(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("name").HasValue("0.0.2"),
+				check.That(data.ResourceName).Key("managed_image_id").Exists(),
+				check.That(data.ResourceName).Key("target_region.#").HasValue("1"),
+				check.That(data.ResourceName).Key("target_region.0.storage_account_type").HasValue("Standard_LRS"),
+			),
+		},
+	})
+}
+
+func TestAccDataSourceSharedImageVersion_sortVersionsBySemver(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_shared_image_version", "test")
+	r := SharedImageVersionDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			// need to create a vm and then reference it in the image creation
+			Config: SharedImageVersionResource{}.setup(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				data.CheckWithClientForResource(ImageResource{}.virtualMachineExists, "azurerm_virtual_machine.testsource"),
+				data.CheckWithClientForResource(ImageResource{}.generalizeVirtualMachine(data), "azurerm_virtual_machine.testsource"),
+			),
 		},
 		{
-			Config: r.customName(data, "recent"),
+			Config: r.sortVersionsBySemver(data),
 			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("name").HasValue("0.0.10"),
 				check.That(data.ResourceName).Key("managed_image_id").Exists(),
 				check.That(data.ResourceName).Key("target_region.#").HasValue("1"),
 				check.That(data.ResourceName).Key("target_region.0.storage_account_type").HasValue("Standard_LRS"),
@@ -105,7 +148,7 @@ data "azurerm_shared_image_version" "test" {
 `, SharedImageVersionResource{}.imageVersion(data))
 }
 
-func (SharedImageVersionDataSource) additionalVersion(data acceptance.TestData) string {
+func (SharedImageVersionDataSource) latest(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -122,18 +165,132 @@ resource "azurerm_shared_image_version" "test2" {
     regional_replica_count = 1
   }
 }
-`, SharedImageVersionResource{}.imageVersion(data))
-}
-
-func (r SharedImageVersionDataSource) customName(data acceptance.TestData, name string) string {
-	return fmt.Sprintf(`
-%s
 
 data "azurerm_shared_image_version" "test" {
-  name                = "%s"
+  name                = "latest"
   gallery_name        = azurerm_shared_image_version.test2.gallery_name
   image_name          = azurerm_shared_image_version.test2.image_name
   resource_group_name = azurerm_shared_image_version.test2.resource_group_name
 }
-`, r.additionalVersion(data), name)
+`, SharedImageVersionResource{}.imageVersion(data))
+}
+
+func (SharedImageVersionDataSource) excludeFromLatest(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_shared_image_version" "test2" {
+  name                = "0.0.2"
+  gallery_name        = azurerm_shared_image_gallery.test.name
+  image_name          = azurerm_shared_image.test.name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  managed_image_id    = azurerm_image.test.id
+  exclude_from_latest = true
+
+  target_region {
+    name                   = azurerm_resource_group.test.location
+    regional_replica_count = 1
+  }
+}
+
+data "azurerm_shared_image_version" "test" {
+  name                = "latest"
+  gallery_name        = azurerm_shared_image_version.test2.gallery_name
+  image_name          = azurerm_shared_image_version.test2.image_name
+  resource_group_name = azurerm_shared_image_version.test2.resource_group_name
+}
+`, SharedImageVersionResource{}.imageVersion(data))
+}
+
+func (SharedImageVersionDataSource) recent(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_shared_image_version" "test2" {
+  name                = "0.0.3"
+  gallery_name        = azurerm_shared_image_gallery.test.name
+  image_name          = azurerm_shared_image.test.name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  managed_image_id    = azurerm_image.test.id
+
+  target_region {
+    name                   = azurerm_resource_group.test.location
+    regional_replica_count = 1
+  }
+}
+
+resource "azurerm_shared_image_version" "test3" {
+  name                = "0.0.2"
+  gallery_name        = azurerm_shared_image_gallery.test.name
+  image_name          = azurerm_shared_image.test.name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  managed_image_id    = azurerm_image.test.id
+
+  target_region {
+    name                   = azurerm_resource_group.test.location
+    regional_replica_count = 1
+  }
+
+  depends_on = [
+    azurerm_shared_image_version.test2
+  ]
+}
+
+data "azurerm_shared_image_version" "test" {
+  name                = "recent"
+  gallery_name        = azurerm_shared_image_version.test3.gallery_name
+  image_name          = azurerm_shared_image_version.test3.image_name
+  resource_group_name = azurerm_shared_image_version.test3.resource_group_name
+}
+`, SharedImageVersionResource{}.imageVersion(data))
+}
+
+func (SharedImageVersionDataSource) sortVersionsBySemver(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_shared_image_version" "test2" {
+  name                = "0.0.9"
+  gallery_name        = azurerm_shared_image_gallery.test.name
+  image_name          = azurerm_shared_image.test.name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  managed_image_id    = azurerm_image.test.id
+
+  target_region {
+    name                   = azurerm_resource_group.test.location
+    regional_replica_count = 1
+  }
+}
+
+resource "azurerm_shared_image_version" "test3" {
+  name                = "0.0.10"
+  gallery_name        = azurerm_shared_image_gallery.test.name
+  image_name          = azurerm_shared_image.test.name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  managed_image_id    = azurerm_image.test.id
+
+  target_region {
+    name                   = azurerm_resource_group.test.location
+    regional_replica_count = 1
+  }
+
+  depends_on = [
+    azurerm_shared_image_version.test2
+  ]
+}
+
+data "azurerm_shared_image_version" "test" {
+  name                = "latest"
+  gallery_name        = azurerm_shared_image_version.test3.gallery_name
+  image_name          = azurerm_shared_image_version.test3.image_name
+  resource_group_name = azurerm_shared_image_version.test3.resource_group_name
+
+  sort_versions_by_semver = true
+}
+`, SharedImageVersionResource{}.imageVersion(data))
 }

--- a/website/docs/d/shared_image_version.html.markdown
+++ b/website/docs/d/shared_image_version.html.markdown
@@ -30,6 +30,8 @@ The following arguments are supported:
 
 ~> **Note:** You may specify `latest` to obtain the latest version or `recent` to obtain the most recently updated version.
 
+~> **Note:** In 3.0, `latest` may return the image version with `exclude_from_latest` set to `true`. Starting from 4.0, `latest` does not return the image version with `exlude_from_latest` set to `true`.
+
 * `image_name` - The name of the Shared Image in which this Version exists.
 
 * `gallery_name` - The name of the Shared Image Gallery in which the Shared Image exists.

--- a/website/docs/d/shared_image_version.html.markdown
+++ b/website/docs/d/shared_image_version.html.markdown
@@ -30,7 +30,7 @@ The following arguments are supported:
 
 ~> **Note:** You may specify `latest` to obtain the latest version or `recent` to obtain the most recently updated version.
 
-~> **Note:** In 3.0, `latest` may return the image version with `exclude_from_latest` set to `true`. Starting from 4.0, `latest` does not return the image version with `exlude_from_latest` set to `true`.
+~> **Note:** In 3.0, `latest` may return an image version with `exclude_from_latest` set to `true`. Starting from 4.0 onwards `latest` will not return image versions with `exlude_from_latest` set to `true`.
 
 * `image_name` - The name of the Shared Image in which this Version exists.
 


### PR DESCRIPTION
Fix #10633

When a shared image version is created with `excludeFromLatest` set to `false`, on Azure Portal or when creating a VM, this version is not considered. Data source `azurerm_shared_image_version` ignores this aspect, which seems not aligned with the behavior. Adding the logic to find the most latest version which is not marked as `excludeFromLatest`. Also updating the test cases so that ordering is also tested, old test cases didn't test the ordering.