### PR TITLE
azurerm_netapp_volume  - ensure avsDataStore is correctly read

### DIFF
--- a/internal/services/netapp/netapp_volume_resource.go
+++ b/internal/services/netapp/netapp_volume_resource.go
@@ -618,9 +618,13 @@ func resourceNetAppVolumeRead(d *pluginsdk.ResourceData, meta interface{}) error
 		d.Set("snapshot_directory_visible", props.SnapshotDirectoryVisible)
 		d.Set("throughput_in_mibps", props.ThroughputMibps)
 		d.Set("storage_quota_in_gb", props.UsageThreshold/1073741824)
+
+		avsDataStore := false
 		if props.AvsDataStore != nil {
-			d.Set("azure_vmware_data_store_enabled", strings.EqualFold(string(*props.AvsDataStore), string(volumes.AvsDataStoreEnabled)))
+			avsDataStore = strings.EqualFold(string(*props.AvsDataStore), string(volumes.AvsDataStoreEnabled))
 		}
+		d.Set("azure_vmware_data_store_enabled", avsDataStore)
+
 		if err := d.Set("export_policy_rule", flattenNetAppVolumeExportPolicyRule(props.ExportPolicy)); err != nil {
 			return fmt.Errorf("setting `export_policy_rule`: %+v", err)
 		}


### PR DESCRIPTION
Hello,

this is a possible fix for #21906 
I am not an go-lang expert, but this compiles and work for me.

The reason is, that it looks like that the azure rest api is sending additional fields for newer created volumes.
One of them is the avsDataStore field. 
This change is setting the value to its default value in case this field was missing in the rest api response.
