### PR TITLE
Add public_network_access_enabled property to app service docs

### DIFF
--- a/website/docs/r/linux_function_app.html.markdown
+++ b/website/docs/r/linux_function_app.html.markdown
@@ -101,7 +101,7 @@ The following arguments are supported:
 
 * `https_only` - (Optional) Can the Function App only be accessed via HTTPS? Defaults to `false`.
 
-* `public_network_access_enabled` - (Optional) Whether or not public network access is enabled for the Function App. Defaults to `true`.
+* `public_network_access_enabled` - (Optional) Should public network access be enabled for the Function App. Defaults to `true`.
 
 * `identity` - (Optional) A `identity` block as defined below.
 

--- a/website/docs/r/linux_function_app.html.markdown
+++ b/website/docs/r/linux_function_app.html.markdown
@@ -101,6 +101,8 @@ The following arguments are supported:
 
 * `https_only` - (Optional) Can the Function App only be accessed via HTTPS? Defaults to `false`.
 
+* `public_network_access_enabled` - (Optional) Whether or not public network access is enabled for the Function App. Defaults to `true`.
+
 * `identity` - (Optional) A `identity` block as defined below.
 
 * `key_vault_reference_identity_id` - (Optional) The User Assigned Identity ID used for accessing KeyVault secrets. The identity must be assigned to the application in the `identity` block. [For more information see - Access vaults with a user-assigned identity](https://docs.microsoft.com/azure/app-service/app-service-key-vault-references#access-vaults-with-a-user-assigned-identity)

--- a/website/docs/r/linux_function_app_slot.html.markdown
+++ b/website/docs/r/linux_function_app_slot.html.markdown
@@ -98,6 +98,8 @@ The following arguments are supported:
 
 * `https_only` - (Optional) Can the Function App Slot only be accessed via HTTPS?
 
+* `public_network_access_enabled` - (Optional) Whether or not public network access is enabled for the Function App. Defaults to `true`.
+
 * `identity` - (Optional) An `identity` block as detailed below.
 
 * `key_vault_reference_identity_id` - (Optional) The User Assigned Identity ID used for accessing KeyVault secrets. The identity must be assigned to the application in the `identity` block. [For more information see - Access vaults with a user-assigned identity](https://docs.microsoft.com/azure/app-service/app-service-key-vault-references#access-vaults-with-a-user-assigned-identity)

--- a/website/docs/r/linux_function_app_slot.html.markdown
+++ b/website/docs/r/linux_function_app_slot.html.markdown
@@ -98,7 +98,8 @@ The following arguments are supported:
 
 * `https_only` - (Optional) Can the Function App Slot only be accessed via HTTPS?
 
-* `public_network_access_enabled` - (Optional) Whether or not public network access is enabled for the Function App. Defaults to `true`.
+* `public_network_access_enabled` - (Optional) Should public network access be enabled for the Function App. Defaults to `true`.
+* ```
 
 * `identity` - (Optional) An `identity` block as detailed below.
 

--- a/website/docs/r/linux_web_app.html.markdown
+++ b/website/docs/r/linux_web_app.html.markdown
@@ -81,6 +81,8 @@ The following arguments are supported:
 
 * `https_only` - (Optional) Should the Linux Web App require HTTPS connections.
 
+* `public_network_access_enabled` - (Optional) Whether or not public network access is enabled for the Linux Web App. Defaults to `true`.
+
 * `identity` - (Optional) An `identity` block as defined below.
 
 * `key_vault_reference_identity_id` - (Optional) The User Assigned Identity ID used for accessing KeyVault secrets. The identity must be assigned to the application in the `identity` block. [For more information see - Access vaults with a user-assigned identity](https://docs.microsoft.com/azure/app-service/app-service-key-vault-references#access-vaults-with-a-user-assigned-identity).

--- a/website/docs/r/linux_web_app.html.markdown
+++ b/website/docs/r/linux_web_app.html.markdown
@@ -81,7 +81,7 @@ The following arguments are supported:
 
 * `https_only` - (Optional) Should the Linux Web App require HTTPS connections.
 
-* `public_network_access_enabled` - (Optional) Whether or not public network access is enabled for the Linux Web App. Defaults to `true`.
+* `public_network_access_enabled` - Should public network access be enabled for the Web App. Defaults to `true`.
 
 * `identity` - (Optional) An `identity` block as defined below.
 

--- a/website/docs/r/linux_web_app_slot.html.markdown
+++ b/website/docs/r/linux_web_app_slot.html.markdown
@@ -84,6 +84,8 @@ The following arguments are supported:
 
 * `https_only` - (Optional) Should the Linux Web App require HTTPS connections.
 
+* `public_network_access_enabled` - (Optional) Whether or not public network access is enabled for the Linux Web App. Defaults to `true`.
+
 * `identity` - (Optional) An `identity` block as defined below.
 
 * `key_vault_reference_identity_id` - (Optional) The User Assigned Identity ID used for accessing KeyVault secrets. The identity must be assigned to the application in the `identity` block. [For more information see - Access vaults with a user-assigned identity](https://docs.microsoft.com/azure/app-service/app-service-key-vault-references#access-vaults-with-a-user-assigned-identity).

--- a/website/docs/r/linux_web_app_slot.html.markdown
+++ b/website/docs/r/linux_web_app_slot.html.markdown
@@ -84,7 +84,7 @@ The following arguments are supported:
 
 * `https_only` - (Optional) Should the Linux Web App require HTTPS connections.
 
-* `public_network_access_enabled` - (Optional) Whether or not public network access is enabled for the Linux Web App. Defaults to `true`.
+* `public_network_access_enabled` - (Optional) Should public network access be enabled for the Web App. Defaults to `true`.
 
 * `identity` - (Optional) An `identity` block as defined below.
 

--- a/website/docs/r/windows_function_app.html.markdown
+++ b/website/docs/r/windows_function_app.html.markdown
@@ -101,7 +101,7 @@ The following arguments are supported:
 
 * `https_only` - (Optional) Can the Function App only be accessed via HTTPS? Defaults to `false`.
 
-* `public_network_access_enabled` - (Optional) Whether or not public network access is enabled for the Function App. Defaults to `true`.
+* `public_network_access_enabled` - Should public network access be enabled for the Function App. Defaults to `true`.
 
 * `identity` - (Optional) A `identity` block as defined below.
 

--- a/website/docs/r/windows_function_app.html.markdown
+++ b/website/docs/r/windows_function_app.html.markdown
@@ -101,6 +101,8 @@ The following arguments are supported:
 
 * `https_only` - (Optional) Can the Function App only be accessed via HTTPS? Defaults to `false`.
 
+* `public_network_access_enabled` - (Optional) Whether or not public network access is enabled for the Function App. Defaults to `true`.
+
 * `identity` - (Optional) A `identity` block as defined below.
 
 * `key_vault_reference_identity_id` - (Optional) The User Assigned Identity ID used for accessing KeyVault secrets. The identity must be assigned to the application in the `identity` block. [For more information see - Access vaults with a user-assigned identity](https://docs.microsoft.com/azure/app-service/app-service-key-vault-references#access-vaults-with-a-user-assigned-identity)

--- a/website/docs/r/windows_function_app_slot.html.markdown
+++ b/website/docs/r/windows_function_app_slot.html.markdown
@@ -97,6 +97,8 @@ The following arguments are supported:
 
 * `https_only` - (Optional) Can the Function App Slot only be accessed via HTTPS?
 
+* `public_network_access_enabled` - (Optional) Whether or not public network access is enabled for the Function App. Defaults to `true`.
+
 * `identity` - (Optional) an `identity` block as detailed below.
 
 * `key_vault_reference_identity_id` - (Optional) The User Assigned Identity ID used for accessing KeyVault secrets. The identity must be assigned to the application in the `identity` block. [For more information see - Access vaults with a user-assigned identity](https://docs.microsoft.com/azure/app-service/app-service-key-vault-references#access-vaults-with-a-user-assigned-identity)

--- a/website/docs/r/windows_function_app_slot.html.markdown
+++ b/website/docs/r/windows_function_app_slot.html.markdown
@@ -97,7 +97,7 @@ The following arguments are supported:
 
 * `https_only` - (Optional) Can the Function App Slot only be accessed via HTTPS?
 
-* `public_network_access_enabled` - (Optional) Whether or not public network access is enabled for the Function App. Defaults to `true`.
+* `public_network_access_enabled` - (Optional) Should public network access be enabled for the Function App. Defaults to `true`.
 
 * `identity` - (Optional) an `identity` block as detailed below.
 

--- a/website/docs/r/windows_web_app.html.markdown
+++ b/website/docs/r/windows_web_app.html.markdown
@@ -78,6 +78,8 @@ The following arguments are supported:
 
 * `https_only` - (Optional) Should the Windows Web App require HTTPS connections.
 
+* `public_network_access_enabled` - (Optional) Whether or not public network access is enabled for the Windows Web App. Defaults to `true`.
+
 * `identity` - (Optional) An `identity` block as defined below.
 
 * `key_vault_reference_identity_id` - (Optional) The User Assigned Identity ID used for accessing KeyVault secrets. The identity must be assigned to the application in the `identity` block. [For more information see - Access vaults with a user-assigned identity](https://docs.microsoft.com/azure/app-service/app-service-key-vault-references#access-vaults-with-a-user-assigned-identity)

--- a/website/docs/r/windows_web_app.html.markdown
+++ b/website/docs/r/windows_web_app.html.markdown
@@ -78,7 +78,7 @@ The following arguments are supported:
 
 * `https_only` - (Optional) Should the Windows Web App require HTTPS connections.
 
-* `public_network_access_enabled` - (Optional) Whether or not public network access is enabled for the Windows Web App. Defaults to `true`.
+* `public_network_access_enabled` - (Optional) Should public network access be enabled for the Web App. Defaults to `true`.
 
 * `identity` - (Optional) An `identity` block as defined below.
 

--- a/website/docs/r/windows_web_app_slot.html.markdown
+++ b/website/docs/r/windows_web_app_slot.html.markdown
@@ -84,7 +84,7 @@ The following arguments are supported:
 
 * `https_only` - (Optional) Should the Windows Web App Slot require HTTPS connections.
 
-* `public_network_access_enabled` - (Optional) Whether or not public network access is enabled for the Windows Web App. Defaults to `true`.
+* `public_network_access_enabled` - (Optional) Should public network access be enabled for the Web App. Defaults to `true`.
 
 * `identity` - (Optional) An `identity` block as defined below.
 

--- a/website/docs/r/windows_web_app_slot.html.markdown
+++ b/website/docs/r/windows_web_app_slot.html.markdown
@@ -84,6 +84,8 @@ The following arguments are supported:
 
 * `https_only` - (Optional) Should the Windows Web App Slot require HTTPS connections.
 
+* `public_network_access_enabled` - (Optional) Whether or not public network access is enabled for the Windows Web App. Defaults to `true`.
+
 * `identity` - (Optional) An `identity` block as defined below.
 
 * `key_vault_reference_identity_id` - (Optional) The User Assigned Identity ID used for accessing KeyVault secrets. The identity must be assigned to the application in the `identity` block. [For more information see - Access vaults with a user-assigned identity](https://docs.microsoft.com/azure/app-service/app-service-key-vault-references#access-vaults-with-a-user-assigned-identity)


### PR DESCRIPTION
Add public_network_access_enabled property (release in https://github.com/hashicorp/terraform-provider-azurerm/releases/tag/v3.64.0) documentation to app service markdowns.
