### PR TITLE
`azurerm_kubernetes_cluster` - supports `AzureLinux` in `os_sku`

### DIFF
--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -251,11 +251,13 @@ func resourceKubernetesClusterNodePool() *pluginsdk.Resource {
 				ForceNew: true,
 				Computed: true, // defaults to Ubuntu if using Linux
 				ValidateFunc: validation.StringInSlice([]string{
+					// TODO 4.0: remove CLBMariner and Mariner
 					string(agentpools.OSSKUCBLMariner),
 					string(agentpools.OSSKUMariner),
 					string(agentpools.OSSKUUbuntu),
 					string(agentpools.OSSKUWindowsTwoZeroOneNine),
 					string(agentpools.OSSKUWindowsTwoZeroTwoTwo),
+					string(agentpools.OSSKUAzureLinux),
 				}, false),
 			},
 

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource_test.go
@@ -817,6 +817,21 @@ func TestAccKubernetesClusterNodePool_osSkuMariner(t *testing.T) {
 	})
 }
 
+func TestAccKubernetesClusterNodePool_osSkuAzureLinux(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster_node_pool", "test")
+	r := KubernetesClusterNodePoolResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.osSku(data, "AzureLinux"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccKubernetesClusterNodePool_dedicatedHost(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster_node_pool", "test")
 	r := KubernetesClusterNodePoolResource{}

--- a/internal/services/containers/kubernetes_cluster_other_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_other_resource_test.go
@@ -630,7 +630,22 @@ func TestAccKubernetesCluster_osSku(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.osSku(data),
+			Config: r.osSku(data, "Ubuntu"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccKubernetesCluster_osSkuAzureLinux(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kubernetes_cluster", "test")
+	r := KubernetesClusterResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.osSku(data, "AzureLinux"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -2140,7 +2155,7 @@ resource "azurerm_kubernetes_cluster" "test" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, privateClusterPublicFqdnEnabled)
 }
 
-func (KubernetesClusterResource) osSku(data acceptance.TestData) string {
+func (KubernetesClusterResource) osSku(data acceptance.TestData, osSku string) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -2161,14 +2176,14 @@ resource "azurerm_kubernetes_cluster" "test" {
     name       = "default"
     node_count = 1
     vm_size    = "Standard_D2s_v3"
-    os_sku     = "Ubuntu"
+    os_sku     = "%s"
   }
 
   identity {
     type = "SystemAssigned"
   }
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, osSku)
 }
 
 func (KubernetesClusterResource) oidcIssuer(data acceptance.TestData, enabled bool) string {

--- a/internal/services/containers/kubernetes_nodepool.go
+++ b/internal/services/containers/kubernetes_nodepool.go
@@ -3,6 +3,7 @@ package containers
 import (
 	"encoding/base64"
 	"fmt"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"regexp"
 	"strconv"
 	"strings"
@@ -198,11 +199,10 @@ func SchemaDefaultNodePool() *pluginsdk.Schema {
 						Optional: true,
 						Computed: true, // defaults to Ubuntu if using Linux
 						ValidateFunc: validation.StringInSlice([]string{
-							string(agentpools.OSSKUCBLMariner),
-							string(agentpools.OSSKUMariner),
 							string(agentpools.OSSKUUbuntu),
 							string(agentpools.OSSKUWindowsTwoZeroOneNine),
 							string(agentpools.OSSKUWindowsTwoZeroTwoTwo),
+							string(agentpools.OSSKUAzureLinux),
 						}, false),
 					},
 
@@ -270,6 +270,17 @@ func SchemaDefaultNodePool() *pluginsdk.Schema {
 				}
 
 				s["zones"] = commonschema.ZonesMultipleOptional()
+
+				if !features.FourPointOhBeta() {
+					s["os_sku"].ValidateFunc = validation.StringInSlice([]string{
+						string(agentpools.OSSKUCBLMariner),
+						string(agentpools.OSSKUMariner),
+						string(agentpools.OSSKUUbuntu),
+						string(agentpools.OSSKUWindowsTwoZeroOneNine),
+						string(agentpools.OSSKUWindowsTwoZeroTwoTwo),
+						string(agentpools.OSSKUAzureLinux),
+					}, false)
+				}
 
 				return s
 			}(),

--- a/internal/services/containers/kubernetes_nodepool.go
+++ b/internal/services/containers/kubernetes_nodepool.go
@@ -3,7 +3,6 @@ package containers
 import (
 	"encoding/base64"
 	"fmt"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"regexp"
 	"strconv"
 	"strings"
@@ -16,6 +15,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-04-02-preview/agentpools"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-04-02-preview/managedclusters"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	computeValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/compute/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/containers/validate"
 	networkValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate"

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -414,7 +414,7 @@ A `default_node_pool` block supports the following:
 
 * `os_disk_type` - (Optional) The type of disk which should be used for the Operating System. Possible values are `Ephemeral` and `Managed`. Defaults to `Managed`.  `temporary_name_for_rotation` must be specified when attempting a change.
 
-* `os_sku` - (Optional) Specifies the OS SKU used by the agent pool. Possible values include: `Ubuntu`, `CBLMariner`, `Mariner`, `Windows2019`, `Windows2022`. If not specified, the default is `Ubuntu` if OSType=Linux or `Windows2019` if OSType=Windows. And the default Windows OSSKU will be changed to `Windows2022` after Windows2019 is deprecated. `temporary_name_for_rotation` must be specified when attempting a change.
+* `os_sku` - (Optional) Specifies the OS SKU used by the agent pool. Possible values include: `Ubuntu`, `AzureLinux`, `Windows2019`, `Windows2022`. If not specified, the default is `Ubuntu` if OSType=Linux or `Windows2019` if OSType=Windows. And the default Windows OSSKU will be changed to `Windows2022` after Windows2019 is deprecated. `temporary_name_for_rotation` must be specified when attempting a change.
 
 * `pod_subnet_id` - (Optional) The ID of the Subnet where the pods in the default Node Pool should exist. Changing this forces a new resource to be created.
 

--- a/website/docs/r/kubernetes_cluster_node_pool.html.markdown
+++ b/website/docs/r/kubernetes_cluster_node_pool.html.markdown
@@ -124,7 +124,7 @@ The following arguments are supported:
 
 * `pod_subnet_id` - (Optional) The ID of the Subnet where the pods in the Node Pool should exist. Changing this forces a new resource to be created.
 
-* `os_sku` - (Optional) Specifies the OS SKU used by the agent pool. Possible values include: `Ubuntu`, `CBLMariner`, `Mariner`, `Windows2019`, `Windows2022`. If not specified, the default is `Ubuntu` if OSType=Linux or `Windows2019` if OSType=Windows. And the default Windows OSSKU will be changed to `Windows2022` after Windows2019 is deprecated. Changing this forces a new resource to be created.
+* `os_sku` - (Optional) Specifies the OS SKU used by the agent pool. Possible values include: `Ubuntu`, `AzureLinux`, `Windows2019`, `Windows2022`. If not specified, the default is `Ubuntu` if OSType=Linux or `Windows2019` if OSType=Windows. And the default Windows OSSKU will be changed to `Windows2022` after Windows2019 is deprecated. Changing this forces a new resource to be created.
 
 * `os_type` - (Optional) The Operating System which should be used for this Node Pool. Changing this forces a new resource to be created. Possible values are `Linux` and `Windows`. Defaults to `Linux`.
 


### PR DESCRIPTION
Tests
```
=== RUN   TestAccKubernetesCluster_osSkuAzureLinux
=== PAUSE TestAccKubernetesCluster_osSkuAzureLinux
=== CONT  TestAccKubernetesCluster_osSkuAzureLinux
--- PASS: TestAccKubernetesCluster_osSkuAzureLinux (583.94s)
PASS
=== RUN   TestAccKubernetesClusterNodePool_osSkuAzureLinux
=== PAUSE TestAccKubernetesClusterNodePool_osSkuAzureLinux
=== CONT  TestAccKubernetesClusterNodePool_osSkuAzureLinux
--- PASS: TestAccKubernetesClusterNodePool_osSkuAzureLinux (659.24s)
PASS

```