### PR TITLE
resource azurerm_dns_zone: Add option to re-use host_name with `dns_zone with soa_record` creation

### DIFF
--- a/internal/services/dns/dns_zone_resource.go
+++ b/internal/services/dns/dns_zone_resource.go
@@ -147,13 +147,6 @@ func resourceDnsZone() *pluginsdk.Resource {
 
 			"tags": commonschema.Tags(),
 		},
-		// CustomizeDiff: pluginsdk.CustomDiffWithAll(
-		// 	pluginsdk.ValueChangeConditionFunc()
-		// 	pluginsdk.ForceNewIfChange("host_name", func(ctx context.Context, old, new, meta interface{}) bool {
-		// 		return false
-		// 		//return (old != nil && old.(string) != "") && (new == nil || new.(string) == "")
-		// 	}),
-		// ),
 	}
 }
 
@@ -385,13 +378,14 @@ func flattenArmDNSZoneSOARecord(input *recordsets.RecordSet) []interface{} {
 }
 
 func soaRecordHostName(ctx context.Context, timeout time.Duration, recordSetsClient *recordsets.RecordSetsClient, id zones.DnsZoneId) (*string, error) {
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-
 	soaRecord := recordsets.NewRecordTypeID(id.SubscriptionId, id.ResourceGroupName, id.DnsZoneName, recordsets.RecordTypeSOA, "@")
 	soaRecordResp, err := recordSetsClient.Get(ctx, soaRecord)
 	if err != nil {
 		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+
+	if soaRecordResp.Model.Properties.SOARecord.Host == nil {
+		return nil, fmt.Errorf("retrieved nil host for %s", id)
 	}
 
 	return soaRecordResp.Model.Properties.SOARecord.Host, nil

--- a/internal/services/dns/dns_zone_resource_test.go
+++ b/internal/services/dns/dns_zone_resource_test.go
@@ -71,11 +71,48 @@ func TestAccDnsZone_withTags(t *testing.T) {
 	})
 }
 
-func TestAccDnsZone_withSOARecord(t *testing.T) {
+func TestAccDnsZone_basicSOARecord(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_dns_zone", "test")
 	r := DnsZoneResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.withBasicSOARecord(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccDnsZone_completeSOARecord(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_dns_zone", "test")
+	r := DnsZoneResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.withCompletedSOARecord(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccDnsZone_updateSOARecord(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_dns_zone", "test")
+	r := DnsZoneResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
 		{
 			Config: r.withBasicSOARecord(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -228,7 +265,6 @@ resource "azurerm_dns_zone" "test" {
 
   soa_record {
     email         = "testemail.com"
-    host_name     = "testhost.contoso.com"
     expire_time   = 2419200
     minimum_ttl   = 200
     refresh_time  = 2600

--- a/internal/services/dns/dns_zone_resource_test.go
+++ b/internal/services/dns/dns_zone_resource_test.go
@@ -206,7 +206,6 @@ resource "azurerm_dns_zone" "test" {
 
   soa_record {
     email     = "testemail.com"
-    host_name = "testhost.contoso.com"
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)

--- a/internal/services/dns/dns_zone_resource_test.go
+++ b/internal/services/dns/dns_zone_resource_test.go
@@ -205,7 +205,7 @@ resource "azurerm_dns_zone" "test" {
   resource_group_name = azurerm_resource_group.test.name
 
   soa_record {
-    email     = "testemail.com"
+    email = "testemail.com"
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)

--- a/website/docs/r/dns_zone.html.markdown
+++ b/website/docs/r/dns_zone.html.markdown
@@ -42,7 +42,7 @@ The `soa_record` block supports:
 
 * `email` - (Required) The email contact for the SOA record.
 
-* `host_name` - (Required) The domain name of the authoritative name server for the SOA record.
+* `host_name` - (Optional) The domain name of the authoritative name server for the SOA record. If not set, computed value from Azure will be used.
 
 * `expire_time` - (Optional) The expire time for the SOA record. Defaults to `2419200`.
 


### PR DESCRIPTION
When a DNS zone is created in Azure, there is a default SOA record which is created.

In this provider, a dns_zone with soa_record is done by:
1. creating the dns_zone
2. overwriting the soa_record of the zone with the data supplied in the soa_record config block

The `soa_record` block makes it mandatory to add the host_name argument when it is specified. This is NOT desired in most cases since the host_name is the MNAME SOA field which is the name of the primary nameserver and is set by Azure.

This commit attempts to fix this issue by:
1. allowing the `host_name` to be omitted when `soa_record` is specified
2. the host_name value will be derived from the original SOA record when the zone is created.

This issue is partly a bug in Azure API since it is is mentioned in the [documentation](https://learn.microsoft.com/en-us/azure/dns/dns-zones-records#soa-records) that it should not be possible to update the 'host' property of the SOA record.