### PR TITLE
`azurerm_mssql_server` - Fix issue where `minimum_tls_version` is being returned as `None` instead of `Disabled`

### DIFF
--- a/internal/services/mssql/mssql_server_resource.go
+++ b/internal/services/mssql/mssql_server_resource.go
@@ -517,6 +517,7 @@ func resourceMsSqlServerRead(d *pluginsdk.ResourceData, meta interface{}) error 
 		d.Set("version", props.Version)
 		d.Set("administrator_login", props.AdministratorLogin)
 		d.Set("fully_qualified_domain_name", props.FullyQualifiedDomainName)
+		// remove `|| *v == "None"` when https://github.com/Azure/azure-rest-api-specs/issues/24348 is addressed
 		if v := props.MinimalTLSVersion; v == nil || *v == "None" {
 			d.Set("minimum_tls_version", "Disabled")
 		} else {
@@ -737,6 +738,7 @@ func flattenSqlServerRestorableDatabases(resp sql.RestorableDroppedDatabaseListR
 
 func msSqlMinimumTLSVersionDiff(ctx context.Context, d *pluginsdk.ResourceDiff, _ interface{}) (err error) {
 	old, new := d.GetChange("minimum_tls_version")
+	// remove `old != "None"` when https://github.com/Azure/azure-rest-api-specs/issues/24348 is addressed
 	if old != "" && old != "None" && old != "Disabled" && new == "Disabled" {
 		err = fmt.Errorf("`minimum_tls_version` cannot be removed once set, please set a valid value for this property")
 	}

--- a/internal/services/mssql/mssql_server_resource.go
+++ b/internal/services/mssql/mssql_server_resource.go
@@ -517,7 +517,7 @@ func resourceMsSqlServerRead(d *pluginsdk.ResourceData, meta interface{}) error 
 		d.Set("version", props.Version)
 		d.Set("administrator_login", props.AdministratorLogin)
 		d.Set("fully_qualified_domain_name", props.FullyQualifiedDomainName)
-		if v := props.MinimalTLSVersion; v == nil {
+		if v := props.MinimalTLSVersion; v == nil || *v == "None" {
 			d.Set("minimum_tls_version", "Disabled")
 		} else {
 			d.Set("minimum_tls_version", props.MinimalTLSVersion)
@@ -737,7 +737,7 @@ func flattenSqlServerRestorableDatabases(resp sql.RestorableDroppedDatabaseListR
 
 func msSqlMinimumTLSVersionDiff(ctx context.Context, d *pluginsdk.ResourceDiff, _ interface{}) (err error) {
 	old, new := d.GetChange("minimum_tls_version")
-	if old != "" && old != "Disabled" && new == "Disabled" {
+	if old != "" && old != "None" && old != "Disabled" && new == "Disabled" {
 		err = fmt.Errorf("`minimum_tls_version` cannot be removed once set, please set a valid value for this property")
 	}
 	return

--- a/internal/services/mssql/mssql_server_resource.go
+++ b/internal/services/mssql/mssql_server_resource.go
@@ -517,7 +517,7 @@ func resourceMsSqlServerRead(d *pluginsdk.ResourceData, meta interface{}) error 
 		d.Set("version", props.Version)
 		d.Set("administrator_login", props.AdministratorLogin)
 		d.Set("fully_qualified_domain_name", props.FullyQualifiedDomainName)
-		// remove `|| *v == "None"` when https://github.com/Azure/azure-rest-api-specs/issues/24348 is addressed
+		// todo remove `|| *v == "None"` when https://github.com/Azure/azure-rest-api-specs/issues/24348 is addressed
 		if v := props.MinimalTLSVersion; v == nil || *v == "None" {
 			d.Set("minimum_tls_version", "Disabled")
 		} else {
@@ -738,7 +738,7 @@ func flattenSqlServerRestorableDatabases(resp sql.RestorableDroppedDatabaseListR
 
 func msSqlMinimumTLSVersionDiff(ctx context.Context, d *pluginsdk.ResourceDiff, _ interface{}) (err error) {
 	old, new := d.GetChange("minimum_tls_version")
-	// remove `old != "None"` when https://github.com/Azure/azure-rest-api-specs/issues/24348 is addressed
+	// todo remove `old != "None"` when https://github.com/Azure/azure-rest-api-specs/issues/24348 is addressed
 	if old != "" && old != "None" && old != "Disabled" && new == "Disabled" {
 		err = fmt.Errorf("`minimum_tls_version` cannot be removed once set, please set a valid value for this property")
 	}


### PR DESCRIPTION
Test case `TestAccMsSqlServer_minimumTLSVersionDisabled` failed with the error  "minimum_tls_version cannot be removed once set, please set a valid value for this property." This is caused by the API returns the value of  `minimum_tls_version`  is `None` when the setting value of `minimum_tls_version` in tf config is `disabled` .  Previously, the API would not return any value in this case. I assume that this is an API breaking change. An API [issue ](https://github.com/Azure/azure-rest-api-specs/issues/24348)has been filed to track it. Meanwhile, submitted this PR to fix the issue.

Test results:
<img width="547" alt="image" src="https://github.com/hashicorp/terraform-provider-azurerm/assets/39109137/905da6a4-b8dd-4914-8693-5d30f31ca92f">
