### PR TITLE
`azurerm_maintenance_configuration`: Read function sets to wrong named properties

### DIFF
--- a/internal/services/maintenance/maintenance_configuration_resource.go
+++ b/internal/services/maintenance/maintenance_configuration_resource.go
@@ -522,10 +522,10 @@ func expandMaintenanceConfigurationInstallPatchesLinux(input []interface{}) *mai
 	if v, ok := v["classifications_to_include"]; ok {
 		linuxParameters.ClassificationsToInclude = utils.ExpandStringSlice(v.([]interface{}))
 	}
-	if v, ok := v["packages_to_exclude"]; ok {
+	if v, ok := v["package_names_mask_to_exclude"]; ok {
 		linuxParameters.PackageNameMasksToExclude = utils.ExpandStringSlice(v.([]interface{}))
 	}
-	if v, ok := v["packages_to_include"]; ok {
+	if v, ok := v["package_names_mask_to_include"]; ok {
 		linuxParameters.PackageNameMasksToInclude = utils.ExpandStringSlice(v.([]interface{}))
 	}
 	return &linuxParameters
@@ -542,11 +542,11 @@ func flattenMaintenanceConfigurationInstallPatchesLinux(input *maintenanceconfig
 		}
 
 		if packageNameMasksToInclude := v.PackageNameMasksToInclude; packageNameMasksToInclude != nil {
-			output["packages_to_exclude"] = utils.FlattenStringSlice(packageNameMasksToInclude)
+			output["package_names_mask_to_exclude"] = utils.FlattenStringSlice(packageNameMasksToInclude)
 		}
 
 		if packageNameMasksToExclude := v.PackageNameMasksToExclude; packageNameMasksToExclude != nil {
-			output["packages_to_include"] = utils.FlattenStringSlice(packageNameMasksToExclude)
+			output["package_names_mask_to_include"] = utils.FlattenStringSlice(packageNameMasksToExclude)
 		}
 
 		results = append(results, output)


### PR DESCRIPTION
Change the code to match the schema and the document. Otherwise, the read returns:

>   | 2023/07/17 15:22:38 setting `install_patches`: Invalid address to set: []string{"install_patches", "0", "linux", "0", "packages_to_exclude"}:
