### PR TITLE
`azurerm_api_management_diagnostic` - prevent sending `operationNameFormat` field for `azuremoniton` diagnostic

### DIFF
--- a/internal/services/apimanagement/api_management_diagnostic_resource.go
+++ b/internal/services/apimanagement/api_management_diagnostic_resource.go
@@ -46,8 +46,8 @@ func resourceApiManagementDiagnostic() *pluginsdk.Resource {
 				Required: true,
 				ForceNew: true,
 				ValidateFunc: validation.StringInSlice([]string{
-					string(apimanagement.DiagnosticIdentifierApplicationInsights),
-					string(apimanagement.DiagnosticIdentifierAzureMonitor),
+					"applicationinsights",
+					"azuremonitor",
 				}, false),
 			},
 
@@ -149,7 +149,7 @@ func resourceApiManagementDiagnosticCreateUpdate(d *pluginsdk.ResourceData, meta
 		},
 	}
 
-	if operationNameFormat, operationNameFormatSet := d.GetOk("operation_name_format"); d.Get("identifier") == apimanagement.DiagnosticIdentifierApplicationInsights {
+	if operationNameFormat, operationNameFormatSet := d.GetOk("operation_name_format"); d.Get("identifier") == "applicationinsights" {
 		if operationNameFormatSet {
 			parameters.OperationNameFormat = apimanagement.OperationNameFormat(operationNameFormat.(string))
 		} else {

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/apimanagement/mgmt/2021-08-01/apimanagement/enums.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/apimanagement/mgmt/2021-08-01/apimanagement/enums.go
@@ -658,6 +658,16 @@ func PossibleNotificationNameValues() []NotificationName {
 	return []NotificationName{NotificationNameAccountClosedPublisher, NotificationNameBCC, NotificationNameNewApplicationNotificationMessage, NotificationNameNewIssuePublisherNotificationMessage, NotificationNamePurchasePublisherNotificationMessage, NotificationNameQuotaLimitApproachingPublisherNotificationMessage, NotificationNameRequestPublisherNotificationMessage}
 }
 
+// DiagnosticIdentifier enumerates the values for diagnostic identifier.
+type DiagnosticIdentifier string
+
+const (
+	// DiagnosticIdentifierApplicationInsights for Application Insights diagnostics.
+	DiagnosticIdentifierApplicationInsights DiagnosticIdentifier = "applicationinsights"
+	// DiagnosticIdentifierApplicationInsights for Azure Monitor diagnostics.
+	DiagnosticIdentifierAzureMonitor DiagnosticIdentifier = "azuremonitor"
+)
+
 // OperationNameFormat enumerates the values for operation name format.
 type OperationNameFormat string
 

--- a/vendor/github.com/Azure/azure-sdk-for-go/services/apimanagement/mgmt/2021-08-01/apimanagement/enums.go
+++ b/vendor/github.com/Azure/azure-sdk-for-go/services/apimanagement/mgmt/2021-08-01/apimanagement/enums.go
@@ -658,16 +658,6 @@ func PossibleNotificationNameValues() []NotificationName {
 	return []NotificationName{NotificationNameAccountClosedPublisher, NotificationNameBCC, NotificationNameNewApplicationNotificationMessage, NotificationNameNewIssuePublisherNotificationMessage, NotificationNamePurchasePublisherNotificationMessage, NotificationNameQuotaLimitApproachingPublisherNotificationMessage, NotificationNameRequestPublisherNotificationMessage}
 }
 
-// DiagnosticIdentifier enumerates the values for diagnostic identifier.
-type DiagnosticIdentifier string
-
-const (
-	// DiagnosticIdentifierApplicationInsights for Application Insights diagnostics.
-	DiagnosticIdentifierApplicationInsights DiagnosticIdentifier = "applicationinsights"
-	// DiagnosticIdentifierApplicationInsights for Azure Monitor diagnostics.
-	DiagnosticIdentifierAzureMonitor DiagnosticIdentifier = "azuremonitor"
-)
-
 // OperationNameFormat enumerates the values for operation name format.
 type OperationNameFormat string
 


### PR DESCRIPTION
Azure API does not allow to sent `operationNameFormat` field while creating/updating `azuremoniton` diagnostic. This field is required only for `applicationinsights`.

It's not possible to create `azuremonitor` diagnostic right now because of the error:
```
Property 'OperationNameFormat' is only supported for Application Insights diagnostics.
```

Fixes #19970  
