### PR TITLE
`azurerm_hdinsight_spark_cluster`, `azurerm_hdinsight_kafka_cluster`, `azurerm_hdinsight_interactive_query_cluster`, `azurerm_hdinsight_hbase_cluster`, `azurerm_hdinsight_hadoop_cluster`: fix require imports acc tests

### DIFF
--- a/internal/services/hdinsight/hdinsight_hadoop_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_hadoop_cluster_resource_test.go
@@ -968,9 +968,7 @@ resource "azurerm_hdinsight_hadoop_cluster" "import" {
         for_each = lookup(roles.value, "head_node", [])
         content {
           password           = lookup(head_node.value, "password", null)
-          subnet_id          = lookup(head_node.value, "subnet_id", null)
           username           = head_node.value.username
-          virtual_network_id = lookup(head_node.value, "virtual_network_id", null)
           vm_size            = head_node.value.vm_size
         }
       }
@@ -979,10 +977,8 @@ resource "azurerm_hdinsight_hadoop_cluster" "import" {
         for_each = lookup(roles.value, "worker_node", [])
         content {
           password              = lookup(worker_node.value, "password", null)
-          subnet_id             = lookup(worker_node.value, "subnet_id", null)
           target_instance_count = worker_node.value.target_instance_count
           username              = worker_node.value.username
-          virtual_network_id    = lookup(worker_node.value, "virtual_network_id", null)
           vm_size               = worker_node.value.vm_size
         }
       }
@@ -991,9 +987,7 @@ resource "azurerm_hdinsight_hadoop_cluster" "import" {
         for_each = lookup(roles.value, "zookeeper_node", [])
         content {
           password           = lookup(zookeeper_node.value, "password", null)
-          subnet_id          = lookup(zookeeper_node.value, "subnet_id", null)
           username           = zookeeper_node.value.username
-          virtual_network_id = lookup(zookeeper_node.value, "virtual_network_id", null)
           vm_size            = zookeeper_node.value.vm_size
         }
       }

