### PR TITLE
`azurerm_container_app` - `min_replicas` and `max_replicas` now support a maximum value of `300`

### DIFF
--- a/internal/services/containerapps/helpers/container_apps.go
+++ b/internal/services/containerapps/helpers/container_apps.go
@@ -689,7 +689,7 @@ func ContainerTemplateSchema() *pluginsdk.Schema {
 					Type:         pluginsdk.TypeInt,
 					Optional:     true,
 					Computed:     true,
-					ValidateFunc: validation.IntBetween(0, 30),
+					ValidateFunc: validation.IntBetween(0, 300),
 					Description:  "The minimum number of replicas for this container.",
 				},
 
@@ -697,7 +697,7 @@ func ContainerTemplateSchema() *pluginsdk.Schema {
 					Type:         pluginsdk.TypeInt,
 					Optional:     true,
 					Default:      10,
-					ValidateFunc: validation.IntBetween(1, 30),
+					ValidateFunc: validation.IntBetween(1, 300),
 					Description:  "The maximum number of replicas for this container.",
 				},
 


### PR DESCRIPTION
Resolves #22417

This changes the replica limit to match documentation: https://learn.microsoft.com/en-us/azure/container-apps/quotas

In our organization we have a container app with 60-180 replicas, and after importing the resource terraform is unable to manage it.