### PR TITLE
Fixing incorrect reference to principal_id

### DIFF
--- a/examples/kubernetes/aci_connector_linux/main.tf
+++ b/examples/kubernetes/aci_connector_linux/main.tf
@@ -70,5 +70,5 @@ resource "azurerm_kubernetes_cluster" "example" {
 resource "azurerm_role_assignment" "example" {
   scope                = azurerm_subnet.example-aci.id
   role_definition_name = "Network Contributor"
-  principal_id         = azurerm_kubernetes_cluster.example.identity.0.principal_id
+  principal_id         = azurerm_kubernetes_cluster.example.aci_connector_linux[0].connector_identity[0].object_id
 }


### PR DESCRIPTION
In the current example template for configuring [aci_connector_linux](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/examples/kubernetes/aci_connector_linux/main.tf) in an AKS cluster, it has never been updated to reference the correct principal_id that is now exported in this update https://github.com/hashicorp/terraform-provider-azurerm/pull/20194/commits/f83be5e903be04d81c0af23ceecd8115c76b8f43

I have updated the example to reference the proper id that will successfully add/update the role assignment in Azure Managed Identity. I apologize if I'm missing any of the required information, this is my first contribution. 

```
azurerm_kubernetes_cluster.example.identity.0.principal_id
```

with

```
azurerm_kubernetes_cluster.example.aci_connector_linux[0].connector_identity[0].object_id
```
