### PR TITLE
`azurerm_automation_software_update_configuration`: set exists slice as nil when load SDK data to schema model

### DIFF
--- a/internal/services/automation/automation_software_update_configuration_resource.go
+++ b/internal/services/automation/automation_software_update_configuration_resource.go
@@ -38,6 +38,7 @@ func (a *AzureQuery) LoadSDKTags(tags map[string][]string) {
 	if tags == nil {
 		return
 	}
+	a.Tags = nil
 	for k, vs := range tags {
 		t := Tag{}
 		t.Tag = k
@@ -181,12 +182,14 @@ func (s *Schedule) LoadSDKModel(info *softwareupdateconfiguration.SUCSchedulePro
 	if setting := info.AdvancedSchedule; setting != nil {
 		s.AdvancedWeekDays = pointer.ToSliceOfStrings(setting.WeekDays)
 		if setting.MonthDays != nil {
+			s.AdvancedMonthDays = nil
 			for _, v := range *(setting.MonthDays) {
 				s.AdvancedMonthDays = append(s.AdvancedMonthDays, int(v))
 			}
 		}
 
 		if setting.MonthlyOccurrences != nil {
+			s.MonthlyOccurrence = nil
 			for _, occ := range *setting.MonthlyOccurrences {
 
 				day := ""


### PR DESCRIPTION
resolves: #21970

The API doesn't return the schedule block when the first version of `software_update_configuration` released, so I used a Decode to load the exists model in state, then cover with SDK data. 

https://github.com/hashicorp/terraform-provider-azurerm/blob/f405d58d1efd58bf81164216601e03ec0caa5573/internal/services/automation/automation_software_update_configuration_resource.go#L1026-L1029


It seems in some regions, like `UK South`,  the API now returns the schedule info the `GET` request. we have to set the `s.MonthlyOccurrence` as nil before append the returned values into the schema model.

local test pass with no diff in second `terraform plan`

![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/2633022/9383cd4c-6afb-445c-a051-a0efd7288e40)
