### PR TITLE
`azurerm_application_insights_workbook ` - fix update display_name without tags

### DIFF
--- a/internal/services/applicationinsights/application_insights_workbook_resource.go
+++ b/internal/services/applicationinsights/application_insights_workbook_resource.go
@@ -203,7 +203,7 @@ func (r ApplicationInsightsWorkbookResource) Update() sdk.ResourceFunc {
 			}
 
 			properties := resp.Model
-			if properties == nil {
+			if properties == nil || properties.Properties == nil {
 				return fmt.Errorf("retrieving %s: properties was nil", id)
 			}
 
@@ -217,6 +217,7 @@ func (r ApplicationInsightsWorkbookResource) Update() sdk.ResourceFunc {
 
 			if metadata.ResourceData.HasChange("display_name") {
 				properties.Properties.DisplayName = model.DisplayName
+				delete(*properties.Tags, "hidden-title")
 			}
 
 			if metadata.ResourceData.HasChange("data_json") {

--- a/internal/services/applicationinsights/application_insights_workbook_resource.go
+++ b/internal/services/applicationinsights/application_insights_workbook_resource.go
@@ -217,7 +217,9 @@ func (r ApplicationInsightsWorkbookResource) Update() sdk.ResourceFunc {
 
 			if metadata.ResourceData.HasChange("display_name") {
 				properties.Properties.DisplayName = model.DisplayName
-				delete(*properties.Tags, "hidden-title")
+				if properties.Tags != nil {
+					delete(*properties.Tags, "hidden-title")
+				}
 			}
 
 			if metadata.ResourceData.HasChange("data_json") {

--- a/internal/services/applicationinsights/application_insights_workbook_resource_test.go
+++ b/internal/services/applicationinsights/application_insights_workbook_resource_test.go
@@ -59,7 +59,7 @@ func TestAccApplicationInsightsWorkbook_complete(t *testing.T) {
 	})
 }
 
-func TestAccApplicationInsightsWorkbook_updateDisplanName(t *testing.T) {
+func TestAccApplicationInsightsWorkbook_updateDisplayName(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_application_insights_workbook", "test")
 	r := ApplicationInsightsWorkbookResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{

--- a/internal/services/applicationinsights/application_insights_workbook_resource_test.go
+++ b/internal/services/applicationinsights/application_insights_workbook_resource_test.go
@@ -22,7 +22,7 @@ func TestAccApplicationInsightsWorkbook_basic(t *testing.T) {
 	r := ApplicationInsightsWorkbookResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.basic(data),
+			Config: r.basic(data, data.RandomInteger),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -36,7 +36,7 @@ func TestAccApplicationInsightsWorkbook_requiresImport(t *testing.T) {
 	r := ApplicationInsightsWorkbookResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.basic(data),
+			Config: r.basic(data, data.RandomInteger),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -51,6 +51,27 @@ func TestAccApplicationInsightsWorkbook_complete(t *testing.T) {
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccApplicationInsightsWorkbook_updateDisplanName(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_application_insights_workbook", "test")
+	r := ApplicationInsightsWorkbookResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data, 1),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basic(data, 2),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -121,7 +142,7 @@ resource "azurerm_resource_group" "test" {
 `, data.RandomInteger, data.Locations.Primary)
 }
 
-func (r ApplicationInsightsWorkbookResource) basic(data acceptance.TestData) string {
+func (r ApplicationInsightsWorkbookResource) basic(data acceptance.TestData, intValue int) string {
 	template := r.template(data)
 	return fmt.Sprintf(`
 				%s
@@ -148,7 +169,7 @@ resource "azurerm_application_insights_workbook" "test" {
     ]
   })
 }
-`, template, data.RandomInteger)
+`, template, intValue)
 }
 
 func (r ApplicationInsightsWorkbookResource) hiddenTitleInTags(data acceptance.TestData) string {
@@ -185,7 +206,7 @@ resource "azurerm_application_insights_workbook" "test" {
 }
 
 func (r ApplicationInsightsWorkbookResource) requiresImport(data acceptance.TestData) string {
-	config := r.basic(data)
+	config := r.basic(data, data.RandomInteger)
 	return fmt.Sprintf(`
 			%s
 


### PR DESCRIPTION
- resolves #22113 

```
TF_ACC=1 go test -v ./internal/services/applicationinsights -parallel 50 -test.run=TestAccApplicationInsightsWorkbook_ -timeout 1440m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccApplicationInsightsWorkbook_basic
=== PAUSE TestAccApplicationInsightsWorkbook_basic
=== RUN   TestAccApplicationInsightsWorkbook_requiresImport
=== PAUSE TestAccApplicationInsightsWorkbook_requiresImport
=== RUN   TestAccApplicationInsightsWorkbook_complete
=== PAUSE TestAccApplicationInsightsWorkbook_complete
=== RUN   TestAccApplicationInsightsWorkbook_updateDisplanName
=== PAUSE TestAccApplicationInsightsWorkbook_updateDisplanName
=== RUN   TestAccApplicationInsightsWorkbook_update
=== PAUSE TestAccApplicationInsightsWorkbook_update
=== RUN   TestAccApplicationInsightsWorkbook_hiddenTitleInTags
=== PAUSE TestAccApplicationInsightsWorkbook_hiddenTitleInTags
=== CONT  TestAccApplicationInsightsWorkbook_basic
=== CONT  TestAccApplicationInsightsWorkbook_updateDisplanName
=== CONT  TestAccApplicationInsightsWorkbook_complete
=== CONT  TestAccApplicationInsightsWorkbook_hiddenTitleInTags
=== CONT  TestAccApplicationInsightsWorkbook_update
=== CONT  TestAccApplicationInsightsWorkbook_requiresImport
--- PASS: TestAccApplicationInsightsWorkbook_hiddenTitleInTags (6.70s)
--- PASS: TestAccApplicationInsightsWorkbook_basic (133.02s)
--- PASS: TestAccApplicationInsightsWorkbook_requiresImport (137.27s)
--- PASS: TestAccApplicationInsightsWorkbook_complete (156.84s)
--- PASS: TestAccApplicationInsightsWorkbook_updateDisplanName (160.42s)
--- PASS: TestAccApplicationInsightsWorkbook_update (273.28s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/applicationinsights   276.837s

```