### PR TITLE
cosmosdb_account_resource: add support for EnableTtlOnCustomPath

### DIFF
--- a/internal/services/cosmos/cosmosdb_account_resource.go
+++ b/internal/services/cosmos/cosmosdb_account_resource.go
@@ -60,24 +60,26 @@ const (
 	databaseAccountCapabilitiesEnableMongoRetryableWrites        databaseAccountCapabilities = "EnableMongoRetryableWrites"
 	databaseAccountCapabilitiesEnableMongoRoleBasedAccessControl databaseAccountCapabilities = "EnableMongoRoleBasedAccessControl"
 	databaseAccountCapabilitiesEnableUniqueCompoundNestedDocs    databaseAccountCapabilities = "EnableUniqueCompoundNestedDocs"
+	databaseAccountCapabilitiesEnableTTLOnCustomPath             databaseAccountCapabilities = "EnableTtlOnCustomPath"
 )
 
 /*
 	The mapping of capabilities and kinds of cosmosdb account confirmed by service team is as follows:
 
-EnableMongo :                    	MongoDB
-EnableCassandra :                	GlobalDocumentDB, Parse
-EnableGremlin :                  	GlobalDocumentDB, Parse
-EnableTable :                    	GlobalDocumentDB, Parse
-EnableAggregationPipeline :      	GlobalDocumentDB, MongoDB, Parse
-EnableServerless :               	GlobalDocumentDB, MongoDB, Parse
-MongoDBv3.4 :                    	GlobalDocumentDB, MongoDB, Parse
-mongoEnableDocLevelTTL :         	GlobalDocumentDB, MongoDB, Parse
-DisableRateLimitingResponses :   	GlobalDocumentDB, MongoDB, Parse
-AllowSelfServeUpgradeToMongo36 : 	GlobalDocumentDB, MongoDB, Parse
-EnableMongoRetryableWrites :		MongoDB
+EnableMongo :                    	  MongoDB
+EnableCassandra :                	  GlobalDocumentDB, Parse
+EnableGremlin :                  	  GlobalDocumentDB, Parse
+EnableTable :                    	  GlobalDocumentDB, Parse
+EnableAggregationPipeline :      	  GlobalDocumentDB, MongoDB, Parse
+EnableServerless :               	  GlobalDocumentDB, MongoDB, Parse
+MongoDBv3.4 :                    	  GlobalDocumentDB, MongoDB, Parse
+mongoEnableDocLevelTTL :         	  GlobalDocumentDB, MongoDB, Parse
+DisableRateLimitingResponses :   	  GlobalDocumentDB, MongoDB, Parse
+AllowSelfServeUpgradeToMongo36 : 	  GlobalDocumentDB, MongoDB, Parse
+EnableMongoRetryableWrites :		    MongoDB
 EnableMongoRoleBasedAccessControl : MongoDB
-EnableUniqueCompoundNestedDocs : 	MongoDB
+EnableUniqueCompoundNestedDocs : 	  MongoDB
+EnableTTLOnCustomPath :             MongoDB
 */
 var capabilitiesToKindMap = map[string]interface{}{
 	strings.ToLower(string(databaseAccountCapabilitiesEnableMongo)):                    []string{strings.ToLower(string(documentdb.DatabaseAccountKindMongoDB))},
@@ -85,6 +87,7 @@ var capabilitiesToKindMap = map[string]interface{}{
 	strings.ToLower(string(databaseAccountCapabilitiesEnableMongoRetryableWrites)):     []string{strings.ToLower(string(documentdb.DatabaseAccountKindMongoDB))},
 	strings.ToLower(string(databaseAccountCapabilitiesEnableMongoRetryableWrites)):     []string{strings.ToLower(string(documentdb.DatabaseAccountKindMongoDB))},
 	strings.ToLower(string(databaseAccountCapabilitiesEnableUniqueCompoundNestedDocs)): []string{strings.ToLower(string(documentdb.DatabaseAccountKindMongoDB))},
+	strings.ToLower(string(databaseAccountCapabilitiesEnableTTLOnCustomPath)):          []string{strings.ToLower(string(documentdb.DatabaseAccountKindMongoDB))},
 	strings.ToLower(string(databaseAccountCapabilitiesEnableCassandra)):                []string{strings.ToLower(string(documentdb.DatabaseAccountKindGlobalDocumentDB)), strings.ToLower(string(documentdb.DatabaseAccountKindParse))},
 	strings.ToLower(string(databaseAccountCapabilitiesEnableGremlin)):                  []string{strings.ToLower(string(documentdb.DatabaseAccountKindGlobalDocumentDB)), strings.ToLower(string(documentdb.DatabaseAccountKindParse))},
 	strings.ToLower(string(databaseAccountCapabilitiesEnableTable)):                    []string{strings.ToLower(string(documentdb.DatabaseAccountKindGlobalDocumentDB)), strings.ToLower(string(documentdb.DatabaseAccountKindParse))},
@@ -411,6 +414,7 @@ func resourceCosmosDbAccount() *pluginsdk.Resource {
 								string(databaseAccountCapabilitiesEnableMongoRetryableWrites),
 								string(databaseAccountCapabilitiesEnableMongoRoleBasedAccessControl),
 								string(databaseAccountCapabilitiesEnableUniqueCompoundNestedDocs),
+								string(databaseAccountCapabilitiesEnableTTLOnCustomPath),
 							}, false),
 						},
 					},
