### PR TITLE
`azurerm_sentinel_data_connector_microsoft_threat_intelligence`: deprecate `bing_safety_phishing_url_lookback_date`

### DIFF
--- a/internal/services/sentinel/sentinel_data_connector_microsoft_threat_intelligence.go
+++ b/internal/services/sentinel/sentinel_data_connector_microsoft_threat_intelligence.go
@@ -60,8 +60,15 @@ func (s DataConnectorMicrosoftThreatIntelligenceResource) Arguments() map[string
 		"microsoft_emerging_threat_feed_lookback_date": {
 			Type:         pluginsdk.TypeString,
 			ForceNew:     true,
-			Required:     true,
+			Optional:     !features.FourPointOh(),
+			Required:     features.FourPointOh(),
 			ValidateFunc: validation.IsRFC3339Time,
+			AtLeastOneOf: func() []string {
+				if !features.FourPointOh() {
+					return []string{"bing_safety_phishing_url_lookback_date", "microsoft_emerging_threat_feed_lookback_date"}
+				}
+				return []string{}
+			}(),
 		},
 	}
 
@@ -74,6 +81,7 @@ func (s DataConnectorMicrosoftThreatIntelligenceResource) Arguments() map[string
 			Optional:     true,
 			ForceNew:     true,
 			ValidateFunc: validation.IsRFC3339Time,
+			AtLeastOneOf: []string{"bing_safety_phishing_url_lookback_date", "microsoft_emerging_threat_feed_lookback_date"},
 		}
 	}
 

--- a/internal/services/sentinel/sentinel_data_connector_microsoft_threat_intelligence.go
+++ b/internal/services/sentinel/sentinel_data_connector_microsoft_threat_intelligence.go
@@ -60,15 +60,8 @@ func (s DataConnectorMicrosoftThreatIntelligenceResource) Arguments() map[string
 		"microsoft_emerging_threat_feed_lookback_date": {
 			Type:         pluginsdk.TypeString,
 			ForceNew:     true,
-			Optional:     !features.FourPointOh(),
-			Required:     features.FourPointOh(),
+			Required:     true,
 			ValidateFunc: validation.IsRFC3339Time,
-			AtLeastOneOf: func() []string {
-				if !features.FourPointOh() {
-					return []string{"bing_safety_phishing_url_lookback_date", "microsoft_emerging_threat_feed_lookback_date"}
-				}
-				return []string{}
-			}(),
 		},
 	}
 
@@ -81,7 +74,6 @@ func (s DataConnectorMicrosoftThreatIntelligenceResource) Arguments() map[string
 			Optional:     true,
 			ForceNew:     true,
 			ValidateFunc: validation.IsRFC3339Time,
-			AtLeastOneOf: []string{"bing_safety_phishing_url_lookback_date", "microsoft_emerging_threat_feed_lookback_date"},
 		}
 	}
 

