### PR TITLE
`azurerm_express_route_port_authorization`: add a lock when create/update/delete authorization of express route port

### DIFF
--- a/internal/services/network/express_route_port_resource.go
+++ b/internal/services/network/express_route_port_resource.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
@@ -227,6 +228,10 @@ func resourceArmExpressRoutePortCreateUpdate(d *pluginsdk.ResourceData, meta int
 		param.ExpressRoutePortPropertiesFormat.BillingType = network.ExpressRoutePortsBillingType(v.(string))
 	}
 
+	// a lock is needed here for subresource express_route_port_authorization needs a lock.
+	locks.ByID(id.ID())
+	defer locks.UnlockByID(id.ID())
+
 	// The link properties can't be specified in first creation. It will result into either error (e.g. setting `adminState`) or being ignored (e.g. setting MACSec)
 	// Hence, if this is a new creation we will do a create-then-update here.
 	if d.IsNewResource() {
@@ -319,6 +324,10 @@ func resourceArmExpressRoutePortDelete(d *pluginsdk.ResourceData, meta interface
 	if err != nil {
 		return err
 	}
+
+	// a lock is needed here for subresource express_route_port_authorization needs a lock.
+	locks.ByID(id.ID())
+	defer locks.UnlockByID(id.ID())
 
 	future, err := client.Delete(ctx, id.ResourceGroup, id.Name)
 	if err != nil {


### PR DESCRIPTION
The API permits only one create/update/delete operation on the same express route port resource. Or the API will reponse error as below. this was found in the failure of AccTest [TestAccExpressRoutePortAuthorization_multiple](https://ci-oss.hashicorp.engineering/test/4949330622923002834?currentProjectId=TerraformOpenSource_TerraformProviders_AzureRMPublic&branch=%3Cdefault%3E)

```
Error: deleting Express Route Port Authorization: (Authorization Name "acctestauth1230529023842741531" / Express Route Port Name "acctestERP-230529023842741531" / Resource Group "acctestRG-230529023842741531"): 
network.ExpressRoutePortAuthorizationsClient#Delete: Failure sending request: StatusCode=0 -- 
Original Error: autorest/azure: Service returned an error. Status=<nil> Code="AnotherOperationInProgress" Message="Another operation on this or dependent resource is in progress. To retrieve status of the operation use uri: 
https://management.azure.com/subscriptions/*******/providers/Microsoft.Network/locations/eastus2/operations/2c22b9e6-04c1-4b53-b5b3-4f6513d2ccd6?api-version=2022-07-01." Details=[]
```

AccTest Result:

```
=== RUN   TestAccExpressRoutePortAuthorization_multiple
--- PASS: TestAccExpressRoutePortAuthorization_multiple (262.05s)
PASS
````
