### PR TITLE
azurerm_cosmosdb_postgresql_cluster - fix RequiredWith option for two parameters

### DIFF
--- a/internal/services/cosmos/cosmosdb_postgresql_cluster_resource.go
+++ b/internal/services/cosmos/cosmosdb_postgresql_cluster_resource.go
@@ -268,7 +268,7 @@ func (r CosmosDbPostgreSQLClusterResource) Arguments() map[string]*pluginsdk.Sch
 			ForceNew:         true,
 			StateFunc:        location.StateFunc,
 			DiffSuppressFunc: location.DiffSuppressFunc,
-			RequiredWith:     []string{"source_resource_id", "point_in_time_in_utc"},
+			RequiredWith:     []string{"source_resource_id"},
 		},
 
 		"source_resource_id": {
@@ -276,7 +276,7 @@ func (r CosmosDbPostgreSQLClusterResource) Arguments() map[string]*pluginsdk.Sch
 			Optional:     true,
 			ForceNew:     true,
 			ValidateFunc: clusters.ValidateServerGroupsv2ID,
-			RequiredWith: []string{"source_location", "point_in_time_in_utc"},
+			RequiredWith: []string{"source_location"},
 		},
 
 		"sql_version": {


### PR DESCRIPTION
Customer tried to create a read replica cluster but failed due to Terraform requiring point_in_time_utc parameter together with source_resource_id and source_location parameters even though it's not required by design.

In this PR I updated the "RequiredWith" option of parameters and locally tested the code.   