### PR TITLE
[New Resource:] `azurerm_databricks_workspace_root_dbfs_customer_managed_key` - deprecate `azurerm_databricks_workspace_customer_managed_key`

### DIFF
--- a/examples/databricks/customer-managed-key/dbfs/README.md
+++ b/examples/databricks/customer-managed-key/dbfs/README.md
@@ -1,6 +1,6 @@
-## Example: Databricks Workspace Databricks File System Customer Managed Keys
+## Example: Databricks Workspace Root Databricks File System Customer Managed Keys
 
-This example provisions a Databricks Workspace within Azure with Databricks File System Customer Managed Keys enabled.
+This example provisions a Databricks Workspace within Azure with Root Databricks File System Customer Managed Keys enabled.
 
 ### Variables
 

--- a/examples/databricks/customer-managed-key/dbfs/main.tf
+++ b/examples/databricks/customer-managed-key/dbfs/main.tf
@@ -26,7 +26,7 @@ resource "azurerm_databricks_workspace" "example" {
   }
 }
 
-resource "azurerm_databricks_workspace_customer_managed_key" "example" {
+resource "azurerm_databricks_workspace_root_dbfs_customer_managed_key" "example" {
   depends_on = [azurerm_key_vault_access_policy.databricks]
 
   workspace_id     = azurerm_databricks_workspace.example.id

--- a/examples/private-endpoint/databricks/managed-services/main.tf
+++ b/examples/private-endpoint/databricks/managed-services/main.tf
@@ -117,7 +117,7 @@ resource "azurerm_databricks_workspace" "example" {
   }
 }
 
-resource "azurerm_databricks_workspace_customer_managed_key" "example" {
+resource "azurerm_databricks_workspace_root_dbfs_customer_managed_key" "example" {
   depends_on = [azurerm_key_vault_access_policy.databricks]
 
   workspace_id     = azurerm_databricks_workspace.example.id

--- a/examples/private-endpoint/databricks/managed-services/main.tf
+++ b/examples/private-endpoint/databricks/managed-services/main.tf
@@ -125,6 +125,8 @@ resource "azurerm_databricks_workspace_root_dbfs_customer_managed_key" "example"
 }
 
 resource "azurerm_private_endpoint" "databricks" {
+  depends_on = [azurerm_databricks_workspace_root_dbfs_customer_managed_key.example]
+
   name                = "${var.prefix}-pe-databricks"
   location            = azurerm_resource_group.example.location
   resource_group_name = azurerm_resource_group.example.name

--- a/internal/services/databricks/databricks_customer_managed_key_resource.go
+++ b/internal/services/databricks/databricks_customer_managed_key_resource.go
@@ -105,7 +105,7 @@ func databricksWorkspaceCustomerManagedKeyCreateUpdate(d *pluginsdk.ResourceData
 		return fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	var keySource workspaces.KeySource
+	keySource := workspaces.KeySourceDefault
 	var params *workspaces.WorkspaceCustomParameters
 
 	if model := workspace.Model; model != nil {
@@ -114,7 +114,7 @@ func databricksWorkspaceCustomerManagedKeyCreateUpdate(d *pluginsdk.ResourceData
 				encryptionEnabled = model.Properties.Parameters.PrepareEncryption.Value
 			}
 
-			if params.Encryption != nil && params.Encryption.Value != nil {
+			if params.Encryption != nil && params.Encryption.Value != nil && params.Encryption.Value.KeySource != nil {
 				keySource = pointer.From(params.Encryption.Value.KeySource)
 			}
 		} else {

--- a/internal/services/databricks/databricks_customer_managed_key_resource_test.go
+++ b/internal/services/databricks/databricks_customer_managed_key_resource_test.go
@@ -63,23 +63,6 @@ func TestAccDatabricksWorkspaceCustomerManagedKey_remove(t *testing.T) {
 	})
 }
 
-func TestAccDatabricksWorkspaceCustomerManagedKey_requiresImport(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_databricks_workspace_customer_managed_key", "test")
-	parent := acceptance.BuildTestData(t, "azurerm_databricks_workspace", "test")
-	r := DatabricksWorkspaceCustomerManagedKeyResource{}
-	cmkTemplate := r.cmkTemplate()
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.basic(data, cmkTemplate),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(parent.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.RequiresImportErrorStep(r.requiresImport),
-	})
-}
-
 func TestAccDatabricksWorkspaceCustomerManagedKey_noIp(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_databricks_workspace_customer_managed_key", "test")
 	parent := acceptance.BuildTestData(t, "azurerm_databricks_workspace", "test")
@@ -154,19 +137,6 @@ resource "azurerm_databricks_workspace" "test" {
 
 %[4]s
 `, data.RandomInteger, "eastus2", keyVault, cmk)
-}
-
-func (DatabricksWorkspaceCustomerManagedKeyResource) requiresImport(data acceptance.TestData) string {
-	cmkTemplate := DatabricksWorkspaceCustomerManagedKeyResource{}.cmkTemplate()
-	template := DatabricksWorkspaceCustomerManagedKeyResource{}.basic(data, cmkTemplate)
-	return fmt.Sprintf(`
-%s
-
-resource "azurerm_databricks_workspace_customer_managed_key" "import" {
-  workspace_id     = azurerm_databricks_workspace.test.id
-  key_vault_key_id = azurerm_key_vault_key.test.id
-}
-`, template)
 }
 
 func (DatabricksWorkspaceCustomerManagedKeyResource) noip(data acceptance.TestData, cmk string) string {

--- a/internal/services/databricks/databricks_root_dbfs_customer_managed_key_resource.go
+++ b/internal/services/databricks/databricks_root_dbfs_customer_managed_key_resource.go
@@ -98,7 +98,7 @@ func databricksWorkspaceRootDbfsCustomerManagedKeyCreate(d *pluginsdk.ResourceDa
 		return fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
-	var keySource workspaces.KeySource
+	keySource := workspaces.KeySourceDefault
 	var params *workspaces.WorkspaceCustomParameters
 
 	if model := workspace.Model; model != nil {
@@ -107,7 +107,7 @@ func databricksWorkspaceRootDbfsCustomerManagedKeyCreate(d *pluginsdk.ResourceDa
 				encryptionEnabled = model.Properties.Parameters.PrepareEncryption.Value
 			}
 
-			if params.Encryption.Value != nil {
+			if params.Encryption != nil && params.Encryption.Value != nil && params.Encryption.Value.KeySource != nil {
 				keySource = pointer.From(params.Encryption.Value.KeySource)
 			}
 		} else {

--- a/internal/services/databricks/databricks_root_dbfs_customer_managed_key_resource_test.go
+++ b/internal/services/databricks/databricks_root_dbfs_customer_managed_key_resource_test.go
@@ -131,7 +131,7 @@ func (r DatabricksWorkspaceRootDbfsCustomerManagedKeyResource) requiresImport(da
 	template := r.basic(data, cmkTemplate)
 	return fmt.Sprintf(`
 %s
-resource "azurerm_databricks_workspace_customer_managed_key" "import" {
+resource "azurerm_databricks_workspace_root_dbfs_customer_managed_key" "import" {
   workspace_id     = azurerm_databricks_workspace.test.id
   key_vault_key_id = azurerm_key_vault_key.test.id
 }

--- a/internal/services/databricks/databricks_root_dbfs_customer_managed_key_resource_test.go
+++ b/internal/services/databricks/databricks_root_dbfs_customer_managed_key_resource_test.go
@@ -1,0 +1,256 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package databricks_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-azure-sdk/resource-manager/databricks/2023-02-01/workspaces"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+type DatabricksWorkspaceRootDbfsCustomerManagedKeyResource struct{}
+
+func TestAccDatabricksWorkspaceRootDbfsCustomerManagedKey_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_databricks_workspace_root_dbfs_customer_managed_key", "test")
+	parent := acceptance.BuildTestData(t, "azurerm_databricks_workspace", "test")
+	r := DatabricksWorkspaceRootDbfsCustomerManagedKeyResource{}
+	cmkTemplate := r.cmkTemplate()
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data, cmkTemplate),
+			Check: acceptance.ComposeTestCheckFunc(
+				// You must look for the parent resource (e.g. Databricks Workspace)
+				// and then derive if the CMK object has been set or not...
+				check.That(parent.ResourceName).ExistsInAzure(r),
+			),
+		},
+		parent.ImportStep(),
+	})
+}
+
+func TestAccDatabricksWorkspaceRootDbfsCustomerManagedKey_remove(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_databricks_workspace_root_dbfs_customer_managed_key", "test")
+	parent := acceptance.BuildTestData(t, "azurerm_databricks_workspace", "test")
+	r := DatabricksWorkspaceRootDbfsCustomerManagedKeyResource{}
+	cmkTemplate := r.cmkTemplate()
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data, cmkTemplate),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(parent.ResourceName).ExistsInAzure(r),
+			),
+		},
+		parent.ImportStep(),
+		{
+			Config: r.basic(data, ""),
+			Check: acceptance.ComposeTestCheckFunc(
+				// Then ensure the encryption settings on the Databricks Workspace
+				// have been reverted to their default state
+				check.That(parent.ResourceName).DoesNotExistInAzure(r),
+			),
+		},
+		parent.ImportStep(),
+	})
+}
+
+func TestAccDatabricksWorkspaceRootDbfsCustomerManagedKey_noIp(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_databricks_workspace_root_dbfs_customer_managed_key", "test")
+	parent := acceptance.BuildTestData(t, "azurerm_databricks_workspace", "test")
+	r := DatabricksWorkspaceRootDbfsCustomerManagedKeyResource{}
+	cmkTemplate := r.cmkTemplate()
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.noip(data, cmkTemplate),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(parent.ResourceName).ExistsInAzure(r),
+			),
+		},
+		parent.ImportStep(),
+		{
+			Config: r.noip(data, ""),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(parent.ResourceName).DoesNotExistInAzure(r),
+				check.That(parent.ResourceName).Key("custom_parameters.0.no_public_ip").IsSet(),
+			),
+		},
+		parent.ImportStep(),
+	})
+}
+
+func (DatabricksWorkspaceRootDbfsCustomerManagedKeyResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := workspaces.ParseWorkspaceID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := clients.DataBricks.WorkspacesClient.Get(ctx, *id)
+	if err != nil {
+		return nil, fmt.Errorf("retrieving %s: %+v", id, err)
+	}
+
+	// This is the only way we can tell if the CMK has actually been provisioned or not...
+	if resp.Model != nil && resp.Model.Properties.Parameters != nil && resp.Model.Properties.Parameters.Encryption != nil && resp.Model.Properties.Parameters.Encryption.Value != nil && resp.Model.Properties.Parameters.Encryption.Value.KeySource != nil {
+		if *resp.Model.Properties.Parameters.Encryption.Value.KeySource == workspaces.KeySourceMicrosoftPointKeyvault {
+			return utils.Bool(true), nil
+		}
+	}
+
+	return utils.Bool(false), nil
+}
+
+func (DatabricksWorkspaceRootDbfsCustomerManagedKeyResource) basic(data acceptance.TestData, cmk string) string {
+	keyVault := DatabricksWorkspaceRootDbfsCustomerManagedKeyResource{}.keyVaultTemplate(data)
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-db-%[1]d"
+  location = "%[2]s"
+}
+
+%[3]s
+
+resource "azurerm_databricks_workspace" "test" {
+  name                = "acctestDBW-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  sku                 = "premium"
+
+  customer_managed_key_enabled      = true
+  infrastructure_encryption_enabled = true
+}
+
+%[4]s
+`, data.RandomInteger, "eastus2", keyVault, cmk)
+}
+
+func (DatabricksWorkspaceRootDbfsCustomerManagedKeyResource) noip(data acceptance.TestData, cmk string) string {
+	keyVault := DatabricksWorkspaceRootDbfsCustomerManagedKeyResource{}.keyVaultTemplate(data)
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-db-%[1]d"
+  location = "%[2]s"
+}
+
+%[3]s
+
+resource "azurerm_databricks_workspace" "test" {
+  name                = "acctestDBW-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  sku                 = "premium"
+
+  customer_managed_key_enabled = true
+
+  custom_parameters {
+    no_public_ip = true
+  }
+}
+
+%[5]s
+`, data.RandomInteger, "eastus2", keyVault, data.RandomString, cmk)
+}
+
+func (DatabricksWorkspaceRootDbfsCustomerManagedKeyResource) cmkTemplate() string {
+	return `
+resource "azurerm_databricks_workspace_root_dbfs_customer_managed_key" "test" {
+  depends_on = [azurerm_key_vault_access_policy.databricks]
+
+  workspace_id     = azurerm_databricks_workspace.test.id
+  key_vault_key_id = azurerm_key_vault_key.test.id
+}
+`
+}
+
+func (DatabricksWorkspaceRootDbfsCustomerManagedKeyResource) keyVaultTemplate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+resource "azurerm_key_vault" "test" {
+  name                = "acctest-kv-%[3]s"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  tenant_id           = data.azurerm_client_config.current.tenant_id
+  sku_name            = "premium"
+
+  soft_delete_retention_days = 7
+}
+
+resource "azurerm_key_vault_key" "test" {
+  depends_on = [azurerm_key_vault_access_policy.terraform]
+
+  name         = "acctest-key-%[1]d"
+  key_vault_id = azurerm_key_vault.test.id
+  key_type     = "RSA"
+  key_size     = 2048
+
+  key_opts = [
+    "decrypt",
+    "encrypt",
+    "sign",
+    "unwrapKey",
+    "verify",
+    "wrapKey",
+  ]
+}
+
+resource "azurerm_key_vault_access_policy" "terraform" {
+  key_vault_id = azurerm_key_vault.test.id
+  tenant_id    = azurerm_key_vault.test.tenant_id
+  object_id    = data.azurerm_client_config.current.object_id
+
+  key_permissions = [
+    "Get",
+    "List",
+    "Create",
+    "Decrypt",
+    "Encrypt",
+    "GetRotationPolicy",
+    "Sign",
+    "UnwrapKey",
+    "Verify",
+    "WrapKey",
+    "Delete",
+    "Restore",
+    "Recover",
+    "Update",
+    "Purge",
+  ]
+}
+
+resource "azurerm_key_vault_access_policy" "databricks" {
+  depends_on = [azurerm_databricks_workspace.test]
+
+  key_vault_id = azurerm_key_vault.test.id
+  tenant_id    = azurerm_databricks_workspace.test.storage_account_identity.0.tenant_id
+  object_id    = azurerm_databricks_workspace.test.storage_account_identity.0.principal_id
+
+  key_permissions = [
+    "Get",
+    "GetRotationPolicy",
+    "UnwrapKey",
+    "WrapKey",
+    "Delete",
+  ]
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}

