### PR TITLE
Docs: fix wrong resource name used in example, rename to

### DIFF
--- a/website/docs/r/cdn_frontdoor_route.html.markdown
+++ b/website/docs/r/cdn_frontdoor_route.html.markdown
@@ -48,7 +48,7 @@ resource "azurerm_cdn_frontdoor_origin" "example" {
   weight             = 1
 }
 
-resource "azurerm_frontdoor_endpoint" "example" {
+resource "azurerm_cdn_frontdoor_endpoint" "example" {
   name                     = "example-endpoint"
   cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.example.id
 }


### PR DESCRIPTION
Fixed wrong resource name, rename `azurerm_frontdoor_endpoint` to `azurerm_cdn_frontdoor_endpoint`