### PR TITLE
Fixed documentation of Virtual Hub as address_prefix is a required fi…

### DIFF
--- a/website/docs/r/virtual_hub.html.markdown
+++ b/website/docs/r/virtual_hub.html.markdown
@@ -43,9 +43,10 @@ The following arguments are supported:
 
 * `location` - (Required) Specifies the supported Azure location where the Virtual Hub should exist. Changing this forces a new resource to be created.
 
+* `address_prefix` - (Required) The Address Prefix which should be used for this Virtual Hub. Changing this forces a new resource to be created. [The address prefix subnet cannot be smaller than a `/24`. Azure recommends using a `/23`](https://docs.microsoft.com/azure/virtual-wan/virtual-wan-faq#what-is-the-recommended-hub-address-space-during-hub-creation).
+
 ---
 
-* `address_prefix` - (Optional) The Address Prefix which should be used for this Virtual Hub. Changing this forces a new resource to be created. [The address prefix subnet cannot be smaller than a `/24`. Azure recommends using a `/23`](https://docs.microsoft.com/azure/virtual-wan/virtual-wan-faq#what-is-the-recommended-hub-address-space-during-hub-creation).
 
 * `hub_routing_preference` - (Optional) The hub routing preference. Possible values are `ExpressRoute`, `ASPath` and `VpnGateway`. Defaults to `ExpressRoute`.
 


### PR DESCRIPTION
Fixed documentation of Virtual Hub as address_prefix is a required field.

address_prefix in azurerm_virtual_hub is a required field. See the error message below:

> │ Error: creating Virtual Hub: (Name "example-virtualhub" / Resource Group "example-resources"): network.VirtualHubsClient#CreateOrUpdate: Failure sending request: StatusCode=400 -- Original Error: Code="AddressPrefixStringCannotBeNullOrEmpty" Message="Address prefix string for resource /subscriptions/dc7479fa-544e-4227-ac19-e504c5fa7205/resourceGroups/example-resources/providers/Microsoft.Network/virtualHubs/example-virtualhub cannot be null or empty." Details=[]