@@ -2097,6 +2101,7 @@ func checkCapabilitiesCanBeUpdated(kind string, oldCapabilities *[]documentdb.Ca
 		strings.ToLower(string(databaseAccountCapabilitiesEnableMongoRetryableWrites)),
 		strings.ToLower(string(databaseAccountCapabilitiesEnableMongoRoleBasedAccessControl)),
 		strings.ToLower(string(databaseAccountCapabilitiesEnableUniqueCompoundNestedDocs)),
+		strings.ToLower(string(databaseAccountCapabilitiesEnableTTLOnCustomPath)),
 	}
 
 	// The feedback from service team: capabilities that can be removed from an existing account

--- a/website/docs/r/cosmosdb_account.html.markdown
+++ b/website/docs/r/cosmosdb_account.html.markdown
@@ -208,11 +208,11 @@ The `geo_location` block Configures the geographic locations the data is replica
 
 A `capabilities` block Configures the capabilities to be enabled for this Cosmos DB account:
 
-* `name` - (Required) The capability to enable - Possible values are `AllowSelfServeUpgradeToMongo36`, `DisableRateLimitingResponses`, `EnableAggregationPipeline`, `EnableCassandra`, `EnableGremlin`, `EnableMongo`, `EnableMongo16MBDocumentSupport`, `EnableMongoRetryableWrites`, `EnableMongoRoleBasedAccessControl`, `EnableServerless`, `EnableTable`, `EnableUniqueCompoundNestedDocs`, `MongoDBv3.4` and `mongoEnableDocLevelTTL`.
+* `name` - (Required) The capability to enable - Possible values are `AllowSelfServeUpgradeToMongo36`, `DisableRateLimitingResponses`, `EnableAggregationPipeline`, `EnableCassandra`, `EnableGremlin`, `EnableMongo`, `EnableMongo16MBDocumentSupport`, `EnableMongoRetryableWrites`, `EnableMongoRoleBasedAccessControl`, `EnableServerless`, `EnableTable`, `EnableUniqueCompoundNestedDocs`, `MongoDBv3.4`, `mongoEnableDocLevelTTL` and `EnableTtlOnCustomPath`.
 
 ~> **NOTE:** Setting `MongoDBv3.4` also requires setting `EnableMongo`. 
 
-~> **NOTE:** Only `AllowSelfServeUpgradeToMongo36`, `DisableRateLimitingResponses`, `EnableAggregationPipeline`, `MongoDBv3.4`, `EnableMongoRetryableWrites`, `EnableMongoRoleBasedAccessControl`, `EnableUniqueCompoundNestedDocs`, `EnableMongo16MBDocumentSupport` and `mongoEnableDocLevelTTL` can be added to an existing Cosmos DB account.
+~> **NOTE:** Only `AllowSelfServeUpgradeToMongo36`, `DisableRateLimitingResponses`, `EnableAggregationPipeline`, `MongoDBv3.4`, `EnableMongoRetryableWrites`, `EnableMongoRoleBasedAccessControl`, `EnableUniqueCompoundNestedDocs`, `EnableMongo16MBDocumentSupport`, `mongoEnableDocLevelTTL`, and `EnableTtlOnCustomPath` can be added to an existing Cosmos DB account.
 
 ~> **NOTE:** Only `DisableRateLimitingResponses` and `EnableMongoRetryableWrites` can be removed from an existing Cosmos DB account.
 


### PR DESCRIPTION
CosmosDB Accounts have a capability called 'EnableTtlOnCustomPath'. 
This capability can be added using `az cli`, however the terraform provider cannot currently deal with it