### PR TITLE
`azurerm_stream_analytics_output_blob`: Fix `batch_min_rows` range

### DIFF
--- a/internal/services/streamanalytics/stream_analytics_output_blob_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_output_blob_resource.go
@@ -108,7 +108,7 @@ func resourceStreamAnalyticsOutputBlob() *pluginsdk.Resource {
 			"batch_min_rows": {
 				Type:         pluginsdk.TypeInt,
 				Optional:     true,
-				ValidateFunc: validation.IntBetween(0, 10000),
+				ValidateFunc: validation.IntBetween(0, 1000000),
 			},
 
 			"storage_account_key": {

--- a/internal/services/streamanalytics/stream_analytics_output_blob_resource_test.go
+++ b/internal/services/streamanalytics/stream_analytics_output_blob_resource_test.go
@@ -240,7 +240,7 @@ resource "azurerm_stream_analytics_output_blob" "test" {
   date_format               = "yyyy-MM-dd"
   time_format               = "HH"
   batch_max_wait_time       = "00:02:00"
-  batch_min_rows            = 5000
+  batch_min_rows            = 1000000
 
   serialization {
     type = "Parquet"

--- a/website/docs/r/stream_analytics_output_blob.html.markdown
+++ b/website/docs/r/stream_analytics_output_blob.html.markdown
@@ -82,7 +82,7 @@ The following arguments are supported:
 
 * `batch_max_wait_time` - (Optional) The maximum wait time per batch in `hh:mm:ss` e.g. `00:02:00` for two minutes.
 
-* `batch_min_rows` - (Optional) The minimum number of rows per batch (must be between `0` and `10000`).
+* `batch_min_rows` - (Optional) The minimum number of rows per batch (must be between `0` and `1000000`).
 
 * `storage_account_key` - (Optional) The Access Key which should be used to connect to this Storage Account.
 


### PR DESCRIPTION
* According to Azure Portal, the range of this `batch_min_rows` has raised to `1000000`, change this range in TF accordingly.

* Test result:

```
PASS: TestAccStreamAnalyticsOutputBlob_parquet (216.88s)
```