--- a/internal/services/databricks/databricks_workspace_data_source_test.go
+++ b/internal/services/databricks/databricks_workspace_data_source_test.go
@@ -102,7 +102,7 @@ resource "azurerm_databricks_workspace" "test" {
   }
 }
 
-resource "azurerm_databricks_workspace_customer_managed_key" "test" {
+resource "azurerm_databricks_workspace_root_dbfs_customer_managed_key" "test" {
   depends_on = [azurerm_key_vault_access_policy.databricks]
 
   workspace_id     = azurerm_databricks_workspace.test.id

--- a/internal/services/databricks/databricks_workspace_resource_test.go
+++ b/internal/services/databricks/databricks_workspace_resource_test.go
@@ -243,14 +243,14 @@ func TestAccDatabricksWorkspace_managedServices(t *testing.T) {
 	})
 }
 
-func TestAccDatabricksWorkspace_managedServicesAndDbfsCMK(t *testing.T) {
+func TestAccDatabricksWorkspace_managedServicesAndRootDbfsCMK(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_databricks_workspace", "test")
 	databricksPrincipalID := getDatabricksPrincipalId(data.Client().SubscriptionID)
 	r := DatabricksWorkspaceResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.managedServicesAndDbfsCMK(data, databricksPrincipalID),
+			Config: r.managedServicesAndRootDbfsCMK(data, databricksPrincipalID),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -275,14 +275,14 @@ func TestAccDatabricksWorkspace_managedDiskCMK(t *testing.T) {
 	})
 }
 
