### PR TITLE
`azurerm_container_app_environment`: Add support for `dapr_ai_connection_string`

### DIFF
--- a/internal/services/containerapps/container_app_environment_resource_test.go
+++ b/internal/services/containerapps/container_app_environment_resource_test.go
@@ -181,11 +181,20 @@ provider "azurerm" {
 
 %[1]s
 
+
+resource "azurerm_application_insights" "test2" {
+  name                = "updateaccappinsights%[2]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  application_type    = "web"
+}
+
 resource "azurerm_container_app_environment" "test" {
   name                       = "accTest-CAEnv%[2]d"
   resource_group_name        = azurerm_resource_group.test.name
   location                   = azurerm_resource_group.test.location
   log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
+  dapr_ai_connection_string  = azurerm_application_insights.test2.connection_string
 
   infrastructure_subnet_id = azurerm_subnet.control.id
 

--- a/website/docs/r/container_app_environment.html.markdown
+++ b/website/docs/r/container_app_environment.html.markdown
@@ -46,6 +46,8 @@ The following arguments are supported:
 
 * `log_analytics_workspace_id` - (Required) The ID for the Log Analytics Workspace to link this Container Apps Managed Environment to. Changing this forces a new resource to be created.
 
+* `dapr_ai_connection_string` - (Optional) Application Insights connection string used by Dapr to export Service to Service communication telemetry.
+
 ---
 
 * `infrastructure_subnet_id` - (Optional) The existing Subnet to use for the Container Apps Control Plane. Changing this forces a new resource to be created. 


### PR DESCRIPTION
<details>
<summary>
Test results: 
</summary>
<br>

```
--- PASS: TestAccContainerAppEnvironment_basic (670.15s)
--- PASS: TestAccContainerAppEnvironment_requiresImport (731.12s)
--- PASS: TestAccContainerAppEnvironment_complete (1616.27s)
```

</details>


`TestAccContainerAppEnvironment_completeUpdate` fails from time to time due to quota issue, no new failures introduced.