### PR TITLE
`azurerm_kubernetes_cluster` - Istio Gateways added to `service_mesh_profile` block 

### DIFF
--- a/internal/services/containers/kubernetes_cluster_data_source.go
+++ b/internal/services/containers/kubernetes_cluster_data_source.go
@@ -678,6 +678,43 @@ func dataSourceKubernetesCluster() *pluginsdk.Resource {
 				},
 			},
 
+			"service_mesh_profile": {
+				Type:     pluginsdk.TypeList,
+				Computed: true,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"mode": {
+							Type:     pluginsdk.TypeString,
+							Computed: true,
+						},
+						"ingress_gateway_internal": {
+							Type:     pluginsdk.TypeList,
+							Computed: true,
+							Elem: &pluginsdk.Resource{
+								Schema: map[string]*pluginsdk.Schema{
+									"enabled": {
+										Type:     pluginsdk.TypeBool,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"ingress_gateway_external": {
+							Type:     pluginsdk.TypeList,
+							Computed: true,
+							Elem: &pluginsdk.Resource{
+								Schema: map[string]*pluginsdk.Schema{
+									"enabled": {
+										Type:     pluginsdk.TypeBool,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+
 			"tags": commonschema.TagsDataSource(),
 		},
 	}
@@ -763,6 +800,11 @@ func dataSourceKubernetesClusterRead(d *pluginsdk.ResourceData, meta interface{}
 			customCaTrustCertList := flattenCustomCaTrustCerts(props.SecurityProfile.CustomCATrustCertificates)
 			if err := d.Set("custom_ca_trust_certificates_base64", customCaTrustCertList); err != nil {
 				return fmt.Errorf("setting `custom_ca_trust_certificates_base64`: %+v", err)
+			}
+
+			serviceMeshProfile := flattenKubernetesClusterAzureServiceMeshProfile(props.ServiceMeshProfile)
+			if err := d.Set("service_mesh_profile", serviceMeshProfile); err != nil {
+				return fmt.Errorf("setting `service_mesh_profile`: %+v", err)
 			}
 
 			kubeletIdentity, err := flattenKubernetesClusterDataSourceIdentityProfile(props.IdentityProfile)

--- a/internal/services/containers/kubernetes_cluster_data_source.go
+++ b/internal/services/containers/kubernetes_cluster_data_source.go
@@ -687,29 +687,13 @@ func dataSourceKubernetesCluster() *pluginsdk.Resource {
 							Type:     pluginsdk.TypeString,
 							Computed: true,
 						},
-						"ingress_gateway_internal": {
-							Type:     pluginsdk.TypeList,
+						"internal_ingress_gateway_enabled": {
+							Type:     pluginsdk.TypeBool,
 							Computed: true,
-							Elem: &pluginsdk.Resource{
-								Schema: map[string]*pluginsdk.Schema{
-									"enabled": {
-										Type:     pluginsdk.TypeBool,
-										Computed: true,
-									},
-								},
-							},
 						},
-						"ingress_gateway_external": {
-							Type:     pluginsdk.TypeList,
+						"external_ingress_gateway_enabled": {
+							Type:     pluginsdk.TypeBool,
 							Computed: true,
-							Elem: &pluginsdk.Resource{
-								Schema: map[string]*pluginsdk.Schema{
-									"enabled": {
-										Type:     pluginsdk.TypeBool,
-										Computed: true,
-									},
-								},
-							},
 						},
 					},
 				},

--- a/internal/services/containers/kubernetes_cluster_data_source_test.go
+++ b/internal/services/containers/kubernetes_cluster_data_source_test.go
@@ -581,8 +581,8 @@ func TestAccDataSourceKubernetesCluster_serviceMesh(t *testing.T) {
 			Config: r.serviceMesh(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("service_mesh_profile.0.mode").HasValue("Istio"),
-				check.That(data.ResourceName).Key("service_mesh_profile.0.ingress_gateway_internal.0.enabled").HasValue("true"),
-				check.That(data.ResourceName).Key("service_mesh_profile.0.ingress_gateway_external.0.enabled").HasValue("true"),
+				check.That(data.ResourceName).Key("service_mesh_profile.0.internal_ingress_gateway_enabled").HasValue("true"),
+				check.That(data.ResourceName).Key("service_mesh_profile.0.external_ingress_gateway_enabled").HasValue("true"),
 			),
 		},
 	})

--- a/internal/services/containers/kubernetes_cluster_network_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_network_resource_test.go
@@ -1168,7 +1168,7 @@ resource "azurerm_kubernetes_cluster" "test" {
 
     ingress_gateway_external {
       enabled = %[4]t
-    }    
+    }
 
   }
 

--- a/internal/services/containers/kubernetes_cluster_network_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_network_resource_test.go
@@ -37,8 +37,8 @@ func TestAccKubernetesCluster_serviceMeshProfile(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("service_mesh_profile.0.mode").HasValue("Istio"),
-				check.That(data.ResourceName).Key("service_mesh_profile.0.ingress_gateway_internal.0.enabled").HasValue("true"),
-				check.That(data.ResourceName).Key("service_mesh_profile.0.ingress_gateway_external.0.enabled").HasValue("true"),
+				check.That(data.ResourceName).Key("service_mesh_profile.0.internal_ingress_gateway_enabled").HasValue("true"),
+				check.That(data.ResourceName).Key("service_mesh_profile.0.external_ingress_gateway_enabled").HasValue("true"),
 			),
 		},
 		data.ImportStep(),
@@ -47,8 +47,8 @@ func TestAccKubernetesCluster_serviceMeshProfile(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("service_mesh_profile.0.mode").HasValue("Istio"),
-				check.That(data.ResourceName).Key("service_mesh_profile.0.ingress_gateway_internal.0.enabled").HasValue("false"),
-				check.That(data.ResourceName).Key("service_mesh_profile.0.ingress_gateway_external.0.enabled").HasValue("false"),
+				check.That(data.ResourceName).Key("service_mesh_profile.0.internal_ingress_gateway_enabled").HasValue("false"),
+				check.That(data.ResourceName).Key("service_mesh_profile.0.external_ingress_gateway_enabled").HasValue("false"),
 			),
 		},
 		data.ImportStep(),
@@ -65,8 +65,8 @@ func TestAccKubernetesCluster_serviceMeshProfileLifeCycle(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("service_mesh_profile.0.mode").DoesNotExist(),
-				check.That(data.ResourceName).Key("service_mesh_profile.0.ingress_gateway_internal").DoesNotExist(),
-				check.That(data.ResourceName).Key("service_mesh_profile.0.ingress_gateway_external").DoesNotExist(),
+				check.That(data.ResourceName).Key("service_mesh_profile.0.internal_ingress_gateway_enabled").DoesNotExist(),
+				check.That(data.ResourceName).Key("service_mesh_profile.0.external_ingress_gateway_enabled").DoesNotExist(),
 			),
 		},
 		data.ImportStep(),
@@ -75,8 +75,8 @@ func TestAccKubernetesCluster_serviceMeshProfileLifeCycle(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("service_mesh_profile.0.mode").HasValue("Istio"),
-				check.That(data.ResourceName).Key("service_mesh_profile.0.ingress_gateway_internal.0.enabled").HasValue("true"),
-				check.That(data.ResourceName).Key("service_mesh_profile.0.ingress_gateway_external.0.enabled").HasValue("false"),
+				check.That(data.ResourceName).Key("service_mesh_profile.0.internal_ingress_gateway_enabled").HasValue("true"),
+				check.That(data.ResourceName).Key("service_mesh_profile.0.external_ingress_gateway_enabled").HasValue("false"),
 			),
 		},
 		data.ImportStep(),
@@ -85,8 +85,8 @@ func TestAccKubernetesCluster_serviceMeshProfileLifeCycle(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("service_mesh_profile.0.mode").DoesNotExist(),
-				check.That(data.ResourceName).Key("service_mesh_profile.0.ingress_gateway_internal").DoesNotExist(),
-				check.That(data.ResourceName).Key("service_mesh_profile.0.ingress_gateway_external").DoesNotExist(),
+				check.That(data.ResourceName).Key("service_mesh_profile.0.internal_ingress_gateway_enabled").DoesNotExist(),
+				check.That(data.ResourceName).Key("service_mesh_profile.0.external_ingress_gateway_enabled").DoesNotExist(),
 			),
 		},
 		data.ImportStep(),
