### PR TITLE
`tests` - fix `TestAccVirtualMachineScaleSetExtension_basicWindows`

### DIFF
--- a/internal/services/compute/virtual_machine_scale_set_extension_resource_test.go
+++ b/internal/services/compute/virtual_machine_scale_set_extension_resource_test.go
@@ -255,16 +255,16 @@ func (r VirtualMachineScaleSetExtensionResource) basicWindows(data acceptance.Te
 %s
 
 resource "azurerm_virtual_machine_scale_set_extension" "test" {
-  name                         = "acctestExt-%d"
+  name                         = "CustomScript"
   virtual_machine_scale_set_id = azurerm_windows_virtual_machine_scale_set.test.id
-  publisher                    = "Microsoft.Azure.Extensions"
-  type                         = "CustomScript"
-  type_handler_version         = "2.0"
+  publisher                    = "Microsoft.Compute"
+  type                         = "CustomScriptExtension"
+  type_handler_version         = "1.10"
   settings = jsonencode({
-    "commandToExecute" = "Write-Host \"Hello\""
+    "commandToExecute" = "powershell.exe -c \"Get-Content env:computername\""
   })
 }
-`, r.templateWindows(data), data.RandomInteger)
+`, r.templateWindows(data))
 }
 
 func (r VirtualMachineScaleSetExtensionResource) autoUpgradeMinorVersionDisabled(data acceptance.TestData) string {


### PR DESCRIPTION
The extension for this windows VMSS test is using the extension for Linux by mistake, updating it to use Windows extension.

Error message: `Code="OperationNotAllowed" Message="Publisher 'Microsoft.Azure.Extensions' and type 'CustomScript' are not supported for OS type 'Windows'. Please use publisher 'Microsoft.Compute' and type 'CustomScriptExtension' instead."`