### PR TITLE
`azurerm_automanage_configuration` - support new property block `backup` and `azure_security_baseline`

### DIFF
--- a/internal/services/automanage/automanage_configuration_resource.go
+++ b/internal/services/automanage/automanage_configuration_resource.go
@@ -187,8 +187,8 @@ func (r AutoManageConfigurationResource) Arguments() map[string]*pluginsdk.Schem
 			},
 		},
 
-		//"AzureSecurityBaseline/Enable": boolean, true if block exists
-		//"AzureSecurityBaseline/AssignmentType": string ("ApplyAndAutoCorrect", "ApplyAndMonitor", "Audit", "DeployAndAutoCorrect"),
+		// "AzureSecurityBaseline/Enable": boolean, true if block exists
+		// "AzureSecurityBaseline/AssignmentType": string ("ApplyAndAutoCorrect", "ApplyAndMonitor", "Audit", "DeployAndAutoCorrect"),
 		"azure_security_baseline": {
 			Type:     pluginsdk.TypeList,
 			Optional: true,
@@ -210,21 +210,21 @@ func (r AutoManageConfigurationResource) Arguments() map[string]*pluginsdk.Schem
 			},
 		},
 
-		//"Backup/Enable": boolean, true if block exists
-		//"Backup/PolicyName": string (length 3 - 150, begin with alphanumeric char, only contain alphanumeric chars and hyphens),
-		//"Backup/TimeZone": timezone,
-		//"Backup/InstantRpRetentionRangeInDays": int (1 - 5 if ScheduleRunFrequency is Daily, 5 if ScheduleRunFrequency is Weekly),
-		//"Backup/SchedulePolicy/ScheduleRunFrequency": string ("Daily", "Weekly"),
-		//"Backup/SchedulePolicy/ScheduleRunTimes": list of DateTime,
-		//"Backup/SchedulePolicy/ScheduleRunDays": list of strings (["Sunday", "Monday", "Wednesday", "Thursday", "Friday", "Saturday"]),
-		//"Backup/SchedulePolicy/SchedulePolicyType": string ("SimpleSchedulePolicy"),
-		//"Backup/RetentionPolicy/RetentionPolicyType": string ("LongTermRetentionPolicy"),
-		//"Backup/RetentionPolicy/DailySchedule/RetentionTimes": list of DateTime,
-		//"Backup/RetentionPolicy/DailySchedule/RetentionDuration/Count": int (7 - 9999),
-		//"Backup/RetentionPolicy/DailySchedule/RetentionDuration/DurationType": string ("Days"),
-		//"Backup/RetentionPolicy/WeeklySchedule/RetentionTimes":, list of DateTime
-		//"Backup/RetentionPolicy/WeeklySchedule/RetentionDuration/Count":, int (1 - 5163)
-		//"Backup/RetentionPolicy/WeeklySchedule/RetentionDuration/DurationType": string ("Weeks"),
+		// "Backup/Enable": boolean, true if block exists
+		// "Backup/PolicyName": string (length 3 - 150, begin with alphanumeric char, only contain alphanumeric chars and hyphens),
+		// "Backup/TimeZone": timezone,
+		// "Backup/InstantRpRetentionRangeInDays": int (1 - 5 if ScheduleRunFrequency is Daily, 5 if ScheduleRunFrequency is Weekly),
+		// "Backup/SchedulePolicy/ScheduleRunFrequency": string ("Daily", "Weekly"),
+		// "Backup/SchedulePolicy/ScheduleRunTimes": list of DateTime,
+		// "Backup/SchedulePolicy/ScheduleRunDays": list of strings (["Sunday", "Monday", "Wednesday", "Thursday", "Friday", "Saturday"]),
+		// "Backup/SchedulePolicy/SchedulePolicyType": string ("SimpleSchedulePolicy"),
+		// "Backup/RetentionPolicy/RetentionPolicyType": string ("LongTermRetentionPolicy"),
+		// "Backup/RetentionPolicy/DailySchedule/RetentionTimes": list of DateTime,
+		// "Backup/RetentionPolicy/DailySchedule/RetentionDuration/Count": int (7 - 9999),
+		// "Backup/RetentionPolicy/DailySchedule/RetentionDuration/DurationType": string ("Days"),
+		// "Backup/RetentionPolicy/WeeklySchedule/RetentionTimes":, list of DateTime
+		// "Backup/RetentionPolicy/WeeklySchedule/RetentionDuration/Count":, int (1 - 5163)
+		// "Backup/RetentionPolicy/WeeklySchedule/RetentionDuration/DurationType": string ("Weeks"),
 		"backup": {
 			Type:     pluginsdk.TypeList,
 			Optional: true,

--- a/internal/services/automanage/automanage_configuration_resource_test.go
+++ b/internal/services/automanage/automanage_configuration_resource_test.go
@@ -40,9 +40,6 @@ func TestAccAutoManageConfigurationProfile_antimalware(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("antimalware.#").HasValue("1"),
 				check.That(data.ResourceName).Key("antimalware.0.exclusions.#").HasValue("1"),
-				check.That(data.ResourceName).Key("antimalware.0.exclusions.0.extensions").HasValue("exe;dll"),
-				check.That(data.ResourceName).Key("antimalware.0.real_time_protection_enabled").HasValue("true"),
-				check.That(data.ResourceName).Key("automation_account_enabled").HasValue("true"),
 			),
 		},
 		data.ImportStep(),
