### PR TITLE
Fixed error while deleting `cdn_frontdoor_origin_path` property

### DIFF
--- a/internal/services/cdn/azuresdkhacks/cdn_frontdoor_route.go
+++ b/internal/services/cdn/azuresdkhacks/cdn_frontdoor_route.go
@@ -138,6 +138,7 @@ func (rupp RouteUpdatePropertiesParameters) MarshalJSON() ([]byte, error) {
 		objectMap["originGroup"] = rupp.OriginGroup
 	}
 
+	// OriginPath must be set to nil to be removed
 	objectMap["originPath"] = rupp.OriginPath
 
 	if rupp.RuleSets != nil {

--- a/internal/services/cdn/azuresdkhacks/cdn_frontdoor_route.go
+++ b/internal/services/cdn/azuresdkhacks/cdn_frontdoor_route.go
@@ -137,9 +137,9 @@ func (rupp RouteUpdatePropertiesParameters) MarshalJSON() ([]byte, error) {
 	if rupp.OriginGroup != nil {
 		objectMap["originGroup"] = rupp.OriginGroup
 	}
-	if rupp.OriginPath != nil {
-		objectMap["originPath"] = rupp.OriginPath
-	}
+
+	objectMap["originPath"] = rupp.OriginPath
+
 	if rupp.RuleSets != nil {
 		objectMap["ruleSets"] = rupp.RuleSets
 	}

--- a/internal/services/cdn/cdn_frontdoor_route_resource.go
+++ b/internal/services/cdn/cdn_frontdoor_route_resource.go
@@ -488,7 +488,10 @@ func resourceCdnFrontDoorRouteUpdate(d *pluginsdk.ResourceData, meta interface{}
 	}
 
 	if d.HasChange("cdn_frontdoor_origin_path") {
-		updateProps.OriginPath = utils.String(d.Get("cdn_frontdoor_origin_path").(string))
+		originPath := d.Get("cdn_frontdoor_origin_path").(string)
+		if originPath != "" {
+			updateProps.OriginPath = utils.String(originPath)
+		}
 	}
 
 	if d.HasChange("patterns_to_match") {

--- a/internal/services/cdn/cdn_frontdoor_route_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_route_resource_test.go
@@ -197,6 +197,7 @@ resource "azurerm_cdn_frontdoor_route" "test" {
   cdn_frontdoor_origin_group_id = azurerm_cdn_frontdoor_origin_group.test.id
   cdn_frontdoor_origin_ids      = [azurerm_cdn_frontdoor_origin.test.id]
   cdn_frontdoor_rule_set_ids    = [azurerm_cdn_frontdoor_rule_set.test.id]
+  cdn_frontdoor_origin_path     = "/example"
 
   enabled                = true
   forwarding_protocol    = "HttpsOnly"


### PR DESCRIPTION
Fixes #22115 

### Acctests result

```
TF_ACC=1 go test -v ./internal/services/cdn -run=TestAccCdnFrontDoorRoute_update -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccCdnFrontDoorRoute_update
=== PAUSE TestAccCdnFrontDoorRoute_update
=== CONT  TestAccCdnFrontDoorRoute_update
--- PASS: TestAccCdnFrontDoorRoute_update (483.78s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/cdn   483.793s
```