### PR TITLE
`azurerm_app_configuration_key` - fix get configuration store ID from endpoint regression

### DIFF
--- a/internal/services/appconfiguration/app_configuration_feature_resource.go
+++ b/internal/services/appconfiguration/app_configuration_feature_resource.go
@@ -274,9 +274,8 @@ func (k FeatureResource) Read() sdk.ResourceFunc {
 				return fmt.Errorf("while parsing resource ID: %+v", err)
 			}
 
-			configurationStoresClient := metadata.Client.AppConfiguration.ConfigurationStoresClient
-			subscriptionId := metadata.Client.Account.SubscriptionId
-			configurationStoreIdRaw, err := metadata.Client.AppConfiguration.ConfigurationStoreIDFromEndpoint(ctx, configurationStoresClient, nestedItemId.ConfigurationStoreEndpoint, subscriptionId)
+			resourceClient := metadata.Client.Resource
+			configurationStoreIdRaw, err := metadata.Client.AppConfiguration.ConfigurationStoreIDFromEndpoint(ctx, resourceClient, nestedItemId.ConfigurationStoreEndpoint)
 			if err != nil {
 				return fmt.Errorf("while retrieving the Resource ID of Configuration Store at Endpoint: %q: %s", nestedItemId.ConfigurationStoreEndpoint, err)
 			}

--- a/internal/services/appconfiguration/app_configuration_key_resource.go
+++ b/internal/services/appconfiguration/app_configuration_key_resource.go
@@ -238,9 +238,8 @@ func (k KeyResource) Read() sdk.ResourceFunc {
 				return fmt.Errorf("while parsing resource ID: %+v", err)
 			}
 
-			configurationStoresClient := metadata.Client.AppConfiguration.ConfigurationStoresClient
-			subscriptionId := metadata.Client.Account.SubscriptionId
-			configurationStoreIdRaw, err := metadata.Client.AppConfiguration.ConfigurationStoreIDFromEndpoint(ctx, configurationStoresClient, nestedItemId.ConfigurationStoreEndpoint, subscriptionId)
+			resourceClient := metadata.Client.Resource
+			configurationStoreIdRaw, err := metadata.Client.AppConfiguration.ConfigurationStoreIDFromEndpoint(ctx, resourceClient, nestedItemId.ConfigurationStoreEndpoint)
 			if err != nil {
 				return fmt.Errorf("while retrieving the Resource ID of Configuration Store at Endpoint: %q: %s", nestedItemId.ConfigurationStoreEndpoint, err)
 			}


### PR DESCRIPTION
resolves https://github.com/hashicorp/terraform-provider-azurerm/issues/22061

The go-azure-sdk ConfigurationStores_List method have some issue resolved in https://github.com/hashicorp/pandora/pull/2600.
Replace ConfigurationStores_List method with Resources_List due to https://github.com/Azure/azure-rest-api-specs/issues/24337, 