### PR TITLE
`azurerm_spring_cloud_service` - support for the `marketplace` property

### DIFF
--- a/internal/services/springcloud/spring_cloud_service_resource.go
+++ b/internal/services/springcloud/spring_cloud_service_resource.go
@@ -143,6 +143,34 @@ func resourceSpringCloudService() *pluginsdk.Resource {
 				Optional: true,
 			},
 
+			"marketplace": {
+				Type:     pluginsdk.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"plan": {
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+
+						"publisher": {
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+
+						"product": {
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+					},
+				},
+			},
+
 			"network": {
 				Type:     pluginsdk.TypeList,
 				Optional: true,
@@ -397,8 +425,9 @@ func resourceSpringCloudServiceCreate(d *pluginsdk.ResourceData, meta interface{
 	resource := appplatform.ServiceResource{
 		Location: utils.String(location),
 		Properties: &appplatform.ClusterResourceProperties{
-			NetworkProfile: expandSpringCloudNetwork(d.Get("network").([]interface{})),
-			ZoneRedundant:  utils.Bool(d.Get("zone_redundant").(bool)),
+			NetworkProfile:      expandSpringCloudNetwork(d.Get("network").([]interface{})),
+			ZoneRedundant:       utils.Bool(d.Get("zone_redundant").(bool)),
+			MarketplaceResource: expandSpringCloudMarketplaceResource(d.Get("marketplace").([]interface{})),
 		},
 		Sku: &appplatform.Sku{
 			Name: utils.String(d.Get("sku_name").(string)),
@@ -748,6 +777,10 @@ func resourceSpringCloudServiceRead(d *pluginsdk.ResourceData, meta interface{})
 			return fmt.Errorf("setting `required_network_traffic_rules`: %+v", err)
 		}
 
+		if err := d.Set("marketplace", flattenSpringCloudMarketplaceResource(props.MarketplaceResource)); err != nil {
+			return fmt.Errorf("setting `marketplace`: %+v", err)
+		}
+
 		if vnetAddons := props.VnetAddons; vnetAddons != nil {
 			if err := d.Set("log_stream_public_endpoint_enabled", utils.Bool(*vnetAddons.LogStreamPublicEndpoint)); err != nil {
 				return fmt.Errorf("setting `log_stream_public_endpoint_enabled`: %+v", err)
@@ -1022,6 +1055,18 @@ func expandSpringCloudBuildService(input []interface{}, springId parse.SpringClo
 		out.ContainerRegistry = utils.String(parse.NewSpringCloudContainerRegistryID(springId.SubscriptionId, springId.ResourceGroup, springId.SpringName, value).ID())
 	}
 	return out
+}
+
+func expandSpringCloudMarketplaceResource(input []interface{}) *appplatform.MarketplaceResource {
+	if len(input) == 0 || input[0] == nil {
+		return nil
+	}
+	v := input[0].(map[string]interface{})
+	return &appplatform.MarketplaceResource{
+		Plan:      utils.String(v["plan"].(string)),
+		Publisher: utils.String(v["publisher"].(string)),
+		Product:   utils.String(v["product"].(string)),
+	}
 }
 
 func flattenSpringCloudConfigServerGitProperty(input *appplatform.ConfigServerProperties, d *pluginsdk.ResourceData) []interface{} {
@@ -1399,4 +1444,29 @@ func flattenSpringCloudBuildService(input *appplatform.BuildServiceProperties) [
 		}
 	}
 	return []interface{}{}
+}
+
+func flattenSpringCloudMarketplaceResource(input *appplatform.MarketplaceResource) []interface{} {
+	if input == nil {
+		return []interface{}{}
+	}
+	plan := ""
+	publisher := ""
+	product := ""
+	if input.Plan != nil {
+		plan = *input.Plan
+	}
+	if input.Publisher != nil {
+		publisher = *input.Publisher
+	}
+	if input.Product != nil {
+		product = *input.Product
+	}
+	return []interface{}{
+		map[string]interface{}{
+			"plan":      plan,
+			"publisher": publisher,
+			"product":   product,
+		},
+	}
 }

--- a/internal/services/springcloud/spring_cloud_service_resource_test.go
+++ b/internal/services/springcloud/spring_cloud_service_resource_test.go
@@ -243,6 +243,21 @@ func TestAccSpringCloudService_containerRegistry(t *testing.T) {
 	})
 }
 
+func TestAccSpringCloudService_marketplace(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_spring_cloud_service", "test")
+	r := SpringCloudServiceResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.marketplace(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (t SpringCloudServiceResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := parse.SpringCloudServiceID(state.ID)
 	if err != nil {
@@ -607,6 +622,32 @@ resource "azurerm_spring_cloud_service" "test" {
   }
 }
 `, data.Locations.Primary, data.RandomInteger, containerRegistryName)
+}
+
+func (SpringCloudServiceResource) marketplace(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-spring-%d"
+  location = "%s"
+}
+
+resource "azurerm_spring_cloud_service" "test" {
+  name                = "acctest-sc-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku_name            = "E0"
+
+  marketplace {
+    plan      = "asa-ent-hr-mtr"
+    publisher = "vmware-inc"
+    product   = "azure-spring-cloud-vmware-tanzu-2"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
 
 func (r SpringCloudServiceResource) requiresImport(data acceptance.TestData) string {

--- a/website/docs/r/spring_cloud_service.html.markdown
+++ b/website/docs/r/spring_cloud_service.html.markdown
@@ -72,6 +72,8 @@ The following arguments are supported:
 
 * `sku_name` - (Optional) Specifies the SKU Name for this Spring Cloud Service. Possible values are `B0`, `S0` and `E0`. Defaults to `S0`. Changing this forces a new resource to be created.
 
+* `marketplace` - (Optional) A `marketplace` block as defined below. This field is applicable only for Spring Cloud Service with enterprise tier.
+
 * `network` - (Optional) A `network` block as defined below. Changing this forces a new resource to be created.
 
 * `config_server_git_setting` - (Optional) A `config_server_git_setting` block as defined below. This field is applicable only for Spring Cloud Service with basic and standard tier.
@@ -133,6 +135,16 @@ The `container_registry` block supports the following:
 The `default_build_service` block supports the following:
 
 * `container_registry_name` - (Optional) Specifies the name of the container registry used in the default build service.
+
+---
+
+The `marketplace` block supports the following:
+
+* `plan` - (Required) Specifies the plan id of the 3rd Party Artifact that is being procured.
+
+* `publisher` - (Required) Specifies the publisher id of the 3rd Party Artifact that is being bought.
+
+* `product` - (Required) Specifies the 3rd Party artifact that is being procured.
 
 ---
 

--- a/website/docs/r/spring_cloud_service.html.markdown
+++ b/website/docs/r/spring_cloud_service.html.markdown
@@ -72,7 +72,7 @@ The following arguments are supported:
 
 * `sku_name` - (Optional) Specifies the SKU Name for this Spring Cloud Service. Possible values are `B0`, `S0` and `E0`. Defaults to `S0`. Changing this forces a new resource to be created.
 
-* `marketplace` - (Optional) A `marketplace` block as defined below. This field is applicable only for Spring Cloud Service with enterprise tier.
+* `marketplace` - (Optional) A `marketplace` block as defined below. Can only be specified when `sku` is set to `E0`.
 
 * `network` - (Optional) A `network` block as defined below. Changing this forces a new resource to be created.
 
@@ -140,9 +140,9 @@ The `default_build_service` block supports the following:
 
 The `marketplace` block supports the following:
 
-* `plan` - (Required) Specifies the plan id of the 3rd Party Artifact that is being procured.
+* `plan` - (Required) Specifies the plan ID of the 3rd Party Artifact that is being procured.
 
-* `publisher` - (Required) Specifies the publisher id of the 3rd Party Artifact that is being bought.
+* `publisher` - (Required) Specifies the publisher ID of the 3rd Party Artifact that is being procured.
 
 * `product` - (Required) Specifies the 3rd Party artifact that is being procured.
 


### PR DESCRIPTION
Hi reviewers,

I understand it's not recommended  to use `Optional+Computed`, but the service will add a default value for the existing services, without `Computed`, it would be a breaking change to the existing users.


```
=== RUN   TestAccSpringCloudService_basic
=== PAUSE TestAccSpringCloudService_basic
=== CONT  TestAccSpringCloudService_basic
--- PASS: TestAccSpringCloudService_basic (415.59s)
=== RUN   TestAccSpringCloudService_update
=== PAUSE TestAccSpringCloudService_update
=== CONT  TestAccSpringCloudService_update
--- PASS: TestAccSpringCloudService_update (1001.05s)
=== RUN   TestAccSpringCloudService_complete
=== PAUSE TestAccSpringCloudService_complete
=== CONT  TestAccSpringCloudService_complete
--- PASS: TestAccSpringCloudService_complete (553.41s)
=== RUN   TestAccSpringCloudService_virtualNetwork
=== PAUSE TestAccSpringCloudService_virtualNetwork
=== CONT  TestAccSpringCloudService_virtualNetwork
=== CONT  TestAccSpringCloudService_virtualNetwork
--- PASS: TestAccSpringCloudService_virtualNetwork (413.76s)
=== RUN   TestAccSpringCloudService_requiresImport
=== PAUSE TestAccSpringCloudService_requiresImport
=== CONT  TestAccSpringCloudService_requiresImport
--- PASS: TestAccSpringCloudService_requiresImport (334.43s)
=== RUN   TestAccSpringCloudService_serviceRegistry
=== PAUSE TestAccSpringCloudService_serviceRegistry
=== CONT  TestAccSpringCloudService_serviceRegistry
--- PASS: TestAccSpringCloudService_serviceRegistry (650.43s)
=== RUN   TestAccSpringCloudService_buildAgentPool
=== PAUSE TestAccSpringCloudService_buildAgentPool
=== CONT  TestAccSpringCloudService_buildAgentPool
--- PASS: TestAccSpringCloudService_buildAgentPool (596.56s)
=== RUN   TestAccSpringCloudService_zoneRedundant
=== PAUSE TestAccSpringCloudService_zoneRedundant
=== CONT  TestAccSpringCloudService_zoneRedundant
--- PASS: TestAccSpringCloudService_zoneRedundant (413.91s)
=== RUN   TestAccSpringCloudService_containerRegistry
=== PAUSE TestAccSpringCloudService_containerRegistry
=== CONT  TestAccSpringCloudService_containerRegistry
--- PASS: TestAccSpringCloudService_containerRegistry (585.85s)
=== RUN   TestAccSpringCloudService_marketplace
=== PAUSE TestAccSpringCloudService_marketplace
=== CONT  TestAccSpringCloudService_marketplace
--- PASS: TestAccSpringCloudService_marketplace (451.26s)
```