### PR TITLE
`azurerm_attestation_provider` - add AzureVM and SEV-SNP attestation types

### DIFF
--- a/internal/services/attestation/attestation_provider_resource.go
+++ b/internal/services/attestation/attestation_provider_resource.go
@@ -58,6 +58,14 @@ func resourceAttestationProvider() *pluginsdk.Resource {
 				return fmt.Errorf("`tpm_policy_base64` can not be removed, add it to `ignore_changes` block to keep the default values")
 			}
 
+			if o, n := diff.GetChange("azure_vm_policy_base64"); o.(string) != "" && n.(string) == "" {
+				return fmt.Errorf("`azure_vm_policy_base64` can not be removed, add it to `ignore_changes` block to keep the default values")
+			}
+
+			if o, n := diff.GetChange("sev_snp_policy_base64"); o.(string) != "" && n.(string) == "" {
+				return fmt.Errorf("`sev_snp_policy_base64` can not be removed, add it to `ignore_changes` block to keep the default values")
+			}
+
 			return nil
 		},
 
@@ -110,13 +118,25 @@ func resourceAttestationProvider() *pluginsdk.Resource {
 					Optional:     true,
 					ValidateFunc: validate.ContainsABase64UriEncodedJWTOfAStoredAttestationPolicy,
 				},
