### PR TITLE
Add examples for pim assignments to management groups

### DIFF
--- a/website/docs/r/pim_active_role_assignment.html.markdown
+++ b/website/docs/r/pim_active_role_assignment.html.markdown
@@ -59,7 +59,7 @@ resource "azurerm_management_group" "example" {
 
 resource "time_static" "example" {}
 
-resource "azurerm_pim_eligible_role_assignment" "example" {
+resource "azurerm_pim_active_role_assignment" "example" {
   scope              = azurerm_management_group.example.id
   role_definition_id = data.azurerm_role_definition.example.id
   principal_id       = data.azurerm_client_config.example.object_id

--- a/website/docs/r/pim_active_role_assignment.html.markdown
+++ b/website/docs/r/pim_active_role_assignment.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Manages a Pim Active Role Assignment.
 
-## Example Usage
+## Example Usage (Subscription)
 
 ```hcl
 data "azurerm_subscription" "primary" {}
@@ -26,6 +26,42 @@ resource "time_static" "example" {}
 resource "azurerm_pim_active_role_assignment" "example" {
   scope              = data.azurerm_subscription.primary.id
   role_definition_id = "${data.azurerm_subscription.primary.id}${data.azurerm_role_definition.example.id}"
+  principal_id       = data.azurerm_client_config.example.object_id
+
+  schedule {
+    start_date_time = time_static.example.rfc3339
+    expiration {
+      duration_hours = 8
+    }
+  }
+
+  justification = "Expiration Duration Set"
+
+  ticket {
+    number = "1"
+    system = "example ticket system"
+  }
+}
+```
+
+## Example Usage (Management Group)
+
+```hcl
+data "azurerm_client_config" "example" {}
+
+data "azurerm_role_definition" "example" {
+  name = "Reader"
+}
+
+resource "azurerm_management_group" "example" {
+  name         = "Example-Management-Group"
+}
+
+resource "time_static" "example" {}
+
+resource "azurerm_pim_eligible_role_assignment" "example" {
+  scope              = azurerm_management_group.example.id
+  role_definition_id = data.azurerm_role_definition.example.id
   principal_id       = data.azurerm_client_config.example.object_id
 
   schedule {

--- a/website/docs/r/pim_eligible_role_assignment.html.markdown
+++ b/website/docs/r/pim_eligible_role_assignment.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Manages a Pim Eligible Role Assignment.
 
-## Example Usage
+## Example Usage (Subscription)
 
 ```hcl
 data "azurerm_subscription" "primary" {}
@@ -26,6 +26,42 @@ resource "time_static" "example" {}
 resource "azurerm_pim_eligible_role_assignment" "example" {
   scope              = data.azurerm_subscription.primary.id
   role_definition_id = "${data.azurerm_subscription.primary.id}${data.azurerm_role_definition.example.id}"
+  principal_id       = data.azurerm_client_config.example.object_id
+
+  schedule {
+    start_date_time = time_static.example.rfc3339
+    expiration {
+      duration_hours = 8
+    }
+  }
+
+  justification = "Expiration Duration Set"
+
+  ticket {
+    number = "1"
+    system = "example ticket system"
+  }
+}
+```
+
+## Example Usage (Management Group)
+
+```hcl
+data "azurerm_client_config" "example" {}
+
+data "azurerm_role_definition" "example" {
+  name = "Reader"
+}
+
+resource "azurerm_management_group" "example" {
+  name         = "Example-Management-Group"
+}
+
+resource "time_static" "example" {}
+
+resource "azurerm_pim_eligible_role_assignment" "example" {
+  scope              = azurerm_management_group.example.id
+  role_definition_id = data.azurerm_role_definition.example.id
   principal_id       = data.azurerm_client_config.example.object_id
 
   schedule {


### PR DESCRIPTION
The included example is a bit unclear  on how to set the `role_definition_id` when adding pim assignments to management groups.

This PR adds a new example to both `azurerm_pim_active_role_assignment` and `azurerm_pim_eligible_role_assignment`