--- a/internal/services/sentinel/sentinel_data_connector_microsoft_threat_intelligence.go
+++ b/internal/services/sentinel/sentinel_data_connector_microsoft_threat_intelligence.go
@@ -76,7 +76,7 @@ func (s DataConnectorMicrosoftThreatIntelligenceResource) Arguments() map[string
 	}
 
 	if !features.FourPointOh() {
-		// this has been removed in newer API version, and it's acutally not working in current API version
+		// this has been removed in newer API version, and it's actually not working in current API version
 		// TODO Remove in 4.0
 		res["bing_safety_phishing_url_lookback_date"] = &schema.Schema{
 			Deprecated:   "This field is deprecated and will be removed in version 4.0 of the AzureRM Provider.",

--- a/internal/services/sentinel/sentinel_data_connector_microsoft_threat_intelligence.go
+++ b/internal/services/sentinel/sentinel_data_connector_microsoft_threat_intelligence.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/workspaces"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/sentinel/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/sentinel/validate"
@@ -33,7 +34,7 @@ type DataConnectorMicrosoftThreatIntelligenceDataType struct {
 }
 
 func (s DataConnectorMicrosoftThreatIntelligenceResource) Arguments() map[string]*schema.Schema {
-	return map[string]*schema.Schema{
+	res := map[string]*schema.Schema{
 		"name": {
 			Type:         pluginsdk.TypeString,
 			Required:     true,
@@ -57,6 +58,7 @@ func (s DataConnectorMicrosoftThreatIntelligenceResource) Arguments() map[string
 		},
 
 		"bing_safety_phishing_url_lookback_date": {
+			Deprecated:   "This field is deprecated and will be removed in version 4.0 of the AzureRM Provider.",
 			Type:         pluginsdk.TypeString,
 			Optional:     true,
 			ForceNew:     true,
@@ -72,6 +74,21 @@ func (s DataConnectorMicrosoftThreatIntelligenceResource) Arguments() map[string
 			AtLeastOneOf: []string{"bing_safety_phishing_url_lookback_date", "microsoft_emerging_threat_feed_lookback_date"},
 		},
 	}
+
+	if !features.FourPointOh() {
+		// this has been removed in newer API version, and it's acutally not working in current API version
+		// TODO Remove in 4.0
+		res["bing_safety_phishing_url_lookback_date"] = &schema.Schema{
+			Deprecated:   "This field is deprecated and will be removed in version 4.0 of the AzureRM Provider.",
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.IsRFC3339Time,
+			AtLeastOneOf: []string{"bing_safety_phishing_url_lookback_date", "microsoft_emerging_threat_feed_lookback_date"},
+		}
+	}
+
+	return res
 }
 
 func (s DataConnectorMicrosoftThreatIntelligenceResource) Attributes() map[string]*schema.Schema {

--- a/internal/services/sentinel/sentinel_data_connector_microsoft_threat_intelligence.go
+++ b/internal/services/sentinel/sentinel_data_connector_microsoft_threat_intelligence.go
@@ -57,6 +57,7 @@ func (s DataConnectorMicrosoftThreatIntelligenceResource) Arguments() map[string
 			ValidateFunc: validation.IsUUID,
 		},
 
+		//lintignore: S013
 		"microsoft_emerging_threat_feed_lookback_date": {
 			Type:         pluginsdk.TypeString,
 			ForceNew:     true,

--- a/internal/services/sentinel/sentinel_data_connector_microsoft_threat_intelligence.go
+++ b/internal/services/sentinel/sentinel_data_connector_microsoft_threat_intelligence.go
@@ -60,9 +60,15 @@ func (s DataConnectorMicrosoftThreatIntelligenceResource) Arguments() map[string
 		"microsoft_emerging_threat_feed_lookback_date": {
 			Type:         pluginsdk.TypeString,
 			ForceNew:     true,
-			Optional:     true,
+			Optional:     !features.FourPointOh(),
+			Required:     features.FourPointOh(),
 			ValidateFunc: validation.IsRFC3339Time,
-			AtLeastOneOf: []string{"bing_safety_phishing_url_lookback_date", "microsoft_emerging_threat_feed_lookback_date"},
+			AtLeastOneOf: func() []string {
+				if !features.FourPointOh() {
+					return []string{"bing_safety_phishing_url_lookback_date", "microsoft_emerging_threat_feed_lookback_date"}
+				}
+				return []string{}
+			}(),
 		},
 	}
 

--- a/internal/services/sentinel/sentinel_data_connector_microsoft_threat_intelligence.go
+++ b/internal/services/sentinel/sentinel_data_connector_microsoft_threat_intelligence.go
@@ -57,15 +57,6 @@ func (s DataConnectorMicrosoftThreatIntelligenceResource) Arguments() map[string
 			ValidateFunc: validation.IsUUID,
 		},
 
-		"bing_safety_phishing_url_lookback_date": {
-			Deprecated:   "This field is deprecated and will be removed in version 4.0 of the AzureRM Provider.",
-			Type:         pluginsdk.TypeString,
-			Optional:     true,
-			ForceNew:     true,
-			ValidateFunc: validation.IsRFC3339Time,
-			AtLeastOneOf: []string{"bing_safety_phishing_url_lookback_date", "microsoft_emerging_threat_feed_lookback_date"},
-		},
-
 		"microsoft_emerging_threat_feed_lookback_date": {
 			Type:         pluginsdk.TypeString,
 			ForceNew:     true,

--- a/internal/services/sentinel/sentinel_data_connector_microsoft_threat_intelligence_test.go
+++ b/internal/services/sentinel/sentinel_data_connector_microsoft_threat_intelligence_test.go
@@ -68,7 +68,6 @@ resource "azurerm_sentinel_data_connector_microsoft_threat_intelligence" "test" 
   log_analytics_workspace_id                   = azurerm_sentinel_log_analytics_workspace_onboarding.test.workspace_id
   tenant_id                                    = data.azurerm_client_config.test.tenant_id
   microsoft_emerging_threat_feed_lookback_date = "1970-01-01T00:00:00Z"
-  bing_safety_phishing_url_lookback_date       = "1970-01-01T00:00:00Z"
 }
 `, r.template(data), data.RandomInteger)
 }

--- a/website/docs/r/sentinel_data_connector_microsoft_threat_intelligence.html.markdown
+++ b/website/docs/r/sentinel_data_connector_microsoft_threat_intelligence.html.markdown
@@ -54,6 +54,8 @@ The following arguments are supported:
 
 * `microsoft_emerging_threat_feed_lookback_date` - (Optional) The lookback date for the Microsoft Emerging Threat Feed in RFC3339. Changing this forces a new Data Connector to be created.
 
+-> **Note:** `microsoft_emerging_threat_feed_lookback_date` will be required in version 4.0 of the provider.
+
 -> **NOTE:** At least one of `bing_safety_phishing_url_lookback_date` and `microsoft_emerging_threat_feed_lookback_date` must be specified.
 
 ---

--- a/website/docs/r/sentinel_data_connector_microsoft_threat_intelligence.html.markdown
+++ b/website/docs/r/sentinel_data_connector_microsoft_threat_intelligence.html.markdown
@@ -36,7 +36,6 @@ resource "azurerm_sentinel_log_analytics_workspace_onboarding" "example" {
 resource "azurerm_sentinel_data_connector_microsoft_threat_intelligence" "example" {
   name                                         = "example-dc-msti"
   log_analytics_workspace_id                   = azurerm_sentinel_log_analytics_workspace_onboarding.example.workspace_id
-  bing_safety_phishing_url_lookback_date       = "1970-01-01T00:00:00Z"
   microsoft_emerging_threat_feed_lookback_date = "1970-01-01T00:00:00Z"
 }
 ```
@@ -50,6 +49,8 @@ The following arguments are supported:
 * `log_analytics_workspace_id` - (Required) The ID of the Log Analytics Workspace. Changing this forces a new Data Connector to be created.
 
 * `bing_safety_phishing_url_lookback_date` - (Optional) The lookback date for the Bing Safety Phishing Url in RFC3339. Changing this forces a new Data Connector to be created.
+
+-> **Note:** `bing_safety_phishing_url_lookback_date` has been deprecated as the API no longer supports it and will be removed in version 4.0 of the provider.
 
 * `microsoft_emerging_threat_feed_lookback_date` - (Optional) The lookback date for the Microsoft Emerging Threat Feed in RFC3339. Changing this forces a new Data Connector to be created.
 


### PR DESCRIPTION
deprecate it as API no longer support it.

test
---
```
❯ tftest sentinel TestAccSentinelDataConnectorMicrosoftThreatIntelligence
=== RUN   TestAccSentinelDataConnectorMicrosoftThreatIntelligence_basic
=== PAUSE TestAccSentinelDataConnectorMicrosoftThreatIntelligence_basic
=== RUN   TestAccSentinelDataConnectorMicrosoftThreatIntelligence_complete
=== PAUSE TestAccSentinelDataConnectorMicrosoftThreatIntelligence_complete
=== CONT  TestAccSentinelDataConnectorMicrosoftThreatIntelligence_basic
=== CONT  TestAccSentinelDataConnectorMicrosoftThreatIntelligence_complete
--- PASS: TestAccSentinelDataConnectorMicrosoftThreatIntelligence_basic (138.94s)
--- PASS: TestAccSentinelDataConnectorMicrosoftThreatIntelligence_complete (187.07s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/sentinel      187.119s
```