### PR TITLE
`azurerm_app_service_connection`: ignore changes on `sticky_settings` to pass ACC tests

### DIFF
--- a/internal/services/serviceconnector/service_connector_app_service_resource_test.go
+++ b/internal/services/serviceconnector/service_connector_app_service_resource_test.go
@@ -152,6 +152,7 @@ resource "azurerm_linux_web_app" "test" {
     ignore_changes = [
       app_settings["AZURE_STORAGEBLOB_RESOURCEENDPOINT"],
       identity,
+      sticky_settings,
     ]
   }
 }
@@ -294,6 +295,7 @@ resource "azurerm_linux_web_app" "test" {
     ignore_changes = [
       app_settings["AZURE_STORAGEBLOB_RESOURCEENDPOINT"],
       identity,
+      sticky_settings,
     ]
   }
 }
@@ -397,6 +399,12 @@ resource "azurerm_subnet" "test1" {
       actions = ["Microsoft.Network/virtualNetworks/subnets/action"]
     }
   }
+
+  lifecycle {
+    ignore_changes = [
+      service_endpoints,
+    ]
+  }
 }
 
 resource "azurerm_linux_web_app" "test" {
@@ -407,6 +415,14 @@ resource "azurerm_linux_web_app" "test" {
   virtual_network_subnet_id = azurerm_subnet.test1.id
 
   site_config {}
+
+  lifecycle {
+    ignore_changes = [
+      app_settings,
+      identity,
+      sticky_settings,
+    ]
+  }
 }
 
 resource "azurerm_app_service_connection" "test" {
@@ -414,7 +430,7 @@ resource "azurerm_app_service_connection" "test" {
   app_service_id     = azurerm_linux_web_app.test.id
   target_resource_id = azurerm_cosmosdb_sql_database.test.id
   client_type        = "java"
-  vnet_solution      = "privateLink"
+  vnet_solution      = "serviceEndpoint"
   authentication {
     type = "systemAssignedIdentity"
   }
@@ -486,6 +502,7 @@ resource "azurerm_linux_web_app" "test" {
     ignore_changes = [
       app_settings,
       identity,
+      sticky_settings,
     ]
   }
 }


### PR DESCRIPTION
* Service connector will make changes to linux web app's sticky_settings and the content of this field will not be returned in read.

* Ignoring this part to make sure tests are passing.

* Test results:

```
--- PASS: TestAccServiceConnectorAppServiceStorageBlob_basic (384.65s)
--- PASS: TestAccServiceConnectorAppServiceStorageBlob_secretStore (571.10s)
--- PASS: TestAccServiceConnectorAppServiceCosmosdb_basic (944.79s)
--- PASS: TestAccServiceConnectorAppService_complete (956.65s)
--- PASS: TestAccServiceConnectorAppServiceCosmosdb_update (1113.52s)
PASS
```