### PR TITLE
`azurerm_logic_app_standard` - Add new computed attribute `auto_swap_slot_name`

### DIFF
--- a/internal/services/logic/logic_app_standard_data_source.go
+++ b/internal/services/logic/logic_app_standard_data_source.go
@@ -53,6 +53,11 @@ func dataSourceLogicAppStandard() *pluginsdk.Resource {
 				},
 			},
 
+			"auto_swap_slot_name": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
+
 			"use_extension_bundle": {
 				Type:     pluginsdk.TypeBool,
 				Computed: true,

--- a/internal/services/logic/logic_app_standard_resource.go
+++ b/internal/services/logic/logic_app_standard_resource.go
@@ -229,6 +229,11 @@ func resourceLogicAppStandard() *pluginsdk.Resource {
 				Optional:     true,
 				ValidateFunc: commonids.ValidateSubnetID,
 			},
+
+			"auto_swap_slot_name": {
+				Type:     pluginsdk.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }

--- a/website/docs/d/logic_app_standard.html.markdown
+++ b/website/docs/d/logic_app_standard.html.markdown
@@ -41,6 +41,8 @@ The following attributes are exported:
 
 * `identity` - An `identity` block as defined below.
 
+* `auto_swap_slot_name` - The Auto-swap slot name.
+
 ---
 
 The `identity` block exports the following:

--- a/website/docs/r/logic_app_standard.html.markdown
+++ b/website/docs/r/logic_app_standard.html.markdown
@@ -298,6 +298,8 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `id` - The ID of the Logic App
 
+* `auto_swap_slot_name` - The Auto-swap slot name.
+
 * `custom_domain_verification_id` - An identifier used by App Service to perform domain ownership verification via DNS TXT record.
 
 * `default_hostname` - The default hostname associated with the Logic App - such as `mysite.azurewebsites.net`


### PR DESCRIPTION
This attribute exists in the code (Read function), but is not defined in the schema. This PR complements the schema and document. Otherwise, Read will fail with following error:

```
  | 2023/07/14 16:54:09 Invalid address to set: []string{"site_config", "0", "auto_swap_slot_name"}:
```