+
+				"azure_vm_policy_base64": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validate.ContainsABase64UriEncodedJWTOfAStoredAttestationPolicy,
+				},
+
+				"sev_snp_policy_base64": {
+					Type:         pluginsdk.TypeString,
+					Optional:     true,
+					ValidateFunc: validate.ContainsABase64UriEncodedJWTOfAStoredAttestationPolicy,
+				},
 			}
 
 			if !features.FourPointOhBeta() {
 				s["policy"] = &pluginsdk.Schema{
 					Type:       pluginsdk.TypeList,
 					Optional:   true,
-					Deprecated: "This field is no longer used and will be removed in v4.0 of the Azure Provider - use `open_enclave_policy_base64`, `sgx_enclave_policy_base64` and `tpm_policy_base64` instead.",
+					Deprecated: "This field is no longer used and will be removed in v4.0 of the Azure Provider - use `open_enclave_policy_base64`, `sgx_enclave_policy_base64`, `tpm_policy_base64`, `azure_vm_policy_base64` and `sev_snp_policy_base64` instead.",
 					Elem: &pluginsdk.Resource{
 						Schema: map[string]*pluginsdk.Schema{
 							"environment_type": {
@@ -205,6 +225,16 @@ func resourceAttestationProviderCreate(d *pluginsdk.ResourceData, meta interface
 			return fmt.Errorf("updating value for `tpm_policy_base64`: %+v", err)
 		}
 	}
+	if v := d.Get("azure_vm_policy_base64"); v != "" {
+		if _, err = dataPlaneClient.Set(ctx, *dataPlaneUri, attestation.TypeAzureVM, d.Get("azure_vm_policy_base64").(string)); err != nil {
+			return fmt.Errorf("updating value for `azure_vm_policy_base64`: %+v", err)
+		}
+	}
+	if v := d.Get("sev_snp_policy_base64"); v != "" {
+		if _, err = dataPlaneClient.Set(ctx, *dataPlaneUri, attestation.TypeSevSnpVM, d.Get("sev_snp_policy_base64").(string)); err != nil {
+			return fmt.Errorf("updating value for `sev_snp_policy_base64`: %+v", err)
+		}
+	}
 
 	return resourceAttestationProviderRead(d, meta)
 }
@@ -251,6 +281,14 @@ func resourceAttestationProviderRead(d *pluginsdk.ResourceData, meta interface{}
 	if err != nil && !utils.ResponseWasBadRequest(tpmPolicy.Response) {
 		return fmt.Errorf("retrieving Tpm Policy for %s: %+v", *id, err)
 	}
+	azureVmPolicy, err := dataPlaneClient.Get(ctx, *dataPlaneUri, attestation.TypeAzureVM)
+	if err != nil && !utils.ResponseWasBadRequest(azureVmPolicy.Response) {
+		return fmt.Errorf("retrieving AzureVM Policy for %s: %+v", *id, err)
+	}
+	sevSnpPolicy, err := dataPlaneClient.Get(ctx, *dataPlaneUri, attestation.TypeSevSnpVM)
+	if err != nil && !utils.ResponseWasBadRequest(sevSnpPolicy.Response) {
+		return fmt.Errorf("retrieving SEV-SNP Policy for %s: %+v", *id, err)
+	}
 
 	d.Set("name", id.AttestationProviderName)
 	d.Set("resource_group_name", id.ResourceGroupName)
@@ -286,6 +324,18 @@ func resourceAttestationProviderRead(d *pluginsdk.ResourceData, meta interface{}
 	}
 	d.Set("tpm_policy_base64", utils.NormalizeNilableString(tpmPolicyData))
 
+	azureVmPolicyData, err := base64DataFromAttestationJWT(azureVmPolicy.Token)
+	if err != nil {
+		return fmt.Errorf("parsing AzureVM policy for %s: %+v", *id, err)
+	}
+	d.Set("azure_vm_policy_base64", utils.NormalizeNilableString(azureVmPolicyData))
+
+	sevSnpPolicyData, err := base64DataFromAttestationJWT(sevSnpPolicy.Token)
+	if err != nil {
+		return fmt.Errorf("parsing SEV-SNP policy for %s: %+v", *id, err)
+	}
+	d.Set("sev_snp_policy_base64", utils.NormalizeNilableString(sevSnpPolicyData))
+
 	if !features.FourPointOhBeta() {
 		if err := d.Set("policy", []interface{}{}); err != nil {
 			return fmt.Errorf("setting `policy`: %+v", err)
@@ -314,7 +364,7 @@ func resourceAttestationProviderUpdate(d *pluginsdk.ResourceData, meta interface
 		}
 	}
 
-	if d.HasChanges("open_enclave_policy_base64", "sgx_enclave_policy_base64", "tpm_policy_base64") {
+	if d.HasChanges("open_enclave_policy_base64", "sgx_enclave_policy_base64", "tpm_policy_base64", "azure_vm_policy_base64", "sev_snp_policy_base64") {
 		dataPlaneUri, err := attestationClients.DataPlaneEndpointForProvider(ctx, *id)
 		if err != nil {
 			return fmt.Errorf("determining Data Plane URI for %s: %+v", *id, err)
@@ -337,6 +387,16 @@ func resourceAttestationProviderUpdate(d *pluginsdk.ResourceData, meta interface
 		if d.HasChange("tpm_policy_base64") {
 			if _, err = dataPlaneClient.Set(ctx, *dataPlaneUri, attestation.TypeTpm, d.Get("tpm_policy_base64").(string)); err != nil {
 				return fmt.Errorf("updating value for `tpm_policy_base64`: %+v", err)
+			}
+		}
+		if d.HasChange("azure_vm_policy_base64") {
+			if _, err = dataPlaneClient.Set(ctx, *dataPlaneUri, attestation.TypeAzureVM, d.Get("azure_vm_policy_base64").(string)); err != nil {
+				return fmt.Errorf("updating value for `azure_vm_policy_base64`: %+v", err)
+			}
+		}
+		if d.HasChange("sev_snp_policy_base64") {
+			if _, err = dataPlaneClient.Set(ctx, *dataPlaneUri, attestation.TypeSevSnpVM, d.Get("sev_snp_policy_base64").(string)); err != nil {
+				return fmt.Errorf("updating value for `sev_snp_policy_base64`: %+v", err)
 			}
 		}
 	}

--- a/internal/services/attestation/attestation_provider_resource_test.go
+++ b/internal/services/attestation/attestation_provider_resource_test.go
@@ -230,6 +230,8 @@ resource "azurerm_attestation_provider" "test" {
       "open_enclave_policy_base64",
       "sgx_enclave_policy_base64",
       "tpm_policy_base64",
+      "azure_vm_policy_base64",
+      "sev_snp_policy_base64",
     ]
   }
 }
@@ -254,6 +256,8 @@ resource "azurerm_attestation_provider" "test" {
       "open_enclave_policy_base64",
       "sgx_enclave_policy_base64",
       "tpm_policy_base64",
+	  "azure_vm_policy_base64",
+      "sev_snp_policy_base64",
     ]
   }
 
@@ -278,6 +282,8 @@ resource "azurerm_attestation_provider" "import" {
       "open_enclave_policy_base64",
       "sgx_enclave_policy_base64",
       "tpm_policy_base64",
+	  "azure_vm_policy_base64",
+      "sev_snp_policy_base64",
     ]
   }
 }
@@ -310,6 +316,8 @@ EOT
       "open_enclave_policy_base64",
       "sgx_enclave_policy_base64",
       "tpm_policy_base64",
+	  "azure_vm_policy_base64",
+      "sev_snp_policy_base64",
     ]
   }
 }