@@ -58,6 +55,22 @@ func TestAccAutoManageConfigurationProfile_antimalware(t *testing.T) {
 	})
 }
 
+func TestAccAutoManageConfigurationProfile_azureSecurityBaseline(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_automanage_configuration", "test")
+	r := AutoManageConfigurationProfileResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.azureSecurityBaseline(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("azure_security_baseline.#").HasValue("1"),
+				check.That(data.ResourceName).Key("azure_security_baseline.0.assignment_type").HasValue("ApplyAndAutoCorrect"),
+			),
+		},
+		data.RequiresImportErrorStep(r.requiresImport),
+	})
+}
+
 func TestAccAutoManageConfigurationProfile_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_automanage_configuration", "test")
 	r := AutoManageConfigurationProfileResource{}
@@ -69,6 +82,72 @@ func TestAccAutoManageConfigurationProfile_requiresImport(t *testing.T) {
 			),
 		},
 		data.RequiresImportErrorStep(r.requiresImport),
+	})
+}
+
+func TestAccAutoManageConfigurationProfile_backup(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_automanage_configuration", "test")
+	r := AutoManageConfigurationProfileResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.backup(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("backup.#").HasValue("1"),
+				check.That(data.ResourceName).Key("backup.0.policy_name").Exists(),
+				check.That(data.ResourceName).Key("backup.0.time_zone").HasValue("UTC"),
+				check.That(data.ResourceName).Key("backup.0.instant_rp_retention_range_in_days").HasValue("2"),
+				check.That(data.ResourceName).Key("backup.0.schedule_policy.#").HasValue("1"),
+				check.That(data.ResourceName).Key("backup.0.schedule_policy.0.schedule_run_frequency").HasValue("Daily"),
+				check.That(data.ResourceName).Key("backup.0.schedule_policy.0.schedule_run_days.#").HasValue("2"),
+				check.That(data.ResourceName).Key("backup.0.schedule_policy.0.schedule_run_days.0").HasValue("Monday"),
+				check.That(data.ResourceName).Key("backup.0.schedule_policy.0.schedule_run_days.1").HasValue("Tuesday"),
+				check.That(data.ResourceName).Key("backup.0.schedule_policy.0.schedule_run_times.#").HasValue("1"),
+				check.That(data.ResourceName).Key("backup.0.schedule_policy.0.schedule_run_times.0").HasValue("12:00"),
+				check.That(data.ResourceName).Key("backup.0.schedule_policy.0.schedule_policy_type").HasValue("SimpleSchedulePolicy"),
+				check.That(data.ResourceName).Key("backup.0.retention_policy.#").HasValue("1"),
+				check.That(data.ResourceName).Key("backup.0.retention_policy.0.retention_policy_type").HasValue("LongTermRetentionPolicy"),
+				check.That(data.ResourceName).Key("backup.0.retention_policy.0.daily_schedule.#").HasValue("1"),
+				check.That(data.ResourceName).Key("backup.0.retention_policy.0.daily_schedule.0.retention_times.#").HasValue("1"),
+				check.That(data.ResourceName).Key("backup.0.retention_policy.0.daily_schedule.0.retention_times.0").HasValue("12:00"),
+				check.That(data.ResourceName).Key("backup.0.retention_policy.0.daily_schedule.0.retention_duration.#").HasValue("1"),
+				check.That(data.ResourceName).Key("backup.0.retention_policy.0.daily_schedule.0.retention_duration.0.count").HasValue("7"),
+				check.That(data.ResourceName).Key("backup.0.retention_policy.0.daily_schedule.0.retention_duration.0.duration_type").HasValue("Days"),
+				check.That(data.ResourceName).Key("backup.0.retention_policy.0.weekly_schedule.#").HasValue("1"),
+				check.That(data.ResourceName).Key("backup.0.retention_policy.0.weekly_schedule.0.retention_times.#").HasValue("1"),
+				check.That(data.ResourceName).Key("backup.0.retention_policy.0.weekly_schedule.0.retention_times.0").HasValue("14:00"),
+				check.That(data.ResourceName).Key("backup.0.retention_policy.0.weekly_schedule.0.retention_duration.#").HasValue("1"),
+				check.That(data.ResourceName).Key("backup.0.retention_policy.0.weekly_schedule.0.retention_duration.0.count").HasValue("4"),
+				check.That(data.ResourceName).Key("backup.0.retention_policy.0.weekly_schedule.0.retention_duration.0.duration_type").HasValue("Weeks"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.backupUpdate(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("backup.#").HasValue("1"),
+				check.That(data.ResourceName).Key("backup.0.policy_name").Exists(),
+				check.That(data.ResourceName).Key("backup.0.time_zone").HasValue("UTC"),
+				check.That(data.ResourceName).Key("backup.0.instant_rp_retention_range_in_days").HasValue("5"),
+				check.That(data.ResourceName).Key("backup.0.schedule_policy.#").HasValue("1"),
+				check.That(data.ResourceName).Key("backup.0.schedule_policy.0.schedule_run_frequency").HasValue("Daily"),
+				check.That(data.ResourceName).Key("backup.0.schedule_policy.0.schedule_run_days.#").HasValue("1"),
+				check.That(data.ResourceName).Key("backup.0.schedule_policy.0.schedule_run_days.0").HasValue("Monday"),
+				check.That(data.ResourceName).Key("backup.0.schedule_policy.0.schedule_run_times.#").HasValue("1"),
+				check.That(data.ResourceName).Key("backup.0.schedule_policy.0.schedule_run_times.0").HasValue("12:00"),
+				check.That(data.ResourceName).Key("backup.0.retention_policy.#").HasValue("1"),
+				check.That(data.ResourceName).Key("backup.0.retention_policy.0.retention_policy_type").HasValue("LongTermRetentionPolicy"),
+				check.That(data.ResourceName).Key("backup.0.retention_policy.0.daily_schedule.#").HasValue("1"),
+				check.That(data.ResourceName).Key("backup.0.retention_policy.0.daily_schedule.0.retention_times.#").HasValue("1"),
+				check.That(data.ResourceName).Key("backup.0.retention_policy.0.daily_schedule.0.retention_times.0").HasValue("12:00"),
+				check.That(data.ResourceName).Key("backup.0.retention_policy.0.daily_schedule.0.retention_duration.#").HasValue("1"),
+				check.That(data.ResourceName).Key("backup.0.retention_policy.0.daily_schedule.0.retention_duration.0.count").HasValue("7"),
+				check.That(data.ResourceName).Key("backup.0.retention_policy.0.daily_schedule.0.retention_duration.0.duration_type").HasValue("Days"),
+				check.That(data.ResourceName).Key("backup.0.retention_policy.0.weekly_schedule.#").HasValue("0"),
+			),
+		},
+		data.ImportStep(),
 	})
 }
 
