### PR TITLE
new data source: `azurerm_kubernetes_cluster_snapshot`

### DIFF
--- a/internal/services/containers/client/client.go
+++ b/internal/services/containers/client/client.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/agentpools"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/maintenanceconfigurations"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/managedclusters"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/managedclustersnapshots"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/snapshots"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/kubernetesconfiguration/2022-11-01/extensions"
 	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
@@ -28,6 +29,7 @@ type Client struct {
 	MaintenanceConfigurationsClient             *maintenanceconfigurations.MaintenanceConfigurationsClient
 	ServicesClient                              *containerservices.ContainerServicesClient
 	SnapshotClient                              *snapshots.SnapshotsClient
+	ManagedClusterSnapshotClient                *managedclustersnapshots.ManagedClusterSnapshotsClient
 	Environment                                 azure.Environment
 }
 
@@ -71,6 +73,9 @@ func NewContainersClient(o *common.ClientOptions) (*Client, error) {
 	snapshotClient := snapshots.NewSnapshotsClientWithBaseURI(o.ResourceManagerEndpoint)
 	o.ConfigureClient(&snapshotClient.Client, o.ResourceManagerAuthorizer)
 
+	managedClusterSnapshotClient := managedclustersnapshots.NewManagedClusterSnapshotsClientWithBaseURI(o.ResourceManagerEndpoint)
+	o.ConfigureClient(&managedClusterSnapshotClient.Client, o.ResourceManagerAuthorizer)
+
 	return &Client{
 		AgentPoolsClient:                            &agentPoolsClient,
 		ContainerInstanceClient:                     &containerInstanceClient,
@@ -81,6 +86,7 @@ func NewContainersClient(o *common.ClientOptions) (*Client, error) {
 		MaintenanceConfigurationsClient:             &maintenanceConfigurationsClient,
 		ServicesClient:                              &servicesClient,
 		SnapshotClient:                              &snapshotClient,
+		ManagedClusterSnapshotClient:                &managedClusterSnapshotClient,
 		Environment:                                 o.AzureEnvironment,
 	}, nil
 }

--- a/internal/services/containers/kubernetes_cluster_snapshot_data_source.go
+++ b/internal/services/containers/kubernetes_cluster_snapshot_data_source.go
@@ -1,0 +1,111 @@
+package containers
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/managedclusters"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/managedclustersnapshots"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/snapshots"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+type KubernetesClusterSnapshotDataSourceModel struct {
+	Name            string            `tfschema:"name"`
+	ResourceGroup   string            `tfschema:"resource_group_name"`
+	SourceClusterId string            `tfschema:"source_cluster_id"`
+	Tags            map[string]string `tfschema:"tags"`
+}
+
+type KubernetesClusterSnapshotDataSource struct{}
+
+var _ sdk.DataSource = KubernetesClusterSnapshotDataSource{}
+
+func (r KubernetesClusterSnapshotDataSource) ResourceType() string {
+	return "azurerm_kubernetes_cluster_snapshot"
+}
+
+func (r KubernetesClusterSnapshotDataSource) ModelObject() interface{} {
+	return &KubernetesNodePoolSnapshotDataSourceModel{}
+}
+
+func (r KubernetesClusterSnapshotDataSource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+	return snapshots.ValidateSnapshotID
+}
+
+func (r KubernetesClusterSnapshotDataSource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"resource_group_name": commonschema.ResourceGroupNameForDataSource(),
+	}
+}
+
+func (r KubernetesClusterSnapshotDataSource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"source_cluster_id": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"tags": tags.SchemaDataSource(),
+	}
+}
+
+func (r KubernetesClusterSnapshotDataSource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Containers.ManagedClusterSnapshotClient
+			subscriptionId := metadata.Client.Account.SubscriptionId
+
+			var state KubernetesClusterSnapshotDataSourceModel
+			if err := metadata.Decode(&state); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			id := managedclustersnapshots.NewManagedClusterSnapshotID(subscriptionId, state.ResourceGroup, state.Name)
+
+			resp, err := client.Get(ctx, id)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return fmt.Errorf("%s was not found", id)
+				}
+				return fmt.Errorf("retrieving %s: %v", id, err)
+			}
+
+			state.Name = id.ManagedClusterSnapshotName
+
+			if model := resp.Model; model != nil {
+				state.Tags = pointer.From(model.Tags)
+
+				if props := model.Properties; props != nil {
+					if snapshotType := props.SnapshotType; snapshotType != nil && *snapshotType == managedclustersnapshots.SnapshotTypeManagedCluster {
+						if props.CreationData != nil && props.CreationData.SourceResourceId != nil {
+							clusterId, err := managedclusters.ParseManagedClusterIDInsensitively(*props.CreationData.SourceResourceId)
+							if err != nil {
+								return err
+							}
+							state.SourceClusterId = clusterId.ID()
+						}
+					}
+				}
+			}
+
+			metadata.SetID(id)
+
+			return metadata.Encode(&state)
+		},
+	}
+}

