### PR TITLE
`tools`: add new tool to generate state migration code

### DIFF
--- a/internal/tools/generator-migration/README.md
+++ b/internal/tools/generator-migration/README.md
@@ -1,0 +1,19 @@
+## State Migration Generator
+
+This application generates the state migration for a resource, mainly to be used for [resource state migration](https://developer.hashicorp.com/terraform/plugin/sdkv2/resources/state-migration). The `UpgradeFunc` body is the only concern to migrate the schema version of a resource with this tool.
+
+## Example Usage
+
+```
+$ go run main.go <resource_type>
+```
+
+E.g.
+
+```
+$ go run main.go azurerm_resource_group
+```
+
+## Arguments
+
+* `resource_type`: The resource type to generate the schema. 

--- a/internal/tools/generator-migration/main.go
+++ b/internal/tools/generator-migration/main.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	_ "embed"
+	"fmt"
+	"go/format"
+	"log"
+	"os"
+	"strings"
+	"text/template"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/provider"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tools/generator-migration/snapshot"
+)
+
+var (
+	//go:embed migration.gotpl
+	tplStr string
+
+	migrationTpl = template.Must(template.New("migration").Parse(tplStr))
+)
+
+type Model struct {
+	TypeName     string
+	ResourceName string
+	FromVersion  int
+	ToVersion    int
+	Schema       string
+	MigratorType string
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		log.Fatalf("Usage: generator-migration <resource_type>")
+	}
+	resource := os.Args[1]
+	res, ok := provider.AzureProvider().ResourcesMap[resource]
+	if !ok {
+		log.Fatalf("unknown resource type: %s", resource)
+	}
+	model := buildModel(resource, res)
+	model.ResourceName = resource
+
+	var buf bytes.Buffer
+	if err := migrationTpl.Execute(&buf, &model); err != nil {
+		log.Fatalf("render code err: %v", err)
+	}
+	code, err := format.Source(buf.Bytes())
+	if err != nil {
+		log.Fatalf("format code err: %v\n\n%s", err, buf.String())
+	}
+	fmt.Printf("%s", string(code))
+}
+
+func buildModel(rt string, res *schema.Resource) Model {
+	var m Model
+	m.ResourceName = rt
+	m.FromVersion = res.SchemaVersion
+	m.ToVersion = res.SchemaVersion + 1
+
+	toUp := true
+	var buf []byte
+	for _, ch := range strings.TrimPrefix(rt, "azurerm") {
+		if ch == '_' {
+			toUp = true
+			continue
+		}
+		if toUp {
+			ch -= 'a' - 'A'
+		}
+		buf = append(buf, byte(ch))
+		toUp = false
+	}
+	m.TypeName = string(buf)
+	m.MigratorType = fmt.Sprintf("%sV%dToV%d", m.TypeName, m.FromVersion, m.ToVersion)
+
+	m.Schema = snapshot.GenSchemaSnapshot(res)
+	return m
+}

--- a/internal/tools/generator-migration/migration.gotpl
+++ b/internal/tools/generator-migration/migration.gotpl
@@ -1,0 +1,25 @@
+{{- /*gotype: github.com/hashicorp/terraform-provider-azurerm/internal/tools/generator-migration.Model*/ -}}
+
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+package migration
+
+import (
+    "context"
+
+    "github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+var _ pluginsdk.StateUpgrade = {{.MigratorType}}{}
+
+type {{.MigratorType}} struct{}
+
+func ({{.MigratorType}}) Schema() map[string]*pluginsdk.Schema {
+    return {{.Schema}}
+}
+
+func ({{.MigratorType}}) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+    return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+        return rawState, nil
+    }
+}

--- a/internal/tools/generator-migration/snapshot/schema_snapshot.go
+++ b/internal/tools/generator-migration/snapshot/schema_snapshot.go
@@ -80,9 +80,10 @@ func SchemaValue(sch *pluginsdk.Schema) Dict {
 		out[Id("Elem")] = Op("&").Qual(SchemaPath, "Resource").Values(ResourceValue(sch))
 	}
 