@@ -332,6 +340,9 @@ resource "azurerm_attestation_provider" "test" {
 
   open_enclave_policy_base64 = %[3]q
   sgx_enclave_policy_base64  = %[3]q
+  tpm_policy_base64  = %[3]q
+  azure_vm_policy_base64 = %[3]q
+  sev_snp_policy_base64 = %[3]q
 
   lifecycle {
     ignore_changes = [

--- a/internal/services/attestation/attestation_provider_resource_test.go
+++ b/internal/services/attestation/attestation_provider_resource_test.go
@@ -230,7 +230,6 @@ resource "azurerm_attestation_provider" "test" {
       "open_enclave_policy_base64",
       "sgx_enclave_policy_base64",
       "tpm_policy_base64",
-      "azure_vm_policy_base64",
       "sev_snp_policy_base64",
     ]
   }
@@ -256,7 +255,6 @@ resource "azurerm_attestation_provider" "test" {
       "open_enclave_policy_base64",
       "sgx_enclave_policy_base64",
       "tpm_policy_base64",
-	  "azure_vm_policy_base64",
       "sev_snp_policy_base64",
     ]
   }
@@ -282,7 +280,6 @@ resource "azurerm_attestation_provider" "import" {
       "open_enclave_policy_base64",
       "sgx_enclave_policy_base64",
       "tpm_policy_base64",
-	  "azure_vm_policy_base64",
       "sev_snp_policy_base64",
     ]
   }
@@ -316,7 +313,6 @@ EOT
       "open_enclave_policy_base64",
       "sgx_enclave_policy_base64",
       "tpm_policy_base64",
-	  "azure_vm_policy_base64",
       "sev_snp_policy_base64",
     ]
   }