--- a/internal/services/hdinsight/hdinsight_hadoop_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_hadoop_cluster_resource_test.go
@@ -967,9 +967,9 @@ resource "azurerm_hdinsight_hadoop_cluster" "import" {
       dynamic "head_node" {
         for_each = lookup(roles.value, "head_node", [])
         content {
-          password           = lookup(head_node.value, "password", null)
-          username           = head_node.value.username
-          vm_size            = head_node.value.vm_size
+          password = lookup(head_node.value, "password", null)
+          username = head_node.value.username
+          vm_size  = head_node.value.vm_size
         }
       }
 
@@ -986,9 +986,9 @@ resource "azurerm_hdinsight_hadoop_cluster" "import" {
       dynamic "zookeeper_node" {
         for_each = lookup(roles.value, "zookeeper_node", [])
         content {
-          password           = lookup(zookeeper_node.value, "password", null)
-          username           = zookeeper_node.value.username
-          vm_size            = zookeeper_node.value.vm_size
+          password = lookup(zookeeper_node.value, "password", null)
+          username = zookeeper_node.value.username
+          vm_size  = zookeeper_node.value.vm_size
         }
       }
     }

--- a/internal/services/hdinsight/hdinsight_hbase_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_hbase_cluster_resource_test.go
@@ -906,9 +906,9 @@ resource "azurerm_hdinsight_hbase_cluster" "import" {
       dynamic "head_node" {
         for_each = lookup(roles.value, "head_node", [])
         content {
-          password           = lookup(head_node.value, "password", null)
-          username           = head_node.value.username
-          vm_size            = head_node.value.vm_size
+          password = lookup(head_node.value, "password", null)
+          username = head_node.value.username
+          vm_size  = head_node.value.vm_size
         }
       }
 
@@ -925,9 +925,9 @@ resource "azurerm_hdinsight_hbase_cluster" "import" {
       dynamic "zookeeper_node" {
         for_each = lookup(roles.value, "zookeeper_node", [])
         content {
-          password           = lookup(zookeeper_node.value, "password", null)
-          username           = zookeeper_node.value.username
-          vm_size            = zookeeper_node.value.vm_size
+          password = lookup(zookeeper_node.value, "password", null)
+          username = zookeeper_node.value.username
+          vm_size  = zookeeper_node.value.vm_size
         }
       }
     }

--- a/internal/services/hdinsight/hdinsight_hbase_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_hbase_cluster_resource_test.go
@@ -907,9 +907,7 @@ resource "azurerm_hdinsight_hbase_cluster" "import" {
         for_each = lookup(roles.value, "head_node", [])
         content {
           password           = lookup(head_node.value, "password", null)
-          subnet_id          = lookup(head_node.value, "subnet_id", null)
           username           = head_node.value.username
-          virtual_network_id = lookup(head_node.value, "virtual_network_id", null)
           vm_size            = head_node.value.vm_size
         }
       }
@@ -918,10 +916,8 @@ resource "azurerm_hdinsight_hbase_cluster" "import" {
         for_each = lookup(roles.value, "worker_node", [])
         content {
           password              = lookup(worker_node.value, "password", null)
-          subnet_id             = lookup(worker_node.value, "subnet_id", null)
           target_instance_count = worker_node.value.target_instance_count
           username              = worker_node.value.username
-          virtual_network_id    = lookup(worker_node.value, "virtual_network_id", null)
           vm_size               = worker_node.value.vm_size
         }
       }
@@ -930,9 +926,7 @@ resource "azurerm_hdinsight_hbase_cluster" "import" {
         for_each = lookup(roles.value, "zookeeper_node", [])
         content {
           password           = lookup(zookeeper_node.value, "password", null)
-          subnet_id          = lookup(zookeeper_node.value, "subnet_id", null)
           username           = zookeeper_node.value.username
-          virtual_network_id = lookup(zookeeper_node.value, "virtual_network_id", null)
           vm_size            = zookeeper_node.value.vm_size
         }
       }

--- a/internal/services/hdinsight/hdinsight_interactive_query_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_interactive_query_cluster_resource_test.go
@@ -969,9 +969,7 @@ resource "azurerm_hdinsight_interactive_query_cluster" "import" {
         for_each = lookup(roles.value, "head_node", [])
         content {
           password           = lookup(head_node.value, "password", null)
-          subnet_id          = lookup(head_node.value, "subnet_id", null)
           username           = head_node.value.username
-          virtual_network_id = lookup(head_node.value, "virtual_network_id", null)
           vm_size            = head_node.value.vm_size
         }
       }
@@ -980,10 +978,8 @@ resource "azurerm_hdinsight_interactive_query_cluster" "import" {
         for_each = lookup(roles.value, "worker_node", [])
         content {
           password              = lookup(worker_node.value, "password", null)
-          subnet_id             = lookup(worker_node.value, "subnet_id", null)
           target_instance_count = worker_node.value.target_instance_count
           username              = worker_node.value.username
-          virtual_network_id    = lookup(worker_node.value, "virtual_network_id", null)
           vm_size               = worker_node.value.vm_size
         }
       }
@@ -992,9 +988,7 @@ resource "azurerm_hdinsight_interactive_query_cluster" "import" {
         for_each = lookup(roles.value, "zookeeper_node", [])
         content {
           password           = lookup(zookeeper_node.value, "password", null)
-          subnet_id          = lookup(zookeeper_node.value, "subnet_id", null)
           username           = zookeeper_node.value.username
-          virtual_network_id = lookup(zookeeper_node.value, "virtual_network_id", null)
           vm_size            = zookeeper_node.value.vm_size
         }
       }

--- a/internal/services/hdinsight/hdinsight_interactive_query_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_interactive_query_cluster_resource_test.go
@@ -968,9 +968,9 @@ resource "azurerm_hdinsight_interactive_query_cluster" "import" {
       dynamic "head_node" {
         for_each = lookup(roles.value, "head_node", [])
         content {
-          password           = lookup(head_node.value, "password", null)
-          username           = head_node.value.username
-          vm_size            = head_node.value.vm_size
+          password = lookup(head_node.value, "password", null)
+          username = head_node.value.username
+          vm_size  = head_node.value.vm_size
         }
       }
 
@@ -987,9 +987,9 @@ resource "azurerm_hdinsight_interactive_query_cluster" "import" {
       dynamic "zookeeper_node" {
         for_each = lookup(roles.value, "zookeeper_node", [])
         content {
-          password           = lookup(zookeeper_node.value, "password", null)
-          username           = zookeeper_node.value.username
-          vm_size            = zookeeper_node.value.vm_size
+          password = lookup(zookeeper_node.value, "password", null)
+          username = zookeeper_node.value.username
+          vm_size  = zookeeper_node.value.vm_size
         }
       }
     }

--- a/internal/services/hdinsight/hdinsight_kafka_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_kafka_cluster_resource_test.go
@@ -747,9 +747,9 @@ resource "azurerm_hdinsight_kafka_cluster" "import" {
       dynamic "head_node" {
         for_each = lookup(roles.value, "head_node", [])
         content {
-          password           = lookup(head_node.value, "password", null)
-          username           = head_node.value.username
-          vm_size            = head_node.value.vm_size
+          password = lookup(head_node.value, "password", null)
+          username = head_node.value.username
+          vm_size  = head_node.value.vm_size
         }
       }
 
@@ -767,9 +767,9 @@ resource "azurerm_hdinsight_kafka_cluster" "import" {
       dynamic "zookeeper_node" {
         for_each = lookup(roles.value, "zookeeper_node", [])
         content {
-          password           = lookup(zookeeper_node.value, "password", null)
-          username           = zookeeper_node.value.username
-          vm_size            = zookeeper_node.value.vm_size
+          password = lookup(zookeeper_node.value, "password", null)
+          username = zookeeper_node.value.username
+          vm_size  = zookeeper_node.value.vm_size
         }
       }
     }

--- a/internal/services/hdinsight/hdinsight_kafka_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_kafka_cluster_resource_test.go
@@ -748,9 +748,7 @@ resource "azurerm_hdinsight_kafka_cluster" "import" {
         for_each = lookup(roles.value, "head_node", [])
         content {
           password           = lookup(head_node.value, "password", null)
-          subnet_id          = lookup(head_node.value, "subnet_id", null)
           username           = head_node.value.username
-          virtual_network_id = lookup(head_node.value, "virtual_network_id", null)
           vm_size            = head_node.value.vm_size
         }
       }
@@ -760,10 +758,8 @@ resource "azurerm_hdinsight_kafka_cluster" "import" {
         content {
           number_of_disks_per_node = worker_node.value.number_of_disks_per_node
           password                 = lookup(worker_node.value, "password", null)
-          subnet_id                = lookup(worker_node.value, "subnet_id", null)
           target_instance_count    = worker_node.value.target_instance_count
           username                 = worker_node.value.username
-          virtual_network_id       = lookup(worker_node.value, "virtual_network_id", null)
           vm_size                  = worker_node.value.vm_size
         }
       }
@@ -772,9 +768,7 @@ resource "azurerm_hdinsight_kafka_cluster" "import" {
         for_each = lookup(roles.value, "zookeeper_node", [])
         content {
           password           = lookup(zookeeper_node.value, "password", null)
-          subnet_id          = lookup(zookeeper_node.value, "subnet_id", null)
           username           = zookeeper_node.value.username
-          virtual_network_id = lookup(zookeeper_node.value, "virtual_network_id", null)
           vm_size            = zookeeper_node.value.vm_size
         }
       }

--- a/internal/services/hdinsight/hdinsight_spark_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_spark_cluster_resource_test.go
@@ -1006,9 +1006,7 @@ resource "azurerm_hdinsight_spark_cluster" "import" {
         for_each = lookup(roles.value, "head_node", [])
         content {
           password           = lookup(head_node.value, "password", null)
-          subnet_id          = lookup(head_node.value, "subnet_id", null)
           username           = head_node.value.username
-          virtual_network_id = lookup(head_node.value, "virtual_network_id", null)
           vm_size            = head_node.value.vm_size
         }
       }
@@ -1017,10 +1015,8 @@ resource "azurerm_hdinsight_spark_cluster" "import" {
         for_each = lookup(roles.value, "worker_node", [])
         content {
           password              = lookup(worker_node.value, "password", null)
-          subnet_id             = lookup(worker_node.value, "subnet_id", null)
           target_instance_count = worker_node.value.target_instance_count
           username              = worker_node.value.username
-          virtual_network_id    = lookup(worker_node.value, "virtual_network_id", null)
           vm_size               = worker_node.value.vm_size
         }
       }
@@ -1029,9 +1025,7 @@ resource "azurerm_hdinsight_spark_cluster" "import" {
         for_each = lookup(roles.value, "zookeeper_node", [])
         content {
           password           = lookup(zookeeper_node.value, "password", null)
-          subnet_id          = lookup(zookeeper_node.value, "subnet_id", null)
           username           = zookeeper_node.value.username
-          virtual_network_id = lookup(zookeeper_node.value, "virtual_network_id", null)
           vm_size            = zookeeper_node.value.vm_size
         }
       }

--- a/internal/services/hdinsight/hdinsight_spark_cluster_resource_test.go
+++ b/internal/services/hdinsight/hdinsight_spark_cluster_resource_test.go
@@ -1005,9 +1005,9 @@ resource "azurerm_hdinsight_spark_cluster" "import" {
       dynamic "head_node" {
         for_each = lookup(roles.value, "head_node", [])
         content {
-          password           = lookup(head_node.value, "password", null)
-          username           = head_node.value.username
-          vm_size            = head_node.value.vm_size
+          password = lookup(head_node.value, "password", null)
+          username = head_node.value.username
+          vm_size  = head_node.value.vm_size
         }
       }
 
@@ -1024,9 +1024,9 @@ resource "azurerm_hdinsight_spark_cluster" "import" {
       dynamic "zookeeper_node" {
         for_each = lookup(roles.value, "zookeeper_node", [])
         content {
-          password           = lookup(zookeeper_node.value, "password", null)
-          username           = zookeeper_node.value.username
-          vm_size            = zookeeper_node.value.vm_size
+          password = lookup(zookeeper_node.value, "password", null)
+          username = zookeeper_node.value.username
+          vm_size  = zookeeper_node.value.vm_size
         }
       }
     }


### PR DESCRIPTION
* The original `lookup` function will find an empty string, which will break the acc tests.

* All related tests are passing as expected.