### PR TITLE
`azurerm_public_ip`: fix acctest `TestAccPublicIpStatic_importIdError` for new ID parse

### DIFF
--- a/internal/services/network/public_ip_resource_test.go
+++ b/internal/services/network/public_ip_resource_test.go
@@ -362,7 +362,7 @@ func TestAccPublicIpStatic_importIdError(t *testing.T) {
 			ImportState:       true,
 			ImportStateVerify: true,
 			ImportStateId:     fmt.Sprintf("/subscriptions/%s/resourceGroups/acctestRG-%d/providers/Microsoft.Network/publicIPAdresses/acctestpublicip-%d", os.Getenv("ARM_SUBSCRIPTION_ID"), data.RandomInteger, data.RandomInteger),
-			ExpectError:       regexp.MustCompile("Error: parsing Resource ID"),
+			ExpectError:       regexp.MustCompile("ID was missing the `publicIPAddresses` element"),
 		},
 	})
 }


### PR DESCRIPTION
<del>
## TestAccVirtualNetworkGatewayConnection_natRuleIds
The API will response a non-empty `shared_key` even not set in create request, so we have to set it as `Computed: true`. Or the AccTest will failed as below:

```
=== CONT  TestAccVirtualNetworkGatewayConnection_natRuleIds
testcase.go:110: Step 1/2 error: After applying this test step, the plan was not empty.
stdout:
Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
~ update in-place
Terraform will perform the following actions:
# azurerm_virtual_network_gateway_connection.test will be updated in-place
~ resource "azurerm_virtual_network_gateway_connection" "test" {
id                                 = "/subscriptions/*******/resourceGroups/acctestRG-230522061759601363/providers/Microsoft.Network/connections/acctestvnetgwconn-230522061759601363"
name                               = "acctestvnetgwconn-230522061759601363"
- shared_key                         = (sensitive value)
# (15 unchanged attributes hidden)
}
Plan: 0 to add, 1 to change, 0 to destroy.
--- FAIL: TestAccVirtualNetworkGatewayConnection_natRuleIds (518.55s)
FAIL
```
</del>

## TestAccPublicIpStatic_importIdError
Update `github.com/hashicorp/terraform-plugin-sdk/v2` to `v2.26.1`. importer validate response a different error format. so have to update the ExpectError in AccTest. 
```
testcase.go:110: Step 2/2 error running import, expected an error with pattern (Error: parsing Resource ID), no match on: exit status 1
Error: ID was missing the `publicIPAddresses` element
--- FAIL: TestAccPublicIpStatic_importIdError (94.13s)
```

Now test pass:
```
=== CONT  TestAccPublicIpStatic_importIdError
--- PASS: TestAccPublicIpStatic_importIdError (253.85s)
PASS
```
