### PR TITLE
Acceptance Test: Enable Authentication using Azure CLI

### DIFF
--- a/internal/acceptance/testclient/client.go
+++ b/internal/acceptance/testclient/client.go
@@ -55,7 +55,7 @@ func Build() (*clients.Client, error) {
 
 			EnableAuthenticatingUsingClientCertificate: true,
 			EnableAuthenticatingUsingClientSecret:      true,
-			EnableAuthenticatingUsingAzureCLI:          false,
+			EnableAuthenticatingUsingAzureCLI:          true,
 			EnableAuthenticatingUsingManagedIdentity:   false,
 			EnableAuthenticationUsingOIDC:              false,
 			EnableAuthenticationUsingGitHubOIDC:        false,

--- a/internal/acceptance/testing.go
+++ b/internal/acceptance/testing.go
@@ -16,13 +16,9 @@ import (
 
 func PreCheck(t *testing.T) {
 	variables := []string{
-		"ARM_CLIENT_ID",
-		"ARM_CLIENT_SECRET",
 		"ARM_SUBSCRIPTION_ID",
 		"ARM_TENANT_ID",
 		"ARM_TEST_LOCATION",
-		"ARM_TEST_LOCATION_ALT",
-		"ARM_TEST_LOCATION_ALT2",
 	}
 
 	for _, variable := range variables {
@@ -85,7 +81,7 @@ func GetAuthConfig(t *testing.T) *auth.Credentials {
 
 		EnableAuthenticatingUsingClientCertificate: true,
 		EnableAuthenticatingUsingClientSecret:      true,
-		EnableAuthenticatingUsingAzureCLI:          false,
+		EnableAuthenticatingUsingAzureCLI:          true,
 		EnableAuthenticatingUsingManagedIdentity:   false,
 		EnableAuthenticationUsingOIDC:              false,
 		EnableAuthenticationUsingGitHubOIDC:        false,


### PR DESCRIPTION
Not everyone is able to provide client secret in order to authenticate with service principal. This changes enables authentication using Azure CLI while authentication using certificate and secret are preserved too. ["NewAuthorizerFromCredentials returns a suitable Authorizer depending on what is defined in the Credentials"](https://github.com/hashicorp/terraform-provider-azurerm/blob/35b106b252848638425164da5b73b1d6e824ffca/vendor/github.com/hashicorp/go-azure-sdk/sdk/auth/auth.go#L14). It also removes some unnecessary pre-check of environment variables. In some acceptance tests `ARM_TEST_LOCATION_ALT` and `ARM_TEST_LOCATION_ALT2` are not necessary so they are removed too. In this way more people can provide contribution.