### PR TITLE
`azurerm_monitor_autoscale_setting` - support for `predictive_scale_mode` and `predictive_scale_look_ahead_time` properties

### DIFF
--- a/internal/services/monitor/monitor_autoscale_setting_resource.go
+++ b/internal/services/monitor/monitor_autoscale_setting_resource.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/validate"
-	azValidate "github.com/hashicorp/terraform-provider-azurerm/helpers/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/monitor/migration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
@@ -76,7 +75,7 @@ func resourceMonitorAutoScaleSetting() *pluginsdk.Resource {
 			"predictive_scale_look_ahead_time": {
 				Type:         pluginsdk.TypeString,
 				Optional:     true,
-				ValidateFunc: azValidate.ISO8601DurationBetween("PT1M", "PT1H"),
+				ValidateFunc: validate.ISO8601DurationBetween("PT1M", "PT1H"),
 			},
 
 			"predictive_scale_mode": {

--- a/internal/services/monitor/monitor_autoscale_setting_resource.go
+++ b/internal/services/monitor/monitor_autoscale_setting_resource.go
@@ -853,13 +853,13 @@ func flattenAzureRmMonitorAutoScaleSettingProfile(profiles []autoscalesettings.A
 
 func flattenAzureRmMonitorAutoScaleSettingPredictive(input *autoscalesettings.PredictiveAutoscalePolicy) []interface{} {
 	if input == nil {
-		return nil
+		return []interface{}{}
 	}
 
-	result := make(map[string]interface{})
-
-	result["look_ahead_time"] = pointer.From(input.ScaleLookAheadTime)
-	result["scale_mode"] = string(input.ScaleMode)
+	result := map[string]interface{}{
+		"look_ahead_time": pointer.From(input.ScaleLookAheadTime),
+		"scale_mode":      string(input.ScaleMode),
+	}
 
 	return []interface{}{result}
 }

--- a/internal/services/monitor/monitor_autoscale_setting_resource.go
+++ b/internal/services/monitor/monitor_autoscale_setting_resource.go
@@ -81,9 +81,13 @@ func resourceMonitorAutoScaleSetting() *pluginsdk.Resource {
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
 						"scale_mode": {
-							Type:         pluginsdk.TypeString,
-							Required:     true,
-							ValidateFunc: validation.StringInSlice(autoscalesettings.PossibleValuesForPredictiveAutoscalePolicyScaleMode(), false),
+							Type:     pluginsdk.TypeString,
+							Required: true,
+							// Disabled is not exposed, omission of this block to mean disabled
+							ValidateFunc: validation.StringInSlice([]string{
+								string(autoscalesettings.PredictiveAutoscalePolicyScaleModeEnabled),
+								string(autoscalesettings.PredictiveAutoscalePolicyScaleModeForecastOnly),
+							}, false),
 						},
 
 						"look_ahead_time": {
@@ -853,6 +857,11 @@ func flattenAzureRmMonitorAutoScaleSettingProfile(profiles []autoscalesettings.A
 
 func flattenAzureRmMonitorAutoScaleSettingPredictive(input *autoscalesettings.PredictiveAutoscalePolicy) []interface{} {
 	if input == nil {
+		return []interface{}{}
+	}
+
+	// omit the block if disabled
+	if input.ScaleMode == autoscalesettings.PredictiveAutoscalePolicyScaleModeDisabled {
 		return []interface{}{}
 	}
 

--- a/internal/services/monitor/monitor_autoscale_setting_resource_test.go
+++ b/internal/services/monitor/monitor_autoscale_setting_resource_test.go
@@ -74,13 +74,13 @@ func TestAccMonitorAutoScaleSetting_multipleProfiles(t *testing.T) {
 	})
 }
 
-func TestAccMonitorAutoScaleSetting_predictiveAutoscalePolicy(t *testing.T) {
+func TestAccMonitorAutoScaleSetting_predictive(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_monitor_autoscale_setting", "test")
 	r := MonitorAutoScaleSettingResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.predictiveAutoscalePolicy(data, "Enabled", "PT1M"),
+			Config: r.predictive(data, "Enabled", "PT1M"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -89,7 +89,7 @@ func TestAccMonitorAutoScaleSetting_predictiveAutoscalePolicy(t *testing.T) {
 	})
 }
 
-func TestAccMonitorAutoScaleSetting_predictiveAutoscalePolicyUpdated(t *testing.T) {
+func TestAccMonitorAutoScaleSetting_predictiveUpdated(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_monitor_autoscale_setting", "test")
 	r := MonitorAutoScaleSettingResource{}
 
@@ -102,14 +102,14 @@ func TestAccMonitorAutoScaleSetting_predictiveAutoscalePolicyUpdated(t *testing.
 		},
 		data.ImportStep(),
 		{
-			Config: r.predictiveAutoscalePolicy(data, "Enabled", "PT1H"),
+			Config: r.predictive(data, "Enabled", "PT1H"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep(),
 		{
-			Config: r.predictiveAutoscalePolicy(data, "ForecastOnly", "PT1M"),
+			Config: r.predictive(data, "ForecastOnly", "PT1M"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -386,6 +386,9 @@ resource "azurerm_monitor_autoscale_setting" "test" {
       }
     }
   }
+  predictive {
+    scale_mode = "Disabled"
+  }
 }
 `, template, data.RandomInteger)
 }
@@ -430,11 +433,14 @@ resource "azurerm_monitor_autoscale_setting" "import" {
       }
     }
   }
+  predictive {
+    scale_mode = "Disabled"
+  }
 }
 `, template)
 }
 
-func (MonitorAutoScaleSettingResource) predictiveAutoscalePolicy(data acceptance.TestData, scaleMode, scaleLookAheadTime string) string {
+func (MonitorAutoScaleSettingResource) predictive(data acceptance.TestData, scaleMode, scaleLookAheadTime string) string {
 	template := MonitorAutoScaleSettingResource{}.template(data)
 	return fmt.Sprintf(`
 %s
@@ -476,12 +482,11 @@ resource "azurerm_monitor_autoscale_setting" "test" {
     }
   }
 
-  predictive_scale_mode            = %q
-  predictive_scale_look_ahead_time = %q
-
+  predictive {
+    scale_mode      = %q
+    look_ahead_time = %q
+  }
 }
-
-
 `, template, data.RandomInteger, scaleMode, scaleLookAheadTime)
 }
 
@@ -568,6 +573,10 @@ resource "azurerm_monitor_autoscale_setting" "test" {
       minutes = [0]
     }
   }
+
+  predictive {
+    scale_mode = "Disabled"
+  }
 }
 `, template, data.RandomInteger)
 }
@@ -612,6 +621,10 @@ resource "azurerm_monitor_autoscale_setting" "test" {
         cooldown  = "PT1M"
       }
     }
+  }
+
+  predictive {
+    scale_mode = "Disabled"
   }
 }
 `, template, data.RandomInteger, defaultVal, min, max)
@@ -680,6 +693,10 @@ resource "azurerm_monitor_autoscale_setting" "test" {
       }
     }
   }
+
+  predictive {
+    scale_mode = "Disabled"
+  }
 }
 `, template, data.RandomInteger)
 }
@@ -731,6 +748,10 @@ resource "azurerm_monitor_autoscale_setting" "test" {
       send_to_subscription_co_administrator = false
       custom_emails                         = ["acctest1-%d@example.com"]
     }
+  }
+
+  predictive {
+    scale_mode = "Disabled"
   }
 }
 `, template, data.RandomInteger, data.RandomInteger)
@@ -784,6 +805,10 @@ resource "azurerm_monitor_autoscale_setting" "test" {
       custom_emails                         = ["acctest1-%d@example.com", "acctest2-%d@example.com"]
     }
   }
