### PR TITLE
`azurerm_cognitive_deployment` - Add support for `VersionUpgradeOption`

### DIFF
--- a/internal/services/cognitive/cognitive_deployment_resource.go
+++ b/internal/services/cognitive/cognitive_deployment_resource.go
@@ -19,11 +19,12 @@ import (
 )
 
 type cognitiveDeploymentModel struct {
-	Name               string                         `tfschema:"name"`
-	CognitiveAccountId string                         `tfschema:"cognitive_account_id"`
-	Model              []DeploymentModelModel         `tfschema:"model"`
-	RaiPolicyName      string                         `tfschema:"rai_policy_name"`
-	ScaleSettings      []DeploymentScaleSettingsModel `tfschema:"scale"`
+	Name                 string                         `tfschema:"name"`
+	CognitiveAccountId   string                         `tfschema:"cognitive_account_id"`
+	Model                []DeploymentModelModel         `tfschema:"model"`
+	RaiPolicyName        string                         `tfschema:"rai_policy_name"`
+	ScaleSettings        []DeploymentScaleSettingsModel `tfschema:"scale"`
+	VersionUpgradeOption string                         `tfschema:"version_upgrade_option"`
 }
 
 type DeploymentModelModel struct {
@@ -108,6 +109,18 @@ func (r CognitiveDeploymentResource) Arguments() map[string]*pluginsdk.Schema {
 			Optional:     true,
 			ForceNew:     true,
 			ValidateFunc: validation.StringIsNotEmpty,
+		},
+
+		"version_upgrade_option": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			ForceNew: true,
+			Default:  string(deployments.DeploymentModelVersionUpgradeOptionOnceNewDefaultVersionAvailable),
+			ValidateFunc: validation.StringInSlice([]string{
+				string(deployments.DeploymentModelVersionUpgradeOptionOnceCurrentVersionExpired),
+				string(deployments.DeploymentModelVersionUpgradeOptionOnceNewDefaultVersionAvailable),
+				string(deployments.DeploymentModelVersionUpgradeOptionNoAutoUpgrade),
+			}, false),
 		},
 	}
 	if !features.FourPointOh() {
@@ -244,6 +257,11 @@ func (r CognitiveDeploymentResource) Create() sdk.ResourceFunc {
 				properties.Properties.RaiPolicyName = &model.RaiPolicyName
 			}
 
+			if model.VersionUpgradeOption != "" {
+				option := deployments.DeploymentModelVersionUpgradeOption(model.VersionUpgradeOption)
+				properties.Properties.VersionUpgradeOption = &option
+			}
+
 			properties.Sku = expandDeploymentSkuModel(model.ScaleSettings)
 
 			if err := client.CreateOrUpdateThenPoll(ctx, id, *properties); err != nil {
@@ -292,6 +310,9 @@ func (r CognitiveDeploymentResource) Read() sdk.ResourceFunc {
 
 				if v := properties.RaiPolicyName; v != nil {
 					state.RaiPolicyName = *v
+				}
+				if v := properties.VersionUpgradeOption; v != nil {
+					state.VersionUpgradeOption = string(*v)
 				}
 				state.ScaleSettings = flattenDeploymentScaleSettingsModel(properties.ScaleSettings)
 			}

--- a/internal/services/cognitive/cognitive_deployment_resource_test.go
+++ b/internal/services/cognitive/cognitive_deployment_resource_test.go
@@ -109,7 +109,7 @@ resource "azurerm_cognitive_account" "test" {
   kind                = "%s"
   sku_name            = "S0"
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, kind)
+`, data.RandomInteger, data.Locations.Secondary, data.RandomInteger, kind)
 }
 
 func (r CognitiveDeploymentTestResource) basic(data acceptance.TestData) string {

--- a/internal/services/cognitive/cognitive_deployment_resource_test.go
+++ b/internal/services/cognitive/cognitive_deployment_resource_test.go
@@ -125,7 +125,7 @@ resource "azurerm_cognitive_deployment" "test" {
   model {
     format  = "OpenAI"
     name    = "text-embedding-ada-002"
-    version = "1"
+    version = "2"
   }
   scale {
     type = "Standard"
@@ -145,7 +145,7 @@ resource "azurerm_cognitive_deployment" "import" {
   model {
     format  = "OpenAI"
     name    = "text-embedding-ada-002"
-    version = "1"
+    version = "2"
   }
   scale {
     type = "Standard"
@@ -171,7 +171,8 @@ resource "azurerm_cognitive_deployment" "test" {
   scale {
     type = "Standard"
   }
-  rai_policy_name = "RAI policy"
+  rai_policy_name        = "RAI policy"
+  version_upgrade_option = "OnceNewDefaultVersionAvailable"
 }
 `, template, data.RandomInteger)
 }

--- a/website/docs/r/cognitive_deployment.html.markdown
+++ b/website/docs/r/cognitive_deployment.html.markdown
@@ -56,6 +56,8 @@ The following arguments are supported:
 
 * `rai_policy_name` - (Optional) The name of RAI policy. Changing this forces a new resource to be created.
 
+* `version_upgrade_option` - (Optional) Deployment model version upgrade option. Possible values are `OnceNewDefaultVersionAvailable`, `OnceCurrentVersionExpired`, and `NoAutoUpgrade`. Defaults to `OnceNewDefaultVersionAvailable`. Changing this forces a new resource to be created.
+
 ---
 
 A `model` block supports the following:


### PR DESCRIPTION
Add support for VersionUpgradeOption so the users can set the model's version they like. This pr should fix #22501 .