### PR TITLE
Fix Msi support for stream analytics job

### DIFF
--- a/internal/services/streamanalytics/stream_analytics_job_resource.go
+++ b/internal/services/streamanalytics/stream_analytics_job_resource.go
@@ -551,7 +551,7 @@ func expandJobStorageAccount(input []interface{}) *streamingjobs.JobStorageAccou
 		return &streamingjobs.JobStorageAccount{
 			AuthenticationMode: utils.ToPtr(streamingjobs.AuthenticationMode(authenticationMode)),
 			AccountName:        utils.String(accountName),
-		} 
+		}
 	} else {
 		return &streamingjobs.JobStorageAccount{
 			AuthenticationMode: utils.ToPtr(streamingjobs.AuthenticationMode(authenticationMode)),

--- a/internal/services/streamanalytics/stream_analytics_job_resource_test.go
+++ b/internal/services/streamanalytics/stream_analytics_job_resource_test.go
@@ -149,6 +149,27 @@ func TestAccStreamAnalyticsJob_jobStorageAccount(t *testing.T) {
 	})
 }
 
+func TestAccStreamAnalyticsJob_jobStorageAccount_Msi(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_stream_analytics_job", "test")
+	r := StreamAnalyticsJobResource{}
+
+	data.ResourceSequentialTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.jobStorageAccount(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		{
+			Config: r.jobStorageAccount_Msi(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (r StreamAnalyticsJobResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := streamingjobs.ParseStreamingJobID(state.ID)
 	if err != nil {
@@ -407,6 +428,50 @@ resource "azurerm_stream_analytics_job" "test" {
   job_storage_account {
     account_name = azurerm_storage_account.test.name
     account_key  = azurerm_storage_account.test.primary_access_key
+  }
+
+  tags = {
+    environment = "Test"
+  }
+
+  transformation_query = <<QUERY
+    SELECT *
+    INTO [YourOutputAlias]
+    FROM [YourInputAlias]
+QUERY
+
+}
+`, data.RandomInteger, data.RandomString, data.Locations.Primary, data.RandomInteger)
+}
+
+func (r StreamAnalyticsJobResource) jobStorageAccount_Msi(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%[3]s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "acctestacc%[2]s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_stream_analytics_job" "test" {
+  name                   = "acctestjob-%[4]d"
+  resource_group_name    = azurerm_resource_group.test.name
+  location               = azurerm_resource_group.test.location
+  streaming_units        = 3
+  content_storage_policy = "JobStorageAccount"
+  job_storage_account {
+	authentication_mode = "Msi"
+    account_name        = azurerm_storage_account.test.name
   }
 
   tags = {

--- a/internal/services/streamanalytics/stream_analytics_job_resource_test.go
+++ b/internal/services/streamanalytics/stream_analytics_job_resource_test.go
@@ -469,9 +469,14 @@ resource "azurerm_stream_analytics_job" "test" {
   location               = azurerm_resource_group.test.location
   streaming_units        = 3
   content_storage_policy = "JobStorageAccount"
+
   job_storage_account {
     authentication_mode = "Msi"
     account_name        = azurerm_storage_account.test.name
+  }
+
+  identity {
+    type = "SystemAssigned"
   }
 
   tags = {

--- a/internal/services/streamanalytics/stream_analytics_job_resource_test.go
+++ b/internal/services/streamanalytics/stream_analytics_job_resource_test.go
@@ -470,7 +470,7 @@ resource "azurerm_stream_analytics_job" "test" {
   streaming_units        = 3
   content_storage_policy = "JobStorageAccount"
   job_storage_account {
-	authentication_mode = "Msi"
+    authentication_mode = "Msi"
     account_name        = azurerm_storage_account.test.name
   }
 

--- a/website/docs/r/stream_analytics_job.html.markdown
+++ b/website/docs/r/stream_analytics_job.html.markdown
@@ -87,11 +87,15 @@ The following arguments are supported:
 
 A `job_storage_account` block supports the following:
 
-* `authentication_mode` - (Optional) The authentication mode of the storage account. The only supported value is `ConnectionString`. Defaults to `ConnectionString`.
+* `authentication_mode` - (Optional) The authentication mode of the storage account. Possibles values are `ConnectionString`, `Msi`. Defaults to `ConnectionString`.
+
+-> **NOTE:** `authentication_mode` must be set to `ConnectionString` when creating a new job and can only be changed afterwards to `Msi`. This is because the job has to exists in order to authenticate against the storage account.
 
 * `account_name` - (Required) The name of the Azure storage account.
 
-* `account_key` - (Required) The account key for the Azure storage account.
+* `account_key` - (Optional) The account key for the Azure storage account.
+
+-> **NOTE:** `account_key` must be set when `authentication_mode` is `ConnectionString`.
 
 ---
 


### PR DESCRIPTION
Fix #19152
Fix #19351

Allow `Msi` option for `job_storage_account` `authentication_mode`.

A stream analytics job can't be directly created using `Msi` option because of cyclic dependency between job and storage account, it can be changed latter on once the job exists.
Therefore `Msi` should be supported.
This PR adds the functionality and even throws an error when using `Msi` option in the create phase.