### PR TITLE
`azurerm_arc_machine_extension` - fix property name in document

### DIFF
--- a/website/docs/r/arc_machine_extension.html.markdown
+++ b/website/docs/r/arc_machine_extension.html.markdown
@@ -48,7 +48,7 @@ The following arguments are supported:
 
 ---
 
-* `automatic_upgrades_enabled` - (Optional) Indicates whether the extension should be automatically upgraded by the platform if there is a newer version available. Supported values are `true` and `false`.
+* `automatic_upgrade_enabled` - (Optional) Indicates whether the extension should be automatically upgraded by the platform if there is a newer version available. Supported values are `true` and `false`.
 
 **NOTE:** When `automatic_upgrade_enabled` can only be set during creation. Any later change will be ignored.
 


### PR DESCRIPTION
`automatic_upgrades_enabled` -> `automatic_upgrade_enabled` the same as in `azurerm_virtual_machine_extension`