### PR TITLE
`azurerm_cosmosdb_account` - fixes regression to `default_identity_type` being switched to `FirstPartyIdentity` on update

### DIFF
--- a/internal/services/cosmos/cosmosdb_account_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_account_resource_test.go
@@ -179,7 +179,7 @@ func TestAccCosmosDBAccount_keyVaultUriUpdateConsistancy(t *testing.T) {
 	})
 }
 
-func TestAccCosmosDBAccount_updateTagsWithUserAssingedDefaultIdentity(t *testing.T) {
+func TestAccCosmosDBAccount_updateTagsWithUserAssignedDefaultIdentity(t *testing.T) {
 	// Regression test case for issue #22466
 	data := acceptance.BuildTestData(t, "azurerm_cosmosdb_account", "test")
 	r := CosmosDBAccountResource{}


### PR DESCRIPTION
(fixes #22466)