### PR TITLE
`azurerm_automation_software_update_configuration` - Refactor and add correct API constraints.

### DIFF
--- a/internal/services/automation/automation_software_update_configuration_resource.go
+++ b/internal/services/automation/automation_software_update_configuration_resource.go
@@ -484,6 +484,7 @@ func (m SoftwareUpdateConfigurationResource) Arguments() map[string]*pluginsdk.S
 					"monthly_occurrence": {
 						Type:     pluginsdk.TypeList,
 						Optional: true,
+						MaxItems: 1,
 						Elem: &pluginsdk.Resource{
 							Schema: map[string]*pluginsdk.Schema{
 								"occurrence": {

--- a/internal/services/automation/automation_software_update_configuration_resource.go
+++ b/internal/services/automation/automation_software_update_configuration_resource.go
@@ -33,6 +33,14 @@ const (
 	FrequencyHour    = "Hour"
 	FrequencyWeek    = "Week"
 	FrequencyMonth   = "Month"
+
+	DaysOfWeekMonday    = "Monday"
+	DaysOfWeekTuesday   = "Tuesday"
+	DaysOfWeekWednesday = "Wednesday"
+	DaysOfWeekThursday  = "Thursday"
+	DaysOfWeekFriday    = "Friday"
+	DaysOfWeekSaturday  = "Saturday"
+	DaysOfWeekSunday    = "Sunday"
 )
 
 type Tag struct {
@@ -264,7 +272,7 @@ func (m SoftwareUpdateConfigurationResource) Arguments() map[string]*pluginsdk.S
 
 				"classifications_included": {
 					Type:     pluginsdk.TypeList,
-					Required: true,
+					Required: true, // TODO 4.0 - Update docs to reflect this breaking change.
 					Elem: &pluginsdk.Schema{
 						Type: pluginsdk.TypeString,
 						ValidateFunc: validation.StringInSlice(softwareupdateconfiguration.PossibleValuesForLinuxUpdateClasses(),
@@ -295,7 +303,7 @@ func (m SoftwareUpdateConfigurationResource) Arguments() map[string]*pluginsdk.S
 			Schema: map[string]*pluginsdk.Schema{
 				"classifications_included": {
 					Type:     pluginsdk.TypeList,
-					Required: true,
+					Required: true, // TODO 4.0 - Update docs to reflect this breaking change.
 					Elem: &pluginsdk.Schema{
 						Type: pluginsdk.TypeString,
 						ValidateFunc: validation.StringInSlice(
@@ -588,8 +596,16 @@ func (m SoftwareUpdateConfigurationResource) Arguments() map[string]*pluginsdk.S
 						Type:     pluginsdk.TypeList,
 						Optional: true,
 						Elem: &pluginsdk.Schema{
-							Type:         pluginsdk.TypeString,
-							ValidateFunc: nil,
+							Type: pluginsdk.TypeString,
+							ValidateFunc: validation.StringInSlice([]string{
+								DaysOfWeekMonday,
+								DaysOfWeekTuesday,
+								DaysOfWeekWednesday,
+								DaysOfWeekThursday,
+								DaysOfWeekFriday,
+								DaysOfWeekSaturday,
+								DaysOfWeekSunday,
+							}, false),
 						},
 					},
 

--- a/internal/services/automation/automation_software_update_configuration_resource.go
+++ b/internal/services/automation/automation_software_update_configuration_resource.go
@@ -937,7 +937,7 @@ func (m SoftwareUpdateConfigurationResource) Read() sdk.ResourceFunc {
 					}}
 				}
 				if post := tasks.PostTask; post != nil {
-					state.PreTask = []UpdateTask{{
+					state.PostTask = []UpdateTask{{
 						Source:     pointer.From(post.Source),
 						Parameters: pointer.From(post.Parameters),
 					}}

--- a/internal/services/automation/automation_software_update_configuration_resource.go
+++ b/internal/services/automation/automation_software_update_configuration_resource.go
@@ -136,10 +136,10 @@ type SoftwareUpdateConfigurationResource struct{}
 var _ sdk.ResourceWithUpdate = SoftwareUpdateConfigurationResource{}
 
 func (m SoftwareUpdateConfigurationResource) Arguments() map[string]*pluginsdk.Schema {
-	linux := &pluginsdk.Resource{}
-	windows := &pluginsdk.Resource{}
+	linux := pluginsdk.Resource{}
+	windows := pluginsdk.Resource{}
 	if !features.FourPointOhBeta() {
-		linux = &pluginsdk.Resource{
+		linux = pluginsdk.Resource{
 			Schema: map[string]*pluginsdk.Schema{
 				"reboot": {
 					Type:     pluginsdk.TypeString,
@@ -196,7 +196,7 @@ func (m SoftwareUpdateConfigurationResource) Arguments() map[string]*pluginsdk.S
 				},
 			},
 		}
-		windows = &pluginsdk.Resource{
+		windows = pluginsdk.Resource{
 			Schema: map[string]*pluginsdk.Schema{
 				"classification_included": {
 					Type:          pluginsdk.TypeString,
@@ -256,7 +256,7 @@ func (m SoftwareUpdateConfigurationResource) Arguments() map[string]*pluginsdk.S
 			},
 		}
 	} else {
-		linux = &pluginsdk.Resource{
+		linux = pluginsdk.Resource{
 			Schema: map[string]*pluginsdk.Schema{
 				"reboot": {
 					Type:     pluginsdk.TypeString,
@@ -299,7 +299,7 @@ func (m SoftwareUpdateConfigurationResource) Arguments() map[string]*pluginsdk.S
 				},
 			},
 		}
-		windows = &pluginsdk.Resource{
+		windows = pluginsdk.Resource{
 			Schema: map[string]*pluginsdk.Schema{
 				"classifications_included": {
 					Type:     pluginsdk.TypeList,
@@ -363,7 +363,7 @@ func (m SoftwareUpdateConfigurationResource) Arguments() map[string]*pluginsdk.S
 			Type:     pluginsdk.TypeList,
 			Optional: true,
 			MaxItems: 1,
-			Elem:     linux,
+			Elem:     &linux,
 			ExactlyOneOf: []string{
 				"windows",
 				"linux",
@@ -374,7 +374,7 @@ func (m SoftwareUpdateConfigurationResource) Arguments() map[string]*pluginsdk.S
 			Type:     pluginsdk.TypeList,
 			Optional: true,
 			MaxItems: 1,
-			Elem:     windows,
+			Elem:     &windows,
 			ExactlyOneOf: []string{
 				"windows",
 				"linux",
@@ -767,8 +767,7 @@ func (m SoftwareUpdateConfigurationResource) Create() sdk.ResourceFunc {
 				}
 			}
 
-			updateConfig, err := expandUpdateConfig(model)
-
+			updateConfig := expandUpdateConfig(model)
 			if _, err = client.SoftwareUpdateConfigurationsCreate(ctx, id, *updateConfig, softwareupdateconfiguration.SoftwareUpdateConfigurationsCreateOperationOptions{}); err != nil {
 				return fmt.Errorf("creating %s: %v", id, err)
 			}
@@ -1200,7 +1199,7 @@ func (m SoftwareUpdateConfigurationResource) IDValidationFunc() pluginsdk.Schema
 	return softwareupdateconfiguration.ValidateSoftwareUpdateConfigurationID
 }
 
-func expandUpdateConfig(input SoftwareUpdateConfigurationModel) (*softwareupdateconfiguration.SoftwareUpdateConfiguration, error) {
+func expandUpdateConfig(input SoftwareUpdateConfigurationModel) *softwareupdateconfiguration.SoftwareUpdateConfiguration {
 	result := &softwareupdateconfiguration.SoftwareUpdateConfiguration{
 		Properties: softwareupdateconfiguration.SoftwareUpdateConfigurationProperties{
 			ScheduleInfo: softwareupdateconfiguration.SUCScheduleProperties{},
@@ -1390,5 +1389,5 @@ func expandUpdateConfig(input SoftwareUpdateConfigurationModel) (*softwareupdate
 
 	result.Properties.UpdateConfiguration = updateConfig
 
-	return result, nil
+	return result
 }

--- a/internal/services/automation/automation_software_update_configuration_resource_test.go
+++ b/internal/services/automation/automation_software_update_configuration_resource_test.go
@@ -260,8 +260,6 @@ func TestAccSoftwareUpdateConfiguration_windowsUpdate(t *testing.T) {
 
 func (a SoftwareUpdateConfigurationResource) defaultTimeZone(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-
-
 %s
 
 resource "azurerm_automation_software_update_configuration" "test" {
@@ -393,8 +391,6 @@ resource "azurerm_automation_software_update_configuration" "test" {
 
 func (a SoftwareUpdateConfigurationResource) withTask(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-
-
 resource "azurerm_automation_runbook" "test" {
   name                    = "Get-AzureVMTutorial"
   location                = azurerm_resource_group.test.location
@@ -533,10 +529,6 @@ resource "azurerm_automation_software_update_configuration" "test" {
 
 func (a SoftwareUpdateConfigurationResource) windowsBasic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-
-
-
-
 %s
 
 resource "azurerm_automation_software_update_configuration" "test" {

--- a/internal/services/automation/automation_software_update_configuration_resource_test.go
+++ b/internal/services/automation/automation_software_update_configuration_resource_test.go
@@ -38,7 +38,7 @@ func (a SoftwareUpdateConfigurationResource) Exists(ctx context.Context, client 
 	}
 	resp, err := client.Automation.SoftwareUpdateConfigClient.SoftwareUpdateConfigurationsGetByName(ctx, *id, softwareupdateconfiguration.SoftwareUpdateConfigurationsGetByNameOperationOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("retrieving Type %s: %+v", *id, err)
+		return nil, fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 	return pointer.To(resp.Model != nil), nil
 }
@@ -53,7 +53,38 @@ func TestAccSoftwareUpdateConfiguration_basic(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		// scheduleInfo.advancedSchedule always return null
+		// scheduleInfo.advancedSchedule always returns null - https://github.com/Azure/azure-rest-api-specs/issues/24436
+		data.ImportStep("schedule.0.advanced", "schedule.0.monthly_occurrence"),
+	})
+}
+
+func TestAccSoftwareUpdateConfiguration_CompleteUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, automation.SoftwareUpdateConfigurationResource{}.ResourceType(), "test")
+	r := newSoftwareUpdateConfigurationResource()
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		// scheduleInfo.advancedSchedule always returns null - https://github.com/Azure/azure-rest-api-specs/issues/24436
+		data.ImportStep("schedule.0.advanced", "schedule.0.monthly_occurrence"),
+		{
+			Config: r.update(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		// scheduleInfo.advancedSchedule always returns null - https://github.com/Azure/azure-rest-api-specs/issues/24436
+		data.ImportStep("schedule.0.advanced", "schedule.0.monthly_occurrence"),
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		// scheduleInfo.advancedSchedule always returns null - https://github.com/Azure/azure-rest-api-specs/issues/24436
 		data.ImportStep("schedule.0.advanced", "schedule.0.monthly_occurrence"),
 	})
 }
@@ -68,7 +99,7 @@ func TestAccSoftwareUpdateConfiguration_withTask(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		// scheduleInfo.advancedSchedule always return null
+		// scheduleInfo.advancedSchedule always returns null - https://github.com/Azure/azure-rest-api-specs/issues/24436
 		data.ImportStep("schedule.0.advanced", "schedule.0.monthly_occurrence"),
 	})
 }
@@ -83,7 +114,7 @@ func TestAccSoftwareUpdateConfiguration_defaultTimeZone(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		// scheduleInfo.advancedSchedule always return null
+		// scheduleInfo.advancedSchedule always returns null - https://github.com/Azure/azure-rest-api-specs/issues/24436
 		data.ImportStep("schedule.0.advanced", "schedule.0.monthly_occurrence"),
 		{
 			Config: r.basic(data),
@@ -91,7 +122,7 @@ func TestAccSoftwareUpdateConfiguration_defaultTimeZone(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		// scheduleInfo.advancedSchedule always return null
+		// scheduleInfo.advancedSchedule always returns null - https://github.com/Azure/azure-rest-api-specs/issues/24436
 		data.ImportStep("schedule.0.advanced", "schedule.0.monthly_occurrence"),
 	})
 }
@@ -106,7 +137,7 @@ func TestAccSoftwareUpdateConfiguration_update(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		// scheduleInfo.advancedSchedule always return null
+		// scheduleInfo.advancedSchedule always returns null - https://github.com/Azure/azure-rest-api-specs/issues/24436
 		data.ImportStep("schedule.0.advanced", "schedule.0.monthly_occurrence"),
 		{
 			Config: r.update(data),
@@ -114,7 +145,7 @@ func TestAccSoftwareUpdateConfiguration_update(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		// scheduleInfo.advancedSchedule always return null
+		// scheduleInfo.advancedSchedule always returns null - https://github.com/Azure/azure-rest-api-specs/issues/24436
 		data.ImportStep("schedule.0.advanced", "schedule.0.monthly_occurrence"),
 	})
 }
@@ -129,7 +160,7 @@ func TestAccSoftwareUpdateConfiguration_windows(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		// scheduleInfo.advancedSchedule always return null
+		// scheduleInfo.advancedSchedule always returns null - https://github.com/Azure/azure-rest-api-specs/issues/24436
 		data.ImportStep("schedule.0.advanced", "schedule.0.monthly_occurrence"),
 	})
 }
@@ -143,7 +174,6 @@ func (a SoftwareUpdateConfigurationResource) defaultTimeZone(data acceptance.Tes
 resource "azurerm_automation_software_update_configuration" "test" {
   automation_account_id = azurerm_automation_account.test.id
   name                  = "acctest-suc-%[2]d"
-  operating_system      = "Linux"
 
   linux {
     classification_included = "Security"
@@ -189,13 +219,11 @@ resource "azurerm_automation_software_update_configuration" "test" {
 func (a SoftwareUpdateConfigurationResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 
-
 %s
 
 resource "azurerm_automation_software_update_configuration" "test" {
   automation_account_id = azurerm_automation_account.test.id
   name                  = "acctest-suc-%[2]d"
-  operating_system      = "Linux"
 
   linux {
     classification_included = "Security"
@@ -268,7 +296,6 @@ CONTENT
 resource "azurerm_automation_software_update_configuration" "test" {
   automation_account_id = azurerm_automation_account.test.id
   name                  = "acctest-suc-%[2]d"
-  operating_system      = "Linux"
 
   linux {
     classification_included = "Security"
@@ -329,7 +356,6 @@ resource "azurerm_automation_software_update_configuration" "test" {
 func (a SoftwareUpdateConfigurationResource) update(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 
-
 %s
 
 data "azurerm_client_config" "current" {}
@@ -337,13 +363,12 @@ data "azurerm_client_config" "current" {}
 resource "azurerm_automation_software_update_configuration" "test" {
   automation_account_id = azurerm_automation_account.test.id
   name                  = "acctest-suc-%[2]d"
-  operating_system      = "Linux"
 
   linux {
     classification_included = "Security"
     excluded_packages       = ["apt"]
     included_packages       = ["vim"]
-    reboot                  = "IfRequired"
+    reboot                  = "Always"
   }
 
   duration            = "PT2H2M2S"
@@ -361,7 +386,7 @@ resource "azurerm_automation_software_update_configuration" "test" {
     }
 
     non_azure_query {
-      function_alias = "savedSearch1"
+      function_alias = "savedSearch2"
       workspace_id   = azurerm_log_analytics_workspace.test.id
     }
   }
@@ -371,7 +396,7 @@ resource "azurerm_automation_software_update_configuration" "test" {
     start_time         = "%[3]s"
     expiry_time        = "%[4]s"
     is_enabled         = true
-    interval           = 1
+    interval           = 2
     frequency          = "Hour"
     time_zone          = "Etc/UTC"
     advanced_week_days = ["Monday", "Tuesday"]
@@ -391,7 +416,6 @@ func (a SoftwareUpdateConfigurationResource) windows(data acceptance.TestData) s
 resource "azurerm_automation_software_update_configuration" "test" {
   automation_account_id = azurerm_automation_account.test.id
   name                  = "acctest-suc-%[2]d"
-  operating_system      = "Windows"
 
   windows {
     classifications_included = ["Critical", "Security"]

--- a/internal/services/automation/automation_software_update_configuration_resource_test.go
+++ b/internal/services/automation/automation_software_update_configuration_resource_test.go
@@ -24,9 +24,10 @@ func newSoftwareUpdateConfigurationResource() SoftwareUpdateConfigurationResourc
 	// The start time of the schedule must be at least 5 minutes after the time you create the schedule,
 	// so we cannot hardcode the time string.
 	// we use timezone as UTC so the time string should be in UTC format
+	ref := time.Now().Round(time.Minute)
 	ins := SoftwareUpdateConfigurationResource{
-		startTime:  time.Now().Add(time.Hour * 10).In(time.UTC).Format(time.RFC3339),
-		expireTime: time.Now().Add(time.Hour * 50).In(time.UTC).Format(time.RFC3339),
+		startTime:  ref.Add(time.Hour * 1).In(time.UTC).Format(time.RFC3339),
+		expireTime: ref.Add(time.Hour * 2).In(time.UTC).Format(time.RFC3339),
 	}
 	return ins
 }
@@ -43,12 +44,58 @@ func (a SoftwareUpdateConfigurationResource) Exists(ctx context.Context, client 
 	return pointer.To(resp.Model != nil), nil
 }
 
-func TestAccSoftwareUpdateConfiguration_basic(t *testing.T) {
+func TestAccSoftwareUpdateConfiguration_linuxBasic(t *testing.T) {
 	data := acceptance.BuildTestData(t, automation.SoftwareUpdateConfigurationResource{}.ResourceType(), "test")
 	r := newSoftwareUpdateConfigurationResource()
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.basic(data),
+			Config: r.linuxBasic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		// scheduleInfo.advancedSchedule always returns null - https://github.com/Azure/azure-rest-api-specs/issues/24436
+		data.ImportStep("schedule.0.advanced", "schedule.0.monthly_occurrence"),
+	})
+}
+
+func TestAccSoftwareUpdateConfiguration_linuxComplete(t *testing.T) {
+	data := acceptance.BuildTestData(t, automation.SoftwareUpdateConfigurationResource{}.ResourceType(), "test")
+	r := newSoftwareUpdateConfigurationResource()
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.linuxComplete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		// scheduleInfo.advancedSchedule always returns null - https://github.com/Azure/azure-rest-api-specs/issues/24436
+		data.ImportStep("schedule.0.advanced", "schedule.0.monthly_occurrence"),
+	})
+}
+
+func TestAccSoftwareUpdateConfiguration_linuxUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, automation.SoftwareUpdateConfigurationResource{}.ResourceType(), "test")
+	r := newSoftwareUpdateConfigurationResource()
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.linuxBasic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		// scheduleInfo.advancedSchedule always returns null - https://github.com/Azure/azure-rest-api-specs/issues/24436
+		data.ImportStep("schedule.0.advanced", "schedule.0.monthly_occurrence"),
+		{
+			Config: r.linuxComplete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		// scheduleInfo.advancedSchedule always returns null - https://github.com/Azure/azure-rest-api-specs/issues/24436
+		data.ImportStep("schedule.0.advanced", "schedule.0.monthly_occurrence"),
+		{
+			Config: r.linuxBasic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -63,7 +110,7 @@ func TestAccSoftwareUpdateConfiguration_CompleteUpdate(t *testing.T) {
 	r := newSoftwareUpdateConfigurationResource()
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.basic(data),
+			Config: r.linuxBasic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -79,7 +126,7 @@ func TestAccSoftwareUpdateConfiguration_CompleteUpdate(t *testing.T) {
 		// scheduleInfo.advancedSchedule always returns null - https://github.com/Azure/azure-rest-api-specs/issues/24436
 		data.ImportStep("schedule.0.advanced", "schedule.0.monthly_occurrence"),
 		{
-			Config: r.basic(data),
+			Config: r.linuxBasic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -117,7 +164,7 @@ func TestAccSoftwareUpdateConfiguration_defaultTimeZone(t *testing.T) {
 		// scheduleInfo.advancedSchedule always returns null - https://github.com/Azure/azure-rest-api-specs/issues/24436
 		data.ImportStep("schedule.0.advanced", "schedule.0.monthly_occurrence"),
 		{
-			Config: r.basic(data),
+			Config: r.linuxBasic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -132,7 +179,7 @@ func TestAccSoftwareUpdateConfiguration_update(t *testing.T) {
 	r := newSoftwareUpdateConfigurationResource()
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.basic(data),
+			Config: r.linuxBasic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -150,12 +197,58 @@ func TestAccSoftwareUpdateConfiguration_update(t *testing.T) {
 	})
 }
 
-func TestAccSoftwareUpdateConfiguration_windows(t *testing.T) {
+func TestAccSoftwareUpdateConfiguration_windowsBasic(t *testing.T) {
 	data := acceptance.BuildTestData(t, automation.SoftwareUpdateConfigurationResource{}.ResourceType(), "test")
 	r := newSoftwareUpdateConfigurationResource()
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.windows(data),
+			Config: r.windowsBasic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		// scheduleInfo.advancedSchedule always returns null - https://github.com/Azure/azure-rest-api-specs/issues/24436
+		data.ImportStep("schedule.0.advanced", "schedule.0.monthly_occurrence"),
+	})
+}
+
+func TestAccSoftwareUpdateConfiguration_windowsComplete(t *testing.T) {
+	data := acceptance.BuildTestData(t, automation.SoftwareUpdateConfigurationResource{}.ResourceType(), "test")
+	r := newSoftwareUpdateConfigurationResource()
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.windowsComplete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		// scheduleInfo.advancedSchedule always returns null - https://github.com/Azure/azure-rest-api-specs/issues/24436
+		data.ImportStep("schedule.0.advanced", "schedule.0.monthly_occurrence"),
+	})
+}
+
+func TestAccSoftwareUpdateConfiguration_windowsUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, automation.SoftwareUpdateConfigurationResource{}.ResourceType(), "test")
+	r := newSoftwareUpdateConfigurationResource()
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.windowsBasic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		// scheduleInfo.advancedSchedule always returns null - https://github.com/Azure/azure-rest-api-specs/issues/24436
+		data.ImportStep("schedule.0.advanced", "schedule.0.monthly_occurrence"),
+		{
+			Config: r.windowsComplete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		// scheduleInfo.advancedSchedule always returns null - https://github.com/Azure/azure-rest-api-specs/issues/24436
+		data.ImportStep("schedule.0.advanced", "schedule.0.monthly_occurrence"),
+		{
+			Config: r.windowsBasic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -216,7 +309,7 @@ resource "azurerm_automation_software_update_configuration" "test" {
 `, a.template(data), data.RandomInteger, a.startTime, a.expireTime)
 }
 
-func (a SoftwareUpdateConfigurationResource) basic(data acceptance.TestData) string {
+func (a SoftwareUpdateConfigurationResource) linuxBasic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 
 %s
@@ -226,10 +319,39 @@ resource "azurerm_automation_software_update_configuration" "test" {
   name                  = "acctest-suc-%[2]d"
 
   linux {
-    classification_included = "Security"
+    classifications_included = ["Security"]
+  }
+
+  target {
+    azure_query {
+      scope     = [azurerm_resource_group.test.id]
+      locations = [azurerm_resource_group.test.location]
+    }
+  }
+
+  schedule {
+    frequency = "OneTime"
+  }
+
+  depends_on = [azurerm_log_analytics_linked_service.test]
+}
+`, a.template(data), data.RandomInteger)
+}
+
+func (a SoftwareUpdateConfigurationResource) linuxComplete(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+
+%s
+
+resource "azurerm_automation_software_update_configuration" "test" {
+  automation_account_id = azurerm_automation_account.test.id
+  name                  = "acctest-suc-%[2]d"
+
+  linux {
+    classifications_included = ["Critical", "Security"]
     excluded_packages       = ["apt"]
     included_packages       = ["vim"]
-    reboot                  = "IfRequired"
+    reboot                  = "RebootOnly"
   }
 
   duration            = "PT1H1M1S"
@@ -250,6 +372,7 @@ resource "azurerm_automation_software_update_configuration" "test" {
   schedule {
     description         = "foo-schedule"
     start_time          = "%[3]s"
+    expiry_time         = "%[4]s"
     is_enabled          = true
     interval            = 1
     frequency           = "Hour"
@@ -407,7 +530,37 @@ resource "azurerm_automation_software_update_configuration" "test" {
 `, a.template(data), data.RandomInteger, a.startTime, a.expireTime)
 }
 
-func (a SoftwareUpdateConfigurationResource) windows(data acceptance.TestData) string {
+func (a SoftwareUpdateConfigurationResource) windowsBasic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+
+
+%s
+
+resource "azurerm_automation_software_update_configuration" "test" {
+  automation_account_id = azurerm_automation_account.test.id
+  name                  = "acctest-suc-%[2]d"
+
+  windows {
+    classifications_included = ["Security"]
+  }
+
+  target {
+    azure_query {
+      scope     = [azurerm_resource_group.test.id]
+      locations = [azurerm_resource_group.test.location]
+    }
+  }
+
+  schedule {
+    frequency           = "OneTime"
+  }
+
+  depends_on = [azurerm_log_analytics_linked_service.test]
+}
+`, a.template(data), data.RandomInteger, a.startTime, a.expireTime)
+}
+
+func (a SoftwareUpdateConfigurationResource) windowsComplete(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 
 
@@ -419,7 +572,7 @@ resource "azurerm_automation_software_update_configuration" "test" {
 
   windows {
     classifications_included = ["Critical", "Security"]
-    reboot                   = "IfRequired"
+    reboot                   = "RebootOnly"
   }
 
   duration            = "PT1H1M1S"
@@ -475,7 +628,7 @@ provider "azurerm" {
 
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-auto-%[1]d"
-  location = "West US"
+  location = "%[2]s"
 }
 
 resource "azurerm_automation_account" "test" {
@@ -498,5 +651,5 @@ resource "azurerm_log_analytics_linked_service" "test" {
   workspace_id        = azurerm_log_analytics_workspace.test.id
   read_access_id      = azurerm_automation_account.test.id
 }
-`, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary)
 }

--- a/internal/services/automation/automation_software_update_configuration_resource_test.go
+++ b/internal/services/automation/automation_software_update_configuration_resource_test.go
@@ -341,6 +341,7 @@ resource "azurerm_automation_software_update_configuration" "test" {
 func (a SoftwareUpdateConfigurationResource) linuxComplete(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 
+
 %s
 
 resource "azurerm_automation_software_update_configuration" "test" {
@@ -349,9 +350,9 @@ resource "azurerm_automation_software_update_configuration" "test" {
 
   linux {
     classifications_included = ["Critical", "Security"]
-    excluded_packages       = ["apt"]
-    included_packages       = ["vim"]
-    reboot                  = "RebootOnly"
+    excluded_packages        = ["apt"]
+    included_packages        = ["vim"]
+    reboot                   = "RebootOnly"
   }
 
   duration            = "PT1H1M1S"
@@ -534,6 +535,8 @@ func (a SoftwareUpdateConfigurationResource) windowsBasic(data acceptance.TestDa
 	return fmt.Sprintf(`
 
 
+
+
 %s
 
 resource "azurerm_automation_software_update_configuration" "test" {
@@ -552,7 +555,7 @@ resource "azurerm_automation_software_update_configuration" "test" {
   }
 
   schedule {
-    frequency           = "OneTime"
+    frequency = "OneTime"
   }
 
   depends_on = [azurerm_log_analytics_linked_service.test]

--- a/website/docs/r/automation_software_update_configuration.html.markdown
+++ b/website/docs/r/automation_software_update_configuration.html.markdown
@@ -82,19 +82,19 @@ The following arguments are supported:
 
 ---
 
-* `duration` - (Optional) Maximum time allowed for the software update configuration run. using format `PT[n]H[n]M[n]S` as per ISO8601.
+* `duration` - (Optional) Maximum time allowed for the software update configuration run. using format `PT[n]H[n]M[n]S` as per ISO8601. Defaults to `PT2H`.
 
-* `linux` - (Optional) A `linux` blocks as defined below.
+* `linux` - (Optional) A `linux` block as defined below.
 
-* `windows` - (Optional) A `windows` blocks as defined below.
+* `windows` - (Optional) A `windows` block as defined below.
 
-~> **NOTE:** One of `linux` or `Windows` must be specified.
+~> **NOTE:** One of `linux` or `windows` must be specified.
 
-* `virtual_machine_ids` - (Optional) Specifies a list of azure resource Ids of azure virtual machines.
+* `virtual_machine_ids` - (Optional) Specifies a list of Azure Resource IDs of azure virtual machines.
 
-* `non_azure_computer_names` - (Optional) Specifies a list of names of non-azure machines for the software update configuration.
+* `non_azure_computer_names` - (Optional) Specifies a list of names of non-Azure machines for the software update configuration.
 
-* `target` - (Optional) One or more `target` blocks as defined below.
+* `target` - (Optional) A `target` blocks as defined below.
 
 * `post_task` - (Optional) A `post_task` blocks as defined below.
 
@@ -106,19 +106,17 @@ The following arguments are supported:
 
 A `linux` block supports the following:
 
-* `classification_included` - (Optional) Specifies the update classifications included in the Software Update Configuration. Possible values are `Unclassified`, `Critical`, `Security` and `Other`.
+* `classifications_included` - (Optional) Specifies the list of update classifications included in the Software Update Configuration. Possible values are `Unclassified`, `Critical`, `Security` and `Other`.
 
 * `excluded_packages` - (Optional) Specifies a list of packages to excluded from the Software Update Configuration.
 
 * `included_packages` - (Optional) Specifies a list of packages to included from the Software Update Configuration.
 
-* `reboot` - (Optional) Specifies the reboot settings after software update, possible values are `IfRequired`, `Never`, `RebootOnly` and `Always`
+* `reboot` - (Optional) Specifies the reboot settings after software update, possible values are `IfRequired`, `Never`, `RebootOnly` and `Always`. Defaults to `IfRequired`.
 
 ---
 
 A `windows` block supports the following:
-
-* `classification_included` - (Optional) (Deprecated) Specifies the update classification. Possible values are `Unclassified`, `Critical`, `Security`, `UpdateRollup`, `FeaturePack`, `ServicePack`, `Definition`, `Tools` and `Updates`.
 
 * `classifications_included` - (Optional) Specifies the list of update classification. Possible values are `Unclassified`, `Critical`, `Security`, `UpdateRollup`, `FeaturePack`, `ServicePack`, `Definition`, `Tools` and `Updates`.
 
@@ -126,7 +124,7 @@ A `windows` block supports the following:
 
 * `included_knowledge_base_numbers` - (Optional) Specifies a list of knowledge base numbers included.
 
-* `reboot` - (Optional) Specifies the reboot settings after software update, possible values are `IfRequired`, `Never`, `RebootOnly` and `Always`.
+* `reboot` - (Optional) Specifies the reboot settings after software update, possible values are `IfRequired`, `Never`, `RebootOnly` and `Always`. Defaults to `IfRequired`.
 
 ---
 
@@ -198,7 +196,7 @@ A `schedule` block supports the following:
 
 * `time_zone` - (Optional) The timezone of the start time. Defaults to `Etc/UTC`. For possible values see: <https://docs.microsoft.com/en-us/rest/api/maps/timezone/gettimezoneenumwindows>
 
-* `advanced_week_days` - (Optional) List of days of the week that the job should execute on. Only valid when frequency is `Week`.
+* `advanced_week_days` - (Optional) List of days of the week that the job should execute on. Only valid when frequency is `Week`. Possible values include `Monday`, `Tuesday`, `Wednesday`, `Thursday`, `Friday`, `Saturday`, and `Sunday`.
 
 * `advanced_month_days` - (Optional) List of days of the month that the job should execute on. Must be between `1` and `31`. `-1` for last day of the month. Only valid when frequency is `Month`.
 

--- a/website/docs/r/automation_software_update_configuration.html.markdown
+++ b/website/docs/r/automation_software_update_configuration.html.markdown
@@ -80,15 +80,15 @@ The following arguments are supported:
 
 * `automation_account_id` - (Required) The ID of Automation Account to manage this Source Control. Changing this forces a new Automation Source Control to be created.
 
-* `operating_system` - (Required) The Operating system of target machines. Possible values are `Windows` and `Linux`.
-
 ---
 
 * `duration` - (Optional) Maximum time allowed for the software update configuration run. using format `PT[n]H[n]M[n]S` as per ISO8601.
 
-* `linux` - (Optional) One or more `linux` blocks as defined below.
+* `linux` - (Optional) A `linux` blocks as defined below.
 
-* `windows` - (Optional) One or more `windows` blocks as defined below.
+* `windows` - (Optional) A `windows` blocks as defined below.
+
+~> **NOTE:** One of `linux` or `Windows` must be specified.
 
 * `virtual_machine_ids` - (Optional) Specifies a list of azure resource Ids of azure virtual machines.
 
@@ -96,11 +96,11 @@ The following arguments are supported:
 
 * `target` - (Optional) One or more `target` blocks as defined below.
 
-* `post_task` - (Optional) One or more `post_task` blocks as defined below.
+* `post_task` - (Optional) A `post_task` blocks as defined below.
 
-* `pre_task` - (Optional) One or more `pre_task` blocks as defined below.
+* `pre_task` - (Optional) A `pre_task` blocks as defined below.
 
-* `schedule` - (Optional) One or more `schedule` blocks as defined below.
+* `schedule` - (Optional) A `schedule` blocks as defined below.
 
 ---
 
@@ -112,7 +112,7 @@ A `linux` block supports the following:
 
 * `included_packages` - (Optional) Specifies a list of packages to included from the Software Update Configuration.
 
-* `reboot` - (Optional) Specifies the reboot settings after software update, possible values are `IfRequired`, `Never` and `Always`
+* `reboot` - (Optional) Specifies the reboot settings after software update, possible values are `IfRequired`, `Never`, `RebootOnly` and `Always`
 
 ---
 
@@ -126,7 +126,7 @@ A `windows` block supports the following:
 
 * `included_knowledge_base_numbers` - (Optional) Specifies a list of knowledge base numbers included.
 
-* `reboot` - (Optional) Specifies the reboot settings after software update, possible values are `IfRequired`, `Never` and `Always`
+* `reboot` - (Optional) Specifies the reboot settings after software update, possible values are `IfRequired`, `Never`, `RebootOnly` and `Always`.
 
 ---
 
@@ -184,9 +184,9 @@ A `post_task` block supports the following:
 
 A `schedule` block supports the following:
 
-* `is_enabled` - (Optional) Whether the schedule is enabled.
+* `frequency` - (Required) The frequency of the schedule. - can be either `OneTime`, `Day`, `Hour`, `Week`, or `Month`.
 
-* `frequency` - (Optional) The frequency of the schedule. - can be either `OneTime`, `Day`, `Hour`, `Week`, or `Month`.
+* `is_enabled` - (Optional) Whether the schedule is enabled.
 
 * `description` - (Optional) A description for this Schedule.
 


### PR DESCRIPTION
Adds schema validation and restrictions based on API limits / requirements:
* `operating_system` has been deprecated and is now controlled by the presence of either a `linux` or `windows` block.
* One of `linux` or `windows` block must now be present. This is a requirement of the API, so is a non-breaking `Optional` to `Required` change.
* `monthly_occurrence` - blocks limited to `1` due to:
```
Failure responding to request: StatusCode=400 -- Original Error:
        autorest/azure: Service returned an error. Status=400 Code="BadRequest"
        Message="{\"Message\":\"The request is
        invalid.\",\"ModelState\":{\"softwareUpdateConfiguration.properties.scheduleInfo.advancedSchedule.monthlyOccurrences\":[\"More
        than one Monthly Occurrence is not supported\"]}}"
```
* `duration` now defaults to `PT2H` as per the service.
* `schedule` block is now limited to `1`, to match the API limit.
* `schedule` block is now `Required` to match the API specification. The API  rejects requests that do not specify this block, with at least a `frequency` value.
* `frequency` is now a `Required` property of the `schedule` block. This is to match the minimum requirements of the API.
* `pre_task` blocks are now limited to `1` to match the API
* `post_task` blocks are now limited to `1` to match the API

closes #21970