+
+  predictive {
+    scale_mode = "Disabled"
+  }
 }
 `, template, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
@@ -827,6 +852,10 @@ resource "azurerm_monitor_autoscale_setting" "test" {
       send_to_subscription_administrator    = false
       send_to_subscription_co_administrator = false
     }
+  }
+
+  predictive {
+    scale_mode = "Disabled"
   }
 }
 `, template, data.RandomInteger)
@@ -872,6 +901,10 @@ resource "azurerm_monitor_autoscale_setting" "test" {
       send_to_subscription_co_administrator = false
     }
   }
+
+  predictive {
+    scale_mode = "Disabled"
+  }
 }
 `, template, data.RandomInteger)
 }
@@ -901,6 +934,10 @@ resource "azurerm_monitor_autoscale_setting" "test" {
       start    = "2020-06-18T00:00:00Z"
       end      = "2020-06-18T23:59:59Z"
     }
+  }
+
+  predictive {
+    scale_mode = "Disabled"
   }
 }
 `, template, data.RandomInteger)
@@ -974,6 +1011,10 @@ resource "azurerm_monitor_autoscale_setting" "test" {
         cooldown  = "PT1M"
       }
     }
+  }
+
+  predictive {
+    scale_mode = "Disabled"
   }
 }
 `, template, data.RandomInteger)
@@ -1052,6 +1093,10 @@ resource "azurerm_monitor_autoscale_setting" "test" {
         cooldown  = "PT1M"
       }
     }
+  }
+
+  predictive {
+    scale_mode = "Disabled"
   }
 }
 `, template, data.RandomInteger)

--- a/internal/services/monitor/monitor_autoscale_setting_resource_test.go
+++ b/internal/services/monitor/monitor_autoscale_setting_resource_test.go
@@ -386,9 +386,6 @@ resource "azurerm_monitor_autoscale_setting" "test" {
       }
     }
   }
