### PR TITLE
New Resource: `azurerm_arc_private_link_scope`

### DIFF
--- a/internal/services/hybridcompute/arc_private_link_scope_resource.go
+++ b/internal/services/hybridcompute/arc_private_link_scope_resource.go
@@ -87,12 +87,10 @@ func (a ArcPrivateLinkScopeResource) Create() sdk.ResourceFunc {
 				Properties: &privatelinkscopes.HybridComputePrivateLinkScopeProperties{},
 			}
 
-			var publicNetwork privatelinkscopes.PublicNetworkAccessType
+			publicNetwork := privatelinkscopes.PublicNetworkAccessTypeDisabled
 
 			if model.PublicNetworkAccessEnabled {
 				publicNetwork = privatelinkscopes.PublicNetworkAccessTypeEnabled
-			} else {
-				publicNetwork = privatelinkscopes.PublicNetworkAccessTypeDisabled
 			}
 
 			properties.Properties.PublicNetworkAccess = &publicNetwork

--- a/internal/services/hybridcompute/arc_private_link_scope_resource.go
+++ b/internal/services/hybridcompute/arc_private_link_scope_resource.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"

--- a/internal/services/hybridcompute/arc_private_link_scope_resource.go
+++ b/internal/services/hybridcompute/arc_private_link_scope_resource.go
@@ -3,6 +3,8 @@ package hybridcompute
 import (
 	"context"
 	"fmt"
+	"time"
+
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
@@ -11,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
-	"time"
 )
 
 type PrivateLinkScopeModel struct {
@@ -80,9 +81,10 @@ func (a ArcPrivateLinkScopeResource) Create() sdk.ResourceFunc {
 			}
 
 			properties := privatelinkscopes.HybridComputePrivateLinkScope{
-				Location: location.Normalize(model.Location),
-				Name:     &model.Name,
-				Tags:     &model.Tags,
+				Location:   location.Normalize(model.Location),
+				Name:       &model.Name,
+				Tags:       &model.Tags,
+				Properties: &privatelinkscopes.HybridComputePrivateLinkScopeProperties{},
 			}
 
 			var publicNetwork privatelinkscopes.PublicNetworkAccessType
@@ -143,6 +145,10 @@ func (a ArcPrivateLinkScopeResource) Update() sdk.ResourceFunc {
 				properties.Properties.PublicNetworkAccess = &publicNetwork
 			}
 
+			if metadata.ResourceData.HasChange("tags") {
+				properties.Tags = &model.Tags
+			}
+
 			if _, err := client.PrivateLinkScopesCreateOrUpdate(ctx, *id, *properties); err != nil {
 				return fmt.Errorf("updating %s: %+v", id, err)
 			}
@@ -187,7 +193,7 @@ func (a ArcPrivateLinkScopeResource) Read() sdk.ResourceFunc {
 				}
 			}
 
-			return metadata.Encode(state)
+			return metadata.Encode(&state)
 		},
 	}
 }

--- a/internal/services/hybridcompute/arc_private_link_scope_resource.go
+++ b/internal/services/hybridcompute/arc_private_link_scope_resource.go
@@ -161,7 +161,7 @@ func (a ArcPrivateLinkScopeResource) Read() sdk.ResourceFunc {
 
 			id, err := privatelinkscopes.ParseProviderPrivateLinkScopeID(metadata.ResourceData.Id())
 			if err != nil {
-				return fmt.Errorf("parsing id: %+v", err)
+				return err
 			}
 
 			existing, err := client.PrivateLinkScopesGet(ctx, *id)

--- a/internal/services/hybridcompute/arc_private_link_scope_resource.go
+++ b/internal/services/hybridcompute/arc_private_link_scope_resource.go
@@ -179,12 +179,13 @@ func (a ArcPrivateLinkScopeResource) Read() sdk.ResourceFunc {
 
 			if model := existing.Model; model != nil {
 				state.Location = location.Normalize(model.Location)
-				if model.Tags != nil {
-					state.Tags = *model.Tags
+				state.Tags = pointer.From(model.Tags)
+
+				publicNetworkAccess := false
+				if props := model.Properties; props != nil && props.PublicNetworkAccess != nil {
+					publicNetworkAccess = *model.Properties.PublicNetworkAccess == privatelinkscopes.PublicNetworkAccessTypeEnabled
 				}
-				if model.Properties != nil && model.Properties.PublicNetworkAccess != nil {
-					state.PublicNetworkAccessEnabled = *model.Properties.PublicNetworkAccess == privatelinkscopes.PublicNetworkAccessTypeEnabled
-				}
+				state.PublicNetworkAccessEnabled = publicNetworkAccess
 			}
 
 			return metadata.Encode(&state)

--- a/internal/services/hybridcompute/arc_private_link_scope_resource.go
+++ b/internal/services/hybridcompute/arc_private_link_scope_resource.go
@@ -1,0 +1,217 @@
+package hybridcompute
+
+import (
+	"context"
+	"fmt"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/privatelinkscopes"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+	"time"
+)
+
+type PrivateLinkScopeModel struct {
+	Name                       string            `tfschema:"name"`
+	Location                   string            `tfschema:"location"`
+	ResourceGroupName          string            `tfschema:"resource_group_name"`
+	Tags                       map[string]string `tfschema:"tags"`
+	PublicNetworkAccessEnabled bool              `tfschema:"public_network_access_enabled"`
+}
+
+var _ sdk.Resource = ArcPrivateLinkScopeResource{}
+
+// ArcPrivateLinkScopeResource is a Resource implementation for the Azure Arc Private Link Scope resource
+type ArcPrivateLinkScopeResource struct{}
+
+func (a ArcPrivateLinkScopeResource) Arguments() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"name": {
+			Type:         schema.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+		"resource_group_name": commonschema.ResourceGroupName(),
+		"location":            commonschema.Location(),
+		"public_network_access_enabled": {
+			Type:     schema.TypeBool,
+			Optional: true,
+			Default:  false,
+		},
+		"tags": commonschema.Tags(),
+	}
+}
+
+func (a ArcPrivateLinkScopeResource) Attributes() map[string]*schema.Schema {
+	return map[string]*schema.Schema{}
+}
+
+func (a ArcPrivateLinkScopeResource) ModelObject() interface{} {
+	return &PrivateLinkScopeModel{}
+}
+
+func (a ArcPrivateLinkScopeResource) ResourceType() string {
+	return "azurerm_arc_private_link_scope"
+}
+
+func (a ArcPrivateLinkScopeResource) Create() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			var model PrivateLinkScopeModel
+			if err := metadata.Decode(&model); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			client := metadata.Client.HybridCompute.PrivateLinkScopesClient
+			subscriptionId := metadata.Client.Account.SubscriptionId
+			id := privatelinkscopes.NewProviderPrivateLinkScopeID(subscriptionId, model.ResourceGroupName, model.Name)
+			existing, err := client.PrivateLinkScopesGet(ctx, id)
+			if err != nil && !response.WasNotFound(existing.HttpResponse) {
+				return fmt.Errorf("checking for existing %s: %+v", id, err)
+			}
+
+			if !response.WasNotFound(existing.HttpResponse) {
+				return metadata.ResourceRequiresImport(a.ResourceType(), id)
+			}
+
+			properties := privatelinkscopes.HybridComputePrivateLinkScope{
+				Location: location.Normalize(model.Location),
+				Name:     &model.Name,
+				Tags:     &model.Tags,
+			}
+
+			var publicNetwork privatelinkscopes.PublicNetworkAccessType
+
+			if model.PublicNetworkAccessEnabled {
+				publicNetwork = privatelinkscopes.PublicNetworkAccessTypeEnabled
+			} else {
+				publicNetwork = privatelinkscopes.PublicNetworkAccessTypeDisabled
+			}
+
+			properties.Properties.PublicNetworkAccess = &publicNetwork
+
+			if _, err := client.PrivateLinkScopesCreateOrUpdate(ctx, id, properties); err != nil {
+				return fmt.Errorf("creating %s: %+v", id, err)
+			}
+
+			metadata.SetID(id)
+			return nil
+		},
+	}
+}
+
+func (a ArcPrivateLinkScopeResource) Update() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.HybridCompute.PrivateLinkScopesClient
+
+			id, err := privatelinkscopes.ParseProviderPrivateLinkScopeID(metadata.ResourceData.Id())
+			if err != nil {
+				return fmt.Errorf("parsing id: %+v", err)
+			}
+
+			var model PrivateLinkScopeModel
+			if err := metadata.Decode(&model); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			existing, err := client.PrivateLinkScopesGet(ctx, *id)
+			if err != nil {
+				return fmt.Errorf("retrieving %s: %+v", *id, err)
+			}
+
+			properties := existing.Model
+			if properties == nil {
+				return fmt.Errorf("retrieving %s: properties was nil", id)
+			}
+
+			var publicNetwork privatelinkscopes.PublicNetworkAccessType
+
+			if metadata.ResourceData.HasChange("public_network_access_enabled") {
+				if model.PublicNetworkAccessEnabled {
+					publicNetwork = privatelinkscopes.PublicNetworkAccessTypeEnabled
+				} else {
+					publicNetwork = privatelinkscopes.PublicNetworkAccessTypeDisabled
+				}
+
+				properties.Properties.PublicNetworkAccess = &publicNetwork
+			}
+
+			if _, err := client.PrivateLinkScopesCreateOrUpdate(ctx, *id, *properties); err != nil {
+				return fmt.Errorf("updating %s: %+v", id, err)
+			}
+
+			metadata.SetID(id)
+			return nil
+		},
+	}
+}
+
+func (a ArcPrivateLinkScopeResource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.HybridCompute.PrivateLinkScopesClient
+
+			id, err := privatelinkscopes.ParseProviderPrivateLinkScopeID(metadata.ResourceData.Id())
+			if err != nil {
+				return fmt.Errorf("parsing id: %+v", err)
+			}
+
+			existing, err := client.PrivateLinkScopesGet(ctx, *id)
+			if err != nil {
+				if response.WasNotFound(existing.HttpResponse) {
+					return metadata.MarkAsGone(id)
+				}
+				return fmt.Errorf("retrieving %s: %+v", *id, err)
+			}
+
+			state := PrivateLinkScopeModel{
+				Name:              id.PrivateLinkScopeName,
+				ResourceGroupName: id.ResourceGroupName,
+			}
+
+			if model := existing.Model; model != nil {
+				state.Location = location.Normalize(model.Location)
+				if model.Tags != nil {
+					state.Tags = *model.Tags
+				}
+				if model.Properties != nil && model.Properties.PublicNetworkAccess != nil {
+					state.PublicNetworkAccessEnabled = *model.Properties.PublicNetworkAccess == privatelinkscopes.PublicNetworkAccessTypeEnabled
+				}
+			}
+
+			return metadata.Encode(state)
+		},
+	}
+}
+
+func (a ArcPrivateLinkScopeResource) Delete() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			client := metadata.Client.HybridCompute.PrivateLinkScopesClient
+
+			id, err := privatelinkscopes.ParseProviderPrivateLinkScopeID(metadata.ResourceData.Id())
+			if err != nil {
+				return fmt.Errorf("parsing id: %+v", err)
+			}
+
+			if err := client.PrivateLinkScopesDeleteThenPoll(ctx, *id); err != nil {
+				return fmt.Errorf("deleting %s: %+v", *id, err)
+			}
+
+			return nil
+		},
+	}
+}
+
+func (a ArcPrivateLinkScopeResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+	return privatelinkscopes.ValidateProviderPrivateLinkScopeID
+}

