### PR TITLE
`azurerm_batch_pool` - fixes `TestAccBatchPool_frontEndPortRanges`

### DIFF
--- a/internal/services/batch/batch_pool_resource_test.go
+++ b/internal/services/batch/batch_pool_resource_test.go
@@ -483,7 +483,7 @@ func TestAccBatchPool_frontEndPortRanges(t *testing.T) {
 				check.That(data.ResourceName).Key("fixed_scale.0.target_dedicated_nodes").HasValue("1"),
 				check.That(data.ResourceName).Key("start_task.#").HasValue("0"),
 				check.That(data.ResourceName).Key("network_configuration.#").HasValue("1"),
-				check.That(data.ResourceName).Key("network_configuration.0.dynamic_vnet_assignment_scope").HasValue("None"),
+				check.That(data.ResourceName).Key("network_configuration.0.dynamic_vnet_assignment_scope").HasValue("none"),
 				check.That(data.ResourceName).Key("network_configuration.0.subnet_id").Exists(),
 				check.That(data.ResourceName).Key("network_configuration.0.public_ips.#").HasValue("1"),
 				check.That(data.ResourceName).Key("network_configuration.0.endpoint_configuration.0.network_security_group_rules.0.source_port_ranges.0").HasValue("*"),


### PR DESCRIPTION
Fixes `TestAccBatchPool_frontEndPortRanges`

GOROOT=C:\Program Files\Go #gosetup
GOPATH=C:\Users\yunliu1\go #gosetup
"C:\Program Files\Go\bin\go.exe" test -c -o C:\Users\yunliu1\AppData\Local\Temp\GoLand\___TestAccBatchPool_frontEndPortRanges_in_github_com_hashicorp_terraform_provider_azurerm_internal_services_batch__1_.test.exe github.com/hashicorp/terraform-provider-azurerm/internal/services/batch #gosetup
"C:\Program Files\Go\bin\go.exe" tool test2json -t C:\Users\yunliu1\AppData\Local\Temp\GoLand\___TestAccBatchPool_frontEndPortRanges_in_github_com_hashicorp_terraform_provider_azurerm_internal_services_batch__1_.test.exe -test.v -test.paniconexit0 -test.run ^\QTestAccBatchPool_frontEndPortRanges\E$ #gosetup
=== RUN   TestAccBatchPool_frontEndPortRanges
=== PAUSE TestAccBatchPool_frontEndPortRanges
=== CONT  TestAccBatchPool_frontEndPortRanges
--- PASS: TestAccBatchPool_frontEndPortRanges (600.67s)
PASS


Process finished with the exit code 0