### PR TITLE
Update mssql_server_extended_auditing_policy.html.markdown

### DIFF
--- a/website/docs/r/mssql_server_extended_auditing_policy.html.markdown
+++ b/website/docs/r/mssql_server_extended_auditing_policy.html.markdown
@@ -268,7 +268,7 @@ The following arguments are supported:
 
 * `log_monitoring_enabled` - (Optional) Enable audit events to Azure Monitor? To enable server audit events to Azure Monitor, please enable its main database audit events to Azure Monitor. Defaults to `true`.
 
-* `storage_account_subscription_id` - (Optional) The ID of the Subscription containing the Storage Account.
+* `storage_account_subscription_id` - (Optional) The ID of the Subscription containing the Storage Account. **Note:** Required if a storage_endpoint has been specified.  
 
 ## Attributes Reference
 


### PR DESCRIPTION
Per Azure support, the storage_account_subscription_id is required if a storage_endpoint has been specified.   The provider doesn't flag this error & it requires UI intervention to make it work if this is omitted.   Customer Exeter Finance discovered this for us.