### PR TITLE
`azurerm_monitor_activity_log_alert` - limit `resource_health` and `service_health` up to one block

### DIFF
--- a/internal/services/monitor/monitor_activity_log_alert_resource.go
+++ b/internal/services/monitor/monitor_activity_log_alert_resource.go
@@ -247,6 +247,7 @@ func resourceMonitorActivityLogAlert() *pluginsdk.Resource {
 							Type:     pluginsdk.TypeList,
 							Computed: true,
 							Optional: true,
+							MaxItems: 1,
 							Elem: &pluginsdk.Resource{
 								Schema: map[string]*pluginsdk.Schema{
 									"current": {
@@ -305,6 +306,7 @@ func resourceMonitorActivityLogAlert() *pluginsdk.Resource {
 							Type:     pluginsdk.TypeList,
 							Computed: true,
 							Optional: true,
+							MaxItems: 1,
 							Elem: &pluginsdk.Resource{
 								Schema: map[string]*pluginsdk.Schema{
 									"events": {


### PR DESCRIPTION
resolves https://github.com/hashicorp/terraform-provider-azurerm/issues/17343