### PR TITLE
azurerm_private_dns_resolver_forwarding_rule_resource - make domain_name force new

### DIFF
--- a/internal/services/privatednsresolver/private_dns_resolver_forwarding_rule_resource.go
+++ b/internal/services/privatednsresolver/private_dns_resolver_forwarding_rule_resource.go
@@ -62,6 +62,7 @@ func (r PrivateDNSResolverForwardingRuleResource) Arguments() map[string]*plugin
 		"domain_name": {
 			Type:         pluginsdk.TypeString,
 			Required:     true,
+			ForceNew:     true,
 			ValidateFunc: validation.StringIsNotEmpty,
 		},
 

--- a/website/docs/r/private_dns_resolver_forwarding_rule.html.markdown
+++ b/website/docs/r/private_dns_resolver_forwarding_rule.html.markdown
@@ -87,7 +87,7 @@ The following arguments are supported:
 
 * `dns_forwarding_ruleset_id` - (Required) Specifies the ID of the Private DNS Resolver Forwarding Ruleset. Changing this forces a new Private DNS Resolver Forwarding Rule to be created.
 
-* `domain_name` - (Required) Specifies the domain name for the Private DNS Resolver Forwarding Rule.
+* `domain_name` - (Required) Specifies the domain name for the Private DNS Resolver Forwarding Rule. Changing this forces a new Private DNS Resolver Forwarding Rule to be created.
 
 * `target_dns_servers` - (Required) Can be specified multiple times to define multiple target DNS servers. Each `target_dns_servers` block as defined below.
 


### PR DESCRIPTION
when trying to perform update in place azure throws an error:

```
forwardingrules.ForwardingRulesClient#CreateOrUpdate: Failure responding to request: StatusCode=409 -- Original Error: autorest/azure: Service returned an error. Status=409 Code="Conflict" Message="Exception of type 'Microsoft.Azure.Networking.Dns.ManagedResolver.Frontend.Contracts.Exceptions.Service.FrontendConflictServiceException' was thrown." Target="" Details=[{}] InnerError={}
```

Probably because it's impossible to do such update through azure portal as well.