### PR TITLE
`azurerm_network_interface` - upgrade API from `2022-07-01` to `2023-02-01`

### DIFF
--- a/internal/services/network/client/client.go
+++ b/internal/services/network/client/client.go
@@ -24,6 +24,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2022-09-01/securityadminconfigurations"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2022-09-01/securityrules"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2022-09-01/staticmembers"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/common"
 	"github.com/tombuildsstuff/kermit/sdk/network/2022-07-01/network"
 )
@@ -59,6 +60,7 @@ type Client struct {
 	ManagerSecurityAdminConfigurationsClient *securityadminconfigurations.SecurityAdminConfigurationsClient
 	ManagerStaticMembersClient               *staticmembers.StaticMembersClient
 	NatRuleClient                            *network.NatRulesClient
+	NetworkInterfacesClient                  *networkinterfaces.NetworkInterfacesClient
 	PointToSiteVpnGatewaysClient             *network.P2sVpnGatewaysClient
 	ProfileClient                            *network.ProfilesClient
 	PacketCapturesClient                     *network.PacketCapturesClient
@@ -228,6 +230,12 @@ func NewClient(o *common.ClientOptions) (*Client, error) {
 	NatRuleClient := network.NewNatRulesClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&NatRuleClient.Client, o.ResourceManagerAuthorizer)
 
+	NetworkInterfacesClient, err := networkinterfaces.NewNetworkInterfacesClientWithBaseURI(o.Environment.ResourceManager)
+	if err != nil {
+		return nil, fmt.Errorf("building network interface client: %+v", err)
+	}
+	o.Configure(NetworkInterfacesClient.Client, o.Authorizers.ResourceManager)
+
 	pointToSiteVpnGatewaysClient := network.NewP2sVpnGatewaysClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&pointToSiteVpnGatewaysClient.Client, o.ResourceManagerAuthorizer)
 
@@ -385,6 +393,7 @@ func NewClient(o *common.ClientOptions) (*Client, error) {
 		ManagerSecurityAdminConfigurationsClient: ManagerSecurityAdminConfigurationsClient,
 		ManagerStaticMembersClient:               ManagerStaticMembersClient,
 		NatRuleClient:                            &NatRuleClient,
+		NetworkInterfacesClient:                  NetworkInterfacesClient,
 		PointToSiteVpnGatewaysClient:             &pointToSiteVpnGatewaysClient,
 		ProfileClient:                            &ProfileClient,
 		PacketCapturesClient:                     &PacketCapturesClient,

--- a/internal/services/network/edge_zone.go
+++ b/internal/services/network/edge_zone.go
@@ -27,3 +27,21 @@ func flattenEdgeZone(input *network.ExtendedLocation) string {
 	}
 	return edgezones.NormalizeNilable(input.Name)
 }
+
+func expandEdgeZoneModel(input string) *edgezones.Model {
+	normalized := edgezones.Normalize(input)
+	if normalized == "" {
+		return nil
+	}
+
+	return &edgezones.Model{
+		Name: normalized,
+	}
+}
+
+func flattenEdgeZoneModel(input *edgezones.Model) string {
+	if input == nil || input.Name == "" {
+		return ""
+	}
+	return edgezones.NormalizeNilable(&input.Name)
+}

--- a/internal/services/network/edge_zone.go
+++ b/internal/services/network/edge_zone.go
@@ -43,5 +43,5 @@ func flattenEdgeZoneModel(input *edgezones.Model) string {
 	if input == nil || input.Name == "" {
 		return ""
 	}
-	return edgezones.NormalizeNilable(&input.Name)
+	return edgezones.Normalize(input.Name)
 }

