### PR TITLE
`azurerm_site_recovery_replication_recovery_plan`: support `azure_to_azure_settings` block in data source

### DIFF
--- a/internal/services/recoveryservices/site_recovery_replication_recovery_plan_data_source.go
+++ b/internal/services/recoveryservices/site_recovery_replication_recovery_plan_data_source.go
@@ -76,6 +76,10 @@ func (r SiteRecoveryReplicationRecoveryPlanDataSource) Read() sdk.ResourceFunc {
 				if group := prop.Groups; group != nil {
 					state.RecoveryGroup = flattenRecoveryGroups(*group)
 				}
+
+				if details := prop.ProviderSpecificDetails; details != nil && len(*details) > 0 {
+					state.A2ASettings = flattenRecoveryPlanProviderSpecficInput(details)
+				}
 			}
 
 			metadata.SetID(id)
@@ -127,6 +131,7 @@ func (r SiteRecoveryReplicationRecoveryPlanDataSource) Attributes() map[string]*
 						Type:     pluginsdk.TypeString,
 						Computed: true,
 					},
+
 					"replicated_protected_items": {
 						Type:     pluginsdk.TypeList,
 						Computed: true,
@@ -134,15 +139,45 @@ func (r SiteRecoveryReplicationRecoveryPlanDataSource) Attributes() map[string]*
 							Type: pluginsdk.TypeString,
 						},
 					},
+
 					"pre_action": {
 						Type:     pluginsdk.TypeSet,
 						Computed: true,
 						Elem:     dataSourceSiteRecoveryReplicationPlanActions(),
 					},
+
 					"post_action": {
 						Type:     pluginsdk.TypeSet,
 						Computed: true,
 						Elem:     dataSourceSiteRecoveryReplicationPlanActions(),
+					},
+				},
+			},
+		},
+
+		"azure_to_azure_settings": {
+			Type:     pluginsdk.TypeList,
+			Computed: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"primary_zone": {
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+
+					"recovery_zone": {
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+
+					"primary_edge_zone": {
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+
+					"recovery_edge_zone": {
+						Type:     schema.TypeString,
+						Computed: true,
 					},
 				},
 			},

--- a/internal/services/recoveryservices/site_recovery_replication_recovery_plan_data_source_test.go
+++ b/internal/services/recoveryservices/site_recovery_replication_recovery_plan_data_source_test.go
@@ -30,6 +30,28 @@ func TestAccDataSourceSiteRecoveryReplicationRecoveryPlan_basic(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceSiteRecoveryReplicationRecoveryPlan_withZones(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_site_recovery_replication_recovery_plan", "test")
+	r := SiteRecoveryReplicationRecoveryPlanDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.withZones(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("name").Exists(),
+				check.That(data.ResourceName).Key("recovery_vault_id").Exists(),
+				check.That(data.ResourceName).Key("source_recovery_fabric_id").Exists(),
+				check.That(data.ResourceName).Key("target_recovery_fabric_id").Exists(),
+				check.That(data.ResourceName).Key("recovery_group.0.type").HasValue("Boot"),
+				check.That(data.ResourceName).Key("recovery_group.1.type").HasValue("Failover"),
+				check.That(data.ResourceName).Key("recovery_group.2.type").HasValue("Shutdown"),
+				check.That(data.ResourceName).Key("azure_to_azure_settings.0.primary_zone").HasValue("1"),
+				check.That(data.ResourceName).Key("azure_to_azure_settings.0.recovery_zone").HasValue("2"),
+			),
+		},
+	})
+}
+
 func (SiteRecoveryReplicationRecoveryPlanDataSource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
@@ -39,4 +61,15 @@ data "azurerm_site_recovery_replication_recovery_plan" "test" {
   recovery_vault_id = azurerm_site_recovery_replication_recovery_plan.test.recovery_vault_id
 }
 `, SiteRecoveryReplicationRecoveryPlan{}.basic(data))
+}
+
+func (SiteRecoveryReplicationRecoveryPlanDataSource) withZones(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_site_recovery_replication_recovery_plan" "test" {
+  name              = azurerm_site_recovery_replication_recovery_plan.test.name
+  recovery_vault_id = azurerm_site_recovery_replication_recovery_plan.test.recovery_vault_id
+}
+`, SiteRecoveryReplicationRecoveryPlan{}.withZones(data))
 }


### PR DESCRIPTION
test
---
```
terraform-provider-azurerm on  tengzh/recovery/recovery_plan_data_source via 🐹 v1.20.4 took 25m7s 
❯ tftest recoveryservices TestAccDataSourceSiteRecoveryReplicationRecoveryPlan
=== RUN   TestAccDataSourceSiteRecoveryReplicationRecoveryPlan_basic
=== PAUSE TestAccDataSourceSiteRecoveryReplicationRecoveryPlan_basic
=== RUN   TestAccDataSourceSiteRecoveryReplicationRecoveryPlan_withZones
=== PAUSE TestAccDataSourceSiteRecoveryReplicationRecoveryPlan_withZones
=== CONT  TestAccDataSourceSiteRecoveryReplicationRecoveryPlan_basic
=== CONT  TestAccDataSourceSiteRecoveryReplicationRecoveryPlan_withZones
--- PASS: TestAccDataSourceSiteRecoveryReplicationRecoveryPlan_basic (3109.58s)
--- PASS: TestAccDataSourceSiteRecoveryReplicationRecoveryPlan_withZones (3148.31s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/recoveryservices      3148.361s
```