### PR TITLE
`azurerm_cosmosdb_postgresql_cluster` - update validation of `citus_version`

### DIFF
--- a/internal/services/cosmos/cosmosdb_postgresql_cluster_resource.go
+++ b/internal/services/cosmos/cosmosdb_postgresql_cluster_resource.go
@@ -138,6 +138,7 @@ func (r CosmosDbPostgreSQLClusterResource) Arguments() map[string]*pluginsdk.Sch
 				"11.0",
 				"11.1",
 				"11.2",
+				"11.3",
 			}, false),
 		},
 

--- a/internal/services/cosmos/cosmosdb_postgresql_cluster_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_postgresql_cluster_resource_test.go
@@ -223,7 +223,7 @@ resource "azurerm_cosmosdb_postgresql_cluster" "test" {
   coordinator_vcore_count         = 4
   node_count                      = 2
 
-  citus_version                        = "11.2"
+  citus_version                        = "11.3"
   coordinator_public_ip_access_enabled = false
   ha_enabled                           = true
   coordinator_server_edition           = "MemoryOptimized"

--- a/website/docs/r/cosmosdb_postgresql_cluster.html.markdown
+++ b/website/docs/r/cosmosdb_postgresql_cluster.html.markdown
@@ -49,7 +49,7 @@ The following arguments are supported:
 
 * `node_count` - (Required) The worker node count of the Azure Cosmos DB for PostgreSQL Cluster. Possible value is between `0` and `20` except `1`.
 
-* `citus_version` - (Optional) The citus extension version on the Azure Cosmos DB for PostgreSQL Cluster. Possible values are `8.3`, `9.0`, `9.1`, `9.2`, `9.3`, `9.4`, `9.5`, `10.0`, `10.1`, `10.2`, `11.0`, `11.1` and `11.2`.
+* `citus_version` - (Optional) The citus extension version on the Azure Cosmos DB for PostgreSQL Cluster. Possible values are `8.3`, `9.0`, `9.1`, `9.2`, `9.3`, `9.4`, `9.5`, `10.0`, `10.1`, `10.2`, `11.0`, `11.1`, `11.2` and `11.3`.
 
 * `coordinator_public_ip_access_enabled` - (Optional) Is public access enabled on coordinator? Defaults to `true`.
 


### PR DESCRIPTION
![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/19754191/bac0e1b0-b9e6-41d5-abb6-3608578f1543)
