### PR TITLE
Added `Kubernetes` and `KubernetesConfiguration` resource providers to auto provider registration

### DIFF
--- a/internal/resourceproviders/required.go
+++ b/internal/resourceproviders/required.go
@@ -47,6 +47,8 @@ func Required() map[string]struct{} {
 		"Microsoft.HealthcareApis":          {},
 		"Microsoft.GuestConfiguration":      {},
 		"Microsoft.KeyVault":                {},
+		"Microsoft.Kubernetes":              {},
+		"Microsoft.KubernetesConfiguration": {},
 		"Microsoft.Kusto":                   {},
 		"microsoft.insights":                {},
 		"Microsoft.Logic":                   {},


### PR DESCRIPTION
The resource providers `Microsoft.Kubernetes` and `Microsoft.KubernetesConfiguration` have to be registered before we can use the following resources:

- `azurerm_kubernetes_cluster_extension`
- `azurerm_kubernetes_flux_configuration`

This PR adds these providers to the auto registration.

Fixes #22462