### PR TITLE
Updated lighthouse_definition documentation.

### DIFF
--- a/website/docs/r/lighthouse_definition.html.markdown
+++ b/website/docs/r/lighthouse_definition.html.markdown
@@ -68,7 +68,7 @@ An `authorization` block supports the following:
 
 An `eligible_authorization` block supports the following:
 
-* `principal_id` - (Required) The Principal ID of the Azure Active Directory.
+* `principal_id` - (Required) Principal ID of the security group/service principal/user that would be assigned permissions to the projected subscription.
 
 * `role_definition_id` - (Required) The Principal ID of the Azure built-in role that defines the permissions that the Azure Active Directory will have on the projected scope.
 


### PR DESCRIPTION
Hi,

I have recently updated the lighthouse_definition.html.markdown file as there was an error for the  'principle_id' argument. Rather than requiring the Azure Active Directory principle ID, it requires the principleID of the identity/group etc. for eligible_authorization. 

Thanks :)