-  predictive {
-    scale_mode = "Disabled"
-  }
 }
 `, template, data.RandomInteger)
 }
@@ -432,9 +429,6 @@ resource "azurerm_monitor_autoscale_setting" "import" {
         cooldown  = "PT1M"
       }
     }
-  }
-  predictive {
-    scale_mode = "Disabled"
   }
 }
 `, template)
@@ -574,9 +568,6 @@ resource "azurerm_monitor_autoscale_setting" "test" {
     }
   }
 
-  predictive {
-    scale_mode = "Disabled"
-  }
 }
 `, template, data.RandomInteger)
 }
@@ -623,9 +614,6 @@ resource "azurerm_monitor_autoscale_setting" "test" {
     }
   }
 
-  predictive {
-    scale_mode = "Disabled"
-  }
 }
 `, template, data.RandomInteger, defaultVal, min, max)
 }
@@ -694,9 +682,6 @@ resource "azurerm_monitor_autoscale_setting" "test" {
     }
   }
 
-  predictive {
-    scale_mode = "Disabled"
-  }
 }
 `, template, data.RandomInteger)
 }
@@ -750,9 +735,6 @@ resource "azurerm_monitor_autoscale_setting" "test" {
     }
   }
 
-  predictive {
-    scale_mode = "Disabled"
-  }
 }
 `, template, data.RandomInteger, data.RandomInteger)
 }
@@ -806,9 +788,6 @@ resource "azurerm_monitor_autoscale_setting" "test" {
     }
   }
 
-  predictive {
-    scale_mode = "Disabled"
-  }
 }
 `, template, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
@@ -854,9 +833,6 @@ resource "azurerm_monitor_autoscale_setting" "test" {
     }
   }
 
-  predictive {
-    scale_mode = "Disabled"
-  }
 }
 `, template, data.RandomInteger)
 }
@@ -902,9 +878,6 @@ resource "azurerm_monitor_autoscale_setting" "test" {
     }
   }
 
-  predictive {
-    scale_mode = "Disabled"
-  }
 }
 `, template, data.RandomInteger)
 }
@@ -936,9 +909,6 @@ resource "azurerm_monitor_autoscale_setting" "test" {
     }
   }
 
-  predictive {
-    scale_mode = "Disabled"
-  }
 }
 `, template, data.RandomInteger)
 }
@@ -1013,9 +983,6 @@ resource "azurerm_monitor_autoscale_setting" "test" {
     }
   }
 
-  predictive {
-    scale_mode = "Disabled"
-  }
 }
 `, template, data.RandomInteger)
 }
@@ -1095,9 +1062,6 @@ resource "azurerm_monitor_autoscale_setting" "test" {
     }
   }
 
-  predictive {
-    scale_mode = "Disabled"
-  }
 }
 `, template, data.RandomInteger)
 }

--- a/internal/services/monitor/monitor_autoscale_setting_resource_test.go
+++ b/internal/services/monitor/monitor_autoscale_setting_resource_test.go
@@ -567,7 +567,6 @@ resource "azurerm_monitor_autoscale_setting" "test" {
       minutes = [0]
     }
   }
-
 }
 `, template, data.RandomInteger)
 }
@@ -613,7 +612,6 @@ resource "azurerm_monitor_autoscale_setting" "test" {
       }
     }
   }
-
 }
 `, template, data.RandomInteger, defaultVal, min, max)
 }
@@ -681,7 +679,6 @@ resource "azurerm_monitor_autoscale_setting" "test" {
       }
     }
   }
-
 }
 `, template, data.RandomInteger)
 }
@@ -734,7 +731,6 @@ resource "azurerm_monitor_autoscale_setting" "test" {
       custom_emails                         = ["acctest1-%d@example.com"]
     }
   }
-
 }
 `, template, data.RandomInteger, data.RandomInteger)
 }
@@ -787,7 +783,6 @@ resource "azurerm_monitor_autoscale_setting" "test" {
       custom_emails                         = ["acctest1-%d@example.com", "acctest2-%d@example.com"]
     }
   }
-
 }
 `, template, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }
@@ -832,7 +827,6 @@ resource "azurerm_monitor_autoscale_setting" "test" {
       send_to_subscription_co_administrator = false
     }
   }
-
 }
 `, template, data.RandomInteger)
 }
@@ -877,7 +871,6 @@ resource "azurerm_monitor_autoscale_setting" "test" {
       send_to_subscription_co_administrator = false
     }
   }
-
 }
 `, template, data.RandomInteger)
 }
@@ -908,7 +901,6 @@ resource "azurerm_monitor_autoscale_setting" "test" {
       end      = "2020-06-18T23:59:59Z"
     }
   }
-
 }
 `, template, data.RandomInteger)
 }
