### PR TITLE
`azurerm_vpn_server_configuration`: fix a potential panic when setting deprecated variables

### DIFF
--- a/internal/services/network/vpn_server_configuration_resource.go
+++ b/internal/services/network/vpn_server_configuration_resource.go
@@ -757,9 +757,6 @@ func expandVpnServerConfigurationRadius(input []interface{}) *vpnServerConfigura
 				RadiusServerScore:   utils.Int64(int64(v["score"].(int))),
 			})
 		}
-	} else {
-		address = val["address"].(string)
-		secret = val["secret"].(string)
 	}
 
 	return &vpnServerConfigurationRadius{

--- a/internal/services/network/vpn_server_configuration_resource.go
+++ b/internal/services/network/vpn_server_configuration_resource.go
@@ -821,14 +821,6 @@ func flattenVpnServerConfigurationRadius(input *network.VpnServerConfigurationPr
 		"server_root_certificate": serverRootCertificates,
 	}
 
-	if input.RadiusServerAddress != nil && *input.RadiusServerAddress != "" {
-		schema["address"] = *input.RadiusServerAddress
-	}
-
-	if input.RadiusServerSecret != nil && *input.RadiusServerSecret != "" {
-		schema["secret"] = *input.RadiusServerSecret
-	}
-
 	if input.RadiusServers != nil && len(*input.RadiusServers) > 0 {
 		servers := make([]interface{}, 0)
 

--- a/website/docs/r/vpn_server_configuration.html.markdown
+++ b/website/docs/r/vpn_server_configuration.html.markdown
@@ -90,7 +90,6 @@ When `vpn_authentication_types` contains `Certificate` the following arguments a
 
 When `vpn_authentication_types` contains `Radius` the following arguments are supported:
 
-* `radius_server` - (Optional / **Deprecated**) A `radius_server` block as defined below.
 * `radius` - (Optional) A `radius` block as defined below.
 
 ---
@@ -121,14 +120,6 @@ A `client_root_certificate` block at the root of the resource supports the follo
 
 ---
 
-A `client_root_certificate` block nested within the `radius_server` block supports the following:
-
-* `name` - (Required) A name used to uniquely identify this certificate.
-
-* `thumbprint` - (Required) The Thumbprint of the Certificate.
-
----
-
 A `ipsec_policy` block supports the following:
 
 * `dh_group` - (Required) The DH Group, used in IKE Phase 1. Possible values include `DHGroup1`, `DHGroup2`, `DHGroup14`, `DHGroup24`, `DHGroup2048`, `ECP256`, `ECP384` and `None`.
@@ -149,23 +140,11 @@ A `ipsec_policy` block supports the following:
 
 ---
 
-A `radius_server` (**Deprecated**) block is Used to configure single Radius Server. The block supports the following:
-
-* `address` - (Required) The Address of the Radius Server.
-
-* `secret` - (Required) The Secret used to communicate with the Radius Server.
-
-* `client_root_certificate` - (Optional) One or more `client_root_certificate` blocks as defined above.
-
-* `server_root_certificate` - (Required) One or more `server_root_certificate` blocks as defined below.
-
----
-
 A `radius` block supports the following:
 
 * `server` - (Required) One or more `server` blocks as defined below.
 
-* `client_root_certificate` - (Optional) One or more `client_root_certificate` blocks as defined above.
+* `client_root_certificate` - (Optional) One or more `client_root_certificate` blocks as defined below.
 
 * `server_root_certificate` - (Optional) One or more `server_root_certificate` blocks as defined below.
 
@@ -178,6 +157,14 @@ A `server` nested within the `radius` block supports the following::
 * `secret` - (Required) The Secret used to communicate with the Radius Server.
 
 * `score` - (Required) The Score of the Radius Server determines the priority of the server. Ranges from 1 to 30.
+
+---
+
+A `client_root_certificate` block nested within the `radius` block supports the following:
+
+* `name` - (Required) A name used to uniquely identify this certificate.
+
+* `thumbprint` - (Required) The Thumbprint of the Certificate.
 
 ---
 


### PR DESCRIPTION
these lines are setting values to not declared schemas, which may cause crash