### PR TITLE
`network_interface_security_group_association` - Allow network_security_group_id to be case insensitive

### DIFF
--- a/internal/services/network/network_interface_security_group_association_resource.go
+++ b/internal/services/network/network_interface_security_group_association_resource.go
@@ -141,6 +141,11 @@ func resourceNetworkInterfaceSecurityGroupAssociationRead(d *pluginsdk.ResourceD
 		return err
 	}
 
+	nsgID, err := parse.NetworkSecurityGroupID(splitId[1])
+	if err != nil {
+		return err
+	}
+
 	read, err := client.Get(ctx, nicID.ResourceGroup, nicID.Name, "")
 	if err != nil {
 		if utils.ResponseWasNotFound(read.Response) {
@@ -165,8 +170,11 @@ func resourceNetworkInterfaceSecurityGroupAssociationRead(d *pluginsdk.ResourceD
 
 	d.Set("network_interface_id", read.ID)
 
-	// nil-checked above
-	d.Set("network_security_group_id", props.NetworkSecurityGroup.ID)
+	if strings.EqualFold(nsgID.ID(), *props.NetworkSecurityGroup.ID) {
+		d.Set("network_security_group_id", nsgID.ID())
+	} else {
+		d.Set("network_security_group_id", props.NetworkSecurityGroup.ID)
+	}
 
 	return nil
 }


### PR DESCRIPTION
This partially addresses the wider-spread issue documented in #20138 

The Azure API will inconsistently return resource IDs with changes to casing, causing terraform plans to incorrectly force-recreate resources:

```
  # azurerm_network_interface_security_group_association.this must be replaced
-/+ resource "azurerm_network_interface_security_group_association" "this" {
      ~ id                        = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-resource-group/providers/Microsoft.Network/networkInterfaces/my-network-interface|/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-resource-group/providers/Microsoft.Network/networkSecurityGroups/my-network-security-group" -> (known after apply)
      ~ network_security_group_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MY-RESOURCE-GROUP/providers/Microsoft.Network/networkSecurityGroups/MY-NETWORK-SECURITY-GROUP" -> "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-resource-group/providers/Microsoft.Network/networkSecurityGroups/my-network-security-group" # forces replacement
        # (1 unchanged attribute hidden)
    }
``` 

The casing changes is intentional by Azure according to [their docs](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules):

> Resource and resource group names are case-insensitive unless specifically noted in the valid characters column.
> 
> When using various APIs to retrieve the name for a resource or resource group, the returned value may have different casing than what you originally specified for the name. The returned value may even display different case values than what is listed in the valid characters table.
> 
> Always perform a case-insensitive comparison of names.

This fix correctly allows plans to correctly report a no-op.

The same behavior can be seen with the `az` cli:

```
$ az network nic show --ids /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-resource-group/providers/Microsoft.Network/networkInterfaces/my-network-interface | jq .networkSecurityGroup
{
  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MY-RESOURCE-GROUP/providers/Microsoft.Network/networkSecurityGroups/MY-NETWORK-SECURITY-GROUP",
  "resourceGroup": "MY-RESOURCE-GROUP"
}

$ az network nsg show --ids /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-resource-group/providers/Microsoft.Network/networkSecurityGroups/my-network-security-group | jq -r '. | "\(.id) \(.resourceGroup)"'
/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/MY-RESOURCE-GROUP/providers/Microsoft.Network/networkSecurityGroups/MY-NETWORK-SECURITY-GROUP MY-RESOURCE-GROUP

$ az group show --subscription 00000000-0000-0000-0000-000000000000 --resource-group my-resource-group |
jq .name
"my-resource-group" # NOTE: the resource group name is lowercase here but uppercase in the earlier API responses
```

NOTE: this is probably worthy of a more generic solution that applies to all resource types but I wanted to at least start the dialogue here