### PR TITLE
`azurerm_kubernetes_cluster` - prevent breaking change in casing for `network_plugin_mode`

### DIFF
--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -836,8 +836,7 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 							Optional: true,
 							ForceNew: true,
 							ValidateFunc: validation.StringInSlice([]string{
-								// TODO 4.0: change it to managedclusters.NetworkPluginModeOverlay
-								"Overlay",
+								string(managedclusters.NetworkPluginModeOverlay),
 							}, false),
 						},
 
@@ -1297,6 +1296,14 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 			ForceNew:     true,
 			Deprecated:   "`docker_bridge_cidr` has been deprecated as the API no longer supports it and will be removed in version 4.0 of the provider.",
 			ValidateFunc: validate.CIDR,
+		}
+		resource.Schema["network_profile"].Elem.(*pluginsdk.Resource).Schema["network_plugin_mode"] = &pluginsdk.Schema{
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			ForceNew: true,
+			ValidateFunc: validation.StringInSlice([]string{
+				"Overlay",
+			}, false),
 		}
 	}
 
@@ -3165,6 +3172,9 @@ func flattenKubernetesClusterNetworkProfile(profile *managedclusters.ContainerSe
 		// Issue: https://github.com/Azure/azure-rest-api-specs/issues/21810
 		if strings.EqualFold(string(*profile.NetworkPluginMode), string(managedclusters.NetworkPluginModeOverlay)) {
 			networkPluginMode = string(managedclusters.NetworkPluginModeOverlay)
+			if !features.FourPointOhBeta() {
+				networkPluginMode = "Overlay"
+			}
 		}
 	}
 	ebpfDataPlane := ""

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -1302,6 +1302,7 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 			Optional: true,
 			ForceNew: true,
 			ValidateFunc: validation.StringInSlice([]string{
+				string(managedclusters.NetworkPluginModeOverlay),
 				"Overlay",
 			}, false),
 		}
@@ -3172,9 +3173,6 @@ func flattenKubernetesClusterNetworkProfile(profile *managedclusters.ContainerSe
 		// Issue: https://github.com/Azure/azure-rest-api-specs/issues/21810
 		if strings.EqualFold(string(*profile.NetworkPluginMode), string(managedclusters.NetworkPluginModeOverlay)) {
 			networkPluginMode = string(managedclusters.NetworkPluginModeOverlay)
-			if !features.FourPointOhBeta() {
-				networkPluginMode = "Overlay"
-			}
 		}
 	}
 	ebpfDataPlane := ""

--- a/internal/services/containers/kubernetes_cluster_validate.go
+++ b/internal/services/containers/kubernetes_cluster_validate.go
@@ -33,7 +33,7 @@ func validateKubernetesCluster(d *pluginsdk.ResourceData, cluster *managedcluste
 
 				// Azure network plugin is not compatible with pod_cidr
 				if podCidr != "" && strings.EqualFold(networkPlugin, "azure") && !strings.EqualFold(networkPluginMode, string(managedclusters.NetworkPluginModeOverlay)) {
-					return fmt.Errorf("`pod_cidr` and `azure` cannot be set together unless specifying `network_plugin_mode` to `Overlay`")
+					return fmt.Errorf("`pod_cidr` and `azure` cannot be set together unless specifying `network_plugin_mode` to `overlay`")
 				}
 
 				// if not All empty values or All set values.

--- a/internal/services/containers/kubernetes_cluster_validate.go
+++ b/internal/services/containers/kubernetes_cluster_validate.go
@@ -32,8 +32,8 @@ func validateKubernetesCluster(d *pluginsdk.ResourceData, cluster *managedcluste
 				isServiceCidrSet := serviceCidr != "" || len(serviceCidrs) != 0
 
 				// Azure network plugin is not compatible with pod_cidr
-				if podCidr != "" && networkPlugin == "azure" && networkPluginMode != string(managedclusters.NetworkPluginModeOverlay) {
-					return fmt.Errorf("`pod_cidr` and `azure` cannot be set together unless specifying `network_plugin_mode` to `overlay`")
+				if podCidr != "" && strings.EqualFold(networkPlugin, "azure") && !strings.EqualFold(networkPluginMode, string(managedclusters.NetworkPluginModeOverlay)) {
+					return fmt.Errorf("`pod_cidr` and `azure` cannot be set together unless specifying `network_plugin_mode` to `Overlay`")
 				}
 
 				// if not All empty values or All set values.


### PR DESCRIPTION
SDK upgrade for `containers` to `2023-04-02-preview` contained a breaking case change in the enum for `NetworkPluginModeOverlay`.

Closes #22151