### PR TITLE
`azurerm_hdinsight_interactive_query_cluster`: Removing unsupported acc test

### DIFF
--- a/internal/services/hdinsight/hdinsight_interactive_query_cluster_resource.go
+++ b/internal/services/hdinsight/hdinsight_interactive_query_cluster_resource.go
@@ -147,7 +147,7 @@ func resourceHDInsightInteractiveQueryCluster() *pluginsdk.Resource {
 					"zookeeper_node": SchemaHDInsightNodeDefinition("roles.0.zookeeper_node", hdInsightInteractiveQueryClusterZookeeperNodeDefinition, true),
 				},
 			},
-			Deprecated: "HDInsight interactive query clusters can only be configured for schedule-based scaling, not load-based.",
+			Deprecated: "HDInsight interactive query clusters can no longer be configured through `autoscale.0.capacity`. Use `autoscale.0.recurrence` instead.",
 		}
 	} else {
 		hdInsightInteractiveQueryClusterWorkerNodeDefinition.CanAutoScaleByCapacity = false

--- a/internal/services/hdinsight/hdinsight_interactive_query_cluster_resource.go
+++ b/internal/services/hdinsight/hdinsight_interactive_query_cluster_resource.go
@@ -32,7 +32,7 @@ var hdInsightInteractiveQueryClusterWorkerNodeDefinition = HDInsightNodeDefiniti
 	CanSpecifyInstanceCount: true,
 	MinInstanceCount:        1,
 	CanSpecifyDisks:         false,
-	CanAutoScaleByCapacity:  true,
+	CanAutoScaleByCapacity:  false,
 	CanAutoScaleOnSchedule:  true,
 }
 

--- a/internal/services/hdinsight/hdinsight_interactive_query_cluster_resource.go
+++ b/internal/services/hdinsight/hdinsight_interactive_query_cluster_resource.go
@@ -115,21 +115,6 @@ func resourceHDInsightInteractiveQueryCluster() *pluginsdk.Resource {
 
 			"storage_account_gen2": SchemaHDInsightsGen2StorageAccounts(),
 
-			"roles": {
-				Type:     pluginsdk.TypeList,
-				Required: true,
-				MaxItems: 1,
-				Elem: &pluginsdk.Resource{
-					Schema: map[string]*pluginsdk.Schema{
-						"head_node": SchemaHDInsightNodeDefinition("roles.0.head_node", hdInsightInteractiveQueryClusterHeadNodeDefinition, true),
-
-						"worker_node": SchemaHDInsightNodeDefinition("roles.0.worker_node", hdInsightInteractiveQueryClusterWorkerNodeDefinition, true),
-
-						"zookeeper_node": SchemaHDInsightNodeDefinition("roles.0.zookeeper_node", hdInsightInteractiveQueryClusterZookeeperNodeDefinition, true),
-					},
-				},
-			},
-
 			"tags": tags.Schema(),
 
 			"https_endpoint": {

--- a/internal/services/hdinsight/hdinsight_interactive_query_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_interactive_query_cluster_resource_test.go
@@ -568,21 +568,6 @@ func TestAccAzureRMHDInsightInteractiveQueryCluster_autoscale(t *testing.T) {
 	r := HDInsightInteractiveQueryClusterResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.autoscale_capacity(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("https_endpoint").Exists(),
-				check.That(data.ResourceName).Key("ssh_endpoint").Exists(),
-			),
-		},
-		data.ImportStep("roles.0.head_node.0.password",
-			"roles.0.head_node.0.vm_size",
-			"roles.0.worker_node.0.password",
-			"roles.0.worker_node.0.vm_size",
-			"roles.0.zookeeper_node.0.password",
-			"roles.0.zookeeper_node.0.vm_size",
-			"storage_account"),
-		{
 			Config: r.autoscale_schedule(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
@@ -2004,55 +1989,6 @@ resource "azurerm_hdinsight_interactive_query_cluster" "test" {
   }
 }
 `, r.template(data), data.RandomString, data.RandomInteger, data.RandomInteger)
-}
-
-func (r HDInsightInteractiveQueryClusterResource) autoscale_capacity(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-%s
-resource "azurerm_hdinsight_interactive_query_cluster" "test" {
-  name                = "acctesthdi-%d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-  cluster_version     = "4.0"
-  tier                = "Standard"
-  component_version {
-    interactive_hive = "3.1"
-  }
-  gateway {
-    username = "acctestusrgw"
-    password = "TerrAform123!"
-  }
-  storage_account {
-    storage_container_id = azurerm_storage_container.test.id
-    storage_account_key  = azurerm_storage_account.test.primary_access_key
-    is_default           = true
-  }
-  roles {
-    head_node {
-      vm_size  = "Standard_D13_V2"
-      username = "acctestusrvm"
-      password = "AccTestvdSC4daf986!"
-    }
-    worker_node {
-      vm_size               = "Standard_D14_V2"
-      username              = "acctestusrvm"
-      password              = "AccTestvdSC4daf986!"
-      target_instance_count = 2
-      autoscale {
-        capacity {
-          min_instance_count = 2
-          max_instance_count = 3
-        }
-      }
-    }
-    zookeeper_node {
-      vm_size  = "Standard_A4_V2"
-      username = "acctestusrvm"
-      password = "AccTestvdSC4daf986!"
-    }
-  }
-}
-`, r.template(data), data.RandomInteger)
 }
 
 func (r HDInsightInteractiveQueryClusterResource) autoscale_schedule(data acceptance.TestData) string {

--- a/website/docs/r/hdinsight_interactive_query_cluster.html.markdown
+++ b/website/docs/r/hdinsight_interactive_query_cluster.html.markdown
@@ -363,19 +363,7 @@ A `extension` block supports the following:
 
 An `autoscale` block supports the following:
 
-* `capacity` - (Optional) A `capacity` block as defined below.
-
 * `recurrence` - (Optional) A `recurrence` block as defined below.
-
--> **NOTE:** Either a `capacity` or `recurrence` block must be specified - but not both.
-
----
-
-A `capacity` block supports the following:
-
-* `max_instance_count` - (Required) The maximum number of worker nodes to autoscale to based on the cluster's activity.
-
-* `min_instance_count` - (Required) The minimum number of worker nodes to autoscale to based on the cluster's activity.
 
 ---
 


### PR DESCRIPTION
* According to [official doc](https://learn.microsoft.com/en-us/azure/hdinsight/hdinsight-autoscale-clusters#cluster-compatibility), hdinsight interactive Query clusters can only be configured for schedule-based scaling, not load-based.

* Tests are passing.
```
=== RUN   TestAccAzureRMHDInsightInteractiveQueryCluster_autoscale
=== PAUSE TestAccAzureRMHDInsightInteractiveQueryCluster_autoscale
=== CONT  TestAccAzureRMHDInsightInteractiveQueryCluster_autoscale
--- PASS: TestAccAzureRMHDInsightInteractiveQueryCluster_autoscale (1315.77s)
PASS

```