### PR TITLE
New Resource: `azurerm_kusto_cosmosdb_data_connection`

### DIFF
--- a/internal/provider/services.go
+++ b/internal/provider/services.go
@@ -154,6 +154,7 @@ func SupportedTypedServices() []sdk.TypedServiceRegistration {
 		iothub.Registration{},
 		iotcentral.Registration{},
 		keyvault.Registration{},
+		kusto.Registration{},
 		labservice.Registration{},
 		loadbalancer.Registration{},
 		loganalytics.Registration{},

--- a/internal/services/kusto/kusto_cosmosdb_data_connection_resource.go
+++ b/internal/services/kusto/kusto_cosmosdb_data_connection_resource.go
@@ -88,11 +88,13 @@ func (r CosmosDBDataConnectionResource) Arguments() map[string]*schema.Schema {
 		"mapping_rule_name": {
 			Type:         pluginsdk.TypeString,
 			Optional:     true,
+			ForceNew:     true,
 			ValidateFunc: validation.StringIsNotEmpty,
 		},
 		"retrieval_start_date": {
 			Type:         pluginsdk.TypeString,
 			Optional:     true,
+			ForceNew:     true,
 			ValidateFunc: validation.StringIsNotEmpty,
 		},
 	}

--- a/internal/services/kusto/kusto_cosmosdb_data_connection_resource.go
+++ b/internal/services/kusto/kusto_cosmosdb_data_connection_resource.go
@@ -167,51 +167,6 @@ func (r CosmosDBDataConnectionResource) Create() sdk.ResourceFunc {
 	}
 }
 
