### PR TITLE
`azurerm_kubernetes_cluster` - Add support for upgrade settings such as `IgnoreKubernetesDeprecations`

### DIFF
--- a/internal/services/containers/kubernetes_cluster_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_resource_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
@@ -782,8 +783,13 @@ resource "azurerm_kubernetes_cluster" "test" {
 
   upgrade_settings {
     controle_plane_upgrade_overrides = ["IgnoreKubernetesDeprecations"]
-    until                            = "3023-06-30T12:00:00Z" 
+    until                            = "%s" 
   }
 }
-  `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, controlPlaneVersion)
+  `,
+		data.RandomInteger,
+		data.Locations.Primary,
+		data.RandomInteger,
+		controlPlaneVersion,
+		time.Now().UTC().Add(5*24*time.Hour).Format("2006-01-02T15:04:05Z")) // Until cannot be more than 30 days in the future
 }

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -249,6 +249,8 @@ resource "azurerm_kubernetes_cluster" "example" {
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
+* `upgrade_settings` - (Optional) An `upgrade_settings` block as defined below.
+
 * `web_app_routing` - (Optional) A `web_app_routing` block as defined below.
 
 * `windows_profile` - (Optional) A `windows_profile` block as defined below.
@@ -858,6 +860,13 @@ A `sysctl_config` block supports the following:
 * `vm_swappiness` - (Optional) The sysctl setting vm.swappiness. Must be between `0` and `100`. Changing this forces a new resource to be created.
 
 * `vm_vfs_cache_pressure` - (Optional) The sysctl setting vm.vfs_cache_pressure. Must be between `0` and `100`. Changing this forces a new resource to be created.
+
+---
+
+An `upgrade_settings` block supports the following:
+
+* `controle_plane_upgrade_overrides` - (Required) The list of upgrade overrides to apply on the AKS control plane.  Only `IgnoreKubernetesDeprecations` is supported.
+* `until` - (Required) Time in the future at which the override will stop being in effect. Must be an RFC3339 compatible string (e.g. `2025-01-25T14:26:04Z`)
 
 ---
 


### PR DESCRIPTION
According to https://learn.microsoft.com/en-us/azure/aks/upgrade-cluster?tabs=azure-cli#bypass-validation-to-ignore-api-changes, it's possible to bypass validation to ignore API changes that would break some existing behavior in the cluster.

For instance, upgrading to 1.26, removes the HPA `v2beta2` API version which workloads (like e.g. Datadog) might be querying. Azure detects this usage and prevents the upgrade to 1.26 in normal conditions.

This PR adds support for those upgrade settings attributes at the cluster resource level.

Example usage:

```hcl
resource "azurerm_kubernetes_cluster" "test" {
...
  upgrade_settings {
    controle_plane_upgrade_overrides = ["IgnoreKubernetesDeprecations"]
    until                            = "3023-06-30T12:00:00Z" 
  }
}
```

fixes #21984 