### PR TITLE
`data.azurerm_kubernetes_cluster` - Fix nil panic by amending nil check

### DIFF
--- a/internal/services/containers/kubernetes_cluster_data_source.go
+++ b/internal/services/containers/kubernetes_cluster_data_source.go
@@ -886,27 +886,27 @@ func flattenKubernetesClusterDataSourceStorageProfile(input *managedclusters.Man
 
 	if input != nil {
 		blobEnabled := false
-		if input.BlobCSIDriver != nil {
+		if input.BlobCSIDriver != nil && input.BlobCSIDriver.Enabled != nil {
 			blobEnabled = *input.BlobCSIDriver.Enabled
 		}
 
 		diskEnabled := true
-		if input.DiskCSIDriver != nil {
+		if input.DiskCSIDriver != nil && input.DiskCSIDriver.Enabled != nil {
 			diskEnabled = *input.DiskCSIDriver.Enabled
 		}
 
 		diskVersion := ""
-		if input.DiskCSIDriver != nil {
+		if input.DiskCSIDriver != nil && input.DiskCSIDriver.Version != nil {
 			diskVersion = *input.DiskCSIDriver.Version
 		}
 
 		fileEnabled := true
-		if input.FileCSIDriver != nil {
+		if input.FileCSIDriver != nil && input.FileCSIDriver.Enabled != nil {
 			fileEnabled = *input.FileCSIDriver.Enabled
 		}
 
 		snapshotController := true
-		if input.SnapshotController != nil {
+		if input.SnapshotController != nil && input.SnapshotController.Enabled != nil {
 			snapshotController = *input.SnapshotController.Enabled
 		}
 


### PR DESCRIPTION
#21850 was not sufficient to fix the potential nil panic, this pr added extra nil checks to fix #21840.