### PR TITLE
`azurerm_kubernetes_cluster` - `cpu_cfs_quota_enabled` defaults to `true` in 4.0

### DIFF
--- a/internal/services/containers/kubernetes_nodepool.go
+++ b/internal/services/containers/kubernetes_nodepool.go
@@ -290,7 +290,7 @@ func SchemaDefaultNodePool() *pluginsdk.Schema {
 }
 
 func schemaNodePoolKubeletConfig() *pluginsdk.Schema {
-	return &pluginsdk.Schema{
+	schema := pluginsdk.Schema{
 		Type:     pluginsdk.TypeList,
 		Optional: true,
 		MaxItems: 1,
@@ -307,6 +307,7 @@ func schemaNodePoolKubeletConfig() *pluginsdk.Schema {
 
 				"cpu_cfs_quota_enabled": {
 					Type:     pluginsdk.TypeBool,
+					Default:  true,
 					Optional: true,
 				},
 
@@ -365,10 +366,16 @@ func schemaNodePoolKubeletConfig() *pluginsdk.Schema {
 			},
 		},
 	}
+
+	if !features.FourPointOhBeta() {
+		schema.Elem.(*pluginsdk.Resource).Schema["cpu_cfs_quota_enabled"].Default = false
+	}
+
+	return &schema
 }
 
 func schemaNodePoolKubeletConfigForceNew() *pluginsdk.Schema {
-	return &pluginsdk.Schema{
+	schema := pluginsdk.Schema{
 		Type:     pluginsdk.TypeList,
 		Optional: true,
 		ForceNew: true,
@@ -388,6 +395,7 @@ func schemaNodePoolKubeletConfigForceNew() *pluginsdk.Schema {
 				"cpu_cfs_quota_enabled": {
 					Type:     pluginsdk.TypeBool,
 					Optional: true,
+					Default:  true,
 					ForceNew: true,
 				},
 
@@ -454,6 +462,12 @@ func schemaNodePoolKubeletConfigForceNew() *pluginsdk.Schema {
 			},
 		},
 	}
+
+	if !features.FourPointOhBeta() {
+		schema.Elem.(*pluginsdk.Resource).Schema["cpu_cfs_quota_enabled"].Default = false
+	}
+
+	return &schema
 }
 
 func schemaNodePoolLinuxOSConfig() *pluginsdk.Schema {

--- a/internal/services/containers/kubernetes_nodepool.go
+++ b/internal/services/containers/kubernetes_nodepool.go
@@ -367,6 +367,7 @@ func schemaNodePoolKubeletConfig() *pluginsdk.Schema {
 		},
 	}
 
+	// TODO 4.0: change the default value to `true` in the document
 	if !features.FourPointOhBeta() {
 		schema.Elem.(*pluginsdk.Resource).Schema["cpu_cfs_quota_enabled"].Default = false
 	}
@@ -463,6 +464,7 @@ func schemaNodePoolKubeletConfigForceNew() *pluginsdk.Schema {
 		},
 	}
 
+	// TODO 4.0: change the default value to `true` in the document
 	if !features.FourPointOhBeta() {
 		schema.Elem.(*pluginsdk.Resource).Schema["cpu_cfs_quota_enabled"].Default = false
 	}


### PR DESCRIPTION
fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/22424
```
=== RUN   TestAccKubernetesClusterNodePool_kubeletAndLinuxOSConfigPartial
=== PAUSE TestAccKubernetesClusterNodePool_kubeletAndLinuxOSConfigPartial
=== CONT  TestAccKubernetesClusterNodePool_kubeletAndLinuxOSConfigPartial
--- PASS: TestAccKubernetesClusterNodePool_kubeletAndLinuxOSConfigPartial (964.68s)
PASS
```