### PR TITLE
Documenting required certificate type for key_vault_certificate - fixes #22461 (#1)

### DIFF
--- a/website/docs/r/key_vault_certificate.html.markdown
+++ b/website/docs/r/key_vault_certificate.html.markdown
@@ -251,6 +251,27 @@ The `certificate` block supports the following:
 * `contents` - (Required) The base64-encoded certificate contents.
 * `password` - (Optional) The password associated with the certificate.
 
+~> **NOTE:** A PEM certificate is already base64 encoded. To successfully import, the `contents` property should include a PEM encoded X509 certificate and a private_key in pkcs8 format. There should only be linux style `\n` line endings and the whole block should have the PEM begin/end blocks around the certificate data and the private key data.
+
+To convert a private key to pkcs8 format with openssl use:
+```shell
+openssl pkcs8 -topk8 -nocrypt -in private_key.pem > private_key_pk8.pem
+```
+
+The PEM content should look something like:
+```text
+-----BEGIN CERTIFICATE-----
+aGVsbG8KaGVsbG8KaGVsbG8KaGVsbG8KaGVsbG8KaGVsbG8KaGVsbG8KaGVsbG8K
+:
+aGVsbG8KaGVsbG8KaGVsbG8KaGVsbG8KaGVsbG8KaGVsbG8KaGVsbG8KaGVsbG8K
+-----END CERTIFICATE-----
+-----BEGIN PRIVATE KEY-----
+d29ybGQKd29ybGQKd29ybGQKd29ybGQKd29ybGQKd29ybGQKd29ybGQKd29ybGQK
+:
+d29ybGQKd29ybGQKd29ybGQKd29ybGQKd29ybGQKd29ybGQKd29ybGQKd29ybGQK
+-----END PRIVATE KEY-----
+```
+
 ---
 
 The `certificate_policy` block supports the following:


### PR DESCRIPTION
Proposed fix for https://github.com/hashicorp/terraform-provider-azurerm/issues/22461 based around https://www.frakkingsweet.com/importing-pem-certificates-into-azure-keyvault/

Updates key_vault_certificate.html.markdown to include a note about importing PEM certificated and private key with this resource.