### PR TITLE
GHA - increment milestone

### DIFF
--- a/.github/workflows/increment-milestone.yaml
+++ b/.github/workflows/increment-milestone.yaml
@@ -4,7 +4,7 @@ name: Increment Milestone
 on:
   push:
     tags:
-      - 'v*.*.0'
+      - 'v*.*.*'
 
 permissions:
   issues: write

--- a/.github/workflows/increment-milestone.yaml
+++ b/.github/workflows/increment-milestone.yaml
@@ -1,0 +1,22 @@
+---
+name: Increment Milestone
+
+on:
+  push:
+    tags:
+      - 'v*.*.0'
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  increment-milestone:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+        with:
+          fetch-depth: 0
+      - name: "Increment Milestone"
+        shell: bash
+        run: bash ./scripts/increment-milestone.sh -u https://api.github.com/repos${{ github.owner }}/${{ github.repository }}/milestones -r ${{github.ref_name}} -t ${{secrets.GITHUB_TOKEN}}

--- a/scripts/increment-milestone.sh
+++ b/scripts/increment-milestone.sh
@@ -54,7 +54,6 @@ if [[ $milestone_number != 0 ]]; then
     date+="T12:00:00Z"
 
     echo "Creating new milestone..."
-    # Create milestone for next release
     curl -L \
     -X POST \
     -H "Accept: application/vnd.github+json" \

--- a/scripts/increment-milestone.sh
+++ b/scripts/increment-milestone.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+while getopts u:r:t: flag
+do
+  case "${flag}" in
+    r) release=${OPTARG};;
+    u) milestone_url=${OPTARG};;
+    t) token=${OPTARG};;
+  esac
+done
+
+echo "Getting current milestone number..."
+milestones=$(curl -L \
+-H "Accept: application/vnd.github+json" \
+-H "Authorization: Bearer $token" \
+-H "X-GitHub-Api-Version: 2022-11-28" \
+"${milestone_url}?state=open&sort=due_on&direction=desc")
+
+milestone_number=0
+milestones_json=$(echo "$milestones" | jq -c -r '.[]')
+for milestone in ${milestones_json[@]}; do
+  if [[ $(echo $milestone | jq -r .title) == "$release" ]]; then
+    milestone_number=$(echo $milestone | jq -r .number)
+    break
+  fi
+done
+
+if [[ $milestone_number != 0 ]]; then
+
+  echo "Closing current milestone..."
+  curl -L \
+  -X PATCH \
+  -H "Accept: application/vnd.github+json" \
+  -H "Authorization: Bearer $token" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  "${milestone_url}/${milestone_number}" \
+  -d '{"state":"closed"}'
+
+  # Get next release version
+  major=0
+  weekly=0
+  regex="v([0-9]+).([0-9]+).([0-9]+)"
+  if [[ $release =~ $regex ]]; then
+    major="${BASH_REMATCH[1]}"
+    weekly="${BASH_REMATCH[2]}"
+  fi
+  weekly=$((weekly + 1 ))
+  new_milestone="v$major.$weekly.0"
+
+  if [[ $major != 0 ]]; then
+
+    # Get next release due date
+    date=$(date -d "next Thursday" +%Y-%m-%d)
+    date+="T12:00:00Z"
+
+    echo "Creating new milestone..."
+    # Create milestone for next release
+    curl -L \
+    -X POST \
+    -H "Accept: application/vnd.github+json" \
+    -H "Authorization: Bearer $token" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "${milestone_url}" \
+    -d "{\"title\":\"$new_milestone\", \"state\":\"open\", \"due_on\":\"$date\"}"
+
+  else
+    echo "Could not increment milestone"
+    exit 1
+  fi
+
+else
+    echo "Could not retrieve current milestone number to close"
+    exit 1
+fi

--- a/scripts/increment-milestone.sh
+++ b/scripts/increment-milestone.sh
@@ -36,35 +36,38 @@ if [[ $milestone_number != 0 ]]; then
   "${milestone_url}/${milestone_number}" \
   -d '{"state":"closed"}'
 
-  # Get next release version
   major=0
   weekly=0
+  patch=0
   regex="v([0-9]+).([0-9]+).([0-9]+)"
   if [[ $release =~ $regex ]]; then
     major="${BASH_REMATCH[1]}"
     weekly="${BASH_REMATCH[2]}"
+    patch="${BASH_REMATCH[3]}"
   fi
-  weekly=$((weekly + 1 ))
-  new_milestone="v$major.$weekly.0"
 
-  if [[ $major != 0 ]]; then
+  if [[ $patch == 0 ]]; then
+    if [[ $major != 0 ]]; then
 
-    # Get next release due date
-    date=$(date -d "next Thursday" +%Y-%m-%d)
-    date+="T12:00:00Z"
+      # Get next release version
+      weekly=$((weekly + 1 ))
+      new_milestone="v$major.$weekly.0"
+      # Get next release due date
+      date=$(date -d "next Thursday" +%Y-%m-%d)
+      date+="T12:00:00Z"
 
-    echo "Creating new milestone..."
-    curl -L \
-    -X POST \
-    -H "Accept: application/vnd.github+json" \
-    -H "Authorization: Bearer $token" \
-    -H "X-GitHub-Api-Version: 2022-11-28" \
-    "${milestone_url}" \
-    -d "{\"title\":\"$new_milestone\", \"state\":\"open\", \"due_on\":\"$date\"}"
-
-  else
-    echo "Could not increment milestone"
-    exit 1
+      echo "Creating new milestone..."
+      curl -L \
+      -X POST \
+      -H "Accept: application/vnd.github+json" \
+      -H "Authorization: Bearer $token" \
+      -H "X-GitHub-Api-Version: 2022-11-28" \
+      "${milestone_url}" \
+      -d "{\"title\":\"$new_milestone\", \"state\":\"open\", \"due_on\":\"$date\"}"
+    else
+      echo "Could not increment milestone"
+      exit 1
+    fi
   fi
 
 else


### PR DESCRIPTION
When a new tag is pushed for the weekly release this should close the milestone associated with the release and create a new milestone for the next weeks release. 
