### PR TITLE
`azurerm_databricks_workspace` - add comment noting changed behavior of `storage_account_sku_name` field...

### DIFF
--- a/internal/services/databricks/databricks_workspace_resource.go
+++ b/internal/services/databricks/databricks_workspace_resource.go
@@ -243,6 +243,7 @@ func resourceDatabricksWorkspace() *pluginsdk.Resource {
 							AtLeastOneOf: workspaceCustomParametersString(),
 						},
 
+						// Per Service Team: This field is actually changeable so the ForceNew is no longer required, however we agreed to not change the current behavior for consistency purposes
 						"storage_account_sku_name": {
 							Type:         pluginsdk.TypeString,
 							ForceNew:     true,


### PR DESCRIPTION
This PR is just adding a single comment as a heads up for anyone else in the code that the service team has changed the behavior of the `storage_account_sku_name` field and that we are intentionally not implementing it at this time.