@@ -1161,15 +1161,8 @@ resource "azurerm_kubernetes_cluster" "test" {
 
   service_mesh_profile {
     mode = "Istio"
-
-    ingress_gateway_internal {
-      enabled = %[3]t
-    }
-
-    ingress_gateway_external {
-      enabled = %[4]t
-    }
-
+    internal_ingress_gateway_enabled = %[3]t
+    external_ingress_gateway_enabled = %[4]t
   }
 
 }

--- a/internal/services/containers/kubernetes_cluster_network_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_network_resource_test.go
@@ -1160,7 +1160,7 @@ resource "azurerm_kubernetes_cluster" "test" {
   }
 
   service_mesh_profile {
-    mode = "Istio"
+    mode                             = "Istio"
     internal_ingress_gateway_enabled = %[3]t
     external_ingress_gateway_enabled = %[4]t
   }

--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -1305,31 +1305,13 @@ func resourceKubernetesCluster() *pluginsdk.Resource {
 								string(managedclusters.ServiceMeshModeIstio),
 							}, false),
 						},
-						"ingress_gateway_internal": {
-							Type:     pluginsdk.TypeList,
-							MaxItems: 1,
+						"internal_ingress_gateway_enabled": {
+							Type:     pluginsdk.TypeBool,
 							Optional: true,
-							Elem: &pluginsdk.Resource{
-								Schema: map[string]*pluginsdk.Schema{
-									"enabled": {
-										Type:     pluginsdk.TypeBool,
-										Required: true,
-									},
-								},
-							},
 						},
-						"ingress_gateway_external": {
-							Type:     pluginsdk.TypeList,
-							MaxItems: 1,
+						"external_ingress_gateway_enabled": {
+							Type:     pluginsdk.TypeBool,
 							Optional: true,
-							Elem: &pluginsdk.Resource{
-								Schema: map[string]*pluginsdk.Schema{
-									"enabled": {
-										Type:     pluginsdk.TypeBool,
-										Required: true,
-									},
-								},
-							},
 						},
 					},
 				},
