### PR TITLE
`azurerm_media*` - mark deprecated as service is being retired

### DIFF
--- a/internal/services/media/media_asset_filter_resource.go
+++ b/internal/services/media/media_asset_filter_resource.go
@@ -24,6 +24,8 @@ func resourceMediaAssetFilter() *pluginsdk.Resource {
 		Update: resourceMediaAssetFilterCreateUpdate,
 		Delete: resourceMediaAssetFilterDelete,
 
+		DeprecationMessage: azureMediaRetirementMessage,
+
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),

--- a/internal/services/media/media_asset_resource.go
+++ b/internal/services/media/media_asset_resource.go
@@ -26,6 +26,8 @@ func resourceMediaAsset() *pluginsdk.Resource {
 		Update: resourceMediaAssetCreateUpdate,
 		Delete: resourceMediaAssetDelete,
 
+		DeprecationMessage: azureMediaRetirementMessage,
+
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),

--- a/internal/services/media/media_content_key_policy_resource.go
+++ b/internal/services/media/media_content_key_policy_resource.go
@@ -28,6 +28,8 @@ func resourceMediaContentKeyPolicy() *pluginsdk.Resource {
 		Update: resourceMediaContentKeyPolicyCreateUpdate,
 		Delete: resourceMediaContentKeyPolicyDelete,
 
+		DeprecationMessage: azureMediaRetirementMessage,
+
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),

--- a/internal/services/media/media_job_resource.go
+++ b/internal/services/media/media_job_resource.go
@@ -26,6 +26,8 @@ func resourceMediaJob() *pluginsdk.Resource {
 		Update: resourceMediaJobUpdate,
 		Delete: resourceMediaJobDelete,
 
+		DeprecationMessage: azureMediaRetirementMessage,
+
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),

--- a/internal/services/media/media_live_output_resource.go
+++ b/internal/services/media/media_live_output_resource.go
@@ -26,6 +26,8 @@ func resourceMediaLiveOutput() *pluginsdk.Resource {
 		Read:   resourceMediaLiveOutputRead,
 		Delete: resourceMediaLiveOutputDelete,
 
+		DeprecationMessage: azureMediaRetirementMessage,
+
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),

--- a/internal/services/media/media_service_account_filter_resource.go
+++ b/internal/services/media/media_service_account_filter_resource.go
@@ -14,6 +14,9 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
+var _ sdk.ResourceWithUpdate = AccountFilterResource{}
+var _ sdk.ResourceWithDeprecationAndNoReplacement = AccountFilterResource{}
+
 type AccountFilterModel struct {
 	Name                     string                  `tfschema:"name"`
 	ResourceGroupName        string                  `tfschema:"resource_group_name"`
@@ -43,6 +46,10 @@ type Condition struct {
 }
 
 type AccountFilterResource struct{}
+
+func (r AccountFilterResource) DeprecationMessage() string {
+	return azureMediaRetirementMessage
+}
 
 func (r AccountFilterResource) Arguments() map[string]*pluginsdk.Schema {
 	return map[string]*pluginsdk.Schema{

--- a/internal/services/media/media_services_account_resource.go
+++ b/internal/services/media/media_services_account_resource.go
@@ -33,6 +33,8 @@ func resourceMediaServicesAccount() *pluginsdk.Resource {
 		Update: resourceMediaServicesAccountCreateUpdate,
 		Delete: resourceMediaServicesAccountDelete,
 
+		DeprecationMessage: azureMediaRetirementMessage,
+
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),

--- a/internal/services/media/media_streaming_endpoint_resource.go
+++ b/internal/services/media/media_streaming_endpoint_resource.go
@@ -29,6 +29,8 @@ func resourceMediaStreamingEndpoint() *pluginsdk.Resource {
 		Update: resourceMediaStreamingEndpointUpdate,
 		Delete: resourceMediaStreamingEndpointDelete,
 
+		DeprecationMessage: azureMediaRetirementMessage,
+
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),

--- a/internal/services/media/media_streaming_live_event_resource.go
+++ b/internal/services/media/media_streaming_live_event_resource.go
@@ -28,6 +28,8 @@ func resourceMediaLiveEvent() *pluginsdk.Resource {
 		Update: resourceMediaLiveEventUpdate,
 		Delete: resourceMediaLiveEventDelete,
 
+		DeprecationMessage: azureMediaRetirementMessage,
+
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),

--- a/internal/services/media/media_streaming_locator_resource.go
+++ b/internal/services/media/media_streaming_locator_resource.go
@@ -26,6 +26,8 @@ func resourceMediaStreamingLocator() *pluginsdk.Resource {
 		Read:   resourceMediaStreamingLocatorRead,
 		Delete: resourceMediaStreamingLocatorDelete,
 
+		DeprecationMessage: azureMediaRetirementMessage,
+
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),

--- a/internal/services/media/media_streaming_policy_resource.go
+++ b/internal/services/media/media_streaming_policy_resource.go
@@ -26,6 +26,8 @@ func resourceMediaStreamingPolicy() *pluginsdk.Resource {
 		Read:   resourceMediaStreamingPolicyRead,
 		Delete: resourceMediaStreamingPolicyDelete,
 
+		DeprecationMessage: azureMediaRetirementMessage,
+
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),

--- a/internal/services/media/media_transform_resource.go
+++ b/internal/services/media/media_transform_resource.go
@@ -28,6 +28,8 @@ func resourceMediaTransform() *pluginsdk.Resource {
 		Update: resourceMediaTransformCreateUpdate,
 		Delete: resourceMediaTransformDelete,
 
+		DeprecationMessage: azureMediaRetirementMessage,
+
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),

--- a/internal/services/media/registration.go
+++ b/internal/services/media/registration.go
@@ -13,7 +13,7 @@ var (
 )
 
 const (
-	azureMediaRetirementMessage = "Azure Media Services is being retired as of June 30th, 2023. Please see https://learn.microsoft.com/en-us/azure/media-services/latest/azure-media-services-retirement"
+	azureMediaRetirementMessage = "Azure Media Services will be retired June 30th, 2024. Please see https://learn.microsoft.com/en-us/azure/media-services/latest/azure-media-services-retirement"
 )
 
 func (r Registration) AssociatedGitHubLabel() string {

--- a/internal/services/media/registration.go
+++ b/internal/services/media/registration.go
@@ -12,6 +12,10 @@ var (
 	_ sdk.UntypedServiceRegistrationWithAGitHubLabel = Registration{}
 )
 
+const (
+	azureMediaRetirementMessage = "Azure Media Services is being retired as of June 30th, 2023. Please see https://learn.microsoft.com/en-us/azure/media-services/latest/azure-media-services-retirement"
+)
+
 func (r Registration) AssociatedGitHubLabel() string {
 	return "service/media"
 }


### PR DESCRIPTION
Azure Media Services will be retired June 30th, 2024. For more information, see the [AMS Retirement Guide](https://learn.microsoft.com/en-us/azure/media-services/latest/azure-media-services-retirement).