### PR TITLE
`azurerm_hpc_cache` - update the `identity` property

### DIFF
--- a/internal/services/hpccache/hpc_cache_resource.go
+++ b/internal/services/hpccache/hpc_cache_resource.go
@@ -999,7 +999,7 @@ func resourceHPCCacheSchema() map[string]*pluginsdk.Schema {
 			Elem:     &pluginsdk.Schema{Type: pluginsdk.TypeString},
 		},
 
-		"identity": commonschema.UserAssignedIdentityOptionalForceNew(),
+		"identity": commonschema.SystemAssignedUserAssignedIdentityOptionalForceNew(),
 
 		"key_vault_key_id": {
 			Type:         pluginsdk.TypeString,

--- a/internal/services/hpccache/hpc_cache_resource_test.go
+++ b/internal/services/hpccache/hpc_cache_resource_test.go
@@ -1013,6 +1013,7 @@ resource "azurerm_key_vault_access_policy" "service-principal" {
     "Get",
     "Purge",
     "Update",
+    "GetRotationPolicy",
   ]
 }
 
@@ -1067,6 +1068,7 @@ resource "azurerm_key_vault_access_policy" "service-principal2" {
     "Get",
     "UnwrapKey",
     "WrapKey",
+    "GetRotationPolicy",
   ]
 }
 

--- a/internal/services/hpccache/hpc_cache_resource_test.go
+++ b/internal/services/hpccache/hpc_cache_resource_test.go
@@ -1129,7 +1129,7 @@ resource "azurerm_hpc_cache" "test" {
   cache_size_in_gb    = 3072
   subnet_id           = azurerm_subnet.test.id
   sku_name            = "Standard_2G"
-  
+
   identity {
     type = "SystemAssigned"
   }

--- a/internal/services/hpccache/hpc_cache_resource_test.go
+++ b/internal/services/hpccache/hpc_cache_resource_test.go
@@ -381,6 +381,36 @@ func TestAccHPCCache_customerManagedKeyUpdateAutoKeyRotation(t *testing.T) {
 	})
 }
 
