### PR TITLE
`azurerm_kubernetes_cluster` - discourage the use of `Mariner` and `CBLMariner` for `os_sku`

### DIFF
--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	computeValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/compute/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/containers/migration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/containers/parse"
@@ -55,320 +56,333 @@ func resourceKubernetesClusterNodePool() *pluginsdk.Resource {
 			0: migration.KubernetesClusterNodePoolV0ToV1{},
 		}),
 
-		Schema: map[string]*pluginsdk.Schema{
-			"name": {
-				Type:         pluginsdk.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: containerValidate.KubernetesAgentPoolName,
-			},
-
-			"kubernetes_cluster_id": {
-				Type:         pluginsdk.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: containerValidate.ClusterID,
-			},
-
-			"node_count": {
-				Type:         pluginsdk.TypeInt,
-				Optional:     true,
-				Computed:     true,
-				ValidateFunc: validation.IntBetween(0, 1000),
-			},
-
-			"tags": commonschema.Tags(),
-
-			"vm_size": {
-				Type:         pluginsdk.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringIsNotEmpty,
-			},
-
-			"host_group_id": {
-				Type:         pluginsdk.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: computeValidate.HostGroupID,
-			},
-
-			// Optional
-			"capacity_reservation_group_id": {
-				Type:         pluginsdk.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: capacityreservationgroups.ValidateCapacityReservationGroupID,
-			},
-
-			"custom_ca_trust_enabled": {
-				Type:     pluginsdk.TypeBool,
-				Optional: true,
-			},
-
-			"enable_auto_scaling": {
-				Type:     pluginsdk.TypeBool,
-				Optional: true,
-			},
-
-			"enable_host_encryption": {
-				Type:     pluginsdk.TypeBool,
-				Optional: true,
-				ForceNew: true,
-			},
-
-			"enable_node_public_ip": {
-				Type:     pluginsdk.TypeBool,
-				Optional: true,
-				ForceNew: true,
-			},
-
-			"eviction_policy": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				ForceNew: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(agentpools.ScaleSetEvictionPolicyDelete),
-					string(agentpools.ScaleSetEvictionPolicyDeallocate),
-				}, false),
-			},
-
-			"kubelet_config": schemaNodePoolKubeletConfigForceNew(),
-
-			"linux_os_config": schemaNodePoolLinuxOSConfigForceNew(),
-
-			"fips_enabled": {
-				Type:     pluginsdk.TypeBool,
-				Optional: true,
-				ForceNew: true,
-			},
-
-			"kubelet_disk_type": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				Computed: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(agentpools.KubeletDiskTypeOS),
-					string(agentpools.KubeletDiskTypeTemporary),
-				}, false),
-			},
-
-			"max_count": {
-				Type:         pluginsdk.TypeInt,
-				Optional:     true,
-				ValidateFunc: validation.IntBetween(0, 1000),
-			},
-
-			"max_pods": {
-				Type:     pluginsdk.TypeInt,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
-
-			"message_of_the_day": {
-				Type:         pluginsdk.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringIsNotEmpty,
-			},
-
-			"mode": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				Default:  string(agentpools.AgentPoolModeUser),
-				ValidateFunc: validation.StringInSlice([]string{
-					string(agentpools.AgentPoolModeSystem),
-					string(agentpools.AgentPoolModeUser),
-				}, false),
-			},
-
-			"min_count": {
-				Type:     pluginsdk.TypeInt,
-				Optional: true,
-				// NOTE: rather than setting `0` users should instead pass `null` here
-				ValidateFunc: validation.IntBetween(0, 1000),
-			},
-
-			"node_network_profile": schemaNodePoolNetworkProfile(),
-
-			"node_labels": {
-				Type:     pluginsdk.TypeMap,
-				Optional: true,
-				Computed: true,
-				Elem: &pluginsdk.Schema{
-					Type: pluginsdk.TypeString,
-				},
-			},
-
-			"node_public_ip_prefix_id": {
-				Type:         pluginsdk.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				RequiredWith: []string{"enable_node_public_ip"},
-			},
-
-			// Node Taints control the behaviour of the Node Pool, as such they should not be computed and
-			// must be specified/reconciled as required
-			"node_taints": {
-				Type:     pluginsdk.TypeList,
-				Optional: true,
-				ForceNew: true,
-				Elem: &pluginsdk.Schema{
-					Type: pluginsdk.TypeString,
-				},
-			},
-
-			"orchestrator_version": {
-				Type:         pluginsdk.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ValidateFunc: validation.StringIsNotEmpty,
-			},
-
-			"os_disk_size_gb": {
-				Type:         pluginsdk.TypeInt,
-				Optional:     true,
-				ForceNew:     true,
-				Computed:     true,
-				ValidateFunc: validation.IntAtLeast(1),
-			},
-
-			"os_disk_type": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Default:  agentpools.OSDiskTypeManaged,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(agentpools.OSDiskTypeEphemeral),
-					string(agentpools.OSDiskTypeManaged),
-				}, false),
-			},
-
-			"os_sku": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Computed: true, // defaults to Ubuntu if using Linux
-				ValidateFunc: validation.StringInSlice([]string{
-					string(agentpools.OSSKUAzureLinux),
-					// TODO 4.0: remove CLBMariner and Mariner
-					string(agentpools.OSSKUCBLMariner),
-					string(agentpools.OSSKUMariner),
-					string(agentpools.OSSKUUbuntu),
-					string(agentpools.OSSKUWindowsTwoZeroOneNine),
-					string(agentpools.OSSKUWindowsTwoZeroTwoTwo),
-				}, false),
-			},
-
-			"os_type": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Default:  string(agentpools.OSTypeLinux),
-				ValidateFunc: validation.StringInSlice([]string{
-					string(agentpools.OSTypeLinux),
-					string(agentpools.OSTypeWindows),
-				}, false),
-			},
-
-			"pod_subnet_id": {
-				Type:         pluginsdk.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: networkValidate.SubnetID,
-			},
-
-			"priority": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Default:  string(agentpools.ScaleSetPriorityRegular),
-				ValidateFunc: validation.StringInSlice([]string{
-					string(agentpools.ScaleSetPriorityRegular),
-					string(agentpools.ScaleSetPrioritySpot),
-				}, false),
-			},
-
-			"proximity_placement_group_id": {
-				Type:         pluginsdk.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: proximityplacementgroups.ValidateProximityPlacementGroupID,
-			},
-
-			"snapshot_id": {
-				Type:         pluginsdk.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: snapshots.ValidateSnapshotID,
-			},
-
-			"spot_max_price": {
-				Type:         pluginsdk.TypeFloat,
-				Optional:     true,
-				ForceNew:     true,
-				Default:      -1.0,
-				ValidateFunc: computeValidate.SpotMaxPrice,
-			},
-
-			"scale_down_mode": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				Default:  string(agentpools.ScaleDownModeDelete),
-				ValidateFunc: validation.StringInSlice([]string{
-					string(agentpools.ScaleDownModeDeallocate),
-					string(agentpools.ScaleDownModeDelete),
-				}, false),
-			},
-
-			"ultra_ssd_enabled": {
-				Type:     pluginsdk.TypeBool,
-				ForceNew: true,
-				Default:  false,
-				Optional: true,
-			},
-
-			"vnet_subnet_id": {
-				Type:         pluginsdk.TypeString,
-				Optional:     true,
-				ForceNew:     true,
-				ValidateFunc: networkValidate.SubnetID,
-			},
-
-			"upgrade_settings": upgradeSettingsSchema(),
-
-			"windows_profile": {
-				Type:     pluginsdk.TypeList,
-				Optional: true,
-				ForceNew: true,
-				MaxItems: 1,
-				Elem: &pluginsdk.Resource{
-					Schema: map[string]*pluginsdk.Schema{
-						"outbound_nat_enabled": {
-							Type:     pluginsdk.TypeBool,
-							Optional: true,
-							ForceNew: true,
-							Default:  true,
-						},
-					},
-				},
-			},
-
-			"workload_runtime": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(agentpools.WorkloadRuntimeOCIContainer),
-					string(agentpools.WorkloadRuntimeWasmWasi),
-					string(agentpools.WorkloadRuntimeKataMshvVMIsolation),
-				}, false),
-			},
-			"zones": commonschema.ZonesMultipleOptionalForceNew(),
-		},
+		Schema: resourceKubernetesClusterNodePoolSchema(),
 	}
 }
 
