### PR TITLE
`azurerm_cdn_frontdoor_rule` - allow `conditions.x.url_path_condition.x.match_values` to be set to `/`

### DIFF
--- a/internal/services/cdn/cdn_frontdoor_rule_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_rule_resource_test.go
@@ -1204,7 +1204,7 @@ resource "azurerm_cdn_frontdoor_rule" "test" {
 
   name                      = "accTestRule%d"
   cdn_frontdoor_rule_set_id = azurerm_cdn_frontdoor_rule_set.test.id
-  
+
   order = 0
 
   actions {

--- a/internal/services/cdn/cdn_frontdoor_rule_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_rule_resource_test.go
@@ -349,7 +349,6 @@ func TestAccCdnFrontDoorRule_allowEmptyQueryString(t *testing.T) {
 }
 
 func TestAccCdnFrontDoorRule_allowForwardSlashUrlConditionMatchValue(t *testing.T) {
-	// NOTE: Regression test case for issue #19682
 	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_rule", "test")
 	r := CdnFrontDoorRuleResource{}
 	data.ResourceTest(t, r, []acceptance.TestStep{

--- a/internal/services/cdn/validate/front_door_validation_helpers.go
+++ b/internal/services/cdn/validate/front_door_validation_helpers.go
@@ -46,7 +46,7 @@ func CdnFrontDoorUrlPathConditionMatchValue(i interface{}, k string) (_ []string
 		return nil, []error{fmt.Errorf("expected type of %q to be string", k)}
 	}
 
-	if strings.HasPrefix(v, "/") {
+	if strings.HasPrefix(v, "/") && len(v) != 1 {
 		return nil, []error{fmt.Errorf(`%q must not begin with the URLs leading slash(e.g. /), got %q`, k, v)}
 	}
 


### PR DESCRIPTION
Fixes #21851

```
--- PASS: TestAccCdnFrontDoorRule_allowForwardSlashUrlConditionMatchValue (522.28s)
```