### PR TITLE
Update required resource providers to remove `Microsoft.Kubernetes` and `Microsoft.KubernetesConfiguration`

### DIFF
--- a/internal/resourceproviders/required.go
+++ b/internal/resourceproviders/required.go
@@ -47,8 +47,6 @@ func Required() map[string]struct{} {
 		"Microsoft.HealthcareApis":          {},
 		"Microsoft.GuestConfiguration":      {},
 		"Microsoft.KeyVault":                {},
-		"Microsoft.Kubernetes":              {},
-		"Microsoft.KubernetesConfiguration": {},
 		"Microsoft.Kusto":                   {},
 		"microsoft.insights":                {},
 		"Microsoft.Logic":                   {},


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/22515

Reverts #22463 as it causes a breaking change.