+func resourceKubernetesClusterNodePoolSchema() map[string]*pluginsdk.Schema {
+	s := map[string]*pluginsdk.Schema{
+		"name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: containerValidate.KubernetesAgentPoolName,
+		},
+
+		"kubernetes_cluster_id": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: containerValidate.ClusterID,
+		},
+
+		"node_count": {
+			Type:         pluginsdk.TypeInt,
+			Optional:     true,
+			Computed:     true,
+			ValidateFunc: validation.IntBetween(0, 1000),
+		},
+
+		"tags": commonschema.Tags(),
+
+		"vm_size": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"host_group_id": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ForceNew:     true,
+			ValidateFunc: computeValidate.HostGroupID,
+		},
+
+		// Optional
+		"capacity_reservation_group_id": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ForceNew:     true,
+			ValidateFunc: capacityreservationgroups.ValidateCapacityReservationGroupID,
+		},
+
+		"custom_ca_trust_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+		},
+
+		"enable_auto_scaling": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+		},
+
+		"enable_host_encryption": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			ForceNew: true,
+		},
+
+		"enable_node_public_ip": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			ForceNew: true,
+		},
+
+		"eviction_policy": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			ForceNew: true,
+			ValidateFunc: validation.StringInSlice([]string{
+				string(agentpools.ScaleSetEvictionPolicyDelete),
+				string(agentpools.ScaleSetEvictionPolicyDeallocate),
+			}, false),
+		},
+
+		"kubelet_config": schemaNodePoolKubeletConfigForceNew(),
+
+		"linux_os_config": schemaNodePoolLinuxOSConfigForceNew(),
+
+		"fips_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			ForceNew: true,
+		},
+
+		"kubelet_disk_type": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			Computed: true,
+			ValidateFunc: validation.StringInSlice([]string{
+				string(agentpools.KubeletDiskTypeOS),
+				string(agentpools.KubeletDiskTypeTemporary),
+			}, false),
+		},
+
+		"max_count": {
+			Type:         pluginsdk.TypeInt,
+			Optional:     true,
+			ValidateFunc: validation.IntBetween(0, 1000),
+		},
+
+		"max_pods": {
+			Type:     pluginsdk.TypeInt,
+			Optional: true,
+			Computed: true,
+			ForceNew: true,
+		},
+
+		"message_of_the_day": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"mode": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			Default:  string(agentpools.AgentPoolModeUser),
+			ValidateFunc: validation.StringInSlice([]string{
+				string(agentpools.AgentPoolModeSystem),
+				string(agentpools.AgentPoolModeUser),
+			}, false),
+		},
+
+		"min_count": {
+			Type:     pluginsdk.TypeInt,
+			Optional: true,
+			// NOTE: rather than setting `0` users should instead pass `null` here
+			ValidateFunc: validation.IntBetween(0, 1000),
+		},
+
+		"node_network_profile": schemaNodePoolNetworkProfile(),
+
+		"node_labels": {
+			Type:     pluginsdk.TypeMap,
+			Optional: true,
+			Computed: true,
+			Elem: &pluginsdk.Schema{
+				Type: pluginsdk.TypeString,
+			},
+		},
+
+		"node_public_ip_prefix_id": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ForceNew:     true,
+			RequiredWith: []string{"enable_node_public_ip"},
+		},
+
+		// Node Taints control the behaviour of the Node Pool, as such they should not be computed and
+		// must be specified/reconciled as required
+		"node_taints": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			ForceNew: true,
+			Elem: &pluginsdk.Schema{
+				Type: pluginsdk.TypeString,
+			},
+		},
+
+		"orchestrator_version": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			Computed:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"os_disk_size_gb": {
+			Type:         pluginsdk.TypeInt,
+			Optional:     true,
+			ForceNew:     true,
+			Computed:     true,
+			ValidateFunc: validation.IntAtLeast(1),
+		},
+
+		"os_disk_type": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			ForceNew: true,
+			Default:  agentpools.OSDiskTypeManaged,
+			ValidateFunc: validation.StringInSlice([]string{
+				string(agentpools.OSDiskTypeEphemeral),
+				string(agentpools.OSDiskTypeManaged),
+			}, false),
+		},
+
+		"os_sku": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			ForceNew: true,
+			Computed: true, // defaults to Ubuntu if using Linux
+			ValidateFunc: validation.StringInSlice([]string{
+				string(agentpools.OSSKUAzureLinux),
+				string(agentpools.OSSKUUbuntu),
+				string(agentpools.OSSKUWindowsTwoZeroOneNine),
+				string(agentpools.OSSKUWindowsTwoZeroTwoTwo),
+			}, false),
+		},
+
+		"os_type": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			ForceNew: true,
+			Default:  string(agentpools.OSTypeLinux),
+			ValidateFunc: validation.StringInSlice([]string{
+				string(agentpools.OSTypeLinux),
+				string(agentpools.OSTypeWindows),
+			}, false),
+		},
+
+		"pod_subnet_id": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ForceNew:     true,
+			ValidateFunc: networkValidate.SubnetID,
+		},
+
+		"priority": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			ForceNew: true,
+			Default:  string(agentpools.ScaleSetPriorityRegular),
+			ValidateFunc: validation.StringInSlice([]string{
+				string(agentpools.ScaleSetPriorityRegular),
+				string(agentpools.ScaleSetPrioritySpot),
+			}, false),
+		},
+
+		"proximity_placement_group_id": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ForceNew:     true,
+			ValidateFunc: proximityplacementgroups.ValidateProximityPlacementGroupID,
+		},
+
+		"snapshot_id": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ForceNew:     true,
+			ValidateFunc: snapshots.ValidateSnapshotID,
+		},
+
+		"spot_max_price": {
+			Type:         pluginsdk.TypeFloat,
+			Optional:     true,
+			ForceNew:     true,
+			Default:      -1.0,
+			ValidateFunc: computeValidate.SpotMaxPrice,
+		},
+
+		"scale_down_mode": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			Default:  string(agentpools.ScaleDownModeDelete),
+			ValidateFunc: validation.StringInSlice([]string{
+				string(agentpools.ScaleDownModeDeallocate),
+				string(agentpools.ScaleDownModeDelete),
+			}, false),
+		},
+
+		"ultra_ssd_enabled": {
+			Type:     pluginsdk.TypeBool,
+			ForceNew: true,
+			Default:  false,
+			Optional: true,
+		},
+
+		"vnet_subnet_id": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ForceNew:     true,
+			ValidateFunc: networkValidate.SubnetID,
+		},
+
+		"upgrade_settings": upgradeSettingsSchema(),
+
+		"windows_profile": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			ForceNew: true,
+			MaxItems: 1,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"outbound_nat_enabled": {
+						Type:     pluginsdk.TypeBool,
+						Optional: true,
+						ForceNew: true,
+						Default:  true,
+					},
+				},
+			},
+		},
+
+		"workload_runtime": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			ValidateFunc: validation.StringInSlice([]string{
+				string(agentpools.WorkloadRuntimeOCIContainer),
+				string(agentpools.WorkloadRuntimeWasmWasi),
+				string(agentpools.WorkloadRuntimeKataMshvVMIsolation),
+			}, false),
+		},
+		"zones": commonschema.ZonesMultipleOptionalForceNew(),
+	}
+
+	if !features.FourPointOhBeta() {
+		s["os_sku"].ValidateFunc = validation.StringInSlice([]string{
+			string(agentpools.OSSKUAzureLinux),
+			string(agentpools.OSSKUCBLMariner),
+			string(agentpools.OSSKUMariner),
+			string(agentpools.OSSKUUbuntu),
+			string(agentpools.OSSKUWindowsTwoZeroOneNine),
+			string(agentpools.OSSKUWindowsTwoZeroTwoTwo),
+		}, false)
+	}
+
+	return s
+}
 func resourceKubernetesClusterNodePoolCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	containersClient := meta.(*clients.Client).Containers
 	clustersClient := containersClient.KubernetesClustersClient