--- a/internal/services/network/network_interface.go
+++ b/internal/services/network/network_interface.go
@@ -4,8 +4,8 @@
 package network
 
 import (
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
-	"github.com/tombuildsstuff/kermit/sdk/network/2022-07-01/network"
 )
 
 type networkInterfaceUpdateInformation struct {
@@ -16,10 +16,10 @@ type networkInterfaceUpdateInformation struct {
 	networkSecurityGroupID                  string
 }
 
-func parseFieldsFromNetworkInterface(input network.InterfacePropertiesFormat) networkInterfaceUpdateInformation {
+func parseFieldsFromNetworkInterface(input networkinterfaces.NetworkInterfacePropertiesFormat) networkInterfaceUpdateInformation {
 	networkSecurityGroupId := ""
-	if input.NetworkSecurityGroup != nil && input.NetworkSecurityGroup.ID != nil {
-		networkSecurityGroupId = *input.NetworkSecurityGroup.ID
+	if input.NetworkSecurityGroup != nil && input.NetworkSecurityGroup.Id != nil {
+		networkSecurityGroupId = *input.NetworkSecurityGroup.Id
 	}
 
 	mapToSlice := func(input map[string]struct{}) []string {
@@ -39,39 +39,39 @@ func parseFieldsFromNetworkInterface(input network.InterfacePropertiesFormat) ne
 
 	if input.IPConfigurations != nil {
 		for _, v := range *input.IPConfigurations {
-			if v.InterfaceIPConfigurationPropertiesFormat == nil {
+			if v.Properties == nil {
 				continue
 			}
 
-			props := *v.InterfaceIPConfigurationPropertiesFormat
+			props := *v.Properties
 			if props.ApplicationSecurityGroups != nil {
 				for _, asg := range *props.ApplicationSecurityGroups {
-					if asg.ID != nil {
-						applicationSecurityGroupIds[*asg.ID] = struct{}{}
+					if asg.Id != nil {
+						applicationSecurityGroupIds[*asg.Id] = struct{}{}
 					}
 				}
 			}
 
 			if props.ApplicationGatewayBackendAddressPools != nil {
 				for _, pool := range *props.ApplicationGatewayBackendAddressPools {
-					if pool.ID != nil {
-						applicationGatewayBackendAddressPoolIds[*pool.ID] = struct{}{}
+					if pool.Id != nil {
+						applicationGatewayBackendAddressPoolIds[*pool.Id] = struct{}{}
 					}
 				}
 			}
 
 			if props.LoadBalancerBackendAddressPools != nil {
 				for _, pool := range *props.LoadBalancerBackendAddressPools {
-					if pool.ID != nil {
-						loadBalancerBackendAddressPoolIds[*pool.ID] = struct{}{}
+					if pool.Id != nil {
+						loadBalancerBackendAddressPoolIds[*pool.Id] = struct{}{}
 					}
 				}
 			}
 
 			if props.LoadBalancerInboundNatRules != nil {
 				for _, rule := range *props.LoadBalancerInboundNatRules {
-					if rule.ID != nil {
-						loadBalancerInboundNatRuleIds[*rule.ID] = struct{}{}
+					if rule.Id != nil {
+						loadBalancerInboundNatRuleIds[*rule.Id] = struct{}{}
 					}
 				}
 			}
@@ -87,50 +87,54 @@ func parseFieldsFromNetworkInterface(input network.InterfacePropertiesFormat) ne
 	}
 }
 
-func mapFieldsToNetworkInterface(input *[]network.InterfaceIPConfiguration, info networkInterfaceUpdateInformation) *[]network.InterfaceIPConfiguration {
+func mapFieldsToNetworkInterface(input *[]networkinterfaces.NetworkInterfaceIPConfiguration, info networkInterfaceUpdateInformation) *[]networkinterfaces.NetworkInterfaceIPConfiguration {
 	output := input
 
-	applicationSecurityGroups := make([]network.ApplicationSecurityGroup, 0)
+	applicationSecurityGroups := make([]networkinterfaces.ApplicationSecurityGroup, 0)
 	for _, id := range info.applicationSecurityGroupIDs {
-		applicationSecurityGroups = append(applicationSecurityGroups, network.ApplicationSecurityGroup{
-			ID: utils.String(id),
+		applicationSecurityGroups = append(applicationSecurityGroups, networkinterfaces.ApplicationSecurityGroup{
+			Id: utils.String(id),
 		})
 	}
 
-	applicationGatewayBackendAddressPools := make([]network.ApplicationGatewayBackendAddressPool, 0)
+	applicationGatewayBackendAddressPools := make([]networkinterfaces.ApplicationGatewayBackendAddressPool, 0)
 	for _, id := range info.applicationGatewayBackendAddressPoolIDs {
-		applicationGatewayBackendAddressPools = append(applicationGatewayBackendAddressPools, network.ApplicationGatewayBackendAddressPool{
-			ID: utils.String(id),
+		applicationGatewayBackendAddressPools = append(applicationGatewayBackendAddressPools, networkinterfaces.ApplicationGatewayBackendAddressPool{
+			Id: utils.String(id),
 		})
 	}
 
-	loadBalancerBackendAddressPools := make([]network.BackendAddressPool, 0)
+	loadBalancerBackendAddressPools := make([]networkinterfaces.BackendAddressPool, 0)
 	for _, id := range info.loadBalancerBackendAddressPoolIDs {
-		loadBalancerBackendAddressPools = append(loadBalancerBackendAddressPools, network.BackendAddressPool{
-			ID: utils.String(id),
+		loadBalancerBackendAddressPools = append(loadBalancerBackendAddressPools, networkinterfaces.BackendAddressPool{
+			Id: utils.String(id),
 		})
 	}
 
-	loadBalancerInboundNatRules := make([]network.InboundNatRule, 0)
+	loadBalancerInboundNatRules := make([]networkinterfaces.InboundNatRule, 0)
 	for _, id := range info.loadBalancerInboundNatRuleIDs {
-		loadBalancerInboundNatRules = append(loadBalancerInboundNatRules, network.InboundNatRule{
-			ID: utils.String(id),
+		loadBalancerInboundNatRules = append(loadBalancerInboundNatRules, networkinterfaces.InboundNatRule{
+			Id: utils.String(id),
 		})
 	}
 
 	for _, config := range *output {
-		if config.InterfaceIPConfigurationPropertiesFormat == nil {
+		if config.Properties == nil {
 			continue
 		}
 
-		if config.InterfaceIPConfigurationPropertiesFormat.PrivateIPAddressVersion != network.IPVersionIPv4 {
+		if config.Properties.PrivateIPAddressVersion == nil {
 			continue
 		}
 
-		config.ApplicationSecurityGroups = &applicationSecurityGroups
-		config.ApplicationGatewayBackendAddressPools = &applicationGatewayBackendAddressPools
-		config.LoadBalancerBackendAddressPools = &loadBalancerBackendAddressPools
-		config.LoadBalancerInboundNatRules = &loadBalancerInboundNatRules
+		if *config.Properties.PrivateIPAddressVersion != networkinterfaces.IPVersionIPvFour {
+			continue
+		}
+
+		config.Properties.ApplicationSecurityGroups = &applicationSecurityGroups
+		config.Properties.ApplicationGatewayBackendAddressPools = &applicationGatewayBackendAddressPools
+		config.Properties.LoadBalancerBackendAddressPools = &loadBalancerBackendAddressPools
+		config.Properties.LoadBalancerInboundNatRules = &loadBalancerInboundNatRules
 	}
 
 	return output

--- a/internal/services/network/network_interface.go
+++ b/internal/services/network/network_interface.go
@@ -119,15 +119,7 @@ func mapFieldsToNetworkInterface(input *[]networkinterfaces.NetworkInterfaceIPCo
 	}
 
 	for _, config := range *output {
-		if config.Properties == nil {
-			continue
-		}
-
-		if config.Properties.PrivateIPAddressVersion == nil {
-			continue
-		}
-
-		if *config.Properties.PrivateIPAddressVersion != networkinterfaces.IPVersionIPvFour {
+		if config.Properties == nil || config.Properties.PrivateIPAddressVersion == nil || *config.Properties.PrivateIPAddressVersion != networkinterfaces.IPVersionIPvFour {
 			continue
 		}
 

--- a/internal/services/network/network_interface_application_security_group_association_resource.go
+++ b/internal/services/network/network_interface_application_security_group_association_resource.go
@@ -9,12 +9,14 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2022-09-01/applicationsecuritygroups"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/migration"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
@@ -28,7 +30,7 @@ func resourceNetworkInterfaceApplicationSecurityGroupAssociation() *pluginsdk.Re
 		Delete: resourceNetworkInterfaceApplicationSecurityGroupAssociationDelete,
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
 			splitId := strings.Split(id, "|")
-			if _, err := parse.NetworkInterfaceID(splitId[0]); err != nil {
+			if _, err := commonids.ParseNetworkInterfaceID(splitId[0]); err != nil {
 				return err
 			}
 			if _, err := applicationsecuritygroups.ParseApplicationSecurityGroupID(splitId[1]); err != nil {
@@ -68,7 +70,7 @@ func resourceNetworkInterfaceApplicationSecurityGroupAssociation() *pluginsdk.Re
 }
 
 func resourceNetworkInterfaceApplicationSecurityGroupAssociationCreate(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.InterfacesClient
+	client := meta.(*clients.Client).Network.NetworkInterfacesClient
 	ctx, cancel := timeouts.ForCreate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -77,17 +79,17 @@ func resourceNetworkInterfaceApplicationSecurityGroupAssociationCreate(d *plugin
 	networkInterfaceId := d.Get("network_interface_id").(string)
 	applicationSecurityGroupId := d.Get("application_security_group_id").(string)
 
-	id, err := parse.NetworkInterfaceID(networkInterfaceId)
+	id, err := commonids.ParseNetworkInterfaceID(networkInterfaceId)
 	if err != nil {
 		return err
 	}
 
-	locks.ByName(id.Name, networkInterfaceResourceName)
-	defer locks.UnlockByName(id.Name, networkInterfaceResourceName)
+	locks.ByName(id.NetworkInterfaceName, networkInterfaceResourceName)
+	defer locks.UnlockByName(id.NetworkInterfaceName, networkInterfaceResourceName)
 
-	read, err := client.Get(ctx, id.ResourceGroup, id.Name, "")
+	read, err := client.Get(ctx, *id, networkinterfaces.DefaultGetOperationOptions())
 	if err != nil {
-		if utils.ResponseWasNotFound(read.Response) {
+		if response.WasNotFound(read.HttpResponse) {
 			log.Printf("[INFO] Network Interface %q does not exist - removing from state", d.Id())
 			d.SetId("")
 			return nil
@@ -96,7 +98,11 @@ func resourceNetworkInterfaceApplicationSecurityGroupAssociationCreate(d *plugin
 		return fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	props := read.InterfacePropertiesFormat
+	if read.Model == nil {
+		return fmt.Errorf("retrieving %s: `model` was nil", *id)
+	}
+
+	props := read.Model.Properties
 	if props == nil {
 		return fmt.Errorf("Error: `properties` was nil for %s", *id)
 	}
@@ -112,15 +118,11 @@ func resourceNetworkInterfaceApplicationSecurityGroupAssociationCreate(d *plugin
 
 	info.applicationSecurityGroupIDs = append(info.applicationSecurityGroupIDs, applicationSecurityGroupId)
 
-	read.InterfacePropertiesFormat.IPConfigurations = mapFieldsToNetworkInterface(props.IPConfigurations, info)
+	props.IPConfigurations = mapFieldsToNetworkInterface(props.IPConfigurations, info)
 
-	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.Name, read)
+	err = client.CreateOrUpdateThenPoll(ctx, *id, *read.Model)
 	if err != nil {
 		return fmt.Errorf("updating Application Security Group Association for %s: %+v", *id, err)
-	}
-
-	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting for completion of Application Security Group Association for %s: %+v", *id, err)
 	}
 
 	d.SetId(resourceId)
@@ -129,7 +131,7 @@ func resourceNetworkInterfaceApplicationSecurityGroupAssociationCreate(d *plugin
 }
 
 func resourceNetworkInterfaceApplicationSecurityGroupAssociationRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.InterfacesClient
+	client := meta.(*clients.Client).Network.NetworkInterfacesClient
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -138,16 +140,16 @@ func resourceNetworkInterfaceApplicationSecurityGroupAssociationRead(d *pluginsd
 		return fmt.Errorf("Expected ID to be in the format {networkInterfaceId}|{applicationSecurityGroupId} but got %q", d.Id())
 	}
 
-	nicID, err := parse.NetworkInterfaceID(splitId[0])
+	nicID, err := commonids.ParseNetworkInterfaceID(splitId[0])
 	if err != nil {
 		return err
 	}
 
 	applicationSecurityGroupId := splitId[1]
 
-	read, err := client.Get(ctx, nicID.ResourceGroup, nicID.Name, "")
+	read, err := client.Get(ctx, *nicID, networkinterfaces.DefaultGetOperationOptions())
 	if err != nil {
-		if utils.ResponseWasNotFound(read.Response) {
+		if response.WasNotFound(read.HttpResponse) {
 			log.Printf("[DEBUG] %s was not found - removing from state!", *nicID)
 			d.SetId("")
 			return nil
@@ -156,33 +158,35 @@ func resourceNetworkInterfaceApplicationSecurityGroupAssociationRead(d *pluginsd
 		return fmt.Errorf("retrieving %s: %+v", *nicID, err)
 	}
 
-	nicProps := read.InterfacePropertiesFormat
-	if nicProps == nil {
-		return fmt.Errorf("Error: `properties` was nil for %s", *nicID)
-	}
-
-	info := parseFieldsFromNetworkInterface(*nicProps)
-	exists := false
-	for _, groupId := range info.applicationSecurityGroupIDs {
-		if groupId == applicationSecurityGroupId {
-			exists = true
+	if model := read.Model; model != nil {
+		nicProps := read.Model.Properties
+		if nicProps == nil {
+			return fmt.Errorf("Error: `properties` was nil for %s", *nicID)
 		}
-	}
 
-	if !exists {
-		log.Printf("[DEBUG] Association between %s and Application Security Group %q was not found - removing from state!", *nicID, applicationSecurityGroupId)
-		d.SetId("")
-		return nil
-	}
+		info := parseFieldsFromNetworkInterface(*nicProps)
+		exists := false
+		for _, groupId := range info.applicationSecurityGroupIDs {
+			if groupId == applicationSecurityGroupId {
+				exists = true
+			}
+		}
 
-	d.Set("application_security_group_id", applicationSecurityGroupId)
-	d.Set("network_interface_id", read.ID)
+		if !exists {
+			log.Printf("[DEBUG] Association between %s and Application Security Group %q was not found - removing from state!", *nicID, applicationSecurityGroupId)
+			d.SetId("")
+			return nil
+		}
+
+		d.Set("application_security_group_id", applicationSecurityGroupId)
+		d.Set("network_interface_id", model.Id)
+	}
 
 	return nil
 }
 
 func resourceNetworkInterfaceApplicationSecurityGroupAssociationDelete(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.InterfacesClient
+	client := meta.(*clients.Client).Network.NetworkInterfacesClient
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
@@ -191,26 +195,30 @@ func resourceNetworkInterfaceApplicationSecurityGroupAssociationDelete(d *plugin
 		return fmt.Errorf("Expected ID to be in the format {networkInterfaceId}|{applicationSecurityGroupId} but got %q", d.Id())
 	}
 
-	nicID, err := parse.NetworkInterfaceID(splitId[0])
+	nicID, err := commonids.ParseNetworkInterfaceID(splitId[0])
 	if err != nil {
 		return err
 	}
 
 	applicationSecurityGroupId := splitId[1]
 
-	locks.ByName(nicID.Name, networkInterfaceResourceName)
-	defer locks.UnlockByName(nicID.Name, networkInterfaceResourceName)
+	locks.ByName(nicID.NetworkInterfaceName, networkInterfaceResourceName)
+	defer locks.UnlockByName(nicID.NetworkInterfaceName, networkInterfaceResourceName)
 
-	read, err := client.Get(ctx, nicID.ResourceGroup, nicID.Name, "")
+	read, err := client.Get(ctx, *nicID, networkinterfaces.DefaultGetOperationOptions())
 	if err != nil {
-		if utils.ResponseWasNotFound(read.Response) {
+		if response.WasNotFound(read.HttpResponse) {
 			return fmt.Errorf("%s was not found!", *nicID)
 		}
 
 		return fmt.Errorf("retrieving  %s: %+v", *nicID, err)
 	}
 
-	props := read.InterfacePropertiesFormat
+	if read.Model == nil {
+		return fmt.Errorf("retrieving %s: `model` was nil", *nicID)
+	}
+
+	props := read.Model.Properties
 	if props == nil {
 		return fmt.Errorf("Error: `properties` was nil for %s", *nicID)
 	}
@@ -228,15 +236,11 @@ func resourceNetworkInterfaceApplicationSecurityGroupAssociationDelete(d *plugin
 		}
 	}
 	info.applicationSecurityGroupIDs = applicationSecurityGroupIds
-	read.InterfacePropertiesFormat.IPConfigurations = mapFieldsToNetworkInterface(props.IPConfigurations, info)
+	props.IPConfigurations = mapFieldsToNetworkInterface(props.IPConfigurations, info)
 
-	future, err := client.CreateOrUpdate(ctx, nicID.ResourceGroup, nicID.Name, read)
+	err = client.CreateOrUpdateThenPoll(ctx, *nicID, *read.Model)
 	if err != nil {
 		return fmt.Errorf("removing Application Security Group for %s: %+v", *nicID, err)
-	}
-
-	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting for removal of Application Security Group for %s: %+v", *nicID, err)
 	}
 
 	return nil

--- a/internal/services/network/network_interface_data_source.go
+++ b/internal/services/network/network_interface_data_source.go
@@ -10,13 +10,12 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
-	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
 func dataSourceNetworkInterface() *pluginsdk.Resource {
@@ -175,7 +174,7 @@ func dataSourceNetworkInterface() *pluginsdk.Resource {
 				},
 			},
 
-			"tags": tags.SchemaDataSource(),
+			"tags": commonschema.TagsDataSource(),
 		},
 	}
 }
@@ -272,9 +271,5 @@ func dataSourceNetworkInterfaceRead(d *pluginsdk.ResourceData, meta interface{})
 		d.Set("enable_accelerated_networking", props.EnableAcceleratedNetworking)
 	}
 
-	if err = d.Set("tags", utils.FlattenPtrMapStringString(model.Tags)); err != nil {
-		return err
-	}
-
-	return nil
+	return tags.FlattenAndSet(d, model.Tags)
 }

--- a/internal/services/network/network_interface_data_source.go
+++ b/internal/services/network/network_interface_data_source.go
@@ -7,10 +7,12 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
@@ -179,15 +181,15 @@ func dataSourceNetworkInterface() *pluginsdk.Resource {
 }
 
 func dataSourceNetworkInterfaceRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.InterfacesClient
+	client := meta.(*clients.Client).Network.NetworkInterfacesClient
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id := parse.NewNetworkInterfaceID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
-	resp, err := client.Get(ctx, id.ResourceGroup, id.Name, "")
+	id := commonids.NewNetworkInterfaceID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
+	resp, err := client.Get(ctx, id, networkinterfaces.DefaultGetOperationOptions())
 	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
+		if response.WasNotFound(resp.HttpResponse) {
 			return fmt.Errorf("Error: %s was not found", id)
 		}
 		return fmt.Errorf("retrieving %s: %+v", id, err)
@@ -195,27 +197,33 @@ func dataSourceNetworkInterfaceRead(d *pluginsdk.ResourceData, meta interface{})
 
 	d.SetId(id.ID())
 
-	d.Set("name", id.Name)
-	d.Set("resource_group_name", id.ResourceGroup)
-	if location := resp.Location; location != nil {
+	d.Set("name", id.NetworkInterfaceName)
+	d.Set("resource_group_name", id.ResourceGroupName)
+
+	model := resp.Model
+	if model == nil {
+		return fmt.Errorf("retrieving %s: `model` was nil", id)
+	}
+
+	if location := model.Location; location != nil {
 		d.Set("location", azure.NormalizeLocation(*location))
 	}
 
-	if props := resp.InterfacePropertiesFormat; props != nil {
+	if props := model.Properties; props != nil {
 		d.Set("mac_address", props.MacAddress)
 
 		privateIpAddress := ""
 		privateIpAddresses := make([]interface{}, 0)
 		if configs := props.IPConfigurations; configs != nil {
 			for _, config := range *configs {
-				if config.InterfaceIPConfigurationPropertiesFormat == nil {
+				if config.Properties == nil {
 					continue
 				}
-				if config.InterfaceIPConfigurationPropertiesFormat.PrivateIPAddress == nil {
+				if config.Properties.PrivateIPAddress == nil {
 					continue
 				}
 
-				ipAddress := *config.InterfaceIPConfigurationPropertiesFormat.PrivateIPAddress
+				ipAddress := *config.Properties.PrivateIPAddress
 				if privateIpAddress == "" {
 					privateIpAddress = ipAddress
 				}
@@ -233,28 +241,28 @@ func dataSourceNetworkInterfaceRead(d *pluginsdk.ResourceData, meta interface{})
 		}
 
 		virtualMachineId := ""
-		if props.VirtualMachine != nil && props.VirtualMachine.ID != nil {
-			virtualMachineId = *props.VirtualMachine.ID
+		if props.VirtualMachine != nil && props.VirtualMachine.Id != nil {
+			virtualMachineId = *props.VirtualMachine.Id
 		}
 		d.Set("virtual_machine_id", virtualMachineId)
 
 		var appliedDNSServers []string
 		var dnsServers []string
-		if dnsSettings := props.DNSSettings; dnsSettings != nil {
-			if s := dnsSettings.AppliedDNSServers; s != nil {
+		if dnsSettings := props.DnsSettings; dnsSettings != nil {
+			if s := dnsSettings.AppliedDnsServers; s != nil {
 				appliedDNSServers = *s
 			}
 
-			if s := dnsSettings.DNSServers; s != nil {
+			if s := dnsSettings.DnsServers; s != nil {
 				dnsServers = *s
 			}
 
-			d.Set("internal_dns_name_label", dnsSettings.InternalDNSNameLabel)
+			d.Set("internal_dns_name_label", dnsSettings.InternalDnsNameLabel)
 		}
 
 		networkSecurityGroupId := ""
-		if props.NetworkSecurityGroup != nil && props.NetworkSecurityGroup.ID != nil {
-			networkSecurityGroupId = *props.NetworkSecurityGroup.ID
+		if props.NetworkSecurityGroup != nil && props.NetworkSecurityGroup.Id != nil {
+			networkSecurityGroupId = *props.NetworkSecurityGroup.Id
 		}
 		d.Set("network_security_group_id", networkSecurityGroupId)
 
@@ -264,5 +272,9 @@ func dataSourceNetworkInterfaceRead(d *pluginsdk.ResourceData, meta interface{})
 		d.Set("enable_accelerated_networking", props.EnableAcceleratedNetworking)
 	}
 
-	return tags.FlattenAndSet(d, resp.Tags)
+	if err = d.Set("tags", utils.FlattenPtrMapStringString(model.Tags)); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/internal/services/network/network_interface_locking.go
+++ b/internal/services/network/network_interface_locking.go
@@ -5,9 +5,9 @@ package network
 
 import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
-	"github.com/tombuildsstuff/kermit/sdk/network/2022-07-01/network"
 )
 
 type networkInterfaceIPConfigurationLockingDetails struct {
@@ -25,7 +25,7 @@ func (details networkInterfaceIPConfigurationLockingDetails) unlock() {
 	locks.UnlockMultipleByName(&details.virtualNetworkNamesToLock, VirtualNetworkResourceName)
 }
 
-func determineResourcesToLockFromIPConfiguration(input *[]network.InterfaceIPConfiguration) (*networkInterfaceIPConfigurationLockingDetails, error) {
+func determineResourcesToLockFromIPConfiguration(input *[]networkinterfaces.NetworkInterfaceIPConfiguration) (*networkInterfaceIPConfigurationLockingDetails, error) {
 	if input == nil {
 		return &networkInterfaceIPConfigurationLockingDetails{
 			subnetNamesToLock:         []string{},
@@ -37,11 +37,11 @@ func determineResourcesToLockFromIPConfiguration(input *[]network.InterfaceIPCon
 	virtualNetworkNamesToLock := make([]string, 0)
 
 	for _, config := range *input {
-		if config.Subnet == nil || config.Subnet.ID == nil {
+		if config.Properties == nil || config.Properties.Subnet == nil || config.Properties.Subnet.Id == nil {
 			continue
 		}
 
-		id, err := commonids.ParseSubnetID(*config.Subnet.ID)
+		id, err := commonids.ParseSubnetID(*config.Properties.Subnet.Id)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/services/network/network_interface_resource.go
+++ b/internal/services/network/network_interface_resource.go
@@ -8,15 +8,17 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	lbvalidate "github.com/hashicorp/terraform-provider-azurerm/internal/services/loadbalancer/validate"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/network/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tags"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -24,7 +26,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
-	"github.com/tombuildsstuff/kermit/sdk/network/2022-07-01/network"
 )
 
 var networkInterfaceResourceName = "azurerm_network_interface"
@@ -37,7 +38,7 @@ func resourceNetworkInterface() *pluginsdk.Resource {
 		Delete: resourceNetworkInterfaceDelete,
 
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
-			_, err := parse.NetworkInterfaceID(id)
+			_, err := commonids.ParseNetworkInterfaceID(id)
 			return err
 		}),
 
@@ -86,10 +87,10 @@ func resourceNetworkInterface() *pluginsdk.Resource {
 						"private_ip_address_version": {
 							Type:     pluginsdk.TypeString,
 							Optional: true,
-							Default:  string(network.IPVersionIPv4),
+							Default:  string(networkinterfaces.IPVersionIPvFour),
 							ValidateFunc: validation.StringInSlice([]string{
-								string(network.IPVersionIPv4),
-								string(network.IPVersionIPv6),
+								string(networkinterfaces.IPVersionIPvFour),
+								string(networkinterfaces.IPVersionIPvSix),
 							}, false),
 						},
 
@@ -97,8 +98,8 @@ func resourceNetworkInterface() *pluginsdk.Resource {
 							Type:     pluginsdk.TypeString,
 							Required: true,
 							ValidateFunc: validation.StringInSlice([]string{
-								string(network.IPAllocationMethodDynamic),
-								string(network.IPAllocationMethodStatic),
+								string(networkinterfaces.IPAllocationMethodDynamic),
+								string(networkinterfaces.IPAllocationMethodStatic),
 							}, false),
 						},
 
@@ -201,23 +202,21 @@ func resourceNetworkInterface() *pluginsdk.Resource {
 }
 
 func resourceNetworkInterfaceCreate(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.InterfacesClient
+	client := meta.(*clients.Client).Network.NetworkInterfacesClient
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id := parse.NewNetworkInterfaceID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
-	if d.IsNewResource() {
-		existing, err := client.Get(ctx, id.ResourceGroup, id.Name, "")
-		if err != nil {
-			if !utils.ResponseWasNotFound(existing.Response) {
-				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
-			}
+	id := commonids.NewNetworkInterfaceID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
+	existing, err := client.Get(ctx, id, networkinterfaces.DefaultGetOperationOptions())
+	if err != nil {
+		if !response.WasNotFound(existing.HttpResponse) {
+			return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
 		}
+	}
 
-		if !utils.ResponseWasNotFound(existing.Response) {
-			return tf.ImportAsExistsError("azurerm_network_interface", id.ID())
-		}
+	if !response.WasNotFound(existing.HttpResponse) {
+		return tf.ImportAsExistsError("azurerm_network_interface", id.ID())
 	}
 
 	location := azure.NormalizeLocation(d.Get("location").(string))
@@ -225,30 +224,30 @@ func resourceNetworkInterfaceCreate(d *pluginsdk.ResourceData, meta interface{})
 	enableAcceleratedNetworking := d.Get("enable_accelerated_networking").(bool)
 	t := d.Get("tags").(map[string]interface{})
 
-	properties := network.InterfacePropertiesFormat{
+	properties := networkinterfaces.NetworkInterfacePropertiesFormat{
 		EnableIPForwarding:          &enableIpForwarding,
 		EnableAcceleratedNetworking: &enableAcceleratedNetworking,
 	}
 
-	locks.ByName(id.Name, networkInterfaceResourceName)
-	defer locks.UnlockByName(id.Name, networkInterfaceResourceName)
+	locks.ByName(id.NetworkInterfaceName, networkInterfaceResourceName)
+	defer locks.UnlockByName(id.NetworkInterfaceName, networkInterfaceResourceName)
 
 	dns, hasDns := d.GetOk("dns_servers")
 	nameLabel, hasNameLabel := d.GetOk("internal_dns_name_label")
 	if hasDns || hasNameLabel {
-		dnsSettings := network.InterfaceDNSSettings{}
+		dnsSettings := networkinterfaces.NetworkInterfaceDnsSettings{}
 
 		if hasDns {
 			dnsRaw := dns.([]interface{})
 			dns := expandNetworkInterfaceDnsServers(dnsRaw)
-			dnsSettings.DNSServers = &dns
+			dnsSettings.DnsServers = &dns
 		}
 
 		if hasNameLabel {
-			dnsSettings.InternalDNSNameLabel = utils.String(nameLabel.(string))
+			dnsSettings.InternalDnsNameLabel = utils.String(nameLabel.(string))
 		}
 
-		properties.DNSSettings = &dnsSettings
+		properties.DnsSettings = &dnsSettings
 	}
 
 	ipConfigsRaw := d.Get("ip_configuration").([]interface{})
@@ -268,21 +267,17 @@ func resourceNetworkInterfaceCreate(d *pluginsdk.ResourceData, meta interface{})
 		properties.IPConfigurations = ipConfigs
 	}
 
-	iface := network.Interface{
-		Name:                      utils.String(id.Name),
-		ExtendedLocation:          expandEdgeZone(d.Get("edge_zone").(string)),
-		Location:                  utils.String(location),
-		InterfacePropertiesFormat: &properties,
-		Tags:                      tags.Expand(t),
+	iface := networkinterfaces.NetworkInterface{
+		Name:             pointer.To(id.NetworkInterfaceName),
+		ExtendedLocation: expandEdgeZoneModel(d.Get("edge_zone").(string)),
+		Location:         utils.String(location),
+		Properties:       &properties,
+		Tags:             utils.ExpandPtrMapStringString(t),
 	}
 
-	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.Name, iface)
+	err = client.CreateOrUpdateThenPoll(ctx, id, iface)
 	if err != nil {
 		return fmt.Errorf("creating %s: %+v", id, err)
-	}
-
-	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting for creation of %s: %+v", id, err)
 	}
 
 	d.SetId(id.ID())
@@ -290,39 +285,43 @@ func resourceNetworkInterfaceCreate(d *pluginsdk.ResourceData, meta interface{})
 }
 
 func resourceNetworkInterfaceUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.InterfacesClient
+	client := meta.(*clients.Client).Network.NetworkInterfacesClient
 	ctx, cancel := timeouts.ForUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := parse.NetworkInterfaceID(d.Id())
+	id, err := commonids.ParseNetworkInterfaceID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	locks.ByName(id.Name, networkInterfaceResourceName)
-	defer locks.UnlockByName(id.Name, networkInterfaceResourceName)
+	locks.ByName(id.NetworkInterfaceName, networkInterfaceResourceName)
+	defer locks.UnlockByName(id.NetworkInterfaceName, networkInterfaceResourceName)
 
 	// first get the existing one so that we can pull things as needed
-	existing, err := client.Get(ctx, id.ResourceGroup, id.Name, "")
+	existing, err := client.Get(ctx, *id, networkinterfaces.DefaultGetOperationOptions())
 	if err != nil {
 		return fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	if existing.InterfacePropertiesFormat == nil {
+	if existing.Model == nil {
+		return fmt.Errorf("retrieving %s: `model` was nil", *id)
+	}
+
+	if existing.Model.Properties == nil {
 		return fmt.Errorf("retrieving %s: `properties` was nil", *id)
 	}
 
 	// then pull out things we need to lock on
-	info := parseFieldsFromNetworkInterface(*existing.InterfacePropertiesFormat)
+	info := parseFieldsFromNetworkInterface(*existing.Model.Properties)
 
 	location := azure.NormalizeLocation(d.Get("location").(string))
-	update := network.Interface{
-		Name:             utils.String(id.Name),
-		ExtendedLocation: expandEdgeZone(d.Get("edge_zone").(string)),
+	update := networkinterfaces.NetworkInterface{
+		Name:             utils.String(id.NetworkInterfaceName),
+		ExtendedLocation: expandEdgeZoneModel(d.Get("edge_zone").(string)),
 		Location:         utils.String(location),
-		InterfacePropertiesFormat: &network.InterfacePropertiesFormat{
+		Properties: &networkinterfaces.NetworkInterfacePropertiesFormat{
 			EnableAcceleratedNetworking: utils.Bool(d.Get("enable_accelerated_networking").(bool)),
-			DNSSettings:                 &network.InterfaceDNSSettings{},
+			DnsSettings:                 &networkinterfaces.NetworkInterfaceDnsSettings{},
 		},
 	}
 
@@ -330,21 +329,21 @@ func resourceNetworkInterfaceUpdate(d *pluginsdk.ResourceData, meta interface{})
 		dnsServersRaw := d.Get("dns_servers").([]interface{})
 		dnsServers := expandNetworkInterfaceDnsServers(dnsServersRaw)
 
-		update.InterfacePropertiesFormat.DNSSettings.DNSServers = &dnsServers
+		update.Properties.DnsSettings.DnsServers = &dnsServers
 	} else {
-		update.InterfacePropertiesFormat.DNSSettings.DNSServers = existing.InterfacePropertiesFormat.DNSSettings.DNSServers
+		update.Properties.DnsSettings.DnsServers = existing.Model.Properties.DnsSettings.DnsServers
 	}
 
 	if d.HasChange("enable_ip_forwarding") {
-		update.InterfacePropertiesFormat.EnableIPForwarding = utils.Bool(d.Get("enable_ip_forwarding").(bool))
+		update.Properties.EnableIPForwarding = utils.Bool(d.Get("enable_ip_forwarding").(bool))
 	} else {
-		update.InterfacePropertiesFormat.EnableIPForwarding = existing.InterfacePropertiesFormat.EnableIPForwarding
+		update.Properties.EnableIPForwarding = existing.Model.Properties.EnableIPForwarding
 	}
 
 	if d.HasChange("internal_dns_name_label") {
-		update.InterfacePropertiesFormat.DNSSettings.InternalDNSNameLabel = utils.String(d.Get("internal_dns_name_label").(string))
+		update.Properties.DnsSettings.InternalDnsNameLabel = utils.String(d.Get("internal_dns_name_label").(string))
 	} else {
-		update.InterfacePropertiesFormat.DNSSettings.InternalDNSNameLabel = existing.InterfacePropertiesFormat.DNSSettings.InternalDNSNameLabel
+		update.Properties.DnsSettings.InternalDnsNameLabel = existing.Model.Properties.DnsSettings.InternalDnsNameLabel
 	}
 
 	if d.HasChange("ip_configuration") {
@@ -364,142 +363,146 @@ func resourceNetworkInterfaceUpdate(d *pluginsdk.ResourceData, meta interface{})
 		// then map the fields managed in other resources back
 		ipConfigs = mapFieldsToNetworkInterface(ipConfigs, info)
 
-		update.InterfacePropertiesFormat.IPConfigurations = ipConfigs
+		update.Properties.IPConfigurations = ipConfigs
 	} else {
-		update.InterfacePropertiesFormat.IPConfigurations = existing.InterfacePropertiesFormat.IPConfigurations
+		update.Properties.IPConfigurations = existing.Model.Properties.IPConfigurations
 	}
 
 	if d.HasChange("tags") {
 		tagsRaw := d.Get("tags").(map[string]interface{})
-		update.Tags = tags.Expand(tagsRaw)
+		update.Tags = utils.ExpandPtrMapStringString(tagsRaw)
 	} else {
-		update.Tags = existing.Tags
+		update.Tags = existing.Model.Tags
 	}
 
 	// this can be managed in another resource, so just port it over
-	update.InterfacePropertiesFormat.NetworkSecurityGroup = existing.InterfacePropertiesFormat.NetworkSecurityGroup
+	update.Properties.NetworkSecurityGroup = existing.Model.Properties.NetworkSecurityGroup
 
-	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.Name, update)
+	err = client.CreateOrUpdateThenPoll(ctx, *id, update)
 	if err != nil {
 		return fmt.Errorf("updating %s: %+v", *id, err)
-	}
-	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting for update of %s: %+v", *id, err)
 	}
 
 	return nil
 }
 
 func resourceNetworkInterfaceRead(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.InterfacesClient
+	client := meta.(*clients.Client).Network.NetworkInterfacesClient
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := parse.NetworkInterfaceID(d.Id())
+	id, err := commonids.ParseNetworkInterfaceID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	resp, err := client.Get(ctx, id.ResourceGroup, id.Name, "")
+	resp, err := client.Get(ctx, *id, networkinterfaces.DefaultGetOperationOptions())
 	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
+		if response.WasNotFound(resp.HttpResponse) {
 			d.SetId("")
 			return nil
 		}
 		return fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	d.Set("name", id.Name)
-	d.Set("resource_group_name", id.ResourceGroup)
-	d.Set("location", location.NormalizeNilable(resp.Location))
-	d.Set("edge_zone", flattenEdgeZone(resp.ExtendedLocation))
+	d.Set("name", id.NetworkInterfaceName)
+	d.Set("resource_group_name", id.ResourceGroupName)
 
-	if props := resp.InterfacePropertiesFormat; props != nil {
-		primaryPrivateIPAddress := ""
-		privateIPAddresses := make([]interface{}, 0)
-		if configs := props.IPConfigurations; configs != nil {
-			for i, config := range *props.IPConfigurations {
-				if ipProps := config.InterfaceIPConfigurationPropertiesFormat; ipProps != nil {
-					v := ipProps.PrivateIPAddress
-					if v == nil {
-						continue
+	if model := resp.Model; model != nil {
+		d.Set("location", location.NormalizeNilable(model.Location))
+		d.Set("edge_zone", flattenEdgeZoneModel(model.ExtendedLocation))
+
+		if props := model.Properties; props != nil {
+			primaryPrivateIPAddress := ""
+			privateIPAddresses := make([]interface{}, 0)
+			if configs := props.IPConfigurations; configs != nil {
+				for i, config := range *props.IPConfigurations {
+					if ipProps := config.Properties; ipProps != nil {
+						v := ipProps.PrivateIPAddress
+						if v == nil {
+							continue
+						}
+
+						if i == 0 {
+							primaryPrivateIPAddress = *v
+						}
+
+						privateIPAddresses = append(privateIPAddresses, *v)
 					}
-
-					if i == 0 {
-						primaryPrivateIPAddress = *v
-					}
-
-					privateIPAddresses = append(privateIPAddresses, *v)
 				}
 			}
-		}
 
-		appliedDNSServers := make([]string, 0)
-		dnsServers := make([]string, 0)
-		internalDnsNameLabel := ""
-		internalDomainNameSuffix := ""
-		if dnsSettings := props.DNSSettings; dnsSettings != nil {
-			appliedDNSServers = flattenNetworkInterfaceDnsServers(dnsSettings.AppliedDNSServers)
-			dnsServers = flattenNetworkInterfaceDnsServers(dnsSettings.DNSServers)
+			appliedDNSServers := make([]string, 0)
+			dnsServers := make([]string, 0)
+			internalDnsNameLabel := ""
+			internalDomainNameSuffix := ""
+			if dnsSettings := props.DnsSettings; dnsSettings != nil {
+				appliedDNSServers = flattenNetworkInterfaceDnsServers(dnsSettings.AppliedDnsServers)
+				dnsServers = flattenNetworkInterfaceDnsServers(dnsSettings.DnsServers)
 
-			if dnsSettings.InternalDNSNameLabel != nil {
-				internalDnsNameLabel = *dnsSettings.InternalDNSNameLabel
+				if dnsSettings.InternalDnsNameLabel != nil {
+					internalDnsNameLabel = *dnsSettings.InternalDnsNameLabel
+				}
+
+				if dnsSettings.InternalDomainNameSuffix != nil {
+					internalDomainNameSuffix = *dnsSettings.InternalDomainNameSuffix
+				}
 			}
 
-			if dnsSettings.InternalDomainNameSuffix != nil {
-				internalDomainNameSuffix = *dnsSettings.InternalDomainNameSuffix
+			virtualMachineId := ""
+			if props.VirtualMachine != nil && props.VirtualMachine.Id != nil {
+				virtualMachineId = *props.VirtualMachine.Id
+			}
+
+			if err := d.Set("applied_dns_servers", appliedDNSServers); err != nil {
+				return fmt.Errorf("setting `applied_dns_servers`: %+v", err)
+			}
+
+			if err := d.Set("dns_servers", dnsServers); err != nil {
+				return fmt.Errorf("setting `applied_dns_servers`: %+v", err)
+			}
+
+			d.Set("enable_ip_forwarding", props.EnableIPForwarding)
+			d.Set("enable_accelerated_networking", props.EnableAcceleratedNetworking)
+			d.Set("internal_dns_name_label", internalDnsNameLabel)
+			d.Set("internal_domain_name_suffix", internalDomainNameSuffix)
+			d.Set("mac_address", props.MacAddress)
+			d.Set("private_ip_address", primaryPrivateIPAddress)
+			d.Set("virtual_machine_id", virtualMachineId)
+
+			if err := d.Set("ip_configuration", flattenNetworkInterfaceIPConfigurations(props.IPConfigurations)); err != nil {
+				return fmt.Errorf("setting `ip_configuration`: %+v", err)
+			}
+
+			if err := d.Set("private_ip_addresses", privateIPAddresses); err != nil {
+				return fmt.Errorf("setting `private_ip_addresses`: %+v", err)
 			}
 		}
 
-		virtualMachineId := ""
-		if props.VirtualMachine != nil && props.VirtualMachine.ID != nil {
-			virtualMachineId = *props.VirtualMachine.ID
-		}
-
-		if err := d.Set("applied_dns_servers", appliedDNSServers); err != nil {
-			return fmt.Errorf("setting `applied_dns_servers`: %+v", err)
-		}
-
-		if err := d.Set("dns_servers", dnsServers); err != nil {
-			return fmt.Errorf("setting `applied_dns_servers`: %+v", err)
-		}
-
-		d.Set("enable_ip_forwarding", resp.EnableIPForwarding)
-		d.Set("enable_accelerated_networking", resp.EnableAcceleratedNetworking)
-		d.Set("internal_dns_name_label", internalDnsNameLabel)
-		d.Set("internal_domain_name_suffix", internalDomainNameSuffix)
-		d.Set("mac_address", props.MacAddress)
-		d.Set("private_ip_address", primaryPrivateIPAddress)
-		d.Set("virtual_machine_id", virtualMachineId)
-
-		if err := d.Set("ip_configuration", flattenNetworkInterfaceIPConfigurations(props.IPConfigurations)); err != nil {
-			return fmt.Errorf("setting `ip_configuration`: %+v", err)
-		}
-
-		if err := d.Set("private_ip_addresses", privateIPAddresses); err != nil {
-			return fmt.Errorf("setting `private_ip_addresses`: %+v", err)
+		if err = d.Set("tags", utils.FlattenPtrMapStringString(model.Tags)); err != nil {
+			return err
 		}
 	}
 
-	return tags.FlattenAndSet(d, resp.Tags)
+	return nil
 }
 
 func resourceNetworkInterfaceDelete(d *pluginsdk.ResourceData, meta interface{}) error {
-	client := meta.(*clients.Client).Network.InterfacesClient
+	client := meta.(*clients.Client).Network.NetworkInterfacesClient
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := parse.NetworkInterfaceID(d.Id())
+	id, err := commonids.ParseNetworkInterfaceID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	locks.ByName(id.Name, networkInterfaceResourceName)
-	defer locks.UnlockByName(id.Name, networkInterfaceResourceName)
+	locks.ByName(id.NetworkInterfaceName, networkInterfaceResourceName)
+	defer locks.UnlockByName(id.NetworkInterfaceName, networkInterfaceResourceName)
 
-	existing, err := client.Get(ctx, id.ResourceGroup, id.Name, "")
+	existing, err := client.Get(ctx, *id, networkinterfaces.DefaultGetOperationOptions())
 	if err != nil {
-		if utils.ResponseWasNotFound(existing.Response) {
+		if response.WasNotFound(existing.HttpResponse) {
 			log.Printf("[DEBUG] %q was not found - removing from state", *id)
 			d.SetId("")
 			return nil
@@ -508,10 +511,15 @@ func resourceNetworkInterfaceDelete(d *pluginsdk.ResourceData, meta interface{})
 		return fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	if existing.InterfacePropertiesFormat == nil {
+	if existing.Model == nil {
+		return fmt.Errorf("retrieving %s: `model` was nil", *id)
+	}
+
+	if existing.Model.Properties == nil {
 		return fmt.Errorf("retrieving %s: `properties` was nil", *id)
 	}
-	props := *existing.InterfacePropertiesFormat
+
+	props := *existing.Model.Properties
 
 	lockingDetails, err := determineResourcesToLockFromIPConfiguration(props.IPConfigurations)
 	if err != nil {
@@ -521,41 +529,37 @@ func resourceNetworkInterfaceDelete(d *pluginsdk.ResourceData, meta interface{})
 	lockingDetails.lock()
 	defer lockingDetails.unlock()
 
-	future, err := client.Delete(ctx, id.ResourceGroup, id.Name)
+	err = client.DeleteThenPoll(ctx, *id)
 	if err != nil {
 		return fmt.Errorf("deleting %s: %+v", *id, err)
-	}
-
-	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-		return fmt.Errorf("waiting for deletion of %s: %+v", *id, err)
 	}
 
 	return nil
 }
 
-func expandNetworkInterfaceIPConfigurations(input []interface{}) (*[]network.InterfaceIPConfiguration, error) {
-	ipConfigs := make([]network.InterfaceIPConfiguration, 0)
+func expandNetworkInterfaceIPConfigurations(input []interface{}) (*[]networkinterfaces.NetworkInterfaceIPConfiguration, error) {
+	ipConfigs := make([]networkinterfaces.NetworkInterfaceIPConfiguration, 0)
 
 	for _, configRaw := range input {
 		data := configRaw.(map[string]interface{})
 
 		subnetId := data["subnet_id"].(string)
 		privateIpAllocationMethod := data["private_ip_address_allocation"].(string)
-		privateIpAddressVersion := network.IPVersion(data["private_ip_address_version"].(string))
+		privateIpAddressVersion := networkinterfaces.IPVersion(data["private_ip_address_version"].(string))
 
-		allocationMethod := network.IPAllocationMethod(privateIpAllocationMethod)
-		properties := network.InterfaceIPConfigurationPropertiesFormat{
-			PrivateIPAllocationMethod: allocationMethod,
-			PrivateIPAddressVersion:   privateIpAddressVersion,
+		allocationMethod := networkinterfaces.IPAllocationMethod(privateIpAllocationMethod)
+		properties := networkinterfaces.NetworkInterfaceIPConfigurationPropertiesFormat{
+			PrivateIPAllocationMethod: &allocationMethod,
+			PrivateIPAddressVersion:   &privateIpAddressVersion,
 		}
 
-		if privateIpAddressVersion == network.IPVersionIPv4 && subnetId == "" {
+		if privateIpAddressVersion == networkinterfaces.IPVersionIPvFour && subnetId == "" {
 			return nil, fmt.Errorf("A Subnet ID must be specified for an IPv4 Network Interface.")
 		}
 
 		if subnetId != "" {
-			properties.Subnet = &network.Subnet{
-				ID: &subnetId,
+			properties.Subnet = &networkinterfaces.Subnet{
+				Id: &subnetId,
 			}
 		}
 
@@ -564,8 +568,8 @@ func expandNetworkInterfaceIPConfigurations(input []interface{}) (*[]network.Int
 		}
 
 		if v := data["public_ip_address_id"].(string); v != "" {
-			properties.PublicIPAddress = &network.PublicIPAddress{
-				ID: &v,
+			properties.PublicIPAddress = &networkinterfaces.PublicIPAddress{
+				Id: &v,
 			}
 		}
 
@@ -574,13 +578,13 @@ func expandNetworkInterfaceIPConfigurations(input []interface{}) (*[]network.Int
 		}
 
 		if v := data["gateway_load_balancer_frontend_ip_configuration_id"].(string); v != "" {
-			properties.GatewayLoadBalancer = &network.SubResource{ID: &v}
+			properties.GatewayLoadBalancer = &networkinterfaces.SubResource{Id: &v}
 		}
 
 		name := data["name"].(string)
-		ipConfigs = append(ipConfigs, network.InterfaceIPConfiguration{
-			Name:                                     &name,
-			InterfaceIPConfigurationPropertiesFormat: &properties,
+		ipConfigs = append(ipConfigs, networkinterfaces.NetworkInterfaceIPConfiguration{
+			Name:       &name,
+			Properties: &properties,
 		})
 	}
 
@@ -588,7 +592,7 @@ func expandNetworkInterfaceIPConfigurations(input []interface{}) (*[]network.Int
 	if len(ipConfigs) > 1 {
 		hasPrimary := false
 		for _, config := range ipConfigs {
-			if config.Primary != nil && *config.Primary {
+			if config.Properties != nil && config.Properties.Primary != nil && *config.Properties.Primary {
 				hasPrimary = true
 				break
 			}
@@ -602,14 +606,14 @@ func expandNetworkInterfaceIPConfigurations(input []interface{}) (*[]network.Int
 	return &ipConfigs, nil
 }
 
-func flattenNetworkInterfaceIPConfigurations(input *[]network.InterfaceIPConfiguration) []interface{} {
+func flattenNetworkInterfaceIPConfigurations(input *[]networkinterfaces.NetworkInterfaceIPConfiguration) []interface{} {
 	if input == nil {
 		return []interface{}{}
 	}
 
 	result := make([]interface{}, 0)
 	for _, ipConfig := range *input {
-		props := ipConfig.InterfaceIPConfigurationPropertiesFormat
+		props := ipConfig.Properties
 
 		name := ""
 		if ipConfig.Name != nil {
@@ -617,8 +621,8 @@ func flattenNetworkInterfaceIPConfigurations(input *[]network.InterfaceIPConfigu
 		}
 
 		subnetId := ""
-		if props.Subnet != nil && props.Subnet.ID != nil {
-			subnetId = *props.Subnet.ID
+		if props.Subnet != nil && props.Subnet.Id != nil {
+			subnetId = *props.Subnet.Id
 		}
 
 		privateIPAddress := ""
@@ -626,14 +630,19 @@ func flattenNetworkInterfaceIPConfigurations(input *[]network.InterfaceIPConfigu
 			privateIPAddress = *props.PrivateIPAddress
 		}
 
+		privateIPAllocationMethod := ""
+		if props.PrivateIPAllocationMethod != nil {
+			privateIPAllocationMethod = string(*props.PrivateIPAllocationMethod)
+		}
+
 		privateIPAddressVersion := ""
-		if props.PrivateIPAddressVersion != "" {
-			privateIPAddressVersion = string(props.PrivateIPAddressVersion)
+		if props.PrivateIPAddressVersion != nil {
+			privateIPAddressVersion = string(*props.PrivateIPAddressVersion)
 		}
 
 		publicIPAddressId := ""
-		if props.PublicIPAddress != nil && props.PublicIPAddress.ID != nil {
-			publicIPAddressId = *props.PublicIPAddress.ID
+		if props.PublicIPAddress != nil && props.PublicIPAddress.Id != nil {
+			publicIPAddressId = *props.PublicIPAddress.Id
 		}
 
 		primary := false
@@ -642,15 +651,15 @@ func flattenNetworkInterfaceIPConfigurations(input *[]network.InterfaceIPConfigu
 		}
 
 		gatewayLBFrontendIPConfigId := ""
-		if props.GatewayLoadBalancer != nil && props.GatewayLoadBalancer.ID != nil {
-			gatewayLBFrontendIPConfigId = *props.GatewayLoadBalancer.ID
+		if props.GatewayLoadBalancer != nil && props.GatewayLoadBalancer.Id != nil {
+			gatewayLBFrontendIPConfigId = *props.GatewayLoadBalancer.Id
 		}
 
 		result = append(result, map[string]interface{}{
 			"name":                          name,
 			"primary":                       primary,
 			"private_ip_address":            privateIPAddress,
-			"private_ip_address_allocation": string(props.PrivateIPAllocationMethod),
+			"private_ip_address_allocation": privateIPAllocationMethod,
 			"private_ip_address_version":    privateIPAddressVersion,
 			"public_ip_address_id":          publicIPAddressId,
 			"subnet_id":                     subnetId,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/README.md
@@ -1,0 +1,360 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces` Documentation
+
+The `networkinterfaces` SDK allows for interaction with the Azure Resource Manager Service `network` (API Version `2023-02-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces"
+```
+
+
+### Client Initialization
+
+```go
+client := networkinterfaces.NewNetworkInterfacesClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `NetworkInterfacesClient.CreateOrUpdate`
+
+```go
+ctx := context.TODO()
+id := networkinterfaces.NewNetworkInterfaceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "networkInterfaceValue")
+
+payload := networkinterfaces.NetworkInterface{
+	// ...
+}
+
+
+if err := client.CreateOrUpdateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `NetworkInterfacesClient.Delete`
+
+```go
+ctx := context.TODO()
+id := networkinterfaces.NewNetworkInterfaceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "networkInterfaceValue")
+
+if err := client.DeleteThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `NetworkInterfacesClient.Get`
+
+```go
+ctx := context.TODO()
+id := networkinterfaces.NewNetworkInterfaceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "networkInterfaceValue")
+
+read, err := client.Get(ctx, id, networkinterfaces.DefaultGetOperationOptions())
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `NetworkInterfacesClient.GetCloudServiceNetworkInterface`
+
+```go
+ctx := context.TODO()
+id := networkinterfaces.NewRoleInstanceNetworkInterfaceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "cloudServiceValue", "roleInstanceValue", "networkInterfaceValue")
+
+read, err := client.GetCloudServiceNetworkInterface(ctx, id, networkinterfaces.DefaultGetCloudServiceNetworkInterfaceOperationOptions())
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `NetworkInterfacesClient.GetEffectiveRouteTable`
+
+```go
+ctx := context.TODO()
+id := networkinterfaces.NewNetworkInterfaceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "networkInterfaceValue")
+
+if err := client.GetEffectiveRouteTableThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `NetworkInterfacesClient.GetVirtualMachineScaleSetIPConfiguration`
+
+```go
+ctx := context.TODO()
+id := networkinterfaces.NewVirtualMachineScaleSetIPConfigurationID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineScaleSetValue", "virtualMachineValue", "networkInterfaceValue", "ipConfigurationValue")
+
+read, err := client.GetVirtualMachineScaleSetIPConfiguration(ctx, id, networkinterfaces.DefaultGetVirtualMachineScaleSetIPConfigurationOperationOptions())
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `NetworkInterfacesClient.GetVirtualMachineScaleSetNetworkInterface`
+
+```go
+ctx := context.TODO()
+id := networkinterfaces.NewVirtualMachineScaleSetNetworkInterfaceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineScaleSetValue", "virtualMachineValue", "networkInterfaceValue")
+
+read, err := client.GetVirtualMachineScaleSetNetworkInterface(ctx, id, networkinterfaces.DefaultGetVirtualMachineScaleSetNetworkInterfaceOperationOptions())
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `NetworkInterfacesClient.List`
+
+```go
+ctx := context.TODO()
+id := networkinterfaces.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+
+// alternatively `client.List(ctx, id)` can be used to do batched pagination
+items, err := client.ListComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `NetworkInterfacesClient.ListAll`
+
+```go
+ctx := context.TODO()
+id := networkinterfaces.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+
+// alternatively `client.ListAll(ctx, id)` can be used to do batched pagination
+items, err := client.ListAllComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `NetworkInterfacesClient.ListCloudServiceNetworkInterfaces`
+
+```go
+ctx := context.TODO()
+id := networkinterfaces.NewProviderCloudServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "cloudServiceValue")
+
+// alternatively `client.ListCloudServiceNetworkInterfaces(ctx, id)` can be used to do batched pagination
+items, err := client.ListCloudServiceNetworkInterfacesComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `NetworkInterfacesClient.ListCloudServiceRoleInstanceNetworkInterfaces`
+
+```go
+ctx := context.TODO()
+id := networkinterfaces.NewRoleInstanceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "cloudServiceValue", "roleInstanceValue")
+
+// alternatively `client.ListCloudServiceRoleInstanceNetworkInterfaces(ctx, id)` can be used to do batched pagination
+items, err := client.ListCloudServiceRoleInstanceNetworkInterfacesComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `NetworkInterfacesClient.ListEffectiveNetworkSecurityGroups`
+
+```go
+ctx := context.TODO()
+id := networkinterfaces.NewNetworkInterfaceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "networkInterfaceValue")
+
+if err := client.ListEffectiveNetworkSecurityGroupsThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `NetworkInterfacesClient.ListVirtualMachineScaleSetIPConfigurations`
+
+```go
+ctx := context.TODO()
+id := networkinterfaces.NewVirtualMachineScaleSetNetworkInterfaceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineScaleSetValue", "virtualMachineValue", "networkInterfaceValue")
+
+// alternatively `client.ListVirtualMachineScaleSetIPConfigurations(ctx, id, networkinterfaces.DefaultListVirtualMachineScaleSetIPConfigurationsOperationOptions())` can be used to do batched pagination
+items, err := client.ListVirtualMachineScaleSetIPConfigurationsComplete(ctx, id, networkinterfaces.DefaultListVirtualMachineScaleSetIPConfigurationsOperationOptions())
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `NetworkInterfacesClient.ListVirtualMachineScaleSetNetworkInterfaces`
+
+```go
+ctx := context.TODO()
+id := networkinterfaces.NewVirtualMachineScaleSetID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineScaleSetValue")
+
+// alternatively `client.ListVirtualMachineScaleSetNetworkInterfaces(ctx, id)` can be used to do batched pagination
+items, err := client.ListVirtualMachineScaleSetNetworkInterfacesComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `NetworkInterfacesClient.ListVirtualMachineScaleSetVMNetworkInterfaces`
+
+```go
+ctx := context.TODO()
+id := networkinterfaces.NewVirtualMachineID("12345678-1234-9876-4563-123456789012", "example-resource-group", "virtualMachineScaleSetValue", "virtualMachineValue")
+
+// alternatively `client.ListVirtualMachineScaleSetVMNetworkInterfaces(ctx, id)` can be used to do batched pagination
+items, err := client.ListVirtualMachineScaleSetVMNetworkInterfacesComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `NetworkInterfacesClient.NetworkInterfaceIPConfigurationsGet`
+
+```go
+ctx := context.TODO()
+id := networkinterfaces.NewNetworkInterfaceIPConfigurationID("12345678-1234-9876-4563-123456789012", "example-resource-group", "networkInterfaceValue", "ipConfigurationValue")
+
+read, err := client.NetworkInterfaceIPConfigurationsGet(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `NetworkInterfacesClient.NetworkInterfaceIPConfigurationsList`
+
+```go
+ctx := context.TODO()
+id := networkinterfaces.NewNetworkInterfaceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "networkInterfaceValue")
+
+// alternatively `client.NetworkInterfaceIPConfigurationsList(ctx, id)` can be used to do batched pagination
+items, err := client.NetworkInterfaceIPConfigurationsListComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `NetworkInterfacesClient.NetworkInterfaceLoadBalancersList`
+
+```go
+ctx := context.TODO()
+id := networkinterfaces.NewNetworkInterfaceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "networkInterfaceValue")
+
+// alternatively `client.NetworkInterfaceLoadBalancersList(ctx, id)` can be used to do batched pagination
+items, err := client.NetworkInterfaceLoadBalancersListComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `NetworkInterfacesClient.NetworkInterfaceTapConfigurationsGet`
+
+```go
+ctx := context.TODO()
+id := networkinterfaces.NewTapConfigurationID("12345678-1234-9876-4563-123456789012", "example-resource-group", "networkInterfaceValue", "tapConfigurationValue")
+
+read, err := client.NetworkInterfaceTapConfigurationsGet(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `NetworkInterfacesClient.NetworkInterfaceTapConfigurationsList`
+
+```go
+ctx := context.TODO()
+id := networkinterfaces.NewNetworkInterfaceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "networkInterfaceValue")
+
+// alternatively `client.NetworkInterfaceTapConfigurationsList(ctx, id)` can be used to do batched pagination
+items, err := client.NetworkInterfaceTapConfigurationsListComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `NetworkInterfacesClient.UpdateTags`
+
+```go
+ctx := context.TODO()
+id := networkinterfaces.NewNetworkInterfaceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "networkInterfaceValue")
+
+payload := networkinterfaces.TagsObject{
+	// ...
+}
+
+
+read, err := client.UpdateTags(ctx, id, payload)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/client.go
@@ -1,0 +1,26 @@
+package networkinterfaces
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/environments"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type NetworkInterfacesClient struct {
+	Client *resourcemanager.Client
+}
+
+func NewNetworkInterfacesClientWithBaseURI(api environments.Api) (*NetworkInterfacesClient, error) {
+	client, err := resourcemanager.NewResourceManagerClient(api, "networkinterfaces", defaultApiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("instantiating NetworkInterfacesClient: %+v", err)
+	}
+
+	return &NetworkInterfacesClient{
+		Client: client,
+	}, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/constants.go
@@ -1,0 +1,1459 @@
+package networkinterfaces
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DdosSettingsProtectionMode string
+
+const (
+	DdosSettingsProtectionModeDisabled                DdosSettingsProtectionMode = "Disabled"
+	DdosSettingsProtectionModeEnabled                 DdosSettingsProtectionMode = "Enabled"
+	DdosSettingsProtectionModeVirtualNetworkInherited DdosSettingsProtectionMode = "VirtualNetworkInherited"
+)
+
+func PossibleValuesForDdosSettingsProtectionMode() []string {
+	return []string{
+		string(DdosSettingsProtectionModeDisabled),
+		string(DdosSettingsProtectionModeEnabled),
+		string(DdosSettingsProtectionModeVirtualNetworkInherited),
+	}
+}
+
+func (s *DdosSettingsProtectionMode) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseDdosSettingsProtectionMode(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseDdosSettingsProtectionMode(input string) (*DdosSettingsProtectionMode, error) {
+	vals := map[string]DdosSettingsProtectionMode{
+		"disabled":                DdosSettingsProtectionModeDisabled,
+		"enabled":                 DdosSettingsProtectionModeEnabled,
+		"virtualnetworkinherited": DdosSettingsProtectionModeVirtualNetworkInherited,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := DdosSettingsProtectionMode(input)
+	return &out, nil
+}
+
+type DeleteOptions string
+
+const (
+	DeleteOptionsDelete DeleteOptions = "Delete"
+	DeleteOptionsDetach DeleteOptions = "Detach"
+)
+
+func PossibleValuesForDeleteOptions() []string {
+	return []string{
+		string(DeleteOptionsDelete),
+		string(DeleteOptionsDetach),
+	}
+}
+
+func (s *DeleteOptions) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseDeleteOptions(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseDeleteOptions(input string) (*DeleteOptions, error) {
+	vals := map[string]DeleteOptions{
+		"delete": DeleteOptionsDelete,
+		"detach": DeleteOptionsDetach,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := DeleteOptions(input)
+	return &out, nil
+}
+
+type EffectiveRouteSource string
+
+const (
+	EffectiveRouteSourceDefault               EffectiveRouteSource = "Default"
+	EffectiveRouteSourceUnknown               EffectiveRouteSource = "Unknown"
+	EffectiveRouteSourceUser                  EffectiveRouteSource = "User"
+	EffectiveRouteSourceVirtualNetworkGateway EffectiveRouteSource = "VirtualNetworkGateway"
+)
+
+func PossibleValuesForEffectiveRouteSource() []string {
+	return []string{
+		string(EffectiveRouteSourceDefault),
+		string(EffectiveRouteSourceUnknown),
+		string(EffectiveRouteSourceUser),
+		string(EffectiveRouteSourceVirtualNetworkGateway),
+	}
+}
+
+func (s *EffectiveRouteSource) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseEffectiveRouteSource(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseEffectiveRouteSource(input string) (*EffectiveRouteSource, error) {
+	vals := map[string]EffectiveRouteSource{
+		"default":               EffectiveRouteSourceDefault,
+		"unknown":               EffectiveRouteSourceUnknown,
+		"user":                  EffectiveRouteSourceUser,
+		"virtualnetworkgateway": EffectiveRouteSourceVirtualNetworkGateway,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := EffectiveRouteSource(input)
+	return &out, nil
+}
+
+type EffectiveRouteState string
+
+const (
+	EffectiveRouteStateActive  EffectiveRouteState = "Active"
+	EffectiveRouteStateInvalid EffectiveRouteState = "Invalid"
+)
+
+func PossibleValuesForEffectiveRouteState() []string {
+	return []string{
+		string(EffectiveRouteStateActive),
+		string(EffectiveRouteStateInvalid),
+	}
+}
+
+func (s *EffectiveRouteState) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseEffectiveRouteState(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseEffectiveRouteState(input string) (*EffectiveRouteState, error) {
+	vals := map[string]EffectiveRouteState{
+		"active":  EffectiveRouteStateActive,
+		"invalid": EffectiveRouteStateInvalid,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := EffectiveRouteState(input)
+	return &out, nil
+}
+
+type EffectiveSecurityRuleProtocol string
+
+const (
+	EffectiveSecurityRuleProtocolAll EffectiveSecurityRuleProtocol = "All"
+	EffectiveSecurityRuleProtocolTcp EffectiveSecurityRuleProtocol = "Tcp"
+	EffectiveSecurityRuleProtocolUdp EffectiveSecurityRuleProtocol = "Udp"
+)
+
+func PossibleValuesForEffectiveSecurityRuleProtocol() []string {
+	return []string{
+		string(EffectiveSecurityRuleProtocolAll),
+		string(EffectiveSecurityRuleProtocolTcp),
+		string(EffectiveSecurityRuleProtocolUdp),
+	}
+}
+
+func (s *EffectiveSecurityRuleProtocol) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseEffectiveSecurityRuleProtocol(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseEffectiveSecurityRuleProtocol(input string) (*EffectiveSecurityRuleProtocol, error) {
+	vals := map[string]EffectiveSecurityRuleProtocol{
+		"all": EffectiveSecurityRuleProtocolAll,
+		"tcp": EffectiveSecurityRuleProtocolTcp,
+		"udp": EffectiveSecurityRuleProtocolUdp,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := EffectiveSecurityRuleProtocol(input)
+	return &out, nil
+}
+
+type FlowLogFormatType string
+
+const (
+	FlowLogFormatTypeJSON FlowLogFormatType = "JSON"
+)
+
+func PossibleValuesForFlowLogFormatType() []string {
+	return []string{
+		string(FlowLogFormatTypeJSON),
+	}
+}
+
+func (s *FlowLogFormatType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseFlowLogFormatType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseFlowLogFormatType(input string) (*FlowLogFormatType, error) {
+	vals := map[string]FlowLogFormatType{
+		"json": FlowLogFormatTypeJSON,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := FlowLogFormatType(input)
+	return &out, nil
+}
+
+type GatewayLoadBalancerTunnelInterfaceType string
+
+const (
+	GatewayLoadBalancerTunnelInterfaceTypeExternal GatewayLoadBalancerTunnelInterfaceType = "External"
+	GatewayLoadBalancerTunnelInterfaceTypeInternal GatewayLoadBalancerTunnelInterfaceType = "Internal"
+	GatewayLoadBalancerTunnelInterfaceTypeNone     GatewayLoadBalancerTunnelInterfaceType = "None"
+)
+
+func PossibleValuesForGatewayLoadBalancerTunnelInterfaceType() []string {
+	return []string{
+		string(GatewayLoadBalancerTunnelInterfaceTypeExternal),
+		string(GatewayLoadBalancerTunnelInterfaceTypeInternal),
+		string(GatewayLoadBalancerTunnelInterfaceTypeNone),
+	}
+}
+
+func (s *GatewayLoadBalancerTunnelInterfaceType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseGatewayLoadBalancerTunnelInterfaceType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseGatewayLoadBalancerTunnelInterfaceType(input string) (*GatewayLoadBalancerTunnelInterfaceType, error) {
+	vals := map[string]GatewayLoadBalancerTunnelInterfaceType{
+		"external": GatewayLoadBalancerTunnelInterfaceTypeExternal,
+		"internal": GatewayLoadBalancerTunnelInterfaceTypeInternal,
+		"none":     GatewayLoadBalancerTunnelInterfaceTypeNone,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := GatewayLoadBalancerTunnelInterfaceType(input)
+	return &out, nil
+}
+
+type GatewayLoadBalancerTunnelProtocol string
+
+const (
+	GatewayLoadBalancerTunnelProtocolNative GatewayLoadBalancerTunnelProtocol = "Native"
+	GatewayLoadBalancerTunnelProtocolNone   GatewayLoadBalancerTunnelProtocol = "None"
+	GatewayLoadBalancerTunnelProtocolVXLAN  GatewayLoadBalancerTunnelProtocol = "VXLAN"
+)
+
+func PossibleValuesForGatewayLoadBalancerTunnelProtocol() []string {
+	return []string{
+		string(GatewayLoadBalancerTunnelProtocolNative),
+		string(GatewayLoadBalancerTunnelProtocolNone),
+		string(GatewayLoadBalancerTunnelProtocolVXLAN),
+	}
+}
+
+func (s *GatewayLoadBalancerTunnelProtocol) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseGatewayLoadBalancerTunnelProtocol(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseGatewayLoadBalancerTunnelProtocol(input string) (*GatewayLoadBalancerTunnelProtocol, error) {
+	vals := map[string]GatewayLoadBalancerTunnelProtocol{
+		"native": GatewayLoadBalancerTunnelProtocolNative,
+		"none":   GatewayLoadBalancerTunnelProtocolNone,
+		"vxlan":  GatewayLoadBalancerTunnelProtocolVXLAN,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := GatewayLoadBalancerTunnelProtocol(input)
+	return &out, nil
+}
+
+type IPAllocationMethod string
+
+const (
+	IPAllocationMethodDynamic IPAllocationMethod = "Dynamic"
+	IPAllocationMethodStatic  IPAllocationMethod = "Static"
+)
+
+func PossibleValuesForIPAllocationMethod() []string {
+	return []string{
+		string(IPAllocationMethodDynamic),
+		string(IPAllocationMethodStatic),
+	}
+}
+
+func (s *IPAllocationMethod) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseIPAllocationMethod(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseIPAllocationMethod(input string) (*IPAllocationMethod, error) {
+	vals := map[string]IPAllocationMethod{
+		"dynamic": IPAllocationMethodDynamic,
+		"static":  IPAllocationMethodStatic,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := IPAllocationMethod(input)
+	return &out, nil
+}
+
+type IPVersion string
+
+const (
+	IPVersionIPvFour IPVersion = "IPv4"
+	IPVersionIPvSix  IPVersion = "IPv6"
+)
+
+func PossibleValuesForIPVersion() []string {
+	return []string{
+		string(IPVersionIPvFour),
+		string(IPVersionIPvSix),
+	}
+}
+
+func (s *IPVersion) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseIPVersion(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseIPVersion(input string) (*IPVersion, error) {
+	vals := map[string]IPVersion{
+		"ipv4": IPVersionIPvFour,
+		"ipv6": IPVersionIPvSix,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := IPVersion(input)
+	return &out, nil
+}
+
+type LoadBalancerBackendAddressAdminState string
+
+const (
+	LoadBalancerBackendAddressAdminStateDown LoadBalancerBackendAddressAdminState = "Down"
+	LoadBalancerBackendAddressAdminStateNone LoadBalancerBackendAddressAdminState = "None"
+	LoadBalancerBackendAddressAdminStateUp   LoadBalancerBackendAddressAdminState = "Up"
+)
+
+func PossibleValuesForLoadBalancerBackendAddressAdminState() []string {
+	return []string{
+		string(LoadBalancerBackendAddressAdminStateDown),
+		string(LoadBalancerBackendAddressAdminStateNone),
+		string(LoadBalancerBackendAddressAdminStateUp),
+	}
+}
+
+func (s *LoadBalancerBackendAddressAdminState) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseLoadBalancerBackendAddressAdminState(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseLoadBalancerBackendAddressAdminState(input string) (*LoadBalancerBackendAddressAdminState, error) {
+	vals := map[string]LoadBalancerBackendAddressAdminState{
+		"down": LoadBalancerBackendAddressAdminStateDown,
+		"none": LoadBalancerBackendAddressAdminStateNone,
+		"up":   LoadBalancerBackendAddressAdminStateUp,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := LoadBalancerBackendAddressAdminState(input)
+	return &out, nil
+}
+
+type LoadBalancerOutboundRuleProtocol string
+
+const (
+	LoadBalancerOutboundRuleProtocolAll LoadBalancerOutboundRuleProtocol = "All"
+	LoadBalancerOutboundRuleProtocolTcp LoadBalancerOutboundRuleProtocol = "Tcp"
+	LoadBalancerOutboundRuleProtocolUdp LoadBalancerOutboundRuleProtocol = "Udp"
+)
+
+func PossibleValuesForLoadBalancerOutboundRuleProtocol() []string {
+	return []string{
+		string(LoadBalancerOutboundRuleProtocolAll),
+		string(LoadBalancerOutboundRuleProtocolTcp),
+		string(LoadBalancerOutboundRuleProtocolUdp),
+	}
+}
+
+func (s *LoadBalancerOutboundRuleProtocol) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseLoadBalancerOutboundRuleProtocol(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseLoadBalancerOutboundRuleProtocol(input string) (*LoadBalancerOutboundRuleProtocol, error) {
+	vals := map[string]LoadBalancerOutboundRuleProtocol{
+		"all": LoadBalancerOutboundRuleProtocolAll,
+		"tcp": LoadBalancerOutboundRuleProtocolTcp,
+		"udp": LoadBalancerOutboundRuleProtocolUdp,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := LoadBalancerOutboundRuleProtocol(input)
+	return &out, nil
+}
+
+type LoadBalancerSkuName string
+
+const (
+	LoadBalancerSkuNameBasic    LoadBalancerSkuName = "Basic"
+	LoadBalancerSkuNameGateway  LoadBalancerSkuName = "Gateway"
+	LoadBalancerSkuNameStandard LoadBalancerSkuName = "Standard"
+)
+
+func PossibleValuesForLoadBalancerSkuName() []string {
+	return []string{
+		string(LoadBalancerSkuNameBasic),
+		string(LoadBalancerSkuNameGateway),
+		string(LoadBalancerSkuNameStandard),
+	}
+}
+
+func (s *LoadBalancerSkuName) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseLoadBalancerSkuName(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseLoadBalancerSkuName(input string) (*LoadBalancerSkuName, error) {
+	vals := map[string]LoadBalancerSkuName{
+		"basic":    LoadBalancerSkuNameBasic,
+		"gateway":  LoadBalancerSkuNameGateway,
+		"standard": LoadBalancerSkuNameStandard,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := LoadBalancerSkuName(input)
+	return &out, nil
+}
+
+type LoadBalancerSkuTier string
+
+const (
+	LoadBalancerSkuTierGlobal   LoadBalancerSkuTier = "Global"
+	LoadBalancerSkuTierRegional LoadBalancerSkuTier = "Regional"
+)
+
+func PossibleValuesForLoadBalancerSkuTier() []string {
+	return []string{
+		string(LoadBalancerSkuTierGlobal),
+		string(LoadBalancerSkuTierRegional),
+	}
+}
+
+func (s *LoadBalancerSkuTier) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseLoadBalancerSkuTier(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseLoadBalancerSkuTier(input string) (*LoadBalancerSkuTier, error) {
+	vals := map[string]LoadBalancerSkuTier{
+		"global":   LoadBalancerSkuTierGlobal,
+		"regional": LoadBalancerSkuTierRegional,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := LoadBalancerSkuTier(input)
+	return &out, nil
+}
+
+type LoadDistribution string
+
+const (
+	LoadDistributionDefault          LoadDistribution = "Default"
+	LoadDistributionSourceIP         LoadDistribution = "SourceIP"
+	LoadDistributionSourceIPProtocol LoadDistribution = "SourceIPProtocol"
+)
+
+func PossibleValuesForLoadDistribution() []string {
+	return []string{
+		string(LoadDistributionDefault),
+		string(LoadDistributionSourceIP),
+		string(LoadDistributionSourceIPProtocol),
+	}
+}
+
+func (s *LoadDistribution) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseLoadDistribution(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseLoadDistribution(input string) (*LoadDistribution, error) {
+	vals := map[string]LoadDistribution{
+		"default":          LoadDistributionDefault,
+		"sourceip":         LoadDistributionSourceIP,
+		"sourceipprotocol": LoadDistributionSourceIPProtocol,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := LoadDistribution(input)
+	return &out, nil
+}
+
+type NatGatewaySkuName string
+
+const (
+	NatGatewaySkuNameStandard NatGatewaySkuName = "Standard"
+)
+
+func PossibleValuesForNatGatewaySkuName() []string {
+	return []string{
+		string(NatGatewaySkuNameStandard),
+	}
+}
+
+func (s *NatGatewaySkuName) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseNatGatewaySkuName(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseNatGatewaySkuName(input string) (*NatGatewaySkuName, error) {
+	vals := map[string]NatGatewaySkuName{
+		"standard": NatGatewaySkuNameStandard,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := NatGatewaySkuName(input)
+	return &out, nil
+}
+
+type NetworkInterfaceAuxiliaryMode string
+
+const (
+	NetworkInterfaceAuxiliaryModeAcceleratedConnections NetworkInterfaceAuxiliaryMode = "AcceleratedConnections"
+	NetworkInterfaceAuxiliaryModeFloating               NetworkInterfaceAuxiliaryMode = "Floating"
+	NetworkInterfaceAuxiliaryModeMaxConnections         NetworkInterfaceAuxiliaryMode = "MaxConnections"
+	NetworkInterfaceAuxiliaryModeNone                   NetworkInterfaceAuxiliaryMode = "None"
+)
+
+func PossibleValuesForNetworkInterfaceAuxiliaryMode() []string {
+	return []string{
+		string(NetworkInterfaceAuxiliaryModeAcceleratedConnections),
+		string(NetworkInterfaceAuxiliaryModeFloating),
+		string(NetworkInterfaceAuxiliaryModeMaxConnections),
+		string(NetworkInterfaceAuxiliaryModeNone),
+	}
+}
+
+func (s *NetworkInterfaceAuxiliaryMode) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseNetworkInterfaceAuxiliaryMode(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseNetworkInterfaceAuxiliaryMode(input string) (*NetworkInterfaceAuxiliaryMode, error) {
+	vals := map[string]NetworkInterfaceAuxiliaryMode{
+		"acceleratedconnections": NetworkInterfaceAuxiliaryModeAcceleratedConnections,
+		"floating":               NetworkInterfaceAuxiliaryModeFloating,
+		"maxconnections":         NetworkInterfaceAuxiliaryModeMaxConnections,
+		"none":                   NetworkInterfaceAuxiliaryModeNone,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := NetworkInterfaceAuxiliaryMode(input)
+	return &out, nil
+}
+
+type NetworkInterfaceAuxiliarySku string
+
+const (
+	NetworkInterfaceAuxiliarySkuAEight NetworkInterfaceAuxiliarySku = "A8"
+	NetworkInterfaceAuxiliarySkuAFour  NetworkInterfaceAuxiliarySku = "A4"
+	NetworkInterfaceAuxiliarySkuAOne   NetworkInterfaceAuxiliarySku = "A1"
+	NetworkInterfaceAuxiliarySkuATwo   NetworkInterfaceAuxiliarySku = "A2"
+	NetworkInterfaceAuxiliarySkuNone   NetworkInterfaceAuxiliarySku = "None"
+)
+
+func PossibleValuesForNetworkInterfaceAuxiliarySku() []string {
+	return []string{
+		string(NetworkInterfaceAuxiliarySkuAEight),
+		string(NetworkInterfaceAuxiliarySkuAFour),
+		string(NetworkInterfaceAuxiliarySkuAOne),
+		string(NetworkInterfaceAuxiliarySkuATwo),
+		string(NetworkInterfaceAuxiliarySkuNone),
+	}
+}
+
+func (s *NetworkInterfaceAuxiliarySku) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseNetworkInterfaceAuxiliarySku(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseNetworkInterfaceAuxiliarySku(input string) (*NetworkInterfaceAuxiliarySku, error) {
+	vals := map[string]NetworkInterfaceAuxiliarySku{
+		"a8":   NetworkInterfaceAuxiliarySkuAEight,
+		"a4":   NetworkInterfaceAuxiliarySkuAFour,
+		"a1":   NetworkInterfaceAuxiliarySkuAOne,
+		"a2":   NetworkInterfaceAuxiliarySkuATwo,
+		"none": NetworkInterfaceAuxiliarySkuNone,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := NetworkInterfaceAuxiliarySku(input)
+	return &out, nil
+}
+
+type NetworkInterfaceMigrationPhase string
+
+const (
+	NetworkInterfaceMigrationPhaseAbort     NetworkInterfaceMigrationPhase = "Abort"
+	NetworkInterfaceMigrationPhaseCommit    NetworkInterfaceMigrationPhase = "Commit"
+	NetworkInterfaceMigrationPhaseCommitted NetworkInterfaceMigrationPhase = "Committed"
+	NetworkInterfaceMigrationPhaseNone      NetworkInterfaceMigrationPhase = "None"
+	NetworkInterfaceMigrationPhasePrepare   NetworkInterfaceMigrationPhase = "Prepare"
+)
+
+func PossibleValuesForNetworkInterfaceMigrationPhase() []string {
+	return []string{
+		string(NetworkInterfaceMigrationPhaseAbort),
+		string(NetworkInterfaceMigrationPhaseCommit),
+		string(NetworkInterfaceMigrationPhaseCommitted),
+		string(NetworkInterfaceMigrationPhaseNone),
+		string(NetworkInterfaceMigrationPhasePrepare),
+	}
+}
+
+func (s *NetworkInterfaceMigrationPhase) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseNetworkInterfaceMigrationPhase(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseNetworkInterfaceMigrationPhase(input string) (*NetworkInterfaceMigrationPhase, error) {
+	vals := map[string]NetworkInterfaceMigrationPhase{
+		"abort":     NetworkInterfaceMigrationPhaseAbort,
+		"commit":    NetworkInterfaceMigrationPhaseCommit,
+		"committed": NetworkInterfaceMigrationPhaseCommitted,
+		"none":      NetworkInterfaceMigrationPhaseNone,
+		"prepare":   NetworkInterfaceMigrationPhasePrepare,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := NetworkInterfaceMigrationPhase(input)
+	return &out, nil
+}
+
+type NetworkInterfaceNicType string
+
+const (
+	NetworkInterfaceNicTypeElastic  NetworkInterfaceNicType = "Elastic"
+	NetworkInterfaceNicTypeStandard NetworkInterfaceNicType = "Standard"
+)
+
+func PossibleValuesForNetworkInterfaceNicType() []string {
+	return []string{
+		string(NetworkInterfaceNicTypeElastic),
+		string(NetworkInterfaceNicTypeStandard),
+	}
+}
+
+func (s *NetworkInterfaceNicType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseNetworkInterfaceNicType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseNetworkInterfaceNicType(input string) (*NetworkInterfaceNicType, error) {
+	vals := map[string]NetworkInterfaceNicType{
+		"elastic":  NetworkInterfaceNicTypeElastic,
+		"standard": NetworkInterfaceNicTypeStandard,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := NetworkInterfaceNicType(input)
+	return &out, nil
+}
+
+type ProbeProtocol string
+
+const (
+	ProbeProtocolHTTP  ProbeProtocol = "Http"
+	ProbeProtocolHTTPS ProbeProtocol = "Https"
+	ProbeProtocolTcp   ProbeProtocol = "Tcp"
+)
+
+func PossibleValuesForProbeProtocol() []string {
+	return []string{
+		string(ProbeProtocolHTTP),
+		string(ProbeProtocolHTTPS),
+		string(ProbeProtocolTcp),
+	}
+}
+
+func (s *ProbeProtocol) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseProbeProtocol(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseProbeProtocol(input string) (*ProbeProtocol, error) {
+	vals := map[string]ProbeProtocol{
+		"http":  ProbeProtocolHTTP,
+		"https": ProbeProtocolHTTPS,
+		"tcp":   ProbeProtocolTcp,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ProbeProtocol(input)
+	return &out, nil
+}
+
+type ProvisioningState string
+
+const (
+	ProvisioningStateDeleting  ProvisioningState = "Deleting"
+	ProvisioningStateFailed    ProvisioningState = "Failed"
+	ProvisioningStateSucceeded ProvisioningState = "Succeeded"
+	ProvisioningStateUpdating  ProvisioningState = "Updating"
+)
+
+func PossibleValuesForProvisioningState() []string {
+	return []string{
+		string(ProvisioningStateDeleting),
+		string(ProvisioningStateFailed),
+		string(ProvisioningStateSucceeded),
+		string(ProvisioningStateUpdating),
+	}
+}
+
+func (s *ProvisioningState) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseProvisioningState(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseProvisioningState(input string) (*ProvisioningState, error) {
+	vals := map[string]ProvisioningState{
+		"deleting":  ProvisioningStateDeleting,
+		"failed":    ProvisioningStateFailed,
+		"succeeded": ProvisioningStateSucceeded,
+		"updating":  ProvisioningStateUpdating,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ProvisioningState(input)
+	return &out, nil
+}
+
+type PublicIPAddressDnsSettingsDomainNameLabelScope string
+
+const (
+	PublicIPAddressDnsSettingsDomainNameLabelScopeNoReuse            PublicIPAddressDnsSettingsDomainNameLabelScope = "NoReuse"
+	PublicIPAddressDnsSettingsDomainNameLabelScopeResourceGroupReuse PublicIPAddressDnsSettingsDomainNameLabelScope = "ResourceGroupReuse"
+	PublicIPAddressDnsSettingsDomainNameLabelScopeSubscriptionReuse  PublicIPAddressDnsSettingsDomainNameLabelScope = "SubscriptionReuse"
+	PublicIPAddressDnsSettingsDomainNameLabelScopeTenantReuse        PublicIPAddressDnsSettingsDomainNameLabelScope = "TenantReuse"
+)
+
+func PossibleValuesForPublicIPAddressDnsSettingsDomainNameLabelScope() []string {
+	return []string{
+		string(PublicIPAddressDnsSettingsDomainNameLabelScopeNoReuse),
+		string(PublicIPAddressDnsSettingsDomainNameLabelScopeResourceGroupReuse),
+		string(PublicIPAddressDnsSettingsDomainNameLabelScopeSubscriptionReuse),
+		string(PublicIPAddressDnsSettingsDomainNameLabelScopeTenantReuse),
+	}
+}
+
+func (s *PublicIPAddressDnsSettingsDomainNameLabelScope) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parsePublicIPAddressDnsSettingsDomainNameLabelScope(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parsePublicIPAddressDnsSettingsDomainNameLabelScope(input string) (*PublicIPAddressDnsSettingsDomainNameLabelScope, error) {
+	vals := map[string]PublicIPAddressDnsSettingsDomainNameLabelScope{
+		"noreuse":            PublicIPAddressDnsSettingsDomainNameLabelScopeNoReuse,
+		"resourcegroupreuse": PublicIPAddressDnsSettingsDomainNameLabelScopeResourceGroupReuse,
+		"subscriptionreuse":  PublicIPAddressDnsSettingsDomainNameLabelScopeSubscriptionReuse,
+		"tenantreuse":        PublicIPAddressDnsSettingsDomainNameLabelScopeTenantReuse,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := PublicIPAddressDnsSettingsDomainNameLabelScope(input)
+	return &out, nil
+}
+
+type PublicIPAddressMigrationPhase string
+
+const (
+	PublicIPAddressMigrationPhaseAbort     PublicIPAddressMigrationPhase = "Abort"
+	PublicIPAddressMigrationPhaseCommit    PublicIPAddressMigrationPhase = "Commit"
+	PublicIPAddressMigrationPhaseCommitted PublicIPAddressMigrationPhase = "Committed"
+	PublicIPAddressMigrationPhaseNone      PublicIPAddressMigrationPhase = "None"
+	PublicIPAddressMigrationPhasePrepare   PublicIPAddressMigrationPhase = "Prepare"
+)
+
+func PossibleValuesForPublicIPAddressMigrationPhase() []string {
+	return []string{
+		string(PublicIPAddressMigrationPhaseAbort),
+		string(PublicIPAddressMigrationPhaseCommit),
+		string(PublicIPAddressMigrationPhaseCommitted),
+		string(PublicIPAddressMigrationPhaseNone),
+		string(PublicIPAddressMigrationPhasePrepare),
+	}
+}
+
+func (s *PublicIPAddressMigrationPhase) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parsePublicIPAddressMigrationPhase(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parsePublicIPAddressMigrationPhase(input string) (*PublicIPAddressMigrationPhase, error) {
+	vals := map[string]PublicIPAddressMigrationPhase{
+		"abort":     PublicIPAddressMigrationPhaseAbort,
+		"commit":    PublicIPAddressMigrationPhaseCommit,
+		"committed": PublicIPAddressMigrationPhaseCommitted,
+		"none":      PublicIPAddressMigrationPhaseNone,
+		"prepare":   PublicIPAddressMigrationPhasePrepare,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := PublicIPAddressMigrationPhase(input)
+	return &out, nil
+}
+
+type PublicIPAddressSkuName string
+
+const (
+	PublicIPAddressSkuNameBasic    PublicIPAddressSkuName = "Basic"
+	PublicIPAddressSkuNameStandard PublicIPAddressSkuName = "Standard"
+)
+
+func PossibleValuesForPublicIPAddressSkuName() []string {
+	return []string{
+		string(PublicIPAddressSkuNameBasic),
+		string(PublicIPAddressSkuNameStandard),
+	}
+}
+
+func (s *PublicIPAddressSkuName) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parsePublicIPAddressSkuName(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parsePublicIPAddressSkuName(input string) (*PublicIPAddressSkuName, error) {
+	vals := map[string]PublicIPAddressSkuName{
+		"basic":    PublicIPAddressSkuNameBasic,
+		"standard": PublicIPAddressSkuNameStandard,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := PublicIPAddressSkuName(input)
+	return &out, nil
+}
+
+type PublicIPAddressSkuTier string
+
+const (
+	PublicIPAddressSkuTierGlobal   PublicIPAddressSkuTier = "Global"
+	PublicIPAddressSkuTierRegional PublicIPAddressSkuTier = "Regional"
+)
+
+func PossibleValuesForPublicIPAddressSkuTier() []string {
+	return []string{
+		string(PublicIPAddressSkuTierGlobal),
+		string(PublicIPAddressSkuTierRegional),
+	}
+}
+
+func (s *PublicIPAddressSkuTier) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parsePublicIPAddressSkuTier(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parsePublicIPAddressSkuTier(input string) (*PublicIPAddressSkuTier, error) {
+	vals := map[string]PublicIPAddressSkuTier{
+		"global":   PublicIPAddressSkuTierGlobal,
+		"regional": PublicIPAddressSkuTierRegional,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := PublicIPAddressSkuTier(input)
+	return &out, nil
+}
+
+type RouteNextHopType string
+
+const (
+	RouteNextHopTypeInternet              RouteNextHopType = "Internet"
+	RouteNextHopTypeNone                  RouteNextHopType = "None"
+	RouteNextHopTypeVirtualAppliance      RouteNextHopType = "VirtualAppliance"
+	RouteNextHopTypeVirtualNetworkGateway RouteNextHopType = "VirtualNetworkGateway"
+	RouteNextHopTypeVnetLocal             RouteNextHopType = "VnetLocal"
+)
+
+func PossibleValuesForRouteNextHopType() []string {
+	return []string{
+		string(RouteNextHopTypeInternet),
+		string(RouteNextHopTypeNone),
+		string(RouteNextHopTypeVirtualAppliance),
+		string(RouteNextHopTypeVirtualNetworkGateway),
+		string(RouteNextHopTypeVnetLocal),
+	}
+}
+
+func (s *RouteNextHopType) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseRouteNextHopType(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseRouteNextHopType(input string) (*RouteNextHopType, error) {
+	vals := map[string]RouteNextHopType{
+		"internet":              RouteNextHopTypeInternet,
+		"none":                  RouteNextHopTypeNone,
+		"virtualappliance":      RouteNextHopTypeVirtualAppliance,
+		"virtualnetworkgateway": RouteNextHopTypeVirtualNetworkGateway,
+		"vnetlocal":             RouteNextHopTypeVnetLocal,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := RouteNextHopType(input)
+	return &out, nil
+}
+
+type SecurityRuleAccess string
+
+const (
+	SecurityRuleAccessAllow SecurityRuleAccess = "Allow"
+	SecurityRuleAccessDeny  SecurityRuleAccess = "Deny"
+)
+
+func PossibleValuesForSecurityRuleAccess() []string {
+	return []string{
+		string(SecurityRuleAccessAllow),
+		string(SecurityRuleAccessDeny),
+	}
+}
+
+func (s *SecurityRuleAccess) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseSecurityRuleAccess(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseSecurityRuleAccess(input string) (*SecurityRuleAccess, error) {
+	vals := map[string]SecurityRuleAccess{
+		"allow": SecurityRuleAccessAllow,
+		"deny":  SecurityRuleAccessDeny,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := SecurityRuleAccess(input)
+	return &out, nil
+}
+
+type SecurityRuleDirection string
+
+const (
+	SecurityRuleDirectionInbound  SecurityRuleDirection = "Inbound"
+	SecurityRuleDirectionOutbound SecurityRuleDirection = "Outbound"
+)
+
+func PossibleValuesForSecurityRuleDirection() []string {
+	return []string{
+		string(SecurityRuleDirectionInbound),
+		string(SecurityRuleDirectionOutbound),
+	}
+}
+
+func (s *SecurityRuleDirection) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseSecurityRuleDirection(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseSecurityRuleDirection(input string) (*SecurityRuleDirection, error) {
+	vals := map[string]SecurityRuleDirection{
+		"inbound":  SecurityRuleDirectionInbound,
+		"outbound": SecurityRuleDirectionOutbound,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := SecurityRuleDirection(input)
+	return &out, nil
+}
+
+type SecurityRuleProtocol string
+
+const (
+	SecurityRuleProtocolAh   SecurityRuleProtocol = "Ah"
+	SecurityRuleProtocolAny  SecurityRuleProtocol = "*"
+	SecurityRuleProtocolEsp  SecurityRuleProtocol = "Esp"
+	SecurityRuleProtocolIcmp SecurityRuleProtocol = "Icmp"
+	SecurityRuleProtocolTcp  SecurityRuleProtocol = "Tcp"
+	SecurityRuleProtocolUdp  SecurityRuleProtocol = "Udp"
+)
+
+func PossibleValuesForSecurityRuleProtocol() []string {
+	return []string{
+		string(SecurityRuleProtocolAh),
+		string(SecurityRuleProtocolAny),
+		string(SecurityRuleProtocolEsp),
+		string(SecurityRuleProtocolIcmp),
+		string(SecurityRuleProtocolTcp),
+		string(SecurityRuleProtocolUdp),
+	}
+}
+
+func (s *SecurityRuleProtocol) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseSecurityRuleProtocol(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseSecurityRuleProtocol(input string) (*SecurityRuleProtocol, error) {
+	vals := map[string]SecurityRuleProtocol{
+		"ah":   SecurityRuleProtocolAh,
+		"*":    SecurityRuleProtocolAny,
+		"esp":  SecurityRuleProtocolEsp,
+		"icmp": SecurityRuleProtocolIcmp,
+		"tcp":  SecurityRuleProtocolTcp,
+		"udp":  SecurityRuleProtocolUdp,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := SecurityRuleProtocol(input)
+	return &out, nil
+}
+
+type TransportProtocol string
+
+const (
+	TransportProtocolAll TransportProtocol = "All"
+	TransportProtocolTcp TransportProtocol = "Tcp"
+	TransportProtocolUdp TransportProtocol = "Udp"
+)
+
+func PossibleValuesForTransportProtocol() []string {
+	return []string{
+		string(TransportProtocolAll),
+		string(TransportProtocolTcp),
+		string(TransportProtocolUdp),
+	}
+}
+
+func (s *TransportProtocol) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseTransportProtocol(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseTransportProtocol(input string) (*TransportProtocol, error) {
+	vals := map[string]TransportProtocol{
+		"all": TransportProtocolAll,
+		"tcp": TransportProtocolTcp,
+		"udp": TransportProtocolUdp,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := TransportProtocol(input)
+	return &out, nil
+}
+
+type VirtualNetworkPrivateEndpointNetworkPolicies string
+
+const (
+	VirtualNetworkPrivateEndpointNetworkPoliciesDisabled VirtualNetworkPrivateEndpointNetworkPolicies = "Disabled"
+	VirtualNetworkPrivateEndpointNetworkPoliciesEnabled  VirtualNetworkPrivateEndpointNetworkPolicies = "Enabled"
+)
+
+func PossibleValuesForVirtualNetworkPrivateEndpointNetworkPolicies() []string {
+	return []string{
+		string(VirtualNetworkPrivateEndpointNetworkPoliciesDisabled),
+		string(VirtualNetworkPrivateEndpointNetworkPoliciesEnabled),
+	}
+}
+
+func (s *VirtualNetworkPrivateEndpointNetworkPolicies) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseVirtualNetworkPrivateEndpointNetworkPolicies(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseVirtualNetworkPrivateEndpointNetworkPolicies(input string) (*VirtualNetworkPrivateEndpointNetworkPolicies, error) {
+	vals := map[string]VirtualNetworkPrivateEndpointNetworkPolicies{
+		"disabled": VirtualNetworkPrivateEndpointNetworkPoliciesDisabled,
+		"enabled":  VirtualNetworkPrivateEndpointNetworkPoliciesEnabled,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := VirtualNetworkPrivateEndpointNetworkPolicies(input)
+	return &out, nil
+}
+
+type VirtualNetworkPrivateLinkServiceNetworkPolicies string
+
+const (
+	VirtualNetworkPrivateLinkServiceNetworkPoliciesDisabled VirtualNetworkPrivateLinkServiceNetworkPolicies = "Disabled"
+	VirtualNetworkPrivateLinkServiceNetworkPoliciesEnabled  VirtualNetworkPrivateLinkServiceNetworkPolicies = "Enabled"
+)
+
+func PossibleValuesForVirtualNetworkPrivateLinkServiceNetworkPolicies() []string {
+	return []string{
+		string(VirtualNetworkPrivateLinkServiceNetworkPoliciesDisabled),
+		string(VirtualNetworkPrivateLinkServiceNetworkPoliciesEnabled),
+	}
+}
+
+func (s *VirtualNetworkPrivateLinkServiceNetworkPolicies) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseVirtualNetworkPrivateLinkServiceNetworkPolicies(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseVirtualNetworkPrivateLinkServiceNetworkPolicies(input string) (*VirtualNetworkPrivateLinkServiceNetworkPolicies, error) {
+	vals := map[string]VirtualNetworkPrivateLinkServiceNetworkPolicies{
+		"disabled": VirtualNetworkPrivateLinkServiceNetworkPoliciesDisabled,
+		"enabled":  VirtualNetworkPrivateLinkServiceNetworkPoliciesEnabled,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := VirtualNetworkPrivateLinkServiceNetworkPolicies(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/id_providercloudservice.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/id_providercloudservice.go
@@ -1,0 +1,127 @@
+package networkinterfaces
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ resourceids.ResourceId = ProviderCloudServiceId{}
+
+// ProviderCloudServiceId is a struct representing the Resource ID for a Provider Cloud Service
+type ProviderCloudServiceId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	CloudServiceName  string
+}
+
+// NewProviderCloudServiceID returns a new ProviderCloudServiceId struct
+func NewProviderCloudServiceID(subscriptionId string, resourceGroupName string, cloudServiceName string) ProviderCloudServiceId {
+	return ProviderCloudServiceId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		CloudServiceName:  cloudServiceName,
+	}
+}
+
+// ParseProviderCloudServiceID parses 'input' into a ProviderCloudServiceId
+func ParseProviderCloudServiceID(input string) (*ProviderCloudServiceId, error) {
+	parser := resourceids.NewParserFromResourceIdType(ProviderCloudServiceId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := ProviderCloudServiceId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
+	}
+
+	if id.CloudServiceName, ok = parsed.Parsed["cloudServiceName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "cloudServiceName", *parsed)
+	}
+
+	return &id, nil
+}
+
+// ParseProviderCloudServiceIDInsensitively parses 'input' case-insensitively into a ProviderCloudServiceId
+// note: this method should only be used for API response data and not user input
+func ParseProviderCloudServiceIDInsensitively(input string) (*ProviderCloudServiceId, error) {
+	parser := resourceids.NewParserFromResourceIdType(ProviderCloudServiceId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := ProviderCloudServiceId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
+	}
+
+	if id.CloudServiceName, ok = parsed.Parsed["cloudServiceName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "cloudServiceName", *parsed)
+	}
+
+	return &id, nil
+}
+
+// ValidateProviderCloudServiceID checks that 'input' can be parsed as a Provider Cloud Service ID
+func ValidateProviderCloudServiceID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseProviderCloudServiceID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Provider Cloud Service ID
+func (id ProviderCloudServiceId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/cloudServices/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.CloudServiceName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Provider Cloud Service ID
+func (id ProviderCloudServiceId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftCompute", "Microsoft.Compute", "Microsoft.Compute"),
+		resourceids.StaticSegment("staticCloudServices", "cloudServices", "cloudServices"),
+		resourceids.UserSpecifiedSegment("cloudServiceName", "cloudServiceValue"),
+	}
+}
+
+// String returns a human-readable description of this Provider Cloud Service ID
+func (id ProviderCloudServiceId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Cloud Service Name: %q", id.CloudServiceName),
+	}
+	return fmt.Sprintf("Provider Cloud Service (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/id_roleinstance.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/id_roleinstance.go
@@ -1,0 +1,140 @@
+package networkinterfaces
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ resourceids.ResourceId = RoleInstanceId{}
+
+// RoleInstanceId is a struct representing the Resource ID for a Role Instance
+type RoleInstanceId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	CloudServiceName  string
+	RoleInstanceName  string
+}
+
+// NewRoleInstanceID returns a new RoleInstanceId struct
+func NewRoleInstanceID(subscriptionId string, resourceGroupName string, cloudServiceName string, roleInstanceName string) RoleInstanceId {
+	return RoleInstanceId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		CloudServiceName:  cloudServiceName,
+		RoleInstanceName:  roleInstanceName,
+	}
+}
+
+// ParseRoleInstanceID parses 'input' into a RoleInstanceId
+func ParseRoleInstanceID(input string) (*RoleInstanceId, error) {
+	parser := resourceids.NewParserFromResourceIdType(RoleInstanceId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := RoleInstanceId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
+	}
+
+	if id.CloudServiceName, ok = parsed.Parsed["cloudServiceName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "cloudServiceName", *parsed)
+	}
+
+	if id.RoleInstanceName, ok = parsed.Parsed["roleInstanceName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "roleInstanceName", *parsed)
+	}
+
+	return &id, nil
+}
+
+// ParseRoleInstanceIDInsensitively parses 'input' case-insensitively into a RoleInstanceId
+// note: this method should only be used for API response data and not user input
+func ParseRoleInstanceIDInsensitively(input string) (*RoleInstanceId, error) {
+	parser := resourceids.NewParserFromResourceIdType(RoleInstanceId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := RoleInstanceId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
+	}
+
+	if id.CloudServiceName, ok = parsed.Parsed["cloudServiceName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "cloudServiceName", *parsed)
+	}
+
+	if id.RoleInstanceName, ok = parsed.Parsed["roleInstanceName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "roleInstanceName", *parsed)
+	}
+
+	return &id, nil
+}
+
+// ValidateRoleInstanceID checks that 'input' can be parsed as a Role Instance ID
+func ValidateRoleInstanceID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseRoleInstanceID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Role Instance ID
+func (id RoleInstanceId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/cloudServices/%s/roleInstances/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.CloudServiceName, id.RoleInstanceName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Role Instance ID
+func (id RoleInstanceId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftCompute", "Microsoft.Compute", "Microsoft.Compute"),
+		resourceids.StaticSegment("staticCloudServices", "cloudServices", "cloudServices"),
+		resourceids.UserSpecifiedSegment("cloudServiceName", "cloudServiceValue"),
+		resourceids.StaticSegment("staticRoleInstances", "roleInstances", "roleInstances"),
+		resourceids.UserSpecifiedSegment("roleInstanceName", "roleInstanceValue"),
+	}
+}
+
+// String returns a human-readable description of this Role Instance ID
+func (id RoleInstanceId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Cloud Service Name: %q", id.CloudServiceName),
+		fmt.Sprintf("Role Instance Name: %q", id.RoleInstanceName),
+	}
+	return fmt.Sprintf("Role Instance (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/id_roleinstancenetworkinterface.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/id_roleinstancenetworkinterface.go
@@ -1,0 +1,153 @@
+package networkinterfaces
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ resourceids.ResourceId = RoleInstanceNetworkInterfaceId{}
+
+// RoleInstanceNetworkInterfaceId is a struct representing the Resource ID for a Role Instance Network Interface
+type RoleInstanceNetworkInterfaceId struct {
+	SubscriptionId       string
+	ResourceGroupName    string
+	CloudServiceName     string
+	RoleInstanceName     string
+	NetworkInterfaceName string
+}
+
+// NewRoleInstanceNetworkInterfaceID returns a new RoleInstanceNetworkInterfaceId struct
+func NewRoleInstanceNetworkInterfaceID(subscriptionId string, resourceGroupName string, cloudServiceName string, roleInstanceName string, networkInterfaceName string) RoleInstanceNetworkInterfaceId {
+	return RoleInstanceNetworkInterfaceId{
+		SubscriptionId:       subscriptionId,
+		ResourceGroupName:    resourceGroupName,
+		CloudServiceName:     cloudServiceName,
+		RoleInstanceName:     roleInstanceName,
+		NetworkInterfaceName: networkInterfaceName,
+	}
+}
+
+// ParseRoleInstanceNetworkInterfaceID parses 'input' into a RoleInstanceNetworkInterfaceId
+func ParseRoleInstanceNetworkInterfaceID(input string) (*RoleInstanceNetworkInterfaceId, error) {
+	parser := resourceids.NewParserFromResourceIdType(RoleInstanceNetworkInterfaceId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := RoleInstanceNetworkInterfaceId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
+	}
+
+	if id.CloudServiceName, ok = parsed.Parsed["cloudServiceName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "cloudServiceName", *parsed)
+	}
+
+	if id.RoleInstanceName, ok = parsed.Parsed["roleInstanceName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "roleInstanceName", *parsed)
+	}
+
+	if id.NetworkInterfaceName, ok = parsed.Parsed["networkInterfaceName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "networkInterfaceName", *parsed)
+	}
+
+	return &id, nil
+}
+
+// ParseRoleInstanceNetworkInterfaceIDInsensitively parses 'input' case-insensitively into a RoleInstanceNetworkInterfaceId
+// note: this method should only be used for API response data and not user input
+func ParseRoleInstanceNetworkInterfaceIDInsensitively(input string) (*RoleInstanceNetworkInterfaceId, error) {
+	parser := resourceids.NewParserFromResourceIdType(RoleInstanceNetworkInterfaceId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := RoleInstanceNetworkInterfaceId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
+	}
+
+	if id.CloudServiceName, ok = parsed.Parsed["cloudServiceName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "cloudServiceName", *parsed)
+	}
+
+	if id.RoleInstanceName, ok = parsed.Parsed["roleInstanceName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "roleInstanceName", *parsed)
+	}
+
+	if id.NetworkInterfaceName, ok = parsed.Parsed["networkInterfaceName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "networkInterfaceName", *parsed)
+	}
+
+	return &id, nil
+}
+
+// ValidateRoleInstanceNetworkInterfaceID checks that 'input' can be parsed as a Role Instance Network Interface ID
+func ValidateRoleInstanceNetworkInterfaceID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseRoleInstanceNetworkInterfaceID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Role Instance Network Interface ID
+func (id RoleInstanceNetworkInterfaceId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/cloudServices/%s/roleInstances/%s/networkInterfaces/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.CloudServiceName, id.RoleInstanceName, id.NetworkInterfaceName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Role Instance Network Interface ID
+func (id RoleInstanceNetworkInterfaceId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftCompute", "Microsoft.Compute", "Microsoft.Compute"),
+		resourceids.StaticSegment("staticCloudServices", "cloudServices", "cloudServices"),
+		resourceids.UserSpecifiedSegment("cloudServiceName", "cloudServiceValue"),
+		resourceids.StaticSegment("staticRoleInstances", "roleInstances", "roleInstances"),
+		resourceids.UserSpecifiedSegment("roleInstanceName", "roleInstanceValue"),
+		resourceids.StaticSegment("staticNetworkInterfaces", "networkInterfaces", "networkInterfaces"),
+		resourceids.UserSpecifiedSegment("networkInterfaceName", "networkInterfaceValue"),
+	}
+}
+
+// String returns a human-readable description of this Role Instance Network Interface ID
+func (id RoleInstanceNetworkInterfaceId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Cloud Service Name: %q", id.CloudServiceName),
+		fmt.Sprintf("Role Instance Name: %q", id.RoleInstanceName),
+		fmt.Sprintf("Network Interface Name: %q", id.NetworkInterfaceName),
+	}
+	return fmt.Sprintf("Role Instance Network Interface (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/id_tapconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/id_tapconfiguration.go
@@ -1,0 +1,140 @@
+package networkinterfaces
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ resourceids.ResourceId = TapConfigurationId{}
+
+// TapConfigurationId is a struct representing the Resource ID for a Tap Configuration
+type TapConfigurationId struct {
+	SubscriptionId       string
+	ResourceGroupName    string
+	NetworkInterfaceName string
+	TapConfigurationName string
+}
+
+// NewTapConfigurationID returns a new TapConfigurationId struct
+func NewTapConfigurationID(subscriptionId string, resourceGroupName string, networkInterfaceName string, tapConfigurationName string) TapConfigurationId {
+	return TapConfigurationId{
+		SubscriptionId:       subscriptionId,
+		ResourceGroupName:    resourceGroupName,
+		NetworkInterfaceName: networkInterfaceName,
+		TapConfigurationName: tapConfigurationName,
+	}
+}
+
+// ParseTapConfigurationID parses 'input' into a TapConfigurationId
+func ParseTapConfigurationID(input string) (*TapConfigurationId, error) {
+	parser := resourceids.NewParserFromResourceIdType(TapConfigurationId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := TapConfigurationId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
+	}
+
+	if id.NetworkInterfaceName, ok = parsed.Parsed["networkInterfaceName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "networkInterfaceName", *parsed)
+	}
+
+	if id.TapConfigurationName, ok = parsed.Parsed["tapConfigurationName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "tapConfigurationName", *parsed)
+	}
+
+	return &id, nil
+}
+
+// ParseTapConfigurationIDInsensitively parses 'input' case-insensitively into a TapConfigurationId
+// note: this method should only be used for API response data and not user input
+func ParseTapConfigurationIDInsensitively(input string) (*TapConfigurationId, error) {
+	parser := resourceids.NewParserFromResourceIdType(TapConfigurationId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := TapConfigurationId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
+	}
+
+	if id.NetworkInterfaceName, ok = parsed.Parsed["networkInterfaceName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "networkInterfaceName", *parsed)
+	}
+
+	if id.TapConfigurationName, ok = parsed.Parsed["tapConfigurationName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "tapConfigurationName", *parsed)
+	}
+
+	return &id, nil
+}
+
+// ValidateTapConfigurationID checks that 'input' can be parsed as a Tap Configuration ID
+func ValidateTapConfigurationID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseTapConfigurationID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Tap Configuration ID
+func (id TapConfigurationId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/networkInterfaces/%s/tapConfigurations/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.NetworkInterfaceName, id.TapConfigurationName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Tap Configuration ID
+func (id TapConfigurationId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftNetwork", "Microsoft.Network", "Microsoft.Network"),
+		resourceids.StaticSegment("staticNetworkInterfaces", "networkInterfaces", "networkInterfaces"),
+		resourceids.UserSpecifiedSegment("networkInterfaceName", "networkInterfaceValue"),
+		resourceids.StaticSegment("staticTapConfigurations", "tapConfigurations", "tapConfigurations"),
+		resourceids.UserSpecifiedSegment("tapConfigurationName", "tapConfigurationValue"),
+	}
+}
+
+// String returns a human-readable description of this Tap Configuration ID
+func (id TapConfigurationId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Network Interface Name: %q", id.NetworkInterfaceName),
+		fmt.Sprintf("Tap Configuration Name: %q", id.TapConfigurationName),
+	}
+	return fmt.Sprintf("Tap Configuration (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/id_virtualmachine.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/id_virtualmachine.go
@@ -1,0 +1,140 @@
+package networkinterfaces
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ resourceids.ResourceId = VirtualMachineId{}
+
+// VirtualMachineId is a struct representing the Resource ID for a Virtual Machine
+type VirtualMachineId struct {
+	SubscriptionId             string
+	ResourceGroupName          string
+	VirtualMachineScaleSetName string
+	VirtualMachineName         string
+}
+
+// NewVirtualMachineID returns a new VirtualMachineId struct
+func NewVirtualMachineID(subscriptionId string, resourceGroupName string, virtualMachineScaleSetName string, virtualMachineName string) VirtualMachineId {
+	return VirtualMachineId{
+		SubscriptionId:             subscriptionId,
+		ResourceGroupName:          resourceGroupName,
+		VirtualMachineScaleSetName: virtualMachineScaleSetName,
+		VirtualMachineName:         virtualMachineName,
+	}
+}
+
+// ParseVirtualMachineID parses 'input' into a VirtualMachineId
+func ParseVirtualMachineID(input string) (*VirtualMachineId, error) {
+	parser := resourceids.NewParserFromResourceIdType(VirtualMachineId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := VirtualMachineId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
+	}
+
+	if id.VirtualMachineScaleSetName, ok = parsed.Parsed["virtualMachineScaleSetName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "virtualMachineScaleSetName", *parsed)
+	}
+
+	if id.VirtualMachineName, ok = parsed.Parsed["virtualMachineName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "virtualMachineName", *parsed)
+	}
+
+	return &id, nil
+}
+
+// ParseVirtualMachineIDInsensitively parses 'input' case-insensitively into a VirtualMachineId
+// note: this method should only be used for API response data and not user input
+func ParseVirtualMachineIDInsensitively(input string) (*VirtualMachineId, error) {
+	parser := resourceids.NewParserFromResourceIdType(VirtualMachineId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := VirtualMachineId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
+	}
+
+	if id.VirtualMachineScaleSetName, ok = parsed.Parsed["virtualMachineScaleSetName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "virtualMachineScaleSetName", *parsed)
+	}
+
+	if id.VirtualMachineName, ok = parsed.Parsed["virtualMachineName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "virtualMachineName", *parsed)
+	}
+
+	return &id, nil
+}
+
+// ValidateVirtualMachineID checks that 'input' can be parsed as a Virtual Machine ID
+func ValidateVirtualMachineID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseVirtualMachineID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Virtual Machine ID
+func (id VirtualMachineId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/virtualMachineScaleSets/%s/virtualMachines/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.VirtualMachineScaleSetName, id.VirtualMachineName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Virtual Machine ID
+func (id VirtualMachineId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftCompute", "Microsoft.Compute", "Microsoft.Compute"),
+		resourceids.StaticSegment("staticVirtualMachineScaleSets", "virtualMachineScaleSets", "virtualMachineScaleSets"),
+		resourceids.UserSpecifiedSegment("virtualMachineScaleSetName", "virtualMachineScaleSetValue"),
+		resourceids.StaticSegment("staticVirtualMachines", "virtualMachines", "virtualMachines"),
+		resourceids.UserSpecifiedSegment("virtualMachineName", "virtualMachineValue"),
+	}
+}
+
+// String returns a human-readable description of this Virtual Machine ID
+func (id VirtualMachineId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Virtual Machine Scale Set Name: %q", id.VirtualMachineScaleSetName),
+		fmt.Sprintf("Virtual Machine Name: %q", id.VirtualMachineName),
+	}
+	return fmt.Sprintf("Virtual Machine (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/id_virtualmachinescaleset.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/id_virtualmachinescaleset.go
@@ -1,0 +1,127 @@
+package networkinterfaces
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ resourceids.ResourceId = VirtualMachineScaleSetId{}
+
+// VirtualMachineScaleSetId is a struct representing the Resource ID for a Virtual Machine Scale Set
+type VirtualMachineScaleSetId struct {
+	SubscriptionId             string
+	ResourceGroupName          string
+	VirtualMachineScaleSetName string
+}
+
+// NewVirtualMachineScaleSetID returns a new VirtualMachineScaleSetId struct
+func NewVirtualMachineScaleSetID(subscriptionId string, resourceGroupName string, virtualMachineScaleSetName string) VirtualMachineScaleSetId {
+	return VirtualMachineScaleSetId{
+		SubscriptionId:             subscriptionId,
+		ResourceGroupName:          resourceGroupName,
+		VirtualMachineScaleSetName: virtualMachineScaleSetName,
+	}
+}
+
+// ParseVirtualMachineScaleSetID parses 'input' into a VirtualMachineScaleSetId
+func ParseVirtualMachineScaleSetID(input string) (*VirtualMachineScaleSetId, error) {
+	parser := resourceids.NewParserFromResourceIdType(VirtualMachineScaleSetId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := VirtualMachineScaleSetId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
+	}
+
+	if id.VirtualMachineScaleSetName, ok = parsed.Parsed["virtualMachineScaleSetName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "virtualMachineScaleSetName", *parsed)
+	}
+
+	return &id, nil
+}
+
+// ParseVirtualMachineScaleSetIDInsensitively parses 'input' case-insensitively into a VirtualMachineScaleSetId
+// note: this method should only be used for API response data and not user input
+func ParseVirtualMachineScaleSetIDInsensitively(input string) (*VirtualMachineScaleSetId, error) {
+	parser := resourceids.NewParserFromResourceIdType(VirtualMachineScaleSetId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := VirtualMachineScaleSetId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
+	}
+
+	if id.VirtualMachineScaleSetName, ok = parsed.Parsed["virtualMachineScaleSetName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "virtualMachineScaleSetName", *parsed)
+	}
+
+	return &id, nil
+}
+
+// ValidateVirtualMachineScaleSetID checks that 'input' can be parsed as a Virtual Machine Scale Set ID
+func ValidateVirtualMachineScaleSetID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseVirtualMachineScaleSetID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Virtual Machine Scale Set ID
+func (id VirtualMachineScaleSetId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/virtualMachineScaleSets/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.VirtualMachineScaleSetName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Virtual Machine Scale Set ID
+func (id VirtualMachineScaleSetId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftCompute", "Microsoft.Compute", "Microsoft.Compute"),
+		resourceids.StaticSegment("staticVirtualMachineScaleSets", "virtualMachineScaleSets", "virtualMachineScaleSets"),
+		resourceids.UserSpecifiedSegment("virtualMachineScaleSetName", "virtualMachineScaleSetValue"),
+	}
+}
+
+// String returns a human-readable description of this Virtual Machine Scale Set ID
+func (id VirtualMachineScaleSetId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Virtual Machine Scale Set Name: %q", id.VirtualMachineScaleSetName),
+	}
+	return fmt.Sprintf("Virtual Machine Scale Set (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/method_createorupdate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/method_createorupdate.go
@@ -1,0 +1,75 @@
+package networkinterfaces
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CreateOrUpdateOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// CreateOrUpdate ...
+func (c NetworkInterfacesClient) CreateOrUpdate(ctx context.Context, id commonids.NetworkInterfaceId, input NetworkInterface) (result CreateOrUpdateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json",
+		ExpectedStatusCodes: []int{
+			http.StatusCreated,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPut,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// CreateOrUpdateThenPoll performs CreateOrUpdate then polls until it's completed
+func (c NetworkInterfacesClient) CreateOrUpdateThenPoll(ctx context.Context, id commonids.NetworkInterfaceId, input NetworkInterface) error {
+	result, err := c.CreateOrUpdate(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing CreateOrUpdate: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after CreateOrUpdate: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/method_delete.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/method_delete.go
@@ -1,0 +1,72 @@
+package networkinterfaces
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DeleteOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// Delete ...
+func (c NetworkInterfacesClient) Delete(ctx context.Context, id commonids.NetworkInterfaceId) (result DeleteOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusNoContent,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodDelete,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// DeleteThenPoll performs Delete then polls until it's completed
+func (c NetworkInterfacesClient) DeleteThenPoll(ctx context.Context, id commonids.NetworkInterfaceId) error {
+	result, err := c.Delete(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing Delete: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after Delete: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/method_get.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/method_get.go
@@ -1,0 +1,81 @@
+package networkinterfaces
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *NetworkInterface
+}
+
+type GetOperationOptions struct {
+	Expand *string
+}
+
+func DefaultGetOperationOptions() GetOperationOptions {
+	return GetOperationOptions{}
+}
+
+func (o GetOperationOptions) ToHeaders() *client.Headers {
+	out := client.Headers{}
+
+	return &out
+}
+
+func (o GetOperationOptions) ToOData() *odata.Query {
+	out := odata.Query{}
+	return &out
+}
+
+func (o GetOperationOptions) ToQuery() *client.QueryParams {
+	out := client.QueryParams{}
+	if o.Expand != nil {
+		out.Append("$expand", fmt.Sprintf("%v", *o.Expand))
+	}
+	return &out
+}
+
+// Get ...
+func (c NetworkInterfacesClient) Get(ctx context.Context, id commonids.NetworkInterfaceId, options GetOperationOptions) (result GetOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodGet,
+		Path:          id.ID(),
+		OptionsObject: options,
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	if err = resp.Unmarshal(&result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/method_getcloudservicenetworkinterface.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/method_getcloudservicenetworkinterface.go
@@ -1,0 +1,80 @@
+package networkinterfaces
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetCloudServiceNetworkInterfaceOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *NetworkInterface
+}
+
+type GetCloudServiceNetworkInterfaceOperationOptions struct {
+	Expand *string
+}
+
+func DefaultGetCloudServiceNetworkInterfaceOperationOptions() GetCloudServiceNetworkInterfaceOperationOptions {
+	return GetCloudServiceNetworkInterfaceOperationOptions{}
+}
+
+func (o GetCloudServiceNetworkInterfaceOperationOptions) ToHeaders() *client.Headers {
+	out := client.Headers{}
+
+	return &out
+}
+
+func (o GetCloudServiceNetworkInterfaceOperationOptions) ToOData() *odata.Query {
+	out := odata.Query{}
+	return &out
+}
+
+func (o GetCloudServiceNetworkInterfaceOperationOptions) ToQuery() *client.QueryParams {
+	out := client.QueryParams{}
+	if o.Expand != nil {
+		out.Append("$expand", fmt.Sprintf("%v", *o.Expand))
+	}
+	return &out
+}
+
+// GetCloudServiceNetworkInterface ...
+func (c NetworkInterfacesClient) GetCloudServiceNetworkInterface(ctx context.Context, id RoleInstanceNetworkInterfaceId, options GetCloudServiceNetworkInterfaceOperationOptions) (result GetCloudServiceNetworkInterfaceOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodGet,
+		Path:          id.ID(),
+		OptionsObject: options,
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	if err = resp.Unmarshal(&result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/method_geteffectiveroutetable.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/method_geteffectiveroutetable.go
@@ -1,0 +1,71 @@
+package networkinterfaces
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetEffectiveRouteTableOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// GetEffectiveRouteTable ...
+func (c NetworkInterfacesClient) GetEffectiveRouteTable(ctx context.Context, id commonids.NetworkInterfaceId) (result GetEffectiveRouteTableOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/effectiveRouteTable", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// GetEffectiveRouteTableThenPoll performs GetEffectiveRouteTable then polls until it's completed
+func (c NetworkInterfacesClient) GetEffectiveRouteTableThenPoll(ctx context.Context, id commonids.NetworkInterfaceId) error {
+	result, err := c.GetEffectiveRouteTable(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing GetEffectiveRouteTable: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after GetEffectiveRouteTable: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/method_getvirtualmachinescalesetipconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/method_getvirtualmachinescalesetipconfiguration.go
@@ -1,0 +1,81 @@
+package networkinterfaces
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetVirtualMachineScaleSetIPConfigurationOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *NetworkInterfaceIPConfiguration
+}
+
+type GetVirtualMachineScaleSetIPConfigurationOperationOptions struct {
+	Expand *string
+}
+
+func DefaultGetVirtualMachineScaleSetIPConfigurationOperationOptions() GetVirtualMachineScaleSetIPConfigurationOperationOptions {
+	return GetVirtualMachineScaleSetIPConfigurationOperationOptions{}
+}
+
+func (o GetVirtualMachineScaleSetIPConfigurationOperationOptions) ToHeaders() *client.Headers {
+	out := client.Headers{}
+
+	return &out
+}
+
+func (o GetVirtualMachineScaleSetIPConfigurationOperationOptions) ToOData() *odata.Query {
+	out := odata.Query{}
+	return &out
+}
+
+func (o GetVirtualMachineScaleSetIPConfigurationOperationOptions) ToQuery() *client.QueryParams {
+	out := client.QueryParams{}
+	if o.Expand != nil {
+		out.Append("$expand", fmt.Sprintf("%v", *o.Expand))
+	}
+	return &out
+}
+
+// GetVirtualMachineScaleSetIPConfiguration ...
+func (c NetworkInterfacesClient) GetVirtualMachineScaleSetIPConfiguration(ctx context.Context, id commonids.VirtualMachineScaleSetIPConfigurationId, options GetVirtualMachineScaleSetIPConfigurationOperationOptions) (result GetVirtualMachineScaleSetIPConfigurationOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodGet,
+		Path:          id.ID(),
+		OptionsObject: options,
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	if err = resp.Unmarshal(&result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/method_getvirtualmachinescalesetnetworkinterface.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/method_getvirtualmachinescalesetnetworkinterface.go
@@ -1,0 +1,81 @@
+package networkinterfaces
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetVirtualMachineScaleSetNetworkInterfaceOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *NetworkInterface
+}
+
+type GetVirtualMachineScaleSetNetworkInterfaceOperationOptions struct {
+	Expand *string
+}
+
+func DefaultGetVirtualMachineScaleSetNetworkInterfaceOperationOptions() GetVirtualMachineScaleSetNetworkInterfaceOperationOptions {
+	return GetVirtualMachineScaleSetNetworkInterfaceOperationOptions{}
+}
+
+func (o GetVirtualMachineScaleSetNetworkInterfaceOperationOptions) ToHeaders() *client.Headers {
+	out := client.Headers{}
+
+	return &out
+}
+
+func (o GetVirtualMachineScaleSetNetworkInterfaceOperationOptions) ToOData() *odata.Query {
+	out := odata.Query{}
+	return &out
+}
+
+func (o GetVirtualMachineScaleSetNetworkInterfaceOperationOptions) ToQuery() *client.QueryParams {
+	out := client.QueryParams{}
+	if o.Expand != nil {
+		out.Append("$expand", fmt.Sprintf("%v", *o.Expand))
+	}
+	return &out
+}
+
+// GetVirtualMachineScaleSetNetworkInterface ...
+func (c NetworkInterfacesClient) GetVirtualMachineScaleSetNetworkInterface(ctx context.Context, id commonids.VirtualMachineScaleSetNetworkInterfaceId, options GetVirtualMachineScaleSetNetworkInterfaceOperationOptions) (result GetVirtualMachineScaleSetNetworkInterfaceOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodGet,
+		Path:          id.ID(),
+		OptionsObject: options,
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	if err = resp.Unmarshal(&result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/method_list.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/method_list.go
@@ -1,0 +1,90 @@
+package networkinterfaces
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]NetworkInterface
+}
+
+type ListCompleteResult struct {
+	Items []NetworkInterface
+}
+
+// List ...
+func (c NetworkInterfacesClient) List(ctx context.Context, id commonids.ResourceGroupId) (result ListOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       fmt.Sprintf("%s/providers/Microsoft.Network/networkInterfaces", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]NetworkInterface `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ListComplete retrieves all the results into a single object
+func (c NetworkInterfacesClient) ListComplete(ctx context.Context, id commonids.ResourceGroupId) (ListCompleteResult, error) {
+	return c.ListCompleteMatchingPredicate(ctx, id, NetworkInterfaceOperationPredicate{})
+}
+
+// ListCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c NetworkInterfacesClient) ListCompleteMatchingPredicate(ctx context.Context, id commonids.ResourceGroupId, predicate NetworkInterfaceOperationPredicate) (result ListCompleteResult, err error) {
+	items := make([]NetworkInterface, 0)
+
+	resp, err := c.List(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ListCompleteResult{
+		Items: items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/method_listall.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/method_listall.go
@@ -1,0 +1,90 @@
+package networkinterfaces
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListAllOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]NetworkInterface
+}
+
+type ListAllCompleteResult struct {
+	Items []NetworkInterface
+}
+
+// ListAll ...
+func (c NetworkInterfacesClient) ListAll(ctx context.Context, id commonids.SubscriptionId) (result ListAllOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       fmt.Sprintf("%s/providers/Microsoft.Network/networkInterfaces", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]NetworkInterface `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ListAllComplete retrieves all the results into a single object
+func (c NetworkInterfacesClient) ListAllComplete(ctx context.Context, id commonids.SubscriptionId) (ListAllCompleteResult, error) {
+	return c.ListAllCompleteMatchingPredicate(ctx, id, NetworkInterfaceOperationPredicate{})
+}
+
+// ListAllCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c NetworkInterfacesClient) ListAllCompleteMatchingPredicate(ctx context.Context, id commonids.SubscriptionId, predicate NetworkInterfaceOperationPredicate) (result ListAllCompleteResult, err error) {
+	items := make([]NetworkInterface, 0)
+
+	resp, err := c.ListAll(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ListAllCompleteResult{
+		Items: items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/method_listcloudservicenetworkinterfaces.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/method_listcloudservicenetworkinterfaces.go
@@ -1,0 +1,89 @@
+package networkinterfaces
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListCloudServiceNetworkInterfacesOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]NetworkInterface
+}
+
+type ListCloudServiceNetworkInterfacesCompleteResult struct {
+	Items []NetworkInterface
+}
+
+// ListCloudServiceNetworkInterfaces ...
+func (c NetworkInterfacesClient) ListCloudServiceNetworkInterfaces(ctx context.Context, id ProviderCloudServiceId) (result ListCloudServiceNetworkInterfacesOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       fmt.Sprintf("%s/networkInterfaces", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]NetworkInterface `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ListCloudServiceNetworkInterfacesComplete retrieves all the results into a single object
+func (c NetworkInterfacesClient) ListCloudServiceNetworkInterfacesComplete(ctx context.Context, id ProviderCloudServiceId) (ListCloudServiceNetworkInterfacesCompleteResult, error) {
+	return c.ListCloudServiceNetworkInterfacesCompleteMatchingPredicate(ctx, id, NetworkInterfaceOperationPredicate{})
+}
+
+// ListCloudServiceNetworkInterfacesCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c NetworkInterfacesClient) ListCloudServiceNetworkInterfacesCompleteMatchingPredicate(ctx context.Context, id ProviderCloudServiceId, predicate NetworkInterfaceOperationPredicate) (result ListCloudServiceNetworkInterfacesCompleteResult, err error) {
+	items := make([]NetworkInterface, 0)
+
+	resp, err := c.ListCloudServiceNetworkInterfaces(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ListCloudServiceNetworkInterfacesCompleteResult{
+		Items: items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/method_listcloudserviceroleinstancenetworkinterfaces.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/method_listcloudserviceroleinstancenetworkinterfaces.go
@@ -1,0 +1,89 @@
+package networkinterfaces
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListCloudServiceRoleInstanceNetworkInterfacesOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]NetworkInterface
+}
+
+type ListCloudServiceRoleInstanceNetworkInterfacesCompleteResult struct {
+	Items []NetworkInterface
+}
+
+// ListCloudServiceRoleInstanceNetworkInterfaces ...
+func (c NetworkInterfacesClient) ListCloudServiceRoleInstanceNetworkInterfaces(ctx context.Context, id RoleInstanceId) (result ListCloudServiceRoleInstanceNetworkInterfacesOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       fmt.Sprintf("%s/networkInterfaces", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]NetworkInterface `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ListCloudServiceRoleInstanceNetworkInterfacesComplete retrieves all the results into a single object
+func (c NetworkInterfacesClient) ListCloudServiceRoleInstanceNetworkInterfacesComplete(ctx context.Context, id RoleInstanceId) (ListCloudServiceRoleInstanceNetworkInterfacesCompleteResult, error) {
+	return c.ListCloudServiceRoleInstanceNetworkInterfacesCompleteMatchingPredicate(ctx, id, NetworkInterfaceOperationPredicate{})
+}
+
+// ListCloudServiceRoleInstanceNetworkInterfacesCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c NetworkInterfacesClient) ListCloudServiceRoleInstanceNetworkInterfacesCompleteMatchingPredicate(ctx context.Context, id RoleInstanceId, predicate NetworkInterfaceOperationPredicate) (result ListCloudServiceRoleInstanceNetworkInterfacesCompleteResult, err error) {
+	items := make([]NetworkInterface, 0)
+
+	resp, err := c.ListCloudServiceRoleInstanceNetworkInterfaces(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ListCloudServiceRoleInstanceNetworkInterfacesCompleteResult{
+		Items: items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/method_listeffectivenetworksecuritygroups.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/method_listeffectivenetworksecuritygroups.go
@@ -1,0 +1,71 @@
+package networkinterfaces
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListEffectiveNetworkSecurityGroupsOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// ListEffectiveNetworkSecurityGroups ...
+func (c NetworkInterfacesClient) ListEffectiveNetworkSecurityGroups(ctx context.Context, id commonids.NetworkInterfaceId) (result ListEffectiveNetworkSecurityGroupsOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/effectiveNetworkSecurityGroups", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// ListEffectiveNetworkSecurityGroupsThenPoll performs ListEffectiveNetworkSecurityGroups then polls until it's completed
+func (c NetworkInterfacesClient) ListEffectiveNetworkSecurityGroupsThenPoll(ctx context.Context, id commonids.NetworkInterfaceId) error {
+	result, err := c.ListEffectiveNetworkSecurityGroups(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing ListEffectiveNetworkSecurityGroups: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after ListEffectiveNetworkSecurityGroups: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/method_listvirtualmachinescalesetipconfigurations.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/method_listvirtualmachinescalesetipconfigurations.go
@@ -1,0 +1,118 @@
+package networkinterfaces
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListVirtualMachineScaleSetIPConfigurationsOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]NetworkInterfaceIPConfiguration
+}
+
+type ListVirtualMachineScaleSetIPConfigurationsCompleteResult struct {
+	Items []NetworkInterfaceIPConfiguration
+}
+
+type ListVirtualMachineScaleSetIPConfigurationsOperationOptions struct {
+	Expand *string
+}
+
+func DefaultListVirtualMachineScaleSetIPConfigurationsOperationOptions() ListVirtualMachineScaleSetIPConfigurationsOperationOptions {
+	return ListVirtualMachineScaleSetIPConfigurationsOperationOptions{}
+}
+
+func (o ListVirtualMachineScaleSetIPConfigurationsOperationOptions) ToHeaders() *client.Headers {
+	out := client.Headers{}
+
+	return &out
+}
+
+func (o ListVirtualMachineScaleSetIPConfigurationsOperationOptions) ToOData() *odata.Query {
+	out := odata.Query{}
+	return &out
+}
+
+func (o ListVirtualMachineScaleSetIPConfigurationsOperationOptions) ToQuery() *client.QueryParams {
+	out := client.QueryParams{}
+	if o.Expand != nil {
+		out.Append("$expand", fmt.Sprintf("%v", *o.Expand))
+	}
+	return &out
+}
+
+// ListVirtualMachineScaleSetIPConfigurations ...
+func (c NetworkInterfacesClient) ListVirtualMachineScaleSetIPConfigurations(ctx context.Context, id commonids.VirtualMachineScaleSetNetworkInterfaceId, options ListVirtualMachineScaleSetIPConfigurationsOperationOptions) (result ListVirtualMachineScaleSetIPConfigurationsOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodGet,
+		Path:          fmt.Sprintf("%s/ipConfigurations", id.ID()),
+		OptionsObject: options,
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]NetworkInterfaceIPConfiguration `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ListVirtualMachineScaleSetIPConfigurationsComplete retrieves all the results into a single object
+func (c NetworkInterfacesClient) ListVirtualMachineScaleSetIPConfigurationsComplete(ctx context.Context, id commonids.VirtualMachineScaleSetNetworkInterfaceId, options ListVirtualMachineScaleSetIPConfigurationsOperationOptions) (ListVirtualMachineScaleSetIPConfigurationsCompleteResult, error) {
+	return c.ListVirtualMachineScaleSetIPConfigurationsCompleteMatchingPredicate(ctx, id, options, NetworkInterfaceIPConfigurationOperationPredicate{})
+}
+
+// ListVirtualMachineScaleSetIPConfigurationsCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c NetworkInterfacesClient) ListVirtualMachineScaleSetIPConfigurationsCompleteMatchingPredicate(ctx context.Context, id commonids.VirtualMachineScaleSetNetworkInterfaceId, options ListVirtualMachineScaleSetIPConfigurationsOperationOptions, predicate NetworkInterfaceIPConfigurationOperationPredicate) (result ListVirtualMachineScaleSetIPConfigurationsCompleteResult, err error) {
+	items := make([]NetworkInterfaceIPConfiguration, 0)
+
+	resp, err := c.ListVirtualMachineScaleSetIPConfigurations(ctx, id, options)
+	if err != nil {
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ListVirtualMachineScaleSetIPConfigurationsCompleteResult{
+		Items: items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/method_listvirtualmachinescalesetnetworkinterfaces.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/method_listvirtualmachinescalesetnetworkinterfaces.go
@@ -1,0 +1,89 @@
+package networkinterfaces
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListVirtualMachineScaleSetNetworkInterfacesOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]NetworkInterface
+}
+
+type ListVirtualMachineScaleSetNetworkInterfacesCompleteResult struct {
+	Items []NetworkInterface
+}
+
+// ListVirtualMachineScaleSetNetworkInterfaces ...
+func (c NetworkInterfacesClient) ListVirtualMachineScaleSetNetworkInterfaces(ctx context.Context, id VirtualMachineScaleSetId) (result ListVirtualMachineScaleSetNetworkInterfacesOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       fmt.Sprintf("%s/networkInterfaces", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]NetworkInterface `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ListVirtualMachineScaleSetNetworkInterfacesComplete retrieves all the results into a single object
+func (c NetworkInterfacesClient) ListVirtualMachineScaleSetNetworkInterfacesComplete(ctx context.Context, id VirtualMachineScaleSetId) (ListVirtualMachineScaleSetNetworkInterfacesCompleteResult, error) {
+	return c.ListVirtualMachineScaleSetNetworkInterfacesCompleteMatchingPredicate(ctx, id, NetworkInterfaceOperationPredicate{})
+}
+
+// ListVirtualMachineScaleSetNetworkInterfacesCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c NetworkInterfacesClient) ListVirtualMachineScaleSetNetworkInterfacesCompleteMatchingPredicate(ctx context.Context, id VirtualMachineScaleSetId, predicate NetworkInterfaceOperationPredicate) (result ListVirtualMachineScaleSetNetworkInterfacesCompleteResult, err error) {
+	items := make([]NetworkInterface, 0)
+
+	resp, err := c.ListVirtualMachineScaleSetNetworkInterfaces(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ListVirtualMachineScaleSetNetworkInterfacesCompleteResult{
+		Items: items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/method_listvirtualmachinescalesetvmnetworkinterfaces.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/method_listvirtualmachinescalesetvmnetworkinterfaces.go
@@ -1,0 +1,89 @@
+package networkinterfaces
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListVirtualMachineScaleSetVMNetworkInterfacesOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]NetworkInterface
+}
+
+type ListVirtualMachineScaleSetVMNetworkInterfacesCompleteResult struct {
+	Items []NetworkInterface
+}
+
+// ListVirtualMachineScaleSetVMNetworkInterfaces ...
+func (c NetworkInterfacesClient) ListVirtualMachineScaleSetVMNetworkInterfaces(ctx context.Context, id VirtualMachineId) (result ListVirtualMachineScaleSetVMNetworkInterfacesOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       fmt.Sprintf("%s/networkInterfaces", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]NetworkInterface `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// ListVirtualMachineScaleSetVMNetworkInterfacesComplete retrieves all the results into a single object
+func (c NetworkInterfacesClient) ListVirtualMachineScaleSetVMNetworkInterfacesComplete(ctx context.Context, id VirtualMachineId) (ListVirtualMachineScaleSetVMNetworkInterfacesCompleteResult, error) {
+	return c.ListVirtualMachineScaleSetVMNetworkInterfacesCompleteMatchingPredicate(ctx, id, NetworkInterfaceOperationPredicate{})
+}
+
+// ListVirtualMachineScaleSetVMNetworkInterfacesCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c NetworkInterfacesClient) ListVirtualMachineScaleSetVMNetworkInterfacesCompleteMatchingPredicate(ctx context.Context, id VirtualMachineId, predicate NetworkInterfaceOperationPredicate) (result ListVirtualMachineScaleSetVMNetworkInterfacesCompleteResult, err error) {
+	items := make([]NetworkInterface, 0)
+
+	resp, err := c.ListVirtualMachineScaleSetVMNetworkInterfaces(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = ListVirtualMachineScaleSetVMNetworkInterfacesCompleteResult{
+		Items: items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/method_networkinterfaceipconfigurationsget.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/method_networkinterfaceipconfigurationsget.go
@@ -1,0 +1,52 @@
+package networkinterfaces
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type NetworkInterfaceIPConfigurationsGetOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *NetworkInterfaceIPConfiguration
+}
+
+// NetworkInterfaceIPConfigurationsGet ...
+func (c NetworkInterfacesClient) NetworkInterfaceIPConfigurationsGet(ctx context.Context, id commonids.NetworkInterfaceIPConfigurationId) (result NetworkInterfaceIPConfigurationsGetOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	if err = resp.Unmarshal(&result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/method_networkinterfaceipconfigurationslist.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/method_networkinterfaceipconfigurationslist.go
@@ -1,0 +1,90 @@
+package networkinterfaces
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type NetworkInterfaceIPConfigurationsListOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]NetworkInterfaceIPConfiguration
+}
+
+type NetworkInterfaceIPConfigurationsListCompleteResult struct {
+	Items []NetworkInterfaceIPConfiguration
+}
+
+// NetworkInterfaceIPConfigurationsList ...
+func (c NetworkInterfacesClient) NetworkInterfaceIPConfigurationsList(ctx context.Context, id commonids.NetworkInterfaceId) (result NetworkInterfaceIPConfigurationsListOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       fmt.Sprintf("%s/ipConfigurations", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]NetworkInterfaceIPConfiguration `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// NetworkInterfaceIPConfigurationsListComplete retrieves all the results into a single object
+func (c NetworkInterfacesClient) NetworkInterfaceIPConfigurationsListComplete(ctx context.Context, id commonids.NetworkInterfaceId) (NetworkInterfaceIPConfigurationsListCompleteResult, error) {
+	return c.NetworkInterfaceIPConfigurationsListCompleteMatchingPredicate(ctx, id, NetworkInterfaceIPConfigurationOperationPredicate{})
+}
+
+// NetworkInterfaceIPConfigurationsListCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c NetworkInterfacesClient) NetworkInterfaceIPConfigurationsListCompleteMatchingPredicate(ctx context.Context, id commonids.NetworkInterfaceId, predicate NetworkInterfaceIPConfigurationOperationPredicate) (result NetworkInterfaceIPConfigurationsListCompleteResult, err error) {
+	items := make([]NetworkInterfaceIPConfiguration, 0)
+
+	resp, err := c.NetworkInterfaceIPConfigurationsList(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = NetworkInterfaceIPConfigurationsListCompleteResult{
+		Items: items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/method_networkinterfaceloadbalancerslist.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/method_networkinterfaceloadbalancerslist.go
@@ -1,0 +1,90 @@
+package networkinterfaces
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type NetworkInterfaceLoadBalancersListOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]LoadBalancer
+}
+
+type NetworkInterfaceLoadBalancersListCompleteResult struct {
+	Items []LoadBalancer
+}
+
+// NetworkInterfaceLoadBalancersList ...
+func (c NetworkInterfacesClient) NetworkInterfaceLoadBalancersList(ctx context.Context, id commonids.NetworkInterfaceId) (result NetworkInterfaceLoadBalancersListOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       fmt.Sprintf("%s/loadBalancers", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]LoadBalancer `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// NetworkInterfaceLoadBalancersListComplete retrieves all the results into a single object
+func (c NetworkInterfacesClient) NetworkInterfaceLoadBalancersListComplete(ctx context.Context, id commonids.NetworkInterfaceId) (NetworkInterfaceLoadBalancersListCompleteResult, error) {
+	return c.NetworkInterfaceLoadBalancersListCompleteMatchingPredicate(ctx, id, LoadBalancerOperationPredicate{})
+}
+
+// NetworkInterfaceLoadBalancersListCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c NetworkInterfacesClient) NetworkInterfaceLoadBalancersListCompleteMatchingPredicate(ctx context.Context, id commonids.NetworkInterfaceId, predicate LoadBalancerOperationPredicate) (result NetworkInterfaceLoadBalancersListCompleteResult, err error) {
+	items := make([]LoadBalancer, 0)
+
+	resp, err := c.NetworkInterfaceLoadBalancersList(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = NetworkInterfaceLoadBalancersListCompleteResult{
+		Items: items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/method_networkinterfacetapconfigurationsget.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/method_networkinterfacetapconfigurationsget.go
@@ -1,0 +1,51 @@
+package networkinterfaces
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type NetworkInterfaceTapConfigurationsGetOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *NetworkInterfaceTapConfiguration
+}
+
+// NetworkInterfaceTapConfigurationsGet ...
+func (c NetworkInterfacesClient) NetworkInterfaceTapConfigurationsGet(ctx context.Context, id TapConfigurationId) (result NetworkInterfaceTapConfigurationsGetOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	if err = resp.Unmarshal(&result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/method_networkinterfacetapconfigurationslist.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/method_networkinterfacetapconfigurationslist.go
@@ -1,0 +1,90 @@
+package networkinterfaces
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type NetworkInterfaceTapConfigurationsListOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]NetworkInterfaceTapConfiguration
+}
+
+type NetworkInterfaceTapConfigurationsListCompleteResult struct {
+	Items []NetworkInterfaceTapConfiguration
+}
+
+// NetworkInterfaceTapConfigurationsList ...
+func (c NetworkInterfacesClient) NetworkInterfaceTapConfigurationsList(ctx context.Context, id commonids.NetworkInterfaceId) (result NetworkInterfaceTapConfigurationsListOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       fmt.Sprintf("%s/tapConfigurations", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]NetworkInterfaceTapConfiguration `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// NetworkInterfaceTapConfigurationsListComplete retrieves all the results into a single object
+func (c NetworkInterfacesClient) NetworkInterfaceTapConfigurationsListComplete(ctx context.Context, id commonids.NetworkInterfaceId) (NetworkInterfaceTapConfigurationsListCompleteResult, error) {
+	return c.NetworkInterfaceTapConfigurationsListCompleteMatchingPredicate(ctx, id, NetworkInterfaceTapConfigurationOperationPredicate{})
+}
+
+// NetworkInterfaceTapConfigurationsListCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c NetworkInterfacesClient) NetworkInterfaceTapConfigurationsListCompleteMatchingPredicate(ctx context.Context, id commonids.NetworkInterfaceId, predicate NetworkInterfaceTapConfigurationOperationPredicate) (result NetworkInterfaceTapConfigurationsListCompleteResult, err error) {
+	items := make([]NetworkInterfaceTapConfiguration, 0)
+
+	resp, err := c.NetworkInterfaceTapConfigurationsList(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = NetworkInterfaceTapConfigurationsListCompleteResult{
+		Items: items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/method_updatetags.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/method_updatetags.go
@@ -1,0 +1,56 @@
+package networkinterfaces
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UpdateTagsOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *NetworkInterface
+}
+
+// UpdateTags ...
+func (c NetworkInterfacesClient) UpdateTags(ctx context.Context, id commonids.NetworkInterfaceId, input TagsObject) (result UpdateTagsOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPatch,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	if err = resp.Unmarshal(&result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_applicationgatewaybackendaddress.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_applicationgatewaybackendaddress.go
@@ -1,0 +1,9 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ApplicationGatewayBackendAddress struct {
+	Fqdn      *string `json:"fqdn,omitempty"`
+	IPAddress *string `json:"ipAddress,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_applicationgatewaybackendaddresspool.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_applicationgatewaybackendaddresspool.go
@@ -1,0 +1,12 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ApplicationGatewayBackendAddressPool struct {
+	Etag       *string                                               `json:"etag,omitempty"`
+	Id         *string                                               `json:"id,omitempty"`
+	Name       *string                                               `json:"name,omitempty"`
+	Properties *ApplicationGatewayBackendAddressPoolPropertiesFormat `json:"properties,omitempty"`
+	Type       *string                                               `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_applicationgatewaybackendaddresspoolpropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_applicationgatewaybackendaddresspoolpropertiesformat.go
@@ -1,0 +1,10 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ApplicationGatewayBackendAddressPoolPropertiesFormat struct {
+	BackendAddresses        *[]ApplicationGatewayBackendAddress `json:"backendAddresses,omitempty"`
+	BackendIPConfigurations *[]NetworkInterfaceIPConfiguration  `json:"backendIPConfigurations,omitempty"`
+	ProvisioningState       *ProvisioningState                  `json:"provisioningState,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_applicationgatewayipconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_applicationgatewayipconfiguration.go
@@ -1,0 +1,12 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ApplicationGatewayIPConfiguration struct {
+	Etag       *string                                            `json:"etag,omitempty"`
+	Id         *string                                            `json:"id,omitempty"`
+	Name       *string                                            `json:"name,omitempty"`
+	Properties *ApplicationGatewayIPConfigurationPropertiesFormat `json:"properties,omitempty"`
+	Type       *string                                            `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_applicationgatewayipconfigurationpropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_applicationgatewayipconfigurationpropertiesformat.go
@@ -1,0 +1,9 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ApplicationGatewayIPConfigurationPropertiesFormat struct {
+	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty"`
+	Subnet            *SubResource       `json:"subnet,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_applicationsecuritygroup.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_applicationsecuritygroup.go
@@ -1,0 +1,14 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ApplicationSecurityGroup struct {
+	Etag       *string                                   `json:"etag,omitempty"`
+	Id         *string                                   `json:"id,omitempty"`
+	Location   *string                                   `json:"location,omitempty"`
+	Name       *string                                   `json:"name,omitempty"`
+	Properties *ApplicationSecurityGroupPropertiesFormat `json:"properties,omitempty"`
+	Tags       *map[string]string                        `json:"tags,omitempty"`
+	Type       *string                                   `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_applicationsecuritygrouppropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_applicationsecuritygrouppropertiesformat.go
@@ -1,0 +1,9 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ApplicationSecurityGroupPropertiesFormat struct {
+	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty"`
+	ResourceGuid      *string            `json:"resourceGuid,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_backendaddresspool.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_backendaddresspool.go
@@ -1,0 +1,12 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type BackendAddressPool struct {
+	Etag       *string                             `json:"etag,omitempty"`
+	Id         *string                             `json:"id,omitempty"`
+	Name       *string                             `json:"name,omitempty"`
+	Properties *BackendAddressPoolPropertiesFormat `json:"properties,omitempty"`
+	Type       *string                             `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_backendaddresspoolpropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_backendaddresspoolpropertiesformat.go
@@ -1,0 +1,18 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type BackendAddressPoolPropertiesFormat struct {
+	BackendIPConfigurations      *[]NetworkInterfaceIPConfiguration    `json:"backendIPConfigurations,omitempty"`
+	DrainPeriodInSeconds         *int64                                `json:"drainPeriodInSeconds,omitempty"`
+	InboundNatRules              *[]SubResource                        `json:"inboundNatRules,omitempty"`
+	LoadBalancerBackendAddresses *[]LoadBalancerBackendAddress         `json:"loadBalancerBackendAddresses,omitempty"`
+	LoadBalancingRules           *[]SubResource                        `json:"loadBalancingRules,omitempty"`
+	Location                     *string                               `json:"location,omitempty"`
+	OutboundRule                 *SubResource                          `json:"outboundRule,omitempty"`
+	OutboundRules                *[]SubResource                        `json:"outboundRules,omitempty"`
+	ProvisioningState            *ProvisioningState                    `json:"provisioningState,omitempty"`
+	TunnelInterfaces             *[]GatewayLoadBalancerTunnelInterface `json:"tunnelInterfaces,omitempty"`
+	VirtualNetwork               *SubResource                          `json:"virtualNetwork,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_customdnsconfigpropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_customdnsconfigpropertiesformat.go
@@ -1,0 +1,9 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type CustomDnsConfigPropertiesFormat struct {
+	Fqdn        *string   `json:"fqdn,omitempty"`
+	IPAddresses *[]string `json:"ipAddresses,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_ddossettings.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_ddossettings.go
@@ -1,0 +1,9 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DdosSettings struct {
+	DdosProtectionPlan *SubResource                `json:"ddosProtectionPlan,omitempty"`
+	ProtectionMode     *DdosSettingsProtectionMode `json:"protectionMode,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_delegation.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_delegation.go
@@ -1,0 +1,12 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type Delegation struct {
+	Etag       *string                            `json:"etag,omitempty"`
+	Id         *string                            `json:"id,omitempty"`
+	Name       *string                            `json:"name,omitempty"`
+	Properties *ServiceDelegationPropertiesFormat `json:"properties,omitempty"`
+	Type       *string                            `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_effectivenetworksecuritygroup.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_effectivenetworksecuritygroup.go
@@ -1,0 +1,11 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type EffectiveNetworkSecurityGroup struct {
+	Association            *EffectiveNetworkSecurityGroupAssociation `json:"association,omitempty"`
+	EffectiveSecurityRules *[]EffectiveNetworkSecurityRule           `json:"effectiveSecurityRules,omitempty"`
+	NetworkSecurityGroup   *SubResource                              `json:"networkSecurityGroup,omitempty"`
+	TagMap                 *map[string][]string                      `json:"tagMap,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_effectivenetworksecuritygroupassociation.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_effectivenetworksecuritygroupassociation.go
@@ -1,0 +1,10 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type EffectiveNetworkSecurityGroupAssociation struct {
+	NetworkInterface *SubResource `json:"networkInterface,omitempty"`
+	NetworkManager   *SubResource `json:"networkManager,omitempty"`
+	Subnet           *SubResource `json:"subnet,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_effectivenetworksecuritygrouplistresult.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_effectivenetworksecuritygrouplistresult.go
@@ -1,0 +1,9 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type EffectiveNetworkSecurityGroupListResult struct {
+	NextLink *string                          `json:"nextLink,omitempty"`
+	Value    *[]EffectiveNetworkSecurityGroup `json:"value,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_effectivenetworksecurityrule.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_effectivenetworksecurityrule.go
@@ -1,0 +1,22 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type EffectiveNetworkSecurityRule struct {
+	Access                           *SecurityRuleAccess            `json:"access,omitempty"`
+	DestinationAddressPrefix         *string                        `json:"destinationAddressPrefix,omitempty"`
+	DestinationAddressPrefixes       *[]string                      `json:"destinationAddressPrefixes,omitempty"`
+	DestinationPortRange             *string                        `json:"destinationPortRange,omitempty"`
+	DestinationPortRanges            *[]string                      `json:"destinationPortRanges,omitempty"`
+	Direction                        *SecurityRuleDirection         `json:"direction,omitempty"`
+	ExpandedDestinationAddressPrefix *[]string                      `json:"expandedDestinationAddressPrefix,omitempty"`
+	ExpandedSourceAddressPrefix      *[]string                      `json:"expandedSourceAddressPrefix,omitempty"`
+	Name                             *string                        `json:"name,omitempty"`
+	Priority                         *int64                         `json:"priority,omitempty"`
+	Protocol                         *EffectiveSecurityRuleProtocol `json:"protocol,omitempty"`
+	SourceAddressPrefix              *string                        `json:"sourceAddressPrefix,omitempty"`
+	SourceAddressPrefixes            *[]string                      `json:"sourceAddressPrefixes,omitempty"`
+	SourcePortRange                  *string                        `json:"sourcePortRange,omitempty"`
+	SourcePortRanges                 *[]string                      `json:"sourcePortRanges,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_effectiveroute.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_effectiveroute.go
@@ -1,0 +1,14 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type EffectiveRoute struct {
+	AddressPrefix              *[]string             `json:"addressPrefix,omitempty"`
+	DisableBgpRoutePropagation *bool                 `json:"disableBgpRoutePropagation,omitempty"`
+	Name                       *string               `json:"name,omitempty"`
+	NextHopIPAddress           *[]string             `json:"nextHopIpAddress,omitempty"`
+	NextHopType                *RouteNextHopType     `json:"nextHopType,omitempty"`
+	Source                     *EffectiveRouteSource `json:"source,omitempty"`
+	State                      *EffectiveRouteState  `json:"state,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_effectiveroutelistresult.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_effectiveroutelistresult.go
@@ -1,0 +1,9 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type EffectiveRouteListResult struct {
+	NextLink *string           `json:"nextLink,omitempty"`
+	Value    *[]EffectiveRoute `json:"value,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_flowlog.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_flowlog.go
@@ -1,0 +1,14 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type FlowLog struct {
+	Etag       *string                  `json:"etag,omitempty"`
+	Id         *string                  `json:"id,omitempty"`
+	Location   *string                  `json:"location,omitempty"`
+	Name       *string                  `json:"name,omitempty"`
+	Properties *FlowLogPropertiesFormat `json:"properties,omitempty"`
+	Tags       *map[string]string       `json:"tags,omitempty"`
+	Type       *string                  `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_flowlogformatparameters.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_flowlogformatparameters.go
@@ -1,0 +1,9 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type FlowLogFormatParameters struct {
+	Type    *FlowLogFormatType `json:"type,omitempty"`
+	Version *int64             `json:"version,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_flowlogpropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_flowlogpropertiesformat.go
@@ -1,0 +1,15 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type FlowLogPropertiesFormat struct {
+	Enabled                    *bool                       `json:"enabled,omitempty"`
+	FlowAnalyticsConfiguration *TrafficAnalyticsProperties `json:"flowAnalyticsConfiguration,omitempty"`
+	Format                     *FlowLogFormatParameters    `json:"format,omitempty"`
+	ProvisioningState          *ProvisioningState          `json:"provisioningState,omitempty"`
+	RetentionPolicy            *RetentionPolicyParameters  `json:"retentionPolicy,omitempty"`
+	StorageId                  string                      `json:"storageId"`
+	TargetResourceGuid         *string                     `json:"targetResourceGuid,omitempty"`
+	TargetResourceId           string                      `json:"targetResourceId"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_frontendipconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_frontendipconfiguration.go
@@ -1,0 +1,17 @@
+package networkinterfaces
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/zones"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type FrontendIPConfiguration struct {
+	Etag       *string                                  `json:"etag,omitempty"`
+	Id         *string                                  `json:"id,omitempty"`
+	Name       *string                                  `json:"name,omitempty"`
+	Properties *FrontendIPConfigurationPropertiesFormat `json:"properties,omitempty"`
+	Type       *string                                  `json:"type,omitempty"`
+	Zones      *zones.Schema                            `json:"zones,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_frontendipconfigurationpropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_frontendipconfigurationpropertiesformat.go
@@ -1,0 +1,19 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type FrontendIPConfigurationPropertiesFormat struct {
+	GatewayLoadBalancer       *SubResource        `json:"gatewayLoadBalancer,omitempty"`
+	InboundNatPools           *[]SubResource      `json:"inboundNatPools,omitempty"`
+	InboundNatRules           *[]SubResource      `json:"inboundNatRules,omitempty"`
+	LoadBalancingRules        *[]SubResource      `json:"loadBalancingRules,omitempty"`
+	OutboundRules             *[]SubResource      `json:"outboundRules,omitempty"`
+	PrivateIPAddress          *string             `json:"privateIPAddress,omitempty"`
+	PrivateIPAddressVersion   *IPVersion          `json:"privateIPAddressVersion,omitempty"`
+	PrivateIPAllocationMethod *IPAllocationMethod `json:"privateIPAllocationMethod,omitempty"`
+	ProvisioningState         *ProvisioningState  `json:"provisioningState,omitempty"`
+	PublicIPAddress           *PublicIPAddress    `json:"publicIPAddress,omitempty"`
+	PublicIPPrefix            *SubResource        `json:"publicIPPrefix,omitempty"`
+	Subnet                    *Subnet             `json:"subnet,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_gatewayloadbalancertunnelinterface.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_gatewayloadbalancertunnelinterface.go
@@ -1,0 +1,11 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GatewayLoadBalancerTunnelInterface struct {
+	Identifier *int64                                  `json:"identifier,omitempty"`
+	Port       *int64                                  `json:"port,omitempty"`
+	Protocol   *GatewayLoadBalancerTunnelProtocol      `json:"protocol,omitempty"`
+	Type       *GatewayLoadBalancerTunnelInterfaceType `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_inboundnatpool.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_inboundnatpool.go
@@ -1,0 +1,12 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type InboundNatPool struct {
+	Etag       *string                         `json:"etag,omitempty"`
+	Id         *string                         `json:"id,omitempty"`
+	Name       *string                         `json:"name,omitempty"`
+	Properties *InboundNatPoolPropertiesFormat `json:"properties,omitempty"`
+	Type       *string                         `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_inboundnatpoolpropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_inboundnatpoolpropertiesformat.go
@@ -1,0 +1,16 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type InboundNatPoolPropertiesFormat struct {
+	BackendPort             int64              `json:"backendPort"`
+	EnableFloatingIP        *bool              `json:"enableFloatingIP,omitempty"`
+	EnableTcpReset          *bool              `json:"enableTcpReset,omitempty"`
+	FrontendIPConfiguration *SubResource       `json:"frontendIPConfiguration,omitempty"`
+	FrontendPortRangeEnd    int64              `json:"frontendPortRangeEnd"`
+	FrontendPortRangeStart  int64              `json:"frontendPortRangeStart"`
+	IdleTimeoutInMinutes    *int64             `json:"idleTimeoutInMinutes,omitempty"`
+	Protocol                TransportProtocol  `json:"protocol"`
+	ProvisioningState       *ProvisioningState `json:"provisioningState,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_inboundnatrule.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_inboundnatrule.go
@@ -1,0 +1,12 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type InboundNatRule struct {
+	Etag       *string                         `json:"etag,omitempty"`
+	Id         *string                         `json:"id,omitempty"`
+	Name       *string                         `json:"name,omitempty"`
+	Properties *InboundNatRulePropertiesFormat `json:"properties,omitempty"`
+	Type       *string                         `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_inboundnatrulepropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_inboundnatrulepropertiesformat.go
@@ -1,0 +1,19 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type InboundNatRulePropertiesFormat struct {
+	BackendAddressPool      *SubResource                     `json:"backendAddressPool,omitempty"`
+	BackendIPConfiguration  *NetworkInterfaceIPConfiguration `json:"backendIPConfiguration,omitempty"`
+	BackendPort             *int64                           `json:"backendPort,omitempty"`
+	EnableFloatingIP        *bool                            `json:"enableFloatingIP,omitempty"`
+	EnableTcpReset          *bool                            `json:"enableTcpReset,omitempty"`
+	FrontendIPConfiguration *SubResource                     `json:"frontendIPConfiguration,omitempty"`
+	FrontendPort            *int64                           `json:"frontendPort,omitempty"`
+	FrontendPortRangeEnd    *int64                           `json:"frontendPortRangeEnd,omitempty"`
+	FrontendPortRangeStart  *int64                           `json:"frontendPortRangeStart,omitempty"`
+	IdleTimeoutInMinutes    *int64                           `json:"idleTimeoutInMinutes,omitempty"`
+	Protocol                *TransportProtocol               `json:"protocol,omitempty"`
+	ProvisioningState       *ProvisioningState               `json:"provisioningState,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_ipconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_ipconfiguration.go
@@ -1,0 +1,11 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type IPConfiguration struct {
+	Etag       *string                          `json:"etag,omitempty"`
+	Id         *string                          `json:"id,omitempty"`
+	Name       *string                          `json:"name,omitempty"`
+	Properties *IPConfigurationPropertiesFormat `json:"properties,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_ipconfigurationprofile.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_ipconfigurationprofile.go
@@ -1,0 +1,12 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type IPConfigurationProfile struct {
+	Etag       *string                                 `json:"etag,omitempty"`
+	Id         *string                                 `json:"id,omitempty"`
+	Name       *string                                 `json:"name,omitempty"`
+	Properties *IPConfigurationProfilePropertiesFormat `json:"properties,omitempty"`
+	Type       *string                                 `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_ipconfigurationprofilepropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_ipconfigurationprofilepropertiesformat.go
@@ -1,0 +1,9 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type IPConfigurationProfilePropertiesFormat struct {
+	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty"`
+	Subnet            *Subnet            `json:"subnet,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_ipconfigurationpropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_ipconfigurationpropertiesformat.go
@@ -1,0 +1,12 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type IPConfigurationPropertiesFormat struct {
+	PrivateIPAddress          *string             `json:"privateIPAddress,omitempty"`
+	PrivateIPAllocationMethod *IPAllocationMethod `json:"privateIPAllocationMethod,omitempty"`
+	ProvisioningState         *ProvisioningState  `json:"provisioningState,omitempty"`
+	PublicIPAddress           *PublicIPAddress    `json:"publicIPAddress,omitempty"`
+	Subnet                    *Subnet             `json:"subnet,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_iptag.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_iptag.go
@@ -1,0 +1,9 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type IPTag struct {
+	IPTagType *string `json:"ipTagType,omitempty"`
+	Tag       *string `json:"tag,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_loadbalancer.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_loadbalancer.go
@@ -1,0 +1,20 @@
+package networkinterfaces
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/edgezones"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type LoadBalancer struct {
+	Etag             *string                       `json:"etag,omitempty"`
+	ExtendedLocation *edgezones.Model              `json:"extendedLocation,omitempty"`
+	Id               *string                       `json:"id,omitempty"`
+	Location         *string                       `json:"location,omitempty"`
+	Name             *string                       `json:"name,omitempty"`
+	Properties       *LoadBalancerPropertiesFormat `json:"properties,omitempty"`
+	Sku              *LoadBalancerSku              `json:"sku,omitempty"`
+	Tags             *map[string]string            `json:"tags,omitempty"`
+	Type             *string                       `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_loadbalancerbackendaddress.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_loadbalancerbackendaddress.go
@@ -1,0 +1,9 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type LoadBalancerBackendAddress struct {
+	Name       *string                                     `json:"name,omitempty"`
+	Properties *LoadBalancerBackendAddressPropertiesFormat `json:"properties,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_loadbalancerbackendaddresspropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_loadbalancerbackendaddresspropertiesformat.go
@@ -1,0 +1,14 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type LoadBalancerBackendAddressPropertiesFormat struct {
+	AdminState                          *LoadBalancerBackendAddressAdminState `json:"adminState,omitempty"`
+	IPAddress                           *string                               `json:"ipAddress,omitempty"`
+	InboundNatRulesPortMapping          *[]NatRulePortMapping                 `json:"inboundNatRulesPortMapping,omitempty"`
+	LoadBalancerFrontendIPConfiguration *SubResource                          `json:"loadBalancerFrontendIPConfiguration,omitempty"`
+	NetworkInterfaceIPConfiguration     *SubResource                          `json:"networkInterfaceIPConfiguration,omitempty"`
+	Subnet                              *SubResource                          `json:"subnet,omitempty"`
+	VirtualNetwork                      *SubResource                          `json:"virtualNetwork,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_loadbalancerpropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_loadbalancerpropertiesformat.go
@@ -1,0 +1,16 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type LoadBalancerPropertiesFormat struct {
+	BackendAddressPools      *[]BackendAddressPool      `json:"backendAddressPools,omitempty"`
+	FrontendIPConfigurations *[]FrontendIPConfiguration `json:"frontendIPConfigurations,omitempty"`
+	InboundNatPools          *[]InboundNatPool          `json:"inboundNatPools,omitempty"`
+	InboundNatRules          *[]InboundNatRule          `json:"inboundNatRules,omitempty"`
+	LoadBalancingRules       *[]LoadBalancingRule       `json:"loadBalancingRules,omitempty"`
+	OutboundRules            *[]OutboundRule            `json:"outboundRules,omitempty"`
+	Probes                   *[]Probe                   `json:"probes,omitempty"`
+	ProvisioningState        *ProvisioningState         `json:"provisioningState,omitempty"`
+	ResourceGuid             *string                    `json:"resourceGuid,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_loadbalancersku.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_loadbalancersku.go
@@ -1,0 +1,9 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type LoadBalancerSku struct {
+	Name *LoadBalancerSkuName `json:"name,omitempty"`
+	Tier *LoadBalancerSkuTier `json:"tier,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_loadbalancingrule.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_loadbalancingrule.go
@@ -1,0 +1,12 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type LoadBalancingRule struct {
+	Etag       *string                            `json:"etag,omitempty"`
+	Id         *string                            `json:"id,omitempty"`
+	Name       *string                            `json:"name,omitempty"`
+	Properties *LoadBalancingRulePropertiesFormat `json:"properties,omitempty"`
+	Type       *string                            `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_loadbalancingrulepropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_loadbalancingrulepropertiesformat.go
@@ -1,0 +1,20 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type LoadBalancingRulePropertiesFormat struct {
+	BackendAddressPool      *SubResource       `json:"backendAddressPool,omitempty"`
+	BackendAddressPools     *[]SubResource     `json:"backendAddressPools,omitempty"`
+	BackendPort             *int64             `json:"backendPort,omitempty"`
+	DisableOutboundSnat     *bool              `json:"disableOutboundSnat,omitempty"`
+	EnableFloatingIP        *bool              `json:"enableFloatingIP,omitempty"`
+	EnableTcpReset          *bool              `json:"enableTcpReset,omitempty"`
+	FrontendIPConfiguration *SubResource       `json:"frontendIPConfiguration,omitempty"`
+	FrontendPort            int64              `json:"frontendPort"`
+	IdleTimeoutInMinutes    *int64             `json:"idleTimeoutInMinutes,omitempty"`
+	LoadDistribution        *LoadDistribution  `json:"loadDistribution,omitempty"`
+	Probe                   *SubResource       `json:"probe,omitempty"`
+	Protocol                TransportProtocol  `json:"protocol"`
+	ProvisioningState       *ProvisioningState `json:"provisioningState,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_natgateway.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_natgateway.go
@@ -1,0 +1,20 @@
+package networkinterfaces
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/zones"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type NatGateway struct {
+	Etag       *string                     `json:"etag,omitempty"`
+	Id         *string                     `json:"id,omitempty"`
+	Location   *string                     `json:"location,omitempty"`
+	Name       *string                     `json:"name,omitempty"`
+	Properties *NatGatewayPropertiesFormat `json:"properties,omitempty"`
+	Sku        *NatGatewaySku              `json:"sku,omitempty"`
+	Tags       *map[string]string          `json:"tags,omitempty"`
+	Type       *string                     `json:"type,omitempty"`
+	Zones      *zones.Schema               `json:"zones,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_natgatewaypropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_natgatewaypropertiesformat.go
@@ -1,0 +1,13 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type NatGatewayPropertiesFormat struct {
+	IdleTimeoutInMinutes *int64             `json:"idleTimeoutInMinutes,omitempty"`
+	ProvisioningState    *ProvisioningState `json:"provisioningState,omitempty"`
+	PublicIPAddresses    *[]SubResource     `json:"publicIpAddresses,omitempty"`
+	PublicIPPrefixes     *[]SubResource     `json:"publicIpPrefixes,omitempty"`
+	ResourceGuid         *string            `json:"resourceGuid,omitempty"`
+	Subnets              *[]SubResource     `json:"subnets,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_natgatewaysku.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_natgatewaysku.go
@@ -1,0 +1,8 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type NatGatewaySku struct {
+	Name *NatGatewaySkuName `json:"name,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_natruleportmapping.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_natruleportmapping.go
@@ -1,0 +1,10 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type NatRulePortMapping struct {
+	BackendPort        *int64  `json:"backendPort,omitempty"`
+	FrontendPort       *int64  `json:"frontendPort,omitempty"`
+	InboundNatRuleName *string `json:"inboundNatRuleName,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_networkinterface.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_networkinterface.go
@@ -1,0 +1,19 @@
+package networkinterfaces
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/edgezones"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type NetworkInterface struct {
+	Etag             *string                           `json:"etag,omitempty"`
+	ExtendedLocation *edgezones.Model                  `json:"extendedLocation,omitempty"`
+	Id               *string                           `json:"id,omitempty"`
+	Location         *string                           `json:"location,omitempty"`
+	Name             *string                           `json:"name,omitempty"`
+	Properties       *NetworkInterfacePropertiesFormat `json:"properties,omitempty"`
+	Tags             *map[string]string                `json:"tags,omitempty"`
+	Type             *string                           `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_networkinterfacednssettings.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_networkinterfacednssettings.go
@@ -1,0 +1,12 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type NetworkInterfaceDnsSettings struct {
+	AppliedDnsServers        *[]string `json:"appliedDnsServers,omitempty"`
+	DnsServers               *[]string `json:"dnsServers,omitempty"`
+	InternalDnsNameLabel     *string   `json:"internalDnsNameLabel,omitempty"`
+	InternalDomainNameSuffix *string   `json:"internalDomainNameSuffix,omitempty"`
+	InternalFqdn             *string   `json:"internalFqdn,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_networkinterfaceipconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_networkinterfaceipconfiguration.go
@@ -1,0 +1,12 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type NetworkInterfaceIPConfiguration struct {
+	Etag       *string                                          `json:"etag,omitempty"`
+	Id         *string                                          `json:"id,omitempty"`
+	Name       *string                                          `json:"name,omitempty"`
+	Properties *NetworkInterfaceIPConfigurationPropertiesFormat `json:"properties,omitempty"`
+	Type       *string                                          `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_networkinterfaceipconfigurationprivatelinkconnectionproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_networkinterfaceipconfigurationprivatelinkconnectionproperties.go
@@ -1,0 +1,10 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type NetworkInterfaceIPConfigurationPrivateLinkConnectionProperties struct {
+	Fqdns              *[]string `json:"fqdns,omitempty"`
+	GroupId            *string   `json:"groupId,omitempty"`
+	RequiredMemberName *string   `json:"requiredMemberName,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_networkinterfaceipconfigurationpropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_networkinterfaceipconfigurationpropertiesformat.go
@@ -1,0 +1,21 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type NetworkInterfaceIPConfigurationPropertiesFormat struct {
+	ApplicationGatewayBackendAddressPools *[]ApplicationGatewayBackendAddressPool                         `json:"applicationGatewayBackendAddressPools,omitempty"`
+	ApplicationSecurityGroups             *[]ApplicationSecurityGroup                                     `json:"applicationSecurityGroups,omitempty"`
+	GatewayLoadBalancer                   *SubResource                                                    `json:"gatewayLoadBalancer,omitempty"`
+	LoadBalancerBackendAddressPools       *[]BackendAddressPool                                           `json:"loadBalancerBackendAddressPools,omitempty"`
+	LoadBalancerInboundNatRules           *[]InboundNatRule                                               `json:"loadBalancerInboundNatRules,omitempty"`
+	Primary                               *bool                                                           `json:"primary,omitempty"`
+	PrivateIPAddress                      *string                                                         `json:"privateIPAddress,omitempty"`
+	PrivateIPAddressVersion               *IPVersion                                                      `json:"privateIPAddressVersion,omitempty"`
+	PrivateIPAllocationMethod             *IPAllocationMethod                                             `json:"privateIPAllocationMethod,omitempty"`
+	PrivateLinkConnectionProperties       *NetworkInterfaceIPConfigurationPrivateLinkConnectionProperties `json:"privateLinkConnectionProperties,omitempty"`
+	ProvisioningState                     *ProvisioningState                                              `json:"provisioningState,omitempty"`
+	PublicIPAddress                       *PublicIPAddress                                                `json:"publicIPAddress,omitempty"`
+	Subnet                                *Subnet                                                         `json:"subnet,omitempty"`
+	VirtualNetworkTaps                    *[]VirtualNetworkTap                                            `json:"virtualNetworkTaps,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_networkinterfacepropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_networkinterfacepropertiesformat.go
@@ -1,0 +1,29 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type NetworkInterfacePropertiesFormat struct {
+	AuxiliaryMode               *NetworkInterfaceAuxiliaryMode      `json:"auxiliaryMode,omitempty"`
+	AuxiliarySku                *NetworkInterfaceAuxiliarySku       `json:"auxiliarySku,omitempty"`
+	DisableTcpStateTracking     *bool                               `json:"disableTcpStateTracking,omitempty"`
+	DnsSettings                 *NetworkInterfaceDnsSettings        `json:"dnsSettings,omitempty"`
+	DscpConfiguration           *SubResource                        `json:"dscpConfiguration,omitempty"`
+	EnableAcceleratedNetworking *bool                               `json:"enableAcceleratedNetworking,omitempty"`
+	EnableIPForwarding          *bool                               `json:"enableIPForwarding,omitempty"`
+	HostedWorkloads             *[]string                           `json:"hostedWorkloads,omitempty"`
+	IPConfigurations            *[]NetworkInterfaceIPConfiguration  `json:"ipConfigurations,omitempty"`
+	MacAddress                  *string                             `json:"macAddress,omitempty"`
+	MigrationPhase              *NetworkInterfaceMigrationPhase     `json:"migrationPhase,omitempty"`
+	NetworkSecurityGroup        *NetworkSecurityGroup               `json:"networkSecurityGroup,omitempty"`
+	NicType                     *NetworkInterfaceNicType            `json:"nicType,omitempty"`
+	Primary                     *bool                               `json:"primary,omitempty"`
+	PrivateEndpoint             *PrivateEndpoint                    `json:"privateEndpoint,omitempty"`
+	PrivateLinkService          *PrivateLinkService                 `json:"privateLinkService,omitempty"`
+	ProvisioningState           *ProvisioningState                  `json:"provisioningState,omitempty"`
+	ResourceGuid                *string                             `json:"resourceGuid,omitempty"`
+	TapConfigurations           *[]NetworkInterfaceTapConfiguration `json:"tapConfigurations,omitempty"`
+	VirtualMachine              *SubResource                        `json:"virtualMachine,omitempty"`
+	VnetEncryptionSupported     *bool                               `json:"vnetEncryptionSupported,omitempty"`
+	WorkloadType                *string                             `json:"workloadType,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_networkinterfacetapconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_networkinterfacetapconfiguration.go
@@ -1,0 +1,12 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type NetworkInterfaceTapConfiguration struct {
+	Etag       *string                                           `json:"etag,omitempty"`
+	Id         *string                                           `json:"id,omitempty"`
+	Name       *string                                           `json:"name,omitempty"`
+	Properties *NetworkInterfaceTapConfigurationPropertiesFormat `json:"properties,omitempty"`
+	Type       *string                                           `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_networkinterfacetapconfigurationpropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_networkinterfacetapconfigurationpropertiesformat.go
@@ -1,0 +1,9 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type NetworkInterfaceTapConfigurationPropertiesFormat struct {
+	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty"`
+	VirtualNetworkTap *VirtualNetworkTap `json:"virtualNetworkTap,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_networksecuritygroup.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_networksecuritygroup.go
@@ -1,0 +1,14 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type NetworkSecurityGroup struct {
+	Etag       *string                               `json:"etag,omitempty"`
+	Id         *string                               `json:"id,omitempty"`
+	Location   *string                               `json:"location,omitempty"`
+	Name       *string                               `json:"name,omitempty"`
+	Properties *NetworkSecurityGroupPropertiesFormat `json:"properties,omitempty"`
+	Tags       *map[string]string                    `json:"tags,omitempty"`
+	Type       *string                               `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_networksecuritygrouppropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_networksecuritygrouppropertiesformat.go
@@ -1,0 +1,15 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type NetworkSecurityGroupPropertiesFormat struct {
+	DefaultSecurityRules *[]SecurityRule     `json:"defaultSecurityRules,omitempty"`
+	FlowLogs             *[]FlowLog          `json:"flowLogs,omitempty"`
+	FlushConnection      *bool               `json:"flushConnection,omitempty"`
+	NetworkInterfaces    *[]NetworkInterface `json:"networkInterfaces,omitempty"`
+	ProvisioningState    *ProvisioningState  `json:"provisioningState,omitempty"`
+	ResourceGuid         *string             `json:"resourceGuid,omitempty"`
+	SecurityRules        *[]SecurityRule     `json:"securityRules,omitempty"`
+	Subnets              *[]Subnet           `json:"subnets,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_outboundrule.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_outboundrule.go
@@ -1,0 +1,12 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type OutboundRule struct {
+	Etag       *string                       `json:"etag,omitempty"`
+	Id         *string                       `json:"id,omitempty"`
+	Name       *string                       `json:"name,omitempty"`
+	Properties *OutboundRulePropertiesFormat `json:"properties,omitempty"`
+	Type       *string                       `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_outboundrulepropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_outboundrulepropertiesformat.go
@@ -1,0 +1,14 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type OutboundRulePropertiesFormat struct {
+	AllocatedOutboundPorts   *int64                           `json:"allocatedOutboundPorts,omitempty"`
+	BackendAddressPool       SubResource                      `json:"backendAddressPool"`
+	EnableTcpReset           *bool                            `json:"enableTcpReset,omitempty"`
+	FrontendIPConfigurations []SubResource                    `json:"frontendIPConfigurations"`
+	IdleTimeoutInMinutes     *int64                           `json:"idleTimeoutInMinutes,omitempty"`
+	Protocol                 LoadBalancerOutboundRuleProtocol `json:"protocol"`
+	ProvisioningState        *ProvisioningState               `json:"provisioningState,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_privateendpoint.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_privateendpoint.go
@@ -1,0 +1,19 @@
+package networkinterfaces
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/edgezones"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateEndpoint struct {
+	Etag             *string                    `json:"etag,omitempty"`
+	ExtendedLocation *edgezones.Model           `json:"extendedLocation,omitempty"`
+	Id               *string                    `json:"id,omitempty"`
+	Location         *string                    `json:"location,omitempty"`
+	Name             *string                    `json:"name,omitempty"`
+	Properties       *PrivateEndpointProperties `json:"properties,omitempty"`
+	Tags             *map[string]string         `json:"tags,omitempty"`
+	Type             *string                    `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_privateendpointconnection.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_privateendpointconnection.go
@@ -1,0 +1,12 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateEndpointConnection struct {
+	Etag       *string                              `json:"etag,omitempty"`
+	Id         *string                              `json:"id,omitempty"`
+	Name       *string                              `json:"name,omitempty"`
+	Properties *PrivateEndpointConnectionProperties `json:"properties,omitempty"`
+	Type       *string                              `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_privateendpointconnectionproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_privateendpointconnectionproperties.go
@@ -1,0 +1,12 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateEndpointConnectionProperties struct {
+	LinkIdentifier                    *string                            `json:"linkIdentifier,omitempty"`
+	PrivateEndpoint                   *PrivateEndpoint                   `json:"privateEndpoint,omitempty"`
+	PrivateEndpointLocation           *string                            `json:"privateEndpointLocation,omitempty"`
+	PrivateLinkServiceConnectionState *PrivateLinkServiceConnectionState `json:"privateLinkServiceConnectionState,omitempty"`
+	ProvisioningState                 *ProvisioningState                 `json:"provisioningState,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_privateendpointipconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_privateendpointipconfiguration.go
@@ -1,0 +1,11 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateEndpointIPConfiguration struct {
+	Etag       *string                                   `json:"etag,omitempty"`
+	Name       *string                                   `json:"name,omitempty"`
+	Properties *PrivateEndpointIPConfigurationProperties `json:"properties,omitempty"`
+	Type       *string                                   `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_privateendpointipconfigurationproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_privateendpointipconfigurationproperties.go
@@ -1,0 +1,10 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateEndpointIPConfigurationProperties struct {
+	GroupId          *string `json:"groupId,omitempty"`
+	MemberName       *string `json:"memberName,omitempty"`
+	PrivateIPAddress *string `json:"privateIPAddress,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_privateendpointproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_privateendpointproperties.go
@@ -1,0 +1,16 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateEndpointProperties struct {
+	ApplicationSecurityGroups           *[]ApplicationSecurityGroup        `json:"applicationSecurityGroups,omitempty"`
+	CustomDnsConfigs                    *[]CustomDnsConfigPropertiesFormat `json:"customDnsConfigs,omitempty"`
+	CustomNetworkInterfaceName          *string                            `json:"customNetworkInterfaceName,omitempty"`
+	IPConfigurations                    *[]PrivateEndpointIPConfiguration  `json:"ipConfigurations,omitempty"`
+	ManualPrivateLinkServiceConnections *[]PrivateLinkServiceConnection    `json:"manualPrivateLinkServiceConnections,omitempty"`
+	NetworkInterfaces                   *[]NetworkInterface                `json:"networkInterfaces,omitempty"`
+	PrivateLinkServiceConnections       *[]PrivateLinkServiceConnection    `json:"privateLinkServiceConnections,omitempty"`
+	ProvisioningState                   *ProvisioningState                 `json:"provisioningState,omitempty"`
+	Subnet                              *Subnet                            `json:"subnet,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_privatelinkservice.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_privatelinkservice.go
@@ -1,0 +1,19 @@
+package networkinterfaces
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/edgezones"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateLinkService struct {
+	Etag             *string                       `json:"etag,omitempty"`
+	ExtendedLocation *edgezones.Model              `json:"extendedLocation,omitempty"`
+	Id               *string                       `json:"id,omitempty"`
+	Location         *string                       `json:"location,omitempty"`
+	Name             *string                       `json:"name,omitempty"`
+	Properties       *PrivateLinkServiceProperties `json:"properties,omitempty"`
+	Tags             *map[string]string            `json:"tags,omitempty"`
+	Type             *string                       `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_privatelinkserviceconnection.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_privatelinkserviceconnection.go
@@ -1,0 +1,12 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateLinkServiceConnection struct {
+	Etag       *string                                 `json:"etag,omitempty"`
+	Id         *string                                 `json:"id,omitempty"`
+	Name       *string                                 `json:"name,omitempty"`
+	Properties *PrivateLinkServiceConnectionProperties `json:"properties,omitempty"`
+	Type       *string                                 `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_privatelinkserviceconnectionproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_privatelinkserviceconnectionproperties.go
@@ -1,0 +1,12 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateLinkServiceConnectionProperties struct {
+	GroupIds                          *[]string                          `json:"groupIds,omitempty"`
+	PrivateLinkServiceConnectionState *PrivateLinkServiceConnectionState `json:"privateLinkServiceConnectionState,omitempty"`
+	PrivateLinkServiceId              *string                            `json:"privateLinkServiceId,omitempty"`
+	ProvisioningState                 *ProvisioningState                 `json:"provisioningState,omitempty"`
+	RequestMessage                    *string                            `json:"requestMessage,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_privatelinkserviceconnectionstate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_privatelinkserviceconnectionstate.go
@@ -1,0 +1,10 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateLinkServiceConnectionState struct {
+	ActionsRequired *string `json:"actionsRequired,omitempty"`
+	Description     *string `json:"description,omitempty"`
+	Status          *string `json:"status,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_privatelinkserviceipconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_privatelinkserviceipconfiguration.go
@@ -1,0 +1,12 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateLinkServiceIPConfiguration struct {
+	Etag       *string                                      `json:"etag,omitempty"`
+	Id         *string                                      `json:"id,omitempty"`
+	Name       *string                                      `json:"name,omitempty"`
+	Properties *PrivateLinkServiceIPConfigurationProperties `json:"properties,omitempty"`
+	Type       *string                                      `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_privatelinkserviceipconfigurationproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_privatelinkserviceipconfigurationproperties.go
@@ -1,0 +1,13 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateLinkServiceIPConfigurationProperties struct {
+	Primary                   *bool               `json:"primary,omitempty"`
+	PrivateIPAddress          *string             `json:"privateIPAddress,omitempty"`
+	PrivateIPAddressVersion   *IPVersion          `json:"privateIPAddressVersion,omitempty"`
+	PrivateIPAllocationMethod *IPAllocationMethod `json:"privateIPAllocationMethod,omitempty"`
+	ProvisioningState         *ProvisioningState  `json:"provisioningState,omitempty"`
+	Subnet                    *Subnet             `json:"subnet,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_privatelinkserviceproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_privatelinkserviceproperties.go
@@ -1,0 +1,17 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateLinkServiceProperties struct {
+	Alias                                *string                              `json:"alias,omitempty"`
+	AutoApproval                         *ResourceSet                         `json:"autoApproval,omitempty"`
+	EnableProxyProtocol                  *bool                                `json:"enableProxyProtocol,omitempty"`
+	Fqdns                                *[]string                            `json:"fqdns,omitempty"`
+	IPConfigurations                     *[]PrivateLinkServiceIPConfiguration `json:"ipConfigurations,omitempty"`
+	LoadBalancerFrontendIPConfigurations *[]FrontendIPConfiguration           `json:"loadBalancerFrontendIpConfigurations,omitempty"`
+	NetworkInterfaces                    *[]NetworkInterface                  `json:"networkInterfaces,omitempty"`
+	PrivateEndpointConnections           *[]PrivateEndpointConnection         `json:"privateEndpointConnections,omitempty"`
+	ProvisioningState                    *ProvisioningState                   `json:"provisioningState,omitempty"`
+	Visibility                           *ResourceSet                         `json:"visibility,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_probe.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_probe.go
@@ -1,0 +1,12 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type Probe struct {
+	Etag       *string                `json:"etag,omitempty"`
+	Id         *string                `json:"id,omitempty"`
+	Name       *string                `json:"name,omitempty"`
+	Properties *ProbePropertiesFormat `json:"properties,omitempty"`
+	Type       *string                `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_probepropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_probepropertiesformat.go
@@ -1,0 +1,15 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ProbePropertiesFormat struct {
+	IntervalInSeconds  *int64             `json:"intervalInSeconds,omitempty"`
+	LoadBalancingRules *[]SubResource     `json:"loadBalancingRules,omitempty"`
+	NumberOfProbes     *int64             `json:"numberOfProbes,omitempty"`
+	Port               int64              `json:"port"`
+	ProbeThreshold     *int64             `json:"probeThreshold,omitempty"`
+	Protocol           ProbeProtocol      `json:"protocol"`
+	ProvisioningState  *ProvisioningState `json:"provisioningState,omitempty"`
+	RequestPath        *string            `json:"requestPath,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_publicipaddress.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_publicipaddress.go
@@ -1,0 +1,22 @@
+package networkinterfaces
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/edgezones"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/zones"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PublicIPAddress struct {
+	Etag             *string                          `json:"etag,omitempty"`
+	ExtendedLocation *edgezones.Model                 `json:"extendedLocation,omitempty"`
+	Id               *string                          `json:"id,omitempty"`
+	Location         *string                          `json:"location,omitempty"`
+	Name             *string                          `json:"name,omitempty"`
+	Properties       *PublicIPAddressPropertiesFormat `json:"properties,omitempty"`
+	Sku              *PublicIPAddressSku              `json:"sku,omitempty"`
+	Tags             *map[string]string               `json:"tags,omitempty"`
+	Type             *string                          `json:"type,omitempty"`
+	Zones            *zones.Schema                    `json:"zones,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_publicipaddressdnssettings.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_publicipaddressdnssettings.go
@@ -1,0 +1,11 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PublicIPAddressDnsSettings struct {
+	DomainNameLabel      *string                                         `json:"domainNameLabel,omitempty"`
+	DomainNameLabelScope *PublicIPAddressDnsSettingsDomainNameLabelScope `json:"domainNameLabelScope,omitempty"`
+	Fqdn                 *string                                         `json:"fqdn,omitempty"`
+	ReverseFqdn          *string                                         `json:"reverseFqdn,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_publicipaddresspropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_publicipaddresspropertiesformat.go
@@ -1,0 +1,23 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PublicIPAddressPropertiesFormat struct {
+	DdosSettings             *DdosSettings                  `json:"ddosSettings,omitempty"`
+	DeleteOption             *DeleteOptions                 `json:"deleteOption,omitempty"`
+	DnsSettings              *PublicIPAddressDnsSettings    `json:"dnsSettings,omitempty"`
+	IPAddress                *string                        `json:"ipAddress,omitempty"`
+	IPConfiguration          *IPConfiguration               `json:"ipConfiguration,omitempty"`
+	IPTags                   *[]IPTag                       `json:"ipTags,omitempty"`
+	IdleTimeoutInMinutes     *int64                         `json:"idleTimeoutInMinutes,omitempty"`
+	LinkedPublicIPAddress    *PublicIPAddress               `json:"linkedPublicIPAddress,omitempty"`
+	MigrationPhase           *PublicIPAddressMigrationPhase `json:"migrationPhase,omitempty"`
+	NatGateway               *NatGateway                    `json:"natGateway,omitempty"`
+	ProvisioningState        *ProvisioningState             `json:"provisioningState,omitempty"`
+	PublicIPAddressVersion   *IPVersion                     `json:"publicIPAddressVersion,omitempty"`
+	PublicIPAllocationMethod *IPAllocationMethod            `json:"publicIPAllocationMethod,omitempty"`
+	PublicIPPrefix           *SubResource                   `json:"publicIPPrefix,omitempty"`
+	ResourceGuid             *string                        `json:"resourceGuid,omitempty"`
+	ServicePublicIPAddress   *PublicIPAddress               `json:"servicePublicIPAddress,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_publicipaddresssku.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_publicipaddresssku.go
@@ -1,0 +1,9 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PublicIPAddressSku struct {
+	Name *PublicIPAddressSkuName `json:"name,omitempty"`
+	Tier *PublicIPAddressSkuTier `json:"tier,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_resourcenavigationlink.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_resourcenavigationlink.go
@@ -1,0 +1,12 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ResourceNavigationLink struct {
+	Etag       *string                       `json:"etag,omitempty"`
+	Id         *string                       `json:"id,omitempty"`
+	Name       *string                       `json:"name,omitempty"`
+	Properties *ResourceNavigationLinkFormat `json:"properties,omitempty"`
+	Type       *string                       `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_resourcenavigationlinkformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_resourcenavigationlinkformat.go
@@ -1,0 +1,10 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ResourceNavigationLinkFormat struct {
+	Link               *string            `json:"link,omitempty"`
+	LinkedResourceType *string            `json:"linkedResourceType,omitempty"`
+	ProvisioningState  *ProvisioningState `json:"provisioningState,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_resourceset.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_resourceset.go
@@ -1,0 +1,8 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ResourceSet struct {
+	Subscriptions *[]string `json:"subscriptions,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_retentionpolicyparameters.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_retentionpolicyparameters.go
@@ -1,0 +1,9 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RetentionPolicyParameters struct {
+	Days    *int64 `json:"days,omitempty"`
+	Enabled *bool  `json:"enabled,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_route.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_route.go
@@ -1,0 +1,12 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type Route struct {
+	Etag       *string                `json:"etag,omitempty"`
+	Id         *string                `json:"id,omitempty"`
+	Name       *string                `json:"name,omitempty"`
+	Properties *RoutePropertiesFormat `json:"properties,omitempty"`
+	Type       *string                `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_routepropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_routepropertiesformat.go
@@ -1,0 +1,12 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RoutePropertiesFormat struct {
+	AddressPrefix     *string            `json:"addressPrefix,omitempty"`
+	HasBgpOverride    *bool              `json:"hasBgpOverride,omitempty"`
+	NextHopIPAddress  *string            `json:"nextHopIpAddress,omitempty"`
+	NextHopType       RouteNextHopType   `json:"nextHopType"`
+	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_routetable.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_routetable.go
@@ -1,0 +1,14 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RouteTable struct {
+	Etag       *string                     `json:"etag,omitempty"`
+	Id         *string                     `json:"id,omitempty"`
+	Location   *string                     `json:"location,omitempty"`
+	Name       *string                     `json:"name,omitempty"`
+	Properties *RouteTablePropertiesFormat `json:"properties,omitempty"`
+	Tags       *map[string]string          `json:"tags,omitempty"`
+	Type       *string                     `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_routetablepropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_routetablepropertiesformat.go
@@ -1,0 +1,12 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RouteTablePropertiesFormat struct {
+	DisableBgpRoutePropagation *bool              `json:"disableBgpRoutePropagation,omitempty"`
+	ProvisioningState          *ProvisioningState `json:"provisioningState,omitempty"`
+	ResourceGuid               *string            `json:"resourceGuid,omitempty"`
+	Routes                     *[]Route           `json:"routes,omitempty"`
+	Subnets                    *[]Subnet          `json:"subnets,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_securityrule.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_securityrule.go
@@ -1,0 +1,12 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SecurityRule struct {
+	Etag       *string                       `json:"etag,omitempty"`
+	Id         *string                       `json:"id,omitempty"`
+	Name       *string                       `json:"name,omitempty"`
+	Properties *SecurityRulePropertiesFormat `json:"properties,omitempty"`
+	Type       *string                       `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_securityrulepropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_securityrulepropertiesformat.go
@@ -1,0 +1,23 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SecurityRulePropertiesFormat struct {
+	Access                               SecurityRuleAccess          `json:"access"`
+	Description                          *string                     `json:"description,omitempty"`
+	DestinationAddressPrefix             *string                     `json:"destinationAddressPrefix,omitempty"`
+	DestinationAddressPrefixes           *[]string                   `json:"destinationAddressPrefixes,omitempty"`
+	DestinationApplicationSecurityGroups *[]ApplicationSecurityGroup `json:"destinationApplicationSecurityGroups,omitempty"`
+	DestinationPortRange                 *string                     `json:"destinationPortRange,omitempty"`
+	DestinationPortRanges                *[]string                   `json:"destinationPortRanges,omitempty"`
+	Direction                            SecurityRuleDirection       `json:"direction"`
+	Priority                             int64                       `json:"priority"`
+	Protocol                             SecurityRuleProtocol        `json:"protocol"`
+	ProvisioningState                    *ProvisioningState          `json:"provisioningState,omitempty"`
+	SourceAddressPrefix                  *string                     `json:"sourceAddressPrefix,omitempty"`
+	SourceAddressPrefixes                *[]string                   `json:"sourceAddressPrefixes,omitempty"`
+	SourceApplicationSecurityGroups      *[]ApplicationSecurityGroup `json:"sourceApplicationSecurityGroups,omitempty"`
+	SourcePortRange                      *string                     `json:"sourcePortRange,omitempty"`
+	SourcePortRanges                     *[]string                   `json:"sourcePortRanges,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_serviceassociationlink.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_serviceassociationlink.go
@@ -1,0 +1,12 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ServiceAssociationLink struct {
+	Etag       *string                                 `json:"etag,omitempty"`
+	Id         *string                                 `json:"id,omitempty"`
+	Name       *string                                 `json:"name,omitempty"`
+	Properties *ServiceAssociationLinkPropertiesFormat `json:"properties,omitempty"`
+	Type       *string                                 `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_serviceassociationlinkpropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_serviceassociationlinkpropertiesformat.go
@@ -1,0 +1,12 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ServiceAssociationLinkPropertiesFormat struct {
+	AllowDelete        *bool              `json:"allowDelete,omitempty"`
+	Link               *string            `json:"link,omitempty"`
+	LinkedResourceType *string            `json:"linkedResourceType,omitempty"`
+	Locations          *[]string          `json:"locations,omitempty"`
+	ProvisioningState  *ProvisioningState `json:"provisioningState,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_servicedelegationpropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_servicedelegationpropertiesformat.go
@@ -1,0 +1,10 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ServiceDelegationPropertiesFormat struct {
+	Actions           *[]string          `json:"actions,omitempty"`
+	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty"`
+	ServiceName       *string            `json:"serviceName,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_serviceendpointpolicy.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_serviceendpointpolicy.go
@@ -1,0 +1,15 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ServiceEndpointPolicy struct {
+	Etag       *string                                `json:"etag,omitempty"`
+	Id         *string                                `json:"id,omitempty"`
+	Kind       *string                                `json:"kind,omitempty"`
+	Location   *string                                `json:"location,omitempty"`
+	Name       *string                                `json:"name,omitempty"`
+	Properties *ServiceEndpointPolicyPropertiesFormat `json:"properties,omitempty"`
+	Tags       *map[string]string                     `json:"tags,omitempty"`
+	Type       *string                                `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_serviceendpointpolicydefinition.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_serviceendpointpolicydefinition.go
@@ -1,0 +1,12 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ServiceEndpointPolicyDefinition struct {
+	Etag       *string                                          `json:"etag,omitempty"`
+	Id         *string                                          `json:"id,omitempty"`
+	Name       *string                                          `json:"name,omitempty"`
+	Properties *ServiceEndpointPolicyDefinitionPropertiesFormat `json:"properties,omitempty"`
+	Type       *string                                          `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_serviceendpointpolicydefinitionpropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_serviceendpointpolicydefinitionpropertiesformat.go
@@ -1,0 +1,11 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ServiceEndpointPolicyDefinitionPropertiesFormat struct {
+	Description       *string            `json:"description,omitempty"`
+	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty"`
+	Service           *string            `json:"service,omitempty"`
+	ServiceResources  *[]string          `json:"serviceResources,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_serviceendpointpolicypropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_serviceendpointpolicypropertiesformat.go
@@ -1,0 +1,13 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ServiceEndpointPolicyPropertiesFormat struct {
+	ContextualServiceEndpointPolicies *[]string                          `json:"contextualServiceEndpointPolicies,omitempty"`
+	ProvisioningState                 *ProvisioningState                 `json:"provisioningState,omitempty"`
+	ResourceGuid                      *string                            `json:"resourceGuid,omitempty"`
+	ServiceAlias                      *string                            `json:"serviceAlias,omitempty"`
+	ServiceEndpointPolicyDefinitions  *[]ServiceEndpointPolicyDefinition `json:"serviceEndpointPolicyDefinitions,omitempty"`
+	Subnets                           *[]Subnet                          `json:"subnets,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_serviceendpointpropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_serviceendpointpropertiesformat.go
@@ -1,0 +1,10 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ServiceEndpointPropertiesFormat struct {
+	Locations         *[]string          `json:"locations,omitempty"`
+	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty"`
+	Service           *string            `json:"service,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_subnet.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_subnet.go
@@ -1,0 +1,12 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type Subnet struct {
+	Etag       *string                 `json:"etag,omitempty"`
+	Id         *string                 `json:"id,omitempty"`
+	Name       *string                 `json:"name,omitempty"`
+	Properties *SubnetPropertiesFormat `json:"properties,omitempty"`
+	Type       *string                 `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_subnetpropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_subnetpropertiesformat.go
@@ -1,0 +1,26 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SubnetPropertiesFormat struct {
+	AddressPrefix                      *string                                          `json:"addressPrefix,omitempty"`
+	AddressPrefixes                    *[]string                                        `json:"addressPrefixes,omitempty"`
+	ApplicationGatewayIPConfigurations *[]ApplicationGatewayIPConfiguration             `json:"applicationGatewayIPConfigurations,omitempty"`
+	Delegations                        *[]Delegation                                    `json:"delegations,omitempty"`
+	IPAllocations                      *[]SubResource                                   `json:"ipAllocations,omitempty"`
+	IPConfigurationProfiles            *[]IPConfigurationProfile                        `json:"ipConfigurationProfiles,omitempty"`
+	IPConfigurations                   *[]IPConfiguration                               `json:"ipConfigurations,omitempty"`
+	NatGateway                         *SubResource                                     `json:"natGateway,omitempty"`
+	NetworkSecurityGroup               *NetworkSecurityGroup                            `json:"networkSecurityGroup,omitempty"`
+	PrivateEndpointNetworkPolicies     *VirtualNetworkPrivateEndpointNetworkPolicies    `json:"privateEndpointNetworkPolicies,omitempty"`
+	PrivateEndpoints                   *[]PrivateEndpoint                               `json:"privateEndpoints,omitempty"`
+	PrivateLinkServiceNetworkPolicies  *VirtualNetworkPrivateLinkServiceNetworkPolicies `json:"privateLinkServiceNetworkPolicies,omitempty"`
+	ProvisioningState                  *ProvisioningState                               `json:"provisioningState,omitempty"`
+	Purpose                            *string                                          `json:"purpose,omitempty"`
+	ResourceNavigationLinks            *[]ResourceNavigationLink                        `json:"resourceNavigationLinks,omitempty"`
+	RouteTable                         *RouteTable                                      `json:"routeTable,omitempty"`
+	ServiceAssociationLinks            *[]ServiceAssociationLink                        `json:"serviceAssociationLinks,omitempty"`
+	ServiceEndpointPolicies            *[]ServiceEndpointPolicy                         `json:"serviceEndpointPolicies,omitempty"`
+	ServiceEndpoints                   *[]ServiceEndpointPropertiesFormat               `json:"serviceEndpoints,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_subresource.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_subresource.go
@@ -1,0 +1,8 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SubResource struct {
+	Id *string `json:"id,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_tagsobject.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_tagsobject.go
@@ -1,0 +1,8 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type TagsObject struct {
+	Tags *map[string]string `json:"tags,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_trafficanalyticsconfigurationproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_trafficanalyticsconfigurationproperties.go
@@ -1,0 +1,12 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type TrafficAnalyticsConfigurationProperties struct {
+	Enabled                  *bool   `json:"enabled,omitempty"`
+	TrafficAnalyticsInterval *int64  `json:"trafficAnalyticsInterval,omitempty"`
+	WorkspaceId              *string `json:"workspaceId,omitempty"`
+	WorkspaceRegion          *string `json:"workspaceRegion,omitempty"`
+	WorkspaceResourceId      *string `json:"workspaceResourceId,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_trafficanalyticsproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_trafficanalyticsproperties.go
@@ -1,0 +1,8 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type TrafficAnalyticsProperties struct {
+	NetworkWatcherFlowAnalyticsConfiguration *TrafficAnalyticsConfigurationProperties `json:"networkWatcherFlowAnalyticsConfiguration,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_virtualnetworktap.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_virtualnetworktap.go
@@ -1,0 +1,14 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualNetworkTap struct {
+	Etag       *string                            `json:"etag,omitempty"`
+	Id         *string                            `json:"id,omitempty"`
+	Location   *string                            `json:"location,omitempty"`
+	Name       *string                            `json:"name,omitempty"`
+	Properties *VirtualNetworkTapPropertiesFormat `json:"properties,omitempty"`
+	Tags       *map[string]string                 `json:"tags,omitempty"`
+	Type       *string                            `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_virtualnetworktappropertiesformat.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/model_virtualnetworktappropertiesformat.go
@@ -1,0 +1,13 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type VirtualNetworkTapPropertiesFormat struct {
+	DestinationLoadBalancerFrontEndIPConfiguration *FrontendIPConfiguration            `json:"destinationLoadBalancerFrontEndIPConfiguration,omitempty"`
+	DestinationNetworkInterfaceIPConfiguration     *NetworkInterfaceIPConfiguration    `json:"destinationNetworkInterfaceIPConfiguration,omitempty"`
+	DestinationPort                                *int64                              `json:"destinationPort,omitempty"`
+	NetworkInterfaceTapConfigurations              *[]NetworkInterfaceTapConfiguration `json:"networkInterfaceTapConfigurations,omitempty"`
+	ProvisioningState                              *ProvisioningState                  `json:"provisioningState,omitempty"`
+	ResourceGuid                                   *string                             `json:"resourceGuid,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/predicates.go
@@ -1,0 +1,126 @@
+package networkinterfaces
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type LoadBalancerOperationPredicate struct {
+	Etag     *string
+	Id       *string
+	Location *string
+	Name     *string
+	Type     *string
+}
+
+func (p LoadBalancerOperationPredicate) Matches(input LoadBalancer) bool {
+
+	if p.Etag != nil && (input.Etag == nil && *p.Etag != *input.Etag) {
+		return false
+	}
+
+	if p.Id != nil && (input.Id == nil && *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Location != nil && (input.Location == nil && *p.Location != *input.Location) {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil && *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil && *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}
+
+type NetworkInterfaceOperationPredicate struct {
+	Etag     *string
+	Id       *string
+	Location *string
+	Name     *string
+	Type     *string
+}
+
+func (p NetworkInterfaceOperationPredicate) Matches(input NetworkInterface) bool {
+
+	if p.Etag != nil && (input.Etag == nil && *p.Etag != *input.Etag) {
+		return false
+	}
+
+	if p.Id != nil && (input.Id == nil && *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Location != nil && (input.Location == nil && *p.Location != *input.Location) {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil && *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil && *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}
+
+type NetworkInterfaceIPConfigurationOperationPredicate struct {
+	Etag *string
+	Id   *string
+	Name *string
+	Type *string
+}
+
+func (p NetworkInterfaceIPConfigurationOperationPredicate) Matches(input NetworkInterfaceIPConfiguration) bool {
+
+	if p.Etag != nil && (input.Etag == nil && *p.Etag != *input.Etag) {
+		return false
+	}
+
+	if p.Id != nil && (input.Id == nil && *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil && *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil && *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}
+
+type NetworkInterfaceTapConfigurationOperationPredicate struct {
+	Etag *string
+	Id   *string
+	Name *string
+	Type *string
+}
+
+func (p NetworkInterfaceTapConfigurationOperationPredicate) Matches(input NetworkInterfaceTapConfiguration) bool {
+
+	if p.Etag != nil && (input.Etag == nil && *p.Etag != *input.Etag) {
+		return false
+	}
+
+	if p.Id != nil && (input.Id == nil && *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil && *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil && *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces/version.go
@@ -1,0 +1,12 @@
+package networkinterfaces
+
+import "fmt"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2023-02-01"
+
+func userAgent() string {
+	return fmt.Sprintf("hashicorp/go-azure-sdk/networkinterfaces/%s", defaultApiVersion)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -515,6 +515,7 @@ github.com/hashicorp/go-azure-sdk/resource-manager/network/2022-09-01/scopeconne
 github.com/hashicorp/go-azure-sdk/resource-manager/network/2022-09-01/securityadminconfigurations
 github.com/hashicorp/go-azure-sdk/resource-manager/network/2022-09-01/securityrules
 github.com/hashicorp/go-azure-sdk/resource-manager/network/2022-09-01/staticmembers
+github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-02-01/networkinterfaces
 github.com/hashicorp/go-azure-sdk/resource-manager/networkfunction/2022-11-01/azuretrafficcollectors
 github.com/hashicorp/go-azure-sdk/resource-manager/newrelic/2022-07-01/monitors
 github.com/hashicorp/go-azure-sdk/resource-manager/nginx/2022-08-01


### PR DESCRIPTION
##  Description

Upgrade API version to support newly added properties: (new properties will be in another PR)
[auxiliaryMode](https://github.com/Azure/azure-rest-api-specs/blob/5758cc23b0022e403d876662d9799f02c9bba3e6/specification/network/resource-manager/Microsoft.Network/stable/2023-02-01/networkInterface.json#L1212)
[auxiliarySku](https://github.com/Azure/azure-rest-api-specs/blob/5758cc23b0022e403d876662d9799f02c9bba3e6/specification/network/resource-manager/Microsoft.Network/stable/2023-02-01/networkInterface.json#L1226)

## Test Result
![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/76987228/08393e08-1dd2-498e-bf8c-68982660050d)
![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/76987228/97e523e1-0d6c-4a8a-a117-395f9de05393)
![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/76987228/1739ee80-c807-4835-ae47-a16e9c2a41ef)

--- PASS: TestAccNetworkInterface_disappears (309.71s)
--- PASS: TestAccNetworkInterface_ipv6 (388.27s)
--- PASS: TestAccNetworkInterface_multipleIPConfigurations (440.64s)
--- PASS: TestAccNetworkInterface_internalDomainNameLabel (480.79s)
--- PASS: TestAccNetworkInterface_pointToGatewayLB (534.90s)
--- PASS: TestAccNetworkInterface_multipleIPConfigurationsSecondaryAsPrimary (542.93s)
--- PASS: TestAccNetworkInterface_enableAcceleratedNetworking (546.67s)
--- PASS: TestAccNetworkInterface_enableIPForwarding (551.44s)
--- PASS: TestAccNetworkInterface_basic (570.84s)
--- PASS: TestAccNetworkInterface_dnsServers (582.01s)
--- PASS: TestAccNetworkInterface_tags (521.22s)
--- PASS: TestAccNetworkInterface_updateMultipleParameters (456.69s)
--- PASS: TestAccNetworkInterface_requiresImport (355.55s)
--- PASS: TestAccNetworkInterface_static (343.84s)
--- PASS: TestAccNetworkInterface_update (463.97s)
--- PASS: TestAccNetworkInterface_publicIP (391.04s)

--- PASS: TestAccDataSourceArmNetworkInterface_basic (227.24s)

--- PASS: TestAccNetworkInterfaceApplicationSecurityGroupAssociation_deleted (264.22s)
--- PASS: TestAccNetworkInterfaceApplicationSecurityGroupAssociation_multipleIPConfigurations (311.62s)
--- PASS: TestAccNetworkInterfaceApplicationSecurityGroupAssociation_requiresImport (338.72s)
--- PASS: TestAccNetworkInterfaceApplicationSecurityGroupAssociation_basic (369.77s)
--- PASS: TestAccNetworkInterfaceApplicationSecurityGroupAssociation_updateNIC (382.26s)