### PR TITLE
`app_service` - Refactor Linux and Windows Web Apps and Slots

### DIFF
--- a/.teamcity/components/settings.kt
+++ b/.teamcity/components/settings.kt
@@ -29,7 +29,7 @@ var serviceTestConfigurationOverrides = mapOf(
         "analysisservices" to testConfiguration(locationOverride = LocationConfiguration("westus", "northeurope", "southcentralus", true), useDevTestSubscription = true),
 
         // App Service Plans for Linux are currently unavailable in WestUS2
-        "appservice" to testConfiguration(startHour = 3, daysOfWeek = "2,4,6", locationOverride = LocationConfiguration("westeurope", "northeurope", "eastus2", false), useDevTestSubscription = true),
+        "appservice" to testConfiguration(startHour = 3, daysOfWeek = "2,4,6", locationOverride = LocationConfiguration("westeurope", "northeurope", "eastus2", true), useDevTestSubscription = true),
 
         // these tests all conflict with one another
         "authorization" to testConfiguration(parallelism = 1),
@@ -157,7 +157,7 @@ var serviceTestConfigurationOverrides = mapOf(
         "voiceservices" to testConfiguration(parallelism = 3, locationOverride = LocationConfiguration("westcentralus", "westcentralus", "westcentralus", false), useDevTestSubscription = true),
 
         // Offset start hour to avoid collision with new App Service, reduce frequency of testing days
-        "web" to testConfiguration(startHour = 3, daysOfWeek = "1,3,5", locationOverride = LocationConfiguration("westeurope", "francecentral", "eastus2", false), useDevTestSubscription = true),
+        "web" to testConfiguration(startHour = 3, daysOfWeek = "1,3,5", locationOverride = LocationConfiguration("westeurope", "francecentral", "eastus2", true), useDevTestSubscription = true),
 
         // moved to alt subsription
         "appconfiguration" to testConfiguration(useDevTestSubscription = true),

--- a/examples/app-service/docker-basic/main.tf
+++ b/examples/app-service/docker-basic/main.tf
@@ -28,8 +28,8 @@ resource "azurerm_linux_web_app" "example" {
 
   site_config {
     application_stack {
-      docker_image     = "jackofallops/azure-containerapps-python-acctest"
-      docker_image_tag = "v0.0.1"
+      docker_image_name   = "nginx:latest"
+      docker_registry_url = "https://index.docker.io"
     }
   }
 }

--- a/examples/app-service/windows-container/main.tf
+++ b/examples/app-service/windows-container/main.tf
@@ -27,8 +27,8 @@ resource "azurerm_windows_web_app" "example" {
 
   site_config {
     application_stack {
-      docker_image_name    = "traefik:windowsservercore-1809"
-      docker_registry_url  = "https://index.docker.io"
+      docker_image_name   = "traefik:windowsservercore-1809"
+      docker_registry_url = "https://index.docker.io"
     }
   }
 }

--- a/examples/app-service/windows-container/main.tf
+++ b/examples/app-service/windows-container/main.tf
@@ -27,8 +27,8 @@ resource "azurerm_windows_web_app" "example" {
 
   site_config {
     application_stack {
-      docker_container_name = "jackofallops/azure-containerapps-python-acctest"
-      docker_container_tag  = "v0.0.1"
+      docker_image_name    = "traefik:windowsservercore-1809"
+      docker_registry_url  = "https://index.docker.io"
     }
   }
 }

--- a/internal/services/appservice/helpers/app_stack.go
+++ b/internal/services/appservice/helpers/app_stack.go
@@ -1,6 +1,7 @@
 package helpers
 
 import (
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 )
@@ -41,256 +42,248 @@ type ApplicationStackWindows struct {
 	PythonVersion           string `tfschema:"python_version"`
 	Python                  bool   `tfschema:"python"`
 	TomcatVersion           string `tfschema:"tomcat_version"`
+
+	DockerRegistryUrl      string `tfschema:"docker_registry_url"`
+	DockerRegistryUsername string `tfschema:"docker_registry_username"`
+	DockerRegistryPassword string `tfschema:"docker_registry_password"`
+	DockerImageName        string `tfschema:"docker_image_name"`
+}
+
+var windowsApplicationStackConstraintThreePointX = []string{
+	"site_config.0.application_stack.0.docker_container_name",
+	"site_config.0.application_stack.0.dotnet_version",
+	"site_config.0.application_stack.0.dotnet_core_version",
+	"site_config.0.application_stack.0.java_version",
+	"site_config.0.application_stack.0.node_version",
+	"site_config.0.application_stack.0.php_version",
+	"site_config.0.application_stack.0.python_version",
+	"site_config.0.application_stack.0.python",
+}
+
+var windowsApplicationStackConstraintFourPointOh = []string{
+	"site_config.0.application_stack.0.docker_image_name",
+	"site_config.0.application_stack.0.dotnet_version",
+	"site_config.0.application_stack.0.dotnet_core_version",
+	"site_config.0.application_stack.0.java_version",
+	"site_config.0.application_stack.0.node_version",
+	"site_config.0.application_stack.0.php_version",
+	"site_config.0.application_stack.0.python_version",
+	"site_config.0.application_stack.0.python",
 }
 
 func windowsApplicationStackSchema() *pluginsdk.Schema {
+	r := &pluginsdk.Resource{
+		Schema: map[string]*pluginsdk.Schema{
+			"dotnet_version": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				Computed: true,
+				ValidateFunc: validation.StringInSlice([]string{ // Note: DotNet versions are abstracted between API and Portal displayed values, so do not match 1:1. A table of the converted values is provided in the resource doc.
+					"v2.0",
+					"v3.0",
+					"v4.0",
+					"v5.0",
+					"v6.0",
+					"v7.0"}, false),
+				AtLeastOneOf: windowsApplicationStackConstraintFourPointOh,
+			},
+
+			"dotnet_core_version": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"v4.0",
+				}, false),
+				AtLeastOneOf: windowsApplicationStackConstraintFourPointOh,
+				Description:  "The version of DotNetCore to use.",
+			},
+
+			"php_version": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				Computed: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					PhpVersionSevenPointOne,  // Deprecated
+					PhpVersionSevenPointFour, // Deprecated
+					PhpVersionOff,            // Portal displays `Off` for `""` meaning use latest available
+				}, false),
+				AtLeastOneOf: windowsApplicationStackConstraintFourPointOh,
+			},
+
+			"python_version": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				Computed:     true,
+				Deprecated:   "This property is deprecated. Values set are not used by the service.",
+				AtLeastOneOf: windowsApplicationStackConstraintFourPointOh,
+				ConflictsWith: []string{
+					"site_config.0.application_stack.0.python",
+				},
+			},
+
+			"python": {
+				Type:         pluginsdk.TypeBool,
+				Optional:     true,
+				Default:      false,
+				AtLeastOneOf: windowsApplicationStackConstraintFourPointOh,
+				ConflictsWith: []string{
+					"site_config.0.application_stack.0.python_version",
+				},
+			},
+
+			"node_version": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"~12", // TODO - Remove in 4.0 due to service Deprecation.
+					"~14",
+					"~16",
+					"~18",
+				}, false),
+				AtLeastOneOf: windowsApplicationStackConstraintFourPointOh,
+			},
+
+			"java_version": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+				AtLeastOneOf: windowsApplicationStackConstraintFourPointOh,
+			},
+
+			"java_embedded_server_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+				Computed: true,
+				ConflictsWith: []string{
+					"site_config.0.application_stack.0.tomcat_version",
+				},
+				RequiredWith: []string{
+					"site_config.0.application_stack.0.java_version",
+				},
+				Description: "Should the application use the embedded web server for the version of Java in use.",
+			},
+
+			"tomcat_version": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsNotEmpty, // This is a long list of regularly changing values, not all valid values of which are made known in the portal/docs
+				ConflictsWith: []string{
+					"site_config.0.application_stack.0.java_embedded_server_enabled",
+				},
+				RequiredWith: []string{
+					"site_config.0.application_stack.0.java_version",
+				},
+			},
+
+			"java_container": {
+				Type:       pluginsdk.TypeString,
+				Optional:   true,
+				Deprecated: "this property has been deprecated in favour of `tomcat_version` and `java_embedded_server_enabled`",
+				ValidateFunc: validation.StringInSlice([]string{
+					"JAVA",
+					"JETTY", // No longer supported / offered - Java SE or Tomcat (10, 9.5, 8) only
+					"TOMCAT",
+				}, false),
+				RequiredWith: []string{
+					"site_config.0.application_stack.0.java_container_version",
+				},
+				ConflictsWith: []string{
+					"site_config.0.application_stack.0.tomcat_version",
+				},
+			},
+
+			"java_container_version": {
+				Type:       pluginsdk.TypeString,
+				Optional:   true,
+				Deprecated: "This property has been deprecated in favour of `tomcat_version` and `java_embedded_server_enabled`",
+				RequiredWith: []string{
+					"site_config.0.application_stack.0.java_container",
+				},
+			},
+
+			"docker_image_name": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ExactlyOneOf: windowsApplicationStackConstraintFourPointOh,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
+			"docker_registry_url": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.IsURLWithHTTPorHTTPS,
+				RequiredWith: []string{"site_config.0.application_stack.0.docker_image_name"},
+			},
+
+			"docker_registry_username": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
+			"docker_registry_password": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+			},
+
+			"current_stack": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				Computed: true, // This will be set to the configured type from above if not explicitly set
+				ValidateFunc: validation.StringInSlice([]string{
+					"dotnet",
+					"dotnetcore",
+					"node",
+					"python",
+					"php",
+					"java",
+				}, false),
+			},
+		},
+	}
+
+	if !features.FourPointOhBeta() {
+		r.Schema["docker_container_registry"] = &pluginsdk.Schema{
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+			Deprecated:   "This property has been deprecated and will be removed in a future release of the provider.",
+		}
+		r.Schema["docker_container_name"] = &pluginsdk.Schema{
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+			AtLeastOneOf: windowsApplicationStackConstraintThreePointX,
+			RequiredWith: []string{
+				"site_config.0.application_stack.0.docker_container_tag",
+			},
+		}
+		r.Schema["docker_container_tag"] = &pluginsdk.Schema{
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+			RequiredWith: []string{
+				"site_config.0.application_stack.0.docker_container_name",
+			},
+		}
+
+		r.Schema["dotnet_version"].AtLeastOneOf = windowsApplicationStackConstraintThreePointX
+		r.Schema["dotnet_core_version"].AtLeastOneOf = windowsApplicationStackConstraintThreePointX
+		r.Schema["php_version"].AtLeastOneOf = windowsApplicationStackConstraintThreePointX
+		r.Schema["python"].AtLeastOneOf = windowsApplicationStackConstraintThreePointX
+		r.Schema["python_version"].AtLeastOneOf = windowsApplicationStackConstraintThreePointX
+		r.Schema["node_version"].AtLeastOneOf = windowsApplicationStackConstraintThreePointX
+		r.Schema["java_version"].AtLeastOneOf = windowsApplicationStackConstraintThreePointX
+	}
+
 	return &pluginsdk.Schema{
 		Type:     pluginsdk.TypeList,
 		Optional: true,
 		Computed: true,
 		MaxItems: 1,
-		Elem: &pluginsdk.Resource{
-			Schema: map[string]*pluginsdk.Schema{
-				"dotnet_version": {
-					Type:     pluginsdk.TypeString,
-					Optional: true,
-					Computed: true,
-					ValidateFunc: validation.StringInSlice([]string{ // Note: DotNet versions are abstracted between API and Portal displayed values, so do not match 1:1. A table of the converted values is provided in the resource doc.
-						"v2.0",
-						"v3.0",
-						"v4.0",
-						"v5.0",
-						"v6.0",
-						"v7.0"}, false),
-					AtLeastOneOf: []string{
-						"site_config.0.application_stack.0.docker_container_name",
-						"site_config.0.application_stack.0.dotnet_version",
-						"site_config.0.application_stack.0.dotnet_core_version",
-						"site_config.0.application_stack.0.java_version",
-						"site_config.0.application_stack.0.node_version",
-						"site_config.0.application_stack.0.php_version",
-						"site_config.0.application_stack.0.python",
-						"site_config.0.application_stack.0.python_version",
-					},
-				},
-
-				"dotnet_core_version": {
-					Type:     pluginsdk.TypeString,
-					Optional: true,
-					ValidateFunc: validation.StringInSlice([]string{
-						"v4.0",
-					}, false),
-					AtLeastOneOf: []string{
-						"site_config.0.application_stack.0.docker_container_name",
-						"site_config.0.application_stack.0.dotnet_version",
-						"site_config.0.application_stack.0.dotnet_core_version",
-						"site_config.0.application_stack.0.java_version",
-						"site_config.0.application_stack.0.node_version",
-						"site_config.0.application_stack.0.php_version",
-						"site_config.0.application_stack.0.python",
-						"site_config.0.application_stack.0.python_version",
-					},
-					Description: "The version of DotNetCore to use.",
-				},
-
-				"php_version": {
-					Type:     pluginsdk.TypeString,
-					Optional: true,
-					Computed: true,
-					ValidateFunc: validation.StringInSlice([]string{
-						PhpVersionSevenPointOne,  // Deprecated
-						PhpVersionSevenPointFour, // Deprecated
-						PhpVersionOff,            // Portal displays `Off` for `""` meaning use latest available
-					}, false),
-					AtLeastOneOf: []string{
-						"site_config.0.application_stack.0.docker_container_name",
-						"site_config.0.application_stack.0.dotnet_version",
-						"site_config.0.application_stack.0.dotnet_core_version",
-						"site_config.0.application_stack.0.java_version",
-						"site_config.0.application_stack.0.node_version",
-						"site_config.0.application_stack.0.php_version",
-						"site_config.0.application_stack.0.python",
-						"site_config.0.application_stack.0.python_version",
-					},
-				},
-
-				"python_version": {
-					Type:       pluginsdk.TypeString,
-					Optional:   true,
-					Computed:   true,
-					Deprecated: "This property is deprecated. Values set are not used by the service.",
-					AtLeastOneOf: []string{
-						"site_config.0.application_stack.0.docker_container_name",
-						"site_config.0.application_stack.0.dotnet_version",
-						"site_config.0.application_stack.0.dotnet_core_version",
-						"site_config.0.application_stack.0.java_version",
-						"site_config.0.application_stack.0.node_version",
-						"site_config.0.application_stack.0.php_version",
-						"site_config.0.application_stack.0.python",
-						"site_config.0.application_stack.0.python_version",
-					},
-					ConflictsWith: []string{
-						"site_config.0.application_stack.0.python",
-					},
-				},
-
-				"python": {
-					Type:     pluginsdk.TypeBool,
-					Optional: true,
-					Default:  false,
-					AtLeastOneOf: []string{
-						"site_config.0.application_stack.0.docker_container_name",
-						"site_config.0.application_stack.0.dotnet_version",
-						"site_config.0.application_stack.0.dotnet_core_version",
-						"site_config.0.application_stack.0.java_version",
-						"site_config.0.application_stack.0.node_version",
-						"site_config.0.application_stack.0.php_version",
-						"site_config.0.application_stack.0.python_version",
-						"site_config.0.application_stack.0.python",
-					},
-					ConflictsWith: []string{
-						"site_config.0.application_stack.0.python_version",
-					},
-				},
-
-				"node_version": {
-					Type:     pluginsdk.TypeString,
-					Optional: true,
-					ValidateFunc: validation.StringInSlice([]string{
-						"~12", // TODO - Remove in 4.0 due to service Deprecation.
-						"~14",
-						"~16",
-						"~18",
-					}, false),
-					AtLeastOneOf: []string{
-						"site_config.0.application_stack.0.docker_container_name",
-						"site_config.0.application_stack.0.dotnet_version",
-						"site_config.0.application_stack.0.dotnet_core_version",
-						"site_config.0.application_stack.0.java_version",
-						"site_config.0.application_stack.0.node_version",
-						"site_config.0.application_stack.0.php_version",
-						"site_config.0.application_stack.0.python_version",
-						"site_config.0.application_stack.0.python",
-					},
-				},
-
-				"java_version": {
-					Type:         pluginsdk.TypeString,
-					Optional:     true,
-					ValidateFunc: validation.StringIsNotEmpty,
-					AtLeastOneOf: []string{
-						"site_config.0.application_stack.0.docker_container_name",
-						"site_config.0.application_stack.0.dotnet_version",
-						"site_config.0.application_stack.0.dotnet_core_version",
-						"site_config.0.application_stack.0.java_version",
-						"site_config.0.application_stack.0.node_version",
-						"site_config.0.application_stack.0.php_version",
-						"site_config.0.application_stack.0.python_version",
-						"site_config.0.application_stack.0.python",
-					},
-				},
-
-				"java_embedded_server_enabled": {
-					Type:     pluginsdk.TypeBool,
-					Optional: true,
-					Computed: true,
-					ConflictsWith: []string{
-						"site_config.0.application_stack.0.tomcat_version",
-					},
-					RequiredWith: []string{
-						"site_config.0.application_stack.0.java_version",
-					},
-					Description: "Should the application use the embedded web server for the version of Java in use.",
-				},
-
-				"tomcat_version": {
-					Type:         pluginsdk.TypeString,
-					Optional:     true,
-					ValidateFunc: validation.StringIsNotEmpty, // This is a long list of regularly changing values, not all valid values of which are made known in the portal/docs
-					ConflictsWith: []string{
-						"site_config.0.application_stack.0.java_embedded_server_enabled",
-					},
-					RequiredWith: []string{
-						"site_config.0.application_stack.0.java_version",
-					},
-				},
-
-				"java_container": {
-					Type:       pluginsdk.TypeString,
-					Optional:   true,
-					Deprecated: "this property has been deprecated in favour of `tomcat_version` and `java_embedded_server_enabled`",
-					ValidateFunc: validation.StringInSlice([]string{
-						"JAVA",
-						"JETTY", // No longer supported / offered - Java SE or Tomcat (10, 9.5, 8) only
-						"TOMCAT",
-					}, false),
-					RequiredWith: []string{
-						"site_config.0.application_stack.0.java_container_version",
-					},
-					ConflictsWith: []string{
-						"site_config.0.application_stack.0.tomcat_version",
-					},
-				},
-
-				"java_container_version": {
-					Type:       pluginsdk.TypeString,
-					Optional:   true,
-					Deprecated: "This property has been deprecated in favour of `tomcat_version` and `java_embedded_server_enabled`",
-					RequiredWith: []string{
-						"site_config.0.application_stack.0.java_container",
-					},
-				},
-
-				"docker_container_name": {
-					Type:         pluginsdk.TypeString,
-					Optional:     true,
-					ValidateFunc: validation.StringIsNotEmpty,
-					AtLeastOneOf: []string{
-						"site_config.0.application_stack.0.docker_container_name",
-						"site_config.0.application_stack.0.dotnet_version",
-						"site_config.0.application_stack.0.dotnet_core_version",
-						"site_config.0.application_stack.0.java_version",
-						"site_config.0.application_stack.0.node_version",
-						"site_config.0.application_stack.0.php_version",
-						"site_config.0.application_stack.0.python_version",
-						"site_config.0.application_stack.0.python",
-					},
-					RequiredWith: []string{
-						"site_config.0.application_stack.0.docker_container_tag",
-					},
-				},
-
-				"docker_container_registry": {
-					Type:         pluginsdk.TypeString,
-					Optional:     true,
-					ValidateFunc: validation.StringIsNotEmpty,
-				},
-
-				"docker_container_tag": {
-					Type:         pluginsdk.TypeString,
-					Optional:     true,
-					ValidateFunc: validation.StringIsNotEmpty,
-					RequiredWith: []string{
-						"site_config.0.application_stack.0.docker_container_name",
-					},
-				},
-
-				"current_stack": {
-					Type:     pluginsdk.TypeString,
-					Optional: true,
-					Computed: true, // This will be set to the configured type from above if not explicitly set
-					ValidateFunc: validation.StringInSlice([]string{
-						"dotnet",
-						"dotnetcore",
-						"node",
-						"python",
-						"php",
-						"java",
-					}, false),
-				},
-			},
-		},
+		Elem:     r,
 	}
