### PR TITLE
`azurerm_cosmosdb_cassandra_cluster` - deprecate `hourBetweenBackups`

### DIFF
--- a/internal/services/cosmos/cosmosdb_cassandra_cluster_resource.go
+++ b/internal/services/cosmos/cosmosdb_cassandra_cluster_resource.go
@@ -109,9 +109,9 @@ func resourceCassandraCluster() *pluginsdk.Resource {
 			},
 
 			"hours_between_backups": {
-				Type:     pluginsdk.TypeInt,
-				Optional: true,
-				Default:  24,
+				Type:       pluginsdk.TypeInt,
+				Optional:   true,
+				Deprecated: "This property has been deprecated by service API and will be removed in v4.0 of the provider",
 			},
 
 			"identity": commonschema.SystemAssignedIdentityOptional(),
@@ -172,7 +172,6 @@ func resourceCassandraClusterCreate(d *pluginsdk.ResourceData, meta interface{})
 			AuthenticationMethod:          &authenticationMethod,
 			CassandraVersion:              utils.String(d.Get("version").(string)),
 			DelegatedManagementSubnetId:   utils.String(d.Get("delegated_management_subnet_id").(string)),
-			HoursBetweenBackups:           utils.Int64(int64(d.Get("hours_between_backups").(int))),
 			InitialCassandraAdminPassword: utils.String(d.Get("default_admin_password").(string)),
 			RepairEnabled:                 utils.Bool(d.Get("repair_enabled").(bool)),
 		},
@@ -233,7 +232,10 @@ func resourceCassandraClusterRead(d *pluginsdk.ResourceData, meta interface{}) e
 				d.Set("authentication_method", string(pointer.From(props.AuthenticationMethod)))
 				d.Set("repair_enabled", props.RepairEnabled)
 				d.Set("version", props.CassandraVersion)
-				d.Set("hours_between_backups", props.HoursBetweenBackups)
+
+				if v, ok := d.GetOk("hours_between_backups"); ok {
+					d.Set("hours_between_backups", v.(string))
+				}
 
 				if err := d.Set("client_certificate_pems", flattenCassandraClusterCertificate(props.ClientCertificates)); err != nil {
 					return fmt.Errorf("setting `client_certificate_pems`: %+v", err)
@@ -289,7 +291,6 @@ func resourceCassandraClusterUpdate(d *pluginsdk.ResourceData, meta interface{})
 			AuthenticationMethod:          &authenticationMethod,
 			CassandraVersion:              utils.String(d.Get("version").(string)),
 			DelegatedManagementSubnetId:   utils.String(d.Get("delegated_management_subnet_id").(string)),
-			HoursBetweenBackups:           utils.Int64(int64(d.Get("hours_between_backups").(int))),
 			InitialCassandraAdminPassword: utils.String(d.Get("default_admin_password").(string)),
 			RepairEnabled:                 utils.Bool(d.Get("repair_enabled").(bool)),
 		},

--- a/internal/services/cosmos/cosmosdb_cassandra_cluster_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_cassandra_cluster_resource_test.go
@@ -133,7 +133,6 @@ resource "azurerm_cosmosdb_cassandra_cluster" "test" {
   client_certificate_pems          = [file("testdata/cert.pem")]
   external_gossip_certificate_pems = [file("testdata/cert.pem")]
   external_seed_node_ip_addresses  = ["10.52.221.2"]
-  hours_between_backups            = 22
 
   identity {
     type = "SystemAssigned"
@@ -165,7 +164,6 @@ resource "azurerm_cosmosdb_cassandra_cluster" "test" {
   client_certificate_pems          = [file("testdata/cert2.pem")]
   external_gossip_certificate_pems = [file("testdata/cert2.pem")]
   external_seed_node_ip_addresses  = ["10.52.221.5"]
-  hours_between_backups            = 0
 
   tags = {
     Env = "Test2"

--- a/internal/services/cosmos/cosmosdb_cassandra_datacenter_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_cassandra_datacenter_resource_test.go
@@ -113,7 +113,8 @@ resource "azurerm_key_vault_access_policy" "current_user" {
     "Recover",
     "Update",
     "WrapKey",
-    "UnwrapKey"
+    "UnwrapKey",
+    "GetRotationPolicy"
   ]
 }
 
@@ -131,7 +132,8 @@ resource "azurerm_key_vault_access_policy" "system_identity" {
     "Recover",
     "Update",
     "WrapKey",
-    "UnwrapKey"
+    "UnwrapKey",
+    "GetRotationPolicy"
   ]
 }
 
@@ -207,7 +209,8 @@ resource "azurerm_key_vault_access_policy" "current_user" {
     "Recover",
     "Update",
     "WrapKey",
-    "UnwrapKey"
+    "UnwrapKey",
+    "GetRotationPolicy"
   ]
 }
 
@@ -225,7 +228,8 @@ resource "azurerm_key_vault_access_policy" "system_identity" {
     "Recover",
     "Update",
     "WrapKey",
-    "UnwrapKey"
+    "UnwrapKey",
+    "GetRotationPolicy"
   ]
 }
 

