### PR TITLE
`azurerm_mssql_server_transparent_data_encryption` - fix acctests failed with `SecurityInvalidAzureKeyVaultRecoveryLevel` issue

### DIFF
--- a/internal/services/mssql/mssql_server_transparent_data_encryption_resource_test.go
+++ b/internal/services/mssql/mssql_server_transparent_data_encryption_resource_test.go
@@ -121,7 +121,7 @@ resource "azurerm_key_vault" "test" {
   enabled_for_disk_encryption = true
   tenant_id                   = data.azurerm_client_config.current.tenant_id
   soft_delete_retention_days  = 7
-  purge_protection_enabled    = false
+  purge_protection_enabled    = true
 
   sku_name = "standard"
 


### PR DESCRIPTION
Tests `TestAccMsSqlServerTransparentDataEncryption_keyVault`,`TestAccMsSqlServerTransparentDataEncryption_autoRotate`,`TestAccMsSqlServerTransparentDataEncryption_update`  failed with `SecurityInvalidAzureKeyVaultRecoveryLevel` issue. Per the [documentation ](https://learn.microsoft.com/en-us/azure/azure-sql/database/transparent-data-encryption-byok-overview?view=azuresql#requirements-for-configuring-customer-managed-tde), soft-delete and purge protection features must be enabled on the key vault to protect from data loss due to accidental key (or key vault) deletion. So submitted this PR to update the `purge_protection_enabled ` to `true` to fix the tests failure.

Test results:
PASS: TestAccMsSqlServerTransparentDataEncryption_autoRotate (768.94s)
PASS: TestAccMsSqlServerTransparentDataEncryption_update (513.30s)
PASS: TestAccMsSqlServerTransparentDataEncryption_keyVault (496.79s)