### PR TITLE
Replace usages of actions-ecosystem/action-remove-labels github action

### DIFF
--- a/.github/workflows/issue-comment-created.yaml
+++ b/.github/workflows/issue-comment-created.yaml
@@ -10,28 +10,31 @@ permissions:
   issues: write
 
 jobs:
-  issue_comment_triage:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions-ecosystem/action-remove-labels@2ce5d41b4b6aa8503e285553f75ed56e0a40bae0 # v1.3.0
-        with:
-          github_token: "${{ secrets.GITHUB_TOKEN }}"
-          labels: stale
-      - uses: actions-ecosystem/action-remove-labels@2ce5d41b4b6aa8503e285553f75ed56e0a40bae0 # v1.3.0
-        if: ${{ !github.event.issue.pull_request }}
-        with:
-          github_token: "${{ secrets.GITHUB_TOKEN }}"
-          labels: waiting-response
-      - uses: actions-ecosystem/action-remove-labels@2ce5d41b4b6aa8503e285553f75ed56e0a40bae0 # v1.3.0
-        if: (github.event.issue.pull_request && github.actor == github.event.issue.user.login)
-        with:
-          github_token: "${{ secrets.GITHUB_TOKEN }}"
-          labels: waiting-response
+  remove-stale:
+    uses: ./.github/workflows/remove-issue-label.yml
+    with:
+      label-name: "stale"
+  remove-waiting-response-from-issue:
+    uses: ./.github/workflows/remove-issue-label.yml
+    if: ${{ !github.event.issue.pull_request }}
+    with:
+      label-name: "waiting-response"
+  remove-waiting-response-from-pr:
+    uses: ./.github/workflows/remove-issue-label.yml
+    if: (github.event.issue.pull_request && github.actor == github.event.issue.user.login)
+    with:
+      label-name: "waiting-response"
 
   pull_request_comment:
     runs-on: ubuntu-latest
     if: github.event.issue.pull_request && endsWith(github.event.comment.body, '/wr')
     steps:
-      - shell: bash
-        run: |
-          curl -X POST -H "Accept: application/vnd.github+json" -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos${{ github.owner }}/${{ github.repository }}/issues/${{ github.event.issue.number }}/labels" -d '{"labels":["waiting-response"]}'
+      - uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ["waiting-response"]
+            })

--- a/.github/workflows/pull-request-new-commit.yaml
+++ b/.github/workflows/pull-request-new-commit.yaml
@@ -9,10 +9,7 @@ on:
     types: [synchronize]
 
 jobs:
-  issue_comment_triage:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions-ecosystem/action-remove-labels@2ce5d41b4b6aa8503e285553f75ed56e0a40bae0 # v1.3.0
-        with:
-          github_token: "${{ secrets.GITHUB_TOKEN }}"
-          labels: waiting-response
+  remove-waiting-response:
+    uses: ./.github/workflows/remove-issue-label.yml
+    with:
+      label-name: "waiting-response"

--- a/.github/workflows/pull-request-reviewed-workflow.yaml
+++ b/.github/workflows/pull-request-reviewed-workflow.yaml
@@ -19,6 +19,7 @@ jobs:
       ghowner: ${{ steps.env_vars.outputs.ghowner }}
       prnumber: ${{ steps.env_vars.outputs.prnumber }}
       action: ${{ steps.env_vars.outputs.action }}
+      artifact_outcome: ${{ steps.env_vars.outputs.artifact_outcome }}
     steps:
       - name: Get Artifact
         id: get_artifact
@@ -36,13 +37,19 @@ jobs:
           echo "ghowner=$(cat artifact/ghowner.txt)" >>${GITHUB_OUTPUT}
           echo "prnumber=$(cat artifact/prnumber.txt)" >>${GITHUB_OUTPUT}
           echo "action=$(cat artifact/action.txt)" >>${GITHUB_OUTPUT}
+          echo "artifact_outcome=success" >>${GITHUB_OUTPUT}
 
-      - name: add waiting-reponse
-        if: steps.get_artifact.outcome == 'success' && steps.env_vars.outputs.action == 'add-waiting-response'
-        run: |
-          curl -X POST -H "Accept: application/vnd.github+json" -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos${{ steps.env_vars.outputs.ghowner }}/${{ steps.env_vars.outputs.ghrepo }}/issues/${{ steps.env_vars.outputs.prnumber }}/labels" -d '{"labels":["waiting-response"]}'
+  add-waiting-reponse:
+    needs: add-or-remove-waiting-response
+    runs-on: ubuntu-latest
+    if: needs.add-or-remove-waiting-response.outputs.artifact_outcome == 'success' && needs.add-or-remove-waiting-response.outputs.action == 'add-waiting-response'
+    steps:
+      - run: |
+          curl -X POST -H "Accept: application/vnd.github+json" -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos${{ needs.add-or-remove-waiting-response.outputs.ghowner }}/${{ needs.add-or-remove-waiting-response.outputs.ghrepo }}/issues/${{ needs.add-or-remove-waiting-response.outputs.prnumber }}/labels" -d '{"labels":["waiting-response"]}'
 
-      - name: remove waiting-reponse
-        if: steps.get_artifact.outcome == 'success' && steps.env_vars.outputs.action == 'remove-waiting-response'
-        run: |
-          curl -X DELETE -H "Accept: application/vnd.github+json" -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos${{ steps.env_vars.outputs.ghowner }}/${{ steps.env_vars.outputs.ghrepo }}/issues/${{ steps.env_vars.outputs.prnumber }}/labels/waiting-response"
+  remove-waiting-reponse:
+    needs: add-or-remove-waiting-response
+    if: needs.add-or-remove-waiting-response.outputs.artifact_outcome == 'success' && needs.add-or-remove-waiting-response.outputs.action == 'remove-waiting-response'
+    uses: ./.github/workflows/remove-issue-label.yml
+    with:
+      label-name: "waiting-response"

--- a/.github/workflows/remove-issue-label.yml
+++ b/.github/workflows/remove-issue-label.yml
@@ -1,0 +1,50 @@
+name: Remove specified label from issue
+
+on:
+  # This file is reused, and called from other workflows
+  workflow_call:
+    inputs:
+      label-name:
+        required: true
+        type: string
+
+
+jobs:
+  remove-label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v6
+        env:
+          REMOVE_LABEL: ${{ inputs.label-name }}
+        with:
+          script: |
+            const { REMOVE_LABEL } = process.env
+            console.log(`Attempting to remove label "${REMOVE_LABEL}"`)
+            
+            const { data } = await github.rest.issues.listLabelsOnIssue({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            })
+            
+            // Return early if there are no labels
+            if (data.length == 0){
+              console.log(`Issue has no labels; not attempting to remove label "${REMOVE_LABEL}"`)
+              return
+            }
+            
+            // Check if REMOVE_LABEL is present
+            const filteredData = data.filter(label => label.name == REMOVE_LABEL)
+            
+            // Return early if filtering didn't identify the label as present
+            if (filteredData.length == 0){
+              console.log(`Label "${REMOVE_LABEL}" not found on issue; not attempting to remove it.`)
+              return
+            }
+            console.log(`Label "${REMOVE_LABEL}" found! Now deleting it from the issue...`)
+            await github.rest.issues.removeLabel({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: REMOVE_LABEL
+            })


### PR DESCRIPTION
Replacing  actions-ecosystem/action-remove-labels because it is using node12 which will no longer be supported by Github soon. 

Borrowing remove-issue-label.yml from: https://github.com/hashicorp/terraform-provider-vsphere/pull/1914 