--- a/internal/services/cosmos/cosmosdb_cassandra_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_cassandra_resource_test.go
@@ -10,14 +10,14 @@ func TestAccCassandraSequential(t *testing.T) {
 	// NOTE: this is a combined test rather than separate split out tests due to all below TCs sharing same sp
 	acceptance.RunTestsInSequence(t, map[string]map[string]func(t *testing.T){
 		"cluster": {
-			"basic":          testAccCassandraCluster_basic,
+			//"basic":          testAccCassandraCluster_basic,
 			"complete":       testAccCassandraCluster_complete,
 			"update":         testAccCassandraCluster_update,
 			"requiresImport": testAccCassandraCluster_requiresImport,
 		},
 		"dataCenter": {
-			"basic":  testAccCassandraDatacenter_basic,
-			"update": testAccCassandraDatacenter_update,
+			"basic": testAccCassandraDatacenter_basic,
+			//"update": testAccCassandraDatacenter_update,
 		},
 	})
 }

--- a/internal/services/cosmos/cosmosdb_cassandra_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_cassandra_resource_test.go
@@ -10,14 +10,14 @@ func TestAccCassandraSequential(t *testing.T) {
 	// NOTE: this is a combined test rather than separate split out tests due to all below TCs sharing same sp
 	acceptance.RunTestsInSequence(t, map[string]map[string]func(t *testing.T){
 		"cluster": {
-			//"basic":          testAccCassandraCluster_basic,
+			"basic":          testAccCassandraCluster_basic,
 			"complete":       testAccCassandraCluster_complete,
 			"update":         testAccCassandraCluster_update,
 			"requiresImport": testAccCassandraCluster_requiresImport,
 		},
 		"dataCenter": {
-			"basic": testAccCassandraDatacenter_basic,
-			//"update": testAccCassandraDatacenter_update,
+			"basic":  testAccCassandraDatacenter_basic,
+			"update": testAccCassandraDatacenter_update,
 		},
 	})
 }

--- a/website/docs/r/cosmosdb_cassandra_cluster.html.markdown
+++ b/website/docs/r/cosmosdb_cassandra_cluster.html.markdown
@@ -85,7 +85,7 @@ The following arguments are supported:
 
 * `external_seed_node_ip_addresses` - (Optional) A list of IP Addresses of the seed nodes in unmanaged the Cassandra Data Center which will be added to the seed node lists of all managed nodes.
 
-* `hours_between_backups` - (Optional) The number of hours to wait between taking a backup of the Cassandra Cluster. Defaults to `24`.
+* `hours_between_backups` - (Optional) (Deprecated) The number of hours to wait between taking a backup of the Cassandra Cluster. Defaults to `24`.
 
 ~> **Note:** To disable this feature, set this property to `0`.
 


### PR DESCRIPTION
Recently we found test case "TestAccCassandraSequential" in teamcity is failed with below error. After investigated, I found this is a regression issue on the “[hoursBetweenBackups](https://nam06.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2FAzure%2Fazure-rest-api-specs%2Fblob%2F904e6604a3e616709510de199aeec63e3bb8b927%2Fspecification%2Fcosmos-db%2Fresource-manager%2FMicrosoft.DocumentDB%2Fstable%2F2022-05-15%2FmanagedCassandra.json%23L932&data=05%7C01%7Cv-cheye%40microsoft.com%7C16ba0e519c8f41e3a07908db578b4d20%7C72f988bf86f141af91ab2d7cd011db47%7C1%7C0%7C638200028095040588%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C3000%7C%7C%7C&sdata=CKzW%2BHoFvEv%2Fh0LI1eAnlUD8vNjt%2BcX7KQmFrj51dtA%3D&reserved=0)” property of Cassandra Cluster. Previously we can set the “hoursBetweenBackups” property successfully and service API would return the corresponding value for this property. But recently though service API accepts “hoursBetweenBackups” while creating/updating but service API wouldn’t return this property anymore. Then I checked with service team and they replied "_To improve our backup service, we have introduced a new property called "backupSchedules" that allows you to define cronExpression ( when to start backups) and retentionInHours (how long to keep them). As a result, the previous parameter "hoursBetweenBackups" has been deprecated._" (Note: Currently "backupSchedules" isn't in azure rest api spec and it will be released to azure rest api spec in near future.). For this situation, I intend to deprecate "hoursBetweenBackups" first to mitigate this issue and then submit another PR to support new property "backupSchedules" once it's released to azure rest api spec. Otherwise I assume users would encounter diff when tf plan as currently service API doesn't return this property anymore.

Note: I filed [issue](https://github.com/Azure/azure-rest-api-specs/issues/24074) on azure-rest-api-spec.

![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/19754191/9612a52d-f782-4503-a503-2b7759c219c0)

--- PASS: TestAccCassandraSequential/cluster/basic (782.93s)
--- PASS: TestAccCassandraSequential/cluster/requiresImport (764.07s)
--- PASS: TestAccCassandraSequential/dataCenter/update (2796.97s)
--- PASS: TestAccCassandraSequential/cluster/update (956.54s)
--- PASS: TestAccCassandraSequential/cluster/complete (880.12s)
--- PASS: TestAccCassandraSequential/dataCenter/basic (2074.04s)