### PR TITLE
Fix cycle in azurerm_static_site_custom_domain TXT validation example

### DIFF
--- a/website/docs/r/static_site_custom_domain.html.markdown
+++ b/website/docs/r/static_site_custom_domain.html.markdown
@@ -59,7 +59,7 @@ resource "azurerm_static_site" "example" {
 
 resource "azurerm_static_site_custom_domain" "example" {
   static_site_id  = azurerm_static_site.example.id
-  domain_name     = "my-domain.${azurerm_dns_txt_record.example.zone_name}"
+  domain_name     = "my-domain.contoso.com"
   validation_type = "dns-txt-token"
 }
 


### PR DESCRIPTION
I didn't think the example would work but I thought I would try it and it doesn't:
```
❯ terraform plan -out tfplan
╷
│ Error: Cycle: azurerm_static_site_custom_domain.this, azurerm_dns_txt_record.validation
│
│
```