@@ -269,4 +348,101 @@ resource "azurerm_automanage_configuration" "test" {
   }
 }
 `, template, data.RandomInteger, data.Locations.Primary)
+}
+
+func (r AutoManageConfigurationProfileResource) azureSecurityBaseline(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+			%s
+
+resource "azurerm_automanage_configuration" "test" {
+  name                = "acctest-amcp-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  azure_security_baseline {
+    assignment_type = "ApplyAndAutoCorrect"
+  }
+}
+`, template, data.RandomInteger)
+}
+
+func (r AutoManageConfigurationProfileResource) backup(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+			%s
+
+resource "azurerm_automanage_configuration" "test" {
+  name                = "acctest-amcp-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  backup {
+    policy_name                        = "acctest-backup-policy-%d"
+    time_zone                          = "UTC"
+    instant_rp_retention_range_in_days = 2
+
+    schedule_policy {
+      schedule_run_frequency = "Daily"
+      schedule_run_days      = ["Monday", "Tuesday"]
+      schedule_run_times     = ["12:00"]
+      schedule_policy_type   = "SimpleSchedulePolicy"
+    }
+
+    retention_policy {
+      retention_policy_type = "LongTermRetentionPolicy"
+
+      daily_schedule {
+        retention_times = ["12:00"]
+        retention_duration {
+          count         = 7
+          duration_type = "Days"
+        }
+      }
+
+      weekly_schedule {
+        retention_times = ["14:00"]
+        retention_duration {
+          count         = 4
+          duration_type = "Weeks"
+        }
+      }
+    }
+  }
+}
+`, template, data.RandomInteger, data.RandomInteger)
+}
+
+func (r AutoManageConfigurationProfileResource) backupUpdate(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+			%s
+
+resource "azurerm_automanage_configuration" "test" {
+  name                = "acctest-amcp-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  backup {
+    policy_name                        = "acctest-backup-policy-%d"
+    time_zone                          = "UTC"
+    instant_rp_retention_range_in_days = 5
+
+    schedule_policy {
+      schedule_run_frequency = "Daily"
+      schedule_run_days      = ["Monday"]
+      schedule_run_times     = ["12:00"]
+    }
+
+    retention_policy {
+      retention_policy_type = "LongTermRetentionPolicy"
+
+      daily_schedule {
+        retention_times = ["12:00"]
+        retention_duration {
+          count         = 7
+          duration_type = "Days"
+        }
+      }
+    }
+  }
+}
+`, template, data.RandomInteger, data.RandomInteger)
 }