+func TestAccHPCCache_systemAssigned(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_hpc_cache", "test")
+	r := HPCCacheResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.systemAssigned(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccHPCCache_systemAssignedAndUserAssigned(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_hpc_cache", "test")
+	r := HPCCacheResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.systemAssignedAndUserAssigned(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (HPCCacheResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := caches.ParseCacheID(state.ID)
 	if err != nil {
@@ -1086,6 +1116,50 @@ resource "azurerm_subnet" "test" {
   address_prefixes     = ["10.0.2.0/24"]
 }
 `, data.Locations.Primary, data.RandomInteger, data.RandomString)
+}
+
+func (r HPCCacheResource) systemAssigned(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_hpc_cache" "test" {
+  name                = "acctest-HPCC-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  cache_size_in_gb    = 3072
+  subnet_id           = azurerm_subnet.test.id
+  sku_name            = "Standard_2G"
+  
+  identity {
+    type = "SystemAssigned"
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r HPCCacheResource) systemAssignedAndUserAssigned(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_hpc_cache" "test" {
+  name                = "acctest-HPCC-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  cache_size_in_gb    = 3072
+  subnet_id           = azurerm_subnet.test.id
+  sku_name            = "Standard_2G"
+
+  identity {
+    type = "SystemAssigned, UserAssigned"
+
+    identity_ids = [
+      azurerm_user_assigned_identity.test.id
+    ]
+  }
+
+  key_vault_key_id = azurerm_key_vault_key.test.id
+}
+`, r.customerManagedKeyTemplate(data), data.RandomInteger)
 }
 
 func (HPCCacheResource) template(data acceptance.TestData) string {

--- a/website/docs/r/hpc_cache.html.markdown
+++ b/website/docs/r/hpc_cache.html.markdown
@@ -192,7 +192,17 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `id` - The `id` of the HPC Cache.
 
+* `identity` - An `identity` block as documented below.
+
 * `mount_addresses` - A list of IP Addresses where the HPC Cache can be mounted.
+
+---
+
+An `identity` block exports the following:
+
+* `principal_id` - The Principal ID associated with this Managed Service Identity.
+
+* `tenant_id` - The Tenant ID associated with this Managed Service Identity.
 
 ## Timeouts
 

--- a/website/docs/r/hpc_cache.html.markdown
+++ b/website/docs/r/hpc_cache.html.markdown
@@ -180,9 +180,11 @@ A `dns` block contains the following:
 
 An `identity` block supports the following:
 
-* `type` - (Required) Specifies the type of Managed Service Identity that should be configured on this HPC Cache. Only possible value is `UserAssigned`. Changing this forces a new resource to be created.
+* `type` - (Required) Specifies the type of Managed Service Identity that should be configured on this HPC Cache. Possible values are `SystemAssigned`, `UserAssigned`, `SystemAssigned, UserAssigned` (to enable both). Changing this forces a new resource to be created.
 
 * `identity_ids` - (Required) Specifies a list of User Assigned Managed Identity IDs to be assigned to this HPC Cache. Changing this forces a new resource to be created.
+
+~> **NOTE:** This is required when `type` is set to `UserAssigned` or `SystemAssigned, UserAssigned`.
 
 ## Attributes Reference
 

--- a/website/docs/r/hpc_cache.html.markdown
+++ b/website/docs/r/hpc_cache.html.markdown
@@ -182,7 +182,7 @@ An `identity` block supports the following:
 
 * `type` - (Required) Specifies the type of Managed Service Identity that should be configured on this HPC Cache. Possible values are `SystemAssigned`, `UserAssigned`, `SystemAssigned, UserAssigned` (to enable both). Changing this forces a new resource to be created.
 
-* `identity_ids` - (Required) Specifies a list of User Assigned Managed Identity IDs to be assigned to this HPC Cache. Changing this forces a new resource to be created.
+* `identity_ids` - (Optional) Specifies a list of User Assigned Managed Identity IDs to be assigned to this HPC Cache. Changing this forces a new resource to be created.
 
 ~> **NOTE:** This is required when `type` is set to `UserAssigned` or `SystemAssigned, UserAssigned`.
 


### PR DESCRIPTION
Recently we found TestAccHPCCache_customerManagedKeyUpdateAutoKeyRotation and TestAccHPCCache_customerManagedKeyWithAutoKeyRotationEnabled are failed with error "missing getrotationpolicy permission" in teamcity. So I tried to fix it. But TCs are still failed with new error "Invalid address to set: []string{"identity", "0", "tenant_id"}" after "getrotationpolicy" is added. After investigated, I found it failed at setting identity after this resource is created successfully. Currently, the identity property only allows "[userAssignedIdentity](https://github.com/hashicorp/terraform-provider-azurerm/blob/8aa80f36c5adea2c51d14fde069d5f6e28be29e8/internal/services/hpccache/hpc_cache_resource.go#L1002)" in tf schema. But while setting, tf treats it as "[systemAssignedAndUserAssignedIdentity](https://github.com/hashicorp/terraform-provider-azurerm/blob/8aa80f36c5adea2c51d14fde069d5f6e28be29e8/internal/services/hpccache/hpc_cache_resource.go#L346)". So it failed. After checked with [azure rest api spec](https://github.com/Azure/azure-rest-api-specs/blob/aea36c92c00247b195efb08a0161ab74859e606e/specification/storagecache/resource-manager/Microsoft.StorageCache/stable/2023-05-01/storagecache.json#L2203), it indicates it supports "systemAssigned", "userAssigned", "systemAssigned, userAssigned" and "None". So I updated the identity property to support more types.

--- PASS: TestAccHPCCache_systemAssigned (1606.61s)
--- PASS: TestAccHPCCache_systemAssignedAndUserAssigned (1680.09s)
--- PASS: TestAccHPCCache_customerManagedKeyUpdateAutoKeyRotation (1546.58s)
--- PASS: TestAccHPCCache_customerManagedKeyWithAutoKeyRotationEnabled (2498.48s)