### PR TITLE
`azurerm_shared_image_gallery` - support for the sharing block

### DIFF
--- a/internal/services/compute/client/client.go
+++ b/internal/services/compute/client/client.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-03/galleries"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-03/galleryapplications"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-03/galleryapplicationversions"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-03/gallerysharingupdate"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/marketplaceordering/2015-06-01/agreements"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/common"
 	"github.com/tombuildsstuff/kermit/sdk/compute/2023-03-01/compute"
@@ -39,6 +40,7 @@ type Client struct {
 	GalleryApplicationVersionsClient *galleryapplicationversions.GalleryApplicationVersionsClient
 	GalleryImagesClient              *compute.GalleryImagesClient
 	GalleryImageVersionsClient       *compute.GalleryImageVersionsClient
+	GallerySharingUpdateClient       *gallerysharingupdate.GallerySharingUpdateClient
 	ImagesClient                     *images.ImagesClient
 	MarketplaceAgreementsClient      *agreements.AgreementsClient
 	ProximityPlacementGroupsClient   *proximityplacementgroups.ProximityPlacementGroupsClient
@@ -95,6 +97,9 @@ func NewClient(o *common.ClientOptions) (*Client, error) {
 
 	galleryImageVersionsClient := compute.NewGalleryImageVersionsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&galleryImageVersionsClient.Client, o.ResourceManagerAuthorizer)
+
+	gallerySharingUpdateClient := gallerysharingupdate.NewGallerySharingUpdateClientWithBaseURI(o.ResourceManagerEndpoint)
+	o.ConfigureClient(&gallerySharingUpdateClient.Client, o.ResourceManagerAuthorizer)
 
 	imagesClient := images.NewImagesClientWithBaseURI(o.ResourceManagerEndpoint)
 	o.ConfigureClient(&imagesClient.Client, o.ResourceManagerAuthorizer)
@@ -161,6 +166,7 @@ func NewClient(o *common.ClientOptions) (*Client, error) {
 		GalleryApplicationVersionsClient: &galleryApplicationVersionsClient,
 		GalleryImagesClient:              &galleryImagesClient,
 		GalleryImageVersionsClient:       &galleryImageVersionsClient,
+		GallerySharingUpdateClient:       &gallerySharingUpdateClient,
 		ImagesClient:                     &imagesClient,
 		MarketplaceAgreementsClient:      marketplaceAgreementsClient,
 		ProximityPlacementGroupsClient:   &proximityPlacementGroupsClient,

--- a/internal/services/compute/linux_virtual_machine_resource_images_test.go
+++ b/internal/services/compute/linux_virtual_machine_resource_images_test.go
@@ -62,6 +62,28 @@ func TestAccLinuxVirtualMachine_imageFromPlan(t *testing.T) {
 	})
 }
 
