### PR TITLE
`azurerm_nginx_certificate` - `key_vault_secret_id` now accepts version-less key vault secret ids

### DIFF
--- a/internal/services/nginx/nginx_certificate_resource.go
+++ b/internal/services/nginx/nginx_certificate_resource.go
@@ -61,7 +61,7 @@ func (m CertificateResource) Arguments() map[string]*pluginsdk.Schema {
 			Type:         pluginsdk.TypeString,
 			Required:     true,
 			ForceNew:     true,
-			ValidateFunc: keyvaultValidate.NestedItemId,
+			ValidateFunc: keyvaultValidate.NestedItemIdWithOptionalVersion,
 		},
 	}
 }


### PR DESCRIPTION
NGINXaaS for Azure API supports versioned and versionless secrets.