### PR TITLE
`azurerm_redis_enterprise_database` - support `redisJson` module for geo-replication

### DIFF
--- a/internal/services/redisenterprise/redis_enterprise_database_resource.go
+++ b/internal/services/redisenterprise/redis_enterprise_database_resource.go
@@ -510,8 +510,8 @@ func expandArmDatabaseModuleArray(input []interface{}, isGeoEnabled bool) (*[]da
 	for _, item := range input {
 		v := item.(map[string]interface{})
 		moduleName := v["name"].(string)
-		if moduleName != "RediSearch" && isGeoEnabled {
-			return nil, fmt.Errorf("Only RediSearch module is allowed with geo-replication")
+		if moduleName != "RediSearch" && moduleName != "RedisJSON" && isGeoEnabled {
+			return nil, fmt.Errorf("Only RediSearch and RedisJSON module are allowed with geo-replication")
 		}
 		results = append(results, databases.Module{
 			Name: moduleName,

--- a/internal/services/redisenterprise/redis_enterprise_database_resource.go
+++ b/internal/services/redisenterprise/redis_enterprise_database_resource.go
@@ -511,7 +511,7 @@ func expandArmDatabaseModuleArray(input []interface{}, isGeoEnabled bool) (*[]da
 		v := item.(map[string]interface{})
 		moduleName := v["name"].(string)
 		if moduleName != "RediSearch" && moduleName != "RedisJSON" && isGeoEnabled {
-			return nil, fmt.Errorf("Only RediSearch and RedisJSON module are allowed with geo-replication")
+			return nil, fmt.Errorf("Only RediSearch and RedisJSON modules are allowed with geo-replication")
 		}
 		results = append(results, databases.Module{
 			Name: moduleName,

--- a/internal/services/redisenterprise/redis_enterprise_database_resource_test.go
+++ b/internal/services/redisenterprise/redis_enterprise_database_resource_test.go
@@ -103,6 +103,20 @@ func TestRedisEnterpriseDatabase_geoDatabaseModule(t *testing.T) {
 	})
 }
 
+func TestRedisEnterpriseDatabase_geoDatabaseWithRedisJsonModule(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_redis_enterprise_database", "test")
+	r := RedisenterpriseDatabaseResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.geoDatabasewithRedisJsonModuleEnabled(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestRedisEnterpriseDatabase_unlinkDatabase(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_redis_enterprise_database", "test")
 	r := RedisenterpriseDatabaseResource{}
@@ -319,6 +333,31 @@ resource "azurerm_redis_enterprise_database" "test" {
   eviction_policy   = "NoEviction"
   module {
     name = "RediSearch"
+    args = ""
+  }
+  linked_database_id = [
+    "${azurerm_redis_enterprise_cluster.test.id}/databases/default",
+    "${azurerm_redis_enterprise_cluster.test1.id}/databases/default",
+    "${azurerm_redis_enterprise_cluster.test2.id}/databases/default"
+  ]
+
+  linked_database_group_nickname = "tftestGeoGroup"
+}
+`, r.template(data))
+}
+
+func (r RedisenterpriseDatabaseResource) geoDatabasewithRedisJsonModuleEnabled(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+resource "azurerm_redis_enterprise_database" "test" {
+  cluster_id          = azurerm_redis_enterprise_cluster.test.id
+  resource_group_name = azurerm_resource_group.test.name
+
+  client_protocol   = "Encrypted"
+  clustering_policy = "EnterpriseCluster"
+  eviction_policy   = "NoEviction"
+  module {
+    name = "RedisJSON"
     args = ""
   }
   linked_database_id = [

--- a/website/docs/r/redis_enterprise_database.html.markdown
+++ b/website/docs/r/redis_enterprise_database.html.markdown
@@ -71,7 +71,7 @@ The following arguments are supported:
 
 * `module` - (Optional) A `module` block as defined below. Changing this forces a new resource to be created.
 
--> **NOTE:** Only RediSearch module is allowed with geo-replication
+-> **NOTE:** Only `RediSearch` and `RedisJSON` module are allowed with geo-replication
 
 * `linked_database_id` - (Optional) A list of database resources to link with this database with a maximum of 5.
 

--- a/website/docs/r/redis_enterprise_database.html.markdown
+++ b/website/docs/r/redis_enterprise_database.html.markdown
@@ -71,7 +71,7 @@ The following arguments are supported:
 
 * `module` - (Optional) A `module` block as defined below. Changing this forces a new resource to be created.
 
--> **NOTE:** Only `RediSearch` and `RedisJSON` module are allowed with geo-replication
+-> **NOTE:** Only `RediSearch` and `RedisJSON` modules are allowed with geo-replication
 
 * `linked_database_id` - (Optional) A list of database resources to link with this database with a maximum of 5.
 


### PR DESCRIPTION
Support `RedisJSON` module for geo-replication as requested by the service team.

Test Result:
PASS: TestRedisEnterpriseDatabase_geoDatabaseWithRedisJsonModule (1229.63s)