### PR TITLE
New Resource: `azurerm_role_assignment_marketplace`

### DIFF
--- a/internal/services/authorization/parse/role_assignment_marketplace.go
+++ b/internal/services/authorization/parse/role_assignment_marketplace.go
@@ -1,0 +1,46 @@
+package parse
+
+import (
+	"fmt"
+	"strings"
+)
+
+type RoleAssignmentMarketplaceId struct {
+	Name     string
+	TenantId string
+}
+
+func (id RoleAssignmentMarketplaceId) AzureResourceID() string {
+	return fmt.Sprintf("/providers/Microsoft.Marketplace/providers/Microsoft.Authorization/roleAssignments/%s", id.Name)
+}
+
+func RoleAssignmentMarketplaceID(input string) (*RoleAssignmentMarketplaceId, error) {
+	if len(input) == 0 {
+		return nil, fmt.Errorf("Role Assignment Marketplace ID is empty string")
+	}
+
+	roleAssignmentId := RoleAssignmentMarketplaceId{}
+
+	parts := strings.Split(input, "|")
+	if len(parts) == 2 {
+		input = parts[0]
+		roleAssignmentId.TenantId = parts[1]
+	}
+
+	idParts := strings.Split(input, "/providers/Microsoft.Authorization/roleAssignments/")
+	if len(idParts) != 2 {
+		return nil, fmt.Errorf("could not parse Role Assignment Marketplace ID %q", input)
+	}
+
+	if idParts[0] != "/providers/Microsoft.Marketplace" {
+		return nil, fmt.Errorf("resource provider %s is invalid", idParts[0])
+	}
+
+	if idParts[1] == "" {
+		return nil, fmt.Errorf("ID was missing a value for the roleAssignments element")
+	}
+
+	roleAssignmentId.Name = idParts[1]
+
+	return &roleAssignmentId, nil
+}

--- a/internal/services/authorization/parse/role_assignment_marketplace_test.go
+++ b/internal/services/authorization/parse/role_assignment_marketplace_test.go
@@ -1,0 +1,67 @@
+package parse
+
+import "testing"
+
+func TestRoleAssignmentMarketplaceID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *RoleAssignmentMarketplaceId
+	}{
+		{
+			Input: "",
+			Error: true,
+		},
+
+		{
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			Input: "/providers/Microsoft.Marketplace/providers/Microsoft.Authorization/roleAssignments/",
+			Error: true,
+		},
+
+		{
+			Input: "/providers/Microsoft.Subscription/providers/Microsoft.Authorization/roleAssignments/23456781-2349-8764-5631-234567890121",
+			Error: true,
+		},
+
+		{
+			Input: "/providers/Microsoft.Marketplace/providers/Microsoft.Authorization/roleAssignments/23456781-2349-8764-5631-234567890121",
+			Expected: &RoleAssignmentMarketplaceId{
+				Name: "23456781-2349-8764-5631-234567890121",
+			},
+		},
+
+		{
+			Input: "/providers/Microsoft.Marketplace/providers/Microsoft.Authorization/roleAssignments/23456781-2349-8764-5631-234567890121|12345678-1234-5678-1234-567890123456",
+			Expected: &RoleAssignmentMarketplaceId{
+				Name:     "23456781-2349-8764-5631-234567890121",
+				TenantId: "12345678-1234-5678-1234-567890123456",
+			},
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := RoleAssignmentMarketplaceID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("expected a value but got an error: %+v", err)
+		}
+
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.Name != v.Expected.Name {
+			t.Fatalf("Expected %q but got %q for Role Assignment Name", v.Expected.Name, actual.Name)
+		}
+	}
+}

--- a/internal/services/authorization/registration.go
+++ b/internal/services/authorization/registration.go
@@ -36,7 +36,8 @@ func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
 // SupportedResources returns the supported Resources supported by this Service
 func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 	return map[string]*pluginsdk.Resource{
-		"azurerm_role_assignment": resourceArmRoleAssignment(),
-		"azurerm_role_definition": resourceArmRoleDefinition(),
+		"azurerm_role_assignment":             resourceArmRoleAssignment(),
+		"azurerm_role_assignment_marketplace": resourceArmRoleAssignmentMarketplace(),
+		"azurerm_role_definition":             resourceArmRoleDefinition(),
 	}
 }

