### PR TITLE
dependencies: bump `go-azure-sdk` to `v0.20230614.1151152`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.1.2
 	github.com/hashicorp/go-azure-helpers v0.56.0
-	github.com/hashicorp/go-azure-sdk v0.20230608.1112153
+	github.com/hashicorp/go-azure-sdk v0.20230614.1151152
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/go-version v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -141,8 +141,8 @@ github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brv
 github.com/hashicorp/go-azure-helpers v0.12.0/go.mod h1:Zc3v4DNeX6PDdy7NljlYpnrdac1++qNW0I4U+ofGwpg=
 github.com/hashicorp/go-azure-helpers v0.56.0 h1:KxDXISHwWe4PKEz6FSSPG8vCXNrFGsCcCn/AI94ccig=
 github.com/hashicorp/go-azure-helpers v0.56.0/go.mod h1:MbnCV9jPmlkbdH7VsoBK8IbCHvo3pLWRbRvq+F6u9sI=
-github.com/hashicorp/go-azure-sdk v0.20230608.1112153 h1:zjy/0svEZcdlYPfGqPjSPp+noB0HzXEeCh4vrBOQtPE=
-github.com/hashicorp/go-azure-sdk v0.20230608.1112153/go.mod h1:ARDIozwF5NoDJDfnh+MlG4eicP0mVxmVt3CQVSbNrq0=
+github.com/hashicorp/go-azure-sdk v0.20230614.1151152 h1:R2KVDHjcjgR9xjaaR1HNkx9KZQEsDu/0lG7xujFO7MA=
+github.com/hashicorp/go-azure-sdk v0.20230614.1151152/go.mod h1:ARDIozwF5NoDJDfnh+MlG4eicP0mVxmVt3CQVSbNrq0=
 github.com/hashicorp/go-checkpoint v0.5.0 h1:MFYpPZCnQqQTE18jFwSII6eUQrD/oxMFp3mlgcqk5mU=
 github.com/hashicorp/go-checkpoint v0.5.0/go.mod h1:7nfLNL10NsxqO4iWuW6tWW0HjZuDrwkBuEQsVcpCOgg=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=

--- a/vendor/github.com/hashicorp/go-azure-sdk/sdk/auth/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/sdk/auth/client.go
@@ -5,6 +5,7 @@ package auth
 
 import (
 	"context"
+	"crypto/tls"
 	"log"
 	"math"
 	"net"
@@ -101,6 +102,9 @@ func httpClient(params httpClientParams) *http.Client {
 	r.RetryWaitMin = params.retryWaitMin
 	r.RetryWaitMax = params.retryWaitMax
 
+	tlsConfig := tls.Config{
+		MinVersion: tls.VersionTLS12,
+	}
 	r.HTTPClient = &http.Client{
 		Transport: &http.Transport{
 			Proxy: proxyFunc,
@@ -110,6 +114,7 @@ func httpClient(params httpClientParams) *http.Client {
 			},
 			MaxIdleConns:          100,
 			IdleConnTimeout:       90 * time.Second,
+			TLSClientConfig:       &tlsConfig,
 			TLSHandshakeTimeout:   10 * time.Second,
 			ExpectContinueTimeout: 1 * time.Second,
 			ForceAttemptHTTP2:     true,

--- a/vendor/github.com/hashicorp/go-azure-sdk/sdk/client/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/sdk/client/client.go
@@ -6,6 +6,7 @@ package client
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
@@ -541,6 +542,9 @@ func (c *Client) retryableClient(checkRetry retryablehttp.CheckRetry) (r *retrya
 	r.ErrorHandler = RetryableErrorHandler
 	r.Logger = log.Default()
 
+	tlsConfig := tls.Config{
+		MinVersion: tls.VersionTLS12,
+	}
 	r.HTTPClient = &http.Client{
 		Transport: &http.Transport{
 			Proxy: http.ProxyFromEnvironment,
@@ -548,6 +552,7 @@ func (c *Client) retryableClient(checkRetry retryablehttp.CheckRetry) (r *retrya
 				d := &net.Dialer{Resolver: &net.Resolver{}}
 				return d.DialContext(ctx, network, addr)
 			},
+			TLSClientConfig:       &tlsConfig,
 			MaxIdleConns:          100,
 			IdleConnTimeout:       90 * time.Second,
 			TLSHandshakeTimeout:   10 * time.Second,

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -135,7 +135,7 @@ github.com/hashicorp/go-azure-helpers/resourcemanager/tags
 github.com/hashicorp/go-azure-helpers/resourcemanager/zones
 github.com/hashicorp/go-azure-helpers/sender
 github.com/hashicorp/go-azure-helpers/storage
-# github.com/hashicorp/go-azure-sdk v0.20230608.1112153
+# github.com/hashicorp/go-azure-sdk v0.20230614.1151152
 ## explicit; go 1.19
 github.com/hashicorp/go-azure-sdk/resource-manager/aad/2021-05-01/domainservices
 github.com/hashicorp/go-azure-sdk/resource-manager/aadb2c/2021-04-01-preview


### PR DESCRIPTION
I am working on PaloAltoNetworks RP. https://github.com/hashicorp/pandora/pull/2644
So I have to upgrade go azure sdk to involve this new package.