### PR TITLE
`azurerm_public_ip`: fix AccTest hardcode location for test regionalTier

### DIFF
--- a/.teamcity/components/settings.kt
+++ b/.teamcity/components/settings.kt
@@ -133,6 +133,9 @@ var serviceTestConfigurationOverrides = mapOf(
         // Network Function is only available in certain locations
         "networkfunction" to testConfiguration(locationOverride = LocationConfiguration("westus2", "eastus2", "westeurope", false)),
 
+        // Network Regional Tire Public IP is only available in
+        "network" to testConfiguration(locationOverride = LocationConfiguration("westeurope", "eastus2", "westus", false)),
+
         "policy" to testConfiguration(useAltSubscription = true),
 
         // Private DNS Resolver is only available in certain locations


### PR DESCRIPTION
only specific regions support `Regional Tire` public ip: https://learn.microsoft.com/en-us/azure/load-balancer/cross-region-overview#home-regions. AccTest will fail in TeamCity if give region not in the list. so hard code the region for this case.

![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/2633022/4fa707a1-289c-40d0-be7d-2dc53bb16c85)
