### PR TITLE
New Resource: `azurerm_resource_tags`

### DIFF
--- a/internal/services/resource/parse/resource_tags.go
+++ b/internal/services/resource/parse/resource_tags.go
@@ -1,0 +1,89 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+type ResourceTagsId struct {
+	SubscriptionId string
+	ResourceGroup  string
+	Provider       string
+	Namespace      string
+	ResourceName   string
+}
+
+func NewResourceTagsID(subscriptionId, resourceGroup, provider, namespace, resourceName string) ResourceTagsId {
+	return ResourceTagsId{
+		SubscriptionId: subscriptionId,
+		ResourceGroup:  resourceGroup,
+		Provider:       provider,
+		Namespace:      namespace,
+		ResourceName:   resourceName,
+	}
+}
+
+func (id ResourceTagsId) String() string {
+	segments := []string{
+		fmt.Sprintf("Subscription ID %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+		fmt.Sprintf("Provider %q", id.Provider),
+		// fmt.Sprintf("Resource Namespace %q", id.Namespace),
+		// fmt.Sprintf("Resource Name %q", id.ResourceName),
+	}
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Resource Tags", segmentsStr)
+}
+
+func (id ResourceTagsId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/%s/%s/%s/providers/Microsoft.Resources/tags/default"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Provider, id.Namespace, id.ResourceName)
+}
+
+func (id ResourceTagsId) ParentResourceID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/%s/%s/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.Provider, id.Namespace, id.ResourceName)
+}
+
+// ResourceTagsID parses a ResourceTags ID into an ResourceTagsId struct
+func ResourceTagsID(input string) (*ResourceTagsId, error) {
+	id, err := resourceids.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+	splitId := strings.Split(input, "/")
+
+	resourceId := ResourceTagsId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+		Provider:       id.Provider,
+		Namespace:      splitId[7],
+		ResourceName:   splitId[8],
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	if resourceId.Provider == "" {
+		return nil, fmt.Errorf("ID was missing the 'provider' element")
+	}
+
+	if resourceId.Namespace == "" {
+		return nil, fmt.Errorf("ID was missing the 'namespace' element")
+	}
+
+	if resourceId.ResourceName == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceName' element")
+	}
+
+	return &resourceId, nil
+}

--- a/internal/services/resource/parse/resource_tags.go
+++ b/internal/services/resource/parse/resource_tags.go
@@ -32,8 +32,8 @@ func (id ResourceTagsId) String() string {
 		fmt.Sprintf("Subscription ID %q", id.SubscriptionId),
 		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
 		fmt.Sprintf("Provider %q", id.Provider),
-		// fmt.Sprintf("Resource Namespace %q", id.Namespace),
-		// fmt.Sprintf("Resource Name %q", id.ResourceName),
+		fmt.Sprintf("Resource Namespace %q", id.Namespace),
+		fmt.Sprintf("Resource Name %q", id.ResourceName),
 	}
 	segmentsStr := strings.Join(segments, " / ")
 	return fmt.Sprintf("%s: (%s)", "Resource Tags", segmentsStr)

--- a/internal/services/resource/parse/resource_tags_test.go
+++ b/internal/services/resource/parse/resource_tags_test.go
@@ -1,0 +1,132 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.Id = ResourceTagsId{}
+
+func TestResourceTagsIDFormatter(t *testing.T) {
+	actual := NewResourceTagsID("12345678-1234-9876-4563-123456789012", "test-rg", "Microsoft.Compute", "virtualMachines", "test-vm").ID()
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachines/test-vm/providers/Microsoft.Resources/tags/default"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestResourceTagsID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *ResourceTagsId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing Provider
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/test-rg/providers/",
+			Error: true,
+		},
+
+		{
+			// missing value for Namespace
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/test-rg/providers/Microsoft.Compute/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachines/",
+			Error: true,
+		},
+
+		{
+			// missing value for TagResource
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachines/test-vm",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachines/test-vm/providers/Microsoft.Resources/tags/default",
+			Expected: &ResourceTagsId{
+				SubscriptionId: "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:  "test-rg",
+				Provider:       "Microsoft.Compute",
+				Namespace:      "virtualMachines",
+				ResourceName:   "test-vm",
+			},
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/test-rg/PROVIDERS/MICROSOFT.COMPUTE/VIRTUALMACHINES/test-vm/PROVIDERS/MICROSOFT.RESOURCES/TAGS/DEFAULT",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := ResourceTagsID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.Provider != v.Expected.Provider {
+			t.Fatalf("Expected %q but got %q for Provider", v.Expected.Provider, actual.Provider)
+		}
+		if actual.Namespace != v.Expected.Namespace {
+			t.Fatalf("Expected %q but got %q for Namespace", v.Expected.Namespace, actual.Namespace)
+		}
+		if actual.ResourceName != v.Expected.ResourceName {
+			t.Fatalf("Expected %q but got %q for ResourceName", v.Expected.ResourceName, actual.ResourceName)
+		}
+	}
+}