--- a/internal/services/containers/kubernetes_cluster_snapshot_data_source_test.go
+++ b/internal/services/containers/kubernetes_cluster_snapshot_data_source_test.go
@@ -1,0 +1,137 @@
+package containers_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/managedclusters"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/managedclustersnapshots"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+type KubernetesClusterSnapshotDataSource struct{}
+
+func TestAccDataSourceKubernetesClusterSnapshot_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_kubernetes_cluster_snapshot", "test")
+	r := KubernetesClusterSnapshotDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.snapshotSource(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				data.CheckWithClientForResource(func(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) error {
+					client := clients.Containers.ManagedClusterSnapshotClient
+					clusterId, err := managedclusters.ParseManagedClusterID(state.ID)
+					if err != nil {
+						return err
+					}
+					id := managedclustersnapshots.NewManagedClusterSnapshotID(clusterId.SubscriptionId, clusterId.ResourceGroupName, data.RandomString)
+					snapshot := managedclustersnapshots.ManagedClusterSnapshot{
+						Location: data.Locations.Primary,
+						Properties: &managedclustersnapshots.ManagedClusterSnapshotProperties{
+							SnapshotType: utils.ToPtr(managedclustersnapshots.SnapshotTypeManagedCluster),
+							CreationData: &managedclustersnapshots.CreationData{
+								SourceResourceId: utils.String(clusterId.ID()),
+							},
+						},
+					}
+					_, err = client.CreateOrUpdate(ctx, id, snapshot)
+					if err != nil {
+						return fmt.Errorf("creating %s: %+v", id, err)
+					}
+					return nil
+				}, "azurerm_kubernetes_cluster.source"),
+			),
+		},
+		{
+			Config: r.snapshotRestore(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("source_cluster_id").IsNotEmpty(),
+			),
+		},
+		{
+			Config: r.snapshotSource(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				data.CheckWithClientForResource(func(ctx context.Context, clients *clients.Client, state *terraform.InstanceState) error {
+					client := clients.Containers.ManagedClusterSnapshotClient
+					clusterId, err := managedclusters.ParseManagedClusterID(state.ID)
+					if err != nil {
+						return err
+					}
+					id := managedclustersnapshots.NewManagedClusterSnapshotID(clusterId.SubscriptionId, clusterId.ResourceGroupName, data.RandomString)
+					_, err = client.Delete(ctx, id)
+					if err != nil {
+						return fmt.Errorf("creating %s: %+v", id, err)
+					}
+					return nil
+				}, "azurerm_kubernetes_cluster.source"),
+			),
+		},
+	})
+}
+
+func (KubernetesClusterSnapshotDataSource) snapshotSource(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-aks-%[2]d"
+  location = "%[1]s"
+}
+
+resource "azurerm_kubernetes_cluster" "source" {
+  name                = "acctestaks%[2]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%[2]d"
+  default_node_pool {
+    name       = "default"
+    node_count = 1
+    vm_size    = "Standard_D2s_v3"
+  }
+  identity {
+    type = "SystemAssigned"
+  }
+}
+ `, data.Locations.Primary, data.RandomInteger)
+}
+
+func (KubernetesClusterSnapshotDataSource) snapshotRestore(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-aks-%[2]d"
+  location = "%[1]s"
+}
+
+resource "azurerm_kubernetes_cluster" "source" {
+  name                = "acctestaks%[2]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  dns_prefix          = "acctestaks%[2]d"
+  default_node_pool {
+    name       = "default"
+    node_count = 1
+    vm_size    = "Standard_D2s_v3"
+  }
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+data "azurerm_kubernetes_cluster_snapshot" "test" {
+  name                = "%[3]s"
+  resource_group_name = azurerm_resource_group.test.name
+}
+ `, data.Locations.Primary, data.RandomInteger, data.RandomString)
+}