--- a/website/docs/r/automanage_configuration.html.markdown
+++ b/website/docs/r/automanage_configuration.html.markdown
@@ -36,13 +36,13 @@ resource "azurerm_automanage_configuration" "example" {
     scheduled_scan_day             = 1
     scheduled_scan_time_in_minutes = 1339
   }
-  
+
   azure_security_baseline {
     assignment_type = "ApplyAndAutoCorrect"
   }
 
-  automation_account_enabled  = true
-  
+  automation_account_enabled = true
+
   backup {
     policy_name                        = "acctest-backup-policy-%d"
     time_zone                          = "UTC"
@@ -75,7 +75,7 @@ resource "azurerm_automanage_configuration" "example" {
       }
     }
   }
-  
+
   boot_diagnostics_enabled    = true
   defender_for_cloud_enabled  = true
   guest_configuration_enabled = true

--- a/website/docs/r/automanage_configuration.html.markdown
+++ b/website/docs/r/automanage_configuration.html.markdown
@@ -36,8 +36,46 @@ resource "azurerm_automanage_configuration" "example" {
     scheduled_scan_day             = 1
     scheduled_scan_time_in_minutes = 1339
   }
+  
+  azure_security_baseline {
+    assignment_type = "ApplyAndAutoCorrect"
+  }
 
   automation_account_enabled  = true
+  
+  backup {
+    policy_name                        = "acctest-backup-policy-%d"
+    time_zone                          = "UTC"
+    instant_rp_retention_range_in_days = 2
+
+    schedule_policy {
+      schedule_run_frequency = "Daily"
+      schedule_run_days      = ["Monday", "Tuesday"]
+      schedule_run_times     = ["12:00"]
+      schedule_policy_type   = "SimpleSchedulePolicy"
+    }
+
+    retention_policy {
+      retention_policy_type = "LongTermRetentionPolicy"
+
+      daily_schedule {
+        retention_times = ["12:00"]
+        retention_duration {
+          count         = 7
+          duration_type = "Days"
+        }
+      }
+
+      weekly_schedule {
+        retention_times = ["14:00"]
+        retention_duration {
+          count         = 4
+          duration_type = "Weeks"
+        }
+      }
+    }
+  }
+  
   boot_diagnostics_enabled    = true
   defender_for_cloud_enabled  = true
   guest_configuration_enabled = true
@@ -61,6 +99,10 @@ The following arguments are supported:
 
 * `antimalware` - (Optional) A `antimalware` block as defined below.
 
