### PR TITLE
`azurerm_app_service_certificate` suppress diff of `key_vault_secret_id` after syncs

### DIFF
--- a/internal/services/web/app_service_certificate_resource.go
+++ b/internal/services/web/app_service_certificate_resource.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	keyVaultParse "github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/parse"
+	keyVaultSuppress "github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/suppress"
 	keyVaultValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/keyvault/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/web/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
@@ -234,11 +235,12 @@ func resourceAppServiceCertificateSchema() map[string]*pluginsdk.Schema {
 		},
 
 		"key_vault_secret_id": {
-			Type:          pluginsdk.TypeString,
-			Optional:      true,
-			ForceNew:      true,
-			ValidateFunc:  keyVaultValidate.NestedItemId,
-			ConflictsWith: []string{"pfx_blob", "password"},
+			Type:             pluginsdk.TypeString,
+			Optional:         true,
+			ForceNew:         true,
+			DiffSuppressFunc: keyVaultSuppress.DiffSuppressIgnoreKeyVaultKeyVersion,
+			ValidateFunc:     keyVaultValidate.NestedItemId,
+			ConflictsWith:    []string{"pfx_blob", "password"},
 		},
 
 		"app_service_plan_id": {


### PR DESCRIPTION
Fixes: #9781

Uses `DiffSuppressIgnoreKeyVaultKeyVersion` as `DiffSuppressFunc` to stop plan change after sync of keys.