### PR TITLE
dependencies: updating to `v0.20230608.1112153` of `github.com/hashicorp/go-azure-sdk`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.1.2
 	github.com/hashicorp/go-azure-helpers v0.56.0
-	github.com/hashicorp/go-azure-sdk v0.20230606.1092251
+	github.com/hashicorp/go-azure-sdk v0.20230608.1112153
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/go-version v1.6.0
@@ -48,7 +48,7 @@ require (
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320 // indirect
 	github.com/hashicorp/go-hclog v1.4.0 // indirect
 	github.com/hashicorp/go-plugin v1.4.8 // indirect
-	github.com/hashicorp/go-retryablehttp v0.7.2 // indirect
+	github.com/hashicorp/go-retryablehttp v0.7.4 // indirect
 	github.com/hashicorp/hc-install v0.5.0 // indirect
 	github.com/hashicorp/hcl/v2 v2.16.2 // indirect
 	github.com/hashicorp/hcl2 v0.0.0-20191002203319-fb75b3253c80 // indirect

--- a/go.sum
+++ b/go.sum
@@ -141,8 +141,8 @@ github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brv
 github.com/hashicorp/go-azure-helpers v0.12.0/go.mod h1:Zc3v4DNeX6PDdy7NljlYpnrdac1++qNW0I4U+ofGwpg=
 github.com/hashicorp/go-azure-helpers v0.56.0 h1:KxDXISHwWe4PKEz6FSSPG8vCXNrFGsCcCn/AI94ccig=
 github.com/hashicorp/go-azure-helpers v0.56.0/go.mod h1:MbnCV9jPmlkbdH7VsoBK8IbCHvo3pLWRbRvq+F6u9sI=
-github.com/hashicorp/go-azure-sdk v0.20230606.1092251 h1:8A7dj8V+gQxumfncEDzmHEM9RnKyMWDu+jXjqOV8/II=
-github.com/hashicorp/go-azure-sdk v0.20230606.1092251/go.mod h1:x2r7/U5MKlTHUO6/hFHRNO03qkRLBYyeQOuEUHkZmEg=
+github.com/hashicorp/go-azure-sdk v0.20230608.1112153 h1:zjy/0svEZcdlYPfGqPjSPp+noB0HzXEeCh4vrBOQtPE=
+github.com/hashicorp/go-azure-sdk v0.20230608.1112153/go.mod h1:ARDIozwF5NoDJDfnh+MlG4eicP0mVxmVt3CQVSbNrq0=
 github.com/hashicorp/go-checkpoint v0.5.0 h1:MFYpPZCnQqQTE18jFwSII6eUQrD/oxMFp3mlgcqk5mU=
 github.com/hashicorp/go-checkpoint v0.5.0/go.mod h1:7nfLNL10NsxqO4iWuW6tWW0HjZuDrwkBuEQsVcpCOgg=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
@@ -160,8 +160,8 @@ github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+l
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-plugin v1.4.8 h1:CHGwpxYDOttQOY7HOWgETU9dyVjOXzniXDqJcYJE1zM=
 github.com/hashicorp/go-plugin v1.4.8/go.mod h1:viDMjcLJuDui6pXb8U4HVfb8AamCWhHGUjr2IrTF67s=
-github.com/hashicorp/go-retryablehttp v0.7.2 h1:AcYqCvkpalPnPF2pn0KamgwamS42TqUDDYFRKq/RAd0=
-github.com/hashicorp/go-retryablehttp v0.7.2/go.mod h1:Jy/gPYAdjqffZ/yFGCFV2doI5wjtH1ewM9u8iYVjtX8=
+github.com/hashicorp/go-retryablehttp v0.7.4 h1:ZQgVdpTdAL7WpMIwLzCfbalOcSUdkDZnpUv3/+BxzFA=
+github.com/hashicorp/go-retryablehttp v0.7.4/go.mod h1:Jy/gPYAdjqffZ/yFGCFV2doI5wjtH1ewM9u8iYVjtX8=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
 github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=

--- a/vendor/github.com/hashicorp/go-azure-sdk/sdk/client/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/sdk/client/client.go
@@ -320,12 +320,6 @@ func (c *Client) Execute(ctx context.Context, req *Request) (*Response, error) {
 
 	var err error
 
-	// Ensure the Content-Lenght header is set for methods that define a meaning for enclosed content, i.e. POST and PUT.
-	// https://www.rfc-editor.org/rfc/rfc9110#section-8.6-5
-	if req.Method == "POST" || req.Method == "PUT" {
-		req.Header.Set("Content-Length", fmt.Sprintf("%d", req.ContentLength))
-	}
-
 	// Check we can read the request body and set a default empty body
 	var reqBody []byte
 	if req.Body != nil {

--- a/vendor/github.com/hashicorp/go-retryablehttp/CHANGELOG.md
+++ b/vendor/github.com/hashicorp/go-retryablehttp/CHANGELOG.md
@@ -1,0 +1,9 @@
+## 0.7.4 (Jun 6, 2023)
+
+BUG FIXES
+
+- client: fixing an issue where the Content-Type header wouldn't be sent with an empty payload when using HTTP/2 [GH-194]
+
+## 0.7.3 (May 15, 2023)
+
+Initial release

--- a/vendor/github.com/hashicorp/go-retryablehttp/CODEOWNERS
+++ b/vendor/github.com/hashicorp/go-retryablehttp/CODEOWNERS
@@ -1,0 +1,1 @@
+* @hashicorp/release-engineering

--- a/vendor/github.com/hashicorp/go-retryablehttp/LICENSE
+++ b/vendor/github.com/hashicorp/go-retryablehttp/LICENSE
@@ -1,3 +1,5 @@
+Copyright (c) 2015 HashiCorp, Inc.
+
 Mozilla Public License, version 2.0
 
 1. Definitions

--- a/vendor/github.com/hashicorp/go-retryablehttp/client.go
+++ b/vendor/github.com/hashicorp/go-retryablehttp/client.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 // Package retryablehttp provides a familiar HTTP client interface with
 // automatic retries and exponential backoff. It is a thin wrapper over the
 // standard net/http client library and exposes nearly the same public API.
@@ -257,10 +260,17 @@ func getBodyReaderAndContentLength(rawBody interface{}) (ReaderFunc, int64, erro
 		if err != nil {
 			return nil, 0, err
 		}
-		bodyReader = func() (io.Reader, error) {
-			return bytes.NewReader(buf), nil
+		if len(buf) == 0 {
+			bodyReader = func() (io.Reader, error) {
+				return http.NoBody, nil
+			}
+			contentLength = 0
+		} else {
+			bodyReader = func() (io.Reader, error) {
+				return bytes.NewReader(buf), nil
+			}
+			contentLength = int64(len(buf))
 		}
-		contentLength = int64(len(buf))
 
 	// No body provided, nothing to do
 	case nil:

--- a/vendor/github.com/hashicorp/go-retryablehttp/roundtripper.go
+++ b/vendor/github.com/hashicorp/go-retryablehttp/roundtripper.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package retryablehttp
 
 import (

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -136,7 +136,7 @@ github.com/hashicorp/go-azure-helpers/resourcemanager/tags
 github.com/hashicorp/go-azure-helpers/resourcemanager/zones
 github.com/hashicorp/go-azure-helpers/sender
 github.com/hashicorp/go-azure-helpers/storage
-# github.com/hashicorp/go-azure-sdk v0.20230606.1092251
+# github.com/hashicorp/go-azure-sdk v0.20230608.1112153
 ## explicit; go 1.19
 github.com/hashicorp/go-azure-sdk/resource-manager/aad/2021-05-01/domainservices
 github.com/hashicorp/go-azure-sdk/resource-manager/aadb2c/2021-04-01-preview
@@ -667,7 +667,7 @@ github.com/hashicorp/go-multierror
 ## explicit; go 1.17
 github.com/hashicorp/go-plugin
 github.com/hashicorp/go-plugin/internal/plugin
-# github.com/hashicorp/go-retryablehttp v0.7.2
+# github.com/hashicorp/go-retryablehttp v0.7.4
 ## explicit; go 1.13
 github.com/hashicorp/go-retryablehttp
 # github.com/hashicorp/go-uuid v1.0.3


### PR DESCRIPTION
Unblocks #21937