### PR TITLE
`azurerm_function_app_function` - update function app function naming restrictions

### DIFF
--- a/internal/services/appservice/validate/function_app_function_name.go
+++ b/internal/services/appservice/validate/function_app_function_name.go
@@ -15,8 +15,8 @@ func FunctionAppFunctionName(input interface{}, key string) (warnings []string, 
 		return
 	}
 
-	if matched := regexp.MustCompile(`^[0-9a-zA-Z](([0-9a-zA-Z-]{0,126})[0-9a-zA-Z])?$`).Match([]byte(v)); !matched {
-		errors = append(errors, fmt.Errorf("%q must start with a letter, may only contain alphanumeric characters and dashes and up to 128 characters in length", key))
+	if matched := regexp.MustCompile(`^[0-9a-zA-Z](([-_0-9a-zA-Z-]{0,126})[-_0-9a-zA-Z])?$`).Match([]byte(v)); !matched {
+		errors = append(errors, fmt.Errorf("%q must start with a letter, may only contain alphanumeric characters, dashes, underscore and up to 128 characters in length", key))
 	}
 
 	return warnings, errors

--- a/internal/services/appservice/validate/function_app_function_name_test.go
+++ b/internal/services/appservice/validate/function_app_function_name_test.go
@@ -24,7 +24,7 @@ func TestFunctionAppFunctionName(t *testing.T) {
 		},
 		{
 			Input: "-notValid",
-			Valid: true,
+			Valid: false,
 		},
 		{
 			Input: "ThisIsALongAndValidNameThatWillWork",

--- a/internal/services/appservice/validate/function_app_function_name_test.go
+++ b/internal/services/appservice/validate/function_app_function_name_test.go
@@ -24,7 +24,7 @@ func TestFunctionAppFunctionName(t *testing.T) {
 		},
 		{
 			Input: "-notValid",
-			Valid: false,
+			Valid: true,
 		},
 		{
 			Input: "ThisIsALongAndValidNameThatWillWork",
@@ -36,7 +36,7 @@ func TestFunctionAppFunctionName(t *testing.T) {
 		},
 		{
 			Input: "EndsInWrongChar-",
-			Valid: false,
+			Valid: true,
 		},
 	}
 


### PR DESCRIPTION
fix https://github.com/hashicorp/terraform-provider-azurerm/issues/22294

Updating function app function name restriction to allow it accepts `-` and `_` as api does:
![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/92154856/aa124de9-4782-4b88-b326-78b0bb08ffd4)
![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/92154856/1a5fa592-d396-4a27-9ffe-2f9cb29adf46)
