### PR TITLE
`azurerm_automation_schedule`: skip set location if expiry_time exceed the upper limit as year 9999

### DIFF
--- a/internal/services/automation/automation_schedule_resource.go
+++ b/internal/services/automation/automation_schedule_resource.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"strings"
 	"time"
+
 	// import time/tzdata to embed timezone information in the program
 	// add this to resolve https://github.com/hashicorp/terraform-provider-azurerm/issues/20690
 	_ "time/tzdata"


### PR DESCRIPTION
also update `DiffSuppressFunc` start_time and expiry_time. or it will cause diff because the API will remove the second part in response value for these two field. like below

```bash
Terraform will perform the following actions:

# azurerm_automation_schedule.test will be updated in-place
  ~ resource "azurerm_automation_schedule" "test" {
    id  = "/subscriptions/85b3dbca-5974-4067-9669-67a141095a76/resourceGroups/acctestRG-230505111254079233/providers/Microsoft.Automation/automationAccounts/acctestAA-230515134829705044/schedules/acctestAS-230515134829705044"           
    name  = "acctestAS-230515134829705044"
 ~ start_time = "2024-04-15T18:01:00+02:00" -> "2024-04-15T18:01:15+02:00"
      # (9 unchanged attributes hidden)
 }                                                                                                                                                                                                                                   Plan: 0 to add, 1 to change, 0 to destroy.                                                                          
```

fixes: #21854