### PR TITLE
`azurerm_container_app`: Add support for `scale_rule`

### DIFF
--- a/internal/services/containerapps/container_app_resource_test.go
+++ b/internal/services/containerapps/container_app_resource_test.go
@@ -62,6 +62,21 @@ func TestAccContainerAppResource_withUserAssignedIdentity(t *testing.T) {
 	})
 }
 
+func TestAccContainerAppResource_withScaleRule(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_container_app", "test")
+	r := ContainerAppResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.withScaleRule(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccContainerAppResource_withIdentityUpdate(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_container_app", "test")
 	r := ContainerAppResource{}
@@ -362,6 +377,40 @@ resource "azurerm_container_app" "test" {
       image  = "jackofallops/azure-containerapps-python-acctest:v0.0.1"
       cpu    = 0.25
       memory = "0.5Gi"
+    }
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r ContainerAppResource) withScaleRule(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_container_app" "test" {
+  name                         = "acctest-capp-%[2]d"
+  resource_group_name          = azurerm_resource_group.test.name
+  container_app_environment_id = azurerm_container_app_environment.test.id
+  revision_mode                = "Single"
+
+  template {
+    container {
+      name   = "acctest-cont-%[2]d"
+      image  = "jackofallops/azure-containerapps-python-acctest:v0.0.1"
+      cpu    = 0.25
+      memory = "0.5Gi"
+    }
+
+    scale_rule {
+      name = "scale-rule-1"
+      azure_queue {
+        queue_name   = "queue1"
+        queue_length = 10
+        auth {
+          secret_ref    = "secret1"
+          trigger_param = "trigger1"
+        }
+      }
     }
   }
 }

--- a/internal/services/containerapps/helpers/container_apps.go
+++ b/internal/services/containerapps/helpers/container_apps.go
@@ -1243,7 +1243,7 @@ type ScaleRuleAuth struct {
 func ScaleRuleAuthSchema() *pluginsdk.Schema {
 	return &pluginsdk.Schema{
 		Type:     pluginsdk.TypeList,
-		Optional: true,
+		Required: true,
 		MaxItems: 1,
 		Elem: &pluginsdk.Resource{
 			Schema: map[string]*pluginsdk.Schema{
@@ -1354,10 +1354,6 @@ func flattenContainerAppScaleRules(input *[]containerapps.ScaleRule) []Container
 }
 
 func expandContainerAppScaleRuleAuth(input []ScaleRuleAuth) *[]containerapps.ScaleRuleAuth {
-	if input == nil || len(input) == 0 {
-		return nil
-	}
-
 	auths := make([]containerapps.ScaleRuleAuth, 0)
 
 	for _, v := range input {

--- a/website/docs/d/container_app.html.markdown
+++ b/website/docs/d/container_app.html.markdown
@@ -73,6 +73,56 @@ A `template` block supports the following:
 
 * `volume` - A `volume` block as detailed below.
 
+* `scale_rule` - A `scale_rule` block as detailed below.
+
+---
+
+A `scale_rule` block supports the following:
+
+* `name` - The name of the scale rule.
+
+* `azure_queue` - A `azure_queue` block as detailed below.
+
+* `custom` - A `custom` block as detailed below.
+
+* `http` - A `http` block as detailed below.
+
+---
+
+A `azure_queue` block supports the following:
+
+* `queue_length` - The length of the queue.
+
+* `queue_name` - The name of the queue.
+
+* `auth` - A `auth` block as detailed below.
+
+---
+
+A `custom` block supports the following:
+
+* `type` - The type of custom scale rule.
+
+* `metadata` - Metadata properties to describe custom scale rule.
+
+* `auth` - A `auth` block as detailed below.
+
+---
+
+A `http` block supports the following:
+
+* `metadata` - Metadata properties to describe http scale rule.
+
+* `auth` - A `auth` block as detailed below.
+
+---
+
+A `auth` block supports the following:
+
+* `secret_ref` - Name of the container app secret from which to pull the authentication parameters.
+
+* `trigger_param` - Trigger parameter that uses the secret.
+
 ---
 
 A `volume` block supports the following:


### PR DESCRIPTION
* Covered `scale_rule` and all fields under it.

* Tests are passing as expected.

```
=== RUN   TestAccContainerAppResource_withScaleRule
=== PAUSE TestAccContainerAppResource_withScaleRule
=== CONT  TestAccContainerAppResource_withScaleRule
--- PASS: TestAccContainerAppResource_withScaleRule (724.05s)
PASS
```