+func TestAccLinuxVirtualMachine_imageFromCommunitySharedImageGallery(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+	r := LinuxVirtualMachineResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.imageFromExistingMachinePrep(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				data.CheckWithClientForResource(ImageResource{}.virtualMachineExists, "azurerm_linux_virtual_machine.source"),
+				data.CheckWithClientForResource(ImageResource{}.generalizeVirtualMachine(data), "azurerm_linux_virtual_machine.source"),
+			),
+		},
+		{
+			Config: r.imageFromCommunitySharedImageGallery(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
 func TestAccLinuxVirtualMachine_imageFromSharedImageGallery(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
 	r := LinuxVirtualMachineResource{}
@@ -107,18 +129,18 @@ func (LinuxVirtualMachineResource) imageFromExistingMachineDependencies(data acc
 locals {
   first_public_key  = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC9ddAwoR0XBoT9kixLX6atgX9dovt9fpR1HO/R9jYwYnuB+SZ845KSqat+U0m6oagZhpsfcEEwjGGjQz6Z1rB6mvffsKq6i74cmm0jO564nBnZQeh31q3sFNs+XdrDtFmnYRqdPHhhr1sw0C/rxbiaE6nYZWRfHW//81nEePKMpjiN8JsrYQNbzEpz8QOBSquwBmXO+LVx//zAbY4jGTa4hjGeNzIgMJZ8Jk/11XbcxSK1PK43BrejHg6kctmEkYvMH/o12RfAeB8okGCRW3scwOozxVrHwxaPgEf03jig+Ag9V+GXNBabL5AWtxcuPN63rUfaAXEIXTHmndwVOxlpLrUf5ox1+ddGyWbLMXzd7akPioof5MNJMq/yuFGC5dY0Z6/+yGRNtShQesVo/czhKEPGIcsIi5gnKdfDB4i9ay2yz8ystnW6jbabcyqejk1Qc61wapaFdhUHL0iD/GW/5ZujDs5C3BT7EIgKLIfAaAx5TBEJyE1KQ/GEOifB8ztDl/gp99o+i2HKABtmYv12y4JVlEUkRckeLrw6luEb3ColHshsQcQGfudGFFgdEdcgBrV4Ch7IkLxVYQl3pegzZiirMPnRKh10r/Hrg6uYxn7sLeTJoD5VOKmqmeK4kFXsZMVtA6/SnxQtUKkKlfLBwBSDrrdgLjBV+KOndiwC7Q=="
   second_public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/NDMj2wG6bSa6jbn6E3LYlUsYiWMp1CQ2sGAijPALW6OrSu30lz7nKpoh8Qdw7/A4nAJgweI5Oiiw5/BOaGENM70Go+VM8LQMSxJ4S7/8MIJEZQp5HcJZ7XDTcEwruknrd8mllEfGyFzPvJOx6QAQocFhXBW6+AlhM3gn/dvV5vdrO8ihjET2GoDUqXPYC57ZuY+/Fz6W3KV8V97BvNUhpY5yQrP5VpnyvvXNFQtzDfClTvZFPuoHQi3/KYPi6O0FSD74vo8JOBZZY09boInPejkm9fvHQqfh0bnN7B6XJoUwC1Qprrx+XIy7ust5AEn5XL7d4lOvcR14MxDDKEp you@me.com"
-  vm_name           = "acctestsourcevm-%d"
-  admin_username    = "testadmin%d"
-  admin_password    = "Password1234!%d"
+  vm_name           = "acctestsourcevm-%[1]d"
+  admin_username    = "testadmin%[1]d"
+  admin_password    = "Password1234!%[1]d"
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
 }
 
 resource "azurerm_virtual_network" "test" {
-  name                = "acctestnw-%d"
+  name                = "acctestnw-%[1]d"
   address_space       = ["10.0.0.0/16"]
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
@@ -132,7 +154,7 @@ resource "azurerm_subnet" "test" {
 }
 
 resource "azurerm_public_ip" "test" {
-  name                = "acctpip-%d"
+  name                = "acctpip-%[1]d"
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
   allocation_method   = "Static"
@@ -140,7 +162,7 @@ resource "azurerm_public_ip" "test" {
 }
 
 resource "azurerm_network_interface" "public" {
-  name                = "acctnicsource-%d"
+  name                = "acctnicsource-%[1]d"
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
 
@@ -153,7 +175,7 @@ resource "azurerm_network_interface" "public" {
 }
 
 resource "azurerm_network_interface" "test" {
-  name                = "acctestnic-%d"
+  name                = "acctestnic-%[1]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
 
@@ -163,13 +185,7 @@ resource "azurerm_network_interface" "test" {
     private_ip_address_allocation = "Dynamic"
   }
 }
-
-resource "azurerm_shared_image_gallery" "test" {
-  name                = "acctestsig%d"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-  location            = "${azurerm_resource_group.test.location}"
-}
-`, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary)
 }
 
 func (r LinuxVirtualMachineResource) imageFromExistingMachinePrep(data acceptance.TestData) string {
@@ -298,15 +314,31 @@ resource "azurerm_linux_virtual_machine" "test" {
 `, r.template(data), data.RandomInteger, publisher, offer, sku)
 }
 
-func (r LinuxVirtualMachineResource) imageFromSharedImageGallery(data acceptance.TestData) string {
+func (r LinuxVirtualMachineResource) imageFromCommunitySharedImageGallery(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
 
 resource "azurerm_image" "test" {
   name                      = "capture"
   location                  = azurerm_resource_group.test.location
   resource_group_name       = azurerm_resource_group.test.name
   source_virtual_machine_id = azurerm_linux_virtual_machine.source.id
+}
+
+resource "azurerm_shared_image_gallery" "test" {
+  name                = "acctestsig%[2]d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  location            = "${azurerm_resource_group.test.location}"
+
+  sharing {
+    permission = "Community"
+    community_gallery {
+      eula            = "https://eula.net"
+      prefix          = "prefix"
+      publisher_email = "publisher@test.net"
+      publisher_uri   = "https://publisher.net"
+    }
+  }
 }
 
 resource "azurerm_shared_image" "test" {
@@ -339,7 +371,80 @@ resource "azurerm_shared_image_version" "test" {
 }
 
 resource "azurerm_linux_virtual_machine" "test" {
-  name                            = "acctestVM-%d"
+  name                            = "acctestVM-%[2]d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = azurerm_resource_group.test.location
+  size                            = "Standard_F2"
+  admin_username                  = "adminuser"
+  disable_password_authentication = false
+  admin_password                  = "P@$$w0rd1234!"
+  source_image_id                 = "/communityGalleries/${azurerm_shared_image_gallery.test.sharing.0.community_gallery.0.name}/images/${azurerm_shared_image_version.test.image_name}/versions/${azurerm_shared_image_version.test.name}"
+
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+}
+`, r.imageFromExistingMachinePrep(data), data.RandomInteger)
+}
+
+func (r LinuxVirtualMachineResource) imageFromSharedImageGallery(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_image" "test" {
+  name                      = "capture"
+  location                  = azurerm_resource_group.test.location
+  resource_group_name       = azurerm_resource_group.test.name
+  source_virtual_machine_id = azurerm_linux_virtual_machine.source.id
+}
+
+resource "azurerm_shared_image_gallery" "test" {
+  name                = "acctestsig%[2]d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  location            = "${azurerm_resource_group.test.location}"
+}
+
+resource "azurerm_shared_image" "test" {
+  name                = "acctest-gallery-image"
+  gallery_name        = azurerm_shared_image_gallery.test.name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  os_type             = "Linux"
+
+  identifier {
+    publisher = "AcceptanceTest-Publisher"
+    offer     = "AcceptanceTest-Offer"
+    sku       = "AcceptanceTest-Sku"
+  }
+}
+
+resource "azurerm_shared_image_version" "test" {
+  name                = "0.0.1"
+  gallery_name        = azurerm_shared_image.test.gallery_name
+  image_name          = azurerm_shared_image.test.name
+  resource_group_name = azurerm_shared_image.test.resource_group_name
+  location            = azurerm_shared_image.test.location
+  managed_image_id    = azurerm_image.test.id
+
+  target_region {
+    name                   = azurerm_shared_image.test.location
+    regional_replica_count = "5"
+    storage_account_type   = "Standard_LRS"
+  }
+}
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                            = "acctestVM-%[2]d"
   resource_group_name             = azurerm_resource_group.test.name
   location                        = azurerm_resource_group.test.location
   size                            = "Standard_F2"

--- a/internal/services/compute/shared_image_gallery_resource.go
+++ b/internal/services/compute/shared_image_gallery_resource.go
@@ -11,18 +11,20 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-03/galleries"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-03/gallerysharingupdate"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/compute/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 )
 
 func resourceSharedImageGallery() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
-		Create: resourceSharedImageGalleryCreateUpdate,
+		Create: resourceSharedImageGalleryCreate,
 		Read:   resourceSharedImageGalleryRead,
-		Update: resourceSharedImageGalleryCreateUpdate,
+		Update: resourceSharedImageGalleryUpdate,
 		Delete: resourceSharedImageGalleryDelete,
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
 			_, err := galleries.ParseGalleryID(id)
@@ -53,6 +55,64 @@ func resourceSharedImageGallery() *pluginsdk.Resource {
 				Optional: true,
 			},
 
+			"sharing": {
+				Type:     pluginsdk.TypeList,
+				Optional: true,
+				ForceNew: true,
+				MaxItems: 1,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"permission": {
+							Type:     pluginsdk.TypeString,
+							Required: true,
+							ForceNew: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								string(galleries.GallerySharingPermissionTypesCommunity),
+							}, false),
+						},
+
+						"community_gallery": {
+							Type:     pluginsdk.TypeList,
+							Optional: true,
+							ForceNew: true,
+							MaxItems: 1,
+							Elem: &pluginsdk.Resource{
+								Schema: map[string]*pluginsdk.Schema{
+									"eula": {
+										Type:         pluginsdk.TypeString,
+										Required:     true,
+										ForceNew:     true,
+										ValidateFunc: validation.StringIsNotEmpty,
+									},
+									"prefix": {
+										Type:         pluginsdk.TypeString,
+										Required:     true,
+										ForceNew:     true,
+										ValidateFunc: validate.SharedImageGalleryPrefix,
+									},
+									"publisher_email": {
+										Type:         pluginsdk.TypeString,
+										Required:     true,
+										ForceNew:     true,
+										ValidateFunc: validation.StringIsNotEmpty,
+									},
+									"publisher_uri": {
+										Type:         pluginsdk.TypeString,
+										Required:     true,
+										ForceNew:     true,
+										ValidateFunc: validation.StringIsNotEmpty,
+									},
+									"name": {
+										Type:     pluginsdk.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+
 			"tags": commonschema.Tags(),
 
 			"unique_name": {
@@ -63,37 +123,50 @@ func resourceSharedImageGallery() *pluginsdk.Resource {
 	}
 }
 
-func resourceSharedImageGalleryCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+func resourceSharedImageGalleryCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Compute.GalleriesClient
+	gallerySharingUpdateClient := meta.(*clients.Client).Compute.GallerySharingUpdateClient
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
-	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
 	id := galleries.NewGalleryID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
-	if d.IsNewResource() {
-		existing, err := client.Get(ctx, id, galleries.DefaultGetOperationOptions())
-		if err != nil {
-			if !response.WasNotFound(existing.HttpResponse) {
-				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
-			}
-		}
-
+	existing, err := client.Get(ctx, id, galleries.DefaultGetOperationOptions())
+	if err != nil {
 		if !response.WasNotFound(existing.HttpResponse) {
-			return tf.ImportAsExistsError("azurerm_shared_image_gallery", id.ID())
+			return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
 		}
+	}
+
+	if !response.WasNotFound(existing.HttpResponse) {
+		return tf.ImportAsExistsError("azurerm_shared_image_gallery", id.ID())
+	}
+
+	sharing, permission, err := expandSharedImageGallerySharing(d.Get("sharing").([]interface{}))
+	if err != nil {
+		return fmt.Errorf("expanding `sharing`: %+v", err)
 	}
 
 	payload := galleries.Gallery{
 		Location: location.Normalize(d.Get("location").(string)),
 		Properties: &galleries.GalleryProperties{
-			Description: pointer.To(d.Get("description").(string)),
+			Description:    pointer.To(d.Get("description").(string)),
+			SharingProfile: sharing,
 		},
 		Tags: tags.Expand(d.Get("tags").(map[string]interface{})),
 	}
 
 	if err := client.CreateOrUpdateThenPoll(ctx, id, payload); err != nil {
-		return fmt.Errorf("creating/updating %s: %+v", id, err)
+		return fmt.Errorf("creating %s: %+v", id, err)
 	}
+
+	if permission == galleries.GallerySharingPermissionTypesCommunity {
+		gallerySharingUpdateId := gallerysharingupdate.NewGalleryID(id.SubscriptionId, id.ResourceGroupName, id.GalleryName)
+		if err = gallerySharingUpdateClient.GallerySharingProfileUpdateThenPoll(ctx, gallerySharingUpdateId, gallerysharingupdate.SharingUpdate{OperationType: gallerysharingupdate.SharingUpdateOperationTypesEnableCommunity}); err != nil {
+			return fmt.Errorf("enabling community sharing of %s: %+v", id, err)
+		}
+	}
+
 	d.SetId(id.ID())
 
 	return resourceSharedImageGalleryRead(d, meta)
@@ -134,6 +207,8 @@ func resourceSharedImageGalleryRead(d *pluginsdk.ResourceData, meta interface{})
 				uniqueName = *props.Identifier.UniqueName
 			}
 			d.Set("unique_name", uniqueName)
+
+			d.Set("sharing", flattenSharedImageGallerySharing(props.SharingProfile))
 		}
 
 		if err := tags.FlattenAndSet(d, model.Tags); err != nil {
@@ -144,8 +219,47 @@ func resourceSharedImageGalleryRead(d *pluginsdk.ResourceData, meta interface{})
 	return nil
 }
 
+func resourceSharedImageGalleryUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Compute.GalleriesClient
+	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := galleries.ParseGalleryID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Get(ctx, *id, galleries.DefaultGetOperationOptions())
+	if err != nil {
+		return fmt.Errorf("retrieving %s: %+v", *id, err)
+	}
+
+	payload := resp.Model
+	if payload == nil {
+		payload = &galleries.Gallery{}
+	}
+
+	if payload.Properties == nil {
+		payload.Properties = &galleries.GalleryProperties{}
+	}
+
+	if d.HasChange("description") {
+		payload.Properties.Description = pointer.To(d.Get("description").(string))
+	}
+
+	if d.HasChange("tags") {
+		payload.Tags = tags.Expand(d.Get("tags").(map[string]interface{}))
+	}
+
+	if err := client.CreateOrUpdateThenPoll(ctx, *id, *payload); err != nil {
+		return fmt.Errorf("updating %s: %+v", id, err)
+	}
+	return resourceSharedImageGalleryRead(d, meta)
+}
+
 func resourceSharedImageGalleryDelete(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Compute.GalleriesClient
+	gallerySharingUpdateClient := meta.(*clients.Client).Compute.GallerySharingUpdateClient
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -154,9 +268,122 @@ func resourceSharedImageGalleryDelete(d *pluginsdk.ResourceData, meta interface{
 		return err
 	}
 
+	resp, err := client.Get(ctx, *id, galleries.DefaultGetOperationOptions())
+	if err != nil {
+		return fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+
+	if model := resp.Model; model != nil {
+		if prop := model.Properties; prop != nil && prop.SharingProfile != nil && prop.SharingProfile.Permissions != nil {
+			if pointer.From(prop.SharingProfile.Permissions) == galleries.GallerySharingPermissionTypesCommunity {
+				gallerySharingUpdateId := gallerysharingupdate.NewGalleryID(id.SubscriptionId, id.ResourceGroupName, id.GalleryName)
+				if err = gallerySharingUpdateClient.GallerySharingProfileUpdateThenPoll(ctx, gallerySharingUpdateId, gallerysharingupdate.SharingUpdate{OperationType: gallerysharingupdate.SharingUpdateOperationTypesReset}); err != nil {
+					return fmt.Errorf("reseting community sharing of %s: %+v", id, err)
+				}
+			}
+		}
+	}
+
 	if err := client.DeleteThenPoll(ctx, *id); err != nil {
 		return fmt.Errorf("deleting %s: %+v", *id, err)
 	}
 
 	return nil
+}
+
+func expandSharedImageGallerySharing(input []interface{}) (*galleries.SharingProfile, galleries.GallerySharingPermissionTypes, error) {
+	if len(input) == 0 || input[0] == nil {
+		return nil, "", nil
+	}
+
+	v := input[0].(map[string]interface{})
+	permission := galleries.GallerySharingPermissionTypes(v["permission"].(string))
+	communityGallery := v["community_gallery"].([]interface{})
+
+	if permission == galleries.GallerySharingPermissionTypesCommunity {
+		if len(communityGallery) == 0 || communityGallery[0] == nil {
+			return nil, permission, fmt.Errorf("`community_gallery` must be set when `permission` is set to `Community`")
+		}
+	}
+
+	return &galleries.SharingProfile{
+		Permissions:          pointer.To(permission),
+		CommunityGalleryInfo: expandSharedImageGalleryCommunityGallery(communityGallery),
+	}, permission, nil
+}
+
+func flattenSharedImageGallerySharing(input *galleries.SharingProfile) []interface{} {
+	if input == nil {
+		return make([]interface{}, 0)
+	}
+
+	permission := ""
+	if v := input.Permissions; v != nil {
+		permission = string(pointer.From(v))
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"permission":        permission,
+			"community_gallery": flattenSharedImageGalleryCommunityGallery(input.CommunityGalleryInfo),
+		},
+	}
+}
+
+func expandSharedImageGalleryCommunityGallery(input []interface{}) *galleries.CommunityGalleryInfo {
+	if len(input) == 0 || input[0] == nil {
+		return nil
+	}
+
+	v := input[0].(map[string]interface{})
+
+	return &galleries.CommunityGalleryInfo{
+		Eula:             pointer.To(v["eula"].(string)),
+		PublicNamePrefix: pointer.To(v["prefix"].(string)),
+		PublisherContact: pointer.To(v["publisher_email"].(string)),
+		PublisherUri:     pointer.To(v["publisher_uri"].(string)),
+	}
+}
+
+func flattenSharedImageGalleryCommunityGallery(input *galleries.CommunityGalleryInfo) []interface{} {
+	if input == nil {
+		return make([]interface{}, 0)
+	}
+
+	eula := ""
+	if input.Eula != nil {
+		eula = pointer.From(input.Eula)
+	}
+
+	publicName := ""
+	if input.PublicNames != nil {
+		if v := pointer.From(input.PublicNames); len(v) > 0 {
+			publicName = v[0]
+		}
+	}
+
+	publicNamePrefix := ""
+	if input.PublicNamePrefix != nil {
+		publicNamePrefix = pointer.From(input.PublicNamePrefix)
+	}
+
+	publisherEmail := ""
+	if input.PublisherContact != nil {
+		publisherEmail = pointer.From(input.PublisherContact)
+	}
+
+	publisherUri := ""
+	if input.PublisherUri != nil {
+		publisherUri = pointer.From(input.PublisherUri)
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"eula":            eula,
+			"name":            publicName,
+			"prefix":          publicNamePrefix,
+			"publisher_email": publisherEmail,
+			"publisher_uri":   publisherUri,
+		},
+	}
 }

--- a/internal/services/compute/validate/shared_image_gallery_public_name_prefix.go
+++ b/internal/services/compute/validate/shared_image_gallery_public_name_prefix.go
@@ -1,0 +1,16 @@
+package validate
+
+import (
+	"fmt"
+	"regexp"
+)
+
+func SharedImageGalleryPrefix(v interface{}, k string) (warnings []string, errors []error) {
+	value := v.(string)
+
+	if !regexp.MustCompile("^[A-Za-z0-9]{5,16}$").MatchString(value) {
+		errors = append(errors, fmt.Errorf("%q must be 5 to 16 characters long, and can only contain alphanumeric", k))
+	}
+
+	return warnings, errors
+}

--- a/internal/services/compute/validate/shared_image_gallery_public_name_prefix_test.go
+++ b/internal/services/compute/validate/shared_image_gallery_public_name_prefix_test.go
@@ -1,0 +1,30 @@
+package validate
+
+import "testing"
+
+func TestSharedImageGalleryPrefix(t *testing.T) {
+	validNames := []string{
+		"Valid012",
+		"abcde",
+		"0123456789012345",
+	}
+	for _, v := range validNames {
+		_, errors := SharedImageGalleryPrefix(v, "example")
+		if len(errors) != 0 {
+			t.Fatalf("%q should be a valid Shared Image Gallery Public Name Prefix: %q", v, errors)
+		}
+	}
+
+	invalidNames := []string{
+		"",
+		"-",
+		"abcd",
+		"01234567890123456",
+	}
+	for _, v := range invalidNames {
+		_, errors := SharedImageGalleryPrefix(v, "name")
+		if len(errors) == 0 {
+			t.Fatalf("%q should be an invalid Shared Image Gallery Public Name Prefix", v)
+		}
+	}
+}

--- a/internal/services/compute/windows_virtual_machine_resource_images_test.go
+++ b/internal/services/compute/windows_virtual_machine_resource_images_test.go
@@ -62,6 +62,27 @@ func TestAccWindowsVirtualMachine_imageFromPlan(t *testing.T) {
 	})
 }
 
+func TestAccWindowsVirtualMachine_imageFromCommunitySharedImageGallery(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+	r := WindowsVirtualMachineResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.imageFromExistingMachinePrep(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				data.CheckWithClientForResource(r.generalizeVirtualMachine, "azurerm_windows_virtual_machine.source"),
+			),
+		},
+		{
+			Config: r.imageFromCommunitySharedImageGallery(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
 func TestAccWindowsVirtualMachine_imageFromSharedImageGallery(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
 	r := WindowsVirtualMachineResource{}
@@ -103,16 +124,16 @@ func TestAccWindowsVirtualMachine_imageFromSourceImageReference(t *testing.T) {
 func (WindowsVirtualMachineResource) imageFromExistingMachineDependencies(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 locals {
-  vm_name = "acctvm-%s"
+  vm_name = "acctvm-%[1]s"
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestRG-%d"
-  location = "%s"
+  name     = "acctestRG-%[2]d"
+  location = "%[3]s"
 }
 
 resource "azurerm_virtual_network" "test" {
-  name                = "acctestnw-%d"
+  name                = "acctestnw-%[2]d"
   address_space       = ["10.0.0.0/16"]
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
@@ -126,7 +147,7 @@ resource "azurerm_subnet" "test" {
 }
 
 resource "azurerm_public_ip" "test" {
-  name                = "acctpip-%d"
+  name                = "acctpip-%[2]d"
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
   allocation_method   = "Static"
@@ -134,7 +155,7 @@ resource "azurerm_public_ip" "test" {
 }
 
 resource "azurerm_network_interface" "public" {
-  name                = "acctnicsource-%d"
+  name                = "acctnicsource-%[2]d"
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
 
@@ -147,7 +168,7 @@ resource "azurerm_network_interface" "public" {
 }
 
 resource "azurerm_network_interface" "test" {
-  name                = "acctestnic-%d"
+  name                = "acctestnic-%[2]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
 
@@ -157,13 +178,7 @@ resource "azurerm_network_interface" "test" {
     private_ip_address_allocation = "Dynamic"
   }
 }
-
-resource "azurerm_shared_image_gallery" "test" {
-  name                = "acctestsig%d"
-  resource_group_name = "${azurerm_resource_group.test.name}"
-  location            = "${azurerm_resource_group.test.location}"
-}
-`, data.RandomString, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+`, data.RandomString, data.RandomInteger, data.Locations.Primary)
 }
 
 func (r WindowsVirtualMachineResource) imageFromExistingMachinePrep(data acceptance.TestData) string {
@@ -271,9 +286,91 @@ resource "azurerm_windows_virtual_machine" "test" {
 `, r.template(data), publisher, offer, sku)
 }
 
+func (r WindowsVirtualMachineResource) imageFromCommunitySharedImageGallery(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_image" "test" {
+  name                      = "capture"
+  location                  = azurerm_resource_group.test.location
+  resource_group_name       = azurerm_resource_group.test.name
+  source_virtual_machine_id = azurerm_windows_virtual_machine.source.id
+}
+
+resource "azurerm_shared_image_gallery" "test" {
+  name                = "acctestsig%[2]d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  location            = "${azurerm_resource_group.test.location}"
+
+  sharing {
+    permission = "Community"
+    community_gallery {
+      eula            = "https://eula.net"
+      prefix          = "prefix"
+      publisher_email = "publisher@test.net"
+      publisher_uri   = "https://publisher.net"
+    }
+  }
+}
+
+resource "azurerm_shared_image" "test" {
+  name                = "acctest-gallery-image"
+  gallery_name        = azurerm_shared_image_gallery.test.name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  os_type             = "Windows"
+
+  identifier {
+    publisher = "AcceptanceTest-Publisher"
+    offer     = "AcceptanceTest-Offer"
+    sku       = "AcceptanceTest-Sku"
+  }
+}
+
+resource "azurerm_shared_image_version" "test" {
+  name                = "0.0.1"
+  gallery_name        = azurerm_shared_image.test.gallery_name
+  image_name          = azurerm_shared_image.test.name
+  resource_group_name = azurerm_shared_image.test.resource_group_name
+  location            = azurerm_shared_image.test.location
+  managed_image_id    = azurerm_image.test.id
+
+  target_region {
+    name                   = azurerm_shared_image.test.location
+    regional_replica_count = "5"
+    storage_account_type   = "Standard_LRS"
+  }
+}
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                = "${local.vm_name}2"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
+  source_image_id     = "/communityGalleries/${azurerm_shared_image_gallery.test.sharing.0.community_gallery.0.name}/images/${azurerm_shared_image_version.test.image_name}/versions/${azurerm_shared_image_version.test.name}"
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+}
+`, r.imageFromExistingMachinePrep(data), data.RandomInteger)
+}
+
 func (r WindowsVirtualMachineResource) imageFromSharedImageGallery(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-%s
+%[1]s
+
+resource "azurerm_shared_image_gallery" "test" {
+  name                = "acctestsig%[2]d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  location            = "${azurerm_resource_group.test.location}"
+}
 
 resource "azurerm_image" "test" {
   name                      = "capture"
@@ -328,7 +425,7 @@ resource "azurerm_windows_virtual_machine" "test" {
     storage_account_type = "Standard_LRS"
   }
 }
-`, r.imageFromExistingMachinePrep(data))
+`, r.imageFromExistingMachinePrep(data), data.RandomInteger)
 }
 
 func (r WindowsVirtualMachineResource) imageFromSourceImageReference(data acceptance.TestData) string {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-03/gallerysharingupdate/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-03/gallerysharingupdate/README.md
@@ -1,0 +1,37 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-03/gallerysharingupdate` Documentation
+
+The `gallerysharingupdate` SDK allows for interaction with the Azure Resource Manager Service `compute` (API Version `2022-03-03`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-03/gallerysharingupdate"
+```
+
+
+### Client Initialization
+
+```go
+client := gallerysharingupdate.NewGallerySharingUpdateClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `GallerySharingUpdateClient.GallerySharingProfileUpdate`
+
+```go
+ctx := context.TODO()
+id := gallerysharingupdate.NewGalleryID("12345678-1234-9876-4563-123456789012", "example-resource-group", "galleryValue")
+
+payload := gallerysharingupdate.SharingUpdate{
+	// ...
+}
+
+
+if err := client.GallerySharingProfileUpdateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-03/gallerysharingupdate/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-03/gallerysharingupdate/client.go
@@ -1,0 +1,18 @@
+package gallerysharingupdate
+
+import "github.com/Azure/go-autorest/autorest"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GallerySharingUpdateClient struct {
+	Client  autorest.Client
+	baseUri string
+}
+
+func NewGallerySharingUpdateClientWithBaseURI(endpoint string) GallerySharingUpdateClient {
+	return GallerySharingUpdateClient{
+		Client:  autorest.NewClientWithUserAgent(userAgent()),
+		baseUri: endpoint,
+	}
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-03/gallerysharingupdate/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-03/gallerysharingupdate/constants.go
@@ -1,0 +1,68 @@
+package gallerysharingupdate
+
+import "strings"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SharingProfileGroupTypes string
+
+const (
+	SharingProfileGroupTypesAADTenants    SharingProfileGroupTypes = "AADTenants"
+	SharingProfileGroupTypesSubscriptions SharingProfileGroupTypes = "Subscriptions"
+)
+
+func PossibleValuesForSharingProfileGroupTypes() []string {
+	return []string{
+		string(SharingProfileGroupTypesAADTenants),
+		string(SharingProfileGroupTypesSubscriptions),
+	}
+}
+
+func parseSharingProfileGroupTypes(input string) (*SharingProfileGroupTypes, error) {
+	vals := map[string]SharingProfileGroupTypes{
+		"aadtenants":    SharingProfileGroupTypesAADTenants,
+		"subscriptions": SharingProfileGroupTypesSubscriptions,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := SharingProfileGroupTypes(input)
+	return &out, nil
+}
+
+type SharingUpdateOperationTypes string
+
+const (
+	SharingUpdateOperationTypesAdd             SharingUpdateOperationTypes = "Add"
+	SharingUpdateOperationTypesEnableCommunity SharingUpdateOperationTypes = "EnableCommunity"
+	SharingUpdateOperationTypesRemove          SharingUpdateOperationTypes = "Remove"
+	SharingUpdateOperationTypesReset           SharingUpdateOperationTypes = "Reset"
+)
+
+func PossibleValuesForSharingUpdateOperationTypes() []string {
+	return []string{
+		string(SharingUpdateOperationTypesAdd),
+		string(SharingUpdateOperationTypesEnableCommunity),
+		string(SharingUpdateOperationTypesRemove),
+		string(SharingUpdateOperationTypesReset),
+	}
+}
+
+func parseSharingUpdateOperationTypes(input string) (*SharingUpdateOperationTypes, error) {
+	vals := map[string]SharingUpdateOperationTypes{
+		"add":             SharingUpdateOperationTypesAdd,
+		"enablecommunity": SharingUpdateOperationTypesEnableCommunity,
+		"remove":          SharingUpdateOperationTypesRemove,
+		"reset":           SharingUpdateOperationTypesReset,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := SharingUpdateOperationTypes(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-03/gallerysharingupdate/id_gallery.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-03/gallerysharingupdate/id_gallery.go
@@ -1,0 +1,127 @@
+package gallerysharingupdate
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ resourceids.ResourceId = GalleryId{}
+
+// GalleryId is a struct representing the Resource ID for a Gallery
+type GalleryId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	GalleryName       string
+}
+
+// NewGalleryID returns a new GalleryId struct
+func NewGalleryID(subscriptionId string, resourceGroupName string, galleryName string) GalleryId {
+	return GalleryId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		GalleryName:       galleryName,
+	}
+}
+
+// ParseGalleryID parses 'input' into a GalleryId
+func ParseGalleryID(input string) (*GalleryId, error) {
+	parser := resourceids.NewParserFromResourceIdType(GalleryId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := GalleryId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
+	}
+
+	if id.GalleryName, ok = parsed.Parsed["galleryName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "galleryName", *parsed)
+	}
+
+	return &id, nil
+}
+
+// ParseGalleryIDInsensitively parses 'input' case-insensitively into a GalleryId
+// note: this method should only be used for API response data and not user input
+func ParseGalleryIDInsensitively(input string) (*GalleryId, error) {
+	parser := resourceids.NewParserFromResourceIdType(GalleryId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := GalleryId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
+	}
+
+	if id.GalleryName, ok = parsed.Parsed["galleryName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "galleryName", *parsed)
+	}
+
+	return &id, nil
+}
+
+// ValidateGalleryID checks that 'input' can be parsed as a Gallery ID
+func ValidateGalleryID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseGalleryID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Gallery ID
+func (id GalleryId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/galleries/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.GalleryName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Gallery ID
+func (id GalleryId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftCompute", "Microsoft.Compute", "Microsoft.Compute"),
+		resourceids.StaticSegment("staticGalleries", "galleries", "galleries"),
+		resourceids.UserSpecifiedSegment("galleryName", "galleryValue"),
+	}
+}
+
+// String returns a human-readable description of this Gallery ID
+func (id GalleryId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Gallery Name: %q", id.GalleryName),
+	}
+	return fmt.Sprintf("Gallery (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-03/gallerysharingupdate/method_gallerysharingprofileupdate_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-03/gallerysharingupdate/method_gallerysharingprofileupdate_autorest.go
@@ -1,0 +1,79 @@
+package gallerysharingupdate
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GallerySharingProfileUpdateOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// GallerySharingProfileUpdate ...
+func (c GallerySharingUpdateClient) GallerySharingProfileUpdate(ctx context.Context, id GalleryId, input SharingUpdate) (result GallerySharingProfileUpdateOperationResponse, err error) {
+	req, err := c.preparerForGallerySharingProfileUpdate(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "gallerysharingupdate.GallerySharingUpdateClient", "GallerySharingProfileUpdate", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForGallerySharingProfileUpdate(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "gallerysharingupdate.GallerySharingUpdateClient", "GallerySharingProfileUpdate", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// GallerySharingProfileUpdateThenPoll performs GallerySharingProfileUpdate then polls until it's completed
+func (c GallerySharingUpdateClient) GallerySharingProfileUpdateThenPoll(ctx context.Context, id GalleryId, input SharingUpdate) error {
+	result, err := c.GallerySharingProfileUpdate(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing GallerySharingProfileUpdate: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after GallerySharingProfileUpdate: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForGallerySharingProfileUpdate prepares the GallerySharingProfileUpdate request.
+func (c GallerySharingUpdateClient) preparerForGallerySharingProfileUpdate(ctx context.Context, id GalleryId, input SharingUpdate) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/share", id.ID())),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForGallerySharingProfileUpdate sends the GallerySharingProfileUpdate request. The method will close the
+// http.Response Body if it receives an error.
+func (c GallerySharingUpdateClient) senderForGallerySharingProfileUpdate(ctx context.Context, req *http.Request) (future GallerySharingProfileUpdateOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-03/gallerysharingupdate/model_sharingprofilegroup.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-03/gallerysharingupdate/model_sharingprofilegroup.go
@@ -1,0 +1,9 @@
+package gallerysharingupdate
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SharingProfileGroup struct {
+	Ids  *[]string                 `json:"ids,omitempty"`
+	Type *SharingProfileGroupTypes `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-03/gallerysharingupdate/model_sharingupdate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-03/gallerysharingupdate/model_sharingupdate.go
@@ -1,0 +1,9 @@
+package gallerysharingupdate
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SharingUpdate struct {
+	Groups        *[]SharingProfileGroup      `json:"groups,omitempty"`
+	OperationType SharingUpdateOperationTypes `json:"operationType"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-03/gallerysharingupdate/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-03/gallerysharingupdate/version.go
@@ -1,0 +1,12 @@
+package gallerysharingupdate
+
+import "fmt"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2022-03-03"
+
+func userAgent() string {
+	return fmt.Sprintf("hashicorp/go-azure-sdk/gallerysharingupdate/%s", defaultApiVersion)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -208,6 +208,7 @@ github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-02/snapshots
 github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-03/galleries
 github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-03/galleryapplications
 github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-03/galleryapplicationversions
+github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-03/gallerysharingupdate
 github.com/hashicorp/go-azure-sdk/resource-manager/confidentialledger/2022-05-13/confidentialledger
 github.com/hashicorp/go-azure-sdk/resource-manager/consumption/2019-10-01/budgets
 github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2022-03-01/certificates

--- a/website/docs/r/shared_image_gallery.html.markdown
+++ b/website/docs/r/shared_image_gallery.html.markdown
@@ -54,6 +54,8 @@ A `sharing` block supports the following:
 
 * `permission` - (Required) The permission of the Shared Image Gallery when sharing. The only possible value now is `Community`. Changing this forces a new resource to be created.
 
+-> **Note:** This requires that the Preview Feature `Microsoft.Compute/CommunityGalleries` is enabled, see [the documentation](https://learn.microsoft.com/azure/virtual-machines/share-gallery-community?tabs=cli) for more information.
+
 * `community_gallery` - (Optional) A `community_gallery` block as defined below. Changing this forces a new resource to be created.
 
 ~> **NOTE:** `community_gallery` must be set when `permission` is set to `Community`.

--- a/website/docs/r/shared_image_gallery.html.markdown
+++ b/website/docs/r/shared_image_gallery.html.markdown
@@ -44,7 +44,31 @@ The following arguments are supported:
 
 * `description` - (Optional) A description for this Shared Image Gallery.
 
+* `sharing` - (Optional) A `sharing` block as defined below. Changing this forces a new resource to be created.
+
 * `tags` - (Optional) A mapping of tags to assign to the Shared Image Gallery.
+
+---
+
+A `sharing` block supports the following:
+
+* `permission` - (Required) The permission of the Shared Image Gallery when sharing. The only possible value now is `Community`. Changing this forces a new resource to be created.
+
+* `community_gallery` - (Optional) A `community_gallery` block as defined below. Changing this forces a new resource to be created.
+
+~> **NOTE:** `community_gallery` must be set when `permission` is set to `Community`.
+
+---
+
+A `community_gallery` block supports the following:
+
+* `eula` - (Required) The End User Licence Agreement for the Shared Image Gallery. Changing this forces a new resource to be created.
+
+* `prefix` - (Required) Prefix of the community public name for the Shared Image Gallery. Changing this forces a new resource to be created.
+
+* `publisher_email` - (Required) Email of the publisher for the Shared Image Gallery. Changing this forces a new resource to be created.
+
+* `publisher_uri` - (Required) URI of the publisher for the Shared Image Gallery. Changing this forces a new resource to be created.
 
 ## Attributes Reference
 
@@ -53,6 +77,12 @@ In addition to the Arguments listed above - the following Attributes are exporte
 * `id` - The ID of the Shared Image Gallery.
 
 * `unique_name` - The Unique Name for this Shared Image Gallery.
+
+---
+
+A `community_gallery` block exports the following:
+
+* `name` - The community public name of the Shared Image Gallery.
 
 ## Timeouts
 


### PR DESCRIPTION
To add support for Community Shared Gallery.
Added tests as well for VM to consume Community Shared Image Version:
https://github.com/hashicorp/terraform-provider-azurerm/blob/f70fe79ef6f7464b191c9cbb3aa46ab064089560/internal/services/compute/linux_virtual_machine_resource.go#L302
There will be another possible value for `sharing_profile.permission` to support Direct Shared Gallery after its GA so  `community_gallery_info` is set to `optional`