### PR TITLE
`data/azurerm_virtual_machine_scale_set` - fix issue with flexible vmss

### DIFF
--- a/internal/services/compute/virtual_machine_scale_set_data_source.go
+++ b/internal/services/compute/virtual_machine_scale_set_data_source.go
@@ -121,6 +121,7 @@ func dataSourceVirtualMachineScaleSet() *pluginsdk.Resource {
 func dataSourceVirtualMachineScaleSetRead(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Compute.VMScaleSetClient
 	instancesClient := meta.(*clients.Client).Compute.VMScaleSetVMsClient
+	vmClient := meta.(*clients.Client).Compute.VMClient
 	networkInterfacesClient := meta.(*clients.Client).Network.InterfacesClient
 	publicIPAddressesClient := meta.(*clients.Client).Network.PublicIPsClient
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
@@ -166,36 +167,47 @@ func dataSourceVirtualMachineScaleSetRead(d *pluginsdk.ResourceData, meta interf
 	instances := make([]interface{}, 0)
 	result, err := instancesClient.ListComplete(ctx, id.ResourceGroup, id.Name, "", "", "")
 	if err != nil {
-		return fmt.Errorf("listing VM Instances for Virtual Machine Scale Set %q (Resource Group %q): %+v", id.ResourceGroup, id.Name, err)
+		return fmt.Errorf("listing VM Instances for %q: %+v", id, err)
 	}
 
+	var connInfo *connectionInfo
 	for result.NotDone() {
 		instance := result.Value()
 		if instance.InstanceID != nil {
 			nics, err := networkInterfacesClient.ListVirtualMachineScaleSetVMNetworkInterfacesComplete(ctx, id.ResourceGroup, id.Name, *instance.InstanceID)
 			if err != nil {
-				return fmt.Errorf("listing Network Interfaces for VM Instance %q for Virtual Machine Scale Set %q (Resource Group %q): %+v", *instance.InstanceID, id.ResourceGroup, id.Name, err)
-			}
+				if !utils.ResponseWasNotFound(nics.Response().Response) {
+					return fmt.Errorf("listing Network Interfaces for VM Instance %q for %q: %+v", *instance.InstanceID, id, err)
+				}
 
-			networkInterfaces := make([]network.Interface, 0)
-			for nics.NotDone() {
-				networkInterfaces = append(networkInterfaces, nics.Value())
-				if err := nics.NextWithContext(ctx); err != nil {
-					return fmt.Errorf("listing next page of Network Interfaces for VM Instance %q of Virtual Machine Scale Set %q (Resource Group %q): %v", *instance.InstanceID, id.ResourceGroup, id.Name, err)
+				// Network Interfaces of VM in Flexible VMSS are accessed from single VM
+				vm, err := vmClient.Get(ctx, id.ResourceGroup, *instance.InstanceID, "")
+				if err != nil {
+					return fmt.Errorf("retrieving VM Instance %q for %q: %+v", *instance.InstanceID, id, err)
+				}
+				connInfoRaw := retrieveConnectionInformation(ctx, networkInterfacesClient, publicIPAddressesClient, vm.VirtualMachineProperties)
+				connInfo = &connInfoRaw
+			} else {
+				networkInterfaces := make([]network.Interface, 0)
+				for nics.NotDone() {
+					networkInterfaces = append(networkInterfaces, nics.Value())
+					if err := nics.NextWithContext(ctx); err != nil {
+						return fmt.Errorf("listing next page of Network Interfaces for VM Instance %q of %q: %v", *instance.InstanceID, id, err)
+					}
+				}
+
+				connInfo, err = getVirtualMachineScaleSetVMConnectionInfo(ctx, networkInterfaces, id.ResourceGroup, id.Name, *instance.InstanceID, publicIPAddressesClient)
+				if err != nil {
+					return err
 				}
 			}
 
-			connectionInfo, err := getVirtualMachineScaleSetVMConnectionInfo(ctx, networkInterfaces, id.ResourceGroup, id.Name, *instance.InstanceID, publicIPAddressesClient)
-			if err != nil {
-				return err
-			}
-
-			flattenedInstances := flattenVirtualMachineScaleSetVM(instance, connectionInfo)
+			flattenedInstances := flattenVirtualMachineScaleSetVM(instance, connInfo)
 			instances = append(instances, flattenedInstances)
 		}
 
 		if err := result.NextWithContext(ctx); err != nil {
-			return fmt.Errorf("listing next page VM Instances for Virtual Machine Scale Set %q (Resource Group %q): %+v", id.ResourceGroup, id.Name, err)
+			return fmt.Errorf("listing next page VM Instances for %q: %+v", id, err)
 		}
 	}
 	if err := d.Set("instances", instances); err != nil {
@@ -265,12 +277,29 @@ func flattenVirtualMachineScaleSetVM(input compute.VirtualMachineScaleSetVM, con
 	output := make(map[string]interface{})
 	output["name"] = *input.Name
 	output["instance_id"] = *input.InstanceID
-	output["latest_model_applied"] = *input.LatestModelApplied
-	output["virtual_machine_id"] = *input.VMID
 
-	props := *input.VirtualMachineScaleSetVMProperties
-	if profile := props.OsProfile; profile != nil {
-		output["computer_name"] = profile.ComputerName
+	if props := input.VirtualMachineScaleSetVMProperties; props != nil {
+		if props.LatestModelApplied != nil {
+			output["latest_model_applied"] = *props.LatestModelApplied
+		}
+
+		if props.VMID != nil {
+			output["virtual_machine_id"] = *props.VMID
+		}
+
+		if profile := props.OsProfile; profile != nil {
+			output["computer_name"] = profile.ComputerName
+		}
+
+		if instance := props.InstanceView; instance != nil {
+			if statues := instance.Statuses; statues != nil {
+				for _, status := range *statues {
+					if status.Code != nil && strings.HasPrefix(strings.ToLower(*status.Code), "powerstate/") {
+						output["power_state"] = strings.SplitN(*status.Code, "/", 2)[1]
+					}
+				}
+			}
+		}
 	}
 
 	zone := ""
@@ -286,16 +315,6 @@ func flattenVirtualMachineScaleSetVM(input compute.VirtualMachineScaleSetVM, con
 		output["private_ip_addresses"] = connectionInfo.privateAddresses
 		output["public_ip_address"] = connectionInfo.primaryPublicAddress
 		output["public_ip_addresses"] = connectionInfo.publicAddresses
-	}
-
-	if instance := input.InstanceView; instance != nil {
-		if statues := instance.Statuses; statues != nil {
-			for _, status := range *statues {
-				if status.Code != nil && strings.HasPrefix(strings.ToLower(*status.Code), "powerstate/") {
-					output["power_state"] = strings.SplitN(*status.Code, "/", 2)[1]
-				}
-			}
-		}
 	}
 
 	return output

--- a/internal/services/compute/virtual_machine_scale_set_data_source.go
+++ b/internal/services/compute/virtual_machine_scale_set_data_source.go
@@ -287,13 +287,13 @@ func flattenVirtualMachineScaleSetVM(input compute.VirtualMachineScaleSetVM, con
 			output["virtual_machine_id"] = *props.VMID
 		}
 
-		if profile := props.OsProfile; profile != nil {
-			output["computer_name"] = profile.ComputerName
+		if profile := props.OsProfile; profile != nil && profile.ComputerName != nil {
+			output["computer_name"] = *profile.ComputerName
 		}
 
 		if instance := props.InstanceView; instance != nil {
-			if statues := instance.Statuses; statues != nil {
-				for _, status := range *statues {
+			if statuses := instance.Statuses; statuses != nil {
+				for _, status := range *statuses {
 					if status.Code != nil && strings.HasPrefix(strings.ToLower(*status.Code), "powerstate/") {
 						output["power_state"] = strings.SplitN(*status.Code, "/", 2)[1]
 					}

--- a/internal/services/compute/virtual_machine_scale_set_data_source_test.go
+++ b/internal/services/compute/virtual_machine_scale_set_data_source_test.go
@@ -108,6 +108,10 @@ func (VirtualMachineScaleSetDataSource) orchestrated(data acceptance.TestData) s
 data "azurerm_virtual_machine_scale_set" "test" {
   name                = azurerm_orchestrated_virtual_machine_scale_set.test.name
   resource_group_name = azurerm_resource_group.test.name
+
+  depends_on = [
+    azurerm_windows_virtual_machine.test
+  ]
 }
 `, template)
 }


### PR DESCRIPTION
captured from `TestAccDataSourceVirtualMachineScaleSet_orchestrated`
`Error: listing Network Interfaces for VM Instance "..." for Virtual Machine Scale Set "..." (Resource Group "..."): network.InterfacesClient#ListVirtualMachineScaleSetVMNetworkInterfaces: Failure responding to request: StatusCode=404`

For flexible (orchestrated) vmss, network interface info are no longer exposed by `ListVirtualMachineScaleSetVMNetworkInterfacesComplete`, we need to get it from the VM itself.