### PR TITLE
`azurerm_kubernetes_cluster` - os_sku not preserved during default node pool resizing

### DIFF
--- a/internal/services/containers/kubernetes_nodepool.go
+++ b/internal/services/containers/kubernetes_nodepool.go
@@ -733,6 +733,9 @@ func ConvertDefaultNodePoolToAgentPool(input *[]managedclusters.ManagedClusterAg
 	if osTypeNodePool := defaultCluster.OsType; osTypeNodePool != nil {
 		agentpool.Properties.OsType = utils.ToPtr(agentpools.OSType(string(*osTypeNodePool)))
 	}
+	if osSku := defaultCluster.OsSKU; osSku != nil {
+		agentpool.Properties.OsSKU = utils.ToPtr(agentpools.OSSKU(*osSku))
+	}
 	if kubeletDiskTypeNodePool := defaultCluster.KubeletDiskType; kubeletDiskTypeNodePool != nil {
 		agentpool.Properties.KubeletDiskType = utils.ToPtr(agentpools.KubeletDiskType(string(*kubeletDiskTypeNodePool)))
 	}


### PR DESCRIPTION


Fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/21971