### PR TITLE
`managed_hsm`: skip managed hsm auth build if not specified like in cn env

### DIFF
--- a/internal/clients/builder.go
+++ b/internal/clients/builder.go
@@ -109,9 +109,14 @@ func Build(ctx context.Context, builder ClientBuilder) (*Client, error) {
 		return nil, fmt.Errorf("building account: %+v", err)
 	}
 
-	managedHSMAuth, err := auth.NewAuthorizerFromCredentials(ctx, *builder.AuthConfig, builder.AuthConfig.Environment.ManagedHSM)
-	if err != nil {
-		return nil, fmt.Errorf("unable to build authorizer for Managed HSM API: %+v", err)
+	var managedHSMAuth auth.Authorizer
+	if _, ok := builder.AuthConfig.Environment.ManagedHSM.ResourceIdentifier(); ok {
+		managedHSMAuth, err = auth.NewAuthorizerFromCredentials(ctx, *builder.AuthConfig, builder.AuthConfig.Environment.ManagedHSM)
+		if err != nil {
+			return nil, fmt.Errorf("unable to build authorizer for Managed HSM API: %+v", err)
+		}
+	} else {
+		log.Printf("[DEBUG] Skipping building the Managed HSM Authorizer since this is not supported in the current Azure Environment")
 	}
 
 	client := Client{

--- a/internal/clients/builder.go
+++ b/internal/clients/builder.go
@@ -69,7 +69,7 @@ func Build(ctx context.Context, builder ClientBuilder) (*Client, error) {
 		return nil, fmt.Errorf("unable to build authorizer for Key Vault API: %+v", err)
 	}
 
-	if _, ok := builder.AuthConfig.Environment.Synapse.ResourceIdentifier(); ok {
+	if builder.AuthConfig.Environment.Synapse.Available() {
 		synapseAuth, err = auth.NewAuthorizerFromCredentials(ctx, *builder.AuthConfig, builder.AuthConfig.Environment.Synapse)
 		if err != nil {
 			return nil, fmt.Errorf("unable to build authorizer for Synapse API: %+v", err)
@@ -78,7 +78,7 @@ func Build(ctx context.Context, builder ClientBuilder) (*Client, error) {
 		log.Printf("[DEBUG] Skipping building the Synapse Authorizer since this is not supported in the current Azure Environment")
 	}
 
-	if _, ok := builder.AuthConfig.Environment.Batch.ResourceIdentifier(); ok {
+	if builder.AuthConfig.Environment.Batch.Available() {
 		batchManagementAuth, err = auth.NewAuthorizerFromCredentials(ctx, *builder.AuthConfig, builder.AuthConfig.Environment.Batch)
 		if err != nil {
 			return nil, fmt.Errorf("unable to build authorizer for Batch Management API: %+v", err)
@@ -110,7 +110,7 @@ func Build(ctx context.Context, builder ClientBuilder) (*Client, error) {
 	}
 
 	var managedHSMAuth auth.Authorizer
-	if _, ok := builder.AuthConfig.Environment.ManagedHSM.ResourceIdentifier(); ok {
+	if builder.AuthConfig.Environment.ManagedHSM.Available() {
 		managedHSMAuth, err = auth.NewAuthorizerFromCredentials(ctx, *builder.AuthConfig, builder.AuthConfig.Environment.ManagedHSM)
 		if err != nil {
 			return nil, fmt.Errorf("unable to build authorizer for Managed HSM API: %+v", err)


### PR DESCRIPTION
managedHSMAuth actually not used for now. it will be used for managed hsm data plane resources(which has not been merged to main now). managed HSM not suported in china regions (Expected GA in Q4 2023).

fixes: #22374


waiting for #22681 to update sdk.