### PR TITLE
Revert "Fix azurerm_cognitive_account identity example"

### DIFF
--- a/website/docs/r/cognitive_account_customer_managed_key.html.markdown
+++ b/website/docs/r/cognitive_account_customer_managed_key.html.markdown
@@ -35,7 +35,7 @@ resource "azurerm_cognitive_account" "example" {
   sku_name              = "E0"
   custom_subdomain_name = "example-account"
   identity {
-    type         = "UserAssigned"
+    type         = "SystemAssigned, UserAssigned"
     identity_ids = [azurerm_user_assigned_identity.example.id]
   }
 }


### PR DESCRIPTION
Reverts hashicorp/terraform-provider-azurerm#21121

I am sorry, the original example was actually correct. `SystemAssigned, UserAssigned` is a valid value.

The concept is that Cognitive Services Account can have multiple identities, `identity_ids` is indeed a list. In this list is possible to have a `SystemAssigned` identity and an arbitrary number of `UserAssigned` identities.

The API is documented here:
https://learn.microsoft.com/en-us/rest/api/cognitiveservices/accountmanagement/accounts/create?tabs=HTTP#resourceidentitytype

taking a screenshot for reference
![Screenshot 2023-05-24 at 18 17 04](https://github.com/hashicorp/terraform-provider-azurerm/assets/789701/886aecc9-9965-468a-8c07-30e1855e1c4d)
