### PR TITLE
`azurerm_mssql_server` changes `minimum_tls_version` value from "Disabled" to "None"

### DIFF
--- a/internal/services/mssql/mssql_server_resource.go
+++ b/internal/services/mssql/mssql_server_resource.go
@@ -158,7 +158,7 @@ func resourceMsSqlServer() *pluginsdk.Resource {
 					"1.0",
 					"1.1",
 					"1.2",
-					"None"
+					"None",
 				}, false),
 			},
 

--- a/internal/services/mssql/mssql_server_resource.go
+++ b/internal/services/mssql/mssql_server_resource.go
@@ -158,7 +158,6 @@ func resourceMsSqlServer() *pluginsdk.Resource {
 					"1.0",
 					"1.1",
 					"1.2",
-					"Disabled",
 					"None"
 				}, false),
 			},
@@ -738,7 +737,7 @@ func flattenSqlServerRestorableDatabases(resp sql.RestorableDroppedDatabaseListR
 
 func msSqlMinimumTLSVersionDiff(ctx context.Context, d *pluginsdk.ResourceDiff, _ interface{}) (err error) {
 	old, new := d.GetChange("minimum_tls_version")
-	if old != "" && old != "Disabled" && old != "None" && new == "None" {
+	if old != "" && old != "None" && new == "None" {
 		err = fmt.Errorf("`minimum_tls_version` cannot be removed once set, please set a valid value for this property")
 	}
 	return

--- a/internal/services/mssql/mssql_server_resource.go
+++ b/internal/services/mssql/mssql_server_resource.go
@@ -159,6 +159,7 @@ func resourceMsSqlServer() *pluginsdk.Resource {
 					"1.1",
 					"1.2",
 					"Disabled",
+					"None"
 				}, false),
 			},
 
@@ -287,7 +288,7 @@ func resourceMsSqlServerCreate(d *pluginsdk.ResourceData, meta interface{}) erro
 		props.ServerProperties.RestrictOutboundNetworkAccess = sql.ServerNetworkAccessFlagEnabled
 	}
 
-	if v := d.Get("minimum_tls_version"); v.(string) != "Disabled" {
+	if v := d.Get("minimum_tls_version"); v.(string) != "None" {
 		props.ServerProperties.MinimalTLSVersion = utils.String(v.(string))
 	}
 
@@ -397,7 +398,7 @@ func resourceMsSqlServerUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 		props.ServerProperties.AdministratorLoginPassword = utils.String(adminPassword)
 	}
 
