### PR TITLE
`tests` - fix TestAccManagedDisk_onlineLiveResize

### DIFF
--- a/internal/services/compute/managed_disk_resource_test.go
+++ b/internal/services/compute/managed_disk_resource_test.go
@@ -2610,12 +2610,11 @@ func (ManagedDiskResource) checkLinuxVirtualMachineWasNotRestarted(ctx context.C
 	wasShutDown := false
 	for logs.NotDone() {
 		val := logs.Value()
-		if val.Authorization == nil || val.Authorization.Action == nil {
-			return fmt.Errorf("parsing activity log for Virtual Machine %q: `model.Authorization` or `model.Authorization.Action` was nil", state.ID)
-		}
-		if strings.EqualFold(*val.Authorization.Action, "Microsoft.Compute/virtualMachines/stop/action") {
-			wasShutDown = true
-			break
+		if val.Authorization != nil && val.Authorization.Action != nil {
+			if strings.EqualFold(*val.Authorization.Action, "Microsoft.Compute/virtualMachines/powerOff/action") {
+				wasShutDown = true
+				break
+			}
 		}
 
 		if err := logs.NextWithContext(ctx); err != nil {


### PR DESCRIPTION
- skipping nil `Authorization`, which causes intermittent failure.
- fix action name from `stop` to `powerOff` (https://learn.microsoft.com/rest/api/compute/virtual-machines/power-off)