### PR TITLE
`azurerm_logic_app_workflow `: fix crash when `access_control` is empty block

### DIFF
--- a/internal/services/logic/logic_app_workflow_resource.go
+++ b/internal/services/logic/logic_app_workflow_resource.go
@@ -797,7 +797,7 @@ func expandLogicAppWorkflowWorkflowParameters(input map[string]interface{}) (map
 }
 
 func expandLogicAppWorkflowAccessControl(input []interface{}) *workflows.FlowAccessControlConfiguration {
-	if len(input) == 0 {
+	if len(input) == 0 || input[0] == nil {
 		return nil
 	}
 	v := input[0].(map[string]interface{})
@@ -869,7 +869,7 @@ func expandLogicAppWorkflowIPAddressRanges(input []interface{}) *[]workflows.IPA
 }
 
 func expandLogicAppWorkflowOpenAuthenticationPolicy(input []interface{}) *map[string]workflows.OpenAuthenticationAccessPolicy {
-	if len(input) == 0 {
+	if len(input) == 0 || input[0] == nil {
 		return nil
 	}
 	results := make(map[string]workflows.OpenAuthenticationAccessPolicy)


### PR DESCRIPTION
fix #22474