### PR TITLE
`azurerm_log_analytics_workspace`: allow changing `sku` between `CapacityReservation` and `PerGB2018`

### DIFF
--- a/internal/services/loganalytics/log_analytics_workspace_resource.go
+++ b/internal/services/loganalytics/log_analytics_workspace_resource.go
@@ -117,7 +117,6 @@ func resourceLogAnalyticsWorkspace() *pluginsdk.Resource {
 			"reservation_capacity_in_gb_per_day": {
 				Type:     pluginsdk.TypeInt,
 				Optional: true,
-				Computed: true,
 				ValidateFunc: validation.IntInSlice([]int{
 					int(workspaces.CapacityReservationLevelOneHundred),
 					int(workspaces.CapacityReservationLevelTwoHundred),
@@ -293,11 +292,10 @@ func resourceLogAnalyticsWorkspaceCreateUpdate(d *pluginsdk.ResourceData, meta i
 	}
 
 	propName := "reservation_capacity_in_gb_per_day"
-	// read from raw config as it's an optional + computed property, GetOk() will read value from state.
-	capacityReservationLevel := d.GetRawConfig().AsValueMap()[propName]
-	if !capacityReservationLevel.IsNull() {
+	capacityReservationLevel, ok := d.GetOk(propName)
+	if ok {
 		if strings.EqualFold(skuName, string(workspaces.WorkspaceSkuNameEnumCapacityReservation)) {
-			capacityReservationLevelValue := workspaces.CapacityReservationLevel(int64(d.Get(propName).(int)))
+			capacityReservationLevelValue := workspaces.CapacityReservationLevel(int64(capacityReservationLevel.(int)))
 			parameters.Properties.Sku.CapacityReservationLevel = &capacityReservationLevelValue
 		} else {
 			return fmt.Errorf("`%s` can only be used with the `CapacityReservation` SKU", propName)

--- a/internal/services/loganalytics/log_analytics_workspace_resource_test.go
+++ b/internal/services/loganalytics/log_analytics_workspace_resource_test.go
@@ -331,6 +331,29 @@ func TestAccLogAnalyticsWorkspace_ToggleDisableLocalAuth(t *testing.T) {
 	})
 }
 
+func TestAccLogAnalyticsWorkspace_updateSku(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_log_analytics_workspace", "test")
+	r := LogAnalyticsWorkspaceResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.withCapacityReservationTypo(data, 100),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("reservation_capacity_in_gb_per_day").HasValue("100"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (t LogAnalyticsWorkspaceResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := workspaces.ParseWorkspaceID(state.ID)
 	if err != nil {

--- a/website/docs/r/log_analytics_workspace.html.markdown
+++ b/website/docs/r/log_analytics_workspace.html.markdown
@@ -45,6 +45,8 @@ The following arguments are supported:
 
 ~> **NOTE:** A new pricing model took effect on `2018-04-03`, which requires the SKU `PerGB2018`. If you're provisioned resources before this date you have the option of remaining with the previous Pricing SKU and using the other SKUs defined above. More information about [the Pricing SKUs is available at the following URI](https://aka.ms/PricingTierWarning).
 
+~> **NOTE:** Changing `sku` forces a new Log Analytics Workspace to be created, except changing between `PerGB2018` and `CapacityReservation`, but changing it to `CapacityReservation` or changing `reservation_capacity_in_gb_per_day` to a higher tier will lead to a 31-days commitment period, during which the sku could not be changed to a lower one. More information about [the commitment perioud](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/cost-logs#commitment-tiers)
+
 ~> **NOTE:** The `Free` SKU has a default `daily_quota_gb` value of `0.5` (GB).
 
 * `retention_in_days` - (Optional) The workspace data retention in days. Possible values are either 7 (Free Tier only) or range between 30 and 730.
@@ -59,7 +61,7 @@ The following arguments are supported:
 
 * `internet_query_enabled` - (Optional) Should the Log Analytics Workspace support querying over the Public Internet? Defaults to `true`.
 
-* `reservation_capacity_in_gb_per_day` - (Optional) The capacity reservation level in GB for this workspace. Must be in increments of 100 between 100 and 5000.
+* `reservation_capacity_in_gb_per_day` - (Optional) The capacity reservation level in GB for this workspace. Possible values are `100`, `200`, `300`, `400`, `500`, `1000`, `2000` and `5000`.
 
 ~> **NOTE:** `reservation_capacity_in_gb_per_day` can only be used when the `sku` is set to `CapacityReservation`.
 

--- a/website/docs/r/log_analytics_workspace.html.markdown
+++ b/website/docs/r/log_analytics_workspace.html.markdown
@@ -45,7 +45,7 @@ The following arguments are supported:
 
 ~> **NOTE:** A new pricing model took effect on `2018-04-03`, which requires the SKU `PerGB2018`. If you're provisioned resources before this date you have the option of remaining with the previous Pricing SKU and using the other SKUs defined above. More information about [the Pricing SKUs is available at the following URI](https://aka.ms/PricingTierWarning).
 
-~> **NOTE:** Changing `sku` forces a new Log Analytics Workspace to be created, except changing between `PerGB2018` and `CapacityReservation`, but changing it to `CapacityReservation` or changing `reservation_capacity_in_gb_per_day` to a higher tier will lead to a 31-days commitment period, during which the sku could not be changed to a lower one. More information about [the commitment perioud](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/cost-logs#commitment-tiers)
+~> **NOTE:** Changing `sku` forces a new Log Analytics Workspace to be created, except when changing between `PerGB2018` and `CapacityReservation`. However, changing `sku` to `CapacityReservation` or changing `reservation_capacity_in_gb_per_day` to a higher tier will lead to a 31-days commitment period, during which the SKU cannot be changed to a lower one. Please refer to [official documentation](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/cost-logs#commitment-tiers) for further information.
 
 ~> **NOTE:** The `Free` SKU has a default `daily_quota_gb` value of `0.5` (GB).
 


### PR DESCRIPTION
fix #12177

changing between `CapacityReservation` and `PerGB2018` does not force new resource to be created, but it will lead to a 31-days commitment period during which it could not be changed to lower pricing tier.  https://learn.microsoft.com/en-us/azure/azure-monitor/logs/cost-logs#commitment-tiers)

test
---
```
❯ tftest loganalytics TestAccLogAnalyticsWorkspace    
=== RUN   TestAccLogAnalyticsWorkspace_basic
=== PAUSE TestAccLogAnalyticsWorkspace_basic
=== RUN   TestAccLogAnalyticsWorkspace_requiresImport
=== PAUSE TestAccLogAnalyticsWorkspace_requiresImport
=== RUN   TestAccLogAnalyticsWorkspace_complete
=== PAUSE TestAccLogAnalyticsWorkspace_complete
=== RUN   TestAccLogAnalyticsWorkspace_freeTier
    log_analytics_workspace_resource_test.go:95: `TestAccLogAnalyticsWorkspace_freeTier` due to subscription pricing tier configuration (e.g. Pricing tier doesn't match the subscription's billing model.)
--- SKIP: TestAccLogAnalyticsWorkspace_freeTier (0.00s)
=== RUN   TestAccLogAnalyticsWorkspace_withDefaultSku
=== PAUSE TestAccLogAnalyticsWorkspace_withDefaultSku
=== RUN   TestAccLogAnalyticsWorkspace_withVolumeCap
=== PAUSE TestAccLogAnalyticsWorkspace_withVolumeCap
=== RUN   TestAccLogAnalyticsWorkspace_removeVolumeCap
=== PAUSE TestAccLogAnalyticsWorkspace_removeVolumeCap
=== RUN   TestAccLogAnalyticsWorkspace_withInternetIngestionEnabled
=== PAUSE TestAccLogAnalyticsWorkspace_withInternetIngestionEnabled
=== RUN   TestAccLogAnalyticsWorkspace_withInternetQueryEnabled
=== PAUSE TestAccLogAnalyticsWorkspace_withInternetQueryEnabled
=== RUN   TestAccLogAnalyticsWorkspace_withCapacityReservation
=== PAUSE TestAccLogAnalyticsWorkspace_withCapacityReservation
=== RUN   TestAccLogAnalyticsWorkspace_negativeOne
=== PAUSE TestAccLogAnalyticsWorkspace_negativeOne
=== RUN   TestAccLogAnalyticsWorkspace_cmkForQueryForced
=== PAUSE TestAccLogAnalyticsWorkspace_cmkForQueryForced
=== RUN   TestAccLogAnalyticsWorkspace_ToggleAllowOnlyResourcePermission
=== PAUSE TestAccLogAnalyticsWorkspace_ToggleAllowOnlyResourcePermission
=== RUN   TestAccLogAnalyticsWorkspace_ToggleDisableLocalAuth
=== PAUSE TestAccLogAnalyticsWorkspace_ToggleDisableLocalAuth
=== RUN   TestAccLogAnalyticsWorkspace_updateSku
=== PAUSE TestAccLogAnalyticsWorkspace_updateSku
=== CONT  TestAccLogAnalyticsWorkspace_basic
=== CONT  TestAccLogAnalyticsWorkspace_withInternetQueryEnabled
=== CONT  TestAccLogAnalyticsWorkspace_ToggleAllowOnlyResourcePermission
=== CONT  TestAccLogAnalyticsWorkspace_withVolumeCap
=== CONT  TestAccLogAnalyticsWorkspace_negativeOne
=== CONT  TestAccLogAnalyticsWorkspace_requiresImport
=== CONT  TestAccLogAnalyticsWorkspace_withDefaultSku
=== CONT  TestAccLogAnalyticsWorkspace_complete
=== NAME  TestAccLogAnalyticsWorkspace_withInternetQueryEnabled
    testcase.go:113: Error running init: exit status 1
        
        Error: Failed to install provider
        
        Error while installing hashicorp/azuread v2.8.0: read tcp
        198.18.0.1:52300->198.18.0.44:443: read: operation timed out
        
--- PASS: TestAccLogAnalyticsWorkspace_requiresImport (146.76s)
=== CONT  TestAccLogAnalyticsWorkspace_updateSku
=== CONT  TestAccLogAnalyticsWorkspace_withInternetIngestionEnabled
--- FAIL: TestAccLogAnalyticsWorkspace_withInternetQueryEnabled (148.63s)
--- PASS: TestAccLogAnalyticsWorkspace_withDefaultSku (166.74s)
=== CONT  TestAccLogAnalyticsWorkspace_ToggleDisableLocalAuth
--- PASS: TestAccLogAnalyticsWorkspace_complete (173.74s)
=== CONT  TestAccLogAnalyticsWorkspace_cmkForQueryForced
--- PASS: TestAccLogAnalyticsWorkspace_negativeOne (214.52s)
=== CONT  TestAccLogAnalyticsWorkspace_withCapacityReservation
--- PASS: TestAccLogAnalyticsWorkspace_basic (229.89s)
=== CONT  TestAccLogAnalyticsWorkspace_removeVolumeCap
--- PASS: TestAccLogAnalyticsWorkspace_withVolumeCap (250.41s)
--- PASS: TestAccLogAnalyticsWorkspace_ToggleAllowOnlyResourcePermission (316.67s)
--- PASS: TestAccLogAnalyticsWorkspace_updateSku (183.77s)
--- PASS: TestAccLogAnalyticsWorkspace_withInternetIngestionEnabled (186.86s)
--- PASS: TestAccLogAnalyticsWorkspace_ToggleDisableLocalAuth (177.66s)
--- PASS: TestAccLogAnalyticsWorkspace_cmkForQueryForced (176.09s)
--- PASS: TestAccLogAnalyticsWorkspace_withCapacityReservation (209.43s)
--- PASS: TestAccLogAnalyticsWorkspace_removeVolumeCap (216.31s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-azurerm/internal/services/loganalytics  446.273s
FAIL
```

rerun the failed one
```
❯ tftest loganalytics TestAccLogAnalyticsWorkspace_withInternetQueryEnabled
=== RUN   TestAccLogAnalyticsWorkspace_withInternetQueryEnabled
=== PAUSE TestAccLogAnalyticsWorkspace_withInternetQueryEnabled
=== CONT  TestAccLogAnalyticsWorkspace_withInternetQueryEnabled
--- PASS: TestAccLogAnalyticsWorkspace_withInternetQueryEnabled (144.83s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/loganalytics  144.886s
```