@@ -4374,24 +4356,20 @@ func expandKubernetesClusterServiceMeshProfile(input []interface{}, existing *ma
 
 		istioIngressGatewaysList := make([]managedclusters.IstioIngressGateway, 0)
 
-		if raw["ingress_gateway_internal"] != nil {
-
-			ingressInternal := raw["ingress_gateway_internal"].([]interface{})[0].(map[string]interface{})
+		if raw["internal_ingress_gateway_enabled"] != nil {
 
 			ingressGatewayElementInternal := managedclusters.IstioIngressGateway{
-				Enabled: ingressInternal["enabled"].(bool),
+				Enabled: raw["internal_ingress_gateway_enabled"].(bool),
 				Mode:    managedclusters.IstioIngressGatewayModeInternal,
 			}
 
 			istioIngressGatewaysList = append(istioIngressGatewaysList, ingressGatewayElementInternal)
 		}
 
-		if raw["ingress_gateway_external"] != nil {
-
-			ingressExternal := raw["ingress_gateway_external"].([]interface{})[0].(map[string]interface{})
+		if raw["external_ingress_gateway_enabled"] != nil {
 
 			ingressGatewayElementExternal := managedclusters.IstioIngressGateway{
-				Enabled: ingressExternal["enabled"].(bool),
+				Enabled: raw["external_ingress_gateway_enabled"].(bool),
 				Mode:    managedclusters.IstioIngressGatewayModeExternal,
 			}
 
@@ -4493,17 +4471,12 @@ func flattenKubernetesClusterAzureServiceMeshProfile(input *managedclusters.Serv
 			var currentIngressKey string
 
 			if mode == managedclusters.IstioIngressGatewayModeExternal {
-				currentIngressKey = "ingress_gateway_external"
+				currentIngressKey = "external_ingress_gateway_enabled"
 			} else {
-				currentIngressKey = "ingress_gateway_internal"
+				currentIngressKey = "internal_ingress_gateway_enabled"
 			}
 
-			returnMap[currentIngressKey] = []interface{}{
-				map[string]interface{}{
-					"enabled": enabled,
-				},
-			}
-
+			returnMap[currentIngressKey] = enabled
 		}
 	}
 

--- a/website/docs/d/kubernetes_cluster.html.markdown
+++ b/website/docs/d/kubernetes_cluster.html.markdown
@@ -371,6 +371,22 @@ A `ssh_key` block exports the following:
 
 * `key_data` - The Public SSH Key used to access the cluster.
 
+---
+
+A `service_mesh_profile` block exports the following:
+
+* `mode` - The mode of the service mesh.
+
+* `ingress_gateway_internal` - Istio Internal Ingress Gateway block
+* `enabled` - Is `ingress_gateway_internal` enabled - either `true` or `false`
+
+* `ingress_gateway_external` - Istio External Ingress Gateway block
+* `enabled` - Is `ingress_gateway_external` enabled - either `true` or `false`
+
+-> **Note:** This requires that the Preview Feature `Microsoft.ContainerService/AzureServiceMeshPreview` is enabled and the Resource Provider is re-registered, see [the documentation](https://learn.microsoft.com/en-us/azure/aks/istio-deploy-addon#register-the-azureservicemeshpreview-feature-flag) for more information.
+
+---
+
 ## Timeouts
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:

--- a/website/docs/d/kubernetes_cluster.html.markdown
+++ b/website/docs/d/kubernetes_cluster.html.markdown
@@ -377,11 +377,9 @@ A `service_mesh_profile` block exports the following:
 
 * `mode` - The mode of the service mesh.
 
-* `ingress_gateway_internal` - Istio Internal Ingress Gateway block
-* `enabled` - Is `ingress_gateway_internal` enabled - either `true` or `false`
+* `internal_ingress_gateway_enabled` - Is Istio Internal Ingress Gateway enabled?
 
-* `ingress_gateway_external` - Istio External Ingress Gateway block
-* `enabled` - Is `ingress_gateway_external` enabled - either `true` or `false`
+* `external_ingress_gateway_enabled` - Is Istio External Ingress Gateway enabled?
 
 -> **Note:** This requires that the Preview Feature `Microsoft.ContainerService/AzureServiceMeshPreview` is enabled and the Resource Provider is re-registered, see [the documentation](https://learn.microsoft.com/en-us/azure/aks/istio-deploy-addon#register-the-azureservicemeshpreview-feature-flag) for more information.
 

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -765,6 +765,16 @@ A `service_mesh_profile` block supports the following:
 
 * `mode` - (Required) The mode of the service mesh. Possible value is `Istio`.
 
+* `ingress_gateway_internal` - (Optional) Istio Internal Ingress Gateway block as defined below
+* `enabled` - (Required) If `ingress_gateway_internal` block is specified, this value should be set to either `true` or `false`
+
+* `ingress_gateway_external` - (Optional) Istio External Ingress Gateway block as defined below
+* `enabled` - (Required) If `ingress_gateway_external` block is specified, this value should be set to either `true` or `false`
+
+-> **Note:** This requires that the Preview Feature `Microsoft.ContainerService/AzureServiceMeshPreview` is enabled and the Resource Provider is re-registered, see [the documentation](https://learn.microsoft.com/en-us/azure/aks/istio-deploy-addon#register-the-azureservicemeshpreview-feature-flag) for more information.
+
+-> **NOTE:** Currently only one Internal Ingress Gateway and one External Ingress Gateway are allowed per cluster
+
 ---
 
 A `service_principal` block supports the following:

--- a/website/docs/r/kubernetes_cluster.html.markdown
+++ b/website/docs/r/kubernetes_cluster.html.markdown
@@ -765,11 +765,9 @@ A `service_mesh_profile` block supports the following:
 
 * `mode` - (Required) The mode of the service mesh. Possible value is `Istio`.
 
-* `ingress_gateway_internal` - (Optional) Istio Internal Ingress Gateway block as defined below
-* `enabled` - (Required) If `ingress_gateway_internal` block is specified, this value should be set to either `true` or `false`
+* `internal_ingress_gateway_enabled` - (Optional) Is Istio Internal Ingress Gateway enabled?
 
-* `ingress_gateway_external` - (Optional) Istio External Ingress Gateway block as defined below
-* `enabled` - (Required) If `ingress_gateway_external` block is specified, this value should be set to either `true` or `false`
+* `external_ingress_gateway_enabled` - (Optional) Is Istio External Ingress Gateway enabled?
 
 -> **Note:** This requires that the Preview Feature `Microsoft.ContainerService/AzureServiceMeshPreview` is enabled and the Resource Provider is re-registered, see [the documentation](https://learn.microsoft.com/en-us/azure/aks/istio-deploy-addon#register-the-azureservicemeshpreview-feature-flag) for more information.
 


### PR DESCRIPTION
Closes #22392

### Acceptance tests

```bash
Running tool: C:\Program Files\Go\bin\go.exe test -timeout 1800s -run ^TestAccKubernetesCluster_serviceMeshProfileLifeCycle$ github.com/hashicorp/terraform-provider-azurerm/internal/services/containers -v

=== RUN   TestAccKubernetesCluster_serviceMeshProfileLifeCycle
=== PAUSE TestAccKubernetesCluster_serviceMeshProfileLifeCycle
=== CONT  TestAccKubernetesCluster_serviceMeshProfileLifeCycle
--- PASS: TestAccKubernetesCluster_serviceMeshProfileLifeCycle (1315.12s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/containers	1315.236s
```


```bash
Running tool: C:\Program Files\Go\bin\go.exe test -timeout 1800s -run ^TestAccKubernetesCluster_serviceMeshProfile$ github.com/hashicorp/terraform-provider-azurerm/internal/services/containers -v

=== RUN   TestAccKubernetesCluster_serviceMeshProfile
=== PAUSE TestAccKubernetesCluster_serviceMeshProfile
=== CONT  TestAccKubernetesCluster_serviceMeshProfile
--- PASS: TestAccKubernetesCluster_serviceMeshProfile (1213.59s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/containers	1213.717s
```


```bash
Running tool: C:\Program Files\Go\bin\go.exe test -timeout 1800s -run ^TestAccDataSourceKubernetesCluster_serviceMesh$ github.com/hashicorp/terraform-provider-azurerm/internal/services/containers -v

=== RUN   TestAccDataSourceKubernetesCluster_serviceMesh
=== PAUSE TestAccDataSourceKubernetesCluster_serviceMesh
=== CONT  TestAccDataSourceKubernetesCluster_serviceMesh
--- PASS: TestAccDataSourceKubernetesCluster_serviceMesh (902.92s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/containers	903.062s

```
