### PR TITLE
`document` - fix example of `azurerm_mssql_server_transparent_data_encryption`

### DIFF
--- a/website/docs/r/mssql_server_transparent_data_encryption.html.markdown
+++ b/website/docs/r/mssql_server_transparent_data_encryption.html.markdown
@@ -72,19 +72,16 @@ resource "azurerm_mssql_server" "example" {
     object_id      = "00000000-0000-0000-0000-000000000000"
   }
 
-  extended_auditing_policy {
-    storage_endpoint                        = azurerm_storage_account.example.primary_blob_endpoint
-    storage_account_access_key              = azurerm_storage_account.example.primary_access_key
-    storage_account_access_key_is_secondary = true
-    retention_in_days                       = 6
-  }
-
   tags = {
     environment = "production"
   }
 
   identity {
     type = "SystemAssigned"
+  }
+
+  lifecycle {
+    ignore_changes = [transparent_data_encryption_key_vault_key_id]
   }
 }
 


### PR DESCRIPTION
Fix #21888
document is missing the `ignore_changes` for the parent resource, causing a diff on second apply. It shall be added similar to what have been done in its acc test:
https://github.com/hashicorp/terraform-provider-azurerm/blob/4729085ade44e177e839936784ed632dbeed5217/internal/services/mssql/mssql_server_transparent_data_encryption_resource_test.go#L227-L229

Removing the deprecated `extended_auditing_policy` as well per #14161