### PR TITLE
pandora: use manually defined client for user assigned identity data source

### DIFF
--- a/internal/services/managedidentity/user_assigned_identity_data_source.go
+++ b/internal/services/managedidentity/user_assigned_identity_data_source.go
@@ -55,7 +55,7 @@ func dataSourceArmUserAssignedIdentity() *pluginsdk.Resource {
 }
 
 func dataSourceArmUserAssignedIdentityRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).ManagedIdentity.ManagedIdentities
+	client := meta.(*clients.Client).ManagedIdentityManual.ManagedIdentityClient
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()


### PR DESCRIPTION
Related to #22054 