### PR TITLE
pandora: manually define managed identity client to allow upstream changes to Pandora's generator-terraform

### DIFF
--- a/internal/clients/client.go
+++ b/internal/clients/client.go
@@ -3,6 +3,7 @@ package clients
 import (
 	"context"
 	"fmt"
+	managedidentity "github.com/hashicorp/terraform-provider-azurerm/internal/services/managedidentity/client"
 
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/validation"
@@ -212,6 +213,8 @@ type Client struct {
 	MachineLearning       *machinelearning.Client
 	Maintenance           *maintenance.Client
 	ManagedApplication    *managedapplication.Client
+	// @stephybun: temporary and manual definition of ManagedIdentity Client to make upstream changes in Pandora's generator-terraform
+	ManagedIdentityManual *managedidentity.Client
 	ManagementGroups      *managementgroup.Client
 	Maps                  *maps.Client
 	MariaDB               *mariadb.Client
@@ -395,6 +398,9 @@ func (client *Client) Build(ctx context.Context, o *common.ClientOptions) error 
 	client.MachineLearning = machinelearning.NewClient(o)
 	client.Maintenance = maintenance.NewClient(o)
 	client.ManagedApplication = managedapplication.NewClient(o)
+	if client.ManagedIdentityManual, err = managedidentity.NewManagedIdentityClient(o); err != nil {
+		return fmt.Errorf("building clients for ManagedIdentity: %+v", err)
+	}
 	client.ManagementGroups = managementgroup.NewClient(o)
 	if client.Maps, err = maps.NewClient(o); err != nil {
 		return fmt.Errorf("building clients for Maps: %+v", err)

--- a/internal/services/managedidentity/client/client.go
+++ b/internal/services/managedidentity/client/client.go
@@ -1,0 +1,21 @@
+package client
+
+import (
+	"github.com/hashicorp/go-azure-sdk/resource-manager/managedidentity/2022-01-31-preview/managedidentities"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/common"
+)
+
+// @stephybun: temporary and manual definition of ManagedIdentity Client to make upstream changes in Pandora's generator-terraform
+
+type Client struct {
+	ManagedIdentityClient *managedidentities.ManagedIdentitiesClient
+}
+
+func NewManagedIdentityClient(o *common.ClientOptions) (*Client, error) {
+	client := managedidentities.NewManagedIdentitiesClientWithBaseURI(o.ResourceManagerEndpoint)
+	o.ConfigureClient(&client.Client, o.ResourceManagerAuthorizer)
+
+	return &Client{
+		ManagedIdentityClient: &client,
+	}, nil
+}

--- a/internal/services/managedidentity/federated_identity_credential_resource.go
+++ b/internal/services/managedidentity/federated_identity_credential_resource.go
@@ -80,7 +80,7 @@ func (r FederatedIdentityCredentialResource) Create() sdk.ResourceFunc {
 	return sdk.ResourceFunc{
 		Timeout: 30 * time.Minute,
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
-			client := metadata.Client.ManagedIdentity.ManagedIdentities
+			client := metadata.Client.ManagedIdentityManual.ManagedIdentityClient
 
 			var config FederatedIdentityCredentialResourceSchema
 			if err := metadata.Decode(&config); err != nil {
@@ -124,7 +124,7 @@ func (r FederatedIdentityCredentialResource) Read() sdk.ResourceFunc {
 	return sdk.ResourceFunc{
 		Timeout: 5 * time.Minute,
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
-			client := metadata.Client.ManagedIdentity.ManagedIdentities
+			client := metadata.Client.ManagedIdentityManual.ManagedIdentityClient
 			schema := FederatedIdentityCredentialResourceSchema{}
 
 			id, err := managedidentities.ParseFederatedIdentityCredentialID(metadata.ResourceData.Id())
@@ -156,7 +156,7 @@ func (r FederatedIdentityCredentialResource) Delete() sdk.ResourceFunc {
 	return sdk.ResourceFunc{
 		Timeout: 30 * time.Minute,
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
-			client := metadata.Client.ManagedIdentity.ManagedIdentities
+			client := metadata.Client.ManagedIdentityManual.ManagedIdentityClient
 
 			var config FederatedIdentityCredentialResourceSchema
 			if err := metadata.Decode(&config); err != nil {

--- a/internal/services/managedidentity/federated_identity_credential_resource_test.go
+++ b/internal/services/managedidentity/federated_identity_credential_resource_test.go
@@ -51,7 +51,7 @@ func (r FederatedIdentityCredentialTestResource) Exists(ctx context.Context, cli
 		return nil, err
 	}
 
-	resp, err := clients.ManagedIdentity.ManagedIdentities.FederatedIdentityCredentialsGet(ctx, *id)
+	resp, err := clients.ManagedIdentityManual.ManagedIdentityClient.FederatedIdentityCredentialsGet(ctx, *id)
 	if err != nil {
 		return nil, fmt.Errorf("reading %s: %+v", *id, err)
 	}


### PR DESCRIPTION
This change in Pandora https://github.com/hashicorp/pandora/pull/2502 modifies the hierarchy of clients and is needed in order to support multiple API versions of the same service.

The resource `azurerm_federated_identity_credential` in `managedidentity` references the Pandora generated client in `client_gen.go` which causes [this GHA](https://github.com/hashicorp/pandora/actions/runs/5185934730/jobs/9346413164) to fail.

We need to manually and temporarily introduce the managed identity client in order for the GHA to successfuly open a PR that makes the required changes to `client_gen.go`.