+
 }
 
 func windowsApplicationStackSchemaComputed() *pluginsdk.Schema {
@@ -390,209 +383,203 @@ type ApplicationStackLinux struct {
 	DockerImageTag      string `tfschema:"docker_image_tag"`
 	DockerImage         string `tfschema:"docker_image"`
 	RubyVersion         string `tfschema:"ruby_version"`
+
+	DockerRegistryUrl      string `tfschema:"docker_registry_url"`
+	DockerRegistryUsername string `tfschema:"docker_registry_username"`
+	DockerRegistryPassword string `tfschema:"docker_registry_password"`
+	DockerImageName        string `tfschema:"docker_image_name"`
+}
+
+var linuxApplicationStackConstraintThreePointX = []string{
+	"site_config.0.application_stack.0.docker_image",
+	"site_config.0.application_stack.0.dotnet_version",
+	"site_config.0.application_stack.0.java_version",
+	"site_config.0.application_stack.0.node_version",
+	"site_config.0.application_stack.0.php_version",
+	"site_config.0.application_stack.0.python_version",
+	"site_config.0.application_stack.0.ruby_version",
+	"site_config.0.application_stack.0.go_version",
+}
+
+var linuxApplicationStackConstraintFourPointOh = []string{
+	"site_config.0.application_stack.0.docker_image_name",
+	"site_config.0.application_stack.0.dotnet_version",
+	"site_config.0.application_stack.0.java_version",
+	"site_config.0.application_stack.0.node_version",
+	"site_config.0.application_stack.0.php_version",
+	"site_config.0.application_stack.0.python_version",
+	"site_config.0.application_stack.0.ruby_version",
+	"site_config.0.application_stack.0.go_version",
 }
 
 func linuxApplicationStackSchema() *pluginsdk.Schema {
+	r := &pluginsdk.Resource{
+		Schema: map[string]*pluginsdk.Schema{
+			"dotnet_version": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"3.1",
+					"5.0", // deprecated
+					"6.0",
+					"7.0",
+				}, false),
+				ExactlyOneOf: linuxApplicationStackConstraintFourPointOh,
+			},
+
+			"go_version": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"1.19",
+					"1.18",
+				}, false),
+				ExactlyOneOf: linuxApplicationStackConstraintFourPointOh,
+			},
+
+			"php_version": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"7.4",
+					"8.0",
+					"8.1",
+					"8.2",
+				}, false),
+				ExactlyOneOf: linuxApplicationStackConstraintFourPointOh,
+			},
+
+			"python_version": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"3.7",
+					"3.8",
+					"3.9",
+					"3.10",
+					"3.11",
+				}, false),
+				ExactlyOneOf: linuxApplicationStackConstraintFourPointOh,
+			},
+
+			"node_version": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"12-lts",
+					"14-lts",
+					"16-lts",
+					"18-lts",
+				}, false),
+				ExactlyOneOf: linuxApplicationStackConstraintFourPointOh,
+			},
+
+			"ruby_version": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"2.6", // Deprecated - accepted but not offered in the portal. Remove in 4.0
+					"2.7", // EOL 31/03/2023 https://github.com/Azure/app-service-linux-docs/blob/master/Runtime_Support/ruby_support.md Remove Ruby support in 4.0?
+				}, false),
+				ExactlyOneOf: linuxApplicationStackConstraintFourPointOh,
+			},
+
+			"java_version": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"8",
+					"11",
+					"17",
+				}, false),
+				ExactlyOneOf: linuxApplicationStackConstraintFourPointOh,
+			},
+
+			"java_server": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"JAVA",
+					"TOMCAT",
+					"JBOSSEAP",
+				}, false),
+				RequiredWith: []string{
+					"site_config.0.application_stack.0.java_version",
+				},
+			},
+
+			"java_server_version": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				RequiredWith: []string{
+					"site_config.0.application_stack.0.java_server",
+				},
+			},
+
+			"docker_image_name": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ExactlyOneOf: linuxApplicationStackConstraintFourPointOh,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
+			"docker_registry_url": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.IsURLWithHTTPorHTTPS,
+				RequiredWith: []string{"site_config.0.application_stack.0.docker_image_name"},
+			},
+
+			"docker_registry_username": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+
+			"docker_registry_password": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+			},
+		},
+	}
+
+	if !features.FourPointOhBeta() {
+		r.Schema["docker_image_tag"] = &pluginsdk.Schema{
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+			RequiredWith: []string{
+				"site_config.0.application_stack.0.docker_image",
+			},
+			Deprecated: "This property has been deprecated and will be removed in 4.0 of the provider.",
+		}
+		r.Schema["docker_image"] = &pluginsdk.Schema{
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+			ExactlyOneOf: linuxApplicationStackConstraintThreePointX,
+			RequiredWith: []string{
+				"site_config.0.application_stack.0.docker_image_tag",
+			},
+			Deprecated: "This property has been deprecated and will be removed in 4.0 of the provider.",
+		}
+
+		r.Schema["dotnet_version"].ExactlyOneOf = linuxApplicationStackConstraintThreePointX
+		r.Schema["go_version"].ExactlyOneOf = linuxApplicationStackConstraintThreePointX
+		r.Schema["php_version"].ExactlyOneOf = linuxApplicationStackConstraintThreePointX
+		r.Schema["python_version"].ExactlyOneOf = linuxApplicationStackConstraintThreePointX
+		r.Schema["node_version"].ExactlyOneOf = linuxApplicationStackConstraintThreePointX
+		r.Schema["ruby_version"].ExactlyOneOf = linuxApplicationStackConstraintThreePointX
+		r.Schema["java_version"].ExactlyOneOf = linuxApplicationStackConstraintThreePointX
+
+	}
+
 	return &pluginsdk.Schema{
 		Type:     pluginsdk.TypeList,
 		Optional: true,
 		Computed: true,
 		MaxItems: 1,
-		Elem: &pluginsdk.Resource{
-			Schema: map[string]*pluginsdk.Schema{
-				"dotnet_version": {
-					Type:     pluginsdk.TypeString,
-					Optional: true,
-					ValidateFunc: validation.StringInSlice([]string{
-						"3.1",
-						"5.0", // deprecated
-						"6.0",
-						"7.0",
-					}, false),
-					ExactlyOneOf: []string{
-						"site_config.0.application_stack.0.docker_image",
-						"site_config.0.application_stack.0.dotnet_version",
-						"site_config.0.application_stack.0.java_version",
-						"site_config.0.application_stack.0.node_version",
-						"site_config.0.application_stack.0.php_version",
-						"site_config.0.application_stack.0.python_version",
-						"site_config.0.application_stack.0.ruby_version",
-						"site_config.0.application_stack.0.go_version",
-					},
-				},
-
-				"go_version": {
-					Type:     pluginsdk.TypeString,
-					Optional: true,
-					ValidateFunc: validation.StringInSlice([]string{
-						"1.19",
-						"1.18",
-					}, false),
-					ExactlyOneOf: []string{
-						"site_config.0.application_stack.0.docker_image",
-						"site_config.0.application_stack.0.dotnet_version",
-						"site_config.0.application_stack.0.java_version",
-						"site_config.0.application_stack.0.node_version",
-						"site_config.0.application_stack.0.php_version",
-						"site_config.0.application_stack.0.python_version",
-						"site_config.0.application_stack.0.ruby_version",
-						"site_config.0.application_stack.0.go_version",
-					},
-				},
-
-				"php_version": {
-					Type:     pluginsdk.TypeString,
-					Optional: true,
-					ValidateFunc: validation.StringInSlice([]string{
-						"7.4",
-						"8.0",
-						"8.1",
-						"8.2",
-					}, false),
-					ExactlyOneOf: []string{
-						"site_config.0.application_stack.0.docker_image",
-						"site_config.0.application_stack.0.dotnet_version",
-						"site_config.0.application_stack.0.java_version",
-						"site_config.0.application_stack.0.node_version",
-						"site_config.0.application_stack.0.php_version",
-						"site_config.0.application_stack.0.python_version",
-						"site_config.0.application_stack.0.ruby_version",
-						"site_config.0.application_stack.0.go_version",
-					},
-				},
-
-				"python_version": {
-					Type:     pluginsdk.TypeString,
-					Optional: true,
-					ValidateFunc: validation.StringInSlice([]string{
-						"3.7",
-						"3.8",
-						"3.9",
-						"3.10",
-						"3.11",
-					}, false),
-					ExactlyOneOf: []string{
-						"site_config.0.application_stack.0.docker_image",
-						"site_config.0.application_stack.0.dotnet_version",
-						"site_config.0.application_stack.0.java_version",
-						"site_config.0.application_stack.0.node_version",
-						"site_config.0.application_stack.0.php_version",
-						"site_config.0.application_stack.0.python_version",
-						"site_config.0.application_stack.0.ruby_version",
-						"site_config.0.application_stack.0.go_version",
-					},
-				},
-
-				"node_version": {
-					Type:     pluginsdk.TypeString,
-					Optional: true,
-					ValidateFunc: validation.StringInSlice([]string{
-						"12-lts",
-						"14-lts",
-						"16-lts",
-						"18-lts",
-					}, false),
-					ExactlyOneOf: []string{
-						"site_config.0.application_stack.0.docker_image",
-						"site_config.0.application_stack.0.dotnet_version",
-						"site_config.0.application_stack.0.java_version",
-						"site_config.0.application_stack.0.node_version",
-						"site_config.0.application_stack.0.php_version",
-						"site_config.0.application_stack.0.python_version",
-						"site_config.0.application_stack.0.ruby_version",
-						"site_config.0.application_stack.0.go_version",
-					},
-				},
-
-				"ruby_version": {
-					Type:     pluginsdk.TypeString,
-					Optional: true,
-					ValidateFunc: validation.StringInSlice([]string{
-						"2.6", // Deprecated - accepted but not offered in the portal. Remove in 4.0
-						"2.7", // EOL 31/03/2023 https://github.com/Azure/app-service-linux-docs/blob/master/Runtime_Support/ruby_support.md Remove Ruby support in 4.0?
-					}, false),
-					ExactlyOneOf: []string{
-						"site_config.0.application_stack.0.docker_image",
-						"site_config.0.application_stack.0.dotnet_version",
-						"site_config.0.application_stack.0.java_version",
-						"site_config.0.application_stack.0.node_version",
-						"site_config.0.application_stack.0.php_version",
-						"site_config.0.application_stack.0.python_version",
-						"site_config.0.application_stack.0.ruby_version",
-						"site_config.0.application_stack.0.go_version",
-					},
-				},
-
-				"java_version": {
-					Type:     pluginsdk.TypeString,
-					Optional: true,
-					ValidateFunc: validation.StringInSlice([]string{
-						"8",
-						"11",
-						"17",
-					}, false),
-					ExactlyOneOf: []string{
-						"site_config.0.application_stack.0.docker_image",
-						"site_config.0.application_stack.0.dotnet_version",
-						"site_config.0.application_stack.0.java_version",
-						"site_config.0.application_stack.0.node_version",
-						"site_config.0.application_stack.0.php_version",
-						"site_config.0.application_stack.0.python_version",
-						"site_config.0.application_stack.0.ruby_version",
-						"site_config.0.application_stack.0.go_version",
-					},
-				},
-
-				"java_server": {
-					Type:     pluginsdk.TypeString,
-					Optional: true,
-					ValidateFunc: validation.StringInSlice([]string{
-						"JAVA",
-						"TOMCAT",
-						"JBOSSEAP",
-					}, false),
-					RequiredWith: []string{
-						"site_config.0.application_stack.0.java_version",
-					},
-				},
-
-				"java_server_version": {
-					Type:     pluginsdk.TypeString,
-					Optional: true,
-					RequiredWith: []string{
-						"site_config.0.application_stack.0.java_server",
-					},
-				},
-
-				"docker_image": {
-					Type:         pluginsdk.TypeString,
-					Optional:     true,
-					ValidateFunc: validation.StringIsNotEmpty,
-					ExactlyOneOf: []string{
-						"site_config.0.application_stack.0.docker_image",
-						"site_config.0.application_stack.0.dotnet_version",
-						"site_config.0.application_stack.0.java_version",
-						"site_config.0.application_stack.0.node_version",
-						"site_config.0.application_stack.0.php_version",
-						"site_config.0.application_stack.0.python_version",
-						"site_config.0.application_stack.0.ruby_version",
-						"site_config.0.application_stack.0.go_version",
-					},
-					RequiredWith: []string{
-						"site_config.0.application_stack.0.docker_image_tag",
-					},
-				},
-
-				"docker_image_tag": {
-					Type:         pluginsdk.TypeString,
-					Optional:     true,
-					ValidateFunc: validation.StringIsNotEmpty,
-					RequiredWith: []string{
-						"site_config.0.application_stack.0.docker_image",
-					},
-				},
-			},
-		},
+		Elem:     r,
 	}
 }
 

--- a/internal/services/appservice/helpers/app_stack.go
+++ b/internal/services/appservice/helpers/app_stack.go
@@ -208,8 +208,9 @@ func windowsApplicationStackSchema() *pluginsdk.Schema {
 			},
 
 			"docker_registry_password": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
+				Type:      pluginsdk.TypeString,
+				Optional:  true,
+				Sensitive: true,
 			},
 
 			"current_stack": {
@@ -375,8 +376,9 @@ func windowsApplicationStackSchemaComputed() *pluginsdk.Schema {
 			},
 
 			"docker_registry_password": {
-				Type:     pluginsdk.TypeString,
-				Computed: true,
+				Type:      pluginsdk.TypeString,
+				Computed:  true,
+				Sensitive: true,
 			},
 		},
 	}
@@ -572,8 +574,9 @@ func linuxApplicationStackSchema() *pluginsdk.Schema {
 			},
 
 			"docker_registry_password": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
+				Type:      pluginsdk.TypeString,
+				Optional:  true,
+				Sensitive: true,
 			},
 		},
 	}
@@ -687,8 +690,9 @@ func linuxApplicationStackSchemaComputed() *pluginsdk.Schema {
 			},
 
 			"docker_registry_password": {
-				Type:     pluginsdk.TypeString,
-				Computed: true,
+				Type:      pluginsdk.TypeString,
+				Computed:  true,
+				Sensitive: true,
 			},
 		},
 	}

--- a/internal/services/appservice/helpers/auto_heal.go
+++ b/internal/services/appservice/helpers/auto_heal.go
@@ -31,7 +31,7 @@ type AutoHealRequestTrigger struct {
 type AutoHealStatusCodeTrigger struct {
 	StatusCodeRange string `tfschema:"status_code_range"` // Conflicts with `StatusCode`, `Win32Code`, and `SubStatus` when not a single value...
 	SubStatus       int    `tfschema:"sub_status"`
-	Win32Status     string `tfschema:"win32_status"`
+	Win32Status     int    `tfschema:"win32_status"`
 	Path            string `tfschema:"path"`
 	Count           int    `tfschema:"count"`
 	Interval        string `tfschema:"interval"` // Format - hh:mm:ss
@@ -238,7 +238,7 @@ func autoHealTriggerSchemaWindows() *pluginsdk.Schema {
 							},
 
 							"win32_status": {
-								Type:     pluginsdk.TypeString,
+								Type:     pluginsdk.TypeInt,
 								Optional: true,
 							},
 
@@ -343,7 +343,7 @@ func autoHealTriggerSchemaWindowsComputed() *pluginsdk.Schema {
 							},
 
 							"win32_status": {
-								Type:     pluginsdk.TypeString,
+								Type:     pluginsdk.TypeInt,
 								Computed: true,
 							},
 
@@ -447,6 +447,12 @@ func expandAutoHealSettingsWindows(autoHealSettings []AutoHealSettingWindows) *w
 				if s.Path != "" {
 					statusCodeTrigger.Path = pointer.To(s.Path)
 				}
+				if s.SubStatus != 0 {
+					statusCodeTrigger.SubStatus = pointer.To(int32(s.SubStatus))
+				}
+				if s.Win32Status != 0 {
+					statusCodeTrigger.Win32Status = pointer.To(int32(s.Win32Status))
+				}
 				statusCodeTriggers = append(statusCodeTriggers, statusCodeTrigger)
 			}
 		}
@@ -511,6 +517,10 @@ func flattenAutoHealSettingsWindows(autoHealRules *web.AutoHealRules) []AutoHeal
 
 				if s.SubStatus != nil {
 					t.SubStatus = int(*s.SubStatus)
+				}
+
+				if s.Win32Status != nil {
+					t.Win32Status = int(pointer.From(s.Win32Status))
 				}
 				statusCodeTriggers = append(statusCodeTriggers, t)
 			}

--- a/internal/services/appservice/helpers/common_web_app_schema.go
+++ b/internal/services/appservice/helpers/common_web_app_schema.go
@@ -1241,8 +1241,8 @@ func ExpandAppSettingsForCreate(settings map[string]string) *[]web.NameValuePair
 	return nil
 }
 
