### PR TITLE
use common client options to configure clients

### DIFF
--- a/internal/services/analysisservices/client/client.go
+++ b/internal/services/analysisservices/client/client.go
@@ -8,7 +8,7 @@ import (
 
 func NewClient(o *common.ClientOptions) *analysisservices_v2017_08_01.Client {
 	client := analysisservices_v2017_08_01.NewClientWithBaseURI(o.ResourceManagerEndpoint, func(c *autorest.Client) {
-		c.Authorizer = o.ResourceManagerAuthorizer
+		o.ConfigureClient(c, o.ResourceManagerAuthorizer)
 	})
 	return &client
 }

--- a/internal/services/azurestackhci/client/client.go
+++ b/internal/services/azurestackhci/client/client.go
@@ -8,7 +8,7 @@ import (
 
 func NewClient(o *common.ClientOptions) *azurestackhci_v2022_12_01.Client {
 	client := azurestackhci_v2022_12_01.NewClientWithBaseURI(o.ResourceManagerEndpoint, func(c *autorest.Client) {
-		c.Authorizer = o.ResourceManagerAuthorizer
+		o.ConfigureClient(c, o.ResourceManagerAuthorizer)
 	})
 
 	return &client

--- a/internal/services/bot/client/client.go
+++ b/internal/services/bot/client/client.go
@@ -25,7 +25,7 @@ func NewClient(o *common.ClientOptions) *Client {
 	o.ConfigureClient(&channelClient.Client, o.ResourceManagerAuthorizer)
 
 	healthBotsClient := healthbot_2022_08_08.NewClientWithBaseURI(o.ResourceManagerEndpoint, func(c *autorest.Client) {
-		c.Authorizer = o.ResourceManagerAuthorizer
+		o.ConfigureClient(c, o.ResourceManagerAuthorizer)
 	})
 
 	return &Client{

--- a/internal/services/fluidrelay/client/client.go
+++ b/internal/services/fluidrelay/client/client.go
@@ -8,7 +8,7 @@ import (
 
 func NewClient(o *common.ClientOptions) *fluidrelay_2022_05_26.Client {
 	client := fluidrelay_2022_05_26.NewClientWithBaseURI(o.ResourceManagerEndpoint, func(c *autorest.Client) {
-		c.Authorizer = o.ResourceManagerAuthorizer
+		o.ConfigureClient(c, o.ResourceManagerAuthorizer)
 	})
 	return &client
 }

--- a/internal/services/iottimeseriesinsights/client/client.go
+++ b/internal/services/iottimeseriesinsights/client/client.go
@@ -8,7 +8,7 @@ import (
 
 func NewClient(o *common.ClientOptions) *timeseriesinsights_v2020_05_15.Client {
 	client := timeseriesinsights_v2020_05_15.NewClientWithBaseURI(o.ResourceManagerEndpoint, func(c *autorest.Client) {
-		c.Authorizer = o.ResourceManagerAuthorizer
+		o.ConfigureClient(c, o.ResourceManagerAuthorizer)
 	})
 	return &client
 }

--- a/internal/services/signalr/client/client.go
+++ b/internal/services/signalr/client/client.go
@@ -20,7 +20,7 @@ func NewClient(o *common.ClientOptions) (*Client, error) {
 	o.Configure(signalRClient.Client, o.Authorizers.ResourceManager)
 
 	webPubSubClient := webpubsub_v2023_02_01.NewClientWithBaseURI(o.ResourceManagerEndpoint, func(c *autorest.Client) {
-		c.Authorizer = o.ResourceManagerAuthorizer
+		o.ConfigureClient(c, o.ResourceManagerAuthorizer)
 	})
 
 	return &Client{


### PR DESCRIPTION
There're some clients that the initialization doesn't use the common client option's configure methods. So these RP's resources don't support features like logging, user-agent, and correlation request id.

I opened this PR to use common client options to configure clients.

There still are some generated client definition should have this change:
```
https://github.com/hashicorp/terraform-provider-azurerm/blob/main/internal/services/containers/client/client_gen.go#L16
https://github.com/hashicorp/terraform-provider-azurerm/blob/main/internal/services/loadtestservice/client/client_gen.go#L16
https://github.com/hashicorp/terraform-provider-azurerm/blob/main/internal/services/managedidentity/client/client_gen.go#L16
```