### PR TITLE
`azurerm_site_recovery_replicated_vm`: fix a bug of setting `network_interface.failover_test_subnet_name` , `network_interface.failover_test_public_ip_address_id` and `network_interface.failover_test_static_ip`

### DIFF
--- a/internal/services/recoveryservices/site_recovery_replicated_vm_resource.go
+++ b/internal/services/recoveryservices/site_recovery_replicated_vm_resource.go
@@ -297,6 +297,7 @@ func networkInterfaceResource() *pluginsdk.Resource {
 				ForceNew:     false,
 				ValidateFunc: validation.StringIsNotEmpty,
 			},
+
 			"target_static_ip": {
 				Type:         pluginsdk.TypeString,
 				Optional:     true,
@@ -311,6 +312,7 @@ func networkInterfaceResource() *pluginsdk.Resource {
 				ForceNew:     false,
 				ValidateFunc: validation.StringIsNotEmpty,
 			},
+
 			"target_subnet_name": {
 				Type:         pluginsdk.TypeString,
 				Optional:     true,
@@ -325,6 +327,7 @@ func networkInterfaceResource() *pluginsdk.Resource {
 				ForceNew:     false,
 				ValidateFunc: azure.ValidateResourceID,
 			},
+
 			"recovery_public_ip_address_id": {
 				Type:         pluginsdk.TypeString,
 				Optional:     true,
@@ -546,9 +549,9 @@ func resourceSiteRecoveryReplicatedItemUpdateInternal(ctx context.Context, d *pl
 		targetStaticIp := vmNicInput["target_static_ip"].(string)
 		targetSubnetName := vmNicInput["target_subnet_name"].(string)
 		recoveryPublicIPAddressID := vmNicInput["recovery_public_ip_address_id"].(string)
-		testStaticIp := vmNicInput["target_static_ip"].(string)
-		testSubNetName := vmNicInput["target_subnet_name"].(string)
-		testPublicIpAddressID := vmNicInput["recovery_public_ip_address_id"].(string)
+		testStaticIp := vmNicInput["failover_test_static_ip"].(string)
+		testSubNetName := vmNicInput["failover_test_subnet_name"].(string)
+		testPublicIpAddressID := vmNicInput["failover_test_public_ip_address_id"].(string)
 
 		nicId := findNicId(state, sourceNicId)
 		if nicId == nil {

--- a/internal/services/recoveryservices/site_recovery_replicated_vm_resource_test.go
+++ b/internal/services/recoveryservices/site_recovery_replicated_vm_resource_test.go
@@ -445,7 +445,7 @@ func (r SiteRecoveryReplicatedVmResource) withTFOSettings(data acceptance.TestDa
 %s
 
 resource "azurerm_virtual_network" "tfo" {
-  name                = "net3-%[1]d"
+  name                = "net3-%[2]d"
   resource_group_name = azurerm_resource_group.test2.name
   address_space       = ["192.168.2.0/24"]
   location            = azurerm_site_recovery_fabric.test2.location
@@ -456,6 +456,14 @@ resource "azurerm_subnet" "tfo" {
   resource_group_name  = azurerm_resource_group.test2.name
   virtual_network_name = azurerm_virtual_network.tfo.name
   address_prefixes     = ["192.168.2.0/24"]
+}
+
+resource "azurerm_public_ip" "tfo" {
+  name                = "pubip%[2]d-tfo"
+  allocation_method   = "Static"
+  location            = azurerm_resource_group.test2.location
+  resource_group_name = azurerm_resource_group.test2.name
+  sku                 = "Basic"
 }
 
 resource "azurerm_site_recovery_replicated_vm" "test" {
@@ -470,7 +478,7 @@ resource "azurerm_site_recovery_replicated_vm" "test" {
   target_resource_group_id                = azurerm_resource_group.test2.id
   target_recovery_fabric_id               = azurerm_site_recovery_fabric.test2.id
   target_recovery_protection_container_id = azurerm_site_recovery_protection_container.test2.id
-  test_network_id                         = azurerm_virtual_network.test2.id
+  test_network_id                         = azurerm_virtual_network.tfo.id
 
   managed_disk {
     disk_id                    = azurerm_virtual_machine.test.storage_os_disk[0].managed_disk_id
@@ -484,8 +492,8 @@ resource "azurerm_site_recovery_replicated_vm" "test" {
     source_network_interface_id        = azurerm_network_interface.test.id
     target_subnet_name                 = azurerm_subnet.test2.name
     recovery_public_ip_address_id      = azurerm_public_ip.test-recovery.id
-    failover_test_subnet_name          = azurerm_subnet.test2.name
-    failover_test_public_ip_address_id = azurerm_public_ip.test-recovery.id
+    failover_test_subnet_name          = azurerm_subnet.tfo.name
+    failover_test_public_ip_address_id = azurerm_public_ip.tfo.id
   }
 
   depends_on = [
@@ -545,6 +553,7 @@ resource "azurerm_key_vault_access_policy" "service-principal" {
     "Get",
     "Purge",
     "Update",
+    "GetRotationPolicy",
   ]
 
   secret_permissions = [
@@ -590,6 +599,7 @@ resource "azurerm_key_vault_access_policy" "disk-encryption" {
     "Get",
     "WrapKey",
     "UnwrapKey",
+    "GetRotationPolicy",
   ]
 
   tenant_id = azurerm_disk_encryption_set.test.identity.0.tenant_id
@@ -803,6 +813,7 @@ resource "azurerm_key_vault_access_policy" "service-principal2" {
     "Get",
     "Purge",
     "Update",
+    "GetRotationPolicy",
   ]
 
   secret_permissions = [
@@ -848,6 +859,7 @@ resource "azurerm_key_vault_access_policy" "disk-encryption2" {
     "Get",
     "WrapKey",
     "UnwrapKey",
+    "GetRotationPolicy",
   ]
 
   tenant_id = azurerm_disk_encryption_set.test2.identity.0.tenant_id
@@ -1118,6 +1130,7 @@ resource "azurerm_key_vault_access_policy" "service-principal" {
     "Delete",
     "Get",
     "Update",
+    "GetRotationPolicy",
   ]
 
   secret_permissions = [

--- a/internal/services/recoveryservices/site_recovery_replicated_vm_resource_test.go
+++ b/internal/services/recoveryservices/site_recovery_replicated_vm_resource_test.go
@@ -40,6 +40,7 @@ func TestAccSiteRecoveryReplicatedVm_withTFOSettings(t *testing.T) {
 			Config: r.withTFOSettings(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("network_interface.0.failover_test_subnet_name").HasValue("snet3"),
 			),
 		},
 		data.ImportStep(),
@@ -442,6 +443,20 @@ resource "azurerm_site_recovery_replicated_vm" "test" {
 func (r SiteRecoveryReplicatedVmResource) withTFOSettings(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
+
+resource "azurerm_virtual_network" "tfo" {
+  name                = "net3-%[1]d"
+  resource_group_name = azurerm_resource_group.test2.name
+  address_space       = ["192.168.2.0/24"]
+  location            = azurerm_site_recovery_fabric.test2.location
+}
+
+resource "azurerm_subnet" "tfo" {
+  name                 = "snet3"
+  resource_group_name  = azurerm_resource_group.test2.name
+  virtual_network_name = azurerm_virtual_network.tfo.name
+  address_prefixes     = ["192.168.2.0/24"]
+}
 
 resource "azurerm_site_recovery_replicated_vm" "test" {
   name                                      = "repl-%[2]d"


### PR DESCRIPTION
fix #22193 

these failed ones are also failing on `main` branch which I assume does not block this PR.
<img width="593" alt="Screenshot 2023-06-21 at 14 40 15" src="https://github.com/hashicorp/terraform-provider-azurerm/assets/51212351/ed2a9640-bda8-4e12-bafd-47a10863dab5">