-func (r CosmosDBDataConnectionResource) Update() sdk.ResourceFunc {
-	return sdk.ResourceFunc{
-		Timeout: 30 * time.Minute,
-		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
-			client := metadata.Client.Kusto.DataConnectionsClient
-			id, err := dataconnections.ParseDataConnectionID(metadata.ResourceData.Id())
-			if err != nil {
-				return fmt.Errorf("parsing %s: %+v", metadata.ResourceData.Id(), err)
-			}
-
-			var model CosmosDBDataConnectionModel
-			if err := metadata.Decode(&model); err != nil {
-				return fmt.Errorf("decoding %s: %+v", r.ResourceType(), err)
-			}
-
-			resp, err := client.Get(ctx, *id)
-			if err != nil {
-				return fmt.Errorf("retrieving %s: %+v", *id, err)
-			}
-
-			properties := resp.Model
-			if properties == nil {
-				return fmt.Errorf("retrieving %s: properties was nil", id)
-			}
-
-			cosmosDbProperties := (*properties).(dataconnections.CosmosDbDataConnection)
-
-			if metadata.ResourceData.HasChange("mapping_rule_name") && cosmosDbProperties.Properties != nil {
-				cosmosDbProperties.Properties.MappingRuleName = &model.MappingRuleName
-			}
-
-			if metadata.ResourceData.HasChange("retrieval_start_date") && cosmosDbProperties.Properties != nil {
-				cosmosDbProperties.Properties.RetrievalStartDate = &model.RetrievalStartDate
-			}
-
-			if err := client.CreateOrUpdateThenPoll(ctx, *id, *properties); err != nil {
-				return fmt.Errorf("updating %s: %+v", *id, err)
-			}
-
-			metadata.SetID(id)
-			return nil
-		},
-	}
-}
-
 func (r CosmosDBDataConnectionResource) Read() sdk.ResourceFunc {
 	return sdk.ResourceFunc{
 		Timeout: 5 * time.Minute,

--- a/internal/services/kusto/kusto_cosmosdb_data_connection_resource.go
+++ b/internal/services/kusto/kusto_cosmosdb_data_connection_resource.go
@@ -73,7 +73,12 @@ func (r CosmosDBDataConnectionResource) Arguments() map[string]*schema.Schema {
 			ForceNew:     true,
 			ValidateFunc: validate.DatabaseName,
 		},
-		"managed_identity_id": commonschema.SystemAssignedUserAssignedIdentityRequiredForceNew(),
+		"managed_identity_id": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: azure.ValidateResourceID,
+		},
 		"table_name": {
 			Type:         pluginsdk.TypeString,
 			Required:     true,

--- a/internal/services/kusto/kusto_cosmosdb_data_connection_resource.go
+++ b/internal/services/kusto/kusto_cosmosdb_data_connection_resource.go
@@ -176,7 +176,7 @@ func (r CosmosDBDataConnectionResource) Read() sdk.ResourceFunc {
 
 			id, err := dataconnections.ParseDataConnectionID(metadata.ResourceData.Id())
 			if err != nil {
-				return fmt.Errorf("parsing %s: %+v", metadata.ResourceData.Id(), err)
+				return err
 			}
 
 			resp, err := client.Get(ctx, *id)

--- a/internal/services/kusto/kusto_cosmosdb_data_connection_resource.go
+++ b/internal/services/kusto/kusto_cosmosdb_data_connection_resource.go
@@ -113,14 +113,14 @@ func (r CosmosDBDataConnectionResource) Create() sdk.ResourceFunc {
 
 			cosmosDbContainerId, err := cosmosdb.ParseContainerID(model.CosmosDbContainerId)
 			if err != nil {
-				return fmt.Errorf("parsing CosmosDB Container ID: %+v", err)
+				return err
 			}
 
 			cosmosDbAccountResourceId := cosmosdb.NewDatabaseAccountID(subscriptionId, model.ResourceGroupName, cosmosDbContainerId.DatabaseAccountName)
 
 			kustoDatabaseId, err := databases.ParseDatabaseID(model.DatabaseId)
 			if err != nil {
-				return fmt.Errorf("parsing Kusto Database ID: %+v", err)
+				return err
 			}
 
 			id := dataconnections.NewDataConnectionID(subscriptionId, model.ResourceGroupName, kustoDatabaseId.ClusterName, kustoDatabaseId.DatabaseName, model.Name)
@@ -206,14 +206,8 @@ func (r CosmosDBDataConnectionResource) Read() sdk.ResourceFunc {
 					state.CosmosDbContainerId = cosmosDbContainerId.ID()
 					state.TableName = properties.TableName
 					state.ManagedIdentityId = properties.ManagedIdentityResourceId
-
-					if properties.MappingRuleName != nil {
-						state.MappingRuleName = *properties.MappingRuleName
-					}
-
-					if properties.RetrievalStartDate != nil {
-						state.RetrievalStartDate = *properties.RetrievalStartDate
-					}
+					state.MappingRuleName = pointer.From(properties.MappingRuleName)
+					state.RetrievalStartDate = pointer.From(properties.RetrievalStartDate)
 				}
 			}
 

--- a/internal/services/kusto/kusto_cosmosdb_data_connection_resource.go
+++ b/internal/services/kusto/kusto_cosmosdb_data_connection_resource.go
@@ -197,7 +197,7 @@ func (r CosmosDBDataConnectionResource) Read() sdk.ResourceFunc {
 				if properties := cosmosDbModel.Properties; properties != nil {
 					cosmosdbAccountId, err := cosmosdb.ParseDatabaseAccountID(properties.CosmosDbAccountResourceId)
 					if err != nil {
-						return fmt.Errorf("parsing CosmosDB Account ID: %+v", err)
+						return err
 					}
 					cosmosDbContainerId := cosmosdb.NewContainerID(id.SubscriptionId, id.ResourceGroupName, cosmosdbAccountId.DatabaseAccountName, properties.CosmosDbDatabase, properties.CosmosDbContainer)
 					state.CosmosDbContainerId = cosmosDbContainerId.ID()

--- a/internal/services/kusto/kusto_cosmosdb_data_connection_resource.go
+++ b/internal/services/kusto/kusto_cosmosdb_data_connection_resource.go
@@ -3,6 +3,8 @@ package kusto
 import (
 	"context"
 	"fmt"
+	"time"
+
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
@@ -13,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/kusto/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"time"
 )
 
 type CosmosDBDataConnectionModel struct {

--- a/internal/services/kusto/kusto_cosmosdb_data_connection_resource.go
+++ b/internal/services/kusto/kusto_cosmosdb_data_connection_resource.go
@@ -94,7 +94,7 @@ func (r CosmosDBDataConnectionResource) Arguments() map[string]*schema.Schema {
 		"retrieval_start_date": {
 			Type:         pluginsdk.TypeString,
 			Optional:     true,
-			ValidateFunc: validation.IsRFC3339Time,
+			ValidateFunc: validation.StringIsNotEmpty,
 		},
 	}
 }
@@ -193,14 +193,14 @@ func (r CosmosDBDataConnectionResource) Update() sdk.ResourceFunc {
 				return fmt.Errorf("retrieving %s: properties was nil", id)
 			}
 
-			cosmosDbProperties := (*properties).(dataconnections.CosmosDbDataConnectionProperties)
+			cosmosDbProperties := (*properties).(dataconnections.CosmosDbDataConnection)
 
-			if metadata.ResourceData.HasChange("mapping_rule_name") {
-				cosmosDbProperties.MappingRuleName = &model.MappingRuleName
+			if metadata.ResourceData.HasChange("mapping_rule_name") && cosmosDbProperties.Properties != nil {
+				cosmosDbProperties.Properties.MappingRuleName = &model.MappingRuleName
 			}
 
-			if metadata.ResourceData.HasChange("retrieval_start_date") {
-				cosmosDbProperties.RetrievalStartDate = &model.RetrievalStartDate
+			if metadata.ResourceData.HasChange("retrieval_start_date") && cosmosDbProperties.Properties != nil {
+				cosmosDbProperties.Properties.RetrievalStartDate = &model.RetrievalStartDate
 			}
 
 			if err := client.CreateOrUpdateThenPoll(ctx, *id, *properties); err != nil {

--- a/internal/services/kusto/kusto_cosmosdb_data_connection_resource.go
+++ b/internal/services/kusto/kusto_cosmosdb_data_connection_resource.go
@@ -1,0 +1,286 @@
+package kusto
+
+import (
+	"context"
+	"fmt"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2022-12-29/dataconnections"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/kusto/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+	"time"
+)
+
+type CosmosDBDataConnectionModel struct {
+	Name               string `tfschema:"name"`
+	ResourceGroupName  string `tfschema:"resource_group_name"`
+	Location           string `tfschema:"location"`
+	CosmosDbAccountId  string `tfschema:"cosmosdb_account_id"`
+	CosmosDbContainer  string `tfschema:"cosmosdb_container"`
+	CosmosDbDatabase   string `tfschema:"cosmosdb_database"`
+	ClusterName        string `tfschema:"cluster_name"`
+	DatabaseName       string `tfschema:"database_name"`
+	ManagedIdentityId  string `tfschema:"managed_identity_id"`
+	MappingRuleName    string `tfschema:"mapping_rule_name"`
+	RetrievalStartDate string `tfschema:"retrieval_start_date"`
+	TableName          string `tfschema:"table_name"`
+}
+
+var _ sdk.Resource = CosmosDBDataConnectionResource{}
+
+type CosmosDBDataConnectionResource struct{}
+
+func (r CosmosDBDataConnectionResource) Arguments() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validate.DataConnectionName,
+		},
+		"resource_group_name": commonschema.ResourceGroupName(),
+		"location":            commonschema.Location(),
+		"cosmosdb_account_id": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: azure.ValidateResourceID,
+		},
+		"cosmosdb_container": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+		"cosmosdb_database": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+		"cluster_name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validate.ClusterName,
+		},
+		"database_name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validate.DatabaseName,
+		},
+		"managed_identity_id": commonschema.SystemAssignedUserAssignedIdentityRequiredForceNew(),
+		"table_name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"mapping_rule_name": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+		"retrieval_start_date": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ValidateFunc: validation.IsRFC3339Time,
+		},
+	}
+}
+
+func (r CosmosDBDataConnectionResource) Attributes() map[string]*schema.Schema {
+	return map[string]*schema.Schema{}
+}
+
+func (r CosmosDBDataConnectionResource) ModelObject() interface{} {
+	return &CosmosDBDataConnectionModel{}
+}
+
+func (r CosmosDBDataConnectionResource) ResourceType() string {
+	return "azurerm_kusto_cosmosdb_data_connection"
+}
+
+func (r CosmosDBDataConnectionResource) Create() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+
+		// the Func returns a function which retrieves the current state of the Resource Group into the state
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			var model CosmosDBDataConnectionModel
+			if err := metadata.Decode(&model); err != nil {
+				return fmt.Errorf("decoding %s: %+v", r.ResourceType(), err)
+			}
+
+			client := metadata.Client.Kusto.DataConnectionsClient
+			subscriptionId := metadata.Client.Account.SubscriptionId
+			id := dataconnections.NewDataConnectionID(subscriptionId, model.ResourceGroupName, model.ClusterName, model.DatabaseName, model.Name)
+
+			existing, err := client.Get(ctx, id)
+			if err != nil && !response.WasNotFound(existing.HttpResponse) {
+				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+			}
+			if !response.WasNotFound(existing.HttpResponse) {
+				return metadata.ResourceRequiresImport(r.ResourceType(), id)
+			}
+
+			properties := dataconnections.CosmosDbDataConnectionProperties{
+				CosmosDbAccountResourceId: model.CosmosDbAccountId,
+				CosmosDbContainer:         model.CosmosDbContainer,
+				CosmosDbDatabase:          model.CosmosDbDatabase,
+				TableName:                 model.TableName,
+				ManagedIdentityResourceId: model.ManagedIdentityId,
+			}
+
+			if model.MappingRuleName != "" {
+				properties.MappingRuleName = &model.MappingRuleName
+			}
+
+			if model.RetrievalStartDate != "" {
+				properties.RetrievalStartDate = &model.RetrievalStartDate
+			}
+
+			l := location.Normalize(model.Location)
+
+			dataConnection := dataconnections.CosmosDbDataConnection{
+				Location:   &l,
+				Name:       &model.Name,
+				Properties: &properties,
+			}
+
+			if err := client.CreateOrUpdateThenPoll(ctx, id, dataConnection); err != nil {
+				return fmt.Errorf("creating %s: %+v", id, err)
+			}
+
+			metadata.SetID(id)
+			return nil
+		},
+	}
+}
+
+func (r CosmosDBDataConnectionResource) Update() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Kusto.DataConnectionsClient
+			id, err := dataconnections.ParseDataConnectionID(metadata.ResourceData.Id())
+			if err != nil {
+				return fmt.Errorf("parsing %s: %+v", metadata.ResourceData.Id(), err)
+			}
+
+			var model CosmosDBDataConnectionModel
+			if err := metadata.Decode(&model); err != nil {
+				return fmt.Errorf("decoding %s: %+v", r.ResourceType(), err)
+			}
+
+			resp, err := client.Get(ctx, *id)
+			if err != nil {
+				return fmt.Errorf("retrieving %s: %+v", *id, err)
+			}
+
+			properties := resp.Model
+			if properties == nil {
+				return fmt.Errorf("retrieving %s: properties was nil", id)
+			}
+
+			cosmosDbProperties := (*properties).(dataconnections.CosmosDbDataConnectionProperties)
+
+			if metadata.ResourceData.HasChange("mapping_rule_name") {
+				cosmosDbProperties.MappingRuleName = &model.MappingRuleName
+			}
+
+			if metadata.ResourceData.HasChange("retrieval_start_date") {
+				cosmosDbProperties.RetrievalStartDate = &model.RetrievalStartDate
+			}
+
+			if err := client.CreateOrUpdateThenPoll(ctx, *id, *properties); err != nil {
+				return fmt.Errorf("updating %s: %+v", *id, err)
+			}
+
+			metadata.SetID(id)
+			return nil
+		},
+	}
+}
+
+func (r CosmosDBDataConnectionResource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Kusto.DataConnectionsClient
+
+			id, err := dataconnections.ParseDataConnectionID(metadata.ResourceData.Id())
+			if err != nil {
+				return fmt.Errorf("parsing %s: %+v", metadata.ResourceData.Id(), err)
+			}
+
+			resp, err := client.Get(ctx, *id)
+			if err != nil {
+				if response.WasNotFound(resp.HttpResponse) {
+					return metadata.MarkAsGone(id)
+				}
+
+				return fmt.Errorf("retrieving %s: %+v", *id, err)
+			}
+
+			state := CosmosDBDataConnectionModel{
+				Name:              id.DataConnectionName,
+				ResourceGroupName: id.ResourceGroupName,
+				ClusterName:       id.ClusterName,
+				DatabaseName:      id.DatabaseName,
+			}
+
+			if model := resp.Model; model != nil {
+				cosmosDbModel := (*model).(dataconnections.CosmosDbDataConnection)
+				state.Location = location.Normalize(*cosmosDbModel.Location)
+
+				if properties := cosmosDbModel.Properties; properties != nil {
+					state.CosmosDbAccountId = properties.CosmosDbAccountResourceId
+					state.CosmosDbContainer = properties.CosmosDbContainer
+					state.CosmosDbDatabase = properties.CosmosDbDatabase
+					state.TableName = properties.TableName
+					state.ManagedIdentityId = properties.ManagedIdentityResourceId
+
+					if properties.MappingRuleName != nil {
+						state.MappingRuleName = *properties.MappingRuleName
+					}
+
+					if properties.RetrievalStartDate != nil {
+						state.RetrievalStartDate = *properties.RetrievalStartDate
+					}
+				}
+			}
+
+			return metadata.Encode(&state)
+		},
+	}
+}
+
+func (r CosmosDBDataConnectionResource) Delete() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.Kusto.DataConnectionsClient
+
+			id, err := dataconnections.ParseDataConnectionID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			if err := client.DeleteThenPoll(ctx, *id); err != nil {
+				return fmt.Errorf("deleting %s: %+v", id, err)
+			}
+
+			return nil
+		},
+	}
+}
+
+func (r CosmosDBDataConnectionResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+	return dataconnections.ValidateDataConnectionID
+}

--- a/internal/services/kusto/kusto_cosmosdb_data_connection_resource.go
+++ b/internal/services/kusto/kusto_cosmosdb_data_connection_resource.go
@@ -85,7 +85,6 @@ func (r CosmosDBDataConnectionResource) Arguments() map[string]*schema.Schema {
 			ForceNew:     true,
 			ValidateFunc: validation.StringIsNotEmpty,
 		},