--- a/internal/services/authorization/role_assignment_marketplace_resource.go
+++ b/internal/services/authorization/role_assignment_marketplace_resource.go
@@ -1,0 +1,262 @@
+package authorization
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/preview/authorization/mgmt/2020-04-01-preview/authorization" // nolint: staticcheck
+	"github.com/hashicorp/go-uuid"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/authorization/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/suppress"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+const (
+	MarketplaceScope = "/providers/Microsoft.Marketplace"
+)
+
+func resourceArmRoleAssignmentMarketplace() *pluginsdk.Resource {
+	return &pluginsdk.Resource{
+		Create: resourceArmRoleAssignmentMarketplaceCreate,
+		Read:   resourceArmRoleAssignmentMarketplaceRead,
+		Delete: resourceArmRoleAssignmentMarketplaceDelete,
+
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := parse.RoleAssignmentMarketplaceID(id)
+			return err
+		}),
+
+		Timeouts: &pluginsdk.ResourceTimeout{
+			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
+			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
+			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
+			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*pluginsdk.Schema{
+			"principal_id": {
+				Type:     pluginsdk.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"name": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.IsUUID,
+			},
+
+			"role_definition_id": {
+				Type:             pluginsdk.TypeString,
+				Optional:         true,
+				Computed:         true,
+				ForceNew:         true,
+				ConflictsWith:    []string{"role_definition_name"},
+				DiffSuppressFunc: suppress.CaseDifference,
+			},
+
+			"role_definition_name": {
+				Type:             pluginsdk.TypeString,
+				Optional:         true,
+				Computed:         true,
+				ForceNew:         true,
+				ConflictsWith:    []string{"role_definition_id"},
+				DiffSuppressFunc: suppress.CaseDifference,
+				ValidateFunc:     validation.StringIsNotEmpty,
+			},
+
+			"principal_type": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
+			"skip_service_principal_aad_check": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+
+			"delegated_managed_identity_resource_id": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: azure.ValidateResourceID,
+			},
+
+			"description": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
+			},
+		},
+	}
+}
+
+func resourceArmRoleAssignmentMarketplaceCreate(d *pluginsdk.ResourceData, meta interface{}) error {
+	roleAssignmentsClient := meta.(*clients.Client).Authorization.RoleAssignmentsClient
+	roleDefinitionsClient := meta.(*clients.Client).Authorization.RoleDefinitionsClient
+	subscriptionClient := meta.(*clients.Client).Subscription.Client
+	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
+	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	name := d.Get("name").(string)
+
+	var roleDefinitionId string
+	if v, ok := d.GetOk("role_definition_id"); ok {
+		roleDefinitionId = v.(string)
+	} else if v, ok := d.GetOk("role_definition_name"); ok {
+		roleName := v.(string)
+		roleDefinitions, err := roleDefinitionsClient.List(ctx, MarketplaceScope, fmt.Sprintf("roleName eq '%s'", roleName))
+		if err != nil {
+			return fmt.Errorf("loading Role Definition List: %+v", err)
+		}
+		if len(roleDefinitions.Values()) != 1 {
+			return fmt.Errorf("loading Role Definition List: could not find role '%s'", roleName)
+		}
+		roleDefinitionId = *roleDefinitions.Values()[0].ID
+	} else {
+		return fmt.Errorf("Error: either role_definition_id or role_definition_name needs to be set")
+	}
+	d.Set("role_definition_id", roleDefinitionId)
+
+	principalId := d.Get("principal_id").(string)
+
+	if name == "" {
+		uuid, err := uuid.GenerateUUID()
+		if err != nil {
+			return fmt.Errorf("generating UUID for Role Assignment: %+v", err)
+		}
+
+		name = uuid
+	}
+
+	tenantId := ""
+	delegatedManagedIdentityResourceID := d.Get("delegated_managed_identity_resource_id").(string)
+	if len(delegatedManagedIdentityResourceID) > 0 {
+		var err error
+		tenantId, err = getTenantIdBySubscriptionId(ctx, subscriptionClient, subscriptionId)
+		if err != nil {
+			return err
+		}
+	}
+
+	existing, err := roleAssignmentsClient.Get(ctx, MarketplaceScope, name, tenantId)
+	if err != nil {
+		if !utils.ResponseWasNotFound(existing.Response) {
+			return fmt.Errorf("checking for presence of existing Role Assignment ID for %q: %+v", name, err)
+		}
+	}
+
+	if existing.ID != nil && *existing.ID != "" {
+		return tf.ImportAsExistsError("azurerm_role_assignment_marketplace", *existing.ID)
+	}
+
+	properties := authorization.RoleAssignmentCreateParameters{
+		RoleAssignmentProperties: &authorization.RoleAssignmentProperties{
+			RoleDefinitionID: utils.String(roleDefinitionId),
+			PrincipalID:      utils.String(principalId),
+			Description:      utils.String(d.Get("description").(string)),
+		},
+	}
+
+	if len(delegatedManagedIdentityResourceID) > 0 {
+		properties.RoleAssignmentProperties.DelegatedManagedIdentityResourceID = utils.String(delegatedManagedIdentityResourceID)
+	}
+
+	skipPrincipalCheck := d.Get("skip_service_principal_aad_check").(bool)
+	if skipPrincipalCheck {
+		properties.RoleAssignmentProperties.PrincipalType = authorization.ServicePrincipal
+	}
+
+	if err := pluginsdk.Retry(d.Timeout(pluginsdk.TimeoutCreate), retryRoleAssignmentsClient(d, MarketplaceScope, name, properties, meta, tenantId)); err != nil {
+		return err
+	}
+
+	read, err := roleAssignmentsClient.Get(ctx, MarketplaceScope, name, tenantId)
+	if err != nil {
+		return err
+	}
+	if read.ID == nil {
+		return fmt.Errorf("cannot read Role Assignment ID for %q", name)
+	}
+
+	d.SetId(parse.ConstructRoleAssignmentId(*read.ID, tenantId))
+	return resourceArmRoleAssignmentMarketplaceRead(d, meta)
+}
+
+func resourceArmRoleAssignmentMarketplaceRead(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Authorization.RoleAssignmentsClient
+	roleDefinitionsClient := meta.(*clients.Client).Authorization.RoleDefinitionsClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.RoleAssignmentMarketplaceID(d.Id())
+	if err != nil {
+		return err
+	}
+	resp, err := client.GetByID(ctx, id.AzureResourceID(), id.TenantId)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("[DEBUG] Role Assignment ID %q was not found - removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("loading Role Assignment %q: %+v", d.Id(), err)
+	}
+
+	d.Set("name", resp.Name)
+
+	if props := resp.RoleAssignmentPropertiesWithScope; props != nil {
+		d.Set("role_definition_id", props.RoleDefinitionID)
+		d.Set("principal_id", props.PrincipalID)
+		d.Set("principal_type", props.PrincipalType)
+		d.Set("delegated_managed_identity_resource_id", props.DelegatedManagedIdentityResourceID)
+		d.Set("description", props.Description)
+
+		// allows for import when role name is used (also if the role name changes a plan will show a diff)
+		if roleId := props.RoleDefinitionID; roleId != nil {
+			roleResp, err := roleDefinitionsClient.GetByID(ctx, *roleId)
+			if err != nil {
+				return fmt.Errorf("loading Role Definition %q: %+v", *roleId, err)
+			}
+
+			if roleProps := roleResp.RoleDefinitionProperties; roleProps != nil {
+				d.Set("role_definition_name", roleProps.RoleName)
+			}
+		}
+	}
+
+	return nil
+}
+
+func resourceArmRoleAssignmentMarketplaceDelete(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Authorization.RoleAssignmentsClient
+	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.RoleAssignmentMarketplaceID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Delete(ctx, MarketplaceScope, id.Name, id.TenantId)
+	if err != nil {
+		if !utils.ResponseWasNotFound(resp.Response) {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/internal/services/authorization/role_assignment_marketplace_resource_test.go
+++ b/internal/services/authorization/role_assignment_marketplace_resource_test.go
@@ -44,7 +44,7 @@ func TestAccRoleAssignmentMarketplace_roleName(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("role_definition_id").Exists(),
-				check.That(data.ResourceName).Key("role_definition_name").HasValue("Marketplace Admin"),
+				check.That(data.ResourceName).Key("role_definition_name").HasValue("Log Analytics Reader"),
 			),
 		},
 		data.ImportStep("skip_service_principal_aad_check"),
@@ -63,7 +63,7 @@ func TestAccRoleAssignmentMarketplace_requiresImport(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("role_definition_id").Exists(),
-				check.That(data.ResourceName).Key("role_definition_name").HasValue("Marketplace Admin"),
+				check.That(data.ResourceName).Key("role_definition_name").HasValue("Log Analytics Reader"),
 			),
 		},
 		{
@@ -181,7 +181,7 @@ data "azurerm_client_config" "test" {
 
 resource "azurerm_role_assignment_marketplace" "test" {
   name                 = "%s"
-  role_definition_name = "Marketplace Admin"
+  role_definition_name = "Log Analytics Reader"
   principal_id         = data.azurerm_client_config.test.object_id
 }
 `, id)

--- a/internal/services/authorization/role_assignment_marketplace_resource_test.go
+++ b/internal/services/authorization/role_assignment_marketplace_resource_test.go
@@ -63,7 +63,7 @@ func TestAccRoleAssignmentMarketplace_requiresImport(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("role_definition_id").Exists(),
-				check.That(data.ResourceName).Key("role_definition_name").HasValue("Log Analytics Reader"),
+				check.That(data.ResourceName).Key("role_definition_name").HasValue("Marketplace Admin"),
 			),
 		},
 		{

--- a/internal/services/authorization/role_assignment_marketplace_resource_test.go
+++ b/internal/services/authorization/role_assignment_marketplace_resource_test.go
@@ -1,0 +1,275 @@
+package authorization_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/authorization/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+type RoleAssignmentMarketplaceResource struct{}
+
+func TestAccRoleAssignmentMarketplace_emptyName(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_role_assignment_marketplace", "test")
+	r := RoleAssignmentMarketplaceResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.emptyNameConfig(),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("name").Exists(),
+			),
+		},
+		data.ImportStep("skip_service_principal_aad_check"),
+	})
+}
+
+func TestAccRoleAssignmentMarketplace_roleName(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_role_assignment_marketplace", "test")
+	id := uuid.New().String()
+
+	r := RoleAssignmentMarketplaceResource{}
+
+	data.ResourceSequentialTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.roleNameConfig(id),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("role_definition_id").Exists(),
+				check.That(data.ResourceName).Key("role_definition_name").HasValue("Marketplace Admin"),
+			),
+		},
+		data.ImportStep("skip_service_principal_aad_check"),
+	})
+}
+
+func TestAccRoleAssignmentMarketplace_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_role_assignment_marketplace", "test")
+	id := uuid.New().String()
+
+	r := RoleAssignmentMarketplaceResource{}
+
+	data.ResourceSequentialTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.roleNameConfig(id),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("role_definition_id").Exists(),
+				check.That(data.ResourceName).Key("role_definition_name").HasValue("Log Analytics Reader"),
+			),
+		},
+		{
+			Config:      r.requiresImportConfig(id),
+			ExpectError: acceptance.RequiresImportError("azurerm_role_assignment_marketplace"),
+		},
+	})
+}
+
+func TestAccRoleAssignmentMarketplace_builtin(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_role_assignment_marketplace", "test")
+	id := uuid.New().String()
+
+	r := RoleAssignmentMarketplaceResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.builtinConfig(id),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("skip_service_principal_aad_check"),
+	})
+}
+
+func TestAccRoleAssignmentMarketplace_ServicePrincipal(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_role_assignment_marketplace", "test")
+	ri := acceptance.RandTimeInt()
+	id := uuid.New().String()
+
+	r := RoleAssignmentMarketplaceResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.servicePrincipal(ri, id),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				acceptance.TestCheckResourceAttr(data.ResourceName, "principal_type", "ServicePrincipal"),
+			),
+		},
+	})
+}
+
+func TestAccRoleAssignmentMarketplace_ServicePrincipalWithType(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_role_assignment_marketplace", "test")
+	ri := acceptance.RandTimeInt()
+	id := uuid.New().String()
+
+	r := RoleAssignmentMarketplaceResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.servicePrincipalWithType(ri, id),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+	})
+}
+
+func TestAccRoleAssignmentMarketplace_ServicePrincipalGroup(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_role_assignment_marketplace", "test")
+	ri := acceptance.RandTimeInt()
+	id := uuid.New().String()
+
+	r := RoleAssignmentMarketplaceResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.group(ri, id),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+	})
+}
+
+func (r RoleAssignmentMarketplaceResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := parse.RoleAssignmentMarketplaceID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.Authorization.RoleAssignmentsClient.GetByID(ctx, state.ID, "")
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			return utils.Bool(false), nil
+		}
+		return nil, fmt.Errorf("retrieving Role Assignment for role %q: %+v", id.Name, err)
+	}
+	return utils.Bool(true), nil
+}
+
+func (RoleAssignmentMarketplaceResource) emptyNameConfig() string {
+	return `
+data "azurerm_client_config" "test" {}
+
+data "azurerm_role_definition" "test" {
+  name = "Monitoring Reader"
+}
+
+resource "azurerm_role_assignment_marketplace" "test" {
+  role_definition_id = "${data.azurerm_role_definition.test.id}"
+  principal_id       = "${data.azurerm_client_config.test.object_id}"
+  description        = "Test Role Assignment"
+}
+`
+}
+
+func (RoleAssignmentMarketplaceResource) roleNameConfig(id string) string {
+	return fmt.Sprintf(`
+data "azurerm_client_config" "test" {
+}
+
+resource "azurerm_role_assignment_marketplace" "test" {
+  name                 = "%s"
+  role_definition_name = "Marketplace Admin"
+  principal_id         = data.azurerm_client_config.test.object_id
+}
+`, id)
+}
+
+func (RoleAssignmentMarketplaceResource) requiresImportConfig(id string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_role_assignment_marketplace" "import" {
+  name                 = azurerm_role_assignment_marketplace.test.name
+  role_definition_name = azurerm_role_assignment_marketplace.test.role_definition_name
+  principal_id         = azurerm_role_assignment_marketplace.test.principal_id
+}
+`, RoleAssignmentMarketplaceResource{}.roleNameConfig(id))
+}
+
+func (RoleAssignmentMarketplaceResource) builtinConfig(id string) string {
+	return fmt.Sprintf(`
+data "azurerm_client_config" "test" {
+}
+
+data "azurerm_role_definition" "test" {
+  name = "Site Recovery Reader"
+}
+
+resource "azurerm_role_assignment_marketplace" "test" {
+  name               = "%s"
+  role_definition_id = "${data.azurerm_role_definition.test.id}"
+  principal_id       = data.azurerm_client_config.test.object_id
+}
+`, id)
+}
+
+func (RoleAssignmentMarketplaceResource) servicePrincipal(rInt int, roleAssignmentID string) string {
+	return fmt.Sprintf(`
+provider "azuread" {}
+
+resource "azuread_application" "test" {
+  display_name = "acctestspa-%d"
+}
+
+resource "azuread_service_principal" "test" {
+  application_id = azuread_application.test.application_id
+}
+
+resource "azurerm_role_assignment_marketplace" "test" {
+  name                 = "%s"
+  role_definition_name = "Reader"
+  principal_id         = azuread_service_principal.test.id
+}
+`, rInt, roleAssignmentID)
+}
+
+func (RoleAssignmentMarketplaceResource) servicePrincipalWithType(rInt int, roleAssignmentID string) string {
+	return fmt.Sprintf(`
+provider "azuread" {}
+
+resource "azuread_application" "test" {
+  display_name = "acctestspa-%d"
+}
+
+resource "azuread_service_principal" "test" {
+  application_id = azuread_application.test.application_id
+}
+
+resource "azurerm_role_assignment_marketplace" "test" {
+  name                             = "%s"
+  role_definition_name             = "Reader"
+  principal_id                     = azuread_service_principal.test.id
+  skip_service_principal_aad_check = true
+}
+`, rInt, roleAssignmentID)
+}
+
+func (RoleAssignmentMarketplaceResource) group(rInt int, roleAssignmentID string) string {
+	return fmt.Sprintf(`
+provider "azuread" {}
+
+resource "azuread_group" "test" {
+  display_name     = "acctestspa-%d"
+  security_enabled = true
+}
+
+resource "azurerm_role_assignment_marketplace" "test" {
+  name                 = "%s"
+  role_definition_name = "Reader"
+  principal_id         = azuread_group.test.id
+}
+`, rInt, roleAssignmentID)
+}

--- a/website/docs/r/role_assignment_marketplace.html.markdown
+++ b/website/docs/r/role_assignment_marketplace.html.markdown
@@ -1,0 +1,73 @@
+---
+subcategory: "Authorization"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_role_assignment_marketplace"
+description: |-
+  Assigns a given Principal (User or Group) to a given Role at marketplace scope.
+---
+
+# azurerm_role_assignment_marketplace
+
+Assigns a given Principal (User or Group) to a given Role at marketplace scope.
+
+## Example Usage
+
+```hcl
+data "azurerm_client_config" "example" {
+}
+
+resource "azurerm_role_assignment_marketplace" "example" {
+  role_definition_name = "Marketplace Admin"
+  principal_id         = data.azurerm_client_config.example.object_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `principal_id` - (Required) The ID of the Principal (User, Group or Service Principal) to assign the Role Definition to. Changing this forces a new resource to be created.
+
+* `name` - (Optional) A unique UUID/GUID for this Role Assignment - one will be generated if not specified. Changing this forces a new resource to be created.
+
+* `role_definition_id` - (Optional) The Scoped-ID of the Role Definition. Changing this forces a new resource to be created. Conflicts with `role_definition_name`.
+
+* `role_definition_name` - (Optional) The name of a built-in Role. Changing this forces a new resource to be created. Conflicts with `role_definition_id`.
+
+~> **NOTE:** The Principal ID is also known as the Object ID (i.e. not the "Application ID" for applications). To assign Azure roles, the Principal must have `Microsoft.Authorization/roleAssignments/write` permissions. See [documentation](https://learn.microsoft.com/en-us/azure/role-based-access-control/role-assignments-portal) for more information. The calling principal must first be assigned Privileged Role Administrator (like `Owner` role) or Global Administrator. See [documentation](https://learn.microsoft.com/en-us/marketplace/create-manage-private-azure-marketplace-new#prerequisites) for more information.
+
+* `delegated_managed_identity_resource_id` - (Optional) The delegated Azure Resource ID which contains a Managed Identity. Changing this forces a new resource to be created.
+
+~> **NOTE:** this field is only used in cross tenant scenario.
+
+* `description` - (Optional) The description for this Role Assignment. Changing this forces a new resource to be created.
+  
+* `skip_service_principal_aad_check` - (Optional) If the `principal_id` is a newly provisioned `Service Principal` set this value to `true` to skip the `Azure Active Directory` check which may fail due to replication lag. This argument is only valid if the `principal_id` is a `Service Principal` identity. Defaults to `false`.
+
+~> **NOTE:** If it is not a `Service Principal` identity it will cause the role assignment to fail.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `id` - The Role Assignment ID.
+
+* `principal_type` - The type of the `principal_id`, e.g. User, Group, Service Principal, Application, etc.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Role Assignment.
+* `update` - (Defaults to 30 minutes) Used when updating the Role Assignment.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Role Assignment.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Role Assignment.
+
+## Import
+
+Role Assignments can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_role_assignment_marketplace.example /providers/Microsoft.Marketplace/providers/Microsoft.Authorization/roleAssignments/00000000-0000-0000-0000-000000000000
+```
+


### PR DESCRIPTION
### Description
fix https://github.com/hashicorp/terraform-provider-azurerm/issues/18387
extract marketplace role assignment out from `azurerm_role_assignment`  into `azurerm_role_assignment_marketplace` according to the comments in https://github.com/hashicorp/terraform-provider-azurerm/pull/18439

### Test Result
![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/76987228/043da94f-bea5-40e4-b21c-a5fef09d7d41)

--- PASS: TestAccRoleAssignmentMarketplace_roleName (68.47s)
--- PASS: TestAccRoleAssignmentMarketplace_requiresImport (62.12s)
--- PASS: TestAccRoleAssignmentMarketplace_builtin (65.51s)
--- PASS: TestAccRoleAssignmentMarketplace_emptyName (67.13s)
--- PASS: TestAccRoleAssignmentMarketplace_ServicePrincipalWithType (69.39s)
--- PASS: TestAccRoleAssignmentMarketplace_ServicePrincipalGroup (101.84s)
--- PASS: TestAccRoleAssignmentMarketplace_ServicePrincipal (101.85s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/authorization 253.538s
