### PR TITLE
`azurerm_redis_enterprise_cluster` - add support for `North Central US` and `West US 3` regions

### DIFF
--- a/internal/services/redisenterprise/redis_enterprise_cluster_resource_test.go
+++ b/internal/services/redisenterprise/redis_enterprise_cluster_resource_test.go
@@ -91,6 +91,34 @@ func TestAccRedisEnterpriseCluster_update(t *testing.T) {
 	})
 }
 
+func TestAccRedisEnterpriseCluster_support_westus3(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_redis_enterprise_cluster", "test")
+	r := RedisEnterpriseClusterResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.supportNewRegions(data, "westus3"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccRedisEnterpriseCluster_support_northcentralus(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_redis_enterprise_cluster", "test")
+	r := RedisEnterpriseClusterResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.supportNewRegions(data, "northcentralus"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (r RedisEnterpriseClusterResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := redisenterprise.ParseRedisEnterpriseID(state.ID)
 	if err != nil {
@@ -189,4 +217,25 @@ resource "azurerm_redis_enterprise_cluster" "test" {
   }
 }
 `, template, data.RandomInteger)
+}
+
+func (r RedisEnterpriseClusterResource) supportNewRegions(data acceptance.TestData, region string) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-redisEnterprise-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_redis_enterprise_cluster" "test" {
+  name                = "acctest-rec-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  sku_name = "Enterprise_E100-2"
+}
+`, data.RandomInteger, region)
 }

--- a/internal/services/redisenterprise/validate/redis_enterprise_cluster_location.go
+++ b/internal/services/redisenterprise/validate/redis_enterprise_cluster_location.go
@@ -52,6 +52,7 @@ func friendlyValidRedisEnterpriseClusterLocations() []string {
 		"Central US EUAP",
 		"East Asia",
 		"East US",
+		"North Central US",
 		"North Europe",
 		"South Central US",
 		"South India",
@@ -60,8 +61,10 @@ func friendlyValidRedisEnterpriseClusterLocations() []string {
 		"UK West",
 		"East US 2",
 		"East US 2 EUAP",
+		"West Central US",
 		"West Europe",
 		"West US",
 		"West US 2",
+		"West US 3",
 	}
 }

--- a/internal/services/redisenterprise/validate/redis_enterprise_cluster_location.go
+++ b/internal/services/redisenterprise/validate/redis_enterprise_cluster_location.go
@@ -61,7 +61,6 @@ func friendlyValidRedisEnterpriseClusterLocations() []string {
 		"UK West",
 		"East US 2",
 		"East US 2 EUAP",
-		"West Central US",
 		"West Europe",
 		"West US",
 		"West US 2",


### PR DESCRIPTION
Support new regions `North Central US` and `West US 3` for Redis Enterprise as requested by the service team.

Test results:

> PASS: TestAccRedisEnterpriseCluster_support_northcentralus (935.70s)
> PASS: TestAccRedisEnterpriseCluster_support_westus3 (1060.55s)