-
 		"mapping_rule_name": {
 			Type:         pluginsdk.TypeString,
 			Optional:     true,

--- a/internal/services/kusto/kusto_cosmosdb_data_connection_resource.go
+++ b/internal/services/kusto/kusto_cosmosdb_data_connection_resource.go
@@ -152,10 +152,8 @@ func (r CosmosDBDataConnectionResource) Create() sdk.ResourceFunc {
 				properties.RetrievalStartDate = &model.RetrievalStartDate
 			}
 
-			l := location.Normalize(model.Location)
-
 			dataConnection := dataconnections.CosmosDbDataConnection{
-				Location:   &l,
+				Location:   pointer.To(location.Normalize(model.Location)),
 				Name:       &model.Name,
 				Properties: &properties,
 			}

--- a/internal/services/kusto/kusto_cosmosdb_data_connection_resource_test.go
+++ b/internal/services/kusto/kusto_cosmosdb_data_connection_resource_test.go
@@ -99,7 +99,6 @@ func (k KustoCosmosDBDataConnectionResource) basic(data acceptance.TestData) str
 
 resource "azurerm_kusto_cosmosdb_data_connection" "test" {
   name                  = "acctestkcd%s"
-  resource_group_name   = azurerm_resource_group.test.name
   location              = azurerm_resource_group.test.location
   cosmosdb_container_id = azurerm_cosmosdb_sql_container.test.id
   kusto_database_id     = azurerm_kusto_database.test.id
@@ -118,7 +117,6 @@ func (k KustoCosmosDBDataConnectionResource) complete(data acceptance.TestData) 
 
 resource "azurerm_kusto_cosmosdb_data_connection" "test" {
   name                  = "acctestkcd%s"
-  resource_group_name   = azurerm_resource_group.test.name
   location              = azurerm_resource_group.test.location
   cosmosdb_container_id = azurerm_cosmosdb_sql_container.test.id
   kusto_database_id     = azurerm_kusto_database.test.id
@@ -136,7 +134,6 @@ func (k KustoCosmosDBDataConnectionResource) requiresImport(data acceptance.Test
 
 resource "azurerm_kusto_cosmosdb_data_connection" "import" {
   name                  = azurerm_kusto_cosmosdb_data_connection.test.name
-  resource_group_name   = azurerm_resource_group.test.name
   location              = azurerm_resource_group.test.location
   cosmosdb_container_id = azurerm_cosmosdb_sql_container.test.id
   kusto_database_id     = azurerm_kusto_database.test.id

--- a/internal/services/kusto/kusto_cosmosdb_data_connection_resource_test.go
+++ b/internal/services/kusto/kusto_cosmosdb_data_connection_resource_test.go
@@ -54,8 +54,6 @@ func TestAccKustoCosmosDBDataConnection_basic(t *testing.T) {
 				check.That(data.ResourceName).Key("table_name").Exists(),
 				check.That(data.ResourceName).Key("managed_identity_id").Exists(),
 				check.That(data.ResourceName).Key("table_name").HasValue("TestTable"),
-				check.That(data.ResourceName).Key("mapping_rule_name").DoesNotExist(),
-				check.That(data.ResourceName).Key("retrieval_start_date").DoesNotExist(),
 			),
 		},
 		data.ImportStep(),
@@ -160,6 +158,16 @@ resource "azurerm_user_assigned_identity" "test" {
   name                = "acctestuami-%d"
 }
 
+data "azurerm_role_definition" "builtin" {
+  name = "DocumentDB Account Contributor"
+}
+
+resource "azurerm_role_assignment" "test" {
+  scope                = azurerm_resource_group.test.id
+  role_definition_name = data.azurerm_role_definition.builtin.name
+  principal_id         = azurerm_user_assigned_identity.test.principal_id
+}
+
 resource "azurerm_cosmosdb_account" "test" {
   name                = "acctest-ca-%d"
   location            = azurerm_resource_group.test.location
@@ -176,11 +184,6 @@ resource "azurerm_cosmosdb_account" "test" {
   geo_location {
     location          = azurerm_resource_group.test.location
     failover_priority = 0
-  }
-
-  identity {
-    type         = "UserAssigned"
-    identity_ids = [azurerm_user_assigned_identity.test.id]
   }
 }
 

--- a/internal/services/kusto/kusto_cosmosdb_data_connection_resource_test.go
+++ b/internal/services/kusto/kusto_cosmosdb_data_connection_resource_test.go
@@ -54,6 +54,8 @@ func TestAccKustoCosmosDBDataConnection_basic(t *testing.T) {
 				check.That(data.ResourceName).Key("table_name").Exists(),
 				check.That(data.ResourceName).Key("managed_identity_id").Exists(),
 				check.That(data.ResourceName).Key("table_name").HasValue("TestTable"),
+				check.That(data.ResourceName).Key("mapping_rule_name").DoesNotExist(),
+				check.That(data.ResourceName).Key("retrieval_start_date").DoesNotExist(),
 			),
 		},
 		data.ImportStep(),
@@ -175,6 +177,11 @@ resource "azurerm_cosmosdb_account" "test" {
     location          = azurerm_resource_group.test.location
     failover_priority = 0
   }
+
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.test.id]
+  }
 }
 
 resource "azurerm_cosmosdb_sql_database" "test" {
@@ -202,7 +209,7 @@ data "azurerm_cosmosdb_sql_role_definition" "test" {
 resource "azurerm_cosmosdb_sql_role_assignment" "test" {
   resource_group_name = azurerm_resource_group.test.name
   account_name        = azurerm_cosmosdb_account.test.name
-  role_definition_id  = azurerm_cosmosdb_sql_role_definition.test.id
+  role_definition_id  = data.azurerm_cosmosdb_sql_role_definition.test.id
   principal_id        = azurerm_user_assigned_identity.test.principal_id
   scope               = azurerm_cosmosdb_account.test.id
 }

--- a/internal/services/kusto/kusto_cosmosdb_data_connection_resource_test.go
+++ b/internal/services/kusto/kusto_cosmosdb_data_connection_resource_test.go
@@ -46,11 +46,8 @@ func TestAccKustoCosmosDBDataConnection_basic(t *testing.T) {
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("cosmosdb_account_id").Exists(),
-				check.That(data.ResourceName).Key("cosmosdb_database").Exists(),
-				check.That(data.ResourceName).Key("cosmosdb_container").Exists(),
-				check.That(data.ResourceName).Key("cluster_name").Exists(),
-				check.That(data.ResourceName).Key("database_name").Exists(),
+				check.That(data.ResourceName).Key("cosmosdb_container_id").Exists(),
+				check.That(data.ResourceName).Key("kusto_database_id").Exists(),
 				check.That(data.ResourceName).Key("table_name").Exists(),
 				check.That(data.ResourceName).Key("managed_identity_id").Exists(),
 				check.That(data.ResourceName).Key("table_name").HasValue("TestTable"),
@@ -68,11 +65,8 @@ func TestAccKustoCosmosDBDataConnection_complete(t *testing.T) {
 			Config: r.complete(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("cosmosdb_account_id").Exists(),
-				check.That(data.ResourceName).Key("cosmosdb_database").Exists(),
-				check.That(data.ResourceName).Key("cosmosdb_container").Exists(),
-				check.That(data.ResourceName).Key("cluster_name").Exists(),
-				check.That(data.ResourceName).Key("database_name").Exists(),
+				check.That(data.ResourceName).Key("cosmosdb_container_id").Exists(),
+				check.That(data.ResourceName).Key("kusto_database_id").Exists(),
 				check.That(data.ResourceName).Key("table_name").Exists(),
 				check.That(data.ResourceName).Key("managed_identity_id").Exists(),
 				check.That(data.ResourceName).Key("table_name").HasValue("TestTable"),
@@ -107,11 +101,8 @@ resource "azurerm_kusto_cosmosdb_data_connection" "test" {
   name                = "acctestkcd%s"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  cosmosdb_account_id = azurerm_cosmosdb_account.test.id
-  cosmosdb_database   = azurerm_cosmosdb_sql_database.test.name
-  cosmosdb_container  = azurerm_cosmosdb_sql_container.test.name
-  cluster_name        = azurerm_kusto_cluster.test.name
-  database_name       = azurerm_kusto_database.test.name
+  cosmosdb_container_id  = azurerm_cosmosdb_sql_container.test.id
+  kusto_database_id       = azurerm_kusto_database.test.id
   managed_identity_id = azurerm_kusto_cluster.test.id
   table_name          = "TestTable"
   lifecycle {
@@ -129,11 +120,8 @@ resource "azurerm_kusto_cosmosdb_data_connection" "test" {
   name                 = "acctestkcd%s"
   resource_group_name  = azurerm_resource_group.test.name
   location             = azurerm_resource_group.test.location
-  cosmosdb_account_id  = azurerm_cosmosdb_account.test.id
-  cosmosdb_database    = azurerm_cosmosdb_sql_database.test.name
-  cosmosdb_container   = azurerm_cosmosdb_sql_container.test.name
-  cluster_name         = azurerm_kusto_cluster.test.name
-  database_name        = azurerm_kusto_database.test.name
+  cosmosdb_container_id  = azurerm_cosmosdb_sql_container.test.id
+  kusto_database_id       = azurerm_kusto_database.test.id
   managed_identity_id  = azurerm_kusto_cluster.test.id
   table_name           = "TestTable"
   mapping_rule_name    = "TestMapping"
@@ -150,11 +138,8 @@ resource "azurerm_kusto_cosmosdb_data_connection" "import" {
   name                = azurerm_kusto_cosmosdb_data_connection.test.name
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  cosmosdb_account_id = azurerm_cosmosdb_account.test.id
-  cosmosdb_database   = azurerm_cosmosdb_sql_database.test.name
-  cosmosdb_container  = azurerm_cosmosdb_sql_container.test.name
-  cluster_name        = azurerm_kusto_cluster.test.name
-  database_name       = azurerm_kusto_database.test.name
+  cosmosdb_container_id  = azurerm_cosmosdb_sql_container.test.id
+  kusto_database_id       = azurerm_kusto_database.test.id
   managed_identity_id = azurerm_kusto_cluster.test.id
   table_name          = "TestTable"
   lifecycle {

--- a/internal/services/kusto/kusto_cosmosdb_data_connection_resource_test.go
+++ b/internal/services/kusto/kusto_cosmosdb_data_connection_resource_test.go
@@ -60,25 +60,10 @@ func TestAccKustoCosmosDBDataConnection_basic(t *testing.T) {
 	})
 }
 
-func TestAccKustoCosmosDBDataConnection_completeUpdated(t *testing.T) {
+func TestAccKustoCosmosDBDataConnection_complete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_kusto_cosmosdb_data_connection", "test")
 	r := KustoCosmosDBDataConnectionResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.basic(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("cosmosdb_account_id").Exists(),
-				check.That(data.ResourceName).Key("cosmosdb_database").Exists(),
-				check.That(data.ResourceName).Key("cosmosdb_container").Exists(),
-				check.That(data.ResourceName).Key("cluster_name").Exists(),
-				check.That(data.ResourceName).Key("database_name").Exists(),
-				check.That(data.ResourceName).Key("table_name").Exists(),
-				check.That(data.ResourceName).Key("managed_identity_id").Exists(),
-				check.That(data.ResourceName).Key("table_name").HasValue("TestTable"),
-			),
-		},
-		data.ImportStep(),
 		{
 			Config: r.complete(data),
 			Check: acceptance.ComposeTestCheckFunc(

--- a/internal/services/kusto/kusto_cosmosdb_data_connection_resource_test.go
+++ b/internal/services/kusto/kusto_cosmosdb_data_connection_resource_test.go
@@ -3,9 +3,9 @@ package kusto_test
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2022-12-29/dataconnections"
 	"testing"
 
+	"github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2022-12-29/dataconnections"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"

--- a/internal/services/kusto/kusto_cosmosdb_data_connection_resource_test.go
+++ b/internal/services/kusto/kusto_cosmosdb_data_connection_resource_test.go
@@ -98,13 +98,13 @@ func (k KustoCosmosDBDataConnectionResource) basic(data acceptance.TestData) str
 %s
 
 resource "azurerm_kusto_cosmosdb_data_connection" "test" {
-  name                = "acctestkcd%s"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-  cosmosdb_container_id  = azurerm_cosmosdb_sql_container.test.id
-  kusto_database_id       = azurerm_kusto_database.test.id
-  managed_identity_id = azurerm_kusto_cluster.test.id
-  table_name          = "TestTable"
+  name                  = "acctestkcd%s"
+  resource_group_name   = azurerm_resource_group.test.name
+  location              = azurerm_resource_group.test.location
+  cosmosdb_container_id = azurerm_cosmosdb_sql_container.test.id
+  kusto_database_id     = azurerm_kusto_database.test.id
+  managed_identity_id   = azurerm_kusto_cluster.test.id
+  table_name            = "TestTable"
   lifecycle {
     ignore_changes = [retrieval_start_date]
   }
@@ -117,15 +117,15 @@ func (k KustoCosmosDBDataConnectionResource) complete(data acceptance.TestData) 
 %s
 
 resource "azurerm_kusto_cosmosdb_data_connection" "test" {
-  name                 = "acctestkcd%s"
-  resource_group_name  = azurerm_resource_group.test.name
-  location             = azurerm_resource_group.test.location
-  cosmosdb_container_id  = azurerm_cosmosdb_sql_container.test.id
-  kusto_database_id       = azurerm_kusto_database.test.id
-  managed_identity_id  = azurerm_kusto_cluster.test.id
-  table_name           = "TestTable"
-  mapping_rule_name    = "TestMapping"
-  retrieval_start_date = "2023-06-26T12:00:00.6554616Z"
+  name                  = "acctestkcd%s"
+  resource_group_name   = azurerm_resource_group.test.name
+  location              = azurerm_resource_group.test.location
+  cosmosdb_container_id = azurerm_cosmosdb_sql_container.test.id
+  kusto_database_id     = azurerm_kusto_database.test.id
+  managed_identity_id   = azurerm_kusto_cluster.test.id
+  table_name            = "TestTable"
+  mapping_rule_name     = "TestMapping"
+  retrieval_start_date  = "2023-06-26T12:00:00.6554616Z"
 }`, template, data.RandomString)
 }
 
@@ -135,13 +135,13 @@ func (k KustoCosmosDBDataConnectionResource) requiresImport(data acceptance.Test
 %s
 
 resource "azurerm_kusto_cosmosdb_data_connection" "import" {
-  name                = azurerm_kusto_cosmosdb_data_connection.test.name
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-  cosmosdb_container_id  = azurerm_cosmosdb_sql_container.test.id
-  kusto_database_id       = azurerm_kusto_database.test.id
-  managed_identity_id = azurerm_kusto_cluster.test.id
-  table_name          = "TestTable"
+  name                  = azurerm_kusto_cosmosdb_data_connection.test.name
+  resource_group_name   = azurerm_resource_group.test.name
+  location              = azurerm_resource_group.test.location
+  cosmosdb_container_id = azurerm_cosmosdb_sql_container.test.id
+  kusto_database_id     = azurerm_kusto_database.test.id
+  managed_identity_id   = azurerm_kusto_cluster.test.id
+  table_name            = "TestTable"
   lifecycle {
     ignore_changes = [retrieval_start_date]
   }

--- a/internal/services/kusto/kusto_cosmosdb_data_connection_resource_test.go
+++ b/internal/services/kusto/kusto_cosmosdb_data_connection_resource_test.go
@@ -1,0 +1,238 @@
+package kusto_test
+
+import (
+	"context"
+	"fmt"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2022-12-29/dataconnections"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+type KustoCosmosDBDataConnectionResource struct{}
+
+func (k KustoCosmosDBDataConnectionResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := dataconnections.ParseDataConnectionID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := clients.Kusto.DataConnectionsClient.Get(ctx, *id)
+	if err != nil {
+		return nil, fmt.Errorf("retrieving %s: %v", id.String(), err)
+	}
+
+	if resp.Model != nil {
+		value, ok := (*resp.Model).(dataconnections.CosmosDbDataConnection)
+		if !ok {
+			return nil, fmt.Errorf("%s is not an CosmosDB Data Connection", id.String())
+		}
+		exists := value.Properties != nil
+		return &exists, nil
+	} else {
+		return nil, fmt.Errorf("response model is empty")
+	}
+}
+
+func TestAccKustoCosmosDBDataConnection_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kusto_cosmosdb_data_connection", "test")
+	r := KustoCosmosDBDataConnectionResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("cosmosdb_account_id").Exists(),
+				check.That(data.ResourceName).Key("cosmosdb_database").Exists(),
+				check.That(data.ResourceName).Key("cosmosdb_container").Exists(),
+				check.That(data.ResourceName).Key("cluster_name").Exists(),
+				check.That(data.ResourceName).Key("database_name").Exists(),
+				check.That(data.ResourceName).Key("table_name").Exists(),
+				check.That(data.ResourceName).Key("managed_identity_id").Exists(),
+				check.That(data.ResourceName).Key("table_name").HasValue("TestTable"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccKustoCosmosDBDataConnection_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kusto_cosmosdb_data_connection", "test")
+	r := KustoCosmosDBDataConnectionResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("cosmosdb_account_id").Exists(),
+				check.That(data.ResourceName).Key("cosmosdb_database").Exists(),
+				check.That(data.ResourceName).Key("cosmosdb_container").Exists(),
+				check.That(data.ResourceName).Key("cluster_name").Exists(),
+				check.That(data.ResourceName).Key("database_name").Exists(),
+				check.That(data.ResourceName).Key("table_name").Exists(),
+				check.That(data.ResourceName).Key("managed_identity_id").Exists(),
+				check.That(data.ResourceName).Key("table_name").HasValue("TestTable"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("cosmosdb_account_id").Exists(),
+				check.That(data.ResourceName).Key("cosmosdb_database").Exists(),
+				check.That(data.ResourceName).Key("cosmosdb_container").Exists(),
+				check.That(data.ResourceName).Key("cluster_name").Exists(),
+				check.That(data.ResourceName).Key("database_name").Exists(),
+				check.That(data.ResourceName).Key("table_name").Exists(),
+				check.That(data.ResourceName).Key("managed_identity_id").Exists(),
+				check.That(data.ResourceName).Key("table_name").HasValue("TestTable"),
+				check.That(data.ResourceName).Key("mapping_rule_name").HasValue("TestMappingRule"),
+				check.That(data.ResourceName).Key("retrieval_start_date").HasValue("2023-02-29T12:00:00.6554616Z"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func (k KustoCosmosDBDataConnectionResource) basic(data acceptance.TestData) string {
+	template := k.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_kusto_cosmosdb_data_connection" "test" {
+	  name                  = "acctestkcd%s"
+	  resource_group_name   = azurerm_resource_group.test.name
+      location              = azurerm_resource_group.test.location
+      cosmosdb_account_id   = azurerm_cosmosdb_account.test.id
+      cosmosdb_database     = azurerm_cosmosdb_sql_database.test.name
+      cosmosdb_container    = azurerm_cosmosdb_sql_container.test.name
+	  cluster_name          = azurerm_kusto_cluster.test.name	
+      database_name         = azurerm_kusto_database.test.name
+      managed_identity_id   = azurerm_user_assigned_identity.test.id
+      table_name            = "TestTable"
+}`, template, data.RandomString)
+}
+
+func (k KustoCosmosDBDataConnectionResource) complete(data acceptance.TestData) string {
+	template := k.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_kusto_cosmosdb_data_connection" "test" {
+	  name                  = "acctestkcd%s"
+	  resource_group_name   = azurerm_resource_group.test.name
+      location              = azurerm_resource_group.test.location
+      cosmosdb_account_id   = azurerm_cosmosdb_account.test.id
+      cosmosdb_database     = azurerm_cosmosdb_sql_database.test.name
+      cosmosdb_container    = azurerm_cosmosdb_sql_container.test.name
+	  cluster_name          = azurerm_kusto_cluster.test.name	
+      database_name         = azurerm_kusto_database.test.name
+      managed_identity_id   = azurerm_user_assigned_identity.test.id
+      table_name            = "TestTable"
+      mapping_rule_name     = "TestMappingRule"
+      retrieval_start_date  = "2023-02-29T12:00:00.6554616Z"
+}`, template, data.RandomString)
+}
+
+func (k KustoCosmosDBDataConnectionResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_user_assigned_identity" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  name                = "acctestuami-%d"
+}
+
+resource "azurerm_cosmosdb_account" "test" {
+  name                = "acctest-ca-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  offer_type          = "Standard"
+  kind                = "GlobalDocumentDB"
+
+  consistency_policy {
+    consistency_level = "Session"
+    max_interval_in_seconds = 5
+    max_staleness_prefix = 100
+  }
+
+  geo_location {
+    location          = azurerm_resource_group.test.location
+    failover_priority = 0
+  }
+}
+
+resource "azurerm_cosmosdb_sql_database" "test" {
+  name                = "acctestcosmosdbsqldb-%d"
+  resource_group_name = azurerm_cosmosdb_account.test.resource_group_name
+  account_name        = azurerm_cosmosdb_account.test.name
+}
+
+resource "azurerm_cosmosdb_sql_container" "test" {
+  name                  = "acctestcosmosdbsqlcon-%d"
+  resource_group_name   = azurerm_cosmosdb_account.test.resource_group_name
+  account_name          = azurerm_cosmosdb_account.test.name
+  database_name         = azurerm_cosmosdb_sql_database.test.name
+  partition_key_path    = "/part"
+  throughput            = 400
+}
+
+data "azurerm_cosmosdb_sql_role_definition" "test" {
+  role_definition_id = "00000000-0000-0000-0000-000000000001"
+  resource_group_name = azurerm_resource_group.test.name
+  account_name        = azurerm_cosmosdb_account.test.name
+}
+
+
+resource "azurerm_cosmosdb_sql_role_assignment" "test" {
+  resource_group_name = azurerm_resource_group.test.name
+  account_name        = azurerm_cosmosdb_account.test.name
+  role_definition_id  = azurerm_cosmosdb_sql_role_definition.test.id
+  principal_id        = azurerm_user_assigned_identity.test.principal_id
+  scope               = azurerm_cosmosdb_account.test.id
+}
+
+resource "azurerm_kusto_cluster" "test" {
+  name                = "acctestkc%s"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku {
+    name     = "Dev(No SLA)_Standard_D11_v2"
+    capacity = 1
+  }
+
+  identity {
+    type = "SystemAssigned, UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.test.id]
+  }
+}
+
+resource "azurerm_kusto_database" "test" {
+  name                = "acctestkd-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  cluster_name        = azurerm_kusto_cluster.test.name
+}
+
+resource "azurerm_kusto_script" "test" {
+  name = "create-table-script"
+  database_id = azurerm_kusto_database.test.id
+  script_content = ".create table TestTable(Id:string, Name:string, _ts:long, _timestamp:datetime)"
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomString, data.RandomInteger)
+}

--- a/internal/services/kusto/kusto_cosmosdb_data_connection_resource_test.go
+++ b/internal/services/kusto/kusto_cosmosdb_data_connection_resource_test.go
@@ -119,19 +119,19 @@ func (k KustoCosmosDBDataConnectionResource) basic(data acceptance.TestData) str
 %s
 
 resource "azurerm_kusto_cosmosdb_data_connection" "test" {
-	  name                  = "acctestkcd%s"
-	  resource_group_name   = azurerm_resource_group.test.name
-      location              = azurerm_resource_group.test.location
-      cosmosdb_account_id   = azurerm_cosmosdb_account.test.id
-      cosmosdb_database     = azurerm_cosmosdb_sql_database.test.name
-      cosmosdb_container    = azurerm_cosmosdb_sql_container.test.name
-	  cluster_name          = azurerm_kusto_cluster.test.name	
-      database_name         = azurerm_kusto_database.test.name
-      managed_identity_id   = azurerm_kusto_cluster.test.id
-      table_name            = "TestTable"
-      lifecycle {
-        ignore_changes = [retrieval_start_date]
-      }
+  name                = "acctestkcd%s"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  cosmosdb_account_id = azurerm_cosmosdb_account.test.id
+  cosmosdb_database   = azurerm_cosmosdb_sql_database.test.name
+  cosmosdb_container  = azurerm_cosmosdb_sql_container.test.name
+  cluster_name        = azurerm_kusto_cluster.test.name
+  database_name       = azurerm_kusto_database.test.name
+  managed_identity_id = azurerm_kusto_cluster.test.id
+  table_name          = "TestTable"
+  lifecycle {
+    ignore_changes = [retrieval_start_date]
+  }
 }`, template, data.RandomString)
 }
 
@@ -141,18 +141,18 @@ func (k KustoCosmosDBDataConnectionResource) complete(data acceptance.TestData) 
 %s
 
 resource "azurerm_kusto_cosmosdb_data_connection" "test" {
-	  name                  = "acctestkcd%s"
-	  resource_group_name   = azurerm_resource_group.test.name
-      location              = azurerm_resource_group.test.location
-      cosmosdb_account_id   = azurerm_cosmosdb_account.test.id
-      cosmosdb_database     = azurerm_cosmosdb_sql_database.test.name
-      cosmosdb_container    = azurerm_cosmosdb_sql_container.test.name
-	  cluster_name          = azurerm_kusto_cluster.test.name	
-      database_name         = azurerm_kusto_database.test.name
-      managed_identity_id   = azurerm_kusto_cluster.test.id
-      table_name            = "TestTable"
-      mapping_rule_name     = "TestMapping"
-      retrieval_start_date  = "2023-06-26T12:00:00.6554616Z"
+  name                 = "acctestkcd%s"
+  resource_group_name  = azurerm_resource_group.test.name
+  location             = azurerm_resource_group.test.location
+  cosmosdb_account_id  = azurerm_cosmosdb_account.test.id
+  cosmosdb_database    = azurerm_cosmosdb_sql_database.test.name
+  cosmosdb_container   = azurerm_cosmosdb_sql_container.test.name
+  cluster_name         = azurerm_kusto_cluster.test.name
+  database_name        = azurerm_kusto_database.test.name
+  managed_identity_id  = azurerm_kusto_cluster.test.id
+  table_name           = "TestTable"
+  mapping_rule_name    = "TestMapping"
+  retrieval_start_date = "2023-06-26T12:00:00.6554616Z"
 }`, template, data.RandomString)
 }
 
@@ -162,19 +162,19 @@ func (k KustoCosmosDBDataConnectionResource) requiresImport(data acceptance.Test
 %s
 
 resource "azurerm_kusto_cosmosdb_data_connection" "import" {
-	  name                  = azurerm_kusto_cosmosdb_data_connection.test.name
-	  resource_group_name   = azurerm_resource_group.test.name
-      location              = azurerm_resource_group.test.location
-      cosmosdb_account_id   = azurerm_cosmosdb_account.test.id
-      cosmosdb_database     = azurerm_cosmosdb_sql_database.test.name
-      cosmosdb_container    = azurerm_cosmosdb_sql_container.test.name
-	  cluster_name          = azurerm_kusto_cluster.test.name	
-      database_name         = azurerm_kusto_database.test.name
-      managed_identity_id   = azurerm_kusto_cluster.test.id
-      table_name            = "TestTable"
-      lifecycle {
-        ignore_changes = [retrieval_start_date]
-      }
+  name                = azurerm_kusto_cosmosdb_data_connection.test.name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  cosmosdb_account_id = azurerm_cosmosdb_account.test.id
+  cosmosdb_database   = azurerm_cosmosdb_sql_database.test.name
+  cosmosdb_container  = azurerm_cosmosdb_sql_container.test.name
+  cluster_name        = azurerm_kusto_cluster.test.name
+  database_name       = azurerm_kusto_database.test.name
+  managed_identity_id = azurerm_kusto_cluster.test.id
+  table_name          = "TestTable"
+  lifecycle {
+    ignore_changes = [retrieval_start_date]
+  }
 }`, template)
 }
 
@@ -209,9 +209,9 @@ resource "azurerm_cosmosdb_account" "test" {
   kind                = "GlobalDocumentDB"
 
   consistency_policy {
-    consistency_level = "Session"
+    consistency_level       = "Session"
     max_interval_in_seconds = 5
-    max_staleness_prefix = 100
+    max_staleness_prefix    = 100
   }
 
   geo_location {
@@ -227,16 +227,16 @@ resource "azurerm_cosmosdb_sql_database" "test" {
 }
 
 resource "azurerm_cosmosdb_sql_container" "test" {
-  name                  = "acctestcosmosdbsqlcon-%d"
-  resource_group_name   = azurerm_cosmosdb_account.test.resource_group_name
-  account_name          = azurerm_cosmosdb_account.test.name
-  database_name         = azurerm_cosmosdb_sql_database.test.name
-  partition_key_path    = "/part"
-  throughput            = 400
+  name                = "acctestcosmosdbsqlcon-%d"
+  resource_group_name = azurerm_cosmosdb_account.test.resource_group_name
+  account_name        = azurerm_cosmosdb_account.test.name
+  database_name       = azurerm_cosmosdb_sql_database.test.name
+  partition_key_path  = "/part"
+  throughput          = 400
 }
 
 data "azurerm_cosmosdb_sql_role_definition" "test" {
-  role_definition_id = "00000000-0000-0000-0000-000000000001"
+  role_definition_id  = "00000000-0000-0000-0000-000000000001"
   resource_group_name = azurerm_resource_group.test.name
   account_name        = azurerm_cosmosdb_account.test.name
 }
@@ -272,8 +272,8 @@ resource "azurerm_kusto_database" "test" {
 }
 
 resource "azurerm_kusto_script" "test" {
-  name = "create-table-script"
-  database_id = azurerm_kusto_database.test.id
+  name           = "create-table-script"
+  database_id    = azurerm_kusto_database.test.id
   script_content = <<SCRIPT
 .create table TestTable(Id:string, Name:string, _ts:long, _timestamp:datetime)
 .create table TestTable ingestion json mapping "TestMapping"

--- a/internal/services/kusto/kusto_cosmosdb_data_connection_resource_test.go
+++ b/internal/services/kusto/kusto_cosmosdb_data_connection_resource_test.go
@@ -64,21 +64,21 @@ func TestAccKustoCosmosDBDataConnection_completeUpdated(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_kusto_cosmosdb_data_connection", "test")
 	r := KustoCosmosDBDataConnectionResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
-		//{
-		//	Config: r.basic(data),
-		//	Check: acceptance.ComposeTestCheckFunc(
-		//		check.That(data.ResourceName).ExistsInAzure(r),
-		//		check.That(data.ResourceName).Key("cosmosdb_account_id").Exists(),
-		//		check.That(data.ResourceName).Key("cosmosdb_database").Exists(),
-		//		check.That(data.ResourceName).Key("cosmosdb_container").Exists(),
-		//		check.That(data.ResourceName).Key("cluster_name").Exists(),
-		//		check.That(data.ResourceName).Key("database_name").Exists(),
-		//		check.That(data.ResourceName).Key("table_name").Exists(),
-		//		check.That(data.ResourceName).Key("managed_identity_id").Exists(),
-		//		check.That(data.ResourceName).Key("table_name").HasValue("TestTable"),
-		//	),
-		//},
-		//data.ImportStep(),
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("cosmosdb_account_id").Exists(),
+				check.That(data.ResourceName).Key("cosmosdb_database").Exists(),
+				check.That(data.ResourceName).Key("cosmosdb_container").Exists(),
+				check.That(data.ResourceName).Key("cluster_name").Exists(),
+				check.That(data.ResourceName).Key("database_name").Exists(),
+				check.That(data.ResourceName).Key("table_name").Exists(),
+				check.That(data.ResourceName).Key("managed_identity_id").Exists(),
+				check.That(data.ResourceName).Key("table_name").HasValue("TestTable"),
+			),
+		},
+		data.ImportStep(),
 		{
 			Config: r.complete(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -92,7 +92,7 @@ func TestAccKustoCosmosDBDataConnection_completeUpdated(t *testing.T) {
 				check.That(data.ResourceName).Key("managed_identity_id").Exists(),
 				check.That(data.ResourceName).Key("table_name").HasValue("TestTable"),
 				check.That(data.ResourceName).Key("mapping_rule_name").HasValue("TestMapping"),
-				// check.That(data.ResourceName).Key("retrieval_start_date").HasValue("2023-06-29T12:00:00.6554616Z"),
+				check.That(data.ResourceName).Key("retrieval_start_date").HasValue("2023-06-26T12:00:00.6554616Z"),
 			),
 		},
 		data.ImportStep(),
@@ -152,7 +152,7 @@ resource "azurerm_kusto_cosmosdb_data_connection" "test" {
       managed_identity_id   = azurerm_kusto_cluster.test.id
       table_name            = "TestTable"
       mapping_rule_name     = "TestMapping"
-      retrieval_start_date  = "2023-06-29T12:00:00.6554616Z"
+      retrieval_start_date  = "2023-06-26T12:00:00.6554616Z"
 }`, template, data.RandomString)
 }
 

--- a/internal/services/kusto/registration.go
+++ b/internal/services/kusto/registration.go
@@ -9,6 +9,18 @@ type Registration struct{}
 
 var _ sdk.UntypedServiceRegistrationWithAGitHubLabel = Registration{}
 
+var _ sdk.TypedServiceRegistrationWithAGitHubLabel = Registration{}
+
+func (r Registration) DataSources() []sdk.DataSource {
+	return []sdk.DataSource{}
+}
+
+func (r Registration) Resources() []sdk.Resource {
+	return []sdk.Resource{
+		CosmosDBDataConnectionResource{},
+	}
+}
+
 func (r Registration) AssociatedGitHubLabel() string {
 	return "service/kusto"
 }

--- a/website/docs/r/kusto_cosmosdb_data_connection.html.markdown
+++ b/website/docs/r/kusto_cosmosdb_data_connection.html.markdown
@@ -3,27 +3,132 @@ subcategory: "Data Explorer"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_kusto_cosmosdb_data_connection"
 description: |-
-  Manages a Data Explorer.
+  Manages a Kusto / Cosmos Database Data Connection.
 ---
 
 # azurerm_kusto_cosmosdb_data_connection
 
-Manages a Data Explorer.
+Manages a Kusto / Cosmos Database Data Connection.
 
 ## Example Usage
 
 ```hcl
-resource "azurerm_kusto_cosmosdb_data_connection" "example" {
-  name = "example"
-  resource_group_name = "example"
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_resource_group" "example" {
+  name     = "accexampleRG"
   location = "West Europe"
-  cosmosdb_account_id = "TODO"
-  cosmosdb_container = "TODO"
-  managed_identity_id = "TODO"
-  cluster_name = "example"
-  database_name = "example"
-  cosmosdb_database = "TODO"
-  table_name = "example"
+}
+
+data "azurerm_role_definition" "builtin" {
+  role_definition_id = "fbdf93bf-df7d-467e-a4d2-9458aa1360c8"
+}
+
+resource "azurerm_role_assignment" "example" {
+  scope                = azurerm_resource_group.example.id
+  role_definition_name = data.azurerm_role_definition.builtin.name
+  principal_id         = azurerm_kusto_cluster.example.identity[0].principal_id
+}
+
+resource "azurerm_cosmosdb_account" "example" {
+  name                = "accexample-ca"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  offer_type          = "Standard"
+  kind                = "GlobalDocumentDB"
+
+  consistency_policy {
+    consistency_level       = "Session"
+    max_interval_in_seconds = 5
+    max_staleness_prefix    = 100
+  }
+
+  geo_location {
+    location          = azurerm_resource_group.example.location
+    failover_priority = 0
+  }
+}
+
+resource "azurerm_cosmosdb_sql_database" "example" {
+  name                = "accexamplecosmosdbsqldb"
+  resource_group_name = azurerm_cosmosdb_account.example.resource_group_name
+  account_name        = azurerm_cosmosdb_account.example.name
+}
+
+resource "azurerm_cosmosdb_sql_container" "example" {
+  name                = "accexamplecosmosdbsqlcon"
+  resource_group_name = azurerm_cosmosdb_account.example.resource_group_name
+  account_name        = azurerm_cosmosdb_account.example.name
+  database_name       = azurerm_cosmosdb_sql_database.example.name
+  partition_key_path  = "/part"
+  throughput          = 400
+}
+
+data "azurerm_cosmosdb_sql_role_definition" "example" {
+  role_definition_id  = "00000000-0000-0000-0000-000000000001"
+  resource_group_name = azurerm_resource_group.example.name
+  account_name        = azurerm_cosmosdb_account.example.name
+}
+
+
+resource "azurerm_cosmosdb_sql_role_assignment" "example" {
+  resource_group_name = azurerm_resource_group.example.name
+  account_name        = azurerm_cosmosdb_account.example.name
+  role_definition_id  = data.azurerm_cosmosdb_sql_role_definition.example.id
+  principal_id        = azurerm_kusto_cluster.example.identity[0].principal_id
+  scope               = azurerm_cosmosdb_account.example.id
+}
+
+resource "azurerm_kusto_cluster" "example" {
+  name                = "accexamplekc%s"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  sku {
+    name     = "Dev(No SLA)_Standard_D11_v2"
+    capacity = 1
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+resource "azurerm_kusto_database" "example" {
+  name                = "accexamplekd"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+  cluster_name        = azurerm_kusto_cluster.example.name
+}
+
+resource "azurerm_kusto_script" "example" {
+  name           = "create-table-script"
+  database_id    = azurerm_kusto_database.example.id
+  script_content = <<SCRIPT
+.create table TestTable(Id:string, Name:string, _ts:long, _timestamp:datetime)
+.create table TestTable ingestion json mapping "TestMapping"
+'['
+'    {"column":"Id","path":"$.id"},'
+'    {"column":"Name","path":"$.name"},'
+'    {"column":"_ts","path":"$._ts"},'
+'    {"column":"_timestamp","path":"$._ts", "transform":"DateTimeFromUnixSeconds"}'
+']'
+.alter table TestTable policy ingestionbatching "{'MaximumBatchingTimeSpan': '0:0:10', 'MaximumNumberOfItems': 10000}"
+SCRIPT
+}
+
+resource "azurerm_kusto_cosmosdb_data_connection" "test" {
+  name                 = "acctestkcd%s"
+  resource_group_name  = azurerm_resource_group.test.name
+  location             = azurerm_resource_group.test.location
+  cosmosdb_account_id  = azurerm_cosmosdb_account.test.id
+  cosmosdb_database    = azurerm_cosmosdb_sql_database.test.name
+  cosmosdb_container   = azurerm_cosmosdb_sql_container.test.name
+  cluster_name         = azurerm_kusto_cluster.test.name
+  database_name        = azurerm_kusto_database.test.name
+  managed_identity_id  = azurerm_kusto_cluster.test.id
+  table_name           = "TestTable"
+  mapping_rule_name    = "TestMapping"
+  retrieval_start_date = "2023-06-26T12:00:00.6554616Z"
 }
 ```
 
@@ -31,31 +136,31 @@ resource "azurerm_kusto_cosmosdb_data_connection" "example" {
 
 The following arguments are supported:
 
-* `cluster_name` - (Required) TODO. Changing this forces a new Data Explorer to be created.
+* `cluster_name` - (Required) The name of the Kusto cluster.Changing this forces a new Data Explorer to be created.
 
-* `cosmosdb_account_id` - (Required) The ID of the TODO. Changing this forces a new Data Explorer to be created.
+* `cosmosdb_account_id` - (Required) The resource ID of the Cosmos DB account used to create the data connection. Changing this forces a new Data Explorer to be created.
 
-* `cosmosdb_container` - (Required) TODO. Changing this forces a new Data Explorer to be created.
+* `cosmosdb_container` - (Required) The name of an existing container in the Cosmos DB database. Changing this forces a new Data Explorer to be created.
 
-* `cosmosdb_database` - (Required) TODO. Changing this forces a new Data Explorer to be created.
+* `cosmosdb_database` - (Required) The name of an existing database in the Cosmos DB account. Changing this forces a new Data Explorer to be created.
 
-* `database_name` - (Required) TODO. Changing this forces a new Data Explorer to be created.
+* `database_name` - (Required) The name of the database in the Kusto cluster. Changing this forces a new Data Explorer to be created.
 
 * `location` - (Required) The Azure Region where the Data Explorer should exist. Changing this forces a new Data Explorer to be created.
 
-* `managed_identity_id` - (Required) The ID of the TODO. Changing this forces a new Data Explorer to be created.
+* `managed_identity_id` - (Required) The resource ID of a managed system or user-assigned identity. The identity is used to authenticate with Cosmos DB. Changing this forces a new Data Explorer to be created.
 
-* `name` - (Required) The name which should be used for this Data Explorer. Changing this forces a new Data Explorer to be created.
+* `name` - (Required) The name of the data connection. Changing this forces a new Data Explorer to be created.
 
 * `resource_group_name` - (Required) The name of the Resource Group where the Data Explorer should exist. Changing this forces a new Data Explorer to be created.
 
-* `table_name` - (Required) TODO. Changing this forces a new Data Explorer to be created.
+* `table_name` - (Required) The case-sensitive name of the existing target table in your cluster. Retrieved data is ingested into this table. Changing this forces a new Data Explorer to be created.
 
 ---
 
-* `mapping_rule_name` - (Optional) TODO.
+* `mapping_rule_name` - (Optional) The name of an existing mapping rule to use when ingesting the retrieved data.
 
-* `retrieval_start_date` - (Optional) TODO.
+* `retrieval_start_date` - (Optional) If defined, the data connection retrieves Cosmos DB documents created or updated after the specified retrieval start date.
 
 ## Attributes Reference
 
@@ -77,5 +182,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 Data Explorers can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_kusto_cosmosdb_data_connection.example C:/Program Files/Git/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Kusto/clusters/cluster1/databases/database1/dataConnections/dataConnection1
+terraform import azurerm_kusto_cosmosdb_data_connection.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Kusto/clusters/cluster1/databases/database1/dataConnections/dataConnection1
 ```

--- a/website/docs/r/kusto_cosmosdb_data_connection.html.markdown
+++ b/website/docs/r/kusto_cosmosdb_data_connection.html.markdown
@@ -16,7 +16,7 @@ Manages a Kusto / Cosmos Database Data Connection.
 data "azurerm_client_config" "current" {}
 
 resource "azurerm_resource_group" "example" {
-  name     = "accexampleRG"
+  name     = "exampleRG"
   location = "West Europe"
 }
 
@@ -31,7 +31,7 @@ resource "azurerm_role_assignment" "example" {
 }
 
 resource "azurerm_cosmosdb_account" "example" {
-  name                = "accexample-ca"
+  name                = "example-ca"
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
   offer_type          = "Standard"
@@ -50,13 +50,13 @@ resource "azurerm_cosmosdb_account" "example" {
 }
 
 resource "azurerm_cosmosdb_sql_database" "example" {
-  name                = "accexamplecosmosdbsqldb"
+  name                = "examplecosmosdbsqldb"
   resource_group_name = azurerm_cosmosdb_account.example.resource_group_name
   account_name        = azurerm_cosmosdb_account.example.name
 }
 
 resource "azurerm_cosmosdb_sql_container" "example" {
-  name                = "accexamplecosmosdbsqlcon"
+  name                = "examplecosmosdbsqlcon"
   resource_group_name = azurerm_cosmosdb_account.example.resource_group_name
   account_name        = azurerm_cosmosdb_account.example.name
   database_name       = azurerm_cosmosdb_sql_database.example.name
@@ -80,7 +80,7 @@ resource "azurerm_cosmosdb_sql_role_assignment" "example" {
 }
 
 resource "azurerm_kusto_cluster" "example" {
-  name                = "accexamplekc%s"
+  name                = "examplekc"
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name
   sku {
@@ -94,7 +94,7 @@ resource "azurerm_kusto_cluster" "example" {
 }
 
 resource "azurerm_kusto_database" "example" {
-  name                = "accexamplekd"
+  name                = "examplekd"
   resource_group_name = azurerm_resource_group.example.name
   location            = azurerm_resource_group.example.location
   cluster_name        = azurerm_kusto_cluster.example.name

--- a/website/docs/r/kusto_cosmosdb_data_connection.html.markdown
+++ b/website/docs/r/kusto_cosmosdb_data_connection.html.markdown
@@ -136,7 +136,7 @@ resource "azurerm_kusto_cosmosdb_data_connection" "test" {
 
 The following arguments are supported:
 
-* `cluster_name` - (Required) The name of the Kusto cluster.Changing this forces a new Data Explorer to be created.
+* `cluster_name` - (Required) The name of the Kusto cluster. Changing this forces a new Data Explorer to be created.
 
 * `cosmosdb_account_id` - (Required) The resource ID of the Cosmos DB account used to create the data connection. Changing this forces a new Data Explorer to be created.
 

--- a/website/docs/r/kusto_cosmosdb_data_connection.html.markdown
+++ b/website/docs/r/kusto_cosmosdb_data_connection.html.markdown
@@ -174,7 +174,6 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 
 * `create` - (Defaults to 30 minutes) Used when creating the Data Explorer.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Data Explorer.
-* `update` - (Defaults to 30 minutes) Used when updating the Data Explorer.
 * `delete` - (Defaults to 30 minutes) Used when deleting the Data Explorer.
 
 ## Import

--- a/website/docs/r/kusto_cosmosdb_data_connection.html.markdown
+++ b/website/docs/r/kusto_cosmosdb_data_connection.html.markdown
@@ -166,7 +166,7 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 
 ## Import
 
-Data Explorers can be imported using the `resource id`, e.g.
+Kusto / Cosmos Database Data Connection can be imported using the `resource id`, e.g.
 
 ```shell
 terraform import azurerm_kusto_cosmosdb_data_connection.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Kusto/clusters/cluster1/databases/database1/dataConnections/dataConnection1

--- a/website/docs/r/kusto_cosmosdb_data_connection.html.markdown
+++ b/website/docs/r/kusto_cosmosdb_data_connection.html.markdown
@@ -136,31 +136,31 @@ resource "azurerm_kusto_cosmosdb_data_connection" "test" {
 
 The following arguments are supported:
 
-* `cluster_name` - (Required) The name of the Kusto cluster. Changing this forces a new Data Explorer to be created.
+* `cluster_name` - (Required) The name of the Kusto cluster. Changing this forces a new Kusto Cosmos DB Connection to be created.
 
-* `cosmosdb_account_id` - (Required) The resource ID of the Cosmos DB account used to create the data connection. Changing this forces a new Data Explorer to be created.
+* `cosmosdb_account_id` - (Required) The resource ID of the Cosmos DB account used to create the data connection. Changing this forces a new Kusto Cosmos DB Connection to be created.
 
-* `cosmosdb_container` - (Required) The name of an existing container in the Cosmos DB database. Changing this forces a new Data Explorer to be created.
+* `cosmosdb_container` - (Required) The name of an existing container in the Cosmos DB database. Changing this forces a new Kusto Cosmos DB Connection to be created.
 
-* `cosmosdb_database` - (Required) The name of an existing database in the Cosmos DB account. Changing this forces a new Data Explorer to be created.
+* `cosmosdb_database` - (Required) The name of an existing database in the Cosmos DB account. Changing this forces a new Kusto Cosmos DB Connection to be created.
 
-* `database_name` - (Required) The name of the database in the Kusto cluster. Changing this forces a new Data Explorer to be created.
+* `database_name` - (Required) The name of the database in the Kusto cluster. Changing this forces a new Kusto Cosmos DB Connection to be created.
 
-* `location` - (Required) The Azure Region where the Data Explorer should exist. Changing this forces a new Data Explorer to be created.
+* `location` - (Required) The Azure Region where the Data Explorer should exist. Changing this forces a new Kusto Cosmos DB Connection to be created.
 
-* `managed_identity_id` - (Required) The resource ID of a managed system or user-assigned identity. The identity is used to authenticate with Cosmos DB. Changing this forces a new Data Explorer to be created.
+* `managed_identity_id` - (Required) The resource ID of a managed system or user-assigned identity. The identity is used to authenticate with Cosmos DB. Changing this forces a new Kusto Cosmos DB Connection to be created.
 
-* `name` - (Required) The name of the data connection. Changing this forces a new Data Explorer to be created.
+* `name` - (Required) The name of the data connection. Changing this forces a new Kusto Cosmos DB Connection to be created.
 
-* `resource_group_name` - (Required) The name of the Resource Group where the Data Explorer should exist. Changing this forces a new Data Explorer to be created.
+* `resource_group_name` - (Required) The name of the Resource Group where the Data Explorer should exist. Changing this forces a new Kusto Cosmos DB Connection to be created.
 
-* `table_name` - (Required) The case-sensitive name of the existing target table in your cluster. Retrieved data is ingested into this table. Changing this forces a new Data Explorer to be created.
+* `table_name` - (Required) The case-sensitive name of the existing target table in your cluster. Retrieved data is ingested into this table. Changing this forces a new Kusto Cosmos DB Connection to be created.
 
 ---
 
-* `mapping_rule_name` - (Optional) The name of an existing mapping rule to use when ingesting the retrieved data.
+* `mapping_rule_name` - (Optional) The name of an existing mapping rule to use when ingesting the retrieved data. Changing this forces a new Kusto Cosmos DB Connection to be created.
 
-* `retrieval_start_date` - (Optional) If defined, the data connection retrieves Cosmos DB documents created or updated after the specified retrieval start date.
+* `retrieval_start_date` - (Optional) If defined, the data connection retrieves Cosmos DB documents created or updated after the specified retrieval start date. Changing this forces a new Kusto Cosmos DB Connection to be created.
 
 ## Attributes Reference
 

--- a/website/docs/r/kusto_cosmosdb_data_connection.html.markdown
+++ b/website/docs/r/kusto_cosmosdb_data_connection.html.markdown
@@ -1,0 +1,81 @@
+---
+subcategory: "Data Explorer"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_kusto_cosmosdb_data_connection"
+description: |-
+  Manages a Data Explorer.
+---
+
+# azurerm_kusto_cosmosdb_data_connection
+
+Manages a Data Explorer.
+
+## Example Usage
+
+```hcl
+resource "azurerm_kusto_cosmosdb_data_connection" "example" {
+  name = "example"
+  resource_group_name = "example"
+  location = "West Europe"
+  cosmosdb_account_id = "TODO"
+  cosmosdb_container = "TODO"
+  managed_identity_id = "TODO"
+  cluster_name = "example"
+  database_name = "example"
+  cosmosdb_database = "TODO"
+  table_name = "example"
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `cluster_name` - (Required) TODO. Changing this forces a new Data Explorer to be created.
+
+* `cosmosdb_account_id` - (Required) The ID of the TODO. Changing this forces a new Data Explorer to be created.
+
+* `cosmosdb_container` - (Required) TODO. Changing this forces a new Data Explorer to be created.
+
+* `cosmosdb_database` - (Required) TODO. Changing this forces a new Data Explorer to be created.
+
+* `database_name` - (Required) TODO. Changing this forces a new Data Explorer to be created.
+
+* `location` - (Required) The Azure Region where the Data Explorer should exist. Changing this forces a new Data Explorer to be created.
+
+* `managed_identity_id` - (Required) The ID of the TODO. Changing this forces a new Data Explorer to be created.
+
+* `name` - (Required) The name which should be used for this Data Explorer. Changing this forces a new Data Explorer to be created.
+
+* `resource_group_name` - (Required) The name of the Resource Group where the Data Explorer should exist. Changing this forces a new Data Explorer to be created.
+
+* `table_name` - (Required) TODO. Changing this forces a new Data Explorer to be created.
+
+---
+
+* `mapping_rule_name` - (Optional) TODO.
+
+* `retrieval_start_date` - (Optional) TODO.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported: 
+
+* `id` - The ID of the Data Explorer.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Data Explorer.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Data Explorer.
+* `update` - (Defaults to 30 minutes) Used when updating the Data Explorer.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Data Explorer.
+
+## Import
+
+Data Explorers can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_kusto_cosmosdb_data_connection.example C:/Program Files/Git/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Kusto/clusters/cluster1/databases/database1/dataConnections/dataConnection1
+```

--- a/website/docs/r/kusto_cosmosdb_data_connection.html.markdown
+++ b/website/docs/r/kusto_cosmosdb_data_connection.html.markdown
@@ -116,19 +116,16 @@ resource "azurerm_kusto_script" "example" {
 SCRIPT
 }
 
-resource "azurerm_kusto_cosmosdb_data_connection" "test" {
-  name                 = "acctestkcd%s"
-  resource_group_name  = azurerm_resource_group.test.name
-  location             = azurerm_resource_group.test.location
-  cosmosdb_account_id  = azurerm_cosmosdb_account.test.id
-  cosmosdb_database    = azurerm_cosmosdb_sql_database.test.name
-  cosmosdb_container   = azurerm_cosmosdb_sql_container.test.name
-  cluster_name         = azurerm_kusto_cluster.test.name
-  database_name        = azurerm_kusto_database.test.name
-  managed_identity_id  = azurerm_kusto_cluster.test.id
-  table_name           = "TestTable"
-  mapping_rule_name    = "TestMapping"
-  retrieval_start_date = "2023-06-26T12:00:00.6554616Z"
+resource "azurerm_kusto_cosmosdb_data_connection" "example" {
+  name                  = "examplekcdcd"
+  resource_group_name   = azurerm_resource_group.example.name
+  location              = azurerm_resource_group.example.location
+  cosmosdb_container_id = azurerm_cosmosdb_sql_container.example.id
+  kusto_database_id     = azurerm_kusto_database.example.id
+  managed_identity_id   = azurerm_kusto_cluster.example.id
+  table_name            = "TestTable"
+  mapping_rule_name     = "TestMapping"
+  retrieval_start_date  = "2023-06-26T12:00:00.6554616Z"
 }
 ```
 
@@ -136,15 +133,9 @@ resource "azurerm_kusto_cosmosdb_data_connection" "test" {
 
 The following arguments are supported:
 
-* `cluster_name` - (Required) The name of the Kusto cluster. Changing this forces a new Kusto Cosmos DB Connection to be created.
+* `cosmosdb_container_id` - (Required) The name of an existing container in the Cosmos DB database. Changing this forces a new Kusto Cosmos DB Connection to be created.
 
-* `cosmosdb_account_id` - (Required) The resource ID of the Cosmos DB account used to create the data connection. Changing this forces a new Kusto Cosmos DB Connection to be created.
-
-* `cosmosdb_container` - (Required) The name of an existing container in the Cosmos DB database. Changing this forces a new Kusto Cosmos DB Connection to be created.
-
-* `cosmosdb_database` - (Required) The name of an existing database in the Cosmos DB account. Changing this forces a new Kusto Cosmos DB Connection to be created.
-
-* `database_name` - (Required) The name of the database in the Kusto cluster. Changing this forces a new Kusto Cosmos DB Connection to be created.
+* `kusto_database_id` - (Required) The name of the database in the Kusto cluster. Changing this forces a new Kusto Cosmos DB Connection to be created.
 
 * `location` - (Required) The Azure Region where the Data Explorer should exist. Changing this forces a new Kusto Cosmos DB Connection to be created.
 
@@ -172,9 +163,9 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the Data Explorer.
-* `read` - (Defaults to 5 minutes) Used when retrieving the Data Explorer.
-* `delete` - (Defaults to 30 minutes) Used when deleting the Data Explorer.
+* `create` - (Defaults to 30 minutes) Used when creating the Kusto / Cosmos Database Data Connection.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Kusto / Cosmos Database Data Connection.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Kusto / Cosmos Database Data Connection.
 
 ## Import
 

--- a/website/docs/r/kusto_cosmosdb_data_connection.html.markdown
+++ b/website/docs/r/kusto_cosmosdb_data_connection.html.markdown
@@ -118,7 +118,6 @@ SCRIPT
 
 resource "azurerm_kusto_cosmosdb_data_connection" "example" {
   name                  = "examplekcdcd"
-  resource_group_name   = azurerm_resource_group.example.name
   location              = azurerm_resource_group.example.location
   cosmosdb_container_id = azurerm_cosmosdb_sql_container.example.id
   kusto_database_id     = azurerm_kusto_database.example.id
@@ -142,8 +141,6 @@ The following arguments are supported:
 * `managed_identity_id` - (Required) The resource ID of a managed system or user-assigned identity. The identity is used to authenticate with Cosmos DB. Changing this forces a new Kusto Cosmos DB Connection to be created.
 
 * `name` - (Required) The name of the data connection. Changing this forces a new Kusto Cosmos DB Connection to be created.
-
-* `resource_group_name` - (Required) The name of the Resource Group where the Data Explorer should exist. Changing this forces a new Kusto Cosmos DB Connection to be created.
 
 * `table_name` - (Required) The case-sensitive name of the existing target table in your cluster. Retrieved data is ingested into this table. Changing this forces a new Kusto Cosmos DB Connection to be created.
 


### PR DESCRIPTION
New Resource: `azurerm_kusto_cosmosdb_data_connection`

Swagger
- https://github.com/Azure/azure-rest-api-specs/blob/main/specification/azure-kusto/resource-manager/Microsoft.Kusto/stable/2022-12-29/kusto.json

New Properties:

* `cluster_name` - (Required) The name of the Kusto cluster. Changing this forces a new Data Explorer to be created.

* `cosmosdb_account_id` - (Required) The resource ID of the Cosmos DB account used to create the data connection. Changing this forces a new Data Explorer to be created.

* `cosmosdb_container` - (Required) The name of an existing container in the Cosmos DB database. Changing this forces a new Data Explorer to be created.

* `cosmosdb_database` - (Required) The name of an existing database in the Cosmos DB account. Changing this forces a new Data Explorer to be created.

* `database_name` - (Required) The name of the database in the Kusto cluster. Changing this forces a new Data Explorer to be created.

* `location` - (Required) The Azure Region where the Data Explorer should exist. Changing this forces a new Data Explorer to be created.

* `managed_identity_id` - (Required) The resource ID of a managed system or user-assigned identity. The identity is used to authenticate with Cosmos DB. Changing this forces a new Data Explorer to be created.

* `name` - (Required) The name of the data connection. Changing this forces a new Data Explorer to be created.

* `resource_group_name` - (Required) The name of the Resource Group where the Data Explorer should exist. Changing this forces a new Data Explorer to be created.

* `table_name` - (Required) The case-sensitive name of the existing target table in your cluster. Retrieved data is ingested into this table. Changing this forces a new Data Explorer to be created.

* `mapping_rule_name` - (Optional) The name of an existing mapping rule to use when ingesting the retrieved data.

* `retrieval_start_date` - (Optional) If defined, the data connection retrieves Cosmos DB documents created or updated after the specified retrieval start date.