--- a/internal/services/hybridcompute/arc_private_link_scope_resource.go
+++ b/internal/services/hybridcompute/arc_private_link_scope_resource.go
@@ -115,7 +115,7 @@ func (a ArcPrivateLinkScopeResource) Update() sdk.ResourceFunc {
 
 			id, err := privatelinkscopes.ParseProviderPrivateLinkScopeID(metadata.ResourceData.Id())
 			if err != nil {
-				return fmt.Errorf("parsing id: %+v", err)
+				return err
 			}
 
 			var model PrivateLinkScopeModel

--- a/internal/services/hybridcompute/arc_private_link_scope_resource.go
+++ b/internal/services/hybridcompute/arc_private_link_scope_resource.go
@@ -200,7 +200,7 @@ func (a ArcPrivateLinkScopeResource) Delete() sdk.ResourceFunc {
 
 			id, err := privatelinkscopes.ParseProviderPrivateLinkScopeID(metadata.ResourceData.Id())
 			if err != nil {
-				return fmt.Errorf("parsing id: %+v", err)
+				return err
 			}
 
 			if err := client.PrivateLinkScopesDeleteThenPoll(ctx, *id); err != nil {

--- a/internal/services/hybridcompute/arc_private_link_scope_resource.go
+++ b/internal/services/hybridcompute/arc_private_link_scope_resource.go
@@ -131,15 +131,11 @@ func (a ArcPrivateLinkScopeResource) Update() sdk.ResourceFunc {
 				return fmt.Errorf("retrieving %s: properties was nil", id)
 			}
 
-			var publicNetwork privatelinkscopes.PublicNetworkAccessType
-
 			if metadata.ResourceData.HasChange("public_network_access_enabled") {
+				publicNetwork := privatelinkscopes.PublicNetworkAccessTypeDisabled
 				if model.PublicNetworkAccessEnabled {
 					publicNetwork = privatelinkscopes.PublicNetworkAccessTypeEnabled
-				} else {
-					publicNetwork = privatelinkscopes.PublicNetworkAccessTypeDisabled
 				}
-
 				properties.Properties.PublicNetworkAccess = &publicNetwork
 			}
 

--- a/internal/services/hybridcompute/arc_private_link_scope_resource_test.go
+++ b/internal/services/hybridcompute/arc_private_link_scope_resource_test.go
@@ -89,10 +89,10 @@ func (r ArcPrivateLinkScopeResource) basic(data acceptance.TestData) string {
 %s
 
 resource "azurerm_arc_private_link_scope" "test" {
-	  name                = "acctestPLS-%d"
-	  resource_group_name = azurerm_resource_group.test.name
-	  location            = azurerm_resource_group.test.location
-}		
+  name                = "acctestPLS-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
 `, r.template(data), data.RandomInteger)
 }
 
@@ -101,15 +101,15 @@ func (r ArcPrivateLinkScopeResource) complete(data acceptance.TestData) string {
 %s
 
 resource "azurerm_arc_private_link_scope" "test" {
-	name                = "acctestPLS-%d"
-	resource_group_name = azurerm_resource_group.test.name
-	location            = azurerm_resource_group.test.location
-	
-	public_network_access_enabled = true
+  name                = "acctestPLS-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
 
-	tags = {
-	  "Environment" = "Production"
-	}
+  public_network_access_enabled = true
+
+  tags = {
+    "Environment" = "Production"
+  }
 }
 `, r.template(data), data.RandomInteger)
 }

--- a/internal/services/hybridcompute/arc_private_link_scope_resource_test.go
+++ b/internal/services/hybridcompute/arc_private_link_scope_resource_test.go
@@ -55,7 +55,7 @@ func TestAccArcPrivateLinkScope_update(t *testing.T) {
 func (r ArcPrivateLinkScopeResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := privatelinkscopes.ParseProviderPrivateLinkScopeID(state.ID)
 	if err != nil {
-		return nil, fmt.Errorf("parsing id: %+v", err)
+		return nil, err
 	}
 
 	client := clients.HybridCompute.PrivateLinkScopesClient

--- a/internal/services/hybridcompute/arc_private_link_scope_resource_test.go
+++ b/internal/services/hybridcompute/arc_private_link_scope_resource_test.go
@@ -1,0 +1,115 @@
+package hybridcompute_test
+
+import (
+	"context"
+	"fmt"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/privatelinkscopes"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"testing"
+)
+
+type ArcPrivateLinkScopeResource struct{}
+
+func TestAccArcPrivateLinkScope_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "", "test")
+	r := ArcPrivateLinkScopeResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccArcPrivateLinkScope_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_arc_machine_extension", "test")
+	r := ArcPrivateLinkScopeResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("tags.#").HasValue("1"),
+				check.That(data.ResourceName).Key("public_network_access_enabled").HasValue("true"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func (r ArcPrivateLinkScopeResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := privatelinkscopes.ParseProviderPrivateLinkScopeID(state.ID)
+	if err != nil {
+		return nil, fmt.Errorf("parsing id: %+v", err)
+	}
+
+	client := clients.HybridCompute.PrivateLinkScopesClient
+
+	resp, err := client.PrivateLinkScopesGet(ctx, *id)
+	exists := false
+	if err == nil {
+		if response.WasNotFound(resp.HttpResponse) {
+			return &exists, nil
+		}
+		return nil, fmt.Errorf("retrieving: %+v", err)
+	}
+	return pointer.To(resp.Model != nil), nil
+}
+
+func (r ArcPrivateLinkScopeResource) template(data acceptance.TestData) interface{} {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {
+  }
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+`,
+		data.RandomInteger, data.Locations.Primary)
+}
+
+func (r ArcPrivateLinkScopeResource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_arc_private_link_scope" "test" {
+	  name                = "acctestPLS-%d"
+	  resource_group_name = azurerm_resource_group.test.name
+	  location            = azurerm_resource_group.test.location
+}		
+`, r.template(data), data.RandomInteger)
+}
+
+func (r ArcPrivateLinkScopeResource) complete(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_arc_private_link_scope" "test" {
+name                = "acctestPLS-%d"
+resource_group_name = azurerm_resource_group.test.name
+location            = azurerm_resource_group.test.location
+tags = {
+"Environment" = "Production"
+}
+public_network_access_enabled = true
+}
+`, r.template(data), data.RandomInteger)
+}

--- a/internal/services/hybridcompute/arc_private_link_scope_resource_test.go
+++ b/internal/services/hybridcompute/arc_private_link_scope_resource_test.go
@@ -3,6 +3,8 @@ package hybridcompute_test
 import (
 	"context"
 	"fmt"
+	"testing"
+
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/privatelinkscopes"
@@ -10,13 +12,12 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
-	"testing"
 )
 
 type ArcPrivateLinkScopeResource struct{}
 
 func TestAccArcPrivateLinkScope_basic(t *testing.T) {
-	data := acceptance.BuildTestData(t, "", "test")
+	data := acceptance.BuildTestData(t, "azurerm_arc_private_link_scope", "test")
 	r := ArcPrivateLinkScopeResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -30,7 +31,7 @@ func TestAccArcPrivateLinkScope_basic(t *testing.T) {
 }
 
 func TestAccArcPrivateLinkScope_update(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_arc_machine_extension", "test")
+	data := acceptance.BuildTestData(t, "azurerm_arc_private_link_scope", "test")
 	r := ArcPrivateLinkScopeResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -44,7 +45,6 @@ func TestAccArcPrivateLinkScope_update(t *testing.T) {
 			Config: r.complete(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("tags.#").HasValue("1"),
 				check.That(data.ResourceName).Key("public_network_access_enabled").HasValue("true"),
 			),
 		},
@@ -62,7 +62,7 @@ func (r ArcPrivateLinkScopeResource) Exists(ctx context.Context, clients *client
 
 	resp, err := client.PrivateLinkScopesGet(ctx, *id)
 	exists := false
-	if err == nil {
+	if err != nil {
 		if response.WasNotFound(resp.HttpResponse) {
 			return &exists, nil
 		}
@@ -74,16 +74,14 @@ func (r ArcPrivateLinkScopeResource) Exists(ctx context.Context, clients *client
 func (r ArcPrivateLinkScopeResource) template(data acceptance.TestData) interface{} {
 	return fmt.Sprintf(`
 provider "azurerm" {
-  features {
-  }
+  features {}
 }
 
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
   location = "%s"
 }
-`,
-		data.RandomInteger, data.Locations.Primary)
+`, data.RandomInteger, data.Locations.Primary)
 }
 
 func (r ArcPrivateLinkScopeResource) basic(data acceptance.TestData) string {
@@ -103,13 +101,15 @@ func (r ArcPrivateLinkScopeResource) complete(data acceptance.TestData) string {
 %s
 
 resource "azurerm_arc_private_link_scope" "test" {
-name                = "acctestPLS-%d"
-resource_group_name = azurerm_resource_group.test.name
-location            = azurerm_resource_group.test.location
-tags = {
-"Environment" = "Production"
-}
-public_network_access_enabled = true
+	name                = "acctestPLS-%d"
+	resource_group_name = azurerm_resource_group.test.name
+	location            = azurerm_resource_group.test.location
+	
+	public_network_access_enabled = true
+
+	tags = {
+	  "Environment" = "Production"
+	}
 }
 `, r.template(data), data.RandomInteger)
 }

--- a/internal/services/hybridcompute/client/client.go
+++ b/internal/services/hybridcompute/client/client.go
@@ -4,6 +4,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/machineextensions"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/machines"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/privateendpointconnections"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/privatelinkscopes"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/common"
 )
 
@@ -11,6 +12,7 @@ type Client struct {
 	MachineExtensionsClient          *machineextensions.MachineExtensionsClient
 	MachinesClient                   *machines.MachinesClient
 	PrivateEndpointConnectionsClient *privateendpointconnections.PrivateEndpointConnectionsClient
+	PrivateLinkScopesClient          *privatelinkscopes.PrivateLinkScopesClient
 }
 
 func NewClient(o *common.ClientOptions) *Client {
@@ -24,9 +26,13 @@ func NewClient(o *common.ClientOptions) *Client {
 	privateEndpointConnectionsClient := privateendpointconnections.NewPrivateEndpointConnectionsClientWithBaseURI(o.ResourceManagerEndpoint)
 	o.ConfigureClient(&privateEndpointConnectionsClient.Client, o.ResourceManagerAuthorizer)
 
+	privateLinkScopesClient := privatelinkscopes.NewPrivateLinkScopesClientWithBaseURI(o.ResourceManagerEndpoint)
+	o.ConfigureClient(&privateLinkScopesClient.Client, o.ResourceManagerAuthorizer)
+
 	return &Client{
 		MachineExtensionsClient:          &machineExtensionsClient,
 		MachinesClient:                   &machinesClient,
 		PrivateEndpointConnectionsClient: &privateEndpointConnectionsClient,
+		PrivateLinkScopesClient:          &privateLinkScopesClient,
 	}
 }

--- a/internal/services/hybridcompute/registration.go
+++ b/internal/services/hybridcompute/registration.go
@@ -50,5 +50,6 @@ func (r Registration) DataSources() []sdk.DataSource {
 func (r Registration) Resources() []sdk.Resource {
 	return []sdk.Resource{
 		ArcMachineExtensionResource{},
+		ArcPrivateLinkScopeResource{},
 	}
 }

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/privatelinkscopes/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/privatelinkscopes/README.md
@@ -1,0 +1,156 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/privatelinkscopes` Documentation
+
+The `privatelinkscopes` SDK allows for interaction with the Azure Resource Manager Service `hybridcompute` (API Version `2022-11-10`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/privatelinkscopes"
+```
+
+
+### Client Initialization
+
+```go
+client := privatelinkscopes.NewPrivateLinkScopesClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `PrivateLinkScopesClient.PrivateLinkScopesCreateOrUpdate`
+
+```go
+ctx := context.TODO()
+id := privatelinkscopes.NewProviderPrivateLinkScopeID("12345678-1234-9876-4563-123456789012", "example-resource-group", "privateLinkScopeValue")
+
+payload := privatelinkscopes.HybridComputePrivateLinkScope{
+	// ...
+}
+
+
+read, err := client.PrivateLinkScopesCreateOrUpdate(ctx, id, payload)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `PrivateLinkScopesClient.PrivateLinkScopesDelete`
+
+```go
+ctx := context.TODO()
+id := privatelinkscopes.NewProviderPrivateLinkScopeID("12345678-1234-9876-4563-123456789012", "example-resource-group", "privateLinkScopeValue")
+
+if err := client.PrivateLinkScopesDeleteThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `PrivateLinkScopesClient.PrivateLinkScopesGet`
+
+```go
+ctx := context.TODO()
+id := privatelinkscopes.NewProviderPrivateLinkScopeID("12345678-1234-9876-4563-123456789012", "example-resource-group", "privateLinkScopeValue")
+
+read, err := client.PrivateLinkScopesGet(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `PrivateLinkScopesClient.PrivateLinkScopesGetValidationDetails`
+
+```go
+ctx := context.TODO()
+id := privatelinkscopes.NewPrivateLinkScopeID("12345678-1234-9876-4563-123456789012", "locationValue", "privateLinkScopeIdValue")
+
+read, err := client.PrivateLinkScopesGetValidationDetails(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `PrivateLinkScopesClient.PrivateLinkScopesGetValidationDetailsForMachine`
+
+```go
+ctx := context.TODO()
+id := privatelinkscopes.NewMachineID("12345678-1234-9876-4563-123456789012", "example-resource-group", "machineValue")
+
+read, err := client.PrivateLinkScopesGetValidationDetailsForMachine(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `PrivateLinkScopesClient.PrivateLinkScopesList`
+
+```go
+ctx := context.TODO()
+id := privatelinkscopes.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+
+// alternatively `client.PrivateLinkScopesList(ctx, id)` can be used to do batched pagination
+items, err := client.PrivateLinkScopesListComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `PrivateLinkScopesClient.PrivateLinkScopesListByResourceGroup`
+
+```go
+ctx := context.TODO()
+id := privatelinkscopes.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+
+// alternatively `client.PrivateLinkScopesListByResourceGroup(ctx, id)` can be used to do batched pagination
+items, err := client.PrivateLinkScopesListByResourceGroupComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `PrivateLinkScopesClient.PrivateLinkScopesUpdateTags`
+
+```go
+ctx := context.TODO()
+id := privatelinkscopes.NewProviderPrivateLinkScopeID("12345678-1234-9876-4563-123456789012", "example-resource-group", "privateLinkScopeValue")
+
+payload := privatelinkscopes.TagsResource{
+	// ...
+}
+
+
+read, err := client.PrivateLinkScopesUpdateTags(ctx, id, payload)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/privatelinkscopes/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/privatelinkscopes/client.go
@@ -1,0 +1,18 @@
+package privatelinkscopes
+
+import "github.com/Azure/go-autorest/autorest"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateLinkScopesClient struct {
+	Client  autorest.Client
+	baseUri string
+}
+
+func NewPrivateLinkScopesClientWithBaseURI(endpoint string) PrivateLinkScopesClient {
+	return PrivateLinkScopesClient{
+		Client:  autorest.NewClientWithUserAgent(userAgent()),
+		baseUri: endpoint,
+	}
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/privatelinkscopes/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/privatelinkscopes/constants.go
@@ -1,0 +1,34 @@
+package privatelinkscopes
+
+import "strings"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PublicNetworkAccessType string
+
+const (
+	PublicNetworkAccessTypeDisabled PublicNetworkAccessType = "Disabled"
+	PublicNetworkAccessTypeEnabled  PublicNetworkAccessType = "Enabled"
+)
+
+func PossibleValuesForPublicNetworkAccessType() []string {
+	return []string{
+		string(PublicNetworkAccessTypeDisabled),
+		string(PublicNetworkAccessTypeEnabled),
+	}
+}
+
+func parsePublicNetworkAccessType(input string) (*PublicNetworkAccessType, error) {
+	vals := map[string]PublicNetworkAccessType{
+		"disabled": PublicNetworkAccessTypeDisabled,
+		"enabled":  PublicNetworkAccessTypeEnabled,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := PublicNetworkAccessType(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/privatelinkscopes/id_machine.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/privatelinkscopes/id_machine.go
@@ -1,0 +1,127 @@
+package privatelinkscopes
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ resourceids.ResourceId = MachineId{}
+
+// MachineId is a struct representing the Resource ID for a Machine
+type MachineId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	MachineName       string
+}
+
+// NewMachineID returns a new MachineId struct
+func NewMachineID(subscriptionId string, resourceGroupName string, machineName string) MachineId {
+	return MachineId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		MachineName:       machineName,
+	}
+}
+
+// ParseMachineID parses 'input' into a MachineId
+func ParseMachineID(input string) (*MachineId, error) {
+	parser := resourceids.NewParserFromResourceIdType(MachineId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := MachineId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
+	}
+
+	if id.MachineName, ok = parsed.Parsed["machineName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "machineName", *parsed)
+	}
+
+	return &id, nil
+}
+
+// ParseMachineIDInsensitively parses 'input' case-insensitively into a MachineId
+// note: this method should only be used for API response data and not user input
+func ParseMachineIDInsensitively(input string) (*MachineId, error) {
+	parser := resourceids.NewParserFromResourceIdType(MachineId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := MachineId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
+	}
+
+	if id.MachineName, ok = parsed.Parsed["machineName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "machineName", *parsed)
+	}
+
+	return &id, nil
+}
+
+// ValidateMachineID checks that 'input' can be parsed as a Machine ID
+func ValidateMachineID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseMachineID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Machine ID
+func (id MachineId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.HybridCompute/machines/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.MachineName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Machine ID
+func (id MachineId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftHybridCompute", "Microsoft.HybridCompute", "Microsoft.HybridCompute"),
+		resourceids.StaticSegment("staticMachines", "machines", "machines"),
+		resourceids.UserSpecifiedSegment("machineName", "machineValue"),
+	}
+}
+
+// String returns a human-readable description of this Machine ID
+func (id MachineId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Machine Name: %q", id.MachineName),
+	}
+	return fmt.Sprintf("Machine (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/privatelinkscopes/id_privatelinkscope.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/privatelinkscopes/id_privatelinkscope.go
@@ -1,0 +1,127 @@
+package privatelinkscopes
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ resourceids.ResourceId = PrivateLinkScopeId{}
+
+// PrivateLinkScopeId is a struct representing the Resource ID for a Private Link Scope
+type PrivateLinkScopeId struct {
+	SubscriptionId     string
+	LocationName       string
+	PrivateLinkScopeId string
+}
+
+// NewPrivateLinkScopeID returns a new PrivateLinkScopeId struct
+func NewPrivateLinkScopeID(subscriptionId string, locationName string, privateLinkScopeId string) PrivateLinkScopeId {
+	return PrivateLinkScopeId{
+		SubscriptionId:     subscriptionId,
+		LocationName:       locationName,
+		PrivateLinkScopeId: privateLinkScopeId,
+	}
+}
+
+// ParsePrivateLinkScopeID parses 'input' into a PrivateLinkScopeId
+func ParsePrivateLinkScopeID(input string) (*PrivateLinkScopeId, error) {
+	parser := resourceids.NewParserFromResourceIdType(PrivateLinkScopeId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := PrivateLinkScopeId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
+	}
+
+	if id.LocationName, ok = parsed.Parsed["locationName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "locationName", *parsed)
+	}
+
+	if id.PrivateLinkScopeId, ok = parsed.Parsed["privateLinkScopeId"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "privateLinkScopeId", *parsed)
+	}
+
+	return &id, nil
+}
+
+// ParsePrivateLinkScopeIDInsensitively parses 'input' case-insensitively into a PrivateLinkScopeId
+// note: this method should only be used for API response data and not user input
+func ParsePrivateLinkScopeIDInsensitively(input string) (*PrivateLinkScopeId, error) {
+	parser := resourceids.NewParserFromResourceIdType(PrivateLinkScopeId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := PrivateLinkScopeId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
+	}
+
+	if id.LocationName, ok = parsed.Parsed["locationName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "locationName", *parsed)
+	}
+
+	if id.PrivateLinkScopeId, ok = parsed.Parsed["privateLinkScopeId"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "privateLinkScopeId", *parsed)
+	}
+
+	return &id, nil
+}
+
+// ValidatePrivateLinkScopeID checks that 'input' can be parsed as a Private Link Scope ID
+func ValidatePrivateLinkScopeID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParsePrivateLinkScopeID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Private Link Scope ID
+func (id PrivateLinkScopeId) ID() string {
+	fmtString := "/subscriptions/%s/providers/Microsoft.HybridCompute/locations/%s/privateLinkScopes/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.LocationName, id.PrivateLinkScopeId)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Private Link Scope ID
+func (id PrivateLinkScopeId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftHybridCompute", "Microsoft.HybridCompute", "Microsoft.HybridCompute"),
+		resourceids.StaticSegment("staticLocations", "locations", "locations"),
+		resourceids.UserSpecifiedSegment("locationName", "locationValue"),
+		resourceids.StaticSegment("staticPrivateLinkScopes", "privateLinkScopes", "privateLinkScopes"),
+		resourceids.UserSpecifiedSegment("privateLinkScopeId", "privateLinkScopeIdValue"),
+	}
+}
+
+// String returns a human-readable description of this Private Link Scope ID
+func (id PrivateLinkScopeId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Location Name: %q", id.LocationName),
+		fmt.Sprintf("Private Link Scope: %q", id.PrivateLinkScopeId),
+	}
+	return fmt.Sprintf("Private Link Scope (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/privatelinkscopes/id_providerprivatelinkscope.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/privatelinkscopes/id_providerprivatelinkscope.go
@@ -1,0 +1,127 @@
+package privatelinkscopes
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ resourceids.ResourceId = ProviderPrivateLinkScopeId{}
+
+// ProviderPrivateLinkScopeId is a struct representing the Resource ID for a Provider Private Link Scope
+type ProviderPrivateLinkScopeId struct {
+	SubscriptionId       string
+	ResourceGroupName    string
+	PrivateLinkScopeName string
+}
+
+// NewProviderPrivateLinkScopeID returns a new ProviderPrivateLinkScopeId struct
+func NewProviderPrivateLinkScopeID(subscriptionId string, resourceGroupName string, privateLinkScopeName string) ProviderPrivateLinkScopeId {
+	return ProviderPrivateLinkScopeId{
+		SubscriptionId:       subscriptionId,
+		ResourceGroupName:    resourceGroupName,
+		PrivateLinkScopeName: privateLinkScopeName,
+	}
+}
+
+// ParseProviderPrivateLinkScopeID parses 'input' into a ProviderPrivateLinkScopeId
+func ParseProviderPrivateLinkScopeID(input string) (*ProviderPrivateLinkScopeId, error) {
+	parser := resourceids.NewParserFromResourceIdType(ProviderPrivateLinkScopeId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := ProviderPrivateLinkScopeId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
+	}
+
+	if id.PrivateLinkScopeName, ok = parsed.Parsed["privateLinkScopeName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "privateLinkScopeName", *parsed)
+	}
+
+	return &id, nil
+}
+
+// ParseProviderPrivateLinkScopeIDInsensitively parses 'input' case-insensitively into a ProviderPrivateLinkScopeId
+// note: this method should only be used for API response data and not user input
+func ParseProviderPrivateLinkScopeIDInsensitively(input string) (*ProviderPrivateLinkScopeId, error) {
+	parser := resourceids.NewParserFromResourceIdType(ProviderPrivateLinkScopeId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := ProviderPrivateLinkScopeId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
+	}
+
+	if id.PrivateLinkScopeName, ok = parsed.Parsed["privateLinkScopeName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "privateLinkScopeName", *parsed)
+	}
+
+	return &id, nil
+}
+
+// ValidateProviderPrivateLinkScopeID checks that 'input' can be parsed as a Provider Private Link Scope ID
+func ValidateProviderPrivateLinkScopeID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseProviderPrivateLinkScopeID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Provider Private Link Scope ID
+func (id ProviderPrivateLinkScopeId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.HybridCompute/privateLinkScopes/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.PrivateLinkScopeName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Provider Private Link Scope ID
+func (id ProviderPrivateLinkScopeId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftHybridCompute", "Microsoft.HybridCompute", "Microsoft.HybridCompute"),
+		resourceids.StaticSegment("staticPrivateLinkScopes", "privateLinkScopes", "privateLinkScopes"),
+		resourceids.UserSpecifiedSegment("privateLinkScopeName", "privateLinkScopeValue"),
+	}
+}
+
+// String returns a human-readable description of this Provider Private Link Scope ID
+func (id ProviderPrivateLinkScopeId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Private Link Scope Name: %q", id.PrivateLinkScopeName),
+	}
+	return fmt.Sprintf("Provider Private Link Scope (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/privatelinkscopes/method_privatelinkscopescreateorupdate_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/privatelinkscopes/method_privatelinkscopescreateorupdate_autorest.go
@@ -1,0 +1,69 @@
+package privatelinkscopes
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateLinkScopesCreateOrUpdateOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *HybridComputePrivateLinkScope
+}
+
+// PrivateLinkScopesCreateOrUpdate ...
+func (c PrivateLinkScopesClient) PrivateLinkScopesCreateOrUpdate(ctx context.Context, id ProviderPrivateLinkScopeId, input HybridComputePrivateLinkScope) (result PrivateLinkScopesCreateOrUpdateOperationResponse, err error) {
+	req, err := c.preparerForPrivateLinkScopesCreateOrUpdate(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "privatelinkscopes.PrivateLinkScopesClient", "PrivateLinkScopesCreateOrUpdate", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "privatelinkscopes.PrivateLinkScopesClient", "PrivateLinkScopesCreateOrUpdate", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForPrivateLinkScopesCreateOrUpdate(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "privatelinkscopes.PrivateLinkScopesClient", "PrivateLinkScopesCreateOrUpdate", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForPrivateLinkScopesCreateOrUpdate prepares the PrivateLinkScopesCreateOrUpdate request.
+func (c PrivateLinkScopesClient) preparerForPrivateLinkScopesCreateOrUpdate(ctx context.Context, id ProviderPrivateLinkScopeId, input HybridComputePrivateLinkScope) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPut(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForPrivateLinkScopesCreateOrUpdate handles the response to the PrivateLinkScopesCreateOrUpdate request. The method always
+// closes the http.Response Body.
+func (c PrivateLinkScopesClient) responderForPrivateLinkScopesCreateOrUpdate(resp *http.Response) (result PrivateLinkScopesCreateOrUpdateOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusCreated, http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/privatelinkscopes/method_privatelinkscopesdelete_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/privatelinkscopes/method_privatelinkscopesdelete_autorest.go
@@ -1,0 +1,78 @@
+package privatelinkscopes
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateLinkScopesDeleteOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+}
+
+// PrivateLinkScopesDelete ...
+func (c PrivateLinkScopesClient) PrivateLinkScopesDelete(ctx context.Context, id ProviderPrivateLinkScopeId) (result PrivateLinkScopesDeleteOperationResponse, err error) {
+	req, err := c.preparerForPrivateLinkScopesDelete(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "privatelinkscopes.PrivateLinkScopesClient", "PrivateLinkScopesDelete", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForPrivateLinkScopesDelete(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "privatelinkscopes.PrivateLinkScopesClient", "PrivateLinkScopesDelete", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// PrivateLinkScopesDeleteThenPoll performs PrivateLinkScopesDelete then polls until it's completed
+func (c PrivateLinkScopesClient) PrivateLinkScopesDeleteThenPoll(ctx context.Context, id ProviderPrivateLinkScopeId) error {
+	result, err := c.PrivateLinkScopesDelete(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing PrivateLinkScopesDelete: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after PrivateLinkScopesDelete: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForPrivateLinkScopesDelete prepares the PrivateLinkScopesDelete request.
+func (c PrivateLinkScopesClient) preparerForPrivateLinkScopesDelete(ctx context.Context, id ProviderPrivateLinkScopeId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsDelete(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForPrivateLinkScopesDelete sends the PrivateLinkScopesDelete request. The method will close the
+// http.Response Body if it receives an error.
+func (c PrivateLinkScopesClient) senderForPrivateLinkScopesDelete(ctx context.Context, req *http.Request) (future PrivateLinkScopesDeleteOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/privatelinkscopes/method_privatelinkscopesget_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/privatelinkscopes/method_privatelinkscopesget_autorest.go
@@ -1,0 +1,68 @@
+package privatelinkscopes
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateLinkScopesGetOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *HybridComputePrivateLinkScope
+}
+
+// PrivateLinkScopesGet ...
+func (c PrivateLinkScopesClient) PrivateLinkScopesGet(ctx context.Context, id ProviderPrivateLinkScopeId) (result PrivateLinkScopesGetOperationResponse, err error) {
+	req, err := c.preparerForPrivateLinkScopesGet(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "privatelinkscopes.PrivateLinkScopesClient", "PrivateLinkScopesGet", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "privatelinkscopes.PrivateLinkScopesClient", "PrivateLinkScopesGet", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForPrivateLinkScopesGet(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "privatelinkscopes.PrivateLinkScopesClient", "PrivateLinkScopesGet", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForPrivateLinkScopesGet prepares the PrivateLinkScopesGet request.
+func (c PrivateLinkScopesClient) preparerForPrivateLinkScopesGet(ctx context.Context, id ProviderPrivateLinkScopeId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForPrivateLinkScopesGet handles the response to the PrivateLinkScopesGet request. The method always
+// closes the http.Response Body.
+func (c PrivateLinkScopesClient) responderForPrivateLinkScopesGet(resp *http.Response) (result PrivateLinkScopesGetOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/privatelinkscopes/method_privatelinkscopesgetvalidationdetails_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/privatelinkscopes/method_privatelinkscopesgetvalidationdetails_autorest.go
@@ -1,0 +1,68 @@
+package privatelinkscopes
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateLinkScopesGetValidationDetailsOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *PrivateLinkScopeValidationDetails
+}
+
+// PrivateLinkScopesGetValidationDetails ...
+func (c PrivateLinkScopesClient) PrivateLinkScopesGetValidationDetails(ctx context.Context, id PrivateLinkScopeId) (result PrivateLinkScopesGetValidationDetailsOperationResponse, err error) {
+	req, err := c.preparerForPrivateLinkScopesGetValidationDetails(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "privatelinkscopes.PrivateLinkScopesClient", "PrivateLinkScopesGetValidationDetails", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "privatelinkscopes.PrivateLinkScopesClient", "PrivateLinkScopesGetValidationDetails", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForPrivateLinkScopesGetValidationDetails(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "privatelinkscopes.PrivateLinkScopesClient", "PrivateLinkScopesGetValidationDetails", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForPrivateLinkScopesGetValidationDetails prepares the PrivateLinkScopesGetValidationDetails request.
+func (c PrivateLinkScopesClient) preparerForPrivateLinkScopesGetValidationDetails(ctx context.Context, id PrivateLinkScopeId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForPrivateLinkScopesGetValidationDetails handles the response to the PrivateLinkScopesGetValidationDetails request. The method always
+// closes the http.Response Body.
+func (c PrivateLinkScopesClient) responderForPrivateLinkScopesGetValidationDetails(resp *http.Response) (result PrivateLinkScopesGetValidationDetailsOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/privatelinkscopes/method_privatelinkscopesgetvalidationdetailsformachine_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/privatelinkscopes/method_privatelinkscopesgetvalidationdetailsformachine_autorest.go
@@ -1,0 +1,69 @@
+package privatelinkscopes
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateLinkScopesGetValidationDetailsForMachineOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *PrivateLinkScopeValidationDetails
+}
+
+// PrivateLinkScopesGetValidationDetailsForMachine ...
+func (c PrivateLinkScopesClient) PrivateLinkScopesGetValidationDetailsForMachine(ctx context.Context, id MachineId) (result PrivateLinkScopesGetValidationDetailsForMachineOperationResponse, err error) {
+	req, err := c.preparerForPrivateLinkScopesGetValidationDetailsForMachine(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "privatelinkscopes.PrivateLinkScopesClient", "PrivateLinkScopesGetValidationDetailsForMachine", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "privatelinkscopes.PrivateLinkScopesClient", "PrivateLinkScopesGetValidationDetailsForMachine", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForPrivateLinkScopesGetValidationDetailsForMachine(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "privatelinkscopes.PrivateLinkScopesClient", "PrivateLinkScopesGetValidationDetailsForMachine", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForPrivateLinkScopesGetValidationDetailsForMachine prepares the PrivateLinkScopesGetValidationDetailsForMachine request.
+func (c PrivateLinkScopesClient) preparerForPrivateLinkScopesGetValidationDetailsForMachine(ctx context.Context, id MachineId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/privateLinkScopes/current", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForPrivateLinkScopesGetValidationDetailsForMachine handles the response to the PrivateLinkScopesGetValidationDetailsForMachine request. The method always
+// closes the http.Response Body.
+func (c PrivateLinkScopesClient) responderForPrivateLinkScopesGetValidationDetailsForMachine(resp *http.Response) (result PrivateLinkScopesGetValidationDetailsForMachineOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/privatelinkscopes/method_privatelinkscopeslist_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/privatelinkscopes/method_privatelinkscopeslist_autorest.go
@@ -1,0 +1,187 @@
+package privatelinkscopes
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateLinkScopesListOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *[]HybridComputePrivateLinkScope
+
+	nextLink     *string
+	nextPageFunc func(ctx context.Context, nextLink string) (PrivateLinkScopesListOperationResponse, error)
+}
+
+type PrivateLinkScopesListCompleteResult struct {
+	Items []HybridComputePrivateLinkScope
+}
+
+func (r PrivateLinkScopesListOperationResponse) HasMore() bool {
+	return r.nextLink != nil
+}
+
+func (r PrivateLinkScopesListOperationResponse) LoadMore(ctx context.Context) (resp PrivateLinkScopesListOperationResponse, err error) {
+	if !r.HasMore() {
+		err = fmt.Errorf("no more pages returned")
+		return
+	}
+	return r.nextPageFunc(ctx, *r.nextLink)
+}
+
+// PrivateLinkScopesList ...
+func (c PrivateLinkScopesClient) PrivateLinkScopesList(ctx context.Context, id commonids.SubscriptionId) (resp PrivateLinkScopesListOperationResponse, err error) {
+	req, err := c.preparerForPrivateLinkScopesList(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "privatelinkscopes.PrivateLinkScopesClient", "PrivateLinkScopesList", nil, "Failure preparing request")
+		return
+	}
+
+	resp.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "privatelinkscopes.PrivateLinkScopesClient", "PrivateLinkScopesList", resp.HttpResponse, "Failure sending request")
+		return
+	}
+
+	resp, err = c.responderForPrivateLinkScopesList(resp.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "privatelinkscopes.PrivateLinkScopesClient", "PrivateLinkScopesList", resp.HttpResponse, "Failure responding to request")
+		return
+	}
+	return
+}
+
+// preparerForPrivateLinkScopesList prepares the PrivateLinkScopesList request.
+func (c PrivateLinkScopesClient) preparerForPrivateLinkScopesList(ctx context.Context, id commonids.SubscriptionId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/providers/Microsoft.HybridCompute/privateLinkScopes", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// preparerForPrivateLinkScopesListWithNextLink prepares the PrivateLinkScopesList request with the given nextLink token.
+func (c PrivateLinkScopesClient) preparerForPrivateLinkScopesListWithNextLink(ctx context.Context, nextLink string) (*http.Request, error) {
+	uri, err := url.Parse(nextLink)
+	if err != nil {
+		return nil, fmt.Errorf("parsing nextLink %q: %+v", nextLink, err)
+	}
+	queryParameters := map[string]interface{}{}
+	for k, v := range uri.Query() {
+		if len(v) == 0 {
+			continue
+		}
+		val := v[0]
+		val = autorest.Encode("query", val)
+		queryParameters[k] = val
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(uri.Path),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForPrivateLinkScopesList handles the response to the PrivateLinkScopesList request. The method always
+// closes the http.Response Body.
+func (c PrivateLinkScopesClient) responderForPrivateLinkScopesList(resp *http.Response) (result PrivateLinkScopesListOperationResponse, err error) {
+	type page struct {
+		Values   []HybridComputePrivateLinkScope `json:"value"`
+		NextLink *string                         `json:"nextLink"`
+	}
+	var respObj page
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&respObj),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	result.Model = &respObj.Values
+	result.nextLink = respObj.NextLink
+	if respObj.NextLink != nil {
+		result.nextPageFunc = func(ctx context.Context, nextLink string) (result PrivateLinkScopesListOperationResponse, err error) {
+			req, err := c.preparerForPrivateLinkScopesListWithNextLink(ctx, nextLink)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "privatelinkscopes.PrivateLinkScopesClient", "PrivateLinkScopesList", nil, "Failure preparing request")
+				return
+			}
+
+			result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "privatelinkscopes.PrivateLinkScopesClient", "PrivateLinkScopesList", result.HttpResponse, "Failure sending request")
+				return
+			}
+
+			result, err = c.responderForPrivateLinkScopesList(result.HttpResponse)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "privatelinkscopes.PrivateLinkScopesClient", "PrivateLinkScopesList", result.HttpResponse, "Failure responding to request")
+				return
+			}
+
+			return
+		}
+	}
+	return
+}
+
+// PrivateLinkScopesListComplete retrieves all of the results into a single object
+func (c PrivateLinkScopesClient) PrivateLinkScopesListComplete(ctx context.Context, id commonids.SubscriptionId) (PrivateLinkScopesListCompleteResult, error) {
+	return c.PrivateLinkScopesListCompleteMatchingPredicate(ctx, id, HybridComputePrivateLinkScopeOperationPredicate{})
+}
+
+// PrivateLinkScopesListCompleteMatchingPredicate retrieves all of the results and then applied the predicate
+func (c PrivateLinkScopesClient) PrivateLinkScopesListCompleteMatchingPredicate(ctx context.Context, id commonids.SubscriptionId, predicate HybridComputePrivateLinkScopeOperationPredicate) (resp PrivateLinkScopesListCompleteResult, err error) {
+	items := make([]HybridComputePrivateLinkScope, 0)
+
+	page, err := c.PrivateLinkScopesList(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading the initial page: %+v", err)
+		return
+	}
+	if page.Model != nil {
+		for _, v := range *page.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	for page.HasMore() {
+		page, err = page.LoadMore(ctx)
+		if err != nil {
+			err = fmt.Errorf("loading the next page: %+v", err)
+			return
+		}
+
+		if page.Model != nil {
+			for _, v := range *page.Model {
+				if predicate.Matches(v) {
+					items = append(items, v)
+				}
+			}
+		}
+	}
+
+	out := PrivateLinkScopesListCompleteResult{
+		Items: items,
+	}
+	return out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/privatelinkscopes/method_privatelinkscopeslistbyresourcegroup_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/privatelinkscopes/method_privatelinkscopeslistbyresourcegroup_autorest.go
@@ -1,0 +1,187 @@
+package privatelinkscopes
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateLinkScopesListByResourceGroupOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *[]HybridComputePrivateLinkScope
+
+	nextLink     *string
+	nextPageFunc func(ctx context.Context, nextLink string) (PrivateLinkScopesListByResourceGroupOperationResponse, error)
+}
+
+type PrivateLinkScopesListByResourceGroupCompleteResult struct {
+	Items []HybridComputePrivateLinkScope
+}
+
+func (r PrivateLinkScopesListByResourceGroupOperationResponse) HasMore() bool {
+	return r.nextLink != nil
+}
+
+func (r PrivateLinkScopesListByResourceGroupOperationResponse) LoadMore(ctx context.Context) (resp PrivateLinkScopesListByResourceGroupOperationResponse, err error) {
+	if !r.HasMore() {
+		err = fmt.Errorf("no more pages returned")
+		return
+	}
+	return r.nextPageFunc(ctx, *r.nextLink)
+}
+
+// PrivateLinkScopesListByResourceGroup ...
+func (c PrivateLinkScopesClient) PrivateLinkScopesListByResourceGroup(ctx context.Context, id commonids.ResourceGroupId) (resp PrivateLinkScopesListByResourceGroupOperationResponse, err error) {
+	req, err := c.preparerForPrivateLinkScopesListByResourceGroup(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "privatelinkscopes.PrivateLinkScopesClient", "PrivateLinkScopesListByResourceGroup", nil, "Failure preparing request")
+		return
+	}
+
+	resp.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "privatelinkscopes.PrivateLinkScopesClient", "PrivateLinkScopesListByResourceGroup", resp.HttpResponse, "Failure sending request")
+		return
+	}
+
+	resp, err = c.responderForPrivateLinkScopesListByResourceGroup(resp.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "privatelinkscopes.PrivateLinkScopesClient", "PrivateLinkScopesListByResourceGroup", resp.HttpResponse, "Failure responding to request")
+		return
+	}
+	return
+}
+
+// preparerForPrivateLinkScopesListByResourceGroup prepares the PrivateLinkScopesListByResourceGroup request.
+func (c PrivateLinkScopesClient) preparerForPrivateLinkScopesListByResourceGroup(ctx context.Context, id commonids.ResourceGroupId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/providers/Microsoft.HybridCompute/privateLinkScopes", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// preparerForPrivateLinkScopesListByResourceGroupWithNextLink prepares the PrivateLinkScopesListByResourceGroup request with the given nextLink token.
+func (c PrivateLinkScopesClient) preparerForPrivateLinkScopesListByResourceGroupWithNextLink(ctx context.Context, nextLink string) (*http.Request, error) {
+	uri, err := url.Parse(nextLink)
+	if err != nil {
+		return nil, fmt.Errorf("parsing nextLink %q: %+v", nextLink, err)
+	}
+	queryParameters := map[string]interface{}{}
+	for k, v := range uri.Query() {
+		if len(v) == 0 {
+			continue
+		}
+		val := v[0]
+		val = autorest.Encode("query", val)
+		queryParameters[k] = val
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(uri.Path),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForPrivateLinkScopesListByResourceGroup handles the response to the PrivateLinkScopesListByResourceGroup request. The method always
+// closes the http.Response Body.
+func (c PrivateLinkScopesClient) responderForPrivateLinkScopesListByResourceGroup(resp *http.Response) (result PrivateLinkScopesListByResourceGroupOperationResponse, err error) {
+	type page struct {
+		Values   []HybridComputePrivateLinkScope `json:"value"`
+		NextLink *string                         `json:"nextLink"`
+	}
+	var respObj page
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&respObj),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	result.Model = &respObj.Values
+	result.nextLink = respObj.NextLink
+	if respObj.NextLink != nil {
+		result.nextPageFunc = func(ctx context.Context, nextLink string) (result PrivateLinkScopesListByResourceGroupOperationResponse, err error) {
+			req, err := c.preparerForPrivateLinkScopesListByResourceGroupWithNextLink(ctx, nextLink)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "privatelinkscopes.PrivateLinkScopesClient", "PrivateLinkScopesListByResourceGroup", nil, "Failure preparing request")
+				return
+			}
+
+			result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "privatelinkscopes.PrivateLinkScopesClient", "PrivateLinkScopesListByResourceGroup", result.HttpResponse, "Failure sending request")
+				return
+			}
+
+			result, err = c.responderForPrivateLinkScopesListByResourceGroup(result.HttpResponse)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "privatelinkscopes.PrivateLinkScopesClient", "PrivateLinkScopesListByResourceGroup", result.HttpResponse, "Failure responding to request")
+				return
+			}
+
+			return
+		}
+	}
+	return
+}
+
+// PrivateLinkScopesListByResourceGroupComplete retrieves all of the results into a single object
+func (c PrivateLinkScopesClient) PrivateLinkScopesListByResourceGroupComplete(ctx context.Context, id commonids.ResourceGroupId) (PrivateLinkScopesListByResourceGroupCompleteResult, error) {
+	return c.PrivateLinkScopesListByResourceGroupCompleteMatchingPredicate(ctx, id, HybridComputePrivateLinkScopeOperationPredicate{})
+}
+
+// PrivateLinkScopesListByResourceGroupCompleteMatchingPredicate retrieves all of the results and then applied the predicate
+func (c PrivateLinkScopesClient) PrivateLinkScopesListByResourceGroupCompleteMatchingPredicate(ctx context.Context, id commonids.ResourceGroupId, predicate HybridComputePrivateLinkScopeOperationPredicate) (resp PrivateLinkScopesListByResourceGroupCompleteResult, err error) {
+	items := make([]HybridComputePrivateLinkScope, 0)
+
+	page, err := c.PrivateLinkScopesListByResourceGroup(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading the initial page: %+v", err)
+		return
+	}
+	if page.Model != nil {
+		for _, v := range *page.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	for page.HasMore() {
+		page, err = page.LoadMore(ctx)
+		if err != nil {
+			err = fmt.Errorf("loading the next page: %+v", err)
+			return
+		}
+
+		if page.Model != nil {
+			for _, v := range *page.Model {
+				if predicate.Matches(v) {
+					items = append(items, v)
+				}
+			}
+		}
+	}
+
+	out := PrivateLinkScopesListByResourceGroupCompleteResult{
+		Items: items,
+	}
+	return out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/privatelinkscopes/method_privatelinkscopesupdatetags_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/privatelinkscopes/method_privatelinkscopesupdatetags_autorest.go
@@ -1,0 +1,69 @@
+package privatelinkscopes
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateLinkScopesUpdateTagsOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *HybridComputePrivateLinkScope
+}
+
+// PrivateLinkScopesUpdateTags ...
+func (c PrivateLinkScopesClient) PrivateLinkScopesUpdateTags(ctx context.Context, id ProviderPrivateLinkScopeId, input TagsResource) (result PrivateLinkScopesUpdateTagsOperationResponse, err error) {
+	req, err := c.preparerForPrivateLinkScopesUpdateTags(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "privatelinkscopes.PrivateLinkScopesClient", "PrivateLinkScopesUpdateTags", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "privatelinkscopes.PrivateLinkScopesClient", "PrivateLinkScopesUpdateTags", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForPrivateLinkScopesUpdateTags(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "privatelinkscopes.PrivateLinkScopesClient", "PrivateLinkScopesUpdateTags", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForPrivateLinkScopesUpdateTags prepares the PrivateLinkScopesUpdateTags request.
+func (c PrivateLinkScopesClient) preparerForPrivateLinkScopesUpdateTags(ctx context.Context, id ProviderPrivateLinkScopeId, input TagsResource) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPatch(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForPrivateLinkScopesUpdateTags handles the response to the PrivateLinkScopesUpdateTags request. The method always
+// closes the http.Response Body.
+func (c PrivateLinkScopesClient) responderForPrivateLinkScopesUpdateTags(resp *http.Response) (result PrivateLinkScopesUpdateTagsOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/privatelinkscopes/model_connectiondetail.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/privatelinkscopes/model_connectiondetail.go
@@ -1,0 +1,12 @@
+package privatelinkscopes
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ConnectionDetail struct {
+	GroupId          *string `json:"groupId,omitempty"`
+	Id               *string `json:"id,omitempty"`
+	LinkIdentifier   *string `json:"linkIdentifier,omitempty"`
+	MemberName       *string `json:"memberName,omitempty"`
+	PrivateIPAddress *string `json:"privateIpAddress,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/privatelinkscopes/model_hybridcomputeprivatelinkscope.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/privatelinkscopes/model_hybridcomputeprivatelinkscope.go
@@ -1,0 +1,18 @@
+package privatelinkscopes
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/systemdata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type HybridComputePrivateLinkScope struct {
+	Id         *string                                  `json:"id,omitempty"`
+	Location   string                                   `json:"location"`
+	Name       *string                                  `json:"name,omitempty"`
+	Properties *HybridComputePrivateLinkScopeProperties `json:"properties,omitempty"`
+	SystemData *systemdata.SystemData                   `json:"systemData,omitempty"`
+	Tags       *map[string]string                       `json:"tags,omitempty"`
+	Type       *string                                  `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/privatelinkscopes/model_hybridcomputeprivatelinkscopeproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/privatelinkscopes/model_hybridcomputeprivatelinkscopeproperties.go
@@ -1,0 +1,11 @@
+package privatelinkscopes
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type HybridComputePrivateLinkScopeProperties struct {
+	PrivateEndpointConnections *[]PrivateEndpointConnectionDataModel `json:"privateEndpointConnections,omitempty"`
+	PrivateLinkScopeId         *string                               `json:"privateLinkScopeId,omitempty"`
+	ProvisioningState          *string                               `json:"provisioningState,omitempty"`
+	PublicNetworkAccess        *PublicNetworkAccessType              `json:"publicNetworkAccess,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/privatelinkscopes/model_privateendpointconnectiondatamodel.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/privatelinkscopes/model_privateendpointconnectiondatamodel.go
@@ -1,0 +1,11 @@
+package privatelinkscopes
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateEndpointConnectionDataModel struct {
+	Id         *string                              `json:"id,omitempty"`
+	Name       *string                              `json:"name,omitempty"`
+	Properties *PrivateEndpointConnectionProperties `json:"properties,omitempty"`
+	Type       *string                              `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/privatelinkscopes/model_privateendpointconnectionproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/privatelinkscopes/model_privateendpointconnectionproperties.go
@@ -1,0 +1,11 @@
+package privatelinkscopes
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateEndpointConnectionProperties struct {
+	GroupIds                          *[]string                                  `json:"groupIds,omitempty"`
+	PrivateEndpoint                   *PrivateEndpointProperty                   `json:"privateEndpoint,omitempty"`
+	PrivateLinkServiceConnectionState *PrivateLinkServiceConnectionStateProperty `json:"privateLinkServiceConnectionState,omitempty"`
+	ProvisioningState                 *string                                    `json:"provisioningState,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/privatelinkscopes/model_privateendpointproperty.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/privatelinkscopes/model_privateendpointproperty.go
@@ -1,0 +1,8 @@
+package privatelinkscopes
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateEndpointProperty struct {
+	Id *string `json:"id,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/privatelinkscopes/model_privatelinkscopevalidationdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/privatelinkscopes/model_privatelinkscopevalidationdetails.go
@@ -1,0 +1,10 @@
+package privatelinkscopes
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateLinkScopeValidationDetails struct {
+	ConnectionDetails   *[]ConnectionDetail      `json:"connectionDetails,omitempty"`
+	Id                  *string                  `json:"id,omitempty"`
+	PublicNetworkAccess *PublicNetworkAccessType `json:"publicNetworkAccess,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/privatelinkscopes/model_privatelinkserviceconnectionstateproperty.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/privatelinkscopes/model_privatelinkserviceconnectionstateproperty.go
@@ -1,0 +1,10 @@
+package privatelinkscopes
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateLinkServiceConnectionStateProperty struct {
+	ActionsRequired *string `json:"actionsRequired,omitempty"`
+	Description     string  `json:"description"`
+	Status          string  `json:"status"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/privatelinkscopes/model_tagsresource.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/privatelinkscopes/model_tagsresource.go
@@ -1,0 +1,8 @@
+package privatelinkscopes
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type TagsResource struct {
+	Tags *map[string]string `json:"tags,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/privatelinkscopes/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/privatelinkscopes/predicates.go
@@ -1,0 +1,32 @@
+package privatelinkscopes
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type HybridComputePrivateLinkScopeOperationPredicate struct {
+	Id       *string
+	Location *string
+	Name     *string
+	Type     *string
+}
+
+func (p HybridComputePrivateLinkScopeOperationPredicate) Matches(input HybridComputePrivateLinkScope) bool {
+
+	if p.Id != nil && (input.Id == nil && *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Location != nil && *p.Location != input.Location {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil && *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil && *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/privatelinkscopes/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/privatelinkscopes/version.go
@@ -1,0 +1,12 @@
+package privatelinkscopes
+
+import "fmt"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2022-11-10"
+
+func userAgent() string {
+	return fmt.Sprintf("hashicorp/go-azure-sdk/privatelinkscopes/%s", defaultApiVersion)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -351,6 +351,7 @@ github.com/hashicorp/go-azure-sdk/resource-manager/healthcareapis/2022-12-01/wor
 github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/machineextensions
 github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/machines
 github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/privateendpointconnections
+github.com/hashicorp/go-azure-sdk/resource-manager/hybridcompute/2022-11-10/privatelinkscopes
 github.com/hashicorp/go-azure-sdk/resource-manager/hybridkubernetes/2021-10-01/connectedclusters
 github.com/hashicorp/go-azure-sdk/resource-manager/insights/2016-03-01/logprofiles
 github.com/hashicorp/go-azure-sdk/resource-manager/insights/2018-03-01/metricalerts

--- a/website/docs/r/arc_private_link_scope.html.markdown
+++ b/website/docs/r/arc_private_link_scope.html.markdown
@@ -29,7 +29,7 @@ resource "azurerm_arc_private_link_scope" "example" {
 
 The following arguments are supported:
 
-* `location` - (Required) The Azure Region where the Arc Private Link Scope should exist. Changing this forces a new Arc Private Link Scope to be created.
+* `location` - (Required) The Azure Region where the Arc Private Link Scope should exist. Changing this forces a new Azure Arc Private Link Scope to be created.
 
 * `name` - (Required) The name which should be used for the Azure Arc Private Link Scope. Changing this forces a new Azure Arc Private Link Scope to be created.
 

--- a/website/docs/r/arc_private_link_scope.html.markdown
+++ b/website/docs/r/arc_private_link_scope.html.markdown
@@ -31,9 +31,9 @@ The following arguments are supported:
 
 * `location` - (Required) The Azure Region where the Arc Private Link Scope should exist. Changing this forces a new Arc Private Link Scope to be created.
 
-* `name` - (Required) The name which should be used for the Azure Arc Private Link Scope. Changing this forces a new Hybrid Compute to be created.
+* `name` - (Required) The name which should be used for the Azure Arc Private Link Scope. Changing this forces a new Azure Arc Private Link Scope to be created.
 
-* `resource_group_name` - (Required) The name of the Resource Group where the Azure Arc Private Link Scope should exist. Changing this forces a new Hybrid Compute to be created.
+* `resource_group_name` - (Required) The name of the Resource Group where the Azure Arc Private Link Scope should exist. Changing this forces a new Azure Arc Private Link Scope to be created.
 
 ---
 
@@ -51,10 +51,10 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the Hybrid Compute.
-* `read` - (Defaults to 5 minutes) Used when retrieving the Hybrid Compute.
-* `update` - (Defaults to 30 minutes) Used when updating the Hybrid Compute.
-* `delete` - (Defaults to 30 minutes) Used when deleting the Hybrid Compute.
+* `create` - (Defaults to 30 minutes) Used when creating the Azure Arc Private Link Scope.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Azure Arc Private Link Scope.
+* `update` - (Defaults to 30 minutes) Used when updating the Azure Arc Private Link Scope.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Azure Arc Private Link Scope.
 
 ## Import
 

--- a/website/docs/r/arc_private_link_scope.html.markdown
+++ b/website/docs/r/arc_private_link_scope.html.markdown
@@ -29,7 +29,7 @@ resource "azurerm_arc_private_link_scope" "example" {
 
 The following arguments are supported:
 
-* `location` - (Required) The Azure Region where the Azure Arc PrivateLinkScope should exist. Changing this forces a new Hybrid Compute to be created.
+* `location` - (Required) The Azure Region where the Arc PrivateLinkScope should exist. Changing this forces a new Arc Private Link Scope to be created.
 
 * `name` - (Required) The name which should be used for the Azure Arc PrivateLinkScope. Changing this forces a new Hybrid Compute to be created.
 

--- a/website/docs/r/arc_private_link_scope.html.markdown
+++ b/website/docs/r/arc_private_link_scope.html.markdown
@@ -1,0 +1,65 @@
+---
+subcategory: "Hybrid Compute"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_arc_private_link_scope"
+description: |-
+  Manages an Azure Arc PrivateLinkScope.
+---
+
+# azurerm_arc_private_link_scope
+
+Manages an Azure Arc PrivateLinkScope.
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "rg-example"
+  location = "west europe"
+}
+
+resource "azurerm_arc_private_link_scope" "example" {
+  name                = "plsexample"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `location` - (Required) The Azure Region where the Azure Arc PrivateLinkScope should exist. Changing this forces a new Hybrid Compute to be created.
+
+* `name` - (Required) The name which should be used for the Azure Arc PrivateLinkScope. Changing this forces a new Hybrid Compute to be created.
+
+* `resource_group_name` - (Required) The name of the Resource Group where the Azure Arc PrivateLinkScope should exist. Changing this forces a new Hybrid Compute to be created.
+
+---
+
+* `public_network_access_enabled` - (Optional) Indicates whether machines associated with the private link scope can also use public Azure Arc service endpoints. Defaults to `false`. Possible values are `true` and `false`.
+
+* `tags` - (Optional) A mapping of tags which should be assigned to the Azure Arc PrivateLinkScope.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported: 
+
+* `id` - The ID of the Azure Arc PrivateLinkScope.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Hybrid Compute.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Hybrid Compute.
+* `update` - (Defaults to 30 minutes) Used when updating the Hybrid Compute.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Hybrid Compute.
+
+## Import
+
+Azure Arc PrivateLinkScope can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_arc_private_link_scope.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.HyrbidCompute/privateLinkScopes/privateLinkScope1
+```

--- a/website/docs/r/arc_private_link_scope.html.markdown
+++ b/website/docs/r/arc_private_link_scope.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # azurerm_arc_private_link_scope
 
-Manages an Azure Arc PrivateLinkScope.
+Manages an Azure Arc Private Link Scope.
 
 ## Example Usage
 
@@ -29,23 +29,23 @@ resource "azurerm_arc_private_link_scope" "example" {
 
 The following arguments are supported:
 
-* `location` - (Required) The Azure Region where the Arc PrivateLinkScope should exist. Changing this forces a new Arc Private Link Scope to be created.
+* `location` - (Required) The Azure Region where the Arc Private Link Scope should exist. Changing this forces a new Arc Private Link Scope to be created.
 
-* `name` - (Required) The name which should be used for the Azure Arc PrivateLinkScope. Changing this forces a new Hybrid Compute to be created.
+* `name` - (Required) The name which should be used for the Azure Arc Private Link Scope. Changing this forces a new Hybrid Compute to be created.
 
-* `resource_group_name` - (Required) The name of the Resource Group where the Azure Arc PrivateLinkScope should exist. Changing this forces a new Hybrid Compute to be created.
+* `resource_group_name` - (Required) The name of the Resource Group where the Azure Arc Private Link Scope should exist. Changing this forces a new Hybrid Compute to be created.
 
 ---
 
 * `public_network_access_enabled` - (Optional) Indicates whether machines associated with the private link scope can also use public Azure Arc service endpoints. Defaults to `false`. Possible values are `true` and `false`.
 
-* `tags` - (Optional) A mapping of tags which should be assigned to the Azure Arc PrivateLinkScope.
+* `tags` - (Optional) A mapping of tags which should be assigned to the Azure Arc Private Link Scope.
 
 ## Attributes Reference
 
 In addition to the Arguments listed above - the following Attributes are exported: 
 
-* `id` - The ID of the Azure Arc PrivateLinkScope.
+* `id` - The ID of the Azure Arc Private Link Scope.
 
 ## Timeouts
 
@@ -58,7 +58,7 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 
 ## Import
 
-Azure Arc PrivateLinkScope can be imported using the `resource id`, e.g.
+Azure Arc Private Link Scope can be imported using the `resource id`, e.g.
 
 ```shell
 terraform import azurerm_arc_private_link_scope.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.HyrbidCompute/privateLinkScopes/privateLinkScope1

--- a/website/docs/r/arc_private_link_scope.html.markdown
+++ b/website/docs/r/arc_private_link_scope.html.markdown
@@ -3,7 +3,7 @@ subcategory: "Hybrid Compute"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_arc_private_link_scope"
 description: |-
-  Manages an Azure Arc PrivateLinkScope.
+  Manages an Azure Arc Private Link Scope.
 ---
 
 # azurerm_arc_private_link_scope


### PR DESCRIPTION
New Resource: `azurerm_arc_private_link_scope`

Swagger Link:

https://github.com/Azure/azure-rest-api-specs/blob/main/specification/hybridcompute/resource-manager/Microsoft.HybridCompute/stable/2022-11-10/privateLinkScopes.json

Tesing Evidence:

```
GOROOT=C:\Program Files\Go #gosetup
GOPATH=C:\Users\yunliu1\go #gosetup
"C:\Program Files\Go\bin\go.exe" test -c -o C:\Users\yunliu1\AppData\Local\JetBrains\GoLand2023.1\tmp\GoLand\___TestAccArcPrivateLinkScope_basic_in_github_com_hashicorp_terraform_provider_azurerm_internal_services_hybridcompute.test.exe github.com/hashicorp/terraform-provider-azurerm/internal/services/hybridcompute #gosetup
"C:\Program Files\Go\bin\go.exe" tool test2json -t C:\Users\yunliu1\AppData\Local\JetBrains\GoLand2023.1\tmp\GoLand\___TestAccArcPrivateLinkScope_basic_in_github_com_hashicorp_terraform_provider_azurerm_internal_services_hybridcompute.test.exe -test.v -test.paniconexit0 -test.run ^\QTestAccArcPrivateLinkScope_basic\E$ #gosetup
=== RUN   TestAccArcPrivateLinkScope_basic
=== PAUSE TestAccArcPrivateLinkScope_basic
=== CONT  TestAccArcPrivateLinkScope_basic
--- PASS: TestAccArcPrivateLinkScope_basic (170.70s)
PASS

Process finished with the exit code 0
```

```
GOROOT=C:\Program Files\Go #gosetup
GOPATH=C:\Users\yunliu1\go #gosetup
"C:\Program Files\Go\bin\go.exe" test -c -o C:\Users\yunliu1\AppData\Local\JetBrains\GoLand2023.1\tmp\GoLand\___TestAccArcPrivateLinkScope_update_in_github_com_hashicorp_terraform_provider_azurerm_internal_services_hybridcompute.test.exe github.com/hashicorp/terraform-provider-azurerm/internal/services/hybridcompute #gosetup
"C:\Program Files\Go\bin\go.exe" tool test2json -t C:\Users\yunliu1\AppData\Local\JetBrains\GoLand2023.1\tmp\GoLand\___TestAccArcPrivateLinkScope_update_in_github_com_hashicorp_terraform_provider_azurerm_internal_services_hybridcompute.test.exe -test.v -test.paniconexit0 -test.run ^\QTestAccArcPrivateLinkScope_update\E$ #gosetup
=== RUN   TestAccArcPrivateLinkScope_update
=== PAUSE TestAccArcPrivateLinkScope_update
=== CONT  TestAccArcPrivateLinkScope_update
--- PASS: TestAccArcPrivateLinkScope_update (245.81s)
PASS


Process finished with the exit code 0
```