+* `azure_security_baseline` - (Optional) A `azure_security_baseline` block as defined below.
+
+* `backup` - (Optional) A `backup` block as defined below.
+
 * `automation_account_enabled` - (Optional) Whether the automation account is enabled. Defaults to `false`.
 
 * `boot_diagnostics_enabled` - (Optional) Whether the boot diagnostics are enabled. Defaults to `false`.
@@ -70,6 +112,8 @@ The following arguments are supported:
 * `guest_configuration_enabled` - (Optional) Whether the guest configuration is enabled. Defaults to `false`.
 
 * `status_change_alert_enabled` - (Optional) Whether the status change alert is enabled. Defaults to `false`.
+
+* `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ---
 
@@ -97,8 +141,73 @@ The following arguments are supported:
 
 * `processes` - (Optional) The processes to exclude from the antimalware scan, separated by `;`. For example `svchost.exe;notepad.exe`.
 
-* `tags` - (Optional) A mapping of tags which should be assigned to the Automanage Configuration.
+---
 
+* `azure_security_baseline` supports the following:
+
+* `assignment_type` - (Optional) The assignment type of the azure security baseline. Possible values are `ApplyAndAutoCorrect`, `ApplyAndMonitor`, `Audit` and `DeployAndAutoCorrect`. Defaults to `ApplyAndAutoCorrect`.
+
+---
+
+* `backup` supports the following:
+
+* `policy_name` - (Optional) The name of the backup policy.
+
+* `time_zone` - (Optional) The timezone of the backup policy. Defaults to `UTC`.
+
+* `instant_rp_retention_range_in_days` - (Optional) The retention range in days of the backup policy. Defaults to `5`.
+
+* `schedule_policy` - (Optional) A `schedule_policy` block as defined below.
+
+* `retention_policy` - (Optional) A `retention_policy` block as defined below.
+
+---
+
+* `schedule_policy` supports the following:
+
+* `schedule_run_frequency` - (Optional) The schedule run frequency of the backup policy. Possible values are `Daily` and `Weekly`. Defaults to `Daily`.
+
+* `schedule_run_times` - (Optional) The schedule run times of the backup policy.
+
+* `schedule_run_days` - (Optional) The schedule run days of the backup policy. Possible values are `Sunday`, `Monday`, `Tuesday`, `Wednesday`, `Thursday`, `Friday` and `Saturday`.
+
+* `schedule_policy_type` - (Optional) The schedule policy type of the backup policy. Possible value is `SimpleSchedulePolicy`.
+
+---
+
+* `retention_policy` supports the following:
+
+* `retention_policy_type` - (Optional) The retention policy type of the backup policy. Possible value is `LongTermRetentionPolicy`.
+
+* `daily_schedule` - (Optional) A `daily_schedule` block as defined below.
+
+* `weekly_schedule` - (Optional) A `weekly_schedule` block as defined below.
+
+---
+
+* `daily_schedule` supports the following:
+
+* `retention_times` - (Optional) The retention times of the backup policy.
+
+* `retention_duration` - (Optional) A `retention_duration` block as defined below.
+
+---
+
+* `weekly_schedule` supports the following:
+
+* `retention_times` - (Optional) The retention times of the backup policy.
+
+* `retention_duration` - (Optional) A `retention_duration` block as defined below.
+
+---
+
+* `retention_duration` supports the following:
+
+* `count` - (Optional) The count of the retention duration of the backup policy. Valid value inside `daily_schedule` is `7` to `9999` and inside `weekly_schedule` is `1` to `5163`.
+
+* `duration_type` - (Optional) The duration type of the retention duration of the backup policy. Valid value inside `daily_schedule` is `Days` and inside `weekly_schedule` is `Weeks`.
+
+---
 ## Attributes Reference
 
 In addition to the Arguments listed above - the following Attributes are exported:


### PR DESCRIPTION
This is the second PR for `azurerm_automanage_configuration`, In this PR, 

- new property block `backup` and `azure_security_baseline` are added. 
- add test cases for new properties.
- update documents for new properties.
- rewrite the expand and flatten logic for better understading and more logical.
- update the order of struct to be alphabetical.

Previous PR: https://github.com/hashicorp/terraform-provider-azurerm/pull/21490

Swagger Link: https://github.com/Azure/azure-rest-api-specs/blob/main/specification/automanage/resource-manager/Microsoft.Automanage/stable/2022-05-04/automanage.json