### PR TITLE
`azurerm_spring_cloud_configuration_service` - support the `generation` property

### DIFF
--- a/internal/services/springcloud/spring_cloud_configuration_service_resource.go
+++ b/internal/services/springcloud/spring_cloud_configuration_service_resource.go
@@ -58,6 +58,15 @@ func resourceSpringCloudConfigurationService() *pluginsdk.Resource {
 				ValidateFunc: validate.SpringCloudServiceID,
 			},
 
+			"generation": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					string(appplatform.ConfigurationServiceGenerationGen1),
+					string(appplatform.ConfigurationServiceGenerationGen2),
+				}, false),
+			},
+
 			"repository": {
 				Type:     pluginsdk.TypeList,
 				Optional: true,
@@ -167,6 +176,7 @@ func resourceSpringCloudConfigurationServiceCreateUpdate(d *pluginsdk.ResourceDa
 
 	configurationServiceResource := appplatform.ConfigurationServiceResource{
 		Properties: &appplatform.ConfigurationServiceProperties{
+			Generation: appplatform.ConfigurationServiceGeneration(d.Get("generation").(string)),
 			Settings: &appplatform.ConfigurationServiceSettings{
 				GitProperty: &appplatform.ConfigurationServiceGitProperty{
 					Repositories: expandConfigurationServiceConfigurationServiceGitRepositoryArray(d.Get("repository").([]interface{})),
@@ -209,6 +219,7 @@ func resourceSpringCloudConfigurationServiceRead(d *pluginsdk.ResourceData, meta
 	d.Set("name", id.ConfigurationServiceName)
 	d.Set("spring_cloud_service_id", parse.NewSpringCloudServiceID(id.SubscriptionId, id.ResourceGroup, id.SpringName).ID())
 	if props := resp.Properties; props != nil {
+		d.Set("generation", props.Generation)
 		if props.Settings != nil && props.Settings.GitProperty != nil {
 			d.Set("repository", flattenConfigurationServiceConfigurationServiceGitRepositoryArray(props.Settings.GitProperty.Repositories, d.Get("repository").([]interface{})))
 		}

--- a/internal/services/springcloud/spring_cloud_configuration_service_resource_test.go
+++ b/internal/services/springcloud/spring_cloud_configuration_service_resource_test.go
@@ -99,6 +99,26 @@ func TestAccSpringCloudConfigurationService_update(t *testing.T) {
 	})
 }
 
+func TestAccSpringCloudConfigurationService_generation(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_spring_cloud_configuration_service", "test")
+	r := SpringCloudConfigurationServiceResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.generation(data, "Gen1"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(), {
+			Config: r.generation(data, "Gen2"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (r SpringCloudConfigurationServiceResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := parse.SpringCloudConfigurationServiceID(state.ID)
 	if err != nil {
@@ -201,4 +221,17 @@ resource "azurerm_spring_cloud_configuration_service" "test" {
   }
 }
 `, template)
+}
+
+func (r SpringCloudConfigurationServiceResource) generation(data acceptance.TestData, generation string) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_spring_cloud_configuration_service" "test" {
+  name                    = "default"
+  spring_cloud_service_id = azurerm_spring_cloud_service.test.id
+  generation              = "%s"
+}
+`, template, generation)
 }

--- a/website/docs/r/spring_cloud_configuration_service.html.markdown
+++ b/website/docs/r/spring_cloud_configuration_service.html.markdown
@@ -57,6 +57,8 @@ The following arguments are supported:
 
 ---
 
+* `generation` - (Optional) The generation of the Spring Cloud Configuration Service. Possible values are `Gen1` and `Gen2`.
+
 * `repository` - (Optional) One or more `repository` blocks as defined below.
 
 ---


### PR DESCRIPTION
```
=== RUN   TestAccSpringCloudConfigurationService_basic
=== PAUSE TestAccSpringCloudConfigurationService_basic
=== CONT  TestAccSpringCloudConfigurationService_basic
--- PASS: TestAccSpringCloudConfigurationService_basic (477.68s)
=== RUN   TestAccSpringCloudConfigurationService_requiresImport
=== PAUSE TestAccSpringCloudConfigurationService_requiresImport
=== CONT  TestAccSpringCloudConfigurationService_requiresImport
--- PASS: TestAccSpringCloudConfigurationService_requiresImport (533.44s)
=== RUN   TestAccSpringCloudConfigurationService_complete
=== PAUSE TestAccSpringCloudConfigurationService_complete
=== CONT  TestAccSpringCloudConfigurationService_complete
--- PASS: TestAccSpringCloudConfigurationService_complete (504.83s)
=== RUN   TestAccSpringCloudConfigurationService_sshAuth
=== PAUSE TestAccSpringCloudConfigurationService_sshAuth
=== CONT  TestAccSpringCloudConfigurationService_sshAuth
--- PASS: TestAccSpringCloudConfigurationService_sshAuth (491.83s)
=== RUN   TestAccSpringCloudConfigurationService_update
=== PAUSE TestAccSpringCloudConfigurationService_update
=== CONT  TestAccSpringCloudConfigurationService_update
--- PASS: TestAccSpringCloudConfigurationService_update (732.91s)
=== RUN   TestAccSpringCloudConfigurationService_generation
=== PAUSE TestAccSpringCloudConfigurationService_generation
=== CONT  TestAccSpringCloudConfigurationService_generation
--- PASS: TestAccSpringCloudConfigurationService_generation (891.22s)
PASS

Process finished with the exit code 0
```