### PR TITLE
Fixed Hub Route Table documentation from "A route block" to "One or more route"

### DIFF
--- a/website/docs/r/virtual_hub_route_table.html.markdown
+++ b/website/docs/r/virtual_hub_route_table.html.markdown
@@ -88,7 +88,7 @@ The following arguments are supported:
 
 * `labels` - (Optional) List of labels associated with this route table.
 
-* `route` - (Optional) One or more `route` block as defined below.
+* `route` - (Optional) One or more `route` blocks as defined below.
 
 ---
 

--- a/website/docs/r/virtual_hub_route_table.html.markdown
+++ b/website/docs/r/virtual_hub_route_table.html.markdown
@@ -88,7 +88,7 @@ The following arguments are supported:
 
 * `labels` - (Optional) List of labels associated with this route table.
 
-* `route` - (Optional) A `route` block as defined below.
+* `route` - (Optional) One or more `route` block as defined below.
 
 ---
 


### PR DESCRIPTION
I was running tests and verified that I can attach multiple routes in a hub route table, where as the documentation only mentioned "a route block". 

Attaching supporting files for it as well.

TF File:
![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/4947393/df625ef7-00da-4c8b-9a09-e443fae1ffff)

Successful State File:
![null](https://github.com/hashicorp/terraform-provider-azurerm/assets/4947393/9a2b0b5f-88fc-492d-9f59-4da82139ac73)

