### PR TITLE
`azurerm_automanage_configuration` - support new property block `log_analytics_enabled`

### DIFF
--- a/internal/services/automanage/automanage_configuration_resource.go
+++ b/internal/services/automanage/automanage_configuration_resource.go
@@ -434,9 +434,7 @@ func (r AutoManageConfigurationResource) Arguments() map[string]*pluginsdk.Schem
 			Default:  false,
 		},
 
-		//"LogAnalytics/Enable": boolean,
-		//"LogAnalytics/Reprovision": boolean,
-		//"LogAnalytics/Workspace": resource ID (Log analytics workspace ID),
+		// "LogAnalytics/Enable": boolean,
 		"log_analytics_enabled": {
 			Type:     pluginsdk.TypeBool,
 			Optional: true,

--- a/internal/services/automanage/automanage_configuration_resource_test.go
+++ b/internal/services/automanage/automanage_configuration_resource_test.go
@@ -331,10 +331,10 @@ func (r AutoManageConfigurationProfileResource) logAnalytics(data acceptance.Tes
 				%s
 
 resource "azurerm_automanage_configuration" "test" {
-	  name                = "acctest-amcp-%d"
-	  resource_group_name = azurerm_resource_group.test.name
-	  location            = "%s"
-	  log_analytics_enabled = true
+  name                  = "acctest-amcp-%d"
+  resource_group_name   = azurerm_resource_group.test.name
+  location              = "%s"
+  log_analytics_enabled = true
 }
 `, template, data.RandomInteger, data.Locations.Primary)
 }

--- a/internal/services/automanage/automanage_configuration_resource_test.go
+++ b/internal/services/automanage/automanage_configuration_resource_test.go
@@ -184,19 +184,7 @@ func TestAccAutoManageConfigurationProfile_logAnalytics(t *testing.T) {
 			Config: r.logAnalytics(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("log_analytics.#").HasValue("1"),
-				check.That(data.ResourceName).Key("log_analytics.0.workspace_id").Exists(),
-				check.That(data.ResourceName).Key("log_analytics.0.reprovision").HasValue("true"),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.logAnalyticsUpdate(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("log_analytics.#").HasValue("1"),
-				check.That(data.ResourceName).Key("log_analytics.0.workspace_id").DoesNotExist(),
-				check.That(data.ResourceName).Key("log_analytics.0.reprovision").HasValue("false"),
+				check.That(data.ResourceName).Key("log_analytics_enabled").HasValue("true"),
 			),
 		},
 		data.ImportStep(),
@@ -204,7 +192,7 @@ func TestAccAutoManageConfigurationProfile_logAnalytics(t *testing.T) {
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("log_analytics.#").HasValue("0"),
+				check.That(data.ResourceName).Key("log_analytics_enabled").HasValue("false"),
 			),
 		},
 		data.ImportStep(),
@@ -346,24 +334,7 @@ resource "azurerm_automanage_configuration" "test" {
 	  name                = "acctest-amcp-%d"
 	  resource_group_name = azurerm_resource_group.test.name
 	  location            = "%s"
-	  log_analytics {
-		reprovision = true
-}
-}
-`, template, data.RandomInteger, data.Locations.Primary)
-}
-
-func (r AutoManageConfigurationProfileResource) logAnalyticsUpdate(data acceptance.TestData) string {
-	template := r.template(data)
-	return fmt.Sprintf(`
-				%s
-	
-resource "azurerm_automanage_configuration" "test" {
-	  name                = "acctest-amcp-%d"
-	  resource_group_name = azurerm_resource_group.test.name
-	  location            = "%s"
-	  log_analytics {
-  		reprovision = false	}
+	  log_analytics_enabled = true
 }
 `, template, data.RandomInteger, data.Locations.Primary)
 }

--- a/website/docs/r/automanage_configuration.html.markdown
+++ b/website/docs/r/automanage_configuration.html.markdown
@@ -79,6 +79,7 @@ resource "azurerm_automanage_configuration" "example" {
   boot_diagnostics_enabled    = true
   defender_for_cloud_enabled  = true
   guest_configuration_enabled = true
+  log_analytics_enabled       = true
   status_change_alert_enabled = true
 
   tags = {
@@ -110,6 +111,8 @@ The following arguments are supported:
 * `defender_for_cloud_enabled` - (Optional) Whether the defender for cloud is enabled. Defaults to `false`.
 
 * `guest_configuration_enabled` - (Optional) Whether the guest configuration is enabled. Defaults to `false`.
+
+* `log_analytics_enabled` - (Optional) Whether log analytics are enabled. Defaults to `false`.
 
 * `status_change_alert_enabled` - (Optional) Whether the status change alert is enabled. Defaults to `false`.
 


### PR DESCRIPTION
This is the third PR for `azurerm_automanage_configuration`, In this PR, 

- new property `log_analytics_enabled` is supported

Note that 

- For trustedLaunchVM/Backup -> All property results in 400 Error so we are not able to support those properties.
- For logAnalytics other properties also result 400 in tests and not able to support.

Previous PR: https://github.com/hashicorp/terraform-provider-azurerm/pull/22081

Swagger Link: https://github.com/Azure/azure-rest-api-specs/blob/main/specification/automanage/resource-manager/Microsoft.Automanage/stable/2022-05-04/automanage.json