--- a/internal/services/containers/registration.go
+++ b/internal/services/containers/registration.go
@@ -58,6 +58,7 @@ func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 func (r Registration) DataSources() []sdk.DataSource {
 	dataSources := []sdk.DataSource{
 		KubernetesNodePoolSnapshotDataSource{},
+		KubernetesClusterSnapshotDataSource{},
 	}
 	dataSources = append(dataSources, r.autoRegistration.DataSources()...)
 	return dataSources

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/managedclustersnapshots/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/managedclustersnapshots/README.md
@@ -1,0 +1,128 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/managedclustersnapshots` Documentation
+
+The `managedclustersnapshots` SDK allows for interaction with the Azure Resource Manager Service `containerservice` (API Version `2023-02-02-preview`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/managedclustersnapshots"
+```
+
+
+### Client Initialization
+
+```go
+client := managedclustersnapshots.NewManagedClusterSnapshotsClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `ManagedClusterSnapshotsClient.CreateOrUpdate`
+
+```go
+ctx := context.TODO()
+id := managedclustersnapshots.NewManagedClusterSnapshotID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterSnapshotValue")
+
+payload := managedclustersnapshots.ManagedClusterSnapshot{
+	// ...
+}
+
+
+read, err := client.CreateOrUpdate(ctx, id, payload)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `ManagedClusterSnapshotsClient.Delete`
+
+```go
+ctx := context.TODO()
+id := managedclustersnapshots.NewManagedClusterSnapshotID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterSnapshotValue")
+
+read, err := client.Delete(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `ManagedClusterSnapshotsClient.Get`
+
+```go
+ctx := context.TODO()
+id := managedclustersnapshots.NewManagedClusterSnapshotID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterSnapshotValue")
+
+read, err := client.Get(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `ManagedClusterSnapshotsClient.List`
+
+```go
+ctx := context.TODO()
+id := managedclustersnapshots.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+
+// alternatively `client.List(ctx, id)` can be used to do batched pagination
+items, err := client.ListComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `ManagedClusterSnapshotsClient.ListByResourceGroup`
+
+```go
+ctx := context.TODO()
+id := managedclustersnapshots.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+
+// alternatively `client.ListByResourceGroup(ctx, id)` can be used to do batched pagination
+items, err := client.ListByResourceGroupComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `ManagedClusterSnapshotsClient.UpdateTags`
+
+```go
+ctx := context.TODO()
+id := managedclustersnapshots.NewManagedClusterSnapshotID("12345678-1234-9876-4563-123456789012", "example-resource-group", "managedClusterSnapshotValue")
+
+payload := managedclustersnapshots.TagsObject{
+	// ...
+}
+
+
+read, err := client.UpdateTags(ctx, id, payload)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/managedclustersnapshots/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/managedclustersnapshots/client.go
@@ -1,0 +1,18 @@
+package managedclustersnapshots
+
+import "github.com/Azure/go-autorest/autorest"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ManagedClusterSnapshotsClient struct {
+	Client  autorest.Client
+	baseUri string
+}
+
+func NewManagedClusterSnapshotsClientWithBaseURI(endpoint string) ManagedClusterSnapshotsClient {
+	return ManagedClusterSnapshotsClient{
+		Client:  autorest.NewClientWithUserAgent(userAgent()),
+		baseUri: endpoint,
+	}
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/managedclustersnapshots/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/managedclustersnapshots/constants.go
@@ -1,0 +1,230 @@
+package managedclustersnapshots
+
+import "strings"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type LoadBalancerSku string
+
+const (
+	LoadBalancerSkuBasic    LoadBalancerSku = "basic"
+	LoadBalancerSkuStandard LoadBalancerSku = "standard"
+)
+
+func PossibleValuesForLoadBalancerSku() []string {
+	return []string{
+		string(LoadBalancerSkuBasic),
+		string(LoadBalancerSkuStandard),
+	}
+}
+
+func parseLoadBalancerSku(input string) (*LoadBalancerSku, error) {
+	vals := map[string]LoadBalancerSku{
+		"basic":    LoadBalancerSkuBasic,
+		"standard": LoadBalancerSkuStandard,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := LoadBalancerSku(input)
+	return &out, nil
+}
+
+type ManagedClusterSKUName string
+
+const (
+	ManagedClusterSKUNameBase ManagedClusterSKUName = "Base"
+)
+
+func PossibleValuesForManagedClusterSKUName() []string {
+	return []string{
+		string(ManagedClusterSKUNameBase),
+	}
+}
+
+func parseManagedClusterSKUName(input string) (*ManagedClusterSKUName, error) {
+	vals := map[string]ManagedClusterSKUName{
+		"base": ManagedClusterSKUNameBase,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ManagedClusterSKUName(input)
+	return &out, nil
+}
+
+type ManagedClusterSKUTier string
+
+const (
+	ManagedClusterSKUTierFree     ManagedClusterSKUTier = "Free"
+	ManagedClusterSKUTierStandard ManagedClusterSKUTier = "Standard"
+)
+
+func PossibleValuesForManagedClusterSKUTier() []string {
+	return []string{
+		string(ManagedClusterSKUTierFree),
+		string(ManagedClusterSKUTierStandard),
+	}
+}
+
+func parseManagedClusterSKUTier(input string) (*ManagedClusterSKUTier, error) {
+	vals := map[string]ManagedClusterSKUTier{
+		"free":     ManagedClusterSKUTierFree,
+		"standard": ManagedClusterSKUTierStandard,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ManagedClusterSKUTier(input)
+	return &out, nil
+}
+
+type NetworkMode string
+
+const (
+	NetworkModeBridge      NetworkMode = "bridge"
+	NetworkModeTransparent NetworkMode = "transparent"
+)
+
+func PossibleValuesForNetworkMode() []string {
+	return []string{
+		string(NetworkModeBridge),
+		string(NetworkModeTransparent),
+	}
+}
+
+func parseNetworkMode(input string) (*NetworkMode, error) {
+	vals := map[string]NetworkMode{
+		"bridge":      NetworkModeBridge,
+		"transparent": NetworkModeTransparent,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := NetworkMode(input)
+	return &out, nil
+}
+
+type NetworkPlugin string
+
+const (
+	NetworkPluginAzure   NetworkPlugin = "azure"
+	NetworkPluginKubenet NetworkPlugin = "kubenet"
+	NetworkPluginNone    NetworkPlugin = "none"
+)
+
+func PossibleValuesForNetworkPlugin() []string {
+	return []string{
+		string(NetworkPluginAzure),
+		string(NetworkPluginKubenet),
+		string(NetworkPluginNone),
+	}
+}
+
+func parseNetworkPlugin(input string) (*NetworkPlugin, error) {
+	vals := map[string]NetworkPlugin{
+		"azure":   NetworkPluginAzure,
+		"kubenet": NetworkPluginKubenet,
+		"none":    NetworkPluginNone,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := NetworkPlugin(input)
+	return &out, nil
+}
+
+type NetworkPluginMode string
+
+const (
+	NetworkPluginModeOverlay NetworkPluginMode = "Overlay"
+)
+
+func PossibleValuesForNetworkPluginMode() []string {
+	return []string{
+		string(NetworkPluginModeOverlay),
+	}
+}
+
+func parseNetworkPluginMode(input string) (*NetworkPluginMode, error) {
+	vals := map[string]NetworkPluginMode{
+		"overlay": NetworkPluginModeOverlay,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := NetworkPluginMode(input)
+	return &out, nil
+}
+
+type NetworkPolicy string
+
+const (
+	NetworkPolicyAzure  NetworkPolicy = "azure"
+	NetworkPolicyCalico NetworkPolicy = "calico"
+	NetworkPolicyCilium NetworkPolicy = "cilium"
+)
+
+func PossibleValuesForNetworkPolicy() []string {
+	return []string{
+		string(NetworkPolicyAzure),
+		string(NetworkPolicyCalico),
+		string(NetworkPolicyCilium),
+	}
+}
+
+func parseNetworkPolicy(input string) (*NetworkPolicy, error) {
+	vals := map[string]NetworkPolicy{
+		"azure":  NetworkPolicyAzure,
+		"calico": NetworkPolicyCalico,
+		"cilium": NetworkPolicyCilium,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := NetworkPolicy(input)
+	return &out, nil
+}
+
+type SnapshotType string
+
+const (
+	SnapshotTypeManagedCluster SnapshotType = "ManagedCluster"
+	SnapshotTypeNodePool       SnapshotType = "NodePool"
+)
+
+func PossibleValuesForSnapshotType() []string {
+	return []string{
+		string(SnapshotTypeManagedCluster),
+		string(SnapshotTypeNodePool),
+	}
+}
+
+func parseSnapshotType(input string) (*SnapshotType, error) {
+	vals := map[string]SnapshotType{
+		"managedcluster": SnapshotTypeManagedCluster,
+		"nodepool":       SnapshotTypeNodePool,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := SnapshotType(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/managedclustersnapshots/id_managedclustersnapshot.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/managedclustersnapshots/id_managedclustersnapshot.go
@@ -1,0 +1,127 @@
+package managedclustersnapshots
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ resourceids.ResourceId = ManagedClusterSnapshotId{}
+
+// ManagedClusterSnapshotId is a struct representing the Resource ID for a Managed Cluster Snapshot
+type ManagedClusterSnapshotId struct {
+	SubscriptionId             string
+	ResourceGroupName          string
+	ManagedClusterSnapshotName string
+}
+
+// NewManagedClusterSnapshotID returns a new ManagedClusterSnapshotId struct
+func NewManagedClusterSnapshotID(subscriptionId string, resourceGroupName string, managedClusterSnapshotName string) ManagedClusterSnapshotId {
+	return ManagedClusterSnapshotId{
+		SubscriptionId:             subscriptionId,
+		ResourceGroupName:          resourceGroupName,
+		ManagedClusterSnapshotName: managedClusterSnapshotName,
+	}
+}
+
+// ParseManagedClusterSnapshotID parses 'input' into a ManagedClusterSnapshotId
+func ParseManagedClusterSnapshotID(input string) (*ManagedClusterSnapshotId, error) {
+	parser := resourceids.NewParserFromResourceIdType(ManagedClusterSnapshotId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := ManagedClusterSnapshotId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
+	}
+
+	if id.ManagedClusterSnapshotName, ok = parsed.Parsed["managedClusterSnapshotName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedClusterSnapshotName", *parsed)
+	}
+
+	return &id, nil
+}
+
+// ParseManagedClusterSnapshotIDInsensitively parses 'input' case-insensitively into a ManagedClusterSnapshotId
+// note: this method should only be used for API response data and not user input
+func ParseManagedClusterSnapshotIDInsensitively(input string) (*ManagedClusterSnapshotId, error) {
+	parser := resourceids.NewParserFromResourceIdType(ManagedClusterSnapshotId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := ManagedClusterSnapshotId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
+	}
+
+	if id.ManagedClusterSnapshotName, ok = parsed.Parsed["managedClusterSnapshotName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "managedClusterSnapshotName", *parsed)
+	}
+
+	return &id, nil
+}
+
+// ValidateManagedClusterSnapshotID checks that 'input' can be parsed as a Managed Cluster Snapshot ID
+func ValidateManagedClusterSnapshotID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseManagedClusterSnapshotID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Managed Cluster Snapshot ID
+func (id ManagedClusterSnapshotId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.ContainerService/managedClusterSnapshots/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.ManagedClusterSnapshotName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Managed Cluster Snapshot ID
+func (id ManagedClusterSnapshotId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftContainerService", "Microsoft.ContainerService", "Microsoft.ContainerService"),
+		resourceids.StaticSegment("staticManagedClusterSnapshots", "managedClusterSnapshots", "managedClusterSnapshots"),
+		resourceids.UserSpecifiedSegment("managedClusterSnapshotName", "managedClusterSnapshotValue"),
+	}
+}
+
+// String returns a human-readable description of this Managed Cluster Snapshot ID
+func (id ManagedClusterSnapshotId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Managed Cluster Snapshot Name: %q", id.ManagedClusterSnapshotName),
+	}
+	return fmt.Sprintf("Managed Cluster Snapshot (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/managedclustersnapshots/method_createorupdate_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/managedclustersnapshots/method_createorupdate_autorest.go
@@ -1,0 +1,69 @@
+package managedclustersnapshots
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CreateOrUpdateOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *ManagedClusterSnapshot
+}
+
+// CreateOrUpdate ...
+func (c ManagedClusterSnapshotsClient) CreateOrUpdate(ctx context.Context, id ManagedClusterSnapshotId, input ManagedClusterSnapshot) (result CreateOrUpdateOperationResponse, err error) {
+	req, err := c.preparerForCreateOrUpdate(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "managedclustersnapshots.ManagedClusterSnapshotsClient", "CreateOrUpdate", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "managedclustersnapshots.ManagedClusterSnapshotsClient", "CreateOrUpdate", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForCreateOrUpdate(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "managedclustersnapshots.ManagedClusterSnapshotsClient", "CreateOrUpdate", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForCreateOrUpdate prepares the CreateOrUpdate request.
+func (c ManagedClusterSnapshotsClient) preparerForCreateOrUpdate(ctx context.Context, id ManagedClusterSnapshotId, input ManagedClusterSnapshot) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPut(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForCreateOrUpdate handles the response to the CreateOrUpdate request. The method always
+// closes the http.Response Body.
+func (c ManagedClusterSnapshotsClient) responderForCreateOrUpdate(resp *http.Response) (result CreateOrUpdateOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusCreated, http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/managedclustersnapshots/method_delete_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/managedclustersnapshots/method_delete_autorest.go
@@ -1,0 +1,66 @@
+package managedclustersnapshots
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DeleteOperationResponse struct {
+	HttpResponse *http.Response
+}
+
+// Delete ...
+func (c ManagedClusterSnapshotsClient) Delete(ctx context.Context, id ManagedClusterSnapshotId) (result DeleteOperationResponse, err error) {
+	req, err := c.preparerForDelete(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "managedclustersnapshots.ManagedClusterSnapshotsClient", "Delete", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "managedclustersnapshots.ManagedClusterSnapshotsClient", "Delete", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForDelete(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "managedclustersnapshots.ManagedClusterSnapshotsClient", "Delete", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForDelete prepares the Delete request.
+func (c ManagedClusterSnapshotsClient) preparerForDelete(ctx context.Context, id ManagedClusterSnapshotId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsDelete(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForDelete handles the response to the Delete request. The method always
+// closes the http.Response Body.
+func (c ManagedClusterSnapshotsClient) responderForDelete(resp *http.Response) (result DeleteOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusNoContent, http.StatusOK),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/managedclustersnapshots/method_get_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/managedclustersnapshots/method_get_autorest.go
@@ -1,0 +1,68 @@
+package managedclustersnapshots
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *ManagedClusterSnapshot
+}
+
+// Get ...
+func (c ManagedClusterSnapshotsClient) Get(ctx context.Context, id ManagedClusterSnapshotId) (result GetOperationResponse, err error) {
+	req, err := c.preparerForGet(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "managedclustersnapshots.ManagedClusterSnapshotsClient", "Get", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "managedclustersnapshots.ManagedClusterSnapshotsClient", "Get", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForGet(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "managedclustersnapshots.ManagedClusterSnapshotsClient", "Get", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForGet prepares the Get request.
+func (c ManagedClusterSnapshotsClient) preparerForGet(ctx context.Context, id ManagedClusterSnapshotId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForGet handles the response to the Get request. The method always
+// closes the http.Response Body.
+func (c ManagedClusterSnapshotsClient) responderForGet(resp *http.Response) (result GetOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/managedclustersnapshots/method_list_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/managedclustersnapshots/method_list_autorest.go
@@ -1,0 +1,187 @@
+package managedclustersnapshots
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *[]ManagedClusterSnapshot
+
+	nextLink     *string
+	nextPageFunc func(ctx context.Context, nextLink string) (ListOperationResponse, error)
+}
+
+type ListCompleteResult struct {
+	Items []ManagedClusterSnapshot
+}
+
+func (r ListOperationResponse) HasMore() bool {
+	return r.nextLink != nil
+}
+
+func (r ListOperationResponse) LoadMore(ctx context.Context) (resp ListOperationResponse, err error) {
+	if !r.HasMore() {
+		err = fmt.Errorf("no more pages returned")
+		return
+	}
+	return r.nextPageFunc(ctx, *r.nextLink)
+}
+
+// List ...
+func (c ManagedClusterSnapshotsClient) List(ctx context.Context, id commonids.SubscriptionId) (resp ListOperationResponse, err error) {
+	req, err := c.preparerForList(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "managedclustersnapshots.ManagedClusterSnapshotsClient", "List", nil, "Failure preparing request")
+		return
+	}
+
+	resp.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "managedclustersnapshots.ManagedClusterSnapshotsClient", "List", resp.HttpResponse, "Failure sending request")
+		return
+	}
+
+	resp, err = c.responderForList(resp.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "managedclustersnapshots.ManagedClusterSnapshotsClient", "List", resp.HttpResponse, "Failure responding to request")
+		return
+	}
+	return
+}
+
+// preparerForList prepares the List request.
+func (c ManagedClusterSnapshotsClient) preparerForList(ctx context.Context, id commonids.SubscriptionId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/providers/Microsoft.ContainerService/managedClusterSnapshots", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// preparerForListWithNextLink prepares the List request with the given nextLink token.
+func (c ManagedClusterSnapshotsClient) preparerForListWithNextLink(ctx context.Context, nextLink string) (*http.Request, error) {
+	uri, err := url.Parse(nextLink)
+	if err != nil {
+		return nil, fmt.Errorf("parsing nextLink %q: %+v", nextLink, err)
+	}
+	queryParameters := map[string]interface{}{}
+	for k, v := range uri.Query() {
+		if len(v) == 0 {
+			continue
+		}
+		val := v[0]
+		val = autorest.Encode("query", val)
+		queryParameters[k] = val
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(uri.Path),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForList handles the response to the List request. The method always
+// closes the http.Response Body.
+func (c ManagedClusterSnapshotsClient) responderForList(resp *http.Response) (result ListOperationResponse, err error) {
+	type page struct {
+		Values   []ManagedClusterSnapshot `json:"value"`
+		NextLink *string                  `json:"nextLink"`
+	}
+	var respObj page
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&respObj),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	result.Model = &respObj.Values
+	result.nextLink = respObj.NextLink
+	if respObj.NextLink != nil {
+		result.nextPageFunc = func(ctx context.Context, nextLink string) (result ListOperationResponse, err error) {
+			req, err := c.preparerForListWithNextLink(ctx, nextLink)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "managedclustersnapshots.ManagedClusterSnapshotsClient", "List", nil, "Failure preparing request")
+				return
+			}
+
+			result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "managedclustersnapshots.ManagedClusterSnapshotsClient", "List", result.HttpResponse, "Failure sending request")
+				return
+			}
+
+			result, err = c.responderForList(result.HttpResponse)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "managedclustersnapshots.ManagedClusterSnapshotsClient", "List", result.HttpResponse, "Failure responding to request")
+				return
+			}
+
+			return
+		}
+	}
+	return
+}
+
+// ListComplete retrieves all of the results into a single object
+func (c ManagedClusterSnapshotsClient) ListComplete(ctx context.Context, id commonids.SubscriptionId) (ListCompleteResult, error) {
+	return c.ListCompleteMatchingPredicate(ctx, id, ManagedClusterSnapshotOperationPredicate{})
+}
+
+// ListCompleteMatchingPredicate retrieves all of the results and then applied the predicate
+func (c ManagedClusterSnapshotsClient) ListCompleteMatchingPredicate(ctx context.Context, id commonids.SubscriptionId, predicate ManagedClusterSnapshotOperationPredicate) (resp ListCompleteResult, err error) {
+	items := make([]ManagedClusterSnapshot, 0)
+
+	page, err := c.List(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading the initial page: %+v", err)
+		return
+	}
+	if page.Model != nil {
+		for _, v := range *page.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	for page.HasMore() {
+		page, err = page.LoadMore(ctx)
+		if err != nil {
+			err = fmt.Errorf("loading the next page: %+v", err)
+			return
+		}
+
+		if page.Model != nil {
+			for _, v := range *page.Model {
+				if predicate.Matches(v) {
+					items = append(items, v)
+				}
+			}
+		}
+	}
+
+	out := ListCompleteResult{
+		Items: items,
+	}
+	return out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/managedclustersnapshots/method_listbyresourcegroup_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/managedclustersnapshots/method_listbyresourcegroup_autorest.go
@@ -1,0 +1,187 @@
+package managedclustersnapshots
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListByResourceGroupOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *[]ManagedClusterSnapshot
+
+	nextLink     *string
+	nextPageFunc func(ctx context.Context, nextLink string) (ListByResourceGroupOperationResponse, error)
+}
+
+type ListByResourceGroupCompleteResult struct {
+	Items []ManagedClusterSnapshot
+}
+
+func (r ListByResourceGroupOperationResponse) HasMore() bool {
+	return r.nextLink != nil
+}
+
+func (r ListByResourceGroupOperationResponse) LoadMore(ctx context.Context) (resp ListByResourceGroupOperationResponse, err error) {
+	if !r.HasMore() {
+		err = fmt.Errorf("no more pages returned")
+		return
+	}
+	return r.nextPageFunc(ctx, *r.nextLink)
+}
+
+// ListByResourceGroup ...
+func (c ManagedClusterSnapshotsClient) ListByResourceGroup(ctx context.Context, id commonids.ResourceGroupId) (resp ListByResourceGroupOperationResponse, err error) {
+	req, err := c.preparerForListByResourceGroup(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "managedclustersnapshots.ManagedClusterSnapshotsClient", "ListByResourceGroup", nil, "Failure preparing request")
+		return
+	}
+
+	resp.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "managedclustersnapshots.ManagedClusterSnapshotsClient", "ListByResourceGroup", resp.HttpResponse, "Failure sending request")
+		return
+	}
+
+	resp, err = c.responderForListByResourceGroup(resp.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "managedclustersnapshots.ManagedClusterSnapshotsClient", "ListByResourceGroup", resp.HttpResponse, "Failure responding to request")
+		return
+	}
+	return
+}
+
+// preparerForListByResourceGroup prepares the ListByResourceGroup request.
+func (c ManagedClusterSnapshotsClient) preparerForListByResourceGroup(ctx context.Context, id commonids.ResourceGroupId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/providers/Microsoft.ContainerService/managedClusterSnapshots", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// preparerForListByResourceGroupWithNextLink prepares the ListByResourceGroup request with the given nextLink token.
+func (c ManagedClusterSnapshotsClient) preparerForListByResourceGroupWithNextLink(ctx context.Context, nextLink string) (*http.Request, error) {
+	uri, err := url.Parse(nextLink)
+	if err != nil {
+		return nil, fmt.Errorf("parsing nextLink %q: %+v", nextLink, err)
+	}
+	queryParameters := map[string]interface{}{}
+	for k, v := range uri.Query() {
+		if len(v) == 0 {
+			continue
+		}
+		val := v[0]
+		val = autorest.Encode("query", val)
+		queryParameters[k] = val
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(uri.Path),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForListByResourceGroup handles the response to the ListByResourceGroup request. The method always
+// closes the http.Response Body.
+func (c ManagedClusterSnapshotsClient) responderForListByResourceGroup(resp *http.Response) (result ListByResourceGroupOperationResponse, err error) {
+	type page struct {
+		Values   []ManagedClusterSnapshot `json:"value"`
+		NextLink *string                  `json:"nextLink"`
+	}
+	var respObj page
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&respObj),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	result.Model = &respObj.Values
+	result.nextLink = respObj.NextLink
+	if respObj.NextLink != nil {
+		result.nextPageFunc = func(ctx context.Context, nextLink string) (result ListByResourceGroupOperationResponse, err error) {
+			req, err := c.preparerForListByResourceGroupWithNextLink(ctx, nextLink)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "managedclustersnapshots.ManagedClusterSnapshotsClient", "ListByResourceGroup", nil, "Failure preparing request")
+				return
+			}
+
+			result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "managedclustersnapshots.ManagedClusterSnapshotsClient", "ListByResourceGroup", result.HttpResponse, "Failure sending request")
+				return
+			}
+
+			result, err = c.responderForListByResourceGroup(result.HttpResponse)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "managedclustersnapshots.ManagedClusterSnapshotsClient", "ListByResourceGroup", result.HttpResponse, "Failure responding to request")
+				return
+			}
+
+			return
+		}
+	}
+	return
+}
+
+// ListByResourceGroupComplete retrieves all of the results into a single object
+func (c ManagedClusterSnapshotsClient) ListByResourceGroupComplete(ctx context.Context, id commonids.ResourceGroupId) (ListByResourceGroupCompleteResult, error) {
+	return c.ListByResourceGroupCompleteMatchingPredicate(ctx, id, ManagedClusterSnapshotOperationPredicate{})
+}
+
+// ListByResourceGroupCompleteMatchingPredicate retrieves all of the results and then applied the predicate
+func (c ManagedClusterSnapshotsClient) ListByResourceGroupCompleteMatchingPredicate(ctx context.Context, id commonids.ResourceGroupId, predicate ManagedClusterSnapshotOperationPredicate) (resp ListByResourceGroupCompleteResult, err error) {
+	items := make([]ManagedClusterSnapshot, 0)
+
+	page, err := c.ListByResourceGroup(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading the initial page: %+v", err)
+		return
+	}
+	if page.Model != nil {
+		for _, v := range *page.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	for page.HasMore() {
+		page, err = page.LoadMore(ctx)
+		if err != nil {
+			err = fmt.Errorf("loading the next page: %+v", err)
+			return
+		}
+
+		if page.Model != nil {
+			for _, v := range *page.Model {
+				if predicate.Matches(v) {
+					items = append(items, v)
+				}
+			}
+		}
+	}
+
+	out := ListByResourceGroupCompleteResult{
+		Items: items,
+	}
+	return out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/managedclustersnapshots/method_updatetags_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/managedclustersnapshots/method_updatetags_autorest.go
@@ -1,0 +1,69 @@
+package managedclustersnapshots
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UpdateTagsOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *ManagedClusterSnapshot
+}
+
+// UpdateTags ...
+func (c ManagedClusterSnapshotsClient) UpdateTags(ctx context.Context, id ManagedClusterSnapshotId, input TagsObject) (result UpdateTagsOperationResponse, err error) {
+	req, err := c.preparerForUpdateTags(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "managedclustersnapshots.ManagedClusterSnapshotsClient", "UpdateTags", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "managedclustersnapshots.ManagedClusterSnapshotsClient", "UpdateTags", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForUpdateTags(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "managedclustersnapshots.ManagedClusterSnapshotsClient", "UpdateTags", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForUpdateTags prepares the UpdateTags request.
+func (c ManagedClusterSnapshotsClient) preparerForUpdateTags(ctx context.Context, id ManagedClusterSnapshotId, input TagsObject) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPatch(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForUpdateTags handles the response to the UpdateTags request. The method always
+// closes the http.Response Body.
+func (c ManagedClusterSnapshotsClient) responderForUpdateTags(resp *http.Response) (result UpdateTagsOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/managedclustersnapshots/model_creationdata.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/managedclustersnapshots/model_creationdata.go
@@ -1,0 +1,8 @@
+package managedclustersnapshots
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CreationData struct {
+	SourceResourceId *string `json:"sourceResourceId,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/managedclustersnapshots/model_managedclusterpropertiesforsnapshot.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/managedclustersnapshots/model_managedclusterpropertiesforsnapshot.go
@@ -1,0 +1,11 @@
+package managedclustersnapshots
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ManagedClusterPropertiesForSnapshot struct {
+	EnableRbac        *bool                      `json:"enableRbac,omitempty"`
+	KubernetesVersion *string                    `json:"kubernetesVersion,omitempty"`
+	NetworkProfile    *NetworkProfileForSnapshot `json:"networkProfile,omitempty"`
+	Sku               *ManagedClusterSKU         `json:"sku,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/managedclustersnapshots/model_managedclustersku.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/managedclustersnapshots/model_managedclustersku.go
@@ -1,0 +1,9 @@
+package managedclustersnapshots
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ManagedClusterSKU struct {
+	Name *ManagedClusterSKUName `json:"name,omitempty"`
+	Tier *ManagedClusterSKUTier `json:"tier,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/managedclustersnapshots/model_managedclustersnapshot.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/managedclustersnapshots/model_managedclustersnapshot.go
@@ -1,0 +1,18 @@
+package managedclustersnapshots
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/systemdata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ManagedClusterSnapshot struct {
+	Id         *string                           `json:"id,omitempty"`
+	Location   string                            `json:"location"`
+	Name       *string                           `json:"name,omitempty"`
+	Properties *ManagedClusterSnapshotProperties `json:"properties,omitempty"`
+	SystemData *systemdata.SystemData            `json:"systemData,omitempty"`
+	Tags       *map[string]string                `json:"tags,omitempty"`
+	Type       *string                           `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/managedclustersnapshots/model_managedclustersnapshotproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/managedclustersnapshots/model_managedclustersnapshotproperties.go
@@ -1,0 +1,10 @@
+package managedclustersnapshots
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ManagedClusterSnapshotProperties struct {
+	CreationData                     *CreationData                        `json:"creationData,omitempty"`
+	ManagedClusterPropertiesReadOnly *ManagedClusterPropertiesForSnapshot `json:"managedClusterPropertiesReadOnly,omitempty"`
+	SnapshotType                     *SnapshotType                        `json:"snapshotType,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/managedclustersnapshots/model_networkprofileforsnapshot.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/managedclustersnapshots/model_networkprofileforsnapshot.go
@@ -1,0 +1,12 @@
+package managedclustersnapshots
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type NetworkProfileForSnapshot struct {
+	LoadBalancerSku   *LoadBalancerSku   `json:"loadBalancerSku,omitempty"`
+	NetworkMode       *NetworkMode       `json:"networkMode,omitempty"`
+	NetworkPlugin     *NetworkPlugin     `json:"networkPlugin,omitempty"`
+	NetworkPluginMode *NetworkPluginMode `json:"networkPluginMode,omitempty"`
+	NetworkPolicy     *NetworkPolicy     `json:"networkPolicy,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/managedclustersnapshots/model_tagsobject.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/managedclustersnapshots/model_tagsobject.go
@@ -1,0 +1,8 @@
+package managedclustersnapshots
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type TagsObject struct {
+	Tags *map[string]string `json:"tags,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/managedclustersnapshots/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/managedclustersnapshots/predicates.go
@@ -1,0 +1,32 @@
+package managedclustersnapshots
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ManagedClusterSnapshotOperationPredicate struct {
+	Id       *string
+	Location *string
+	Name     *string
+	Type     *string
+}
+
+func (p ManagedClusterSnapshotOperationPredicate) Matches(input ManagedClusterSnapshot) bool {
+
+	if p.Id != nil && (input.Id == nil && *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Location != nil && *p.Location != input.Location {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil && *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil && *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/managedclustersnapshots/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/managedclustersnapshots/version.go
@@ -1,0 +1,12 @@
+package managedclustersnapshots
+
+import "fmt"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2023-02-02-preview"
+
+func userAgent() string {
+	return fmt.Sprintf("hashicorp/go-azure-sdk/managedclustersnapshots/%s", defaultApiVersion)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -251,6 +251,7 @@ github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2022-09-02-p
 github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/agentpools
 github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/maintenanceconfigurations
 github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/managedclusters
+github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/managedclustersnapshots
 github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-02-02-preview/snapshots
 github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-05-15/cosmosdb
 github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-05-15/managedcassandras

--- a/website/docs/d/kubernetes_cluster_snapshot.html.markdown
+++ b/website/docs/d/kubernetes_cluster_snapshot.html.markdown
@@ -1,0 +1,42 @@
+---
+subcategory: "Container"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_kubernetes_cluster_snapshot"
+description: |-
+  Gets information about an existing Kubernetes Cluster Snapshot
+---
+
+# Data Source: azurerm_kubernetes_cluster_snapshot
+
+Use this data source to access information about an existing Kubernetes Cluster Snapshot.
+
+## Example Usage
+
+```hcl
+data "azurerm_kubernetes_node_pool_snapshot" "example" {
+  name                = "example"
+  resource_group_name = "example-resources"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - The name of the Kubernetes Cluster Snapshot.
+
+* `resource_group_name` - The name of the Resource Group in which the Kubernetes Cluster Snapshot exists.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the Kubernetes Node Pool Snapshot.
+
+* `source_cluster_id` - The ID of the source Cluster.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `read` - (Defaults to 5 minutes) Used when retrieving the Kubernetes Cluster Snapshot.

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -235,6 +235,8 @@ resource "azurerm_kubernetes_cluster" "example" {
 
 -> **Note:** Whilst the AKS API previously supported the `Paid` SKU - the AKS API introduced a breaking change in API Version `2023-02-01` (used in v3.51.0 and later) where the value `Paid` must now be set to `Standard`.
 
+* `snapshot_id` - (Optional)  The ID of the Snapshot which should be used to create this cluster. Changing this forces a new resource to be created.
+
 * `storage_profile` - (Optional) A `storage_profile` block as defined below.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.


### PR DESCRIPTION
```
=== RUN   TestAccKubernetesCluster_snapshotId
=== PAUSE TestAccKubernetesCluster_snapshotId
=== CONT  TestAccKubernetesCluster_snapshotId
--- PASS: TestAccKubernetesCluster_snapshotId (1377.46s)
PASS

=== RUN   TestAccDataSourceKubernetesClusterSnapshot_basic
=== PAUSE TestAccDataSourceKubernetesClusterSnapshot_basic
=== CONT  TestAccDataSourceKubernetesClusterSnapshot_basic
--- PASS: TestAccDataSourceKubernetesClusterSnapshot_basic (656.52s)
PASS

```