@@ -982,7 +974,6 @@ resource "azurerm_monitor_autoscale_setting" "test" {
       }
     }
   }
-
 }
 `, template, data.RandomInteger)
 }
@@ -1061,7 +1052,6 @@ resource "azurerm_monitor_autoscale_setting" "test" {
       }
     }
   }
-
 }
 `, template, data.RandomInteger)
 }

--- a/website/docs/r/monitor_autoscale_setting.html.markdown
+++ b/website/docs/r/monitor_autoscale_setting.html.markdown
@@ -136,6 +136,9 @@ resource "azurerm_monitor_autoscale_setting" "example" {
     }
   }
 
+  predictive_scale_mode            = "Enabled"
+  predictive_scale_look_ahead_time = "PT5M"
+
   notification {
     email {
       send_to_subscription_administrator    = true
@@ -437,6 +440,10 @@ The following arguments are supported:
 * `enabled` - (Optional) Specifies whether automatic scaling is enabled for the target resource. Defaults to `true`.
 
 * `notification` - (Optional) Specifies a `notification` block as defined below.
+
+* `predictive_scale_mode` - (Optional) Specifies the predictive scale mode. Possible values are `Disabled`, `Enabled` and `ForecastOnly`. Default to `Disabled`.
+
+* `predictive_scale_look_ahead_time` - (Optional) Specifies the amount of time by which instances are launched in advance. It must be between `PT1M` and `PT1H` in ISO 8601 format.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 

--- a/website/docs/r/monitor_autoscale_setting.html.markdown
+++ b/website/docs/r/monitor_autoscale_setting.html.markdown
@@ -583,7 +583,7 @@ A `dimensions` block supports the following:
 
 A `predictive` block supports the following:
 
-* `scale_mode` - (Required) Specifies the predictive scale mode. Possible values are `Disabled`, `Enabled` and `ForecastOnly`.
+* `scale_mode` - (Required) Specifies the predictive scale mode. Possible values are `Enabled` or `ForecastOnly`.
 
 * `look_ahead_time` - (Optional) Specifies the amount of time by which instances are launched in advance. It must be between `PT1M` and `PT1H` in ISO 8601 format.
 

--- a/website/docs/r/monitor_autoscale_setting.html.markdown
+++ b/website/docs/r/monitor_autoscale_setting.html.markdown
@@ -136,8 +136,10 @@ resource "azurerm_monitor_autoscale_setting" "example" {
     }
   }
 
-  predictive_scale_mode            = "Enabled"
-  predictive_scale_look_ahead_time = "PT5M"
+  predictive {
+    scale_mode      = "Enabled"
+    look_ahead_time = "PT5M"
+  }
 
   notification {
     email {
@@ -441,9 +443,7 @@ The following arguments are supported:
 
 * `notification` - (Optional) Specifies a `notification` block as defined below.
 
-* `predictive_scale_mode` - (Optional) Specifies the predictive scale mode. Possible values are `Disabled`, `Enabled` and `ForecastOnly`. Default to `Disabled`.
-
-* `predictive_scale_look_ahead_time` - (Optional) Specifies the amount of time by which instances are launched in advance. It must be between `PT1M` and `PT1H` in ISO 8601 format.
+* `predictive` - (Optional) A `predictive` block as defined below.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
@@ -578,6 +578,14 @@ A `dimensions` block supports the following:
 * `operator` - (Required) The dimension operator. Possible values are `Equals` and `NotEquals`. `Equals` means being equal to any of the values. `NotEquals` means being not equal to any of the values.
 
 * `values` - (Required) A list of dimension values.
+
+---
+
+A `predictive` block supports the following:
+
+* `scale_mode` - (Required) Specifies the predictive scale mode. Possible values are `Disabled`, `Enabled` and `ForecastOnly`.
+
+* `look_ahead_time` - (Optional) Specifies the amount of time by which instances are launched in advance. It must be between `PT1M` and `PT1H` in ISO 8601 format.
 
 ## Attributes Reference
 


### PR DESCRIPTION
resolves https://github.com/hashicorp/terraform-provider-azurerm/issues/21819

ref:
- [predictive autoscale](https://learn.microsoft.com/en-us/azure/azure-monitor/autoscale/autoscale-predictive)
- [swagger](https://github.com/Azure/azure-rest-api-specs/blob/5beac822673a0729373017d941c73043c803ddb6/specification/monitor/resource-manager/Microsoft.Insights/stable/2022-10-01/autoscale_API.json#LL684C6-L684C6)


<img width="614" alt="image" src="https://github.com/hashicorp/terraform-provider-azurerm/assets/104055472/cafc4cf2-aa24-40f7-9a28-aebe20bd007d">

