### PR TITLE
`azurerm_batch_account` - support `network_profile`

### DIFF
--- a/internal/services/batch/batch_account_resource.go
+++ b/internal/services/batch/batch_account_resource.go
@@ -110,6 +110,19 @@ func resourceBatchAccount() *pluginsdk.Resource {
 				Default:  true,
 			},
 
+			"network_profile": {
+				Type:     pluginsdk.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"account_access": resourceBatchAccountEndpointAccessProfileSchema(),
+
+						"node_management_access": resourceBatchAccountEndpointAccessProfileSchema(),
+					},
+				},
+			},
+
 			"key_vault_reference": {
 				Type:     pluginsdk.TypeList,
 				Optional: true,
@@ -217,6 +230,10 @@ func resourceBatchAccountCreate(d *pluginsdk.ResourceData, meta interface{}) err
 
 	if enabled := d.Get("public_network_access_enabled").(bool); !enabled {
 		parameters.Properties.PublicNetworkAccess = utils.ToPtr(batchaccount.PublicNetworkAccessTypeDisabled)
+	}
+
+	if v, ok := d.GetOk("network_profile"); ok {
+		parameters.Properties.NetworkProfile = expandBatchAccountNetworkProfile(v.([]interface{}))
 	}
 
 	// if pool allocation mode is UserSubscription, a key vault reference needs to be set
@@ -330,6 +347,10 @@ func resourceBatchAccountRead(d *pluginsdk.ResourceData, meta interface{}) error
 				d.Set("public_network_access_enabled", *v == batchaccount.PublicNetworkAccessTypeEnabled)
 			}
 
+			if err := d.Set("network_profile", flattenBatchAccountNetworkProfile(props.NetworkProfile)); err != nil {
+				return fmt.Errorf("setting `network_profile`: %+v", err)
+			}
+
 			d.Set("pool_allocation_mode", string(pointer.From(props.PoolAllocationMode)))
 
 			if err := d.Set("encryption", flattenEncryption(props.Encryption)); err != nil {
@@ -403,6 +424,10 @@ func resourceBatchAccountUpdate(d *pluginsdk.ResourceData, meta interface{}) err
 		} else {
 			parameters.Properties.PublicNetworkAccess = utils.ToPtr(batchaccount.PublicNetworkAccessTypeDisabled)
 		}
+	}
+
+	if d.HasChange("network_profile") {
+		parameters.Properties.NetworkProfile = expandBatchAccountNetworkProfile(d.Get("network_profile").([]interface{}))
 	}
 
 	if d.HasChange("storage_account_id") {
@@ -496,6 +521,41 @@ func expandAllowedAuthenticationModes(input []interface{}) *[]batchaccount.Authe
 	return &allowedAuthModes
 }
 
+func expandBatchAccountNetworkProfile(input []interface{}) *batchaccount.NetworkProfile {
+	if len(input) == 0 || input[0] == nil {
+		return &batchaccount.NetworkProfile{}
+	}
+
+	networkProfile := input[0].(map[string]interface{})
+	return &batchaccount.NetworkProfile{
+		AccountAccess:        expandBatchAccountEndpointAccessProfile(networkProfile["account_access"].([]interface{})),
+		NodeManagementAccess: expandBatchAccountEndpointAccessProfile(networkProfile["node_management_access"].([]interface{})),
+	}
+}
+
+func expandBatchAccountEndpointAccessProfile(input []interface{}) *batchaccount.EndpointAccessProfile {
+	if len(input) == 0 || input[0] == nil {
+		return nil
+	}
+
+	accessProfile := input[0].(map[string]interface{})
+
+	ipRulesRaw := accessProfile["ip_rule"].([]interface{})
+	ipRules := make([]batchaccount.IPRule, 0)
+	for _, ipRule := range ipRulesRaw {
+		ipRuleRaw := ipRule.(map[string]interface{})
+		ipRules = append(ipRules, batchaccount.IPRule{
+			Action: batchaccount.IPRuleAction(ipRuleRaw["action"].(string)),
+			Value:  ipRuleRaw["ip_range"].(string),
+		})
+	}
+
+	return &batchaccount.EndpointAccessProfile{
+		DefaultAction: batchaccount.EndpointAccessDefaultAction(accessProfile["default_action"].(string)),
+		IPRules:       pointer.To(ipRules),
+	}
+}
+
 func flattenAllowedAuthenticationModes(input *[]batchaccount.AuthenticationMode) []string {
 	if input == nil || len(*input) == 0 {
 		return []string{}
@@ -520,6 +580,44 @@ func flattenEncryption(encryptionProperties *batchaccount.EncryptionProperties) 
 	}
 }
 
