### PR TITLE
`azurerm_resource_deployment_script_*` - fix issue where `identity` wasn't specified but was being sent as `TypeNone` to the api

### DIFF
--- a/internal/services/resource/resource_deployment_script_azure_cli_resource.go
+++ b/internal/services/resource/resource_deployment_script_azure_cli_resource.go
@@ -79,7 +79,9 @@ func (r ResourceDeploymentScriptAzureCliResource) Create() sdk.ResourceFunc {
 				return err
 			}
 
-			properties.Identity = identityValue
+			if identityValue != nil && identityValue.Type != identity.TypeNone {
+				properties.Identity = identityValue
+			}
 
 			if model.Arguments != "" {
 				properties.Properties.Arguments = &model.Arguments

--- a/internal/services/resource/resource_deployment_script_azure_power_shell_resource.go
+++ b/internal/services/resource/resource_deployment_script_azure_power_shell_resource.go
@@ -79,7 +79,9 @@ func (r ResourceDeploymentScriptAzurePowerShellResource) Create() sdk.ResourceFu
 				return err
 			}
 
-			properties.Identity = identityValue
+			if identityValue != nil && identityValue.Type != identity.TypeNone {
+				properties.Identity = identityValue
+			}
 
 			if model.Arguments != "" {
 				properties.Properties.Arguments = &model.Arguments


### PR DESCRIPTION

![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/76987228/852142f2-652d-44bb-84b7-a0b6a8d2c22c)

--- PASS: TestAccResourceDeploymentScriptAzurePowerShell_scriptUri (232.92s)
--- PASS: TestAccResourceDeploymentScriptAzureCLI_requiresImport (258.26s)
--- PASS: TestAccResourceDeploymentScriptAzurePowerShell_requiresImport (259.80s)
--- PASS: TestAccResourceDeploymentScriptAzureCLI_complete (261.86s)
--- PASS: TestAccResourceDeploymentScriptAzureCLI_basic (298.89s)
--- PASS: TestAccResourceDeploymentScriptAzurePowerShell_basic (303.84s)
--- PASS: TestAccResourceDeploymentScriptAzurePowerShell_complete (318.41s)
--- PASS: TestAccResourceDeploymentScriptAzurePowerShell_update (325.89s)
--- PASS: TestAccResourceDeploymentScriptAzureCLI_update (378.07s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/resource      383.068s