-	if v := d.Get("minimum_tls_version"); v.(string) != "Disabled" {
+	if v := d.Get("minimum_tls_version"); v.(string) != "None" {
 		props.ServerProperties.MinimalTLSVersion = utils.String(v.(string))
 	}
 
@@ -518,7 +519,7 @@ func resourceMsSqlServerRead(d *pluginsdk.ResourceData, meta interface{}) error 
 		d.Set("administrator_login", props.AdministratorLogin)
 		d.Set("fully_qualified_domain_name", props.FullyQualifiedDomainName)
 		if v := props.MinimalTLSVersion; v == nil {
-			d.Set("minimum_tls_version", "Disabled")
+			d.Set("minimum_tls_version", "None")
 		} else {
 			d.Set("minimum_tls_version", props.MinimalTLSVersion)
 		}
@@ -737,7 +738,7 @@ func flattenSqlServerRestorableDatabases(resp sql.RestorableDroppedDatabaseListR
 
 func msSqlMinimumTLSVersionDiff(ctx context.Context, d *pluginsdk.ResourceDiff, _ interface{}) (err error) {
 	old, new := d.GetChange("minimum_tls_version")
-	if old != "" && old != "Disabled" && new == "Disabled" {
+	if old != "" && old != "Disabled" && old != "None" && new == "None" {
 		err = fmt.Errorf("`minimum_tls_version` cannot be removed once set, please set a valid value for this property")
 	}
 	return

--- a/internal/services/mssql/mssql_server_resource.go
+++ b/internal/services/mssql/mssql_server_resource.go
@@ -159,6 +159,7 @@ func resourceMsSqlServer() *pluginsdk.Resource {
 					"1.1",
 					"1.2",
 					"None",
+					"Disabled",
 				}, false),
 			},
 
@@ -287,7 +288,7 @@ func resourceMsSqlServerCreate(d *pluginsdk.ResourceData, meta interface{}) erro
 		props.ServerProperties.RestrictOutboundNetworkAccess = sql.ServerNetworkAccessFlagEnabled
 	}
 
-	if v := d.Get("minimum_tls_version"); v.(string) != "None" {
+	if v := d.Get("minimum_tls_version"); v.(string) != "None" && v.(string) != "Disabled" {
 		props.ServerProperties.MinimalTLSVersion = utils.String(v.(string))
 	}
 
@@ -397,7 +398,7 @@ func resourceMsSqlServerUpdate(d *pluginsdk.ResourceData, meta interface{}) erro
 		props.ServerProperties.AdministratorLoginPassword = utils.String(adminPassword)
 	}
 
-	if v := d.Get("minimum_tls_version"); v.(string) != "None" {
+	if v := d.Get("minimum_tls_version"); v.(string) != "None" && v.(string) != "Disabled" {
 		props.ServerProperties.MinimalTLSVersion = utils.String(v.(string))
 	}
 
@@ -737,7 +738,7 @@ func flattenSqlServerRestorableDatabases(resp sql.RestorableDroppedDatabaseListR
 
 func msSqlMinimumTLSVersionDiff(ctx context.Context, d *pluginsdk.ResourceDiff, _ interface{}) (err error) {
 	old, new := d.GetChange("minimum_tls_version")
-	if old != "" && old != "None" && new == "None" {
+	if old != "" && old != "None" && new == "None" || new == "Disabled" {
 		err = fmt.Errorf("`minimum_tls_version` cannot be removed once set, please set a valid value for this property")
 	}
 	return

--- a/internal/services/mssql/mssql_server_resource_test.go
+++ b/internal/services/mssql/mssql_server_resource_test.go
@@ -303,7 +303,7 @@ resource "azurerm_mssql_server" "test" {
   version                      = "12.0"
   administrator_login          = "missadministrator"
   administrator_login_password = "thisIsKat11"
-  minimum_tls_version          = "Disabled"
+  minimum_tls_version          = "None"
 
   identity {
     type = "SystemAssigned"

--- a/website/docs/r/mssql_server.html.markdown
+++ b/website/docs/r/mssql_server.html.markdown
@@ -155,9 +155,9 @@ The following arguments are supported:
 
 ~> **NOTE:** When using a firewall with a `Key Vault`, you must enable the option `Allow trusted Microsoft services to bypass the firewall`.
 
-* `minimum_tls_version` - (Optional) The Minimum TLS Version for all SQL Database and SQL Data Warehouse databases associated with the server. Valid values are: `1.0`, `1.1` , `1.2` and `Disabled`. Defaults to `1.2`.
+* `minimum_tls_version` - (Optional) The Minimum TLS Version for all SQL Database and SQL Data Warehouse databases associated with the server. Valid values are: `1.0`, `1.1` , `1.2` and `None`. Defaults to `1.2`.
 
-~> **NOTE:** The `minimum_tls_version` is set to `Disabled` means all TLS versions are allowed. After you enforce a version of `minimum_tls_version`, it's not possible to revert to `Disabled`.
+~> **NOTE:** The `minimum_tls_version` is set to `None` means all TLS versions are allowed. After you enforce a version of `minimum_tls_version`, it's not possible to revert to `None`.
 
 * `public_network_access_enabled` - (Optional) Whether public network access is allowed for this server. Defaults to `true`.
 


### PR DESCRIPTION
It looks like Azure have changed the value for `minimum_tls_version` from "Disabled" to "None" in the API.
The function `msSqlMinimumTLSVersionDiff` checks for the value "Disabled" and thus always throws an error now.

This is my first time with go and contributing here so if there is a better way to do this than please advise 🙂 

fixes #21882