### PR TITLE
`data.azurerm_kubernetes_cluster` - Fix nil panic by correcting nil check expression

### DIFF
--- a/internal/services/containers/kubernetes_cluster_data_source.go
+++ b/internal/services/containers/kubernetes_cluster_data_source.go
@@ -896,12 +896,12 @@ func flattenKubernetesClusterDataSourceStorageProfile(input *managedclusters.Man
 		}
 
 		diskVersion := ""
-		if input.FileCSIDriver != nil {
+		if input.DiskCSIDriver != nil {
 			diskVersion = *input.DiskCSIDriver.Version
 		}
 
 		fileEnabled := true
-		if input.DiskCSIDriver != nil {
+		if input.FileCSIDriver != nil {
 			fileEnabled = *input.FileCSIDriver.Enabled
 		}
 


### PR DESCRIPTION
This pr should fix #21840 by correcting nil check expressions.