### PR TITLE
"azurerm_sentinel_threat_intelligence_indicator": fix client init

### DIFF
--- a/internal/services/sentinel/client/client.go
+++ b/internal/services/sentinel/client/client.go
@@ -53,7 +53,7 @@ func NewClient(o *common.ClientOptions) *Client {
 	analyticsSettingsClient := securityinsight.NewSecurityMLAnalyticsSettingsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&analyticsSettingsClient.Client, o.ResourceManagerAuthorizer)
 
-	threatIntelligenceClient := securityinsight.NewThreatIntelligenceIndicatorClient(o.ResourceManagerEndpoint)
+	threatIntelligenceClient := securityinsight.NewThreatIntelligenceIndicatorClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&threatIntelligenceClient.Client, o.ResourceManagerAuthorizer)
 
 	metadataClient := metadata.NewMetadataClientWithBaseURI(o.ResourceManagerEndpoint)


### PR DESCRIPTION
the client was inited in a wrong way, and just fix it

test
---
```
❯ tftest sentinel TestAccSecurityInsightsIndicator                                   
=== RUN   TestAccSecurityInsightsIndicator_basicDomainName
=== PAUSE TestAccSecurityInsightsIndicator_basicDomainName
=== RUN   TestAccSecurityInsightsIndicator_basicFile
=== PAUSE TestAccSecurityInsightsIndicator_basicFile
=== RUN   TestAccSecurityInsightsIndicator_basicIpV4
=== PAUSE TestAccSecurityInsightsIndicator_basicIpV4
=== RUN   TestAccSecurityInsightsIndicator_basicIpV6
=== PAUSE TestAccSecurityInsightsIndicator_basicIpV6
=== RUN   TestAccSecurityInsightsIndicator_requiresImport
=== PAUSE TestAccSecurityInsightsIndicator_requiresImport
=== RUN   TestAccSecurityInsightsIndicator_complete
=== PAUSE TestAccSecurityInsightsIndicator_complete
=== RUN   TestAccSecurityInsightsIndicator_update
=== PAUSE TestAccSecurityInsightsIndicator_update
=== CONT  TestAccSecurityInsightsIndicator_basicDomainName
=== CONT  TestAccSecurityInsightsIndicator_requiresImport
=== CONT  TestAccSecurityInsightsIndicator_basicIpV4
=== CONT  TestAccSecurityInsightsIndicator_basicIpV6
=== CONT  TestAccSecurityInsightsIndicator_basicFile
=== CONT  TestAccSecurityInsightsIndicator_update
=== CONT  TestAccSecurityInsightsIndicator_complete
--- PASS: TestAccSecurityInsightsIndicator_basicFile (161.24s)
--- PASS: TestAccSecurityInsightsIndicator_basicIpV6 (210.71s)
--- PASS: TestAccSecurityInsightsIndicator_basicDomainName (227.33s)
--- PASS: TestAccSecurityInsightsIndicator_requiresImport (235.05s)
--- PASS: TestAccSecurityInsightsIndicator_complete (236.36s)
--- PASS: TestAccSecurityInsightsIndicator_basicIpV4 (245.99s)
--- PASS: TestAccSecurityInsightsIndicator_update (251.79s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/sentinel      251.867s
```