### PR TITLE
`azurerm_nginx_certificate`: support update `key_virtual_path`, `certificate_virtual_path` and `key_vault_secret_id` fields

### DIFF
--- a/internal/services/nginx/nginx_certificate_resource.go
+++ b/internal/services/nginx/nginx_certificate_resource.go
@@ -201,7 +201,7 @@ func (m CertificateResource) Read() sdk.ResourceFunc {
 
 func (m CertificateResource) Delete() sdk.ResourceFunc {
 	return sdk.ResourceFunc{
-		Timeout: 30 * time.Minute,
+		Timeout: 10 * time.Minute,
 		Func: func(ctx context.Context, meta sdk.ResourceMetaData) error {
 			id, err := nginxcertificate.ParseCertificateID(meta.ResourceData.Id())
 			if err != nil {

--- a/internal/services/nginx/nginx_certificate_resource_test.go
+++ b/internal/services/nginx/nginx_certificate_resource_test.go
@@ -42,6 +42,27 @@ func TestAccCertificate_basic(t *testing.T) {
 	})
 }
 
+func TestAccCertificate_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, nginx.CertificateResource{}.ResourceType(), "test")
+	r := CertificateResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.update(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccCertificate_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, nginx.CertificateResource{}.ResourceType(), "test")
 	r := CertificateResource{}
@@ -59,7 +80,6 @@ func TestAccCertificate_requiresImport(t *testing.T) {
 func (a CertificateResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 
-
 %s
 
 resource "azurerm_nginx_certificate" "test" {
@@ -70,6 +90,67 @@ resource "azurerm_nginx_certificate" "test" {
   key_vault_secret_id      = azurerm_key_vault_certificate.test.secret_id
 }
 `, a.template(data), data.RandomInteger, data.Locations.Primary)
+}
+
+func (a CertificateResource) update(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+
+%s
+
+resource "azurerm_key_vault_certificate" "test2" {
+  name         = "acctestcert2%[2]d"
+  key_vault_id = azurerm_key_vault.test.id
+
+  certificate_policy {
+    issuer_parameters {
+      name = "Self"
+    }
+
+    key_properties {
+      exportable = true
+      key_size   = 2048
+      key_type   = "RSA"
+      reuse_key  = true
+    }
+
+    lifetime_action {
+      action {
+        action_type = "AutoRenew"
+      }
+
+      trigger {
+        days_before_expiry = 30
+      }
+    }
+
+    secret_properties {
+      content_type = "application/x-pem-file"
+    }
+
+    x509_certificate_properties {
+      key_usage = [
+        "cRLSign",
+        "dataEncipherment",
+        "digitalSignature",
+        "keyAgreement",
+        "keyEncipherment",
+        "keyCertSign",
+      ]
+
+      subject            = "CN=hello-world"
+      validity_in_months = 12
+    }
+  }
+}
+
+resource "azurerm_nginx_certificate" "test" {
+  name                     = "acctest%[2]d"
+  nginx_deployment_id      = azurerm_nginx_deployment.test.id
+  key_virtual_path         = "/src/cert/soservermekey2.key"
+  certificate_virtual_path = "/src/cert/server2.cert"
+  key_vault_secret_id      = azurerm_key_vault_certificate.test2.secret_id
+}
+`, a.template(data), data.RandomInteger)
 }
 
 func (a CertificateResource) requiresImport(data acceptance.TestData) string {

--- a/website/docs/r/nginx_certificate.html.markdown
+++ b/website/docs/r/nginx_certificate.html.markdown
@@ -146,7 +146,7 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 * `create` - (Defaults to 30 minutes) Used when creating the Nginx Certificate.
 * `update` - (Defaults to 30 minutes) Used when updating the Nginx Certificate.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Nginx Certificate.
-* `delete` - (Defaults to 30 minutes) Used when deleting the Nginx Certificate.
+* `delete` - (Defaults to 10 minutes) Used when deleting the Nginx Certificate.
 
 ## Import
 

--- a/website/docs/r/nginx_certificate.html.markdown
+++ b/website/docs/r/nginx_certificate.html.markdown
@@ -127,11 +127,11 @@ The following arguments are supported:
 
 * `nginx_deployment_id` - (Required) The ID of the Nginx Deployment that this Certificate should be associated with. Changing this forces a new Nginx Certificate to be created.
 
-* `certificate_virtual_path` - (Required) Specify the path to the cert file of this certificate. Changing this forces a new Nginx Certificate to be created.
+* `certificate_virtual_path` - (Required) Specify the path to the cert file of this certificate.
 
-* `key_virtual_path` - (Required) Specify the path to the key file of this certificate. Changing this forces a new Nginx Certificate to be created.
+* `key_virtual_path` - (Required) Specify the path to the key file of this certificate.
 
-* `key_vault_secret_id` - (Required) Specify the ID of the Key Vault Secret for this certificate. Changing this forces a new Nginx Certificate to be created.
+* `key_vault_secret_id` - (Required) Specify the ID of the Key Vault Secret for this certificate.
 
 ## Attributes Reference
 
@@ -144,8 +144,9 @@ In addition to the Arguments listed above - the following Attributes are exporte
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
 * `create` - (Defaults to 30 minutes) Used when creating the Nginx Certificate.
+* `update` - (Defaults to 30 minutes) Used when updating the Nginx Certificate.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Nginx Certificate.
-* `delete` - (Defaults to 10 minutes) Used when deleting the Nginx Certificate.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Nginx Certificate.
 
 ## Import
 


### PR DESCRIPTION
fixes: #22092 . these fieds should support update.