--- a/internal/services/resource/registration.go
+++ b/internal/services/resource/registration.go
@@ -49,6 +49,7 @@ func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 		"azurerm_subscription_template_deployment":     subscriptionTemplateDeploymentResource(),
 		"azurerm_template_deployment":                  resourceTemplateDeployment(),
 		"azurerm_tenant_template_deployment":           tenantTemplateDeploymentResource(),
+		"azurerm_resource_tags":                        resourceTags(),
 	}
 }
 

--- a/internal/services/resource/resource_tags_resource.go
+++ b/internal/services/resource/resource_tags_resource.go
@@ -1,0 +1,134 @@
+package resource
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2020-06-01/resources"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/resource/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
+)
+
+func resourceTags() *pluginsdk.Resource {
+	return &pluginsdk.Resource{
+		Create: resourceTagsCreateOrUpdate,
+		Update: resourceTagsCreateOrUpdate,
+		Read:   resourceTagsRead,
+		Delete: resourceTagsDelete,
+
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := parse.ResourceTagsID(id)
+			return err
+		}),
+
+		Timeouts: &pluginsdk.ResourceTimeout{
+			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
+			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
+			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
+			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*pluginsdk.Schema{
+			"resource_id": {
+				Type:     pluginsdk.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"tags": tags.Schema(),
+		},
+	}
+}
+
+func resourceTagsCreateOrUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Resource.TagsClient
+	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.ResourceTagsID(d.Get("resource_id").(string))
+	if err != nil {
+		return fmt.Errorf("could not parse resource ID for tagsId \"%s\": %v", id, err)
+	}
+	t := d.Get("tags").(map[string]interface{})
+
+	if d.IsNewResource() {
+		existing, err := client.GetAtScope(ctx, id.ParentResourceID())
+		if err != nil {
+			if !response.WasNotFound(existing.Request.Response) {
+				return fmt.Errorf("checking for presence of existing %s: %+v", id.ParentResourceID(), err)
+			}
+		}
+
+		for tag := range d.Get("tags").(map[string]interface{}) {
+			if existing.Properties.Tags[tag] != nil {
+				return tf.ImportAsExistsError("azurerm_resource_tags", tag)
+			}
+		}
+	}
+
+	payload := resources.TagsResource{
+		Properties: &resources.Tags{
+			Tags: tags.Expand(t),
+		},
+	}
+
+	if _, err := client.CreateOrUpdateAtScope(ctx, id.ParentResourceID(), payload); err != nil {
+		return fmt.Errorf("creating %s: %+v", id.ParentResourceID(), err)
+	}
+
+	tagsId := fmt.Sprintf("%s/providers/Microsoft.Resources/tags/default", id.ParentResourceID())
+
+	d.SetId(tagsId)
+	return resourceTagsRead(d, meta)
+}
+
+func resourceTagsRead(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Resource.TagsClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.ResourceTagsID(d.Id())
+	if err != nil {
+		return fmt.Errorf(d.Id(), err)
+	}
+
+	resp, err := client.GetAtScope(ctx, id.ParentResourceID())
+	if err != nil {
+		if response.WasNotFound(resp.Request.Response) {
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("retrieving %s: %+v", id.ID(), err)
+	}
+	d.Set("resource_id", id.ParentResourceID())
+	return tags.FlattenAndSet(d, resp.Properties.Tags)
+}
+
+func resourceTagsDelete(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Resource.TagsClient
+	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	resourceId := d.Get("resource_id").(string)
+
+	id, err := parse.ResourceTagsID(resourceId)
+	if err != nil {
+		return err
+	}
+
+	if resp, err := client.DeleteAtScope(ctx, resourceId); err != nil {
+		if response.WasNotFound(resp.Request.Response) {
+			return nil
+		}
+
+		return fmt.Errorf("deleting %s: %+v", *id, err)
+	}
+
+	return nil
+}

--- a/internal/services/resource/resource_tags_resource.go
+++ b/internal/services/resource/resource_tags_resource.go
@@ -81,9 +81,7 @@ func resourceTagsCreateOrUpdate(d *pluginsdk.ResourceData, meta interface{}) err
 		return fmt.Errorf("creating %s: %+v", id.ParentResourceID(), err)
 	}
 
