### PR TITLE
`tests` - change `Standard_M64s` to `Standard_M8ms` to reduce cpu usage

### DIFF
--- a/internal/services/compute/virtual_machine_data_disk_attachment_resource_test.go
+++ b/internal/services/compute/virtual_machine_data_disk_attachment_resource_test.go
@@ -475,7 +475,7 @@ resource "azurerm_virtual_machine" "test" {
   location              = azurerm_resource_group.test.location
   resource_group_name   = azurerm_resource_group.test.name
   network_interface_ids = [azurerm_network_interface.test.id]
-  vm_size               = "Standard_M64s"
+  vm_size               = "Standard_M8ms"
 
   delete_os_disk_on_termination = true
 

--- a/internal/services/legacy/virtual_machine_managed_disks_resource_test.go
+++ b/internal/services/legacy/virtual_machine_managed_disks_resource_test.go
@@ -509,7 +509,7 @@ resource "azurerm_virtual_machine" "test" {
   location              = azurerm_resource_group.test.location
   resource_group_name   = azurerm_resource_group.test.name
   network_interface_ids = [azurerm_network_interface.test.id]
-  vm_size               = "Standard_M64s"
+  vm_size               = "Standard_M8ms"
 
   delete_os_disk_on_termination    = true
   delete_data_disks_on_termination = true
@@ -598,7 +598,7 @@ resource "azurerm_virtual_machine" "test" {
   location              = azurerm_resource_group.test.location
   resource_group_name   = azurerm_resource_group.test.name
   network_interface_ids = [azurerm_network_interface.test.id]
-  vm_size               = "Standard_M64s"
+  vm_size               = "Standard_M8ms"
 
   delete_os_disk_on_termination    = true
   delete_data_disks_on_termination = true


### PR DESCRIPTION
updating sku in VM tests of write accelerator. M64s needs 64 cpu count, which is easy to exceed the quota, thus reducing it to M8ms which needs 8 cpu count.
Error message: `Current Limit: 128, Current Usage: 128, Additional Required: 64, (Minimum) New Limit Required: 192`