-func FilterUnmanagedAppSettings(input map[string]string) map[string]string {
-	maxPingFailures := "WEBSITE_HEALTHCHECK_MAXPINGFAILURES"
+// FilterManagedAppSettings removes app_settings values from the state that are controlled directly be schema properties.
+func FilterManagedAppSettings(input map[string]string) map[string]string {
 	unmanagedSettings := []string{
 		"DOCKER_REGISTRY_SERVER_URL",
 		"DOCKER_REGISTRY_SERVER_USERNAME",
@@ -1255,8 +1255,31 @@ func FilterUnmanagedAppSettings(input map[string]string) map[string]string {
 		"spring.datasource.password",
 		"spring.datasource.url",
 		"spring.datasource.username",
-		maxPingFailures,
+		"WEBSITE_HEALTHCHECK_MAXPINGFAILURES",
 	}
+
+	for _, v := range unmanagedSettings { //nolint:typecheck
+		delete(input, v)
+	}
+
+	return input
+}
+
+// FilterManagedAppSettingsDeprecated removes app_settings values from the state that are controlled directly be
+// schema properties when the deprecated docker settings are used. This function should be removed in 4.0
+func FilterManagedAppSettingsDeprecated(input map[string]string) map[string]string {
+	unmanagedSettings := []string{
+		"DIAGNOSTICS_AZUREBLOBCONTAINERSASURL",
+		"DIAGNOSTICS_AZUREBLOBRETENTIONINDAYS",
+		"WEBSITE_HTTPLOGGING_CONTAINER_URL",
+		"WEBSITE_HTTPLOGGING_RETENTION_DAYS",
+		"WEBSITE_VNET_ROUTE_ALL",
+		"spring.datasource.password",
+		"spring.datasource.url",
+		"spring.datasource.username",
+		"WEBSITE_HEALTHCHECK_MAXPINGFAILURES",
+	}
+
 	for _, v := range unmanagedSettings { //nolint:typecheck
 		delete(input, v)
 	}
@@ -1338,7 +1361,7 @@ func DisabledLogsConfig() *web.SiteLogsConfig {
 	}
 }
 
-func isFreeOrSharedServicePlan(inputSKU string) bool {
+func IsFreeOrSharedServicePlan(inputSKU string) bool {
 	result := false
 	for _, sku := range freeSkus {
 		if inputSKU == sku {

--- a/internal/services/appservice/helpers/fx_strings.go
+++ b/internal/services/appservice/helpers/fx_strings.go
@@ -75,7 +75,11 @@ func decodeApplicationStackLinux(fxString string) ApplicationStackLinux {
 	case "RUBY":
 		result.RubyVersion = parts[1]
 
-	default: // DOCKER is the expected default here as "custom" images require it
+	case "COMPOSE":
+		// TODO
+	case "DOCKER":
+		// Deprecated / bugged - to be removed post 4.0
+		// new docker parsing is done later
 		if dockerParts := strings.Split(parts[1], ":"); len(dockerParts) == 2 {
 			result.DockerImage = dockerParts[0]
 			result.DockerImageTag = dockerParts[1]

--- a/internal/services/appservice/helpers/fx_strings.go
+++ b/internal/services/appservice/helpers/fx_strings.go
@@ -28,9 +28,7 @@ type FxStringPrefix string
 
 var urlSchemes = []string{
 	"https://",
-	"HTTPS://",
 	"http://",
-	"HTTP://",
 }
 
 func decodeApplicationStackLinux(fxString string) ApplicationStackLinux {
@@ -302,15 +300,10 @@ func EncodeDockerFxStringWindows(image string, registryUrl string) string {
 	template := "DOCKER|%s/%s"
 	dockerHubTemplate := "DOCKER|%s"
 
-	for _, prefix := range urlSchemes {
-		if strings.HasPrefix(registryUrl, prefix) {
-			registryUrl = strings.TrimPrefix(registryUrl, prefix)
-			continue
-		}
-	}
+	registryUrl = trimURLScheme(registryUrl)
 
 	// Windows App Services fail to auth if the index portion of the image ref is `index.docker.io` so it must not be included.
-	if registryUrl == "index.docker.io" {
+	if strings.EqualFold(registryUrl, "index.docker.io") {
 		return fmt.Sprintf(dockerHubTemplate, image)
 	}
 

--- a/internal/services/appservice/helpers/fx_strings.go
+++ b/internal/services/appservice/helpers/fx_strings.go
@@ -11,10 +11,11 @@ import (
 const (
 	FxStringPrefixDocker         FxStringPrefix = "DOCKER"
 	FxStringPrefixDotNet         FxStringPrefix = "DOTNET"
+	FxStringPrefixDotNetCore     FxStringPrefix = "DOTNETCORE"
 	FxStringPrefixDotNetIsolated FxStringPrefix = "DOTNET-ISOLATED"
 	FxStringPrefixGo             FxStringPrefix = "GO"
 	FxStringPrefixJava           FxStringPrefix = "JAVA"
-	FxStringPrefixJBoss          FxStringPrefix = "JBOSS"
+	FxStringPrefixJBoss          FxStringPrefix = "JBOSSEAP"
 	FxStringPrefixNode           FxStringPrefix = "NODE"
 	FxStringPrefixPhp            FxStringPrefix = "PHP"
 	FxStringPrefixPowerShell     FxStringPrefix = "POWERSHELL"
@@ -40,7 +41,7 @@ func decodeApplicationStackLinux(fxString string) ApplicationStackLinux {
 	}
 
 	switch FxStringPrefix(strings.ToUpper(parts[0])) {
-	case FxStringPrefixDotNetIsolated, FxStringPrefixDotNet:
+	case FxStringPrefixDotNetIsolated, FxStringPrefixDotNet, FxStringPrefixDotNetCore:
 		result.NetFrameworkVersion = parts[1]
 
 	case FxStringPrefixGo:

--- a/internal/services/appservice/helpers/fx_strings.go
+++ b/internal/services/appservice/helpers/fx_strings.go
@@ -8,6 +8,23 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
+const (
+	FxStringPrefixDocker         FxStringPrefix = "DOCKER"
+	FxStringPrefixDotNet         FxStringPrefix = "DOTNET"
+	FxStringPrefixDotNetIsolated FxStringPrefix = "DOTNET-ISOLATED"
+	FxStringPrefixGo             FxStringPrefix = "GO"
+	FxStringPrefixJava           FxStringPrefix = "JAVA"
+	FxStringPrefixJBoss          FxStringPrefix = "JBOSS"
+	FxStringPrefixNode           FxStringPrefix = "NODE"
+	FxStringPrefixPhp            FxStringPrefix = "PHP"
+	FxStringPrefixPowerShell     FxStringPrefix = "POWERSHELL"
+	FxStringPrefixPython         FxStringPrefix = "PYTHON"
+	FxStringPrefixRuby           FxStringPrefix = "RUBY"
+	FxStringPrefixTomcat         FxStringPrefix = "TOMCAT"
+)
+
+type FxStringPrefix string
+
 var urlSchemes = []string{
 	"https://",
 	"HTTPS://",
@@ -22,17 +39,17 @@ func decodeApplicationStackLinux(fxString string) ApplicationStackLinux {
 		return result
 	}
 
-	switch strings.ToUpper(parts[0]) {
-	case "DOTNETCORE", "DOTNET":
+	switch FxStringPrefix(strings.ToUpper(parts[0])) {
+	case FxStringPrefixDotNetIsolated, FxStringPrefixDotNet:
 		result.NetFrameworkVersion = parts[1]
 
-	case "GO":
+	case FxStringPrefixGo:
 		result.GoVersion = parts[1]
 
-	case "NODE":
+	case FxStringPrefixNode:
 		result.NodeVersion = parts[1]
 
-	case LinuxJavaServerJava:
+	case FxStringPrefixJava:
 		result.JavaServer = LinuxJavaServerJava
 		javaParts := strings.Split(parts[1], "-")
 		if strings.HasPrefix(parts[1], "8") {
@@ -46,7 +63,7 @@ func decodeApplicationStackLinux(fxString string) ApplicationStackLinux {
 		}
 		result.JavaServerVersion = javaParts[0]
 
-	case LinuxJavaServerTomcat:
+	case FxStringPrefixTomcat:
 		result.JavaServer = LinuxJavaServerTomcat
 		javaParts := strings.Split(parts[1], "-")
 		if len(javaParts) == 2 {
@@ -56,7 +73,7 @@ func decodeApplicationStackLinux(fxString string) ApplicationStackLinux {
 			result.JavaVersion = javaVersion
 		}
 
-	case LinuxJavaServerJboss:
+	case FxStringPrefixJBoss:
 		result.JavaServer = LinuxJavaServerJboss
 		javaParts := strings.Split(parts[1], "-")
 		if len(javaParts) == 2 {
@@ -66,24 +83,24 @@ func decodeApplicationStackLinux(fxString string) ApplicationStackLinux {
 			result.JavaVersion = javaVersion
 		}
 
-	case "PHP":
+	case FxStringPrefixPhp:
 		result.PhpVersion = parts[1]
 
-	case "PYTHON":
+	case FxStringPrefixPython:
 		result.PythonVersion = parts[1]
 
-	case "RUBY":
+	case FxStringPrefixRuby:
 		result.RubyVersion = parts[1]
 
 	case "COMPOSE":
-		// TODO
-	case "DOCKER":
+		// TODO ?
+	default:
 		// Deprecated / bugged - to be removed post 4.0
 		// new docker parsing is done later
-		if dockerParts := strings.Split(parts[1], ":"); len(dockerParts) == 2 {
-			result.DockerImage = dockerParts[0]
-			result.DockerImageTag = dockerParts[1]
-		}
+		//if dockerParts := strings.Split(parts[1], ":"); len(dockerParts) == 2 {
+		//	result.DockerImage = dockerParts[0]
+		//	result.DockerImageTag = dockerParts[1]
+		//}
 	}
 
 	return result
@@ -98,31 +115,31 @@ func EncodeFunctionAppLinuxFxVersion(input []ApplicationStackLinuxFunctionApp) *
 	var appType, appString string
 	switch {
 	case appStack.NodeVersion != "":
-		appType = "NODE"
+		appType = string(FxStringPrefixNode)
 		appString = appStack.NodeVersion
 
 	case appStack.DotNetVersion != "":
 		if appStack.DotNetIsolated {
-			appType = "DOTNET-ISOLATED"
+			appType = string(FxStringPrefixDotNetIsolated)
 		} else {
-			appType = "DOTNET"
+			appType = string(FxStringPrefixDotNet)
 		}
 		appString = appStack.DotNetVersion
 
 	case appStack.PythonVersion != "":
-		appType = "PYTHON"
+		appType = string(FxStringPrefixPython)
 		appString = appStack.PythonVersion
 
 	case appStack.JavaVersion != "":
-		appType = "JAVA"
+		appType = string(FxStringPrefixJava)
 		appString = appStack.JavaVersion
 
 	case appStack.PowerShellCoreVersion != "":
-		appType = "POWERSHELL"
+		appType = string(FxStringPrefixPowerShell)
 		appString = appStack.PowerShellCoreVersion
 
 	case len(appStack.Docker) > 0 && appStack.Docker[0].ImageName != "":
-		appType = "DOCKER"
+		appType = string(FxStringPrefixDocker)
 		dockerCfg := appStack.Docker[0]
 		if dockerCfg.RegistryURL != "" {
 			dockerUrl := dockerCfg.RegistryURL
@@ -152,28 +169,28 @@ func DecodeFunctionAppLinuxFxVersion(input string) ([]ApplicationStackLinuxFunct
 
 	result := make([]ApplicationStackLinuxFunctionApp, 0)
 
-	switch strings.ToLower(parts[0]) {
-	case "dotnet":
+	switch FxStringPrefix(strings.ToUpper(parts[0])) {
+	case FxStringPrefixDotNet:
 		appStack := ApplicationStackLinuxFunctionApp{DotNetVersion: parts[1]}
 		result = append(result, appStack)
 
-	case "dotnet-isolated":
+	case FxStringPrefixDotNetIsolated:
 		appStack := ApplicationStackLinuxFunctionApp{DotNetVersion: parts[1], DotNetIsolated: true}
 		result = append(result, appStack)
 
-	case "node":
+	case FxStringPrefixNode:
 		appStack := ApplicationStackLinuxFunctionApp{NodeVersion: parts[1]}
 		result = append(result, appStack)
 
-	case "python":
+	case FxStringPrefixPython:
 		appStack := ApplicationStackLinuxFunctionApp{PythonVersion: parts[1]}
 		result = append(result, appStack)
 
-	case "java":
+	case FxStringPrefixJava:
 		appStack := ApplicationStackLinuxFunctionApp{JavaVersion: parts[1]}
 		result = append(result, appStack)
 
-	case "powershell":
+	case FxStringPrefixPowerShell:
 		appStack := ApplicationStackLinuxFunctionApp{PowerShellCoreVersion: parts[1]}
 		result = append(result, appStack)
 
@@ -216,6 +233,7 @@ func DecodeFunctionAppDockerFxString(input string, partial ApplicationStackDocke
 
 	return []ApplicationStackDocker{partial}, nil
 }
+
 func JavaLinuxFxStringBuilder(javaMajorVersion, javaServer, javaServerVersion string) (*string, error) {
 	switch javaMajorVersion {
 	case "8":
@@ -274,4 +292,40 @@ func JavaLinuxFxStringBuilder(javaMajorVersion, javaServer, javaServerVersion st
 
 	}
 	return nil, fmt.Errorf("unsupported combination of `java_version`, `java_server`, and `java_server_version`")
+}
+
+func EncodeDockerFxString(image string, registryUrl string) string {
+	template := "DOCKER|%s/%s"
+
+	for _, prefix := range urlSchemes {
+		if strings.HasPrefix(registryUrl, prefix) {
+			registryUrl = strings.TrimPrefix(registryUrl, prefix)
+			continue
+		}
+	}
+
+	return fmt.Sprintf(template, registryUrl, image)
+}
+
+func EncodeDockerFxStringWindows(image string, registryUrl string) string {
+	template := "DOCKER|%s/%s"
+	dockerHubTemplate := "DOCKER|%s"
+
+	for _, prefix := range urlSchemes {
+		if strings.HasPrefix(registryUrl, prefix) {
+			registryUrl = strings.TrimPrefix(registryUrl, prefix)
+			continue
+		}
+	}
+
+	// Windows App Services fail to auth if the index portion of the image ref is `index.docker.io` so it must not be included.
+	if registryUrl == "index.docker.io" {
+		return fmt.Sprintf(dockerHubTemplate, image)
+	}
+
+	return fmt.Sprintf(template, registryUrl, image)
+}
+
+func FxStringHasPrefix(input string, prefix FxStringPrefix) bool {
+	return strings.HasPrefix(strings.ToUpper(input), string(prefix))
 }

--- a/internal/services/appservice/helpers/fx_strings.go
+++ b/internal/services/appservice/helpers/fx_strings.go
@@ -94,14 +94,7 @@ func decodeApplicationStackLinux(fxString string) ApplicationStackLinux {
 		result.RubyVersion = parts[1]
 
 	case "COMPOSE":
-		// TODO ?
-	default:
-		// Deprecated / bugged - to be removed post 4.0
-		// new docker parsing is done later
-		//if dockerParts := strings.Split(parts[1], ":"); len(dockerParts) == 2 {
-		//	result.DockerImage = dockerParts[0]
-		//	result.DockerImageTag = dockerParts[1]
-		//}
+		// TODO
 	}
 
 	return result

--- a/internal/services/appservice/helpers/fx_strings.go
+++ b/internal/services/appservice/helpers/fx_strings.go
@@ -92,9 +92,6 @@ func decodeApplicationStackLinux(fxString string) ApplicationStackLinux {
 
 	case FxStringPrefixRuby:
 		result.RubyVersion = parts[1]
-
-	case "COMPOSE":
-		// TODO
 	}
 
 	return result

--- a/internal/services/appservice/helpers/fx_strings.go
+++ b/internal/services/appservice/helpers/fx_strings.go
@@ -286,12 +286,7 @@ func JavaLinuxFxStringBuilder(javaMajorVersion, javaServer, javaServerVersion st
 func EncodeDockerFxString(image string, registryUrl string) string {
 	template := "DOCKER|%s/%s"
 
-	for _, prefix := range urlSchemes {
-		if strings.HasPrefix(registryUrl, prefix) {
-			registryUrl = strings.TrimPrefix(registryUrl, prefix)
-			continue
-		}
-	}
+	registryUrl = trimURLScheme(registryUrl)
 
 	return fmt.Sprintf(template, registryUrl, image)
 }

--- a/internal/services/appservice/helpers/linux_web_app_schema.go
+++ b/internal/services/appservice/helpers/linux_web_app_schema.go
@@ -579,7 +579,7 @@ func autoHealTriggerSchemaLinux() *pluginsdk.Schema {
 							},
 
 							"win32_status": {
-								Type:         pluginsdk.TypeString,
+								Type:         pluginsdk.TypeInt,
 								Optional:     true,
 								ValidateFunc: nil, // TODO - no docs on this, needs investigation
 							},
@@ -680,7 +680,7 @@ func autoHealTriggerSchemaLinuxComputed() *pluginsdk.Schema {
 							},
 
 							"win32_status": {
-								Type:     pluginsdk.TypeString,
+								Type:     pluginsdk.TypeInt,
 								Computed: true,
 							},
 

--- a/internal/services/appservice/helpers/linux_web_app_schema.go
+++ b/internal/services/appservice/helpers/linux_web_app_schema.go
@@ -762,27 +762,27 @@ func (s *SiteConfigLinux) ExpandForCreate(appSettings map[string]string) (*web.S
 	if len(s.ApplicationStack) == 1 {
 		linuxAppStack := s.ApplicationStack[0]
 		if linuxAppStack.NetFrameworkVersion != "" {
-			expanded.LinuxFxVersion = pointer.To(fmt.Sprintf("DOTNETCORE|%s", linuxAppStack.NetFrameworkVersion))
+			expanded.LinuxFxVersion = pointer.To(fmt.Sprintf("%s|%s", FxStringPrefixDotNetCore, linuxAppStack.NetFrameworkVersion))
 		}
 
 		if linuxAppStack.GoVersion != "" {
-			expanded.LinuxFxVersion = pointer.To(fmt.Sprintf("GO|%s", linuxAppStack.GoVersion))
+			expanded.LinuxFxVersion = pointer.To(fmt.Sprintf("%s|%s", FxStringPrefixGo, linuxAppStack.GoVersion))
 		}
 
 		if linuxAppStack.PhpVersion != "" {
-			expanded.LinuxFxVersion = pointer.To(fmt.Sprintf("PHP|%s", linuxAppStack.PhpVersion))
+			expanded.LinuxFxVersion = pointer.To(fmt.Sprintf("%s|%s", FxStringPrefixPhp, linuxAppStack.PhpVersion))
 		}
 
 		if linuxAppStack.NodeVersion != "" {
-			expanded.LinuxFxVersion = pointer.To(fmt.Sprintf("NODE|%s", linuxAppStack.NodeVersion))
+			expanded.LinuxFxVersion = pointer.To(fmt.Sprintf("%s|%s", FxStringPrefixNode, linuxAppStack.NodeVersion))
 		}
 
 		if linuxAppStack.RubyVersion != "" {
-			expanded.LinuxFxVersion = pointer.To(fmt.Sprintf("RUBY|%s", linuxAppStack.RubyVersion))
+			expanded.LinuxFxVersion = pointer.To(fmt.Sprintf("%s|%s", FxStringPrefixRuby, linuxAppStack.RubyVersion))
 		}
 
 		if linuxAppStack.PythonVersion != "" {
-			expanded.LinuxFxVersion = pointer.To(fmt.Sprintf("PYTHON|%s", linuxAppStack.PythonVersion))
+			expanded.LinuxFxVersion = pointer.To(fmt.Sprintf("%s|%s", FxStringPrefixPython, linuxAppStack.PythonVersion))
 		}
 
 		if linuxAppStack.JavaServer != "" {

--- a/internal/services/appservice/helpers/utils.go
+++ b/internal/services/appservice/helpers/utils.go
@@ -1,0 +1,20 @@
+package helpers
+
+import "strings"
+
+func trimURLScheme(input string) string {
+	schemes := []string{
+		"https://",
+		"HTTPS://",
+		"http://",
+		"HTTP://",
+	}
+
+	for _, v := range schemes {
+		if strings.HasPrefix(input, v) {
+			return strings.TrimPrefix(input, v)
+		}
+	}
+
+	return input
+}

--- a/internal/services/appservice/helpers/utils.go
+++ b/internal/services/appservice/helpers/utils.go
@@ -5,14 +5,11 @@ import "strings"
 func trimURLScheme(input string) string {
 	schemes := []string{
 		"https://",
-		"HTTPS://",
 		"http://",
-		"HTTP://",
 	}
-
 	for _, v := range schemes {
-		if strings.HasPrefix(input, v) {
-			return strings.TrimPrefix(input, v)
+		if strings.HasPrefix(strings.ToLower(input), v) {
+			return input[len(v):]
 		}
 	}
 

--- a/internal/services/appservice/helpers/web_app_slot_schema.go
+++ b/internal/services/appservice/helpers/web_app_slot_schema.go
@@ -1024,7 +1024,7 @@ func (s *SiteConfigWindowsWebAppSlot) ExpandForCreate(appSettings map[string]str
 		}
 
 		if winAppStack.DockerImageName != "" {
-			expanded.WindowsFxVersion = pointer.To(EncodeDockerFxString(winAppStack.DockerImageName, winAppStack.DockerRegistryUrl))
+			expanded.WindowsFxVersion = pointer.To(EncodeDockerFxStringWindows(winAppStack.DockerImageName, winAppStack.DockerRegistryUrl))
 			appSettings["DOCKER_REGISTRY_SERVER_URL"] = winAppStack.DockerRegistryUrl
 			appSettings["DOCKER_REGISTRY_SERVER_USERNAME"] = winAppStack.DockerRegistryUsername
 			appSettings["DOCKER_REGISTRY_SERVER_PASSWORD"] = winAppStack.DockerRegistryPassword
@@ -1161,7 +1161,7 @@ func (s *SiteConfigWindowsWebAppSlot) ExpandForUpdate(metadata sdk.ResourceMetaD
 			}
 
 			if winAppStack.DockerImageName != "" {
-				expanded.WindowsFxVersion = pointer.To(EncodeDockerFxString(winAppStack.DockerImageName, winAppStack.DockerRegistryUrl))
+				expanded.WindowsFxVersion = pointer.To(EncodeDockerFxStringWindows(winAppStack.DockerImageName, winAppStack.DockerRegistryUrl))
 				appSettings["DOCKER_REGISTRY_SERVER_URL"] = winAppStack.DockerRegistryUrl
 				appSettings["DOCKER_REGISTRY_SERVER_USERNAME"] = winAppStack.DockerRegistryUsername
 				appSettings["DOCKER_REGISTRY_SERVER_PASSWORD"] = winAppStack.DockerRegistryPassword
@@ -1249,6 +1249,7 @@ func (s *SiteConfigWindowsWebAppSlot) ExpandForUpdate(metadata sdk.ResourceMetaD
 		}
 		expanded.Cors = cors
 	}
+
 	if metadata.ResourceData.HasChange("site_config.0.auto_heal_setting") {
 		expanded.AutoHealRules = expandAutoHealSettingsWindows(s.AutoHealSettings)
 	}
@@ -1331,20 +1332,6 @@ func (s *SiteConfigWindowsWebAppSlot) Flatten(appSiteSlotConfig *web.SiteConfig,
 	}
 
 	s.WindowsFxVersion = pointer.From(appSiteSlotConfig.WindowsFxVersion)
-	if s.WindowsFxVersion != "" {
-		// Decode the string to docker values
-		parts := strings.Split(strings.TrimPrefix(s.WindowsFxVersion, "DOCKER|"), ":")
-		if len(parts) == 2 {
-			winAppStack.DockerContainerTag = parts[1]
-			path := strings.Split(parts[0], "/")
-			if len(path) > 1 {
-				winAppStack.DockerContainerRegistry = path[0]
-				winAppStack.DockerContainerName = strings.TrimPrefix(parts[0], fmt.Sprintf("%s/", path[0]))
-			} else {
-				winAppStack.DockerContainerName = path[0]
-			}
-		}
-	}
 	winAppStack.CurrentStack = currentStack
 
 	s.ApplicationStack = []ApplicationStackWindows{winAppStack}

--- a/internal/services/appservice/helpers/web_app_slot_schema.go
+++ b/internal/services/appservice/helpers/web_app_slot_schema.go
@@ -2,12 +2,12 @@ package helpers
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"strconv"
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/services/web/mgmt/2021-03-01/web" // nolint: staticcheck
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	apimValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/apimanagement/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"

--- a/internal/services/appservice/helpers/web_app_slot_schema.go
+++ b/internal/services/appservice/helpers/web_app_slot_schema.go
@@ -1359,13 +1359,13 @@ func (s *SiteConfigWindowsWebAppSlot) SetHealthCheckEvictionTime(input map[strin
 }
 
 func (s *SiteConfigWindowsWebAppSlot) ParseNodeVersion(input map[string]string) map[string]string {
-	if nodeVer, ok := input["WEBSITE_NODE_DEFAULT_VERSION"]; ok {
+	if nodeVer, ok := input["WEBSITE_NODE_DEFAULT_VERSION"]; ok && nodeVer != "6.9.1" {
 		if s.ApplicationStack == nil {
 			s.ApplicationStack = make([]ApplicationStackWindows, 0)
 		}
 		s.ApplicationStack[0].NodeVersion = nodeVer
-		delete(input, "WEBSITE_NODE_DEFAULT_VERSION")
 	}
+	delete(input, "WEBSITE_NODE_DEFAULT_VERSION")
 
 	return input
 }

--- a/internal/services/appservice/helpers/web_app_slot_schema.go
+++ b/internal/services/appservice/helpers/web_app_slot_schema.go
@@ -2,6 +2,7 @@ package helpers
 
 import (
 	"fmt"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"strconv"
 	"strings"
 
@@ -539,42 +540,173 @@ func SiteConfigSchemaWindowsWebAppSlot() *pluginsdk.Schema {
 	}
 }
 
-func ExpandSiteConfigLinuxWebAppSlot(siteConfig []SiteConfigLinuxWebAppSlot, existing *web.SiteConfig, metadata sdk.ResourceMetaData) (*web.SiteConfig, error) {
-	if len(siteConfig) == 0 {
-		return nil, nil
-	}
+func (s *SiteConfigLinuxWebAppSlot) ExpandForCreate(appSettings map[string]string) *web.SiteConfig {
 	expanded := &web.SiteConfig{}
-	if existing != nil {
-		expanded = existing
+	expanded.AlwaysOn = pointer.To(s.AlwaysOn)
+	expanded.AcrUseManagedIdentityCreds = pointer.To(s.UseManagedIdentityACR)
+	expanded.HTTP20Enabled = pointer.To(s.Http2Enabled)
+	expanded.ScmIPSecurityRestrictionsUseMain = pointer.To(s.ScmUseMainIpRestriction)
+	expanded.LocalMySQLEnabled = pointer.To(s.LocalMysql)
+	expanded.LoadBalancing = web.SiteLoadBalancing(s.LoadBalancing)
+	expanded.ManagedPipelineMode = web.ManagedPipelineMode(s.ManagedPipelineMode)
+	expanded.RemoteDebuggingEnabled = pointer.To(s.RemoteDebugging)
+	expanded.Use32BitWorkerProcess = pointer.To(s.Use32BitWorker)
+	expanded.WebSocketsEnabled = pointer.To(s.WebSockets)
+	expanded.FtpsState = web.FtpsState(s.FtpsState)
+	expanded.MinTLSVersion = web.SupportedTLSVersions(s.MinTlsVersion)
+	expanded.ScmMinTLSVersion = web.SupportedTLSVersions(s.ScmMinTlsVersion)
+	expanded.AutoHealEnabled = pointer.To(s.AutoHeal)
+	expanded.VnetRouteAllEnabled = pointer.To(s.VnetRouteAllEnabled)
+
+	if s.ApiManagementConfigId != "" {
+		expanded.APIManagementConfig = &web.APIManagementConfig{
+			ID: pointer.To(s.ApiManagementConfigId),
+		}
 	}
 
-	linuxSlotSiteConfig := siteConfig[0]
-
-	if metadata.ResourceData.HasChange("site_config.0.always_on") {
-		expanded.AlwaysOn = pointer.To(linuxSlotSiteConfig.AlwaysOn)
+	if s.ApiDefinition != "" {
+		expanded.APIDefinition = &web.APIDefinitionInfo{
+			URL: pointer.To(s.ApiDefinition),
+		}
 	}
+
+	if s.AppCommandLine != "" {
+		expanded.AppCommandLine = pointer.To(s.AppCommandLine)
+	}
+
+	if len(s.ApplicationStack) == 1 {
+		linuxAppStack := s.ApplicationStack[0]
+		if linuxAppStack.NetFrameworkVersion != "" {
+			expanded.LinuxFxVersion = pointer.To(fmt.Sprintf("DOTNETCORE|%s", linuxAppStack.NetFrameworkVersion))
+		}
+
+		if linuxAppStack.GoVersion != "" {
+			expanded.LinuxFxVersion = pointer.To(fmt.Sprintf("GO|%s", linuxAppStack.GoVersion))
+		}
+
+		if linuxAppStack.PhpVersion != "" {
+			expanded.LinuxFxVersion = pointer.To(fmt.Sprintf("PHP|%s", linuxAppStack.PhpVersion))
+		}
+
+		if linuxAppStack.NodeVersion != "" {
+			expanded.LinuxFxVersion = pointer.To(fmt.Sprintf("NODE|%s", linuxAppStack.NodeVersion))
+		}
+
+		if linuxAppStack.RubyVersion != "" {
+			expanded.LinuxFxVersion = pointer.To(fmt.Sprintf("RUBY|%s", linuxAppStack.RubyVersion))
+		}
+
+		if linuxAppStack.PythonVersion != "" {
+			expanded.LinuxFxVersion = pointer.To(fmt.Sprintf("PYTHON|%s", linuxAppStack.PythonVersion))
+		}
+
+		if linuxAppStack.JavaServer != "" {
+			javaString, err := JavaLinuxFxStringBuilder(linuxAppStack.JavaVersion, linuxAppStack.JavaServer, linuxAppStack.JavaServerVersion)
+			if err != nil {
+				// TODO return nil, fmt.Errorf("could not build linuxFxVersion string: %+v", err)
+			}
+			expanded.LinuxFxVersion = javaString
+		}
+
+		if !features.FourPointOhBeta() {
+			if linuxAppStack.DockerImage != "" {
+				expanded.LinuxFxVersion = pointer.To(fmt.Sprintf("DOCKER|%s:%s", linuxAppStack.DockerImage, linuxAppStack.DockerImageTag))
+			}
+		}
+
+		if linuxAppStack.DockerImageName != "" {
+			expanded.LinuxFxVersion = pointer.To(EncodeDockerFxString(linuxAppStack.DockerImageName, linuxAppStack.DockerRegistryUrl))
+			appSettings["DOCKER_REGISTRY_SERVER_URL"] = linuxAppStack.DockerRegistryUrl
+			appSettings["DOCKER_REGISTRY_SERVER_USERNAME"] = linuxAppStack.DockerRegistryUsername
+			appSettings["DOCKER_REGISTRY_SERVER_PASSWORD"] = linuxAppStack.DockerRegistryPassword
+		}
+	}
+
+	expanded.AppSettings = ExpandAppSettingsForCreate(appSettings)
+
+	if s.ContainerRegistryMSI != "" {
+		expanded.AcrUserManagedIdentityID = pointer.To(s.ContainerRegistryMSI)
+	}
+
+	if len(s.DefaultDocuments) != 0 {
+		expanded.DefaultDocuments = pointer.To(s.DefaultDocuments)
+	}
+
+	if len(s.IpRestriction) != 0 {
+		ipRestrictions, err := ExpandIpRestrictions(s.IpRestriction)
+		if err != nil {
+			// TODO - Needs errors?
+		}
+
+		expanded.IPSecurityRestrictions = ipRestrictions
+	}
+
+	if len(s.ScmIpRestriction) != 0 {
+		ipRestrictions, err := ExpandIpRestrictions(s.ScmIpRestriction)
+		if err != nil {
+			// TODO - Needs errors?
+		}
+
+		expanded.ScmIPSecurityRestrictions = ipRestrictions
+	}
+
+	if s.RemoteDebuggingVersion != "" {
+		expanded.RemoteDebuggingVersion = pointer.To(s.RemoteDebuggingVersion)
+	}
+
+	if s.HealthCheckPath != "" {
+		expanded.HealthCheckPath = pointer.To(s.HealthCheckPath)
+	}
+
+	if len(s.Cors) != 0 {
+		expanded.Cors = ExpandCorsSettings(s.Cors)
+	}
+
+	if len(s.AutoHealSettings) == 1 {
+		expanded.AutoHealRules = expandAutoHealSettingsLinux(s.AutoHealSettings)
+	}
+
+	return expanded
+}
+
+func (s *SiteConfigLinuxWebAppSlot) ExpandForUpdate(metadata sdk.ResourceMetaData, existing *web.SiteConfig, appSettings map[string]string) *web.SiteConfig {
+	expanded := *existing
+
+	expanded.AcrUseManagedIdentityCreds = pointer.To(s.UseManagedIdentityACR)
+	expanded.AutoHealEnabled = pointer.To(s.AutoHeal)
+	expanded.HTTP20Enabled = pointer.To(s.Http2Enabled)
+	expanded.LocalMySQLEnabled = pointer.To(s.LocalMysql)
+	expanded.RemoteDebuggingEnabled = pointer.To(s.RemoteDebugging)
+	expanded.ScmIPSecurityRestrictionsUseMain = pointer.To(s.ScmUseMainIpRestriction)
+	expanded.Use32BitWorkerProcess = pointer.To(s.Use32BitWorker)
+	expanded.WebSocketsEnabled = pointer.To(s.WebSockets)
+	expanded.VnetRouteAllEnabled = pointer.To(s.VnetRouteAllEnabled)
 
 	if metadata.ResourceData.HasChange("site_config.0.api_management_api_id") {
 		expanded.APIManagementConfig = &web.APIManagementConfig{
-			ID: pointer.To(linuxSlotSiteConfig.ApiManagementConfigId),
+			ID: pointer.To(s.ApiManagementConfigId),
 		}
 	}
 
 	if metadata.ResourceData.HasChange("site_config.0.api_definition_url") {
 		expanded.APIDefinition = &web.APIDefinitionInfo{
-			URL: pointer.To(linuxSlotSiteConfig.ApiDefinition),
+			URL: pointer.To(s.ApiDefinition),
 		}
 	}
 
 	if metadata.ResourceData.HasChange("site_config.0.app_command_line") {
-		expanded.AppCommandLine = pointer.To(linuxSlotSiteConfig.AppCommandLine)
+		expanded.AppCommandLine = pointer.To(s.AppCommandLine)
 	}
 
 	if metadata.ResourceData.HasChange("site_config.0.application_stack") {
-		if len(linuxSlotSiteConfig.ApplicationStack) == 1 {
-			linuxAppStack := linuxSlotSiteConfig.ApplicationStack[0]
+		if len(s.ApplicationStack) == 1 {
+			linuxAppStack := s.ApplicationStack[0]
 			if linuxAppStack.NetFrameworkVersion != "" {
 				expanded.LinuxFxVersion = pointer.To(fmt.Sprintf("DOTNETCORE|%s", linuxAppStack.NetFrameworkVersion))
+			}
+
+			if linuxAppStack.GoVersion != "" {
+				expanded.LinuxFxVersion = pointer.To(fmt.Sprintf("GO|%s", linuxAppStack.GoVersion))
 			}
 
 			if linuxAppStack.PhpVersion != "" {
@@ -585,114 +717,96 @@ func ExpandSiteConfigLinuxWebAppSlot(siteConfig []SiteConfigLinuxWebAppSlot, exi
 				expanded.LinuxFxVersion = pointer.To(fmt.Sprintf("NODE|%s", linuxAppStack.NodeVersion))
 			}
 
-			if linuxAppStack.PythonVersion != "" {
-				expanded.LinuxFxVersion = pointer.To(fmt.Sprintf("PYTHON|%s", linuxAppStack.PythonVersion))
-			}
-
 			if linuxAppStack.RubyVersion != "" {
 				expanded.LinuxFxVersion = pointer.To(fmt.Sprintf("RUBY|%s", linuxAppStack.RubyVersion))
+			}
+
+			if linuxAppStack.PythonVersion != "" {
+				expanded.LinuxFxVersion = pointer.To(fmt.Sprintf("PYTHON|%s", linuxAppStack.PythonVersion))
 			}
 
 			if linuxAppStack.JavaServer != "" {
 				javaString, err := JavaLinuxFxStringBuilder(linuxAppStack.JavaVersion, linuxAppStack.JavaServer, linuxAppStack.JavaServerVersion)
 				if err != nil {
-					return nil, fmt.Errorf("could not build linuxFxVersion string: %+v", err)
+					// TODO
+					//return nil, fmt.Errorf("could not build linuxFxVersion string: %+v", err)
 				}
 				expanded.LinuxFxVersion = javaString
 			}
 
-			if linuxAppStack.DockerImage != "" {
-				expanded.LinuxFxVersion = pointer.To(fmt.Sprintf("DOCKER|%s:%s", linuxAppStack.DockerImage, linuxAppStack.DockerImageTag))
+			if !features.FourPointOhBeta() {
+				if linuxAppStack.DockerImage != "" {
+					expanded.LinuxFxVersion = pointer.To(fmt.Sprintf("DOCKER|%s:%s", linuxAppStack.DockerImage, linuxAppStack.DockerImageTag))
+				}
+			}
+
+			if linuxAppStack.DockerImageName != "" {
+				expanded.LinuxFxVersion = pointer.To(EncodeDockerFxString(linuxAppStack.DockerImageName, linuxAppStack.DockerRegistryUrl))
+				appSettings["DOCKER_REGISTRY_SERVER_URL"] = linuxAppStack.DockerRegistryUrl
+				appSettings["DOCKER_REGISTRY_SERVER_USERNAME"] = linuxAppStack.DockerRegistryUsername
+				appSettings["DOCKER_REGISTRY_SERVER_PASSWORD"] = linuxAppStack.DockerRegistryPassword
 			}
 		} else {
 			expanded.LinuxFxVersion = pointer.To("")
 		}
 	}
 
-	expanded.AcrUseManagedIdentityCreds = pointer.To(linuxSlotSiteConfig.UseManagedIdentityACR)
-
 	if metadata.ResourceData.HasChange("site_config.0.container_registry_managed_identity_client_id") {
-		expanded.AcrUserManagedIdentityID = pointer.To(linuxSlotSiteConfig.ContainerRegistryMSI)
+		expanded.AcrUserManagedIdentityID = pointer.To(s.ContainerRegistryMSI)
 	}
 
 	if metadata.ResourceData.HasChange("site_config.0.default_documents") {
-		expanded.DefaultDocuments = &linuxSlotSiteConfig.DefaultDocuments
-	}
-
-	if metadata.ResourceData.HasChange("site_config.0.http2_enabled") {
-		expanded.HTTP20Enabled = pointer.To(linuxSlotSiteConfig.Http2Enabled)
+		expanded.DefaultDocuments = &s.DefaultDocuments
 	}
 
 	if metadata.ResourceData.HasChange("site_config.0.ip_restriction") {
-		ipRestrictions, err := ExpandIpRestrictions(linuxSlotSiteConfig.IpRestriction)
+		ipRestrictions, err := ExpandIpRestrictions(s.IpRestriction)
 		if err != nil {
-			return nil, err
+			// TODO
+			//return nil, err
 		}
 		expanded.IPSecurityRestrictions = ipRestrictions
 	}
 
-	expanded.ScmIPSecurityRestrictionsUseMain = pointer.To(linuxSlotSiteConfig.ScmUseMainIpRestriction)
-
 	if metadata.ResourceData.HasChange("site_config.0.scm_ip_restriction") {
-		scmIpRestrictions, err := ExpandIpRestrictions(linuxSlotSiteConfig.ScmIpRestriction)
+		scmIpRestrictions, err := ExpandIpRestrictions(s.ScmIpRestriction)
 		if err != nil {
-			return nil, err
+			// TODO
+			//return nil, err
 		}
 		expanded.ScmIPSecurityRestrictions = scmIpRestrictions
 	}
 
-	if metadata.ResourceData.HasChange("site_config.0.local_mysql_enabled") {
-		expanded.LocalMySQLEnabled = pointer.To(linuxSlotSiteConfig.LocalMysql)
-	}
-
 	if metadata.ResourceData.HasChange("site_config.0.load_balancing_mode") {
-		expanded.LoadBalancing = web.SiteLoadBalancing(linuxSlotSiteConfig.LoadBalancing)
+		expanded.LoadBalancing = web.SiteLoadBalancing(s.LoadBalancing)
 	}
 
 	if metadata.ResourceData.HasChange("site_config.0.managed_pipeline_mode") {
-		expanded.ManagedPipelineMode = web.ManagedPipelineMode(linuxSlotSiteConfig.ManagedPipelineMode)
-	}
-
-	if metadata.ResourceData.HasChange("site_config.0.remote_debugging_enabled") {
-		expanded.RemoteDebuggingEnabled = pointer.To(linuxSlotSiteConfig.RemoteDebugging)
+		expanded.ManagedPipelineMode = web.ManagedPipelineMode(s.ManagedPipelineMode)
 	}
 
 	if metadata.ResourceData.HasChange("site_config.0.remote_debugging_version") {
-		expanded.RemoteDebuggingVersion = pointer.To(linuxSlotSiteConfig.RemoteDebuggingVersion)
-	}
-
-	expanded.Use32BitWorkerProcess = pointer.To(linuxSlotSiteConfig.Use32BitWorker)
-
-	if metadata.ResourceData.HasChange("site_config.0.websockets_enabled") {
-		expanded.WebSocketsEnabled = pointer.To(linuxSlotSiteConfig.WebSockets)
+		expanded.RemoteDebuggingVersion = pointer.To(s.RemoteDebuggingVersion)
 	}
 
 	if metadata.ResourceData.HasChange("site_config.0.ftps_state") {
-		expanded.FtpsState = web.FtpsState(linuxSlotSiteConfig.FtpsState)
+		expanded.FtpsState = web.FtpsState(s.FtpsState)
 	}
 
 	if metadata.ResourceData.HasChange("site_config.0.health_check_path") {
-		expanded.HealthCheckPath = pointer.To(linuxSlotSiteConfig.HealthCheckPath)
-	}
-
-	if metadata.ResourceData.HasChange("site_config.0.worker_count") {
-		expanded.NumberOfWorkers = pointer.To(int32(linuxSlotSiteConfig.WorkerCount))
+		expanded.HealthCheckPath = pointer.To(s.HealthCheckPath)
 	}
 
 	if metadata.ResourceData.HasChange("site_config.0.minimum_tls_version") {
-		expanded.MinTLSVersion = web.SupportedTLSVersions(linuxSlotSiteConfig.MinTlsVersion)
+		expanded.MinTLSVersion = web.SupportedTLSVersions(s.MinTlsVersion)
 	}
 
 	if metadata.ResourceData.HasChange("site_config.0.scm_minimum_tls_version") {
-		expanded.ScmMinTLSVersion = web.SupportedTLSVersions(linuxSlotSiteConfig.ScmMinTlsVersion)
-	}
-
-	if metadata.ResourceData.HasChange("site_config.0.auto_swap_slot_name") {
-		expanded.AutoSwapSlotName = pointer.To(linuxSlotSiteConfig.AutoSwapSlotName)
+		expanded.ScmMinTLSVersion = web.SupportedTLSVersions(s.ScmMinTlsVersion)
 	}
 
 	if metadata.ResourceData.HasChange("site_config.0.cors") {
-		cors := ExpandCorsSettings(linuxSlotSiteConfig.Cors)
+		cors := ExpandCorsSettings(s.Cors)
 		if cors == nil {
 			cors = &web.CorsSettings{
 				AllowedOrigins: &[]string{},
@@ -701,19 +815,11 @@ func ExpandSiteConfigLinuxWebAppSlot(siteConfig []SiteConfigLinuxWebAppSlot, exi
 		expanded.Cors = cors
 	}
 
-	if metadata.ResourceData.HasChange("site_config.0.auto_heal_enabled") {
-		expanded.AutoHealEnabled = pointer.To(linuxSlotSiteConfig.AutoHeal)
-	}
-
 	if metadata.ResourceData.HasChange("site_config.0.auto_heal_setting") {
-		expanded.AutoHealRules = expandAutoHealSettingsLinux(linuxSlotSiteConfig.AutoHealSettings)
+		expanded.AutoHealRules = expandAutoHealSettingsLinux(s.AutoHealSettings)
 	}
 
-	if metadata.ResourceData.HasChange("site_config.0.vnet_route_all_enabled") {
-		expanded.VnetRouteAllEnabled = pointer.To(linuxSlotSiteConfig.VnetRouteAllEnabled)
-	}
-
-	return expanded, nil
+	return &expanded
 }
 
 func (s *SiteConfigLinuxWebAppSlot) Flatten(appSiteSlotConfig *web.SiteConfig) {
@@ -776,6 +882,9 @@ func (s *SiteConfigLinuxWebAppSlot) SetHealthCheckEvictionTime(input map[string]
 
 func (s *SiteConfigLinuxWebAppSlot) DecodeDockerAppStack(input map[string]string) {
 	applicationStack := ApplicationStackLinux{}
+	if len(s.ApplicationStack) == 1 {
+		applicationStack = s.ApplicationStack[0]
+	}
 
 	if v, ok := input["DOCKER_REGISTRY_SERVER_URL"]; ok {
 		applicationStack.DockerRegistryUrl = v
@@ -791,130 +900,224 @@ func (s *SiteConfigLinuxWebAppSlot) DecodeDockerAppStack(input map[string]string
 
 	registryHost := trimURLScheme(applicationStack.DockerRegistryUrl)
 	dockerString := strings.TrimPrefix(s.LinuxFxVersion, "DOCKER|")
-	applicationStack.DockerImage = strings.TrimPrefix(dockerString, registryHost)
+	applicationStack.DockerImageName = strings.TrimPrefix(dockerString, registryHost)
 
 	s.ApplicationStack = []ApplicationStackLinux{applicationStack}
 }
 
-func FlattenSiteConfigLinuxWebAppSlot(appSiteSlotConfig *web.SiteConfig, healthCheckCount *int) []SiteConfigLinuxWebAppSlot {
-	if appSiteSlotConfig == nil {
-		return nil
+func (s *SiteConfigLinuxWebAppSlot) DecodeDockerDeprecatedAppStack(input map[string]string, usesDeprecated bool) {
+	applicationStack := ApplicationStackLinux{}
+	if len(s.ApplicationStack) == 1 {
+		applicationStack = s.ApplicationStack[0]
+	}
+	if !usesDeprecated {
+
+		if v, ok := input["DOCKER_REGISTRY_SERVER_URL"]; ok {
+			applicationStack.DockerRegistryUrl = v
+		}
+
+		if v, ok := input["DOCKER_REGISTRY_SERVER_USERNAME"]; ok {
+			applicationStack.DockerRegistryUsername = v
+		}
+
+		if v, ok := input["DOCKER_REGISTRY_SERVER_PASSWORD"]; ok {
+			applicationStack.DockerRegistryPassword = v
+		}
+
+		registryHost := trimURLScheme(applicationStack.DockerRegistryUrl)
+		dockerString := strings.TrimPrefix(s.LinuxFxVersion, "DOCKER|")
+		applicationStack.DockerImageName = strings.TrimPrefix(dockerString, registryHost+"/")
+	} else {
+		parts := strings.Split(s.LinuxFxVersion, "|")
+		if dockerParts := strings.Split(parts[1], ":"); len(dockerParts) == 2 {
+			applicationStack.DockerImage = dockerParts[0]
+			applicationStack.DockerImageTag = dockerParts[1]
+		}
 	}
 
-	siteConfig := SiteConfigLinuxWebAppSlot{
-		AlwaysOn:                pointer.From(appSiteSlotConfig.AlwaysOn),
-		AppCommandLine:          pointer.From(appSiteSlotConfig.AppCommandLine),
-		AutoHeal:                pointer.From(appSiteSlotConfig.AutoHealEnabled),
-		AutoHealSettings:        flattenAutoHealSettingsLinux(appSiteSlotConfig.AutoHealRules),
-		AutoSwapSlotName:        pointer.From(appSiteSlotConfig.AutoSwapSlotName),
-		ContainerRegistryMSI:    pointer.From(appSiteSlotConfig.AcrUserManagedIdentityID),
-		Cors:                    FlattenCorsSettings(appSiteSlotConfig.Cors),
-		DetailedErrorLogging:    pointer.From(appSiteSlotConfig.DetailedErrorLoggingEnabled),
-		Http2Enabled:            pointer.From(appSiteSlotConfig.HTTP20Enabled),
-		IpRestriction:           FlattenIpRestrictions(appSiteSlotConfig.IPSecurityRestrictions),
-		ManagedPipelineMode:     string(appSiteSlotConfig.ManagedPipelineMode),
-		ScmType:                 string(appSiteSlotConfig.ScmType),
-		FtpsState:               string(appSiteSlotConfig.FtpsState),
-		HealthCheckPath:         pointer.From(appSiteSlotConfig.HealthCheckPath),
-		HealthCheckEvictionTime: pointer.From(healthCheckCount),
-		LoadBalancing:           string(appSiteSlotConfig.LoadBalancing),
-		LocalMysql:              pointer.From(appSiteSlotConfig.LocalMySQLEnabled),
-		MinTlsVersion:           string(appSiteSlotConfig.MinTLSVersion),
-		WorkerCount:             int(pointer.From(appSiteSlotConfig.NumberOfWorkers)),
-		RemoteDebugging:         pointer.From(appSiteSlotConfig.RemoteDebuggingEnabled),
-		RemoteDebuggingVersion:  strings.ToUpper(pointer.From(appSiteSlotConfig.RemoteDebuggingVersion)),
-		ScmIpRestriction:        FlattenIpRestrictions(appSiteSlotConfig.ScmIPSecurityRestrictions),
-		ScmMinTlsVersion:        string(appSiteSlotConfig.ScmMinTLSVersion),
-		ScmUseMainIpRestriction: pointer.From(appSiteSlotConfig.ScmIPSecurityRestrictionsUseMain),
-		Use32BitWorker:          pointer.From(appSiteSlotConfig.Use32BitWorkerProcess),
-		UseManagedIdentityACR:   pointer.From(appSiteSlotConfig.AcrUseManagedIdentityCreds),
-		WebSockets:              pointer.From(appSiteSlotConfig.WebSocketsEnabled),
-		VnetRouteAllEnabled:     pointer.From(appSiteSlotConfig.VnetRouteAllEnabled),
-	}
-
-	if appSiteSlotConfig.APIManagementConfig != nil && appSiteSlotConfig.APIManagementConfig.ID != nil {
-		siteConfig.ApiManagementConfigId = *appSiteSlotConfig.APIManagementConfig.ID
-	}
-
-	if appSiteSlotConfig.APIDefinition != nil && appSiteSlotConfig.APIDefinition.URL != nil {
-		siteConfig.ApiDefinition = *appSiteSlotConfig.APIDefinition.URL
-	}
-
-	if appSiteSlotConfig.DefaultDocuments != nil {
-		siteConfig.DefaultDocuments = *appSiteSlotConfig.DefaultDocuments
-	}
-
-	if appSiteSlotConfig.LinuxFxVersion != nil {
-		var linuxAppStack ApplicationStackLinux
-		siteConfig.LinuxFxVersion = *appSiteSlotConfig.LinuxFxVersion
-		// Decode the string to docker values
-		linuxAppStack = decodeApplicationStackLinux(siteConfig.LinuxFxVersion)
-		siteConfig.ApplicationStack = []ApplicationStackLinux{linuxAppStack}
-	}
-
-	return []SiteConfigLinuxWebAppSlot{siteConfig}
+	s.ApplicationStack = []ApplicationStackLinux{applicationStack}
 }
 
-func ExpandSiteConfigWindowsWebAppSlot(siteConfig []SiteConfigWindowsWebAppSlot, existing *web.SiteConfig, metadata sdk.ResourceMetaData) (*web.SiteConfig, *string, error) {
-	if len(siteConfig) == 0 {
-		return nil, nil, nil
-	}
-
+func (s *SiteConfigWindowsWebAppSlot) ExpandForCreate(appSettings map[string]string) *web.SiteConfig {
 	expanded := &web.SiteConfig{}
+
+	expanded.AlwaysOn = pointer.To(s.AlwaysOn)
+	expanded.AcrUseManagedIdentityCreds = pointer.To(s.UseManagedIdentityACR)
+	expanded.AutoHealEnabled = pointer.To(s.AutoHeal)
+	expanded.FtpsState = web.FtpsState(s.FtpsState)
+	expanded.HTTP20Enabled = pointer.To(s.Http2Enabled)
+	expanded.LoadBalancing = web.SiteLoadBalancing(s.LoadBalancing)
+	expanded.LocalMySQLEnabled = pointer.To(s.LocalMysql)
+	expanded.ManagedPipelineMode = web.ManagedPipelineMode(s.ManagedPipelineMode)
+	expanded.MinTLSVersion = web.SupportedTLSVersions(s.MinTlsVersion)
+	expanded.RemoteDebuggingEnabled = pointer.To(s.RemoteDebugging)
+	expanded.ScmIPSecurityRestrictionsUseMain = pointer.To(s.ScmUseMainIpRestriction)
+	expanded.ScmMinTLSVersion = web.SupportedTLSVersions(s.ScmMinTlsVersion)
+	expanded.Use32BitWorkerProcess = pointer.To(s.Use32BitWorker)
+	expanded.WebSocketsEnabled = pointer.To(s.WebSockets)
+	expanded.VirtualApplications = expandVirtualApplications(s.VirtualApplications)
+	expanded.VnetRouteAllEnabled = pointer.To(s.VnetRouteAllEnabled)
+
+	if s.ApiManagementConfigId != "" {
+		expanded.APIManagementConfig = &web.APIManagementConfig{
+			ID: pointer.To(s.ApiManagementConfigId),
+		}
+	}
+
+	if s.ApiDefinition != "" {
+		expanded.APIDefinition = &web.APIDefinitionInfo{
+			URL: pointer.To(s.ApiDefinition),
+		}
+	}
+
+	if s.AppCommandLine != "" {
+		expanded.AppCommandLine = pointer.To(s.AppCommandLine)
+	}
+
+	expanded.AppSettings = ExpandAppSettingsForCreate(appSettings)
+
+	if len(s.ApplicationStack) == 1 {
+		winAppStack := s.ApplicationStack[0]
+		if winAppStack.NetFrameworkVersion != "" {
+			expanded.NetFrameworkVersion = pointer.To(winAppStack.NetFrameworkVersion)
+		}
+		if winAppStack.NetCoreVersion != "" {
+			expanded.NetFrameworkVersion = pointer.To(winAppStack.NetCoreVersion)
+		}
+		if winAppStack.PhpVersion != "" {
+			if winAppStack.PhpVersion != PhpVersionOff {
+				expanded.PhpVersion = pointer.To(winAppStack.PhpVersion)
+			} else {
+				expanded.PhpVersion = pointer.To("")
+			}
+		}
+		if winAppStack.PythonVersion != "" || winAppStack.Python {
+			expanded.PythonVersion = pointer.To(winAppStack.PythonVersion)
+		}
+		if winAppStack.JavaVersion != "" {
+			expanded.JavaVersion = pointer.To(winAppStack.JavaVersion)
+			switch {
+			case winAppStack.JavaEmbeddedServer:
+				expanded.JavaContainer = pointer.To(JavaContainerEmbeddedServer)
+				expanded.JavaContainerVersion = pointer.To(JavaContainerEmbeddedServerVersion)
+			case winAppStack.TomcatVersion != "":
+				expanded.JavaContainer = pointer.To(JavaContainerTomcat)
+				expanded.JavaContainerVersion = pointer.To(winAppStack.TomcatVersion)
+			case winAppStack.JavaContainer != "":
+				expanded.JavaContainer = pointer.To(winAppStack.JavaContainer)
+				expanded.JavaContainerVersion = pointer.To(winAppStack.JavaContainerVersion)
+			}
+		}
+		if !features.FourPointOhBeta() {
+			if winAppStack.DockerContainerName != "" || winAppStack.DockerContainerRegistry != "" || winAppStack.DockerContainerTag != "" {
+				if winAppStack.DockerContainerRegistry != "" {
+					expanded.WindowsFxVersion = pointer.To(fmt.Sprintf("DOCKER|%s/%s:%s", winAppStack.DockerContainerRegistry, winAppStack.DockerContainerName, winAppStack.DockerContainerTag))
+				} else {
+					expanded.WindowsFxVersion = pointer.To(fmt.Sprintf("DOCKER|%s:%s", winAppStack.DockerContainerName, winAppStack.DockerContainerTag))
+				}
+			}
+		}
+
+		if winAppStack.DockerImageName != "" {
+			expanded.WindowsFxVersion = pointer.To(EncodeDockerFxString(winAppStack.DockerImageName, winAppStack.DockerRegistryUrl))
+			appSettings["DOCKER_REGISTRY_SERVER_URL"] = winAppStack.DockerRegistryUrl
+			appSettings["DOCKER_REGISTRY_SERVER_USERNAME"] = winAppStack.DockerRegistryUsername
+			appSettings["DOCKER_REGISTRY_SERVER_PASSWORD"] = winAppStack.DockerRegistryPassword
+
+		}
+
+	} else {
+		expanded.WindowsFxVersion = pointer.To("")
+	}
+
+	if s.ContainerRegistryUserMSI != "" {
+		expanded.AcrUserManagedIdentityID = pointer.To(s.ContainerRegistryUserMSI)
+	}
+
+	if len(s.DefaultDocuments) != 0 {
+		expanded.DefaultDocuments = pointer.To(s.DefaultDocuments)
+	}
+
+	if len(s.IpRestriction) != 0 {
+		ipRestrictions, err := ExpandIpRestrictions(s.IpRestriction)
+		if err != nil {
+			// TODO
+			//return nil, nil, fmt.Errorf("expanding IP Restrictions: %+v", err)
+		}
+		expanded.IPSecurityRestrictions = ipRestrictions
+	}
+
+	if len(s.ScmIpRestriction) != 0 {
+		scmIpRestrictions, err := ExpandIpRestrictions(s.ScmIpRestriction)
+		if err != nil {
+			// TODO
+			//return nil, nil, fmt.Errorf("expanding SCM IP Restrictions: %+v", err)
+		}
+		expanded.ScmIPSecurityRestrictions = scmIpRestrictions
+	}
+
+	if s.RemoteDebuggingVersion != "" {
+		expanded.RemoteDebuggingVersion = pointer.To(s.RemoteDebuggingVersion)
+	}
+
+	if s.HealthCheckPath != "" {
+		expanded.HealthCheckPath = pointer.To(s.HealthCheckPath)
+	}
+
+	if s.WorkerCount != 0 {
+		expanded.NumberOfWorkers = pointer.To(int32(s.WorkerCount))
+	}
+
+	if len(s.Cors) != 0 {
+		expanded.Cors = ExpandCorsSettings(s.Cors)
+	}
+
+	if len(s.AutoHealSettings) != 0 {
+		expanded.AutoHealRules = expandAutoHealSettingsWindows(s.AutoHealSettings)
+	}
+	return expanded
+}
+
+func (s *SiteConfigWindowsWebAppSlot) ExpandForUpdate(metadata sdk.ResourceMetaData, existing *web.SiteConfig, appSettings map[string]string) *web.SiteConfig {
+	expanded := web.SiteConfig{}
 	if existing != nil {
-		expanded = existing
+		expanded = *existing
 	}
 
-	winSlotSiteConfig := siteConfig[0]
-
-	currentStack := ""
-
-	if len(winSlotSiteConfig.ApplicationStack) == 1 {
-		winAppStack := winSlotSiteConfig.ApplicationStack[0]
-		currentStack = winAppStack.CurrentStack
-	}
-
-	if metadata.ResourceData.HasChange("site_config.0.always_on") {
-		expanded.AlwaysOn = pointer.To(winSlotSiteConfig.AlwaysOn)
-	}
+	expanded.AlwaysOn = pointer.To(s.AlwaysOn)
+	expanded.AcrUseManagedIdentityCreds = pointer.To(s.UseManagedIdentityACR)
+	expanded.AutoHealEnabled = pointer.To(s.AutoHeal)
+	expanded.HTTP20Enabled = pointer.To(s.Http2Enabled)
+	expanded.ScmIPSecurityRestrictionsUseMain = pointer.To(s.ScmUseMainIpRestriction)
+	expanded.LocalMySQLEnabled = pointer.To(s.LocalMysql)
+	expanded.RemoteDebuggingEnabled = pointer.To(s.RemoteDebugging)
+	expanded.Use32BitWorkerProcess = pointer.To(s.Use32BitWorker)
+	expanded.WebSocketsEnabled = pointer.To(s.WebSockets)
 
 	if metadata.ResourceData.HasChange("site_config.0.api_management_api_id") {
 		expanded.APIManagementConfig = &web.APIManagementConfig{
-			ID: pointer.To(winSlotSiteConfig.ApiManagementConfigId),
+			ID: pointer.To(s.ApiManagementConfigId),
 		}
 	}
 
 	if metadata.ResourceData.HasChange("site_config.0.api_definition_url") {
 		expanded.APIDefinition = &web.APIDefinitionInfo{
-			URL: pointer.To(winSlotSiteConfig.ApiDefinition),
+			URL: pointer.To(s.ApiDefinition),
 		}
 	}
 
 	if metadata.ResourceData.HasChange("site_config.0.app_command_line") {
-		expanded.AppCommandLine = pointer.To(winSlotSiteConfig.AppCommandLine)
+		expanded.AppCommandLine = pointer.To(s.AppCommandLine)
 	}
 
 	if metadata.ResourceData.HasChange("site_config.0.application_stack") {
-		if len(winSlotSiteConfig.ApplicationStack) == 1 {
-			winAppStack := winSlotSiteConfig.ApplicationStack[0]
-
+		if len(s.ApplicationStack) == 1 {
+			winAppStack := s.ApplicationStack[0]
 			if winAppStack.NetFrameworkVersion != "" {
 				expanded.NetFrameworkVersion = pointer.To(winAppStack.NetFrameworkVersion)
-				if currentStack == "" {
-					currentStack = CurrentStackDotNet
-				}
 			}
 			if winAppStack.NetCoreVersion != "" {
 				expanded.NetFrameworkVersion = pointer.To(winAppStack.NetCoreVersion)
-				if currentStack == "" {
-					currentStack = CurrentStackDotNetCore
-				}
-			}
-			if winAppStack.NodeVersion != "" {
-				// Note: node version is now exclusively controlled via app_setting.WEBSITE_NODE_DEFAULT_VERSION
-				if currentStack == "" {
-					currentStack = CurrentStackNode
-				}
 			}
 			if winAppStack.PhpVersion != "" {
 				if winAppStack.PhpVersion != PhpVersionOff {
@@ -922,15 +1125,9 @@ func ExpandSiteConfigWindowsWebAppSlot(siteConfig []SiteConfigWindowsWebAppSlot,
 				} else {
 					expanded.PhpVersion = pointer.To("")
 				}
-				if currentStack == "" {
-					currentStack = CurrentStackPhp
-				}
 			}
 			if winAppStack.PythonVersion != "" || winAppStack.Python {
 				expanded.PythonVersion = pointer.To(winAppStack.PythonVersion)
-				if currentStack == "" {
-					currentStack = CurrentStackPython
-				}
 			}
 			if winAppStack.JavaVersion != "" {
 				expanded.JavaVersion = pointer.To(winAppStack.JavaVersion)
@@ -938,26 +1135,30 @@ func ExpandSiteConfigWindowsWebAppSlot(siteConfig []SiteConfigWindowsWebAppSlot,
 				case winAppStack.JavaEmbeddedServer:
 					expanded.JavaContainer = pointer.To(JavaContainerEmbeddedServer)
 					expanded.JavaContainerVersion = pointer.To(JavaContainerEmbeddedServerVersion)
-
 				case winAppStack.TomcatVersion != "":
 					expanded.JavaContainer = pointer.To(JavaContainerTomcat)
 					expanded.JavaContainerVersion = pointer.To(winAppStack.TomcatVersion)
-
 				case winAppStack.JavaContainer != "":
 					expanded.JavaContainer = pointer.To(winAppStack.JavaContainer)
 					expanded.JavaContainerVersion = pointer.To(winAppStack.JavaContainerVersion)
 				}
-
-				if currentStack == "" {
-					currentStack = CurrentStackJava
+			}
+			if !features.FourPointOhBeta() {
+				if winAppStack.DockerContainerName != "" || winAppStack.DockerContainerRegistry != "" || winAppStack.DockerContainerTag != "" {
+					if winAppStack.DockerContainerRegistry != "" {
+						expanded.WindowsFxVersion = pointer.To(fmt.Sprintf("DOCKER|%s/%s:%s", winAppStack.DockerContainerRegistry, winAppStack.DockerContainerName, winAppStack.DockerContainerTag))
+					} else {
+						expanded.WindowsFxVersion = pointer.To(fmt.Sprintf("DOCKER|%s:%s", winAppStack.DockerContainerName, winAppStack.DockerContainerTag))
+					}
 				}
 			}
-			if winAppStack.DockerContainerName != "" || winAppStack.DockerContainerRegistry != "" || winAppStack.DockerContainerTag != "" {
-				if winAppStack.DockerContainerRegistry != "" {
-					expanded.WindowsFxVersion = pointer.To(fmt.Sprintf("DOCKER|%s/%s:%s", winAppStack.DockerContainerRegistry, winAppStack.DockerContainerName, winAppStack.DockerContainerTag))
-				} else {
-					expanded.WindowsFxVersion = pointer.To(fmt.Sprintf("DOCKER|%s:%s", winAppStack.DockerContainerName, winAppStack.DockerContainerTag))
-				}
+
+			if winAppStack.DockerImageName != "" {
+				expanded.WindowsFxVersion = pointer.To(EncodeDockerFxString(winAppStack.DockerImageName, winAppStack.DockerRegistryUrl))
+				appSettings["DOCKER_REGISTRY_SERVER_URL"] = winAppStack.DockerRegistryUrl
+				appSettings["DOCKER_REGISTRY_SERVER_USERNAME"] = winAppStack.DockerRegistryUsername
+				appSettings["DOCKER_REGISTRY_SERVER_PASSWORD"] = winAppStack.DockerRegistryPassword
+
 			}
 
 		} else {
@@ -966,99 +1167,66 @@ func ExpandSiteConfigWindowsWebAppSlot(siteConfig []SiteConfigWindowsWebAppSlot,
 	}
 
 	if metadata.ResourceData.HasChange("site_config.0.virtual_application") {
-		expanded.VirtualApplications = expandVirtualApplicationsForUpdate(winSlotSiteConfig.VirtualApplications)
+		expanded.VirtualApplications = expandVirtualApplicationsForUpdate(s.VirtualApplications)
 	} else {
-		expanded.VirtualApplications = expandVirtualApplications(winSlotSiteConfig.VirtualApplications)
-	}
-
-	if metadata.ResourceData.HasChange("site_config.0.container_registry_use_managed_identity") {
-		expanded.AcrUseManagedIdentityCreds = pointer.To(winSlotSiteConfig.UseManagedIdentityACR)
+		expanded.VirtualApplications = expandVirtualApplications(s.VirtualApplications)
 	}
 
 	if metadata.ResourceData.HasChange("site_config.0.container_registry_managed_identity_client_id") {
-		expanded.AcrUserManagedIdentityID = pointer.To(winSlotSiteConfig.ContainerRegistryUserMSI)
+		expanded.AcrUserManagedIdentityID = pointer.To(s.ContainerRegistryUserMSI)
 	}
 
 	if metadata.ResourceData.HasChange("site_config.0.default_documents") {
-		expanded.DefaultDocuments = &winSlotSiteConfig.DefaultDocuments
-	}
-
-	if metadata.ResourceData.HasChange("site_config.0.http2_enabled") {
-		expanded.HTTP20Enabled = pointer.To(winSlotSiteConfig.Http2Enabled)
+		expanded.DefaultDocuments = pointer.To(s.DefaultDocuments)
 	}
 
 	if metadata.ResourceData.HasChange("site_config.0.ip_restriction") {
-		ipRestrictions, err := ExpandIpRestrictions(winSlotSiteConfig.IpRestriction)
-		if err != nil {
-			return nil, nil, err
-		}
+		// TODO
+		ipRestrictions, _ := ExpandIpRestrictions(s.IpRestriction)
+
 		expanded.IPSecurityRestrictions = ipRestrictions
 	}
 
-	if metadata.ResourceData.HasChange("site_config.0.scm_use_main_ip_restriction") {
-		expanded.ScmIPSecurityRestrictionsUseMain = pointer.To(winSlotSiteConfig.ScmUseMainIpRestriction)
-	}
-
 	if metadata.ResourceData.HasChange("site_config.0.scm_ip_restriction") {
-		scmIpRestrictions, err := ExpandIpRestrictions(winSlotSiteConfig.ScmIpRestriction)
-		if err != nil {
-			return nil, nil, err
-		}
+		// TODO
+		scmIpRestrictions, _ := ExpandIpRestrictions(s.ScmIpRestriction)
 		expanded.ScmIPSecurityRestrictions = scmIpRestrictions
 	}
 
-	if metadata.ResourceData.HasChange("site_config.0.local_mysql_enabled") {
-		expanded.LocalMySQLEnabled = pointer.To(winSlotSiteConfig.LocalMysql)
-	}
-
 	if metadata.ResourceData.HasChange("site_config.0.load_balancing_mode") {
-		expanded.LoadBalancing = web.SiteLoadBalancing(winSlotSiteConfig.LoadBalancing)
+		expanded.LoadBalancing = web.SiteLoadBalancing(s.LoadBalancing)
 	}
 
 	if metadata.ResourceData.HasChange("site_config.0.managed_pipeline_mode") {
-		expanded.ManagedPipelineMode = web.ManagedPipelineMode(winSlotSiteConfig.ManagedPipelineMode)
-	}
-
-	if metadata.ResourceData.HasChange("site_config.0.remote_debugging_enabled") {
-		expanded.RemoteDebuggingEnabled = pointer.To(winSlotSiteConfig.RemoteDebugging)
+		expanded.ManagedPipelineMode = web.ManagedPipelineMode(s.ManagedPipelineMode)
 	}
 
 	if metadata.ResourceData.HasChange("site_config.0.remote_debugging_version") {
-		expanded.RemoteDebuggingVersion = pointer.To(winSlotSiteConfig.RemoteDebuggingVersion)
-	}
-
-	expanded.Use32BitWorkerProcess = pointer.To(winSlotSiteConfig.Use32BitWorker)
-
-	if metadata.ResourceData.HasChange("site_config.0.websockets_enabled") {
-		expanded.WebSocketsEnabled = pointer.To(winSlotSiteConfig.WebSockets)
+		expanded.RemoteDebuggingVersion = pointer.To(s.RemoteDebuggingVersion)
 	}
 
 	if metadata.ResourceData.HasChange("site_config.0.ftps_state") {
-		expanded.FtpsState = web.FtpsState(winSlotSiteConfig.FtpsState)
+		expanded.FtpsState = web.FtpsState(s.FtpsState)
 	}
 
 	if metadata.ResourceData.HasChange("site_config.0.health_check_path") {
-		expanded.HealthCheckPath = pointer.To(winSlotSiteConfig.HealthCheckPath)
+		expanded.HealthCheckPath = pointer.To(s.HealthCheckPath)
 	}
 
 	if metadata.ResourceData.HasChange("site_config.0.worker_count") {
-		expanded.NumberOfWorkers = pointer.To(int32(winSlotSiteConfig.WorkerCount))
+		expanded.NumberOfWorkers = pointer.To(int32(s.WorkerCount))
 	}
 
 	if metadata.ResourceData.HasChange("site_config.0.minimum_tls_version") {
-		expanded.MinTLSVersion = web.SupportedTLSVersions(winSlotSiteConfig.MinTlsVersion)
+		expanded.MinTLSVersion = web.SupportedTLSVersions(s.MinTlsVersion)
 	}
 
 	if metadata.ResourceData.HasChange("site_config.0.scm_minimum_tls_version") {
-		expanded.ScmMinTLSVersion = web.SupportedTLSVersions(winSlotSiteConfig.ScmMinTlsVersion)
-	}
-
-	if metadata.ResourceData.HasChange("site_config.0.auto_swap_slot_name") {
-		expanded.AutoSwapSlotName = pointer.To(winSlotSiteConfig.AutoSwapSlotName)
+		expanded.ScmMinTLSVersion = web.SupportedTLSVersions(s.ScmMinTlsVersion)
 	}
 
 	if metadata.ResourceData.HasChange("site_config.0.cors") {
-		cors := ExpandCorsSettings(winSlotSiteConfig.Cors)
+		cors := ExpandCorsSettings(s.Cors)
 		if cors == nil {
 			cors = &web.CorsSettings{
 				AllowedOrigins: &[]string{},
@@ -1066,20 +1234,15 @@ func ExpandSiteConfigWindowsWebAppSlot(siteConfig []SiteConfigWindowsWebAppSlot,
 		}
 		expanded.Cors = cors
 	}
-
-	if metadata.ResourceData.HasChange("site_config.0.auto_heal_enabled") {
-		expanded.AutoHealEnabled = pointer.To(winSlotSiteConfig.AutoHeal)
-	}
-
 	if metadata.ResourceData.HasChange("site_config.0.auto_heal_setting") {
-		expanded.AutoHealRules = expandAutoHealSettingsWindows(winSlotSiteConfig.AutoHealSettings)
+		expanded.AutoHealRules = expandAutoHealSettingsWindows(s.AutoHealSettings)
 	}
 
 	if metadata.ResourceData.HasChange("site_config.0.vnet_route_all_enabled") {
-		expanded.VnetRouteAllEnabled = pointer.To(winSlotSiteConfig.VnetRouteAllEnabled)
+		expanded.VnetRouteAllEnabled = pointer.To(s.VnetRouteAllEnabled)
 	}
 
-	return expanded, &currentStack, nil
+	return &expanded
 }
 
 func (s *SiteConfigWindowsWebAppSlot) Flatten(appSiteSlotConfig *web.SiteConfig, currentStack string) {
@@ -1194,6 +1357,9 @@ func (s *SiteConfigWindowsWebAppSlot) ParseNodeVersion(input map[string]string) 
 
 func (s *SiteConfigWindowsWebAppSlot) DecodeDockerAppStack(input map[string]string) {
 	applicationStack := ApplicationStackWindows{}
+	if len(s.ApplicationStack) == 1 {
+		applicationStack = s.ApplicationStack[0]
+	}
 
 	if v, ok := input["DOCKER_REGISTRY_SERVER_URL"]; ok {
 		applicationStack.DockerRegistryUrl = v
@@ -1210,6 +1376,45 @@ func (s *SiteConfigWindowsWebAppSlot) DecodeDockerAppStack(input map[string]stri
 	registryHost := trimURLScheme(applicationStack.DockerRegistryUrl)
 	dockerString := strings.TrimPrefix(s.WindowsFxVersion, "DOCKER|")
 	applicationStack.DockerImageName = strings.TrimPrefix(dockerString, registryHost)
+
+	s.ApplicationStack = []ApplicationStackWindows{applicationStack}
+}
+
+func (s *SiteConfigWindowsWebAppSlot) DecodeDockerDeprecatedAppStack(input map[string]string, usesDeprecated bool) {
+	applicationStack := ApplicationStackWindows{}
+	if len(s.ApplicationStack) == 1 {
+		applicationStack = s.ApplicationStack[0]
+	}
+
+	if !usesDeprecated {
+		if v, ok := input["DOCKER_REGISTRY_SERVER_URL"]; ok {
+			applicationStack.DockerRegistryUrl = v
+		}
+
+		if v, ok := input["DOCKER_REGISTRY_SERVER_USERNAME"]; ok {
+			applicationStack.DockerRegistryUsername = v
+		}
+
+		if v, ok := input["DOCKER_REGISTRY_SERVER_PASSWORD"]; ok {
+			applicationStack.DockerRegistryPassword = v
+		}
+
+		registryHost := trimURLScheme(applicationStack.DockerRegistryUrl)
+		dockerString := strings.TrimPrefix(s.WindowsFxVersion, "DOCKER|")
+		applicationStack.DockerImageName = strings.TrimPrefix(dockerString, registryHost)
+	} else {
+		parts := strings.Split(strings.TrimPrefix(s.WindowsFxVersion, "DOCKER|"), ":")
+		if len(parts) == 2 {
+			applicationStack.DockerContainerTag = parts[1]
+			path := strings.Split(parts[0], "/")
+			if len(path) > 1 {
+				applicationStack.DockerContainerRegistry = path[0]
+				applicationStack.DockerContainerName = strings.TrimPrefix(parts[0], fmt.Sprintf("%s/", path[0]))
+			} else {
+				applicationStack.DockerContainerName = path[0]
+			}
+		}
+	}
 
 	s.ApplicationStack = []ApplicationStackWindows{applicationStack}
 }

--- a/internal/services/appservice/helpers/web_app_slot_schema.go
+++ b/internal/services/appservice/helpers/web_app_slot_schema.go
@@ -540,7 +540,7 @@ func SiteConfigSchemaWindowsWebAppSlot() *pluginsdk.Schema {
 	}
 }
 
-func (s *SiteConfigLinuxWebAppSlot) ExpandForCreate(appSettings map[string]string) *web.SiteConfig {
+func (s *SiteConfigLinuxWebAppSlot) ExpandForCreate(appSettings map[string]string) (*web.SiteConfig, error) {
 	expanded := &web.SiteConfig{}
 	expanded.AlwaysOn = pointer.To(s.AlwaysOn)
 	expanded.AcrUseManagedIdentityCreds = pointer.To(s.UseManagedIdentityACR)
@@ -603,7 +603,7 @@ func (s *SiteConfigLinuxWebAppSlot) ExpandForCreate(appSettings map[string]strin
 		if linuxAppStack.JavaServer != "" {
 			javaString, err := JavaLinuxFxStringBuilder(linuxAppStack.JavaVersion, linuxAppStack.JavaServer, linuxAppStack.JavaServerVersion)
 			if err != nil {
-				// TODO return nil, fmt.Errorf("could not build linuxFxVersion string: %+v", err)
+				return nil, fmt.Errorf("could not build linuxFxVersion string: %+v", err)
 			}
 			expanded.LinuxFxVersion = javaString
 		}
@@ -635,7 +635,7 @@ func (s *SiteConfigLinuxWebAppSlot) ExpandForCreate(appSettings map[string]strin
 	if len(s.IpRestriction) != 0 {
 		ipRestrictions, err := ExpandIpRestrictions(s.IpRestriction)
 		if err != nil {
-			// TODO - Needs errors?
+			return nil, err
 		}
 
 		expanded.IPSecurityRestrictions = ipRestrictions
@@ -644,7 +644,7 @@ func (s *SiteConfigLinuxWebAppSlot) ExpandForCreate(appSettings map[string]strin
 	if len(s.ScmIpRestriction) != 0 {
 		ipRestrictions, err := ExpandIpRestrictions(s.ScmIpRestriction)
 		if err != nil {
-			// TODO - Needs errors?
+			return nil, err
 		}
 
 		expanded.ScmIPSecurityRestrictions = ipRestrictions
@@ -666,10 +666,10 @@ func (s *SiteConfigLinuxWebAppSlot) ExpandForCreate(appSettings map[string]strin
 		expanded.AutoHealRules = expandAutoHealSettingsLinux(s.AutoHealSettings)
 	}
 
-	return expanded
+	return expanded, nil
 }
 
-func (s *SiteConfigLinuxWebAppSlot) ExpandForUpdate(metadata sdk.ResourceMetaData, existing *web.SiteConfig, appSettings map[string]string) *web.SiteConfig {
+func (s *SiteConfigLinuxWebAppSlot) ExpandForUpdate(metadata sdk.ResourceMetaData, existing *web.SiteConfig, appSettings map[string]string) (*web.SiteConfig, error) {
 	expanded := *existing
 
 	expanded.AcrUseManagedIdentityCreds = pointer.To(s.UseManagedIdentityACR)
@@ -728,8 +728,7 @@ func (s *SiteConfigLinuxWebAppSlot) ExpandForUpdate(metadata sdk.ResourceMetaDat
 			if linuxAppStack.JavaServer != "" {
 				javaString, err := JavaLinuxFxStringBuilder(linuxAppStack.JavaVersion, linuxAppStack.JavaServer, linuxAppStack.JavaServerVersion)
 				if err != nil {
-					// TODO
-					//return nil, fmt.Errorf("could not build linuxFxVersion string: %+v", err)
+					return nil, fmt.Errorf("could not build linuxFxVersion string: %+v", err)
 				}
 				expanded.LinuxFxVersion = javaString
 			}
@@ -762,8 +761,7 @@ func (s *SiteConfigLinuxWebAppSlot) ExpandForUpdate(metadata sdk.ResourceMetaDat
 	if metadata.ResourceData.HasChange("site_config.0.ip_restriction") {
 		ipRestrictions, err := ExpandIpRestrictions(s.IpRestriction)
 		if err != nil {
-			// TODO
-			//return nil, err
+			return nil, err
 		}
 		expanded.IPSecurityRestrictions = ipRestrictions
 	}
@@ -771,8 +769,7 @@ func (s *SiteConfigLinuxWebAppSlot) ExpandForUpdate(metadata sdk.ResourceMetaDat
 	if metadata.ResourceData.HasChange("site_config.0.scm_ip_restriction") {
 		scmIpRestrictions, err := ExpandIpRestrictions(s.ScmIpRestriction)
 		if err != nil {
-			// TODO
-			//return nil, err
+			return nil, err
 		}
 		expanded.ScmIPSecurityRestrictions = scmIpRestrictions
 	}
@@ -819,7 +816,7 @@ func (s *SiteConfigLinuxWebAppSlot) ExpandForUpdate(metadata sdk.ResourceMetaDat
 		expanded.AutoHealRules = expandAutoHealSettingsLinux(s.AutoHealSettings)
 	}
 
-	return &expanded
+	return &expanded, nil
 }
 
 func (s *SiteConfigLinuxWebAppSlot) Flatten(appSiteSlotConfig *web.SiteConfig) {
@@ -938,7 +935,7 @@ func (s *SiteConfigLinuxWebAppSlot) DecodeDockerDeprecatedAppStack(input map[str
 	s.ApplicationStack = []ApplicationStackLinux{applicationStack}
 }
 
-func (s *SiteConfigWindowsWebAppSlot) ExpandForCreate(appSettings map[string]string) *web.SiteConfig {
+func (s *SiteConfigWindowsWebAppSlot) ExpandForCreate(appSettings map[string]string) (*web.SiteConfig, error) {
 	expanded := &web.SiteConfig{}
 
 	expanded.AlwaysOn = pointer.To(s.AlwaysOn)
@@ -1041,8 +1038,7 @@ func (s *SiteConfigWindowsWebAppSlot) ExpandForCreate(appSettings map[string]str
 	if len(s.IpRestriction) != 0 {
 		ipRestrictions, err := ExpandIpRestrictions(s.IpRestriction)
 		if err != nil {
-			// TODO
-			//return nil, nil, fmt.Errorf("expanding IP Restrictions: %+v", err)
+			return nil, fmt.Errorf("expanding IP Restrictions: %+v", err)
 		}
 		expanded.IPSecurityRestrictions = ipRestrictions
 	}
@@ -1050,8 +1046,7 @@ func (s *SiteConfigWindowsWebAppSlot) ExpandForCreate(appSettings map[string]str
 	if len(s.ScmIpRestriction) != 0 {
 		scmIpRestrictions, err := ExpandIpRestrictions(s.ScmIpRestriction)
 		if err != nil {
-			// TODO
-			//return nil, nil, fmt.Errorf("expanding SCM IP Restrictions: %+v", err)
+			return nil, fmt.Errorf("expanding SCM IP Restrictions: %+v", err)
 		}
 		expanded.ScmIPSecurityRestrictions = scmIpRestrictions
 	}
@@ -1075,10 +1070,10 @@ func (s *SiteConfigWindowsWebAppSlot) ExpandForCreate(appSettings map[string]str
 	if len(s.AutoHealSettings) != 0 {
 		expanded.AutoHealRules = expandAutoHealSettingsWindows(s.AutoHealSettings)
 	}
-	return expanded
+	return expanded, nil
 }
 
-func (s *SiteConfigWindowsWebAppSlot) ExpandForUpdate(metadata sdk.ResourceMetaData, existing *web.SiteConfig, appSettings map[string]string) *web.SiteConfig {
+func (s *SiteConfigWindowsWebAppSlot) ExpandForUpdate(metadata sdk.ResourceMetaData, existing *web.SiteConfig, appSettings map[string]string) (*web.SiteConfig, error) {
 	expanded := web.SiteConfig{}
 	if existing != nil {
 		expanded = *existing
@@ -1181,15 +1176,19 @@ func (s *SiteConfigWindowsWebAppSlot) ExpandForUpdate(metadata sdk.ResourceMetaD
 	}
 
 	if metadata.ResourceData.HasChange("site_config.0.ip_restriction") {
-		// TODO
-		ipRestrictions, _ := ExpandIpRestrictions(s.IpRestriction)
+		ipRestrictions, err := ExpandIpRestrictions(s.IpRestriction)
+		if err != nil {
+			return nil, err
+		}
 
 		expanded.IPSecurityRestrictions = ipRestrictions
 	}
 
 	if metadata.ResourceData.HasChange("site_config.0.scm_ip_restriction") {
-		// TODO
-		scmIpRestrictions, _ := ExpandIpRestrictions(s.ScmIpRestriction)
+		scmIpRestrictions, err := ExpandIpRestrictions(s.ScmIpRestriction)
+		if err != nil {
+			return nil, err
+		}
 		expanded.ScmIPSecurityRestrictions = scmIpRestrictions
 	}
 
@@ -1242,7 +1241,7 @@ func (s *SiteConfigWindowsWebAppSlot) ExpandForUpdate(metadata sdk.ResourceMetaD
 		expanded.VnetRouteAllEnabled = pointer.To(s.VnetRouteAllEnabled)
 	}
 
-	return &expanded
+	return &expanded, nil
 }
 
 func (s *SiteConfigWindowsWebAppSlot) Flatten(appSiteSlotConfig *web.SiteConfig, currentStack string) {

--- a/internal/services/appservice/helpers/web_app_slot_schema.go
+++ b/internal/services/appservice/helpers/web_app_slot_schema.go
@@ -624,6 +624,10 @@ func (s *SiteConfigLinuxWebAppSlot) ExpandForCreate(appSettings map[string]strin
 
 	expanded.AppSettings = ExpandAppSettingsForCreate(appSettings)
 
+	if s.AutoSwapSlotName != "" {
+		expanded.AutoSwapSlotName = pointer.To(s.AutoSwapSlotName)
+	}
+
 	if s.ContainerRegistryMSI != "" {
 		expanded.AcrUserManagedIdentityID = pointer.To(s.ContainerRegistryMSI)
 	}
@@ -748,6 +752,10 @@ func (s *SiteConfigLinuxWebAppSlot) ExpandForUpdate(metadata sdk.ResourceMetaDat
 		} else {
 			expanded.LinuxFxVersion = pointer.To("")
 		}
+	}
+
+	if metadata.ResourceData.HasChange("site_config.0.auto_swap_slot_name") {
+		expanded.AutoSwapSlotName = pointer.To(s.AutoSwapSlotName)
 	}
 
 	if metadata.ResourceData.HasChange("site_config.0.container_registry_managed_identity_client_id") {
@@ -1027,6 +1035,10 @@ func (s *SiteConfigWindowsWebAppSlot) ExpandForCreate(appSettings map[string]str
 		expanded.WindowsFxVersion = pointer.To("")
 	}
 
+	if s.AutoSwapSlotName != "" {
+		expanded.AutoSwapSlotName = pointer.To(s.AutoSwapSlotName)
+	}
+
 	if s.ContainerRegistryUserMSI != "" {
 		expanded.AcrUserManagedIdentityID = pointer.To(s.ContainerRegistryUserMSI)
 	}
@@ -1159,6 +1171,10 @@ func (s *SiteConfigWindowsWebAppSlot) ExpandForUpdate(metadata sdk.ResourceMetaD
 		} else {
 			expanded.WindowsFxVersion = pointer.To("")
 		}
+	}
+
+	if metadata.ResourceData.HasChange("site_config.0.auto_swap_slot_name") {
+		expanded.AutoSwapSlotName = pointer.To(s.AutoSwapSlotName)
 	}
 
 	if metadata.ResourceData.HasChange("site_config.0.virtual_application") {

--- a/internal/services/appservice/helpers/windows_web_app_schema.go
+++ b/internal/services/appservice/helpers/windows_web_app_schema.go
@@ -440,7 +440,7 @@ func SiteConfigSchemaWindowsComputed() *pluginsdk.Schema {
 	}
 }
 
-func (s *SiteConfigWindows) ExpandForCreate(appSettings map[string]string) *web.SiteConfig {
+func (s *SiteConfigWindows) ExpandForCreate(appSettings map[string]string) (*web.SiteConfig, error) {
 	expanded := &web.SiteConfig{}
 
 	expanded.AlwaysOn = pointer.To(s.AlwaysOn)
@@ -543,8 +543,7 @@ func (s *SiteConfigWindows) ExpandForCreate(appSettings map[string]string) *web.
 	if len(s.IpRestriction) != 0 {
 		ipRestrictions, err := ExpandIpRestrictions(s.IpRestriction)
 		if err != nil {
-			// TODO
-			//return nil, nil, fmt.Errorf("expanding IP Restrictions: %+v", err)
+			return nil, fmt.Errorf("expanding IP Restrictions: %+v", err)
 		}
 		expanded.IPSecurityRestrictions = ipRestrictions
 	}
@@ -552,8 +551,7 @@ func (s *SiteConfigWindows) ExpandForCreate(appSettings map[string]string) *web.
 	if len(s.ScmIpRestriction) != 0 {
 		scmIpRestrictions, err := ExpandIpRestrictions(s.ScmIpRestriction)
 		if err != nil {
-			// TODO
-			//return nil, nil, fmt.Errorf("expanding SCM IP Restrictions: %+v", err)
+			return nil, fmt.Errorf("expanding SCM IP Restrictions: %+v", err)
 		}
 		expanded.ScmIPSecurityRestrictions = scmIpRestrictions
 	}
@@ -578,10 +576,10 @@ func (s *SiteConfigWindows) ExpandForCreate(appSettings map[string]string) *web.
 		expanded.AutoHealRules = expandAutoHealSettingsWindows(s.AutoHealSettings)
 	}
 
-	return expanded
+	return expanded, nil
 }
 
-func (s *SiteConfigWindows) ExpandForUpdate(metadata sdk.ResourceMetaData, existing *web.SiteConfig, appSettings map[string]string) *web.SiteConfig {
+func (s *SiteConfigWindows) ExpandForUpdate(metadata sdk.ResourceMetaData, existing *web.SiteConfig, appSettings map[string]string) (*web.SiteConfig, error) {
 	expanded := web.SiteConfig{}
 	if existing != nil {
 		expanded = *existing
@@ -684,15 +682,19 @@ func (s *SiteConfigWindows) ExpandForUpdate(metadata sdk.ResourceMetaData, exist
 	}
 
 	if metadata.ResourceData.HasChange("site_config.0.ip_restriction") {
-		// TODO
-		ipRestrictions, _ := ExpandIpRestrictions(s.IpRestriction)
+		ipRestrictions, err := ExpandIpRestrictions(s.IpRestriction)
+		if err != nil {
+			return nil, err
+		}
 
 		expanded.IPSecurityRestrictions = ipRestrictions
 	}
 
 	if metadata.ResourceData.HasChange("site_config.0.scm_ip_restriction") {
-		// TODO
-		scmIpRestrictions, _ := ExpandIpRestrictions(s.ScmIpRestriction)
+		scmIpRestrictions, err := ExpandIpRestrictions(s.ScmIpRestriction)
+		if err != nil {
+			return nil, err
+		}
 		expanded.ScmIPSecurityRestrictions = scmIpRestrictions
 	}
 
@@ -745,7 +747,7 @@ func (s *SiteConfigWindows) ExpandForUpdate(metadata sdk.ResourceMetaData, exist
 		expanded.VnetRouteAllEnabled = pointer.To(s.VnetRouteAllEnabled)
 	}
 
-	return &expanded
+	return &expanded, nil
 }
 
 func (s *SiteConfigWindows) Flatten(appSiteConfig *web.SiteConfig, currentStack string) error {

--- a/internal/services/appservice/helpers/windows_web_app_schema.go
+++ b/internal/services/appservice/helpers/windows_web_app_schema.go
@@ -906,6 +906,7 @@ func (s *SiteConfigWindows) ParseNodeVersion(input map[string]string) map[string
 	if nodeVer, ok := input["WEBSITE_NODE_DEFAULT_VERSION"]; ok {
 		if s.ApplicationStack == nil {
 			s.ApplicationStack = make([]ApplicationStackWindows, 0)
+			s.ApplicationStack[0] = ApplicationStackWindows{}
 		}
 		s.ApplicationStack[0].NodeVersion = nodeVer
 		delete(input, "WEBSITE_NODE_DEFAULT_VERSION")

--- a/internal/services/appservice/helpers/windows_web_app_schema.go
+++ b/internal/services/appservice/helpers/windows_web_app_schema.go
@@ -2,12 +2,12 @@ package helpers
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"strconv"
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/services/web/mgmt/2021-03-01/web" // nolint: staticcheck
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/apimanagement/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/apimanagement/validate"
@@ -823,21 +823,6 @@ func (s *SiteConfigWindows) Flatten(appSiteConfig *web.SiteConfig, currentStack 
 	}
 
 	s.WindowsFxVersion = pointer.From(appSiteConfig.WindowsFxVersion)
-	//if s.WindowsFxVersion != "" {
-	//	// TODO - These are deprecated and will be removed in 4.0, need to wrap in feature flag
-	//	// Decode the string to docker values
-	//	parts := strings.Split(strings.TrimPrefix(s.WindowsFxVersion, "DOCKER|"), ":")
-	//	if len(parts) == 2 {
-	//		winAppStack.DockerContainerTag = parts[1]
-	//		path := strings.Split(parts[0], "/")
-	//		if len(path) > 1 {
-	//			winAppStack.DockerContainerRegistry = path[0]
-	//			winAppStack.DockerContainerName = strings.TrimPrefix(parts[0], fmt.Sprintf("%s/", path[0]))
-	//		} else {
-	//			winAppStack.DockerContainerName = path[0]
-	//		}
-	//	}
-	//}
 
 	winAppStack.CurrentStack = currentStack
 

--- a/internal/services/appservice/linux_function_app_resource.go
+++ b/internal/services/appservice/linux_function_app_resource.go
@@ -692,7 +692,11 @@ func (r LinuxFunctionAppResource) Read() sdk.ResourceFunc {
 			}
 
 			if hostingEnv := props.HostingEnvironmentProfile; hostingEnv != nil {
-				state.HostingEnvId = pointer.From(hostingEnv.ID)
+				hostingEnvId, err := parse.AppServiceEnvironmentIDInsensitively(*hostingEnv.ID)
+				if err != nil {
+					return err
+				}
+				state.HostingEnvId = hostingEnvId.ID()
 			}
 
 			if v := props.OutboundIPAddresses; v != nil {

--- a/internal/services/appservice/linux_web_app_data_source.go
+++ b/internal/services/appservice/linux_web_app_data_source.go
@@ -342,14 +342,14 @@ func (r LinuxWebAppDataSource) Read() sdk.ResourceFunc {
 			siteConfig.Flatten(webAppSiteConfig.SiteConfig)
 			siteConfig.SetHealthCheckEvictionTime(webApp.AppSettings)
 
-			if strings.HasPrefix(siteConfig.LinuxFxVersion, "DOCKER") {
+			if helpers.FxStringHasPrefix(siteConfig.LinuxFxVersion, helpers.FxStringPrefixDocker) {
 				siteConfig.DecodeDockerAppStack(webApp.AppSettings)
 			}
 
 			webApp.SiteConfig = []helpers.SiteConfigLinux{siteConfig}
 
 			// Filter out all settings we've consumed above
-			webApp.AppSettings = helpers.FilterUnmanagedAppSettings(webApp.AppSettings)
+			webApp.AppSettings = helpers.FilterManagedAppSettings(webApp.AppSettings)
 
 			webApp.StorageAccounts = helpers.FlattenStorageAccounts(storageAccounts)
 

--- a/internal/services/appservice/linux_web_app_resource.go
+++ b/internal/services/appservice/linux_web_app_resource.go
@@ -92,6 +92,7 @@ func (r LinuxWebAppResource) Arguments() map[string]*pluginsdk.Schema {
 			Elem: &pluginsdk.Schema{
 				Type: pluginsdk.TypeString,
 			},
+			ValidateFunc: validate.AppSettings,
 		},
 
 		"auth_settings": helpers.AuthSettingsSchema(),

--- a/internal/services/appservice/linux_web_app_resource.go
+++ b/internal/services/appservice/linux_web_app_resource.go
@@ -3,7 +3,6 @@ package appservice
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"strconv"
 	"strings"
 	"time"
@@ -13,6 +12,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/appservice/helpers"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/appservice/parse"
@@ -322,7 +322,10 @@ func (r LinuxWebAppResource) Create() sdk.ResourceFunc {
 				}
 			}
 
-			siteConfig := sc.ExpandForCreate(webApp.AppSettings)
+			siteConfig, err := sc.ExpandForCreate(webApp.AppSettings)
+			if err != nil {
+				return err
+			}
 
 			expandedIdentity, err := expandIdentity(metadata.ResourceData.Get("identity").([]interface{}))
 			if err != nil {
@@ -736,7 +739,10 @@ func (r LinuxWebAppResource) Update() sdk.ResourceFunc {
 			}
 
 			if metadata.ResourceData.HasChange("site_config") || servicePlanChange {
-				existing.SiteConfig = sc.ExpandForUpdate(metadata, existing.SiteConfig, state.AppSettings)
+				existing.SiteConfig, err = sc.ExpandForUpdate(metadata, existing.SiteConfig, state.AppSettings)
+				if err != nil {
+					return err
+				}
 			}
 
 			if metadata.ResourceData.HasChange("virtual_network_subnet_id") {

--- a/internal/services/appservice/linux_web_app_resource.go
+++ b/internal/services/appservice/linux_web_app_resource.go
@@ -317,7 +317,7 @@ func (r LinuxWebAppResource) Create() sdk.ResourceFunc {
 			if servicePlan.Sku != nil && servicePlan.Sku.Name != nil {
 				if helpers.IsFreeOrSharedServicePlan(*servicePlan.Sku.Name) {
 					if sc.AlwaysOn {
-						return fmt.Errorf("always_on feature has to be turned off before switching to a free/shared Sku")
+						return fmt.Errorf("always_on cannot be set to true when using Free, F1, D1 Sku")
 					}
 				}
 			}

--- a/internal/services/appservice/linux_web_app_resource.go
+++ b/internal/services/appservice/linux_web_app_resource.go
@@ -560,7 +560,11 @@ func (r LinuxWebAppResource) Read() sdk.ResourceFunc {
 				}
 
 				if hostingEnv := props.HostingEnvironmentProfile; hostingEnv != nil {
-					state.HostingEnvId = pointer.From(hostingEnv.ID)
+					hostingEnvId, err := parse.AppServiceEnvironmentIDInsensitively(*hostingEnv.ID)
+					if err != nil {
+						return err
+					}
+					state.HostingEnvId = hostingEnvId.ID()
 				}
 
 				if subnetId := pointer.From(props.VirtualNetworkSubnetID); subnetId != "" {

--- a/internal/services/appservice/linux_web_app_resource_test.go
+++ b/internal/services/appservice/linux_web_app_resource_test.go
@@ -3,13 +3,13 @@ package appservice_test
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/appservice/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"

--- a/internal/services/appservice/linux_web_app_slot_resource.go
+++ b/internal/services/appservice/linux_web_app_slot_resource.go
@@ -516,6 +516,7 @@ func (r LinuxWebAppSlotResource) Read() sdk.ResourceFunc {
 					OutboundIPAddressList:         strings.Split(pointer.From(props.OutboundIPAddresses), ","),
 					PossibleOutboundIPAddresses:   pointer.From(props.PossibleOutboundIPAddresses),
 					PossibleOutboundIPAddressList: strings.Split(pointer.From(props.PossibleOutboundIPAddresses), ","),
+					ServicePlanID:                 pointer.From(props.ServerFarmID),
 					Tags:                          tags.ToTypedObject(webAppSlot.Tags),
 				}
 

--- a/internal/services/appservice/linux_web_app_slot_resource.go
+++ b/internal/services/appservice/linux_web_app_slot_resource.go
@@ -3,7 +3,6 @@ package appservice
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"strconv"
 	"strings"
 	"time"
@@ -12,6 +11,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/appservice/helpers"
@@ -301,7 +301,10 @@ func (r LinuxWebAppSlotResource) Create() sdk.ResourceFunc {
 			}
 
 			sc := webAppSlot.SiteConfig[0]
-			siteConfig := sc.ExpandForCreate(webAppSlot.AppSettings)
+			siteConfig, err := sc.ExpandForCreate(webAppSlot.AppSettings)
+			if err != nil {
+				return err
+			}
 
 			expandedIdentity, err := expandIdentity(metadata.ResourceData.Get("identity").([]interface{}))
 			if err != nil {
@@ -711,7 +714,7 @@ func (r LinuxWebAppSlotResource) Update() sdk.ResourceFunc {
 
 			if metadata.ResourceData.HasChange("site_config") {
 				sc := state.SiteConfig[0]
-				siteConfig := sc.ExpandForUpdate(metadata, existing.SiteConfig, state.AppSettings)
+				siteConfig, err := sc.ExpandForUpdate(metadata, existing.SiteConfig, state.AppSettings)
 				if err != nil {
 					return fmt.Errorf("expanding Site Config for Linux %s: %+v", id, err)
 				}

--- a/internal/services/appservice/linux_web_app_slot_resource.go
+++ b/internal/services/appservice/linux_web_app_slot_resource.go
@@ -103,6 +103,7 @@ func (r LinuxWebAppSlotResource) Arguments() map[string]*pluginsdk.Schema {
 			Elem: &pluginsdk.Schema{
 				Type: pluginsdk.TypeString,
 			},
+			ValidateFunc: validate.AppSettings,
 		},
 
 		"auth_settings": helpers.AuthSettingsSchema(),

--- a/internal/services/appservice/linux_web_app_slot_resource.go
+++ b/internal/services/appservice/linux_web_app_slot_resource.go
@@ -516,7 +516,6 @@ func (r LinuxWebAppSlotResource) Read() sdk.ResourceFunc {
 					OutboundIPAddressList:         strings.Split(pointer.From(props.OutboundIPAddresses), ","),
 					PossibleOutboundIPAddresses:   pointer.From(props.PossibleOutboundIPAddresses),
 					PossibleOutboundIPAddressList: strings.Split(pointer.From(props.PossibleOutboundIPAddresses), ","),
-					ServicePlanID:                 pointer.From(props.ServerFarmID),
 					Tags:                          tags.ToTypedObject(webAppSlot.Tags),
 				}
 

--- a/internal/services/appservice/linux_web_app_slot_resource_test.go
+++ b/internal/services/appservice/linux_web_app_slot_resource_test.go
@@ -3,12 +3,12 @@ package appservice_test
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"testing"
 
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/appservice/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"

--- a/internal/services/appservice/parse/app_service_environment.go
+++ b/internal/services/appservice/parse/app_service_environment.go
@@ -67,3 +67,47 @@ func AppServiceEnvironmentID(input string) (*AppServiceEnvironmentId, error) {
 
 	return &resourceId, nil
 }
+
+// AppServiceEnvironmentIDInsensitively parses an AppServiceEnvironment ID into an AppServiceEnvironmentId struct, insensitively
+// This should only be used to parse an ID for rewriting, the AppServiceEnvironmentID
+// method should be used instead for validation etc.
+//
+// Whilst this may seem strange, this enables Terraform have consistent casing
+// which works around issues in Core, whilst handling broken API responses.
+func AppServiceEnvironmentIDInsensitively(input string) (*AppServiceEnvironmentId, error) {
+	id, err := resourceids.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := AppServiceEnvironmentId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	// find the correct casing for the 'hostingEnvironments' segment
+	hostingEnvironmentsKey := "hostingEnvironments"
+	for key := range id.Path {
+		if strings.EqualFold(key, hostingEnvironmentsKey) {
+			hostingEnvironmentsKey = key
+			break
+		}
+	}
+	if resourceId.HostingEnvironmentName, err = id.PopSegment(hostingEnvironmentsKey); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/internal/services/appservice/parse/app_service_environment_test.go
+++ b/internal/services/appservice/parse/app_service_environment_test.go
@@ -110,3 +110,120 @@ func TestAppServiceEnvironmentID(t *testing.T) {
 		}
 	}
 }
+
+func TestAppServiceEnvironmentIDInsensitively(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *AppServiceEnvironmentId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing HostingEnvironmentName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Web/",
+			Error: true,
+		},
+
+		{
+			// missing value for HostingEnvironmentName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Web/hostingEnvironments/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Web/hostingEnvironments/hostingEnvironment1",
+			Expected: &AppServiceEnvironmentId{
+				SubscriptionId:         "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:          "resGroup1",
+				HostingEnvironmentName: "hostingEnvironment1",
+			},
+		},
+
+		{
+			// lower-cased segment names
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Web/hostingenvironments/hostingEnvironment1",
+			Expected: &AppServiceEnvironmentId{
+				SubscriptionId:         "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:          "resGroup1",
+				HostingEnvironmentName: "hostingEnvironment1",
+			},
+		},
+
+		{
+			// upper-cased segment names
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Web/HOSTINGENVIRONMENTS/hostingEnvironment1",
+			Expected: &AppServiceEnvironmentId{
+				SubscriptionId:         "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:          "resGroup1",
+				HostingEnvironmentName: "hostingEnvironment1",
+			},
+		},
+
+		{
+			// mixed-cased segment names
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Web/HoStInGeNvIrOnMeNtS/hostingEnvironment1",
+			Expected: &AppServiceEnvironmentId{
+				SubscriptionId:         "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:          "resGroup1",
+				HostingEnvironmentName: "hostingEnvironment1",
+			},
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := AppServiceEnvironmentIDInsensitively(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.HostingEnvironmentName != v.Expected.HostingEnvironmentName {
+			t.Fatalf("Expected %q but got %q for HostingEnvironmentName", v.Expected.HostingEnvironmentName, actual.HostingEnvironmentName)
+		}
+	}
+}

--- a/internal/services/appservice/resourceids.go
+++ b/internal/services/appservice/resourceids.go
@@ -4,7 +4,7 @@ package appservice
 //go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=WebAppSlot -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Web/sites/site1/slots/slot1
 //go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=FunctionApp -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Web/sites/site1
 //go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=FunctionAppSlot -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Web/sites/site1/slots/slot1
-//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=AppServiceEnvironment -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Web/hostingEnvironments/hostingEnvironment1
+//go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=AppServiceEnvironment -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Web/hostingEnvironments/hostingEnvironment1 -rewrite=true
 //go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=FunctionAppFunction -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Web/sites/site1/functions/function1
 //go:generate go run ../../tools/generator-resource-id/main.go -path=./ -name=AppHybridConnection -id=/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Web/sites/site1/hybridConnectionNamespaces/hybridConnectionNamespace1/relays/relay1
 

--- a/internal/services/appservice/validate/app_settings.go
+++ b/internal/services/appservice/validate/app_settings.go
@@ -1,0 +1,58 @@
+package validate
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
+)
+
+var UnmanagedSettings = []string{
+	"DOCKER_REGISTRY_SERVER_URL",
+	"DOCKER_REGISTRY_SERVER_USERNAME",
+	"DOCKER_REGISTRY_SERVER_PASSWORD",
+	"DIAGNOSTICS_AZUREBLOBCONTAINERSASURL",
+	"DIAGNOSTICS_AZUREBLOBRETENTIONINDAYS",
+	"WEBSITE_HTTPLOGGING_CONTAINER_URL",
+	"WEBSITE_HTTPLOGGING_RETENTION_DAYS",
+	"WEBSITE_VNET_ROUTE_ALL",
+	"spring.datasource.password",
+	"spring.datasource.url",
+	"spring.datasource.username",
+	"WEBSITE_HEALTHCHECK_MAXPINGFAILURES",
+}
+var UnmanagedSettingsDeprecated = []string{
+	"DIAGNOSTICS_AZUREBLOBCONTAINERSASURL",
+	"DIAGNOSTICS_AZUREBLOBRETENTIONINDAYS",
+	"WEBSITE_HTTPLOGGING_CONTAINER_URL",
+	"WEBSITE_HTTPLOGGING_RETENTION_DAYS",
+	"WEBSITE_VNET_ROUTE_ALL",
+	"spring.datasource.password",
+	"spring.datasource.url",
+	"spring.datasource.username",
+	"WEBSITE_HEALTHCHECK_MAXPINGFAILURES",
+}
+
+func AppSettings(input interface{}, key string) (warnings []string, errors []error) {
+	if appSettings, ok := input.(map[string]interface{}); ok {
+		for k := range appSettings {
+			if !features.FourPointOhBeta() {
+				for _, f := range UnmanagedSettingsDeprecated {
+					if strings.EqualFold(k, f) {
+						errors = append(errors, fmt.Errorf("cannot set a value for %s in %s", k, key))
+					}
+				}
+			} else {
+				for _, f := range UnmanagedSettings {
+					if strings.EqualFold(k, f) {
+						errors = append(errors, fmt.Errorf("cannot set a value for %s in %s", k, key))
+					}
+				}
+			}
+		}
+	} else {
+		errors = append(errors, fmt.Errorf("expected %s to be a map of strings", key))
+		return
+	}
+	return
+}

--- a/internal/services/appservice/windows_function_app_resource.go
+++ b/internal/services/appservice/windows_function_app_resource.go
@@ -689,7 +689,11 @@ func (r WindowsFunctionAppResource) Read() sdk.ResourceFunc {
 			}
 
 			if hostingEnv := props.HostingEnvironmentProfile; hostingEnv != nil {
-				state.HostingEnvId = pointer.From(hostingEnv.ID)
+				hostingEnvId, err := parse.AppServiceEnvironmentIDInsensitively(*hostingEnv.ID)
+				if err != nil {
+					return err
+				}
+				state.HostingEnvId = hostingEnvId.ID()
 			}
 
 			if v := props.OutboundIPAddresses; v != nil {

--- a/internal/services/appservice/windows_web_app_data_source.go
+++ b/internal/services/appservice/windows_web_app_data_source.go
@@ -344,7 +344,7 @@ func (d WindowsWebAppDataSource) Read() sdk.ResourceFunc {
 			webApp.AppSettings = siteConfig.ParseNodeVersion(webApp.AppSettings)
 
 			siteConfig.SetHealthCheckEvictionTime(webApp.AppSettings)
-			if strings.HasPrefix(siteConfig.WindowsFxVersion, "DOCKER") {
+			if helpers.FxStringHasPrefix(siteConfig.WindowsFxVersion, helpers.FxStringPrefixDocker) {
 				siteConfig.DecodeDockerAppStack(webApp.AppSettings)
 			}
 

--- a/internal/services/appservice/windows_web_app_resource.go
+++ b/internal/services/appservice/windows_web_app_resource.go
@@ -314,7 +314,7 @@ func (r WindowsWebAppResource) Create() sdk.ResourceFunc {
 			if servicePlan.Sku != nil && servicePlan.Sku.Name != nil {
 				if helpers.IsFreeOrSharedServicePlan(*servicePlan.Sku.Name) {
 					if sc.AlwaysOn {
-						return fmt.Errorf("always_on feature has to be turned off before switching to a free/shared Sku")
+						return fmt.Errorf("always_on cannot be set to true when using Free, F1, D1 Sku")
 					}
 				}
 			}

--- a/internal/services/appservice/windows_web_app_resource.go
+++ b/internal/services/appservice/windows_web_app_resource.go
@@ -608,7 +608,9 @@ func (r WindowsWebAppResource) Read() sdk.ResourceFunc {
 			}
 
 			siteConfig := helpers.SiteConfigWindows{}
-			siteConfig.Flatten(webAppSiteConfig.SiteConfig, currentStack)
+			if err := siteConfig.Flatten(webAppSiteConfig.SiteConfig, currentStack); err != nil {
+				return err
+			}
 			siteConfig.SetHealthCheckEvictionTime(state.AppSettings)
 			state.AppSettings = siteConfig.ParseNodeVersion(state.AppSettings)
 

--- a/internal/services/appservice/windows_web_app_resource.go
+++ b/internal/services/appservice/windows_web_app_resource.go
@@ -591,7 +591,11 @@ func (r WindowsWebAppResource) Read() sdk.ResourceFunc {
 				}
 
 				if hostingEnv := props.HostingEnvironmentProfile; hostingEnv != nil {
-					state.HostingEnvId = pointer.From(hostingEnv.ID)
+					hostingEnvId, err := parse.AppServiceEnvironmentIDInsensitively(*hostingEnv.ID)
+					if err != nil {
+						return err
+					}
+					state.HostingEnvId = hostingEnvId.ID()
 				}
 
 				if subnetId := pointer.From(props.VirtualNetworkSubnetID); subnetId != "" {

--- a/internal/services/appservice/windows_web_app_resource.go
+++ b/internal/services/appservice/windows_web_app_resource.go
@@ -90,6 +90,7 @@ func (r WindowsWebAppResource) Arguments() map[string]*pluginsdk.Schema {
 			Elem: &pluginsdk.Schema{
 				Type: pluginsdk.TypeString,
 			},
+			ValidateFunc: validate.AppSettings,
 		},
 
 		"auth_settings": helpers.AuthSettingsSchema(),

--- a/internal/services/appservice/windows_web_app_resource.go
+++ b/internal/services/appservice/windows_web_app_resource.go
@@ -327,7 +327,7 @@ func (r WindowsWebAppResource) Create() sdk.ResourceFunc {
 			currentStack := ""
 			if len(sc.ApplicationStack) == 1 {
 				currentStack = sc.ApplicationStack[0].CurrentStack
-				if currentStack == helpers.CurrentStackNode {
+				if currentStack == helpers.CurrentStackNode || sc.ApplicationStack[0].NodeVersion != "" {
 					if webApp.AppSettings == nil {
 						webApp.AppSettings = make(map[string]string, 0)
 					}

--- a/internal/services/appservice/windows_web_app_resource.go
+++ b/internal/services/appservice/windows_web_app_resource.go
@@ -3,7 +3,6 @@ package appservice
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"strconv"
 	"strings"
 	"time"
@@ -13,6 +12,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/appservice/helpers"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/appservice/parse"
@@ -319,7 +319,10 @@ func (r WindowsWebAppResource) Create() sdk.ResourceFunc {
 				}
 			}
 
-			siteConfig := sc.ExpandForCreate(webApp.AppSettings)
+			siteConfig, err := sc.ExpandForCreate(webApp.AppSettings)
+			if err != nil {
+				return err
+			}
 
 			currentStack := ""
 			if len(sc.ApplicationStack) == 1 {
@@ -783,7 +786,10 @@ func (r WindowsWebAppResource) Update() sdk.ResourceFunc {
 			}
 
 			if metadata.ResourceData.HasChange("site_config") || servicePlanChange {
-				existing.SiteConfig = sc.ExpandForUpdate(metadata, existing.SiteConfig, state.AppSettings)
+				existing.SiteConfig, err = sc.ExpandForUpdate(metadata, existing.SiteConfig, state.AppSettings)
+				if err != nil {
+					return err
+				}
 			}
 
 			updateFuture, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.SiteName, existing)

--- a/internal/services/appservice/windows_web_app_resource.go
+++ b/internal/services/appservice/windows_web_app_resource.go
@@ -563,7 +563,6 @@ func (r WindowsWebAppResource) Read() sdk.ResourceFunc {
 				state = WindowsWebAppModel{
 					Name:                          id.SiteName,
 					ResourceGroup:                 id.ResourceGroup,
-					ServicePlanId:                 pointer.From(props.ServerFarmID),
 					Location:                      location.NormalizeNilable(webApp.Location),
 					AuthSettings:                  helpers.FlattenAuthSettings(auth),
 					AuthV2Settings:                helpers.FlattenAuthV2Settings(authV2),
@@ -589,6 +588,13 @@ func (r WindowsWebAppResource) Read() sdk.ResourceFunc {
 					PossibleOutboundIPAddressList: strings.Split(pointer.From(props.PossibleOutboundIPAddresses), ","),
 					Tags:                          tags.ToTypedObject(webApp.Tags),
 				}
+
+				serverFarmId, err := parse.ServicePlanID(pointer.From(props.ServerFarmID))
+				if err != nil {
+					return fmt.Errorf("parsing Service Plan ID for %s: %+v", id, err)
+				}
+
+				state.ServicePlanId = serverFarmId.ID()
 
 				if hostingEnv := props.HostingEnvironmentProfile; hostingEnv != nil {
 					hostingEnvId, err := parse.AppServiceEnvironmentIDInsensitively(*hostingEnv.ID)

--- a/internal/services/appservice/windows_web_app_resource_test.go
+++ b/internal/services/appservice/windows_web_app_resource_test.go
@@ -1151,6 +1151,20 @@ func TestAccWindowsWebApp_withAutoHealRulesStatusCodeRange(t *testing.T) {
 		data.ImportStep(),
 	})
 }
+func TestAccWindowsWebApp_withAutoHealRulesSubStatus(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_web_app", "test")
+	r := WindowsWebAppResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.autoHealRulesSubStatus(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
 
 func TestAccWindowsWebApp_withAutoHealRulesSlowRequest(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_windows_web_app", "test")
@@ -2617,6 +2631,48 @@ resource "azurerm_windows_web_app" "test" {
       action {
         action_type                    = "Recycle"
         minimum_process_execution_time = "00:05:00"
+      }
+    }
+  }
+}
+`, r.baseTemplate(data), data.RandomInteger)
+}
+
+func (r WindowsWebAppResource) autoHealRulesSubStatus(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_windows_web_app" "test" {
+  name                = "acctestWA-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  service_plan_id     = azurerm_service_plan.test.id
+
+  site_config {
+    auto_heal_enabled = true
+
+    auto_heal_setting {
+      trigger {
+        status_code {
+          count = 1
+          status_code_range = 500
+          sub_status = 37
+          interval = "00:01:00"
+        }
+        status_code {
+         count = 1
+         status_code_range = 500
+         sub_status = 30
+         win32_status = 0
+         interval = "00:10:00"
+        }
+      }
+      action {
+        action_type = "Recycle"
       }
     }
   }

--- a/internal/services/appservice/windows_web_app_resource_test.go
+++ b/internal/services/appservice/windows_web_app_resource_test.go
@@ -2338,37 +2338,6 @@ resource "azurerm_windows_web_app" "test" {
 `, r.baseTemplate(data), data.RandomInteger, dotNetVersion)
 }
 
-func (r WindowsWebAppResource) dockerMCR(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-%s
-
-resource "azurerm_windows_web_app" "test" {
-  name                = "acctestWA-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  service_plan_id     = azurerm_service_plan.test.id
-
-  app_settings = {
-    "DOCKER_REGISTRY_SERVER_URL"          = "https://mcr.microsoft.com"
-    "DOCKER_REGISTRY_SERVER_USERNAME"     = ""
-    "DOCKER_REGISTRY_SERVER_PASSWORD"     = ""
-    "WEBSITES_ENABLE_APP_SERVICE_STORAGE" = "false"
-  }
-
-  site_config {
-    application_stack {
-      docker_container_name = "windows-cssc/python3.7servercore"
-      docker_container_tag  = "ltsc2022"
-    }
-  }
-}
-`, r.premiumV3PlanContainerTemplate(data), data.RandomInteger)
-}
-
 func (r WindowsWebAppResource) dockerHub(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
@@ -2674,17 +2643,17 @@ resource "azurerm_windows_web_app" "test" {
     auto_heal_setting {
       trigger {
         status_code {
-          count = 1
+          count             = 1
           status_code_range = 500
-          sub_status = 37
-          interval = "00:01:00"
+          sub_status        = 37
+          interval          = "00:01:00"
         }
         status_code {
-         count = 1
-         status_code_range = 500
-         sub_status = 30
-         win32_status = 0
-         interval = "00:10:00"
+          count             = 1
+          status_code_range = 500
+          sub_status        = 30
+          win32_status      = 0
+          interval          = "00:10:00"
         }
       }
       action {
@@ -2716,18 +2685,18 @@ resource "azurerm_windows_web_app" "test" {
     auto_heal_setting {
       trigger {
         status_code {
-          count = 4
-          interval = "00:10:00"
+          count             = 4
+          interval          = "00:10:00"
           status_code_range = "403"
         }
         status_code {
-          count = 4
-          interval = "00:20:00"
+          count             = 4
+          interval          = "00:20:00"
           status_code_range = "500-599"
         }
         status_code {
-          count = 4
-          interval = "00:12:00"
+          count             = 4
+          interval          = "00:12:00"
           status_code_range = "400-401"
         }
       }

--- a/internal/services/appservice/windows_web_app_resource_test.go
+++ b/internal/services/appservice/windows_web_app_resource_test.go
@@ -823,33 +823,6 @@ func TestAccWindowsWebApp_withJava110414Tomcat10020(t *testing.T) {
 	})
 }
 
-func TestAccWindowsWebApp_dockerMCR(t *testing.T) {
-	if features.FourPointOhBeta() {
-		t.Skipf("Skippped as deprecated property removed in 4.0")
-	}
-
-	data := acceptance.BuildTestData(t, "azurerm_windows_web_app", "test")
-	r := WindowsWebAppResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.dockerMCR(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("site_config.0.windows_fx_version").HasValue("DOCKER|windows-cssc/python3.7.2nanoserver:ltsc2022"),
-			),
-		},
-		data.ImportStep("app_settings.%",
-			"site_config.0.application_stack.0.docker_container_name",
-			"site_config.0.application_stack.0.docker_container_tag",
-			"site_config.0.application_stack.0.docker_image_name",
-			"site_config.0.application_stack.0.docker_registry_url",
-			"app_settings.DOCKER_REGISTRY_SERVER_PASSWORD",
-			"app_settings.DOCKER_REGISTRY_SERVER_URL",
-			"app_settings.DOCKER_REGISTRY_SERVER_USERNAME"),
-	})
-}
-
 func TestAccWindowsWebApp_dockerHub(t *testing.T) {
 	if features.FourPointOhBeta() {
 		t.Skipf("Skippped as deprecated property removed in 4.0")
@@ -890,7 +863,7 @@ func TestAccWindowsWebApp_withDockerDeprecatedUpgrade(t *testing.T) {
 			Config: r.dockerHub(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("site_config.0.windows_fx_version").HasValue("DOCKER|hello-world:latest"),
+				check.That(data.ResourceName).Key("site_config.0.windows_fx_version").HasValue("DOCKER|traefik:windowsservercore-1809"),
 			),
 		},
 		data.ImportStep("app_settings.%",
@@ -2358,8 +2331,8 @@ resource "azurerm_windows_web_app" "test" {
 
   site_config {
     application_stack {
-      docker_container_name = "hello-world"
-      docker_container_tag  = "latest"
+      docker_container_name = "windows-cssc/python3.7servercore"
+      docker_container_tag  = "ltsc2022"
     }
   }
 }

--- a/internal/services/appservice/windows_web_app_resource_test.go
+++ b/internal/services/appservice/windows_web_app_resource_test.go
@@ -2358,10 +2358,8 @@ resource "azurerm_windows_web_app" "test" {
 
   site_config {
     application_stack {
-      docker_container_name = "windows-cssc/python3.7.2nanoserver"
-      docker_container_tag  = "ltsc2022"
-      //docker_container_name = "azure-app-service/windows/parkingpage"
-      //docker_container_tag  = "latest"
+      docker_container_name = "hello-world"
+      docker_container_tag  = "latest"
     }
   }
 }

--- a/internal/services/appservice/windows_web_app_slot_resource.go
+++ b/internal/services/appservice/windows_web_app_slot_resource.go
@@ -300,7 +300,7 @@ func (r WindowsWebAppSlotResource) Create() sdk.ResourceFunc {
 			currentStack := ""
 			if len(sc.ApplicationStack) == 1 {
 				currentStack = sc.ApplicationStack[0].CurrentStack
-				if currentStack == helpers.CurrentStackNode {
+				if currentStack == helpers.CurrentStackNode || sc.ApplicationStack[0].NodeVersion != "" {
 					if webAppSlot.AppSettings == nil {
 						webAppSlot.AppSettings = make(map[string]string, 0)
 					}
@@ -574,10 +574,6 @@ func (r WindowsWebAppSlotResource) Read() sdk.ResourceFunc {
 			}
 
 			state.AppSettings = helpers.FlattenWebStringDictionary(appSettings)
-			if err != nil {
-				return fmt.Errorf("flattening app settings for Windows %s: %+v", id, err)
-			}
-
 			currentStack := ""
 			currentStackPtr, ok := siteMetadata.Properties["CURRENT_STACK"]
 			if ok {

--- a/internal/services/appservice/windows_web_app_slot_resource.go
+++ b/internal/services/appservice/windows_web_app_slot_resource.go
@@ -761,6 +761,15 @@ func (r WindowsWebAppSlotResource) Update() sdk.ResourceFunc {
 				return fmt.Errorf("wating to update %s: %+v", id, err)
 			}
 
+			// (@jackofallops) - Windows Web App Slots need the siteConfig sending individually to actually accept the `windowsFxVersion` value or it's set as `DOCKER|` only.
+			siteConfigUpdate := web.SiteConfigResource{
+				SiteConfig: existing.SiteConfig,
+			}
+			_, err = client.UpdateConfigurationSlot(ctx, id.ResourceGroup, id.SiteName, siteConfigUpdate, id.SlotName)
+			if err != nil {
+				return fmt.Errorf("updating %s site config: %+v", id, err)
+			}
+
 			siteMetadata := web.StringDictionary{Properties: map[string]*string{}}
 			siteMetadata.Properties["CURRENT_STACK"] = pointer.To(currentStack)
 			if _, err := client.UpdateMetadataSlot(ctx, id.ResourceGroup, id.SiteName, siteMetadata, id.SlotName); err != nil {

--- a/internal/services/appservice/windows_web_app_slot_resource.go
+++ b/internal/services/appservice/windows_web_app_slot_resource.go
@@ -3,7 +3,6 @@ package appservice
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"strconv"
 	"strings"
 	"time"
@@ -12,6 +11,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/appservice/helpers"
@@ -292,7 +292,10 @@ func (r WindowsWebAppSlotResource) Create() sdk.ResourceFunc {
 			}
 
 			sc := webAppSlot.SiteConfig[0]
-			siteConfig := sc.ExpandForCreate(webAppSlot.AppSettings)
+			siteConfig, err := sc.ExpandForCreate(webAppSlot.AppSettings)
+			if err != nil {
+				return err
+			}
 
 			currentStack := ""
 			if len(sc.ApplicationStack) == 1 {
@@ -735,7 +738,10 @@ func (r WindowsWebAppSlotResource) Update() sdk.ResourceFunc {
 			}
 
 			if metadata.ResourceData.HasChange("site_config") {
-				existing.SiteConfig = sc.ExpandForUpdate(metadata, existing.SiteConfig, state.AppSettings)
+				existing.SiteConfig, err = sc.ExpandForUpdate(metadata, existing.SiteConfig, state.AppSettings)
+				if err != nil {
+					return err
+				}
 			}
 
 			if metadata.ResourceData.HasChange("virtual_network_subnet_id") {

--- a/internal/services/appservice/windows_web_app_slot_resource.go
+++ b/internal/services/appservice/windows_web_app_slot_resource.go
@@ -103,6 +103,7 @@ func (r WindowsWebAppSlotResource) Arguments() map[string]*pluginsdk.Schema {
 			Elem: &pluginsdk.Schema{
 				Type: pluginsdk.TypeString,
 			},
+			ValidateFunc: validate.AppSettings,
 		},
 
 		"auth_settings": helpers.AuthSettingsSchema(),

--- a/internal/services/appservice/windows_web_app_slot_resource.go
+++ b/internal/services/appservice/windows_web_app_slot_resource.go
@@ -559,8 +559,13 @@ func (r WindowsWebAppSlotResource) Read() sdk.ResourceFunc {
 				}
 
 				if hostingEnv := props.HostingEnvironmentProfile; hostingEnv != nil {
-					state.HostingEnvId = pointer.From(hostingEnv.ID)
+					hostingEnvId, err := parse.AppServiceEnvironmentIDInsensitively(*hostingEnv.ID)
+					if err != nil {
+						return err
+					}
+					state.HostingEnvId = hostingEnvId.ID()
 				}
+
 				parentAppFarmId, err := parse.ServicePlanIDInsensitively(*webApp.SiteProperties.ServerFarmID)
 				if err != nil {
 					return err

--- a/internal/services/appservice/windows_web_app_slot_resource_test.go
+++ b/internal/services/appservice/windows_web_app_slot_resource_test.go
@@ -3,6 +3,7 @@ package appservice_test
 import (
 	"context"
 	"fmt"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"testing"
 
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
@@ -797,15 +798,117 @@ func TestAccWindowsWebAppSlot_withJava11014Tomcat9(t *testing.T) {
 	})
 }
 
-func TestAccWindowsWebAppSlot_withDocker(t *testing.T) {
+func TestAccWindowsWebAppSlot_withDockerHub(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skipf("Skippped as deprecated property removed in 4.0")
+	}
+
 	data := acceptance.BuildTestData(t, "azurerm_windows_web_app_slot", "test")
 	r := WindowsWebAppSlotResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.docker(data),
+			Config: r.dockerHub(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("app_settings.%",
+			"site_config.0.application_stack.0.docker_container_name",
+			"site_config.0.application_stack.0.docker_container_tag",
+			"site_config.0.application_stack.0.docker_image_name",
+			"site_config.0.application_stack.0.docker_registry_url",
+			"app_settings.DOCKER_REGISTRY_SERVER_PASSWORD",
+			"app_settings.DOCKER_REGISTRY_SERVER_URL",
+			"app_settings.DOCKER_REGISTRY_SERVER_USERNAME"),
+	})
+}
+
+func TestAccWindowsWebAppSlot_withDockerMCR(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skipf("Skippped as deprecated property removed in 4.0")
+	}
+
+	data := acceptance.BuildTestData(t, "azurerm_windows_web_app_slot", "test")
+	r := WindowsWebAppSlotResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.dockerMCR(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("app_settings.%",
+			"site_config.0.application_stack.0.docker_container_name",
+			"site_config.0.application_stack.0.docker_container_tag",
+			"site_config.0.application_stack.0.docker_image_name",
+			"site_config.0.application_stack.0.docker_registry_url",
+			"app_settings.DOCKER_REGISTRY_SERVER_PASSWORD",
+			"app_settings.DOCKER_REGISTRY_SERVER_URL",
+			"app_settings.DOCKER_REGISTRY_SERVER_USERNAME"),
+	})
+}
+
+func TestAccWindowsWebAppSlot_withDockerDeprecatedUpgrade(t *testing.T) {
+	if features.FourPointOhBeta() {
+		t.Skipf("Skippped as deprecated property removed in 4.0")
+	}
+
+	data := acceptance.BuildTestData(t, "azurerm_windows_web_app_slot", "test")
+	r := WindowsWebAppSlotResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.dockerMCR(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("app_settings.%",
+			"site_config.0.application_stack.0.docker_container_name",
+			"site_config.0.application_stack.0.docker_container_tag",
+			"site_config.0.application_stack.0.docker_image_name",
+			"site_config.0.application_stack.0.docker_registry_url",
+			"app_settings.DOCKER_REGISTRY_SERVER_PASSWORD",
+			"app_settings.DOCKER_REGISTRY_SERVER_URL",
+			"app_settings.DOCKER_REGISTRY_SERVER_USERNAME"),
+		{
+			Config: r.dockerImageName(data, "https://index.docker.io", "hello-world:latest"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("site_config.0.windows_fx_version").HasValue("DOCKER|hello-world:latest"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccWindowsWebAppSlot_withDockerImageMCR(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_web_app", "test")
+	r := WindowsWebAppSlotResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.dockerImageName(data, "https://mcr.microsoft.com", "azure-app-service/windows/parkingpage:latest"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("site_config.0.windows_fx_version").HasValue("DOCKER|mcr.microsoft.com/azure-app-service/windows/parkingpage:latest"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccWindowsWebAppSlot_withDockerImageDockerHub(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_web_app", "test")
+	r := WindowsWebAppSlotResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.dockerImageName(data, "https://index.docker.io", "traefik:windowsservercore-1809"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("site_config.0.windows_fx_version").HasValue("DOCKER|traefik:windowsservercore-1809"),
 			),
 		},
 		data.ImportStep(),
@@ -1753,7 +1856,7 @@ resource "azurerm_windows_web_app_slot" "test" {
 `, r.baseTemplate(data), data.RandomInteger, javaVersion, tomcatVersion)
 }
 
-func (r WindowsWebAppSlotResource) docker(data acceptance.TestData) string {
+func (r WindowsWebAppSlotResource) dockerHub(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -1774,12 +1877,67 @@ resource "azurerm_windows_web_app_slot" "test" {
 
   site_config {
     application_stack {
-      docker_container_name = "%s"
-      docker_container_tag  = "%s"
+      docker_container_name = "traefik"
+      docker_container_tag  = "windowsservercore-1809"
     }
   }
 }
-`, r.premiumV3PlanContainerTemplate(data), data.RandomInteger, "hello-world", "latest")
+`, r.premiumV3PlanContainerTemplateDocker(data), data.RandomInteger)
+}
+
+func (r WindowsWebAppSlotResource) dockerMCR(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_windows_web_app_slot" "test" {
+  name           = "acctestWAS-%d"
+  app_service_id = azurerm_windows_web_app.test.id
+
+  app_settings = {
+    "DOCKER_REGISTRY_SERVER_URL"          = "https://mcr.microsoft.com"
+    "DOCKER_REGISTRY_SERVER_USERNAME"     = ""
+    "DOCKER_REGISTRY_SERVER_PASSWORD"     = ""
+    "WEBSITES_ENABLE_APP_SERVICE_STORAGE" = "false"
+  }
+
+  site_config {
+    application_stack {
+      docker_container_name = "azure-app-service/windows/parkingpage"
+      docker_container_tag  = "latest"
+    }
+  }
+}
+`, r.premiumV3PlanContainerTemplate(data), data.RandomInteger)
+}
+
+func (r WindowsWebAppSlotResource) dockerImageName(data acceptance.TestData, registryUrl, containerImage string) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_windows_web_app_slot" "test" {
+  name           = "acctestWAS-%d"
+  app_service_id = azurerm_windows_web_app.test.id
+
+  app_settings = {
+    "WEBSITES_ENABLE_APP_SERVICE_STORAGE" = "false"
+  }
+
+  site_config {
+    application_stack {
+      docker_image_name   = "%s"
+      docker_registry_url = "%s"
+    }
+  }
+}
+`, r.premiumV3PlanContainerTemplate(data), data.RandomInteger, containerImage, registryUrl)
 }
 
 func (r WindowsWebAppSlotResource) identitySystemAssigned(data acceptance.TestData) string {
@@ -2105,6 +2263,45 @@ resource "azurerm_windows_web_app" "test" {
   service_plan_id     = azurerm_service_plan.test.id
 
   site_config {}
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func (WindowsWebAppSlotResource) premiumV3PlanContainerTemplateDocker(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_service_plan" "test" {
+  name                = "acctestASP-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku_name            = "P1v3"
+  os_type             = "WindowsContainer"
+}
+
+resource "azurerm_windows_web_app" "test" {
+  name                = "acctestWA-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  service_plan_id     = azurerm_service_plan.test.id
+
+  app_settings = {
+    "DOCKER_REGISTRY_SERVER_URL"          = "https://index.docker.io"
+    "DOCKER_REGISTRY_SERVER_USERNAME"     = ""
+    "DOCKER_REGISTRY_SERVER_PASSWORD"     = ""
+    "WEBSITES_ENABLE_APP_SERVICE_STORAGE" = "false"
+  }
+
+  site_config {
+    application_stack {
+      docker_container_name = "traefik"
+      docker_container_tag  = "windowsservercore-1809"
+    }
+  }
 }
 `, data.RandomInteger, data.Locations.Primary)
 }

--- a/internal/services/appservice/windows_web_app_slot_resource_test.go
+++ b/internal/services/appservice/windows_web_app_slot_resource_test.go
@@ -1906,8 +1906,8 @@ resource "azurerm_windows_web_app_slot" "test" {
 
   site_config {
     application_stack {
-      docker_container_name = "azure-app-service/windows/parkingpage"
-      docker_container_tag  = "latest"
+      docker_container_name = "windows-cssc/python3.7.2nanoserver"
+      docker_container_tag  = "ltsc2022"
     }
   }
 }

--- a/internal/services/appservice/windows_web_app_slot_resource_test.go
+++ b/internal/services/appservice/windows_web_app_slot_resource_test.go
@@ -3,12 +3,12 @@ package appservice_test
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"testing"
 
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/appservice/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"

--- a/internal/services/appservice/windows_web_app_slot_resource_test.go
+++ b/internal/services/appservice/windows_web_app_slot_resource_test.go
@@ -824,32 +824,6 @@ func TestAccWindowsWebAppSlot_withDockerHub(t *testing.T) {
 	})
 }
 
-func TestAccWindowsWebAppSlot_withDockerMCR(t *testing.T) {
-	if features.FourPointOhBeta() {
-		t.Skipf("Skippped as deprecated property removed in 4.0")
-	}
-
-	data := acceptance.BuildTestData(t, "azurerm_windows_web_app_slot", "test")
-	r := WindowsWebAppSlotResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.dockerMCR(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.ImportStep("app_settings.%",
-			"site_config.0.application_stack.0.docker_container_name",
-			"site_config.0.application_stack.0.docker_container_tag",
-			"site_config.0.application_stack.0.docker_image_name",
-			"site_config.0.application_stack.0.docker_registry_url",
-			"app_settings.DOCKER_REGISTRY_SERVER_PASSWORD",
-			"app_settings.DOCKER_REGISTRY_SERVER_URL",
-			"app_settings.DOCKER_REGISTRY_SERVER_USERNAME"),
-	})
-}
-
 func TestAccWindowsWebAppSlot_withDockerDeprecatedUpgrade(t *testing.T) {
 	if features.FourPointOhBeta() {
 		t.Skipf("Skippped as deprecated property removed in 4.0")
@@ -860,9 +834,10 @@ func TestAccWindowsWebAppSlot_withDockerDeprecatedUpgrade(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.dockerMCR(data),
+			Config: r.dockerHub(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("site_config.0.windows_fx_version").HasValue("DOCKER|traefik:windowsservercore-1809"),
 			),
 		},
 		data.ImportStep("app_settings.%",
@@ -1906,7 +1881,7 @@ resource "azurerm_windows_web_app_slot" "test" {
 
   site_config {
     application_stack {
-      docker_container_name = "windows-cssc/python3.7.2nanoserver"
+      docker_container_name = "windows-cssc/python3.7servercore"
       docker_container_tag  = "ltsc2022"
     }
   }

--- a/internal/services/appservice/windows_web_app_slot_resource_test.go
+++ b/internal/services/appservice/windows_web_app_slot_resource_test.go
@@ -885,7 +885,7 @@ func TestAccWindowsWebAppSlot_withDockerDeprecatedUpgrade(t *testing.T) {
 }
 
 func TestAccWindowsWebAppSlot_withDockerImageMCR(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_windows_web_app", "test")
+	data := acceptance.BuildTestData(t, "azurerm_windows_web_app_slot", "test")
 	r := WindowsWebAppSlotResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -900,7 +900,7 @@ func TestAccWindowsWebAppSlot_withDockerImageMCR(t *testing.T) {
 }
 
 func TestAccWindowsWebAppSlot_withDockerImageDockerHub(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_windows_web_app", "test")
+	data := acceptance.BuildTestData(t, "azurerm_windows_web_app_slot", "test")
 	r := WindowsWebAppSlotResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{

--- a/internal/services/appservice/windows_web_app_slot_resource_test.go
+++ b/internal/services/appservice/windows_web_app_slot_resource_test.go
@@ -1860,35 +1860,6 @@ resource "azurerm_windows_web_app_slot" "test" {
 `, r.premiumV3PlanContainerTemplateDocker(data), data.RandomInteger)
 }
 
-func (r WindowsWebAppSlotResource) dockerMCR(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-%s
-
-resource "azurerm_windows_web_app_slot" "test" {
-  name           = "acctestWAS-%d"
-  app_service_id = azurerm_windows_web_app.test.id
-
-  app_settings = {
-    "DOCKER_REGISTRY_SERVER_URL"          = "https://mcr.microsoft.com"
-    "DOCKER_REGISTRY_SERVER_USERNAME"     = ""
-    "DOCKER_REGISTRY_SERVER_PASSWORD"     = ""
-    "WEBSITES_ENABLE_APP_SERVICE_STORAGE" = "false"
-  }
-
-  site_config {
-    application_stack {
-      docker_container_name = "windows-cssc/python3.7servercore"
-      docker_container_tag  = "ltsc2022"
-    }
-  }
-}
-`, r.premiumV3PlanContainerTemplate(data), data.RandomInteger)
-}
-
 func (r WindowsWebAppSlotResource) dockerImageName(data acceptance.TestData, registryUrl, containerImage string) string {
 	return fmt.Sprintf(`
 provider "azurerm" {

--- a/website/docs/d/linux_web_app.html.markdown
+++ b/website/docs/d/linux_web_app.html.markdown
@@ -129,13 +129,13 @@ An `application_logs` block exports the following:
 
 An `application_stack` block exports the following:
 
-* `docker_image_name` - (Optional) The docker image, including tag, to be used
+* `docker_image_name` - The docker image, including tag, used by this Linux Web App.
 
-* `docker_registry_url` - (Optional) The URL of the container registry where the `docker_image_name` is located. e.g. `https://index.docker.io` or `https://mcr.microsoft.com`. This value is required with `docker_image_name`.
+* `docker_registry_url` - The URL of the container registry where the `docker_image_name` is located.
 
-* `docker_registry_username` - (Optional) The User Name to use for authentication against the registry to pull the image.
+* `docker_registry_username` - The User Name to use for authentication against the registry to pull the image.
 
-* `docker_registry_password` - (Optional) The User Name to use for authentication against the registry to pull the image.
+* `docker_registry_password` - The User Name to use for authentication against the registry to pull the image.
 
 * `dotnet_version` - The version of .NET in use.
 

--- a/website/docs/d/linux_web_app.html.markdown
+++ b/website/docs/d/linux_web_app.html.markdown
@@ -129,9 +129,13 @@ An `application_logs` block exports the following:
 
 An `application_stack` block exports the following:
 
-* `docker_image` - The Docker image reference, including repository.
+* `docker_image_name` - (Optional) The docker image, including tag, to be used
 
-* `docker_image_tag` - The image Tag.
+* `docker_registry_url` - (Optional) The URL of the container registry where the `docker_image_name` is located. e.g. `https://index.docker.io` or `https://mcr.microsoft.com`. This value is required with `docker_image_name`.
+
+* `docker_registry_username` - (Optional) The User Name to use for authentication against the registry to pull the image.
+
+* `docker_registry_password` - (Optional) The User Name to use for authentication against the registry to pull the image.
 
 * `dotnet_version` - The version of .NET in use.
 

--- a/website/docs/d/windows_web_app.html.markdown
+++ b/website/docs/d/windows_web_app.html.markdown
@@ -131,13 +131,13 @@ An `application_stack` block exports the following:
 
 * `current_stack` - The Current Stack value of the Windows Web App.
 
-* `docker_image_name` - (Optional) The docker image, including tag, to be used
+* `docker_image_name` - The docker image, including tag, used by this Windows Web App.
 
-* `docker_registry_url` - (Optional) The URL of the container registry where the `docker_image_name` is located. e.g. `https://index.docker.io` or `https://mcr.microsoft.com`. This value is required with `docker_image_name`.
+* `docker_registry_url` - The URL of the container registry where the `docker_image_name` is located.
 
-* `docker_registry_username` - (Optional) The User Name to use for authentication against the registry to pull the image.
+* `docker_registry_username` - The User Name to use for authentication against the registry to pull the image.
 
-* `docker_registry_password` - (Optional) The User Name to use for authentication against the registry to pull the image.
+* `docker_registry_password` - The User Name to use for authentication against the registry to pull the image.
 
 * `dotnet_version` - The version of .NET in use.
 

--- a/website/docs/d/windows_web_app.html.markdown
+++ b/website/docs/d/windows_web_app.html.markdown
@@ -131,11 +131,13 @@ An `application_stack` block exports the following:
 
 * `current_stack` - The Current Stack value of the Windows Web App.
 
-* `docker_container_name` - The name of the Docker Container in used.
+* `docker_image_name` - (Optional) The docker image, including tag, to be used
 
-* `docker_container_registry` - The Container Registry where the Docker Container is pulled from.
+* `docker_registry_url` - (Optional) The URL of the container registry where the `docker_image_name` is located. e.g. `https://index.docker.io` or `https://mcr.microsoft.com`. This value is required with `docker_image_name`.
 
-* `docker_container_tag` - The Docker Container Tag of the Container in use.
+* `docker_registry_username` - (Optional) The User Name to use for authentication against the registry to pull the image.
+
+* `docker_registry_password` - (Optional) The User Name to use for authentication against the registry to pull the image.
 
 * `dotnet_version` - The version of .NET in use.
 

--- a/website/docs/r/linux_web_app.html.markdown
+++ b/website/docs/r/linux_web_app.html.markdown
@@ -146,6 +146,8 @@ An `application_stack` block supports the following:
 
 * `docker_registry_password` - (Optional) The User Name to use for authentication against the registry to pull the image.
 
+~> **NOTE:** `docker_registry_url`, `docker_registry_username`, and `docker_registry_password` replace the use of the `app_settings` values of `DOCKER_REGISTRY_SERVER_URL`, `DOCKER_REGISTRY_SERVER_USERNAME` and `DOCKER_REGISTRY_SERVER_PASSWORD` respectively, these values will be managed by the provider and should not be specified in the `app_settings` map.
+
 * `dotnet_version` - (Optional) The version of .NET to use. Possible values include `3.1`, `5.0`, `6.0` and `7.0`.
 
 * `go_version` - (Optional) The version of Go to use. Possible values include `1.18`, and `1.19`.

--- a/website/docs/r/linux_web_app.html.markdown
+++ b/website/docs/r/linux_web_app.html.markdown
@@ -138,7 +138,7 @@ An `application_logs` block supports the following:
 An `application_stack` block supports the following:
 
 
-* `docker_image_name` - (Optional) The docker image, including tag, to be used
+* `docker_image_name` - (Optional) The docker image, including tag, to be used. e.g. `appsvc/staticsite:latest`.
 
 * `docker_registry_url` - (Optional) The URL of the container registry where the `docker_image_name` is located. e.g. `https://index.docker.io` or `https://mcr.microsoft.com`. This value is required with `docker_image_name`.
 

--- a/website/docs/r/linux_web_app.html.markdown
+++ b/website/docs/r/linux_web_app.html.markdown
@@ -137,9 +137,14 @@ An `application_logs` block supports the following:
 
 An `application_stack` block supports the following:
 
-* `docker_image` - (Optional) The Docker image reference, including repository host as needed.
 
-* `docker_image_tag` - (Optional) The image Tag to use. e.g. `latest`.
+* `docker_image_name` - (Optional) The docker image, including tag, to be used
+
+* `docker_registry_url` - (Optional) The URL of the container registry where the `docker_image_name` is located. e.g. `https://index.docker.io` or `https://mcr.microsoft.com`. This value is required with `docker_image_name`.
+
+* `docker_registry_username` - (Optional) The User Name to use for authentication against the registry to pull the image.
+
+* `docker_registry_password` - (Optional) The User Name to use for authentication against the registry to pull the image.
 
 * `dotnet_version` - (Optional) The version of .NET to use. Possible values include `3.1`, `5.0`, `6.0` and `7.0`.
 

--- a/website/docs/r/linux_web_app_slot.html.markdown
+++ b/website/docs/r/linux_web_app_slot.html.markdown
@@ -140,9 +140,13 @@ An `application_logs` block supports the following:
 
 An `application_stack` block supports the following:
 
-* `docker_image` - (Optional) The Docker image reference, including repository host as needed.
+* `docker_image_name` - (Optional) The docker image, including tag, to be used
 
-* `docker_image_tag` - (Optional) The image Tag to use. e.g. `latest`.
+* `docker_registry_url` - (Optional) The URL of the container registry where the `docker_image_name` is located. e.g. `https://index.docker.io` or `https://mcr.microsoft.com`. This value is required with `docker_image_name`.
+
+* `docker_registry_username` - (Optional) The User Name to use for authentication against the registry to pull the image.
+
+* `docker_registry_password` - (Optional) The User Name to use for authentication against the registry to pull the image.
 
 * `dotnet_version` - (Optional) The version of .NET to use. Possible values include `3.1`, `5.0`, `6.0` and `7.0`.
 

--- a/website/docs/r/linux_web_app_slot.html.markdown
+++ b/website/docs/r/linux_web_app_slot.html.markdown
@@ -148,6 +148,8 @@ An `application_stack` block supports the following:
 
 * `docker_registry_password` - (Optional) The User Name to use for authentication against the registry to pull the image.
 
+~> **NOTE:** `docker_registry_url`, `docker_registry_username`, and `docker_registry_password` replace the use of the `app_settings` values of `DOCKER_REGISTRY_SERVER_URL`, `DOCKER_REGISTRY_SERVER_USERNAME` and `DOCKER_REGISTRY_SERVER_PASSWORD` respectively, these values will be managed by the provider and should not be specified in the `app_settings` map.
+
 * `dotnet_version` - (Optional) The version of .NET to use. Possible values include `3.1`, `5.0`, `6.0` and `7.0`.
 
 * `go_version` - (Optional) The version of Go to use. Possible values include `1.18`, and `1.19`.

--- a/website/docs/r/linux_web_app_slot.html.markdown
+++ b/website/docs/r/linux_web_app_slot.html.markdown
@@ -140,7 +140,7 @@ An `application_logs` block supports the following:
 
 An `application_stack` block supports the following:
 
-* `docker_image_name` - (Optional) The docker image, including tag, to be used
+* `docker_image_name` - (Optional) The docker image, including tag, to be used. e.g. `appsvc/staticsite:latest`.
 
 * `docker_registry_url` - (Optional) The URL of the container registry where the `docker_image_name` is located. e.g. `https://index.docker.io` or `https://mcr.microsoft.com`. This value is required with `docker_image_name`.
 

--- a/website/docs/r/windows_web_app.html.markdown
+++ b/website/docs/r/windows_web_app.html.markdown
@@ -142,11 +142,13 @@ An `application_stack` block supports the following:
 
 ~> **NOTE:** Whilst this property is Optional omitting it can cause unexpected behaviour, in particular for display of settings in the Azure Portal.
 
-* `docker_container_name` - (Optional) The name of the Docker Container. For example `azure-app-service/samples/aspnethelloworld`
+* `docker_image_name` - (Optional) The docker image, including tag, to be used
 
-* `docker_container_registry` - (Optional) The registry Host on which the specified Docker Container can be located. For example `mcr.microsoft.com`
+* `docker_registry_url` - (Optional) The URL of the container registry where the `docker_image_name` is located. e.g. `https://index.docker.io` or `https://mcr.microsoft.com`. This value is required with `docker_image_name`.
 
-* `docker_container_tag` - (Optional) The Image Tag of the specified Docker Container to use. For example `latest`
+* `docker_registry_username` - (Optional) The User Name to use for authentication against the registry to pull the image.
+
+* `docker_registry_password` - (Optional) The User Name to use for authentication against the registry to pull the image.
 
 * `dotnet_version` - (Optional) The version of .NET to use when `current_stack` is set to `dotnet`. Possible values include `v2.0`,`v3.0`, `v4.0`, `v5.0`, `v6.0` and `v7.0`.
 

--- a/website/docs/r/windows_web_app.html.markdown
+++ b/website/docs/r/windows_web_app.html.markdown
@@ -150,6 +150,8 @@ An `application_stack` block supports the following:
 
 * `docker_registry_password` - (Optional) The User Name to use for authentication against the registry to pull the image.
 
+~> **NOTE:** `docker_registry_url`, `docker_registry_username`, and `docker_registry_password` replace the use of the `app_settings` values of `DOCKER_REGISTRY_SERVER_URL`, `DOCKER_REGISTRY_SERVER_USERNAME` and `DOCKER_REGISTRY_SERVER_PASSWORD` respectively, these values will be managed by the provider and should not be specified in the `app_settings` map.
+
 * `dotnet_version` - (Optional) The version of .NET to use when `current_stack` is set to `dotnet`. Possible values include `v2.0`,`v3.0`, `v4.0`, `v5.0`, `v6.0` and `v7.0`.
 
 ~> **NOTE:** The Portal displayed values and the actual underlying API values differ for this setting, as follows:

--- a/website/docs/r/windows_web_app.html.markdown
+++ b/website/docs/r/windows_web_app.html.markdown
@@ -142,7 +142,7 @@ An `application_stack` block supports the following:
 
 ~> **NOTE:** Whilst this property is Optional omitting it can cause unexpected behaviour, in particular for display of settings in the Azure Portal.
 
-* `docker_image_name` - (Optional) The docker image, including tag, to be used
+* `docker_image_name` - (Optional) The docker image, including tag, to be used. e.g. `azure-app-service/windows/parkingpage:latest`.
 
 * `docker_registry_url` - (Optional) The URL of the container registry where the `docker_image_name` is located. e.g. `https://index.docker.io` or `https://mcr.microsoft.com`. This value is required with `docker_image_name`.
 

--- a/website/docs/r/windows_web_app_slot.html.markdown
+++ b/website/docs/r/windows_web_app_slot.html.markdown
@@ -146,7 +146,7 @@ An `application_stack` block supports the following:
 
 ~> **NOTE:** Whilst this property is Optional omitting it can cause unexpected behaviour, in particular for display of settings in the Azure Portal.
 
-* `docker_image_name` - (Optional) The docker image, including tag, to be used
+* `docker_image_name` - (Optional) The docker image, including tag, to be used. e.g. `azure-app-service/windows/parkingpage:latest`.
 
 * `docker_registry_url` - (Optional) The URL of the container registry where the `docker_image_name` is located. e.g. `https://index.docker.io` or `https://mcr.microsoft.com`. This value is required with `docker_image_name`.
 

--- a/website/docs/r/windows_web_app_slot.html.markdown
+++ b/website/docs/r/windows_web_app_slot.html.markdown
@@ -154,6 +154,8 @@ An `application_stack` block supports the following:
 
 * `docker_registry_password` - (Optional) The User Name to use for authentication against the registry to pull the image.
 
+~> **NOTE:** `docker_registry_url`, `docker_registry_username`, and `docker_registry_password` replace the use of the `app_settings` values of `DOCKER_REGISTRY_SERVER_URL`, `DOCKER_REGISTRY_SERVER_USERNAME` and `DOCKER_REGISTRY_SERVER_PASSWORD` respectively, these values will be managed by the provider and should not be specified in the `app_settings` map.
+
 * `dotnet_version` - (Optional) The version of .NET to use when `current_stack` is set to `dotnet`. Possible values include `v2.0`,`v3.0`, `v4.0`, `v5.0`, `v6.0` and `v7.0`.
 
 * `dotnet_core_version` - (Optional) The version of .NET to use when `current_stack` is set to `dotnetcore`. Possible values include `v4.0`.

--- a/website/docs/r/windows_web_app_slot.html.markdown
+++ b/website/docs/r/windows_web_app_slot.html.markdown
@@ -146,11 +146,13 @@ An `application_stack` block supports the following:
 
 ~> **NOTE:** Whilst this property is Optional omitting it can cause unexpected behaviour, in particular for display of settings in the Azure Portal.
 
-* `docker_container_name` - (Optional) The name of the Docker Container. For example `azure-app-service/samples/aspnethelloworld`
+* `docker_image_name` - (Optional) The docker image, including tag, to be used
 
-* `docker_container_registry` - (Optional) The registry Host on which the specified Docker Container can be located. For example `mcr.microsoft.com`
+* `docker_registry_url` - (Optional) The URL of the container registry where the `docker_image_name` is located. e.g. `https://index.docker.io` or `https://mcr.microsoft.com`. This value is required with `docker_image_name`.
 
-* `docker_container_tag` - (Optional) The Image Tag of the specified Docker Container to use. For example `latest`
+* `docker_registry_username` - (Optional) The User Name to use for authentication against the registry to pull the image.
+
+* `docker_registry_password` - (Optional) The User Name to use for authentication against the registry to pull the image.
 
 * `dotnet_version` - (Optional) The version of .NET to use when `current_stack` is set to `dotnet`. Possible values include `v2.0`,`v3.0`, `v4.0`, `v5.0`, `v6.0` and `v7.0`.
 


### PR DESCRIPTION
Also fixes Docker `app_stack` functionality throughout.

* `azurerm_linux_web_app` - deprecated `docker_image` and `docker_image_tag` in favour of `docker_image_name`, `docker_registry_url`, `docker_registry_username`, and `docker_registry_password`. These settings now manage the respective `app_settings` values of the same name.
* `azurerm_linux_web_app_slot` - deprecated `docker_image` and `docker_image_tag` in favour of `docker_image_name`, `docker_registry_url`, `docker_registry_username`, and `docker_registry_password`. These settings now manage the respective `app_settings` values of the same name.
* `azurerm_windows_web_app` - deprecated `docker_container_registry`, `docker_container_name`, and `docker_container_tag` in favour of `docker_image_name`, `docker_registry_url`, `docker_registry_username`, and `docker_registry_password`. These settings now manage the respective `app_settings` values of the same name.
* `azurerm_windows_web_app_slot` - deprecated `docker_container_registry`, `docker_container_name`, and `docker_container_tag` in favour of `docker_image_name`, `docker_registry_url`, `docker_registry_username`, and `docker_registry_password`. These settings now manage the respective `app_settings` values of the same name.

** Breaking Change **
Due to a change in the underlying data type for the API and a related bug in the provider, the `win32_status` property of the `status_code` block in `auto_heal` has change from `string` to `int`. 

example:
```
resource "azurerm_windows_web_app" “example” {
  name                = "example-app"
  location            = azurerm_resource_group.example.location
  resource_group_name = azurerm_resource_group.example.name
  service_plan_id     = azurerm_service_plan.example.id

  site_config {
    auto_heal_enabled = true

    auto_heal_setting {
      trigger {
        status_code {
          count             = 1
          status_code_range = 500
          sub_status        = 30
          win32_status      = 230 # <-- Here
          interval          = "00:10:00"
        }
      }
      action {
        action_type = "Recycle"
      }
    }
  }
}

```


fixes #17862 (supersedes #21831)
supersedes #20735
