### PR TITLE
Support no public ip on firewall `ip_configuration` for forced tunneling

### DIFF
--- a/internal/services/firewall/firewall_resource.go
+++ b/internal/services/firewall/firewall_resource.go
@@ -105,7 +105,7 @@ func resourceFirewall() *pluginsdk.Resource {
 						},
 						"public_ip_address_id": {
 							Type:         pluginsdk.TypeString,
-							Required:     true,
+							Optional:     true,
 							ValidateFunc: networkValidate.PublicIpAddressID,
 						},
 						"private_ip_address": {
@@ -552,11 +552,13 @@ func expandFirewallIPConfigurations(configs []interface{}) (*[]network.AzureFire
 
 		ipConfig := network.AzureFirewallIPConfiguration{
 			Name: utils.String(name),
-			AzureFirewallIPConfigurationPropertiesFormat: &network.AzureFirewallIPConfigurationPropertiesFormat{
-				PublicIPAddress: &network.SubResource{
-					ID: utils.String(pubID),
-				},
-			},
+			AzureFirewallIPConfigurationPropertiesFormat: &network.AzureFirewallIPConfigurationPropertiesFormat{},
+		}
+
+		if pubID != "" {
+			ipConfig.AzureFirewallIPConfigurationPropertiesFormat.PublicIPAddress = &network.SubResource{
+				ID: utils.String(pubID),
+			}
 		}
 
 		if subnetId != "" {

--- a/internal/services/firewall/firewall_resource_test.go
+++ b/internal/services/firewall/firewall_resource_test.go
@@ -752,8 +752,8 @@ resource "azurerm_firewall" "test" {
   sku_tier            = "Standard"
 
   ip_configuration {
-    name                 = "configuration"
-    subnet_id            = azurerm_subnet.test.id
+    name      = "configuration"
+    subnet_id = azurerm_subnet.test.id
   }
 
   management_ip_configuration {

--- a/internal/services/firewall/firewall_resource_test.go
+++ b/internal/services/firewall/firewall_resource_test.go
@@ -119,6 +119,26 @@ func TestAccFirewall_withManagementIpSameName(t *testing.T) {
 	})
 }
 
+func TestAccFirewall_withManagementIpNoMainPublicIp(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_firewall", "test")
+	r := FirewallResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.withManagementIpNoMainPublicIp(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("ip_configuration.0.name").HasValue("configuration"),
+				check.That(data.ResourceName).Key("ip_configuration.0.private_ip_address").Exists(),
+				check.That(data.ResourceName).Key("ip_configuration.0.public_ip_address_id").HasValue(""),
+				check.That(data.ResourceName).Key("management_ip_configuration.0.name").HasValue("management_configuration"),
+				check.That(data.ResourceName).Key("management_ip_configuration.0.public_ip_address_id").Exists(),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccFirewall_withMultiplePublicIPs(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_firewall", "test")
 	r := FirewallResource{}
@@ -682,6 +702,69 @@ resource "azurerm_firewall" "test" {
   threat_intel_mode = "Alert"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
+func (FirewallResource) withManagementIpNoMainPublicIp(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-fw-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvirtnet%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "AzureFirewallSubnet"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.1.0/24"]
+}
+
+resource "azurerm_subnet" "test_mgmt" {
+  name                 = "AzureFirewallManagementSubnet"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.2.0/24"]
+}
+
+resource "azurerm_public_ip" "test_mgmt" {
+  name                = "acctestmgmtpip%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+}
+
+resource "azurerm_firewall" "test" {
+  name                = "acctestfirewall%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku_name            = "AZFW_VNet"
+  sku_tier            = "Standard"
+
+  ip_configuration {
+    name                 = "configuration"
+    subnet_id            = azurerm_subnet.test.id
+  }
+
+  management_ip_configuration {
+    name                 = "management_configuration"
+    subnet_id            = azurerm_subnet.test_mgmt.id
+    public_ip_address_id = azurerm_public_ip.test_mgmt.id
+  }
+
+  threat_intel_mode = "Alert"
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
 
 func (FirewallResource) multiplePublicIps(data acceptance.TestData) string {

--- a/website/docs/r/firewall.html.markdown
+++ b/website/docs/r/firewall.html.markdown
@@ -102,7 +102,9 @@ An `ip_configuration` block supports the following:
 
 -> **NOTE** At least one and only one `ip_configuration` block may contain a `subnet_id`.
 
-* `public_ip_address_id` - (Required) The ID of the Public IP Address associated with the firewall.
+* `public_ip_address_id` - (Optional) The ID of the Public IP Address associated with the firewall.
+
+-> **NOTE** A public ip address is required unless a `management_ip_configuration` block is specified.
 
 -> **NOTE** When multiple `ip_configuration` blocks with `public_ip_address_id` are configured, `terraform apply` will raise an error when one or some of these `ip_configuration` blocks are removed. because the `public_ip_address_id` is still used by the `firewall` resource until the `firewall` resource is updated. and the destruction of `azurerm_public_ip` happens before the update of firewall by default. to destroy of `azurerm_public_ip` will cause the error. The workaround is to set `create_before_destroy=true` to the `azurerm_public_ip` resource `lifecycle` block. See more detail: [destroying.md#create-before-destroy](https://github.com/hashicorp/terraform/blob/main/docs/destroying.md#create-before-destroy)
 


### PR DESCRIPTION
Azure supports a firewall in forced tunneling mode to have no public IP configured for the IP configuration against the `AzureFirewallSubnet` subnet.

fixes [#14055](https://github.com/hashicorp/terraform-provider-azurerm/issues/14055)