@@ -341,7 +337,6 @@ resource "azurerm_attestation_provider" "test" {
   open_enclave_policy_base64 = %[3]q
   sgx_enclave_policy_base64  = %[3]q
   tpm_policy_base64  = %[3]q
-  azure_vm_policy_base64 = %[3]q
   sev_snp_policy_base64 = %[3]q
 
   lifecycle {

--- a/internal/services/attestation/attestation_provider_resource_test.go
+++ b/internal/services/attestation/attestation_provider_resource_test.go
@@ -203,7 +203,7 @@ func testGenerateTestCertificate(organization string) (string, error) {
 
 func (AttestationProviderResource) template(data acceptance.TestData) string {
 	// currently only supported in "East US 2", "West Central US" & "UK South"
-	data.Locations.Primary = "uksouth"
+	data.Locations.Primary = "westus"
 	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-attestation-%d"
@@ -336,8 +336,8 @@ resource "azurerm_attestation_provider" "test" {
 
   open_enclave_policy_base64 = %[3]q
   sgx_enclave_policy_base64  = %[3]q
-  tpm_policy_base64  = %[3]q
-  sev_snp_policy_base64 = %[3]q
+  tpm_policy_base64          = %[3]q
+  sev_snp_policy_base64      = %[3]q
 
   lifecycle {
     ignore_changes = [

--- a/vendor/github.com/tombuildsstuff/kermit/sdk/attestation/2022-08-01/attestation/enums.go
+++ b/vendor/github.com/tombuildsstuff/kermit/sdk/attestation/2022-08-01/attestation/enums.go
@@ -66,13 +66,9 @@ const (
 	TypeSgxEnclave Type = "SgxEnclave"
 	// TypeTpm Edge TPM Virtualization Based Security
 	TypeTpm Type = "Tpm"
-	// TODO: Upstream and replace before merge, for testing purposes only
-	// TypeAzureVM is the AzureVM attestation type.
-	TypeAzureVM Type = "AzureGuest"
 )
 
 // PossibleTypeValues returns an array of possible values for the Type const type.
 func PossibleTypeValues() []Type {
-	// TODO: Upstream and replace before merge, for testing purposes only
-	return []Type{TypeOpenEnclave, TypeSevSnpVM, TypeSgxEnclave, TypeTpm, TypeAzureVM}
+	return []Type{TypeOpenEnclave, TypeSevSnpVM, TypeSgxEnclave, TypeTpm}
 }

--- a/vendor/github.com/tombuildsstuff/kermit/sdk/attestation/2022-08-01/attestation/enums.go
+++ b/vendor/github.com/tombuildsstuff/kermit/sdk/attestation/2022-08-01/attestation/enums.go
@@ -66,9 +66,13 @@ const (
 	TypeSgxEnclave Type = "SgxEnclave"
 	// TypeTpm Edge TPM Virtualization Based Security
 	TypeTpm Type = "Tpm"
+	// TODO: Upstream and replace before merge, for testing purposes only
+	// TypeAzureVM is the AzureVM attestation type.
+	TypeAzureVM Type = "AzureGuest"
 )
 
 // PossibleTypeValues returns an array of possible values for the Type const type.
 func PossibleTypeValues() []Type {
-	return []Type{TypeOpenEnclave, TypeSevSnpVM, TypeSgxEnclave, TypeTpm}
+	// TODO: Upstream and replace before merge, for testing purposes only
+	return []Type{TypeOpenEnclave, TypeSevSnpVM, TypeSgxEnclave, TypeTpm, TypeAzureVM}
 }

--- a/website/docs/r/attestation_provider.html.markdown
+++ b/website/docs/r/attestation_provider.html.markdown
@@ -47,8 +47,6 @@ The following arguments are supported:
 
 * `tpm_policy_base64` - (Optional) Specifies the base64 URI Encoded RFC 7519 JWT that should be used for the Attestation Policy.
 
-* `azure_vm_policy_base64` - (Optional) Specifies the base64 URI Encoded RFC 7519 JWT that should be used for the Attestation Policy.
-
 * `sev_snp_policy_base64` - (Optional) Specifies the base64 URI Encoded RFC 7519 JWT that should be used for the Attestation Policy.
 
 -> [More information on the JWT Policies can be found in this article on `learn.microsoft.com`](https://learn.microsoft.com/azure/attestation/author-sign-policy).

--- a/website/docs/r/attestation_provider.html.markdown
+++ b/website/docs/r/attestation_provider.html.markdown
@@ -41,11 +41,15 @@ The following arguments are supported:
 
 -> **NOTE:** If the `policy_signing_certificate_data` argument contains more than one valid X.509 certificate only the first certificate will be used.
 
-* `open_enclave_policy_base64` - (Optional) Specifies the base64 URI Encoded RFC 7519 JWT that should be used for the TPM Policy.
+* `open_enclave_policy_base64` - (Optional) Specifies the base64 URI Encoded RFC 7519 JWT that should be used for the Attestation Policy.
 
-* `sgx_enclave_policy_base64` - (Optional) Specifies the base64 URI Encoded RFC 7519 JWT that should be used for the TPM Policy.
+* `sgx_enclave_policy_base64` - (Optional) Specifies the base64 URI Encoded RFC 7519 JWT that should be used for the Attestation Policy.
 
-* `tpm_policy_base64` - (Optional) Specifies the base64 URI Encoded RFC 7519 JWT that should be used for the TPM Policy.
+* `tpm_policy_base64` - (Optional) Specifies the base64 URI Encoded RFC 7519 JWT that should be used for the Attestation Policy.
+
+* `azure_vm_policy_base64` - (Optional) Specifies the base64 URI Encoded RFC 7519 JWT that should be used for the Attestation Policy.
+
+* `sev_snp_policy_base64` - (Optional) Specifies the base64 URI Encoded RFC 7519 JWT that should be used for the Attestation Policy.
 
 -> [More information on the JWT Policies can be found in this article on `learn.microsoft.com`](https://learn.microsoft.com/azure/attestation/author-sign-policy).
 


### PR DESCRIPTION
### Context
- As stated in #21918, the Terraform provider (nor the SDK) currently support setting attestation policies for the `AzureVM` (Trusted launch) and `SEV-SNP` attestation types.

### Proposed Changes
- Add the `sev_snp_policy_base64` and `azure_vm_policy_base64` fields to the `azurerm_attestation_provider` resource.
- TODO: For now, I edited the `enums.go` file in the SDK manually to test the changes. I assume I would need to get a PR to the SDK upstreamed to get these changes in?

### Related Issue
- Closes #21918 