### PR TITLE
Update kubernetes_cluster.html.markdown

### DIFF
--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -592,7 +592,7 @@ A `network_profile` block supports the following:
 
 * `network_plugin` - (Required) Network plugin to use for networking. Currently supported values are `azure`, `kubenet` and `none`. Changing this forces a new resource to be created.
 
--> **Note:** When `network_plugin` is set to `azure` - the `vnet_subnet_id` field in the `default_node_pool` block must be set and `pod_cidr` must not be set.
+-> **Note:** When `network_plugin` is set to `azure` - the `pod_cidr` field must not be set.
 
 * `network_mode` - (Optional) Network mode to be used with Azure CNI. Possible values are `bridge` and `transparent`. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
works nicely without the vnet_subnet_id field in the default_node_pool block. In examples also vnet_subnet_id is not used when network_plugin is set to azure