### PR TITLE
`azurerm_media_transform` - supports for `experimental_options` in custom preset

### DIFF
--- a/internal/services/media/media_transform_resource.go
+++ b/internal/services/media/media_transform_resource.go
@@ -893,6 +893,13 @@ func resourceMediaTransform() *pluginsdk.Resource {
 											},
 										},
 									},
+									"experimental_options": {
+										Type:     pluginsdk.TypeMap,
+										Optional: true,
+										Elem: &pluginsdk.Schema{
+											Type: pluginsdk.TypeString,
+										},
+									},
 									"filter": {
 										Type:     pluginsdk.TypeList,
 										Optional: true,
@@ -1404,6 +1411,11 @@ func expandPreset(transform map[string]interface{}) (encodings.Preset, error) {
 			return nil, err
 		}
 
+		experimentalOptions, err := expandExperimentalOptions(preset["experimental_options"].(map[string]interface{}))
+		if err != nil {
+			return nil, err
+		}
+
 		filters, err := expandCustomPresetFilters(preset["filter"].([]interface{}))
 		if err != nil {
 			return nil, err
@@ -1414,9 +1426,10 @@ func expandPreset(transform map[string]interface{}) (encodings.Preset, error) {
 			return nil, err
 		}
 		builtInPreset := &encodings.StandardEncoderPreset{
-			Codecs:  codecs,
-			Filters: filters,
-			Formats: formats,
+			Codecs:              codecs,
+			ExperimentalOptions: experimentalOptions,
+			Filters:             filters,
+			Formats:             formats,
 		}
 		return builtInPreset, nil
 	}
@@ -1514,9 +1527,10 @@ func flattenPreset(input encodings.Preset) flattenedPresets {
 
 	if v, ok := input.(encodings.StandardEncoderPreset); ok {
 		out.customPresets = append(out.customPresets, map[string]interface{}{
-			"codec":  flattenCustomPresetCodecs(v.Codecs),
-			"filter": flattenCustomPresetFilters(v.Filters),
-			"format": flattenCustomPresetFormats(v.Formats),
+			"codec":                flattenCustomPresetCodecs(v.Codecs),
+			"experimental_options": flattenExperimentalOptions(v.ExperimentalOptions),
+			"filter":               flattenCustomPresetFilters(v.Filters),
+			"format":               flattenCustomPresetFormats(v.Formats),
 		})
 	}
 
@@ -1684,7 +1698,7 @@ func expandExperimentalOptions(input map[string]interface{}) (*map[string]string
 		key := k
 		value, ok := v.(string)
 		if !ok {
-			return nil, fmt.Errorf(" experimental options value %q to be a string", value)
+			return nil, fmt.Errorf("expect experimental options value %q to be a string", value)
 		}
 		output[key] = value
 	}

--- a/internal/services/media/media_transform_resource_test.go
+++ b/internal/services/media/media_transform_resource_test.go
@@ -495,6 +495,10 @@ resource "azurerm_media_transform" "test" {
         }
       }
 
+      experimental_options = {
+        env = "prod"
+      }
+
       filter {
         crop_rectangle {
           height = "240"

--- a/website/docs/r/media_transform.html.markdown
+++ b/website/docs/r/media_transform.html.markdown
@@ -477,6 +477,8 @@ A `custom_preset` block supports the following:
 
 * `format` - (Required) One or more `format` blocks as defined below.
 
+* `experimental_options` - (Optional) Dictionary containing key value pairs for parameters not exposed in the preset itself.
+
 * `filter` - (Optional) A `filter` block as defined below.
  
 ---


### PR DESCRIPTION
```
TF_ACC=1 go test -v ./internal/services/media -parallel 50 -test.run=TestAccMediaTransform -timeout 1440m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccMediaTransform_basic
=== PAUSE TestAccMediaTransform_basic
=== RUN   TestAccMediaTransform_requiresImport
=== PAUSE TestAccMediaTransform_requiresImport
=== RUN   TestAccMediaTransform_complete
=== PAUSE TestAccMediaTransform_complete
=== RUN   TestAccMediaTransform_update
=== PAUSE TestAccMediaTransform_update
=== CONT  TestAccMediaTransform_basic
=== CONT  TestAccMediaTransform_complete
=== CONT  TestAccMediaTransform_requiresImport
=== CONT  TestAccMediaTransform_update
--- PASS: TestAccMediaTransform_requiresImport (217.67s)
--- PASS: TestAccMediaTransform_basic (252.71s)
--- PASS: TestAccMediaTransform_complete (265.03s)
--- PASS: TestAccMediaTransform_update (378.57s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/media 378.607s
```