-	tagsId := fmt.Sprintf("%s/providers/Microsoft.Resources/tags/default", id.ParentResourceID())
-
-	d.SetId(tagsId)
+	d.SetId(id.ID())
 	return resourceTagsRead(d, meta)
 }
 

--- a/internal/services/resource/resource_tags_resource_test.go
+++ b/internal/services/resource/resource_tags_resource_test.go
@@ -1,0 +1,161 @@
+package resource_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/resource/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+type ResourceTagsResource struct{}
+
+func TestAccResourceTags_ReadOnlyBasicKeyVault(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_resource_tags", "test")
+	r := ResourceTagsResource{}
+
+	data.ResourceTestSkipCheckDestroyed(t, []acceptance.TestStep{
+		{
+			Config: r.ReadOnlyBasicKeyVault(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccResourceTags_ReadOnlyBasicStorageAccount(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_resource_tags", "test")
+	r := ResourceTagsResource{}
+
+	data.ResourceTestSkipCheckDestroyed(t, []acceptance.TestStep{
+		{
+			Config: r.ReadOnlyBasicStorageAccount(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccResourceTags_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_resource_tags", "test")
+	r := ResourceTagsResource{}
+
+	data.ResourceTestSkipCheckDestroyed(t, []acceptance.TestStep{
+		{
+			Config: r.ReadOnlyBasicKeyVault(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.RequiresImportErrorStep(r.requiresImport),
+	})
+}
+
+func (t ResourceTagsResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := parse.ResourceTagsID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := clients.Resource.TagsClient.GetAtScope(ctx, id.ParentResourceID())
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %+v", *id, err)
+	}
+
+	return utils.Bool(resp.Properties.Tags != nil), nil
+}
+
+func (ResourceTagsResource) ReadOnlyBasicKeyVault(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-storage-%d"
+  location = "%s"
+}
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_key_vault" "test" {
+  name                       = "vault%d"
+  location                   = azurerm_resource_group.test.location
+  resource_group_name        = azurerm_resource_group.test.name
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "standard"
+
+  enable_rbac_authorization  = true
+
+  contact {
+	email = "test@example.com"
+  }
+
+  lifecycle {
+	ignore_changes = [tags]
+  }
+}
+
+resource "azurerm_resource_tags" "test" {
+  resource_id = azurerm_key_vault.test.id
+  tags = {
+    "test" = "test",
+  }
+}
+
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (ResourceTagsResource) ReadOnlyBasicStorageAccount(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-storage-%d"
+  location = "%s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                = "tagstest%s"
+  resource_group_name = azurerm_resource_group.test.name
+
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+
+  lifecycle {
+	ignore_changes = [tags]
+  }
+}
+
+resource "azurerm_resource_tags" "test" {
+  resource_id = azurerm_storage_account.test.id
+  tags = {
+    "test" = "test",
+  }
+}
+
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}
+
+func (r ResourceTagsResource) requiresImport(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_resource_tags" "import" {
+  resource_id       = azurerm_resource_tags.test.resource_id
+  tags      		= azurerm_resource_tags.test.tags
+}
+`, r.ReadOnlyBasicKeyVault(data))
+}

--- a/internal/services/resource/validate/resource_tags_id.go
+++ b/internal/services/resource/validate/resource_tags_id.go
@@ -1,0 +1,23 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/resource/parse"
+)
+
+func ResourceTagsID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := parse.ResourceTagsID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}

--- a/internal/services/resource/validate/resource_tags_id_test.go
+++ b/internal/services/resource/validate/resource_tags_id_test.go
@@ -1,0 +1,88 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import "testing"
+
+func TestResourceTagsID(t *testing.T) {
+	cases := []struct {
+		Input string
+		Valid bool
+	}{
+
+		{
+			// empty
+			Input: "",
+			Valid: false,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Valid: false,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Valid: false,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Valid: false,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Valid: false,
+		},
+
+		{
+			// missing Provider
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/test-rg/providers/",
+			Valid: false,
+		},
+
+		{
+			// missing value for Namespace
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/test-rg/providers/Microsoft.Compute/",
+			Valid: false,
+		},
+
+		{
+			// missing ResourceName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachines/",
+			Valid: false,
+		},
+
+		{
+			// missing value for TagResource
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachines/test-vm",
+			Valid: false,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachines/test-vm/providers/Microsoft.Resources/tags/default",
+			Valid: true,
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/test-rg/PROVIDERS/MICROSOFT.COMPUTE/VIRTUALMACHINES/test-vm/PROVIDERS/MICROSOFT.RESOURCES/TAGS/DEFAULT",
+			Valid: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Logf("[DEBUG] Testing Value %s", tc.Input)
+		_, errors := ResourceTagsID(tc.Input, "test")
+		valid := len(errors) == 0
+
+		if tc.Valid != valid {
+			t.Fatalf("Expected %t but got %t", tc.Valid, valid)
+		}
+	}
+}

--- a/website/docs/r/resource_tags.html.markdown
+++ b/website/docs/r/resource_tags.html.markdown
@@ -1,0 +1,75 @@
+---
+subcategory: "Management"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_resource_tags"
+description: |-
+  Manages Resource Tags.
+---
+
+# azurerm_resource_tags
+
+Manages Azure Resource Tags.
+~> **Note** You must ignore the tags property on the resource you are trying to manage the tags on. Below is an example of this.
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "example-rg"
+  location = "West Europe"
+}
+
+resource "azurerm_storage_account" "example" {
+  name                = "tagsstorage132428"
+  resource_group_name = azurerm_resource_group.example.name
+
+  location                 = azurerm_resource_group.example.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+
+  lifecycle {
+	ignore_changes = [tags]
+  }
+}
+
+resource "azurerm_resource_tags" "example" {
+  resource_id = azurerm_storage_account.example.id
+  
+  tags = {
+    key = "value"
+  }
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `resource_id` - (Required) The ID of the resource you want to manage the tags of. Changing this forces a new Resource Tags resource to be created.
+
+---
+
+* `tags` - (Optional) A mapping of tags which should be assigned to the Resource Tags.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported: 
+
+* `id` - The ID of the Resource Tags resource.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Resource Tags.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Resource Tags.
+* `update` - (Defaults to 30 minutes) Used when updating the Resource Tags.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Resource Tags.
+
+## Import
+
+Resource Tagss can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_resource_tags.example /subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachines/test-vm/providers/Microsoft.Resources/tags/default
+```


### PR DESCRIPTION
# Reason 
Me and some current/older colleagues have had some usecases for managing the tags on different unmanaged resources on our Azure platform. These usecase resources are not managed by Terraform and in some cases we would also prefer it that way. One of the usecases is to use tags for an Azure budget, and instead of importing every resource in Terraform or setting the tags by hand on the unmanaged resources, this new resource can manage the tags without the resource being Terraform managed itself.

# What does it do?
The `azurerm_resource_tags` resource manages tags on an AzureRM resource. The resource itself does not need to be managed by Terraform.

# Acceptance tests output
## TestAccResourceTags_ReadOnlyBasicKeyVault:
```shell
terraform-provider-azurerm $  make acctests SERVICE='resource' TESTARGS='-run=TestAccResourceTags_ReadOnlyBasicKeyVault' TESTTIMEOUT='60m' 
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/resource -run=TestAccResourceTags_ReadOnlyBasicKeyVault -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccResourceTags_ReadOnlyBasicKeyVault
=== PAUSE TestAccResourceTags_ReadOnlyBasicKeyVault
=== CONT  TestAccResourceTags_ReadOnlyBasicKeyVault
--- PASS: TestAccResourceTags_ReadOnlyBasicKeyVault (203.18s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/resource      203.193s
```

## TestAccResourceTags_ReadOnlyBasicStorageAccount:
```shell
terraform-provider-azurerm $  make acctests SERVICE='resource' TESTARGS='-run=TestAccResourceTags_ReadOnlyBasicStorageAccount' TESTTIMEOUT='60m'
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/resource -run=TestAccResourceTags_ReadOnlyBasicStorageAccount -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccResourceTags_ReadOnlyBasicStorageAccount
=== PAUSE TestAccResourceTags_ReadOnlyBasicStorageAccount
=== CONT  TestAccResourceTags_ReadOnlyBasicStorageAccount
--- PASS: TestAccResourceTags_ReadOnlyBasicStorageAccount (62.90s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/resource      201.243s
```

## TestAccResourceTags_requiresImport:
```shell
terraform-provider-azurerm $  make acctests SERVICE='resource' TESTARGS='-run=TestAccResourceTags_requiresImport' TESTTIMEOUT='60m'        
==> Checking that code complies with gofmt requirements...
==> Checking that Custom Timeouts are used...
==> Checking that acceptance test packages are used...
TF_ACC=1 go test -v ./internal/services/resource -run=TestAccResourceTags_requiresImport -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccResourceTags_requiresImport
=== PAUSE TestAccResourceTags_requiresImport
=== CONT  TestAccResourceTags_requiresImport
--- PASS: TestAccResourceTags_requiresImport (205.79s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/resource      205.799s
```

# Related issues
- Fixes #18596