### PR TITLE
`azurerm_frontdoor`, `azurerm_linux_virtual_machine`, `azurerm_windows_virtual_machine`, `azurerm_ssh_public_key` - Fix nil panic by throwing error when the resource was missing during update

### DIFF
--- a/internal/services/compute/linux_virtual_machine_resource.go
+++ b/internal/services/compute/linux_virtual_machine_resource.go
@@ -956,10 +956,6 @@ func resourceLinuxVirtualMachineUpdate(d *pluginsdk.ResourceData, meta interface
 	log.Printf("[DEBUG] Retrieving Linux Virtual Machine %q (Resource Group %q)..", id.Name, id.ResourceGroup)
 	existing, err := client.Get(ctx, id.ResourceGroup, id.Name, compute.InstanceViewTypesUserData)
 	if err != nil {
-		if utils.ResponseWasNotFound(existing.Response) {
-			return nil
-		}
-
 		return fmt.Errorf("retrieving Linux Virtual Machine %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 	}
 

--- a/internal/services/compute/ssh_public_key_resource.go
+++ b/internal/services/compute/ssh_public_key_resource.go
@@ -150,12 +150,8 @@ func resourceSshPublicKeyUpdate(d *pluginsdk.ResourceData, meta interface{}) err
 		return err
 	}
 
-	existing, err := client.Get(ctx, *id)
+	_, err = client.Get(ctx, *id)
 	if err != nil {
-		if response.WasNotFound(existing.HttpResponse) {
-			return nil
-		}
-
 		return fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 

--- a/internal/services/compute/windows_virtual_machine_resource.go
+++ b/internal/services/compute/windows_virtual_machine_resource.go
@@ -1006,10 +1006,6 @@ func resourceWindowsVirtualMachineUpdate(d *pluginsdk.ResourceData, meta interfa
 	log.Printf("[DEBUG] Retrieving Windows Virtual Machine %q (Resource Group %q)..", id.Name, id.ResourceGroup)
 	existing, err := client.Get(ctx, id.ResourceGroup, id.Name, compute.InstanceViewTypesUserData)
 	if err != nil {
-		if utils.ResponseWasNotFound(existing.Response) {
-			return nil
-		}
-
 		return fmt.Errorf("retrieving Windows Virtual Machine %q (Resource Group %q): %+v", id.Name, id.ResourceGroup, err)
 	}
 

--- a/internal/services/frontdoor/frontdoor_resource.go
+++ b/internal/services/frontdoor/frontdoor_resource.go
@@ -135,8 +135,7 @@ func resourceFrontDoorUpdate(d *pluginsdk.ResourceData, meta interface{}) error 
 	// remove in 3.0
 	// due to a change in the RP, if a Frontdoor exists in a location other than 'Global' it may continue to
 	// exist in that location, if this is a brand new Frontdoor it must be created in the 'Global' location
-	location := "Global"
-	cfgLocation, hasLocation := d.GetOk("location")
+	var location string
 
 	exists, err := client.Get(ctx, id)
 	if err != nil || exists.Model == nil {
@@ -145,6 +144,7 @@ func resourceFrontDoorUpdate(d *pluginsdk.ResourceData, meta interface{}) error 
 		location = azure.NormalizeLocation(*exists.Model.Location)
 	}
 
+	cfgLocation, hasLocation := d.GetOk("location")
 	if hasLocation {
 		if location != azure.NormalizeLocation(cfgLocation) {
 			return fmt.Errorf("the Front Door %q (Resource Group %q) already exists in %q and cannot be moved to the %q location", name, resourceGroup, location, cfgLocation)

--- a/internal/services/frontdoor/frontdoor_resource.go
+++ b/internal/services/frontdoor/frontdoor_resource.go
@@ -140,9 +140,7 @@ func resourceFrontDoorUpdate(d *pluginsdk.ResourceData, meta interface{}) error 
 
 	exists, err := client.Get(ctx, id)
 	if err != nil || exists.Model == nil {
-		if !response.WasNotFound(exists.HttpResponse) {
-			return fmt.Errorf("locating %s: %+v", id, err)
-		}
+		return fmt.Errorf("locating %s: %+v", id, err)
 	} else {
 		location = azure.NormalizeLocation(*exists.Model.Location)
 	}


### PR DESCRIPTION
When executing update, if the resource was deleted out-of-band already, the current implementation would lead to a nil panic. This pr fix #21972 throwing the error even http status code is `404`.

Another possible approach is like [what we do in `azurerm_linux_virtual_machine`](https://github.com/hashicorp/terraform-provider-azurerm/blob/main/internal/services/compute/linux_virtual_machine_resource.go#L959-L961), just swallow the error and do nothing in this scenario.

I personally prefer throwing out the error since the real situation is different than the operator's assumption, the provider should notify the user about this drift explicitly.