### PR TITLE
azurerm_synapse_firewall_rule: fix rule name regex

### DIFF
--- a/internal/services/synapse/validate/firewall_rule_name.go
+++ b/internal/services/synapse/validate/firewall_rule_name.go
@@ -16,11 +16,12 @@ func FirewallRuleName(i interface{}, k string) (warnings []string, errors []erro
 	}
 
 	// The name attribute rules are :
-	// 1. can contain only letters, numbers, underscore and hyphen.
+	// 1. Can't contain '<,>,*,%,&,:,\,/,?'.
+	// 2. Can't end with '.'
 	// 2. The value must be between 1 and 128 characters long
 
-	if !regexp.MustCompile(`^[a-zA-Z\d-_]{1,128}$`).MatchString(v) {
-		errors = append(errors, fmt.Errorf("%s can contain only letters, numbers, underscore and hyphen, and be between 1 and 128 characters long", k))
+	if !regexp.MustCompile(`^[^<>*%&:\\/?]{0,127}[^.<>*%&:\\/?]$`).MatchString(v) {
+		errors = append(errors, fmt.Errorf("%s can't contain '<,>,*,%%,&,:,\\,/,?', can't end with '.', and must be between 1 and 128 characters long", k))
 		return
 	}
 

--- a/internal/services/synapse/validate/firewall_rule_name_test.go
+++ b/internal/services/synapse/validate/firewall_rule_name_test.go
@@ -33,6 +33,11 @@ func TestFirewallRuleName(t *testing.T) {
 			expected: true,
 		},
 		{
+			// can contain utf-8 chars
+			input:    "øüå-rule",
+			expected: true,
+		},
+		{
 			// can't contain `*`
 			input:    "abcon*demand",
 			expected: false,


### PR DESCRIPTION
Hi,

The rule name regex is actually more lenient. To quote azure:
```
The firewall rule name cannot be empty, it cannot contain a
slash (/) or a backslash (\), can't end with '.', and can't
contain '<,>,*,%,&,:,\,/,?'. Additionally, the firewall rule
name cannot exceed 128 characters.
```
As can be seen on the validation image:
![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/17879459/eefd1a6e-5dd0-407a-89e0-bbd97b8459d6)

Thanks and cheers !

