### PR TITLE
Add `resource_id` to `azurerm_shared_image_version`

### DIFF
--- a/internal/services/compute/shared_image_versions_data_source.go
+++ b/internal/services/compute/shared_image_versions_data_source.go
@@ -45,6 +45,11 @@ func dataSourceSharedImageVersions() *pluginsdk.Resource {
 				Computed: true,
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
+						"id": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+
 						"name": {
 							Type:     pluginsdk.TypeString,
 							Computed: true,
@@ -141,7 +146,7 @@ func flattenSharedImageVersions(input []compute.GalleryImageVersion, filterTags 
 	results := make([]interface{}, 0)
 
 	for _, imageVersion := range input {
-		flattenedIPAddress := flattenSharedImageVersion(imageVersion)
+		flattenedImageVersion := flattenSharedImageVersion(imageVersion)
 		found := true
 		// Loop through our filter tags and see if they match
 		for k, v := range filterTags {
@@ -154,7 +159,7 @@ func flattenSharedImageVersions(input []compute.GalleryImageVersion, filterTags 
 		}
 
 		if found {
-			results = append(results, flattenedIPAddress)
+			results = append(results, flattenedImageVersion)
 		}
 	}
 
@@ -164,6 +169,7 @@ func flattenSharedImageVersions(input []compute.GalleryImageVersion, filterTags 
 func flattenSharedImageVersion(input compute.GalleryImageVersion) map[string]interface{} {
 	output := make(map[string]interface{})
 
+	output["id"] = input.ID
 	output["name"] = input.Name
 	output["location"] = location.NormalizeNilable(input.Location)
 

--- a/internal/services/compute/shared_image_versions_data_source_test.go
+++ b/internal/services/compute/shared_image_versions_data_source_test.go
@@ -28,6 +28,7 @@ func TestAccDataSourceSharedImageVersions_basic(t *testing.T) {
 		{
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("images.0.id").Exists(),
 				check.That(data.ResourceName).Key("images.0.managed_image_id").Exists(),
 				check.That(data.ResourceName).Key("images.0.target_region.#").HasValue("1"),
 				check.That(data.ResourceName).Key("images.0.target_region.0.storage_account_type").HasValue("Standard_LRS"),

--- a/website/docs/d/shared_image_versions.html.markdown
+++ b/website/docs/d/shared_image_versions.html.markdown
@@ -49,6 +49,10 @@ A `images` block exports the following:
 
 * `managed_image_id` - The ID of the Managed Image which was the source of this Shared Image Version.
 
+* `name` - The name of the Image Version.
+
+* `id` - The ID of this Shared Image Version.
+
 * `target_region` - One or more `target_region` blocks as documented below.
 
 * `tags` - A mapping of tags assigned to the Shared Image.


### PR DESCRIPTION
Added the `resource_id` to the images block.
Added the above and missing name field to the docs
Renamed `flattenedIPAddress` to `flattenedImageVersion` as I believe this name was a typo
Updated test case to check for `resource_id`