--- a/internal/services/containers/kubernetes_cluster_node_pool_resource.go
+++ b/internal/services/containers/kubernetes_cluster_node_pool_resource.go
@@ -252,6 +252,7 @@ func resourceKubernetesClusterNodePool() *pluginsdk.Resource {
 				Computed: true, // defaults to Ubuntu if using Linux
 				ValidateFunc: validation.StringInSlice([]string{
 					string(agentpools.OSSKUAzureLinux),
+					// TODO 4.0: remove CLBMariner and Mariner
 					string(agentpools.OSSKUCBLMariner),
 					string(agentpools.OSSKUMariner),
 					string(agentpools.OSSKUUbuntu),

--- a/internal/services/containers/kubernetes_nodepool.go
+++ b/internal/services/containers/kubernetes_nodepool.go
@@ -199,6 +199,7 @@ func SchemaDefaultNodePool() *pluginsdk.Schema {
 						Computed: true, // defaults to Ubuntu if using Linux
 						ValidateFunc: validation.StringInSlice([]string{
 							string(agentpools.OSSKUAzureLinux),
+							// TODO 4.0: remove CLBMariner and Mariner
 							string(agentpools.OSSKUCBLMariner),
 							string(agentpools.OSSKUMariner),
 							string(agentpools.OSSKUUbuntu),

--- a/internal/services/containers/kubernetes_nodepool.go
+++ b/internal/services/containers/kubernetes_nodepool.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-04-02-preview/agentpools"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerservice/2023-04-02-preview/managedclusters"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	computeValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/compute/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/containers/validate"
 	networkValidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate"
@@ -199,9 +200,6 @@ func SchemaDefaultNodePool() *pluginsdk.Schema {
 						Computed: true, // defaults to Ubuntu if using Linux
 						ValidateFunc: validation.StringInSlice([]string{
 							string(agentpools.OSSKUAzureLinux),
-							// TODO 4.0: remove CLBMariner and Mariner
-							string(agentpools.OSSKUCBLMariner),
-							string(agentpools.OSSKUMariner),
 							string(agentpools.OSSKUUbuntu),
 							string(agentpools.OSSKUWindowsTwoZeroOneNine),
 							string(agentpools.OSSKUWindowsTwoZeroTwoTwo),
@@ -272,6 +270,17 @@ func SchemaDefaultNodePool() *pluginsdk.Schema {
 				}
 
 				s["zones"] = commonschema.ZonesMultipleOptional()
+
+				if !features.FourPointOhBeta() {
+					s["os_sku"].ValidateFunc = validation.StringInSlice([]string{
+						string(agentpools.OSSKUAzureLinux),
+						string(agentpools.OSSKUCBLMariner),
+						string(agentpools.OSSKUMariner),
+						string(agentpools.OSSKUUbuntu),
+						string(agentpools.OSSKUWindowsTwoZeroOneNine),
+						string(agentpools.OSSKUWindowsTwoZeroTwoTwo),
+					}, false)
+				}
 
 				return s
 			}(),

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -414,7 +414,7 @@ A `default_node_pool` block supports the following:
 
 * `os_disk_type` - (Optional) The type of disk which should be used for the Operating System. Possible values are `Ephemeral` and `Managed`. Defaults to `Managed`.  `temporary_name_for_rotation` must be specified when attempting a change.
 
-* `os_sku` - (Optional) Specifies the OS SKU used by the agent pool. Possible values include: `AzureLinux`, `Ubuntu`, `CBLMariner`, `Mariner`, `Windows2019`, `Windows2022`. If not specified, the default is `Ubuntu` if OSType=Linux or `Windows2019` if OSType=Windows. And the default Windows OSSKU will be changed to `Windows2022` after Windows2019 is deprecated. `temporary_name_for_rotation` must be specified when attempting a change.
+* `os_sku` - (Optional) Specifies the OS SKU used by the agent pool. Possible values include: `AzureLinux`, `Ubuntu`, `Windows2019`, `Windows2022`. If not specified, the default is `Ubuntu` if OSType=Linux or `Windows2019` if OSType=Windows. And the default Windows OSSKU will be changed to `Windows2022` after Windows2019 is deprecated. `temporary_name_for_rotation` must be specified when attempting a change.
 
 * `pod_subnet_id` - (Optional) The ID of the Subnet where the pods in the default Node Pool should exist. Changing this forces a new resource to be created.
 

--- a/website/docs/r/kubernetes_cluster_node_pool.html.markdown
+++ b/website/docs/r/kubernetes_cluster_node_pool.html.markdown
@@ -124,7 +124,7 @@ The following arguments are supported:
 
 * `pod_subnet_id` - (Optional) The ID of the Subnet where the pods in the Node Pool should exist. Changing this forces a new resource to be created.
 
-* `os_sku` - (Optional) Specifies the OS SKU used by the agent pool. Possible values include: `AzureLinux`, `Ubuntu`, `CBLMariner`, `Mariner`, `Windows2019`, `Windows2022`. If not specified, the default is `Ubuntu` if OSType=Linux or `Windows2019` if OSType=Windows. And the default Windows OSSKU will be changed to `Windows2022` after Windows2019 is deprecated. Changing this forces a new resource to be created.
+* `os_sku` - (Optional) Specifies the OS SKU used by the agent pool. Possible values include: `AzureLinux`, `Ubuntu`, `Windows2019`, `Windows2022`. If not specified, the default is `Ubuntu` if OSType=Linux or `Windows2019` if OSType=Windows. And the default Windows OSSKU will be changed to `Windows2022` after Windows2019 is deprecated. Changing this forces a new resource to be created.
 
 * `os_type` - (Optional) The Operating System which should be used for this Node Pool. Changing this forces a new resource to be created. Possible values are `Linux` and `Windows`. Defaults to `Linux`.
 


### PR DESCRIPTION
"AzureLinux" is newly named OSsku and needs to replace OSsku "Mariner".  The service team wants to discourage the use of `Mariner` and `CBLMariner`.