### PR TITLE
`azurerm_api_management_api` Remove wsdl_selector check, because its not required in all cases.

### DIFF
--- a/internal/services/apimanagement/api_management_api_resource.go
+++ b/internal/services/apimanagement/api_management_api_resource.go
@@ -422,11 +422,6 @@ func resourceApiManagementApiCreateUpdate(d *pluginsdk.ResourceData, meta interf
 		}
 		wsdlSelectorVs := importV["wsdl_selector"].([]interface{})
 
-		// `wsdl_selector` is necessary under format `wsdl`
-		if len(wsdlSelectorVs) == 0 && contentFormat == string(apimanagement.ContentFormatWsdl) {
-			return fmt.Errorf("`wsdl_selector` is required when content format is `wsdl` in API Management API %q", id.Name)
-		}
-
 		if len(wsdlSelectorVs) > 0 {
 			wsdlSelectorV := wsdlSelectorVs[0].(map[string]interface{})
 			wSvcName := wsdlSelectorV["service_name"].(string)

--- a/internal/services/apimanagement/api_management_api_resource_test.go
+++ b/internal/services/apimanagement/api_management_api_resource_test.go
@@ -599,6 +599,27 @@ resource "azurerm_api_management_api" "test" {
   import {
     content_value  = file("testdata/api_management_api_wsdl.xml")
     content_format = "wsdl"
+  }
+}
+`, r.template(data, SkuNameConsumption), data.RandomInteger)
+}
+
+func (r ApiManagementApiResource) importWsdlWithSelector(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_api_management_api" "test" {
+  name                = "acctestapi-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  api_management_name = azurerm_api_management.test.name
+  display_name        = "api1"
+  path                = "api1"
+  protocols           = ["https"]
+  revision            = "1"
+
+  import {
+    content_value  = file("testdata/api_management_api_wsdl_multiple.xml")
+    content_format = "wsdl"
 
     wsdl_selector {
       service_name  = "Calculator"

--- a/internal/services/apimanagement/api_management_api_resource_test.go
+++ b/internal/services/apimanagement/api_management_api_resource_test.go
@@ -270,6 +270,29 @@ func TestAccApiManagementApi_importWsdl(t *testing.T) {
 	})
 }
 
+func TestAccApiManagementApi_importWsdlWithSelector(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_api", "test")
+	r := ApiManagementApiResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.importWsdlWithSelector(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		{
+			ResourceName:      data.ResourceName,
+			ImportState:       true,
+			ImportStateVerify: true,
+			ImportStateVerifyIgnore: []string{
+				// not returned from the API
+				"import",
+			},
+		},
+	})
+}
+
 func TestAccApiManagementApi_importUpdate(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_api", "test")
 	r := ApiManagementApiResource{}

--- a/internal/services/apimanagement/testdata/api_management_api_wsdl_multiple.xml
+++ b/internal/services/apimanagement/testdata/api_management_api_wsdl_multiple.xml
@@ -81,5 +81,20 @@
         <wsdl:port name="CalculatorHttpsSoap11Endpoint" binding="ns:CalculatorSoap11Binding">
             <soap:address location="https://acceptancetests.terraform.io/services/Calculator.CalculatorHttpsSoap11Endpoint/" />
         </wsdl:port>
+        <wsdl:port name="CalculatorHttpSoap11Endpoint" binding="ns:CalculatorSoap11Binding">
+            <soap:address location="http://acceptancetests.terraform.io/services/Calculator.CalculatorHttpSoap11Endpoint/" />
+        </wsdl:port>
+        <wsdl:port name="CalculatorHttpSoap12Endpoint" binding="ns:CalculatorSoap12Binding">
+            <soap12:address location="http://acceptancetests.terraform.io/services/Calculator.CalculatorHttpSoap12Endpoint/" />
+        </wsdl:port>
+        <wsdl:port name="CalculatorHttpsSoap12Endpoint" binding="ns:CalculatorSoap12Binding">
+            <soap12:address location="https://acceptancetests.terraform.io/services/Calculator.CalculatorHttpsSoap12Endpoint/" />
+        </wsdl:port>
+        <wsdl:port name="CalculatorHttpsEndpoint" binding="ns:CalculatorHttpBinding">
+            <http:address location="https://acceptancetests.terraform.io/services/Calculator.CalculatorHttpsEndpoint/" />
+        </wsdl:port>
+        <wsdl:port name="CalculatorHttpEndpoint" binding="ns:CalculatorHttpBinding">
+            <http:address location="http://acceptancetests.terraform.io/services/Calculator.CalculatorHttpEndpoint/" />
+        </wsdl:port>
     </wsdl:service>
 </wsdl:definitions>


### PR DESCRIPTION
This removes the `wsdl_selector` check. This selector is only required if the imported WSDL schema contains multiple services/endpoints.

Fixes #22489