### PR TITLE
docs: Add workaround to azurerm_static_site_custom_domain TXT validation

### DIFF
--- a/website/docs/r/static_site_custom_domain.html.markdown
+++ b/website/docs/r/static_site_custom_domain.html.markdown
@@ -69,7 +69,8 @@ resource "azurerm_dns_txt_record" "example" {
   resource_group_name = azurerm_resource_group.example.name
   ttl                 = 300
   record {
-    value = azurerm_static_site_custom_domain.example.validation_token
+    # Use a static value to workaround Azure API not returning the validation token after validation has completed
+    value = azurerm_static_site_custom_domain.example.validation_token == "" ? "validated" : azurerm_static_site_custom_domain.example.validation_token
   }
 }
 ```


### PR DESCRIPTION
I'm not sure if there's any better way for terraform to handle this.
Workaround discovered in https://github.com/hashicorp/terraform-provider-azurerm/issues/14750#issuecomment-1232338244

It seems to have hit plenty of people.
Could we document this as a work around?

Fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/14750