-	if sch.Set != nil {
-		out[Id("Set")] = Id("TODO")
-	}
+	// todo if need support `Set`?
+	// if sch.Set != nil {
+	// 	out[Id("Set")] = Id("TODO")
+	// }
 
 	return out
 }

--- a/internal/tools/generator-migration/snapshot/schema_snapshot.go
+++ b/internal/tools/generator-migration/snapshot/schema_snapshot.go
@@ -1,0 +1,88 @@
+package snapshot
+
+import (
+	"fmt"
+
+	. "github.com/dave/jennifer/jen"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+const SchemaPath = "github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+
+func GenSchemaSnapshot(res *pluginsdk.Resource) string {
+	m := SchemaMap(res.Schema)
+	return fmt.Sprintf("%#v", m)
+}
+
+func ResourceValue(res *pluginsdk.Resource) Dict {
+	return Dict{
+		Id("Schema"): SchemaMap(res.Schema),
+	}
+}
+
+func SchemaMap(m map[string]*pluginsdk.Schema) *Statement {
+	dict := Dict{}
+	for k, v := range m {
+		dict[Lit(k)] = Values(SchemaValue(v))
+	}
+	return Map(String()).Op("*").Qual(SchemaPath, "Schema").Values(dict)
+}
+
+func SchemaValue(sch *pluginsdk.Schema) Dict {
+	out := Dict{}
+
+	var t Code
+	switch sch.Type {
+	case pluginsdk.TypeBool:
+		t = Qual(SchemaPath, "TypeBool")
+	case pluginsdk.TypeInt:
+		t = Qual(SchemaPath, "TypeInt")
+	case pluginsdk.TypeFloat:
+		t = Qual(SchemaPath, "TypeFloat")
+	case pluginsdk.TypeString:
+		t = Qual(SchemaPath, "TypeString")
+	case pluginsdk.TypeList:
+		t = Qual(SchemaPath, "TypeList")
+	case pluginsdk.TypeMap:
+		t = Qual(SchemaPath, "TypeMap")
+	case pluginsdk.TypeSet:
+		t = Qual(SchemaPath, "TypeSet")
+	}
+	out[Id("Type")] = t
+
+	if sch.Required {
+		out[Id("Required")] = True()
+	}
+
+	if sch.Optional {
+		out[Id("Optional")] = True()
+	}
+
+	if sch.Computed {
+		out[Id("Computed")] = True()
+	}
+
+	if sch.ForceNew {
+		out[Id("ForceNew")] = True()
+	}
+
+	switch sch.ConfigMode {
+	case pluginsdk.SchemaConfigModeAttr:
+		out[Id("ConfigMode")] = Qual(SchemaPath, "SchemaConfigModeAttr")
+	case pluginsdk.SchemaConfigModeBlock:
+		out[Id("ConfigMode")] = Qual(SchemaPath, "SchemaConfigModeBlock")
+	}
+
+	switch sch := sch.Elem.(type) {
+	case *pluginsdk.Schema:
+		out[Id("Elem")] = Op("&").Qual(SchemaPath, "Schema").Values(SchemaValue(sch))
+	case *pluginsdk.Resource:
+		out[Id("Elem")] = Op("&").Qual(SchemaPath, "Resource").Values(ResourceValue(sch))
+	}
+
+	if sch.Set != nil {
+		out[Id("Set")] = Id("TODO")
+	}
+
+	return out
+}


### PR DESCRIPTION
this tool can read the schema version and generate the migration code automatically, the schema is based on the  [internal/tools/generator-schema-snapshot](https://github.com/hashicorp/terraform-provider-azurerm/tree/2e0ef13d1d8b5510cb77948d3ccd5ce8397f03fb/internal/tools/generator-schema-snapshot).

so we can finish the state migration only to fullfill the `UpgradeFunc` body.

Usage:
```
cd internal/tools/generator-migration
go run main.go azurerm_application_gateway >../../services/network/migration/application_gateway.go
```