-func TestAccDatabricksWorkspace_managedServicesDbfsCMKAndPrivateLink(t *testing.T) {
+func TestAccDatabricksWorkspace_managedServicesRootDbfsCMKAndPrivateLink(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_databricks_workspace", "test")
 	databricksPrincipalID := getDatabricksPrincipalId(data.Client().SubscriptionID)
 	r := DatabricksWorkspaceResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.managedServicesDbfsCMKAndPrivateLink(data, databricksPrincipalID),
+			Config: r.managedServicesRootDbfsCMKAndPrivateLink(data, databricksPrincipalID),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -1365,7 +1365,7 @@ resource "azurerm_key_vault_access_policy" "managed" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomString, databricksPrincipalID)
 }
 
-func (DatabricksWorkspaceResource) managedServicesAndDbfsCMK(data acceptance.TestData, databricksPrincipalID string) string {
+func (DatabricksWorkspaceResource) managedServicesAndRootDbfsCMK(data acceptance.TestData, databricksPrincipalID string) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -1396,7 +1396,7 @@ resource "azurerm_databricks_workspace" "test" {
   }
 }
 
-resource "azurerm_databricks_workspace_customer_managed_key" "test" {
+resource "azurerm_databricks_workspace_root_dbfs_customer_managed_key" "test" {
   depends_on = [azurerm_key_vault_access_policy.databricks]
 
   workspace_id     = azurerm_databricks_workspace.test.id
@@ -1601,7 +1601,7 @@ resource "azurerm_key_vault_access_policy" "databricks" {
 `, data.RandomInteger, data.Locations.Primary, data.RandomString, databricksPrincipalID)
 }
 
-func (DatabricksWorkspaceResource) managedServicesDbfsCMKAndPrivateLink(data acceptance.TestData, databricksPrincipalID string) string {
+func (DatabricksWorkspaceResource) managedServicesRootDbfsCMKAndPrivateLink(data acceptance.TestData, databricksPrincipalID string) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -1718,7 +1718,7 @@ resource "azurerm_databricks_workspace" "test" {
   }
 }
 
-resource "azurerm_databricks_workspace_customer_managed_key" "test" {
+resource "azurerm_databricks_workspace_root_dbfs_customer_managed_key" "test" {
   depends_on = [azurerm_key_vault_access_policy.databricks]
 
   workspace_id     = azurerm_databricks_workspace.test.id

--- a/internal/services/databricks/databricks_workspace_resource_test.go
+++ b/internal/services/databricks/databricks_workspace_resource_test.go
@@ -1806,6 +1806,8 @@ resource "azurerm_key_vault_access_policy" "databricks" {
 }
 
 resource "azurerm_private_endpoint" "databricks" {
+  depends_on = [azurerm_databricks_workspace_root_dbfs_customer_managed_key.test]
+
   name                = "acctest-endpoint-%[1]d"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name

--- a/internal/services/databricks/registration.go
+++ b/internal/services/databricks/registration.go
@@ -43,7 +43,7 @@ func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
 func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 	return map[string]*pluginsdk.Resource{
 		"azurerm_databricks_workspace":                                resourceDatabricksWorkspace(),
-		"azurerm_databricks_workspace_customer_managed_key":           resourceDatabricksWorkspaceCustomerManagedKey(),
+		"azurerm_databricks_workspace_customer_managed_key":           resourceDatabricksWorkspaceCustomerManagedKey(), // TODO: Remove in 4.0
 		"azurerm_databricks_workspace_root_dbfs_customer_managed_key": resourceDatabricksWorkspaceRootDbfsCustomerManagedKey(),
 		"azurerm_databricks_virtual_network_peering":                  resourceDatabricksVirtualNetworkPeering(),
 	}

--- a/internal/services/databricks/registration.go
+++ b/internal/services/databricks/registration.go
@@ -42,9 +42,10 @@ func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
 // SupportedResources returns the supported Resources supported by this Service
 func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 	return map[string]*pluginsdk.Resource{
-		"azurerm_databricks_workspace":                      resourceDatabricksWorkspace(),
-		"azurerm_databricks_workspace_customer_managed_key": resourceDatabricksWorkspaceCustomerManagedKey(),
-		"azurerm_databricks_virtual_network_peering":        resourceDatabricksVirtualNetworkPeering(),
+		"azurerm_databricks_workspace":                                resourceDatabricksWorkspace(),
+		"azurerm_databricks_workspace_customer_managed_key":           resourceDatabricksWorkspaceCustomerManagedKey(),
+		"azurerm_databricks_workspace_root_dbfs_customer_managed_key": resourceDatabricksWorkspaceRootDbfsCustomerManagedKey(),
+		"azurerm_databricks_virtual_network_peering":                  resourceDatabricksVirtualNetworkPeering(),
 	}
 }
 

--- a/website/docs/r/databricks_workspace_customer_managed_key.html.markdown
+++ b/website/docs/r/databricks_workspace_customer_managed_key.html.markdown
@@ -3,12 +3,12 @@ subcategory: "Databricks"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_databricks_workspace_customer_managed_key"
 description: |-
-  Manages a Customer Managed Key for a Databricks Workspace
+  Manages a Customer Managed Key for a Databricks Workspace DBFS root
 ---
 
 # azurerm_databricks_workspace_customer_managed_key
 
-Manages a Customer Managed Key for a Databricks Workspace
+Manages a Customer Managed Key for a Databricks Workspace DBFS root
 
 ## Example Usage
 

--- a/website/docs/r/databricks_workspace_root_dbfs_customer_managed_key.html.markdown
+++ b/website/docs/r/databricks_workspace_root_dbfs_customer_managed_key.html.markdown
@@ -1,16 +1,14 @@
 ---
 subcategory: "Databricks"
 layout: "azurerm"
-page_title: "Azure Resource Manager: azurerm_databricks_workspace_customer_managed_key"
+page_title: "Azure Resource Manager: azurerm_databricks_workspace_root_dbfs_customer_managed_key"
 description: |-
-  Manages a Customer Managed Key for a Databricks Workspace root DBFS
+  Manages a Customer Managed Key for the Databricks Workspaces root Databricks File System(DBFS)
 ---
 
-# azurerm_databricks_workspace_customer_managed_key
+# azurerm_databricks_workspace_root_dbfs_customer_managed_key
 
-Manages a Customer Managed Key for a Databricks Workspace root DBFS
-
-!>**IMPORTANT:** This resource has been deprecated and will be removed from the 4.0 Azure provider. Please use the `azurerm_databricks_workspace_root_dbfs_customer_managed_key` resource instead.
+Manages a Customer Managed Key for the Databricks Workspaces root Databricks File System(DBFS)
 
 ## Example Usage
 
@@ -121,9 +119,9 @@ resource "azurerm_key_vault_access_policy" "databricks" {
 
 The following arguments are supported:
 
-* `workspace_id` - (Required) The ID of the Databricks Workspace..
+* `workspace_id` - (Required) The resource ID of the Databricks Workspace.
 
-* `key_vault_key_id` - (Required) The ID of the Key Vault.
+* `key_vault_key_id` - (Required) The resource ID of the Key Vault Key to be used.
 
 ## Attributes Reference
 
@@ -135,15 +133,15 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `create` - (Defaults to 30 minutes) Used when creating the Customer Managed Key for this Databricks Workspace.
-* `update` - (Defaults to 30 minutes) Used when updating the Customer Managed Key for this Databricks Workspace.
-* `read` - (Defaults to 5 minutes) Used when retrieving the Customer Managed Key for this Databricks Workspace.
-* `delete` - (Defaults to 30 minutes) Used when deleting the Customer Managed Key for this Databricks Workspace.
+* `create` - (Defaults to 30 minutes) Used when creating the Root DBFS Customer Managed Key for this Databricks Workspace.
+* `update` - (Defaults to 30 minutes) Used when updating the Root DBFS Customer Managed Key for this Databricks Workspace.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Root DBFS Customer Managed Key for this Databricks Workspace.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Root DBFS Customer Managed Key for this Databricks Workspace.
 
 ## Import
 
-Databricks Workspace Customer Managed Key can be imported using the `resource id`, e.g.
+Databricks Workspace Root DBFS Customer Managed Key can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_databricks_workspace_customer_managed_key.workspace1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Databricks/workspaces/workspace1
+terraform import azurerm_databricks_workspace_root_dbfs_customer_managed_key.workspace1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Databricks/workspaces/workspace1
 ```


### PR DESCRIPTION
In the updated `2023-02-01` version of the Databricks API the field this resource controls/wraps has been re-purposed to manage the `root DBFS` encryption key.

Given the above mentioned changes in the API, this PR will deprecate the old Databricks CMK resource in favor of the same resource but being renamed to bring its naming more into alignment with it's intended purpose. (e.g., managing the `Root DBFS` CMK encryption key).

(fixes: #22394)