### PR TITLE
`azurerm_key_vault`: keyvault dataplane auth remove auth callback

### DIFF
--- a/internal/clients/builder.go
+++ b/internal/clients/builder.go
@@ -129,7 +129,7 @@ func Build(ctx context.Context, builder ClientBuilder) (*Client, error) {
 		TerraformVersion: builder.TerraformVersion,
 
 		BatchManagementAuthorizer: authWrapper.AutorestAuthorizer(batchManagementAuth),
-		KeyVaultAuthorizer:        authWrapper.AutorestAuthorizer(keyVaultAuth).BearerAuthorizerCallback(),
+		KeyVaultAuthorizer:        authWrapper.AutorestAuthorizer(keyVaultAuth),
 		ResourceManagerAuthorizer: authWrapper.AutorestAuthorizer(resourceManagerAuth),
 		StorageAuthorizer:         authWrapper.AutorestAuthorizer(storageAuth),
 		SynapseAuthorizer:         authWrapper.AutorestAuthorizer(synapseAuth),


### PR DESCRIPTION
try to fixes #22262 . Have a look into this and it seems the `BearerAuthorizerCallback()` is not needed and some failed AccTests seem not relate to this PR. I'm not sure of this maybe @manicminer could you please have a look?

![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/2633022/5bda50b1-09a3-4e44-b914-184874020136)