+func flattenBatchAccountNetworkProfile(input *batchaccount.NetworkProfile) []interface{} {
+	if input == nil || input.AccountAccess == nil && input.NodeManagementAccess == nil {
+		return []interface{}{}
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"account_access":         flattenBatchAccountEndpointAccessProfile(input.AccountAccess),
+			"node_management_access": flattenBatchAccountEndpointAccessProfile(input.NodeManagementAccess),
+		},
+	}
+}
+
+func flattenBatchAccountEndpointAccessProfile(input *batchaccount.EndpointAccessProfile) []interface{} {
+	if input == nil {
+		return []interface{}{}
+	}
+
+	ipRules := make([]interface{}, 0)
+	if input.IPRules != nil {
+		for _, ipRule := range *input.IPRules {
+			flattenedIpRule := map[string]interface{}{
+				"action":   string(ipRule.Action),
+				"ip_range": ipRule.Value,
+			}
+			ipRules = append(ipRules, flattenedIpRule)
+		}
+
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"default_action": string(input.DefaultAction),
+			"ip_rule":        ipRules,
+		},
+	}
+}
+
 func isShardKeyAllowed(input []interface{}) bool {
 	if len(input) == 0 {
 		return false
@@ -530,4 +628,49 @@ func isShardKeyAllowed(input []interface{}) bool {
 		}
 	}
 	return false
+}
+
+func resourceBatchAccountEndpointAccessProfileSchema() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:         pluginsdk.TypeList,
+		Optional:     true,
+		MaxItems:     1,
+		AtLeastOneOf: []string{"network_profile.0.account_access", "network_profile.0.node_management_access"},
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"default_action": {
+					Type:     pluginsdk.TypeString,
+					Optional: true,
+					Default:  batchaccount.EndpointAccessDefaultActionDeny,
+					ValidateFunc: validation.StringInSlice([]string{
+						string(batchaccount.EndpointAccessDefaultActionAllow),
+						string(batchaccount.EndpointAccessDefaultActionDeny),
+					}, false),
+				},
+
+				"ip_rule": {
+					Type:     pluginsdk.TypeList,
+					Optional: true,
+					Elem: &pluginsdk.Resource{
+						Schema: map[string]*pluginsdk.Schema{
+							"ip_range": {
+								Type:         pluginsdk.TypeString,
+								Required:     true,
+								ValidateFunc: validate.BatchAccountIpRange,
+							},
+
+							"action": {
+								Type:     pluginsdk.TypeString,
+								Optional: true,
+								Default:  string(batchaccount.IPRuleActionAllow),
+								ValidateFunc: validation.StringInSlice([]string{
+									string(batchaccount.IPRuleActionAllow),
+								}, false),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
 }

--- a/internal/services/batch/batch_account_resource_test.go
+++ b/internal/services/batch/batch_account_resource_test.go
@@ -256,6 +256,39 @@ func TestAccBatchAccount_autoStorageBatchAuthMode(t *testing.T) {
 	})
 }
 
+func TestAccBatchAccount_networkProfile(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_batch_account", "test")
+	r := BatchAccountResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basicWithNetworkProfile(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("network_profile.0.account_access.0.default_action").HasValue("Deny"),
+				check.That(data.ResourceName).Key("network_profile.0.node_management_access.0.default_action").HasValue("Deny"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basicWithNetworkProfileUpdated(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("network_profile.0.account_access.0.ip_rule.0.action").HasValue("Allow"),
+				check.That(data.ResourceName).Key("network_profile.0.node_management_access.0.ip_rule.0.action").HasValue("Allow"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccBatchAccount_publicNetworkAccess(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_batch_account", "test")
 	r := BatchAccountResource{}
@@ -982,6 +1015,79 @@ resource "azurerm_batch_account" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Secondary, data.RandomString, data.RandomString, data.RandomString)
+}
+
+func (BatchAccountResource) basicWithNetworkProfile(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "testaccRG-batch-%d"
+  location = "%s"
+}
+
+resource "azurerm_batch_account" "test" {
+  name                 = "testaccbatch%s"
+  resource_group_name  = azurerm_resource_group.test.name
+  location             = azurerm_resource_group.test.location
+  pool_allocation_mode = "BatchService"
+
+  network_profile {
+    account_access {
+    }
+
+    node_management_access {
+    }
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}
+
+func (BatchAccountResource) basicWithNetworkProfileUpdated(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "testaccRG-batch-%d"
+  location = "%s"
+}
+
+resource "azurerm_batch_account" "test" {
+  name                 = "testaccbatch%s"
+  resource_group_name  = azurerm_resource_group.test.name
+  location             = azurerm_resource_group.test.location
+  pool_allocation_mode = "BatchService"
+
+  network_profile {
+    account_access {
+      default_action = "Allow"
+      ip_rule {
+        ip_range = "10.0.1.0"
+      }
+
+      ip_rule {
+        ip_range = "10.0.3.0/24"
+      }
+    }
+
+    node_management_access {
+      default_action = "Allow"
+
+      ip_rule {
+        ip_range = "10.0.2.0"
+      }
+
+      ip_rule {
+        ip_range = "10.0.4.0/24"
+      }
+    }
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }
 
 func (BatchAccountResource) basicWithPublicNetWorkAccessDisabled(data acceptance.TestData) string {

--- a/internal/services/batch/validate/batch_account_ip_range.go
+++ b/internal/services/batch/validate/batch_account_ip_range.go
@@ -1,0 +1,17 @@
+package validate
+
+import (
+	"fmt"
+	"regexp"
+)
+
+func BatchAccountIpRange(v interface{}, k string) (warnings []string, errors []error) {
+	value := v.(string)
+
+	re := regexp.MustCompile(`^([0-9]{1,3}\.){3}[0-9]{1,3}(/([0-9]|[1-2][0-9]|30))?$`)
+	if re != nil && !re.MatchString(value) {
+		errors = append(errors, fmt.Errorf("%s must start with IPV4 address and/or slash, number of bits (0-30) as prefix. Example: 127.0.0.1/8. Got %q.", k, value))
+	}
+
+	return warnings, errors
+}

--- a/internal/services/batch/validate/batch_account_ip_range_test.go
+++ b/internal/services/batch/validate/batch_account_ip_range_test.go
@@ -1,0 +1,41 @@
+package validate
+
+import "testing"
+
+func TestBatchAccountIpRange(t *testing.T) {
+	cases := []struct {
+		IPRange string
+		Errors  int
+	}{
+		{
+			IPRange: "0.0.0.0",
+			Errors:  0,
+		},
+		{
+			IPRange: "23.45.0.1/30",
+			Errors:  0,
+		},
+		{
+			IPRange: "",
+			Errors:  1,
+		},
+		{
+			IPRange: "23.45.0.1/31",
+			Errors:  1,
+		},
+		{
+			IPRange: "23.45.0.1/32",
+			Errors:  1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.IPRange, func(t *testing.T) {
+			_, errors := BatchAccountIpRange(tc.IPRange, "ip_range")
+
+			if len(errors) != tc.Errors {
+				t.Fatalf("Expected BatchAccountIpRange to return %d error(s) not %d", tc.Errors, len(errors))
+			}
+		})
+	}
+}

--- a/website/docs/r/batch_account.html.markdown
+++ b/website/docs/r/batch_account.html.markdown
@@ -55,6 +55,8 @@ The following arguments are supported:
 
 * `identity` - (Optional) An `identity` block as defined below.
 
+* `network_profile` - (Optional) A `network_profile` block as defined below.
+
 * `pool_allocation_mode` - (Optional) Specifies the mode to use for pool allocation. Possible values are `BatchService` or `UserSubscription`. Defaults to `BatchService`.
 
 * `public_network_access_enabled` - (Optional) Whether public network access is allowed for this server. Defaults to `true`.
@@ -90,6 +92,39 @@ An `identity` block supports the following:
 * `identity_ids` - (Optional) A list of User Assigned Managed Identity IDs to be assigned to this Batch Account.
 
 ~> **NOTE:** This is required when `type` is set to `UserAssigned` or `SystemAssigned, UserAssigned`.
+
+---
+
+A `network_profile` block supports the following:
+
+* `account_access` - (Optional) An `account_access` block as defined below.
+
+* `node_management_access` - (Optional) A `node_management_access` block as defined below.
+
+~> **NOTE:** At least one of `account_access` or `node_management_access` must be specified.
+
+---
+
+An `account_access` block supports the following:
+
+* `default_action` - (Optional) Specifies the default action for the account access. Possible values are `Allow` and `Deny`. Defaults to `Deny`.
+
+* `ip_rule` - (Optional) One or more `ip_rule` blocks as defined below.
+---
+
+A `node_management_access` block supports the following:
+
+* `default_action` - (Optional) Specifies the default action for the node management access. Possible values are `Allow` and `Deny`. Defaults to `Deny`.
+
+* `ip_rule` - (Optional) One or more `ip_rule` blocks as defined below.
+
+---
+
+An `ip_rule` block supports the following:
+
+* `ip_range` - (Required) The CIDR block from which requests will match the rule.
+
+* `action` - (Optional) Specifies the action of the ip rule. The only possible value is `Allow`. Defaults to `Allow`.
 
 ---
 


### PR DESCRIPTION
To support accessing Batch Account from selected network range
Document: https://learn.microsoft.com/azure/batch/public-network-access#access-from-selected-public-networks