### PR TITLE
security_center_subscription_pricing_resource: add extensions support

### DIFF
--- a/internal/services/securitycenter/security_center_subscription_pricing_resource.go
+++ b/internal/services/securitycenter/security_center_subscription_pricing_resource.go
@@ -84,7 +84,7 @@ func resourceSecurityCenterSubscriptionPricing() *pluginsdk.Resource {
 				Optional: true,
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
-						"is_enabled": {
+						"enabled": {
 							Type:     pluginsdk.TypeString,
 							Required: true,
 						},
@@ -180,7 +180,7 @@ func resourceSecurityCenterSubscriptionPricingRead(d *pluginsdk.ResourceData, me
 		if properties := resp.Model.Properties; properties != nil {
 			d.Set("tier", properties.PricingTier)
 			d.Set("subplan", properties.SubPlan)
-			d.Set("extensions", properties.Extensions)
+			d.Set("extensions", *(properties.Extensions))
 		}
 	}
 
@@ -221,7 +221,7 @@ func ConvertInputExtensionToSDKModel(inputList []interface{}) *[]pricings_v2023_
 		input := v.(map[string]interface{})
 		output := pricings_v2023_01_01.Extension{
 			Name:      input["name"].(string),
-			IsEnabled: pricings_v2023_01_01.IsEnabled(input["is_enabled"].(string)),
+			IsEnabled: pricings_v2023_01_01.IsEnabled(input["enabled"].(string)),
 		}
 		if output.IsEnabled == "True" {
 			if vAdditional, ok := input["additional_extension_properties"]; ok {

--- a/internal/services/securitycenter/security_center_subscription_pricing_resource.go
+++ b/internal/services/securitycenter/security_center_subscription_pricing_resource.go
@@ -134,7 +134,7 @@ func resourceSecurityCenterSubscriptionPricingUpdate(d *pluginsdk.ResourceData, 
 		}
 	}
 
-	if apiResponse.Model != nil && apiResponse.Model.Properties != nil && apiResponse.Model.Properties.Extensions != nil {
+	if err == nil && apiResponse.Model != nil && apiResponse.Model.Properties != nil && apiResponse.Model.Properties.Extensions != nil {
 		extensionsStatusFromBackend = *apiResponse.Model.Properties.Extensions
 	}
 

--- a/internal/services/securitycenter/security_center_subscription_pricing_resource.go
+++ b/internal/services/securitycenter/security_center_subscription_pricing_resource.go
@@ -245,13 +245,12 @@ func flattenExtensions(inputList *[]pricings_v2023_01_01.Extension) []interface{
 
 	for _, input := range *inputList {
 		output := map[string]interface{}{
-			"enabled":          input.IsEnabled,
-			"name":             input.Name,
-			"operation_status": input.OperationStatus,
+			"enabled": input.IsEnabled,
+			"name":    input.Name,
 		}
 		if input.AdditionalExtensionProperties != nil {
 			output["additional_extension_properties"] = *input.AdditionalExtensionProperties
-		}:wq
+		}
 
 		outputList = append(outputList, output)
 	}

--- a/internal/services/securitycenter/security_center_subscription_pricing_resource.go
+++ b/internal/services/securitycenter/security_center_subscription_pricing_resource.go
@@ -141,7 +141,7 @@ func resourceSecurityCenterSubscriptionPricingUpdate(d *pluginsdk.ResourceData, 
 
 	// can not set extensions for free tier
 	if pricing.Properties.PricingTier == pricings_v2023_01_01.PricingTierStandard {
-		if vExt, okExt := d.GetOk("extension"); okExt {
+		if d.HasChange("extension") {
 			var extensions = expandSecurityCenterSubscriptionPricingExtensions(vExt.([]interface{}))
 			pricing.Properties.Extensions = extensions
 		}

--- a/internal/services/securitycenter/security_center_subscription_pricing_resource.go
+++ b/internal/services/securitycenter/security_center_subscription_pricing_resource.go
@@ -6,6 +6,7 @@ package securitycenter
 import (
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/security/mgmt/v3.0/security" // nolint: staticcheck
@@ -118,17 +119,23 @@ func resourceSecurityCenterSubscriptionPricingUpdate(d *pluginsdk.ResourceData, 
 		},
 	}
 
+	extensionsStatusFromBackend := []pricings_v2023_01_01.Extension{}
+
+	apiResponse, err := client.Get(ctx, id)
 	if d.IsNewResource() {
-		existing, err := client.Get(ctx, id)
 		if err != nil {
-			if !response.WasNotFound(existing.HttpResponse) {
-				return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
+			if !response.WasNotFound(apiResponse.HttpResponse) {
+				return fmt.Errorf("checking for presence of apiResponse %s: %+v", id, err)
 			}
 		}
 
-		if existing.Model != nil && existing.Model.Properties != nil && existing.Model.Properties.PricingTier != pricings_v2023_01_01.PricingTierFree {
+		if apiResponse.Model != nil && apiResponse.Model.Properties != nil && apiResponse.Model.Properties.PricingTier != pricings_v2023_01_01.PricingTierFree {
 			return fmt.Errorf("the pricing tier of this subscription is not Free \r %+v", tf.ImportAsExistsError("azurerm_security_center_subscription_pricing", id.ID()))
 		}
+	}
+
+	if apiResponse.Model != nil && apiResponse.Model.Properties != nil && apiResponse.Model.Properties.Extensions != nil {
+		extensionsStatusFromBackend = *apiResponse.Model.Properties.Extensions
 	}
 
 	if vSub, okSub := d.GetOk("subplan"); okSub {
@@ -138,7 +145,7 @@ func resourceSecurityCenterSubscriptionPricingUpdate(d *pluginsdk.ResourceData, 
 	// can not set extensions for free tier
 	if pricing.Properties.PricingTier == pricings_v2023_01_01.PricingTierStandard {
 		if d.HasChange("extension") {
-			var extensions = expandSecurityCenterSubscriptionPricingExtensions(d.Get("extension").(*pluginsdk.Set).List())
+			var extensions = expandSecurityCenterSubscriptionPricingExtensions(d.Get("extension").(*pluginsdk.Set).List(), &extensionsStatusFromBackend)
 			pricing.Properties.Extensions = extensions
 		}
 	}
@@ -177,11 +184,9 @@ func resourceSecurityCenterSubscriptionPricingRead(d *pluginsdk.ResourceData, me
 		if properties := resp.Model.Properties; properties != nil {
 			d.Set("tier", properties.PricingTier)
 			d.Set("subplan", properties.SubPlan)
-			if properties.Extensions != nil {
-				err = d.Set("extension", flattenExtensions(properties.Extensions))
-				if err != nil {
-					return fmt.Errorf("setting `extension`: %+v", err)
-				}
+			err = d.Set("extension", flattenExtensions(properties.Extensions))
+			if err != nil {
+				return fmt.Errorf("setting `extension`: %+v", err)
 			}
 		}
 	}
@@ -213,20 +218,45 @@ func resourceSecurityCenterSubscriptionPricingDelete(d *pluginsdk.ResourceData, 
 	return nil
 }
 
-func expandSecurityCenterSubscriptionPricingExtensions(inputList []interface{}) *[]pricings_v2023_01_01.Extension {
+func expandSecurityCenterSubscriptionPricingExtensions(inputList []interface{}, extensionsStatusFromBackend *[]pricings_v2023_01_01.Extension) *[]pricings_v2023_01_01.Extension {
 	if len(inputList) == 0 {
 		return nil
 	}
+	var extensionStatuses = map[string]bool{}
+	var extensionProperties = map[string]*interface{}{}
 
 	var outputList []pricings_v2023_01_01.Extension
 	for _, v := range inputList {
 		input := v.(map[string]interface{})
-		output := pricings_v2023_01_01.Extension{
-			Name:      input["name"].(string),
-			IsEnabled: "True",
-		}
+		extensionStatuses[input["name"].(string)] = true
+
 		if vAdditional, ok := input["additional_extension_properties"]; ok {
-			output.AdditionalExtensionProperties = &vAdditional
+			extensionProperties[input["name"].(string)] = &vAdditional
+		}
+	}
+
+	if extensionsStatusFromBackend != nil {
+		for _, backendExtension := range *extensionsStatusFromBackend {
+			_, ok := extensionStatuses[backendExtension.Name]
+			// set any extension that does not appear in the template to be false
+			if !ok {
+				extensionStatuses[backendExtension.Name] = false
+			}
+		}
+	}
+
+	for extensionName, toBeEnabled := range extensionStatuses {
+
+		isEnabled := pricings_v2023_01_01.IsEnabledFalse
+		if toBeEnabled {
+			isEnabled = pricings_v2023_01_01.IsEnabledTrue
+		}
+		output := pricings_v2023_01_01.Extension{
+			Name:      extensionName,
+			IsEnabled: isEnabled,
+		}
+		if vAdditional, ok := extensionProperties[extensionName]; ok {
+			output.AdditionalExtensionProperties = vAdditional
 		}
 		outputList = append(outputList, output)
 	}
@@ -244,7 +274,7 @@ func flattenExtensions(inputList *[]pricings_v2023_01_01.Extension) []interface{
 
 	for _, input := range *inputList {
 		// only keep enabled extensions
-		if input.IsEnabled == "False" {
+		if !strings.EqualFold(string(input.IsEnabled), "true") {
 			continue
 		}
 

--- a/internal/services/securitycenter/security_center_subscription_pricing_resource.go
+++ b/internal/services/securitycenter/security_center_subscription_pricing_resource.go
@@ -101,22 +101,6 @@ func resourceSecurityCenterSubscriptionPricing() *pluginsdk.Resource {
 								ValidateFunc: validation.StringIsNotWhiteSpace,
 							},
 						},
-						"operation_status": {
-							Type:     pluginsdk.TypeList,
-							Computed: true,
-							Elem: &pluginsdk.Resource{
-								Schema: map[string]*pluginsdk.Schema{
-									"code": {
-										Computed: true,
-										Type:     pluginsdk.TypeString,
-									},
-									"message": {
-										Computed: true,
-										Type:     pluginsdk.TypeString,
-									},
-								},
-							},
-						},
 					},
 				},
 			},
@@ -272,13 +256,6 @@ func flattenExtensions(inputList *[]pricings_v2023_01_01.Extension) []interface{
 		}
 		if input.AdditionalExtensionProperties != nil {
 			output["additional_extension_properties"] = *input.AdditionalExtensionProperties
-		}
-
-		if input.OperationStatus != nil {
-			status := make(map[string]interface{})
-			status["code"] = input.OperationStatus.Code
-			status["message"] = input.OperationStatus.Message
-			output["operation_status"] = &[]interface{}{status}
 		}
 
 		outputList = append(outputList, output)

--- a/internal/services/securitycenter/security_center_subscription_pricing_resource.go
+++ b/internal/services/securitycenter/security_center_subscription_pricing_resource.go
@@ -180,7 +180,9 @@ func resourceSecurityCenterSubscriptionPricingRead(d *pluginsdk.ResourceData, me
 		if properties := resp.Model.Properties; properties != nil {
 			d.Set("tier", properties.PricingTier)
 			d.Set("subplan", properties.SubPlan)
-			d.Set("extensions", *(properties.Extensions))
+			if properties.Extensions != nil {
+				d.Set("extensions", *(properties.Extensions))
+			}
 		}
 	}
 

--- a/internal/services/securitycenter/security_center_subscription_pricing_resource.go
+++ b/internal/services/securitycenter/security_center_subscription_pricing_resource.go
@@ -129,7 +129,7 @@ func resourceSecurityCenterSubscriptionPricingUpdate(d *pluginsdk.ResourceData, 
 			}
 		}
 
-		if apiResponse.Model != nil && apiResponse.Model.Properties != nil && apiResponse.Model.Properties.PricingTier != pricings_v2023_01_01.PricingTierFree {
+		if err == nil && apiResponse.Model != nil && apiResponse.Model.Properties != nil && apiResponse.Model.Properties.PricingTier != pricings_v2023_01_01.PricingTierFree {
 			return fmt.Errorf("the pricing tier of this subscription is not Free \r %+v", tf.ImportAsExistsError("azurerm_security_center_subscription_pricing", id.ID()))
 		}
 	}

--- a/internal/services/securitycenter/security_center_subscription_pricing_resource.go
+++ b/internal/services/securitycenter/security_center_subscription_pricing_resource.go
@@ -80,7 +80,7 @@ func resourceSecurityCenterSubscriptionPricing() *pluginsdk.Resource {
 				Optional: true,
 			},
 			"extension": {
-				Type:     pluginsdk.TypeList,
+				Type:     pluginsdk.TypeSet,
 				Optional: true,
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
@@ -258,11 +258,12 @@ func expandSecurityCenterSubscriptionPricingExtensions(inputList []interface{}) 
 
 func flattenExtensions(inputList *[]pricings_v2023_01_01.Extension) []interface{} {
 
+        outputList := make([]interface{}, 0)
+        
 	if inputList == nil {
-		return nil
+		return outputList
 	}
 
-	outputList := make([]interface{}, 0)
 
 	for _, input := range *inputList {
 		output := map[string]interface{}{

--- a/internal/services/securitycenter/security_center_subscription_pricing_resource.go
+++ b/internal/services/securitycenter/security_center_subscription_pricing_resource.go
@@ -138,7 +138,7 @@ func resourceSecurityCenterSubscriptionPricingUpdate(d *pluginsdk.ResourceData, 
 	// can not set extensions for free tier
 	if pricing.Properties.PricingTier == pricings_v2023_01_01.PricingTierStandard {
 		if d.HasChange("extension") {
-			var extensions = expandSecurityCenterSubscriptionPricingExtensions(d.Get("extension").([]interface{}))
+			var extensions = expandSecurityCenterSubscriptionPricingExtensions(d.Get("extension").(*pluginsdk.Set).List())
 			pricing.Properties.Extensions = extensions
 		}
 	}

--- a/internal/services/securitycenter/security_center_subscription_pricing_resource.go
+++ b/internal/services/securitycenter/security_center_subscription_pricing_resource.go
@@ -119,8 +119,6 @@ func resourceSecurityCenterSubscriptionPricingUpdate(d *pluginsdk.ResourceData, 
 		},
 	}
 
-	extensionsStatusFromBackend := []pricings_v2023_01_01.Extension{}
-
 	apiResponse, err := client.Get(ctx, id)
 	if d.IsNewResource() {
 		if err != nil {
@@ -134,6 +132,7 @@ func resourceSecurityCenterSubscriptionPricingUpdate(d *pluginsdk.ResourceData, 
 		}
 	}
 
+	extensionsStatusFromBackend := make([]pricings_v2023_01_01.Extension, 0)
 	if err == nil && apiResponse.Model != nil && apiResponse.Model.Properties != nil && apiResponse.Model.Properties.Extensions != nil {
 		extensionsStatusFromBackend = *apiResponse.Model.Properties.Extensions
 	}
@@ -141,10 +140,9 @@ func resourceSecurityCenterSubscriptionPricingUpdate(d *pluginsdk.ResourceData, 
 	if vSub, okSub := d.GetOk("subplan"); okSub {
 		pricing.Properties.SubPlan = utils.String(vSub.(string))
 	}
-
-	// can not set extensions for free tier
-	if pricing.Properties.PricingTier == pricings_v2023_01_01.PricingTierStandard {
-		if d.HasChange("extension") {
+	if d.HasChange("extension") || d.IsNewResource() {
+		// can not set extensions for free tier
+		if pricing.Properties.PricingTier == pricings_v2023_01_01.PricingTierStandard {
 			var extensions = expandSecurityCenterSubscriptionPricingExtensions(d.Get("extension").(*pluginsdk.Set).List(), &extensionsStatusFromBackend)
 			pricing.Properties.Extensions = extensions
 		}

--- a/internal/services/securitycenter/security_center_subscription_pricing_resource.go
+++ b/internal/services/securitycenter/security_center_subscription_pricing_resource.go
@@ -249,8 +249,7 @@ func flattenExtensions(inputList *[]pricings_v2023_01_01.Extension) []interface{
 		}
 
 		output := map[string]interface{}{
-			"enabled": input.IsEnabled,
-			"name":    input.Name,
+			"name": input.Name,
 		}
 		if input.AdditionalExtensionProperties != nil {
 			output["additional_extension_properties"] = *input.AdditionalExtensionProperties

--- a/internal/services/securitycenter/security_center_subscription_pricing_resource.go
+++ b/internal/services/securitycenter/security_center_subscription_pricing_resource.go
@@ -245,11 +245,13 @@ func flattenExtensions(inputList *[]pricings_v2023_01_01.Extension) []interface{
 
 	for _, input := range *inputList {
 		output := map[string]interface{}{
-			"enabled":                         input.IsEnabled,
-			"name":                            input.Name,
-			"additional_extension_properties": *input.AdditionalExtensionProperties,
-			"operation_status":                input.OperationStatus,
+			"enabled":          input.IsEnabled,
+			"name":             input.Name,
+			"operation_status": input.OperationStatus,
 		}
+		if input.AdditionalExtensionProperties != nil {
+			output["additional_extension_properties"] = *input.AdditionalExtensionProperties
+		}:wq
 
 		outputList = append(outputList, output)
 	}

--- a/internal/services/securitycenter/security_center_subscription_pricing_resource_test.go
+++ b/internal/services/securitycenter/security_center_subscription_pricing_resource_test.go
@@ -170,15 +170,15 @@ resource "azurerm_security_center_subscription_pricing" "test" {
   resource_type = "CloudPosture"
   extension {
     name= "SensitiveDataDiscovery"
-    is_enabled = "True"
+    enabled = "True"
   }
   extension {
     name= "AgentlessDiscoveryForKubernetes"
-    is_enabled = "False"
+    enabled = "False"
   }
   extension {
     name= "AgentlessVmScanning"
-    is_enabled = "True"
+    enabled = "True"
     additional_extension_properties = {
 ExclusionTags = "[]"
     }

--- a/internal/services/securitycenter/security_center_subscription_pricing_resource_test.go
+++ b/internal/services/securitycenter/security_center_subscription_pricing_resource_test.go
@@ -167,15 +167,15 @@ provider "azurerm" {
 }
 
 resource "azurerm_security_center_subscription_pricing" "test" {
-  tier= "Standard"
+  tier          = "Standard"
   resource_type = "CloudPosture"
   extension {
-    name    = "SensitiveDataDiscovery"
+    name = "SensitiveDataDiscovery"
   }
   extension {
-    name    = "AgentlessVmScanning"
+    name = "AgentlessVmScanning"
     additional_extension_properties = {
-ExclusionTags = "[]"
+      ExclusionTags = "[]"
     }
 
   }

--- a/internal/services/securitycenter/security_center_subscription_pricing_resource_test.go
+++ b/internal/services/securitycenter/security_center_subscription_pricing_resource_test.go
@@ -170,15 +170,16 @@ resource "azurerm_security_center_subscription_pricing" "test" {
   tier= "Standard"
   resource_type = "CloudPosture"
   extension {
-    name= "SensitiveDataDiscovery"
+    name    = "SensitiveDataDiscovery"
     enabled = "True"
   }
   extension {
-    name= "AgentlessVmScanning"
-    enabled = "False"
+    name    = "AgentlessVmScanning"
+    enabled = "True"
     additional_extension_properties = {
-		ExclusionTags = "[]"
+ExclusionTags = "[]"
     }
+
   }
 }
 `

--- a/internal/services/securitycenter/security_center_subscription_pricing_resource_test.go
+++ b/internal/services/securitycenter/security_center_subscription_pricing_resource_test.go
@@ -110,6 +110,7 @@ func TestAccSecurityCenterSubscriptionPricing_cloudPostureExtension(t *testing.T
 				check.That(data.ResourceName).Key("tier").HasValue("Standard"),
 				check.That(data.ResourceName).Key("resource_type").HasValue("CloudPosture"),
 				check.That(data.ResourceName).Key("extension").IsNotEmpty(),
+				check.That(data.ResourceName).Key("extension").HasValue("AgentlessVmScanning"),
 			),
 		},
 		data.ImportStep(),
@@ -173,16 +174,11 @@ resource "azurerm_security_center_subscription_pricing" "test" {
     enabled = "True"
   }
   extension {
-    name= "AgentlessDiscoveryForKubernetes"
-    enabled = "False"
-  }
-  extension {
     name= "AgentlessVmScanning"
-    enabled = "True"
+    enabled = "False"
     additional_extension_properties = {
-ExclusionTags = "[]"
+		ExclusionTags = "[]"
     }
-
   }
 }
 `

--- a/internal/services/securitycenter/security_center_subscription_pricing_resource_test.go
+++ b/internal/services/securitycenter/security_center_subscription_pricing_resource_test.go
@@ -171,11 +171,9 @@ resource "azurerm_security_center_subscription_pricing" "test" {
   resource_type = "CloudPosture"
   extension {
     name    = "SensitiveDataDiscovery"
-    enabled = "True"
   }
   extension {
     name    = "AgentlessVmScanning"
-    enabled = "True"
     additional_extension_properties = {
 ExclusionTags = "[]"
     }

--- a/internal/services/securitycenter/security_center_subscription_pricing_resource_test.go
+++ b/internal/services/securitycenter/security_center_subscription_pricing_resource_test.go
@@ -109,11 +109,29 @@ func TestAccSecurityCenterSubscriptionPricing_cloudPostureExtension(t *testing.T
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("tier").HasValue("Standard"),
 				check.That(data.ResourceName).Key("resource_type").HasValue("CloudPosture"),
-				check.That(data.ResourceName).Key("extension").IsNotEmpty(),
-				check.That(data.ResourceName).Key("extension").HasValue("AgentlessVmScanning"),
+				check.That(data.ResourceName).Key("extension.#").HasValue("2"),
 			),
 		},
 		data.ImportStep(),
+		{
+			Config: r.cloudPostureExtensionUpdated(),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("tier").HasValue("Standard"),
+				check.That(data.ResourceName).Key("resource_type").HasValue("CloudPosture"),
+				check.That(data.ResourceName).Key("extension.#").HasValue("3"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.cloudPostureExtension(),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("tier").HasValue("Standard"),
+				check.That(data.ResourceName).Key("resource_type").HasValue("CloudPosture"),
+				check.That(data.ResourceName).Key("extension.#").HasValue("2"),
+			),
+		},
 	})
 }
 
@@ -169,15 +187,46 @@ provider "azurerm" {
 resource "azurerm_security_center_subscription_pricing" "test" {
   tier          = "Standard"
   resource_type = "CloudPosture"
+
   extension {
     name = "SensitiveDataDiscovery"
   }
+
   extension {
     name = "AgentlessVmScanning"
     additional_extension_properties = {
       ExclusionTags = "[]"
     }
+  }
+}
+`
+}
 
+func (SecurityCenterSubscriptionPricingResource) cloudPostureExtensionUpdated() string {
+	return `
+provider "azurerm" {
+  features {
+
+  }
+}
+
+resource "azurerm_security_center_subscription_pricing" "test" {
+  tier          = "Standard"
+  resource_type = "CloudPosture"
+
+  extension {
+    name = "ContainerRegistriesVulnerabilityAssessments"
+  }
+
+  extension {
+    name = "AgentlessVmScanning"
+    additional_extension_properties = {
+      ExclusionTags = "[]"
+    }
+  }
+
+  extension {
+    name = "AgentlessDiscoveryForKubernetes"
   }
 }
 `

--- a/website/docs/r/security_center_subscription_pricing.html.markdown
+++ b/website/docs/r/security_center_subscription_pricing.html.markdown
@@ -21,28 +21,6 @@ resource "azurerm_security_center_subscription_pricing" "example" {
 }
 ```
 
-Example for extensions
-```hcl
-resource "azurerm_security_center_subscription_pricing" "test" {
-  tier= "Standard"
-  resource_type = "CloudPosture"
-  extension {
-    name= "SensitiveDataDiscovery"
-    enabled = "True"
-  }
-  extension {
-    name= "AgentlessDiscoveryForKubernetes"
-    enabled = "False"
-  }
-  extension {
-    name= "AgentlessVmScanning"
-    enabled = "True"
-    additional_extension_properties = {
-        ExclusionTags = "[]"
-    }
-  }
-}
-```
 ## Argument Reference
 
 The following arguments are supported:
@@ -50,7 +28,18 @@ The following arguments are supported:
 * `tier` - (Required) The pricing tier to use. Possible values are `Free` and `Standard`.
 * `resource_type` - (Optional) The resource type this setting affects. Possible values are `AppServices`, `ContainerRegistry`, `KeyVaults`, `KubernetesService`, `SqlServers`, `SqlServerVirtualMachines`, `StorageAccounts`, `VirtualMachines`, `Arm`, `Dns`, `OpenSourceRelationalDatabases`, `Containers`, `CosmosDbs` and `CloudPosture`. Defaults to `VirtualMachines`
 * `subplan` - (Optional) Resource type pricing subplan. Contact your MSFT representative for possible values.
-* `extension` - (Optional) Resource type pricing extensions. Contact your MSFT representative for possible values.
+* `extension` - (Optional) One or more `extension` blocks as defined below.
+
+---
+
+A `extension` block supports the following:
+
+* `name` - (Required) The name of extension.
+
+* `enabled` - (Required) enable or disable the extension.
+
+* `additional_extension_properties` - (Optional) Key/Value paris that are required for some extensions.
+
 
 ~> **NOTE:** Changing the pricing tier to `Standard` affects all resources of the given type in the subscription and could be quite costly.
 

--- a/website/docs/r/security_center_subscription_pricing.html.markdown
+++ b/website/docs/r/security_center_subscription_pricing.html.markdown
@@ -28,6 +28,7 @@ The following arguments are supported:
 * `tier` - (Required) The pricing tier to use. Possible values are `Free` and `Standard`.
 * `resource_type` - (Optional) The resource type this setting affects. Possible values are `AppServices`, `ContainerRegistry`, `KeyVaults`, `KubernetesService`, `SqlServers`, `SqlServerVirtualMachines`, `StorageAccounts`, `VirtualMachines`, `Arm`, `Dns`, `OpenSourceRelationalDatabases`, `Containers`, `CosmosDbs` and `CloudPosture`. Defaults to `VirtualMachines`
 * `subplan` - (Optional) Resource type pricing subplan. Contact your MSFT representative for possible values.
+* `extensions` - (Optional) Resource type pricing extensions. Contact your MSFT representative for possible values.
 
 ~> **NOTE:** Changing the pricing tier to `Standard` affects all resources of the given type in the subscription and could be quite costly.
 

--- a/website/docs/r/security_center_subscription_pricing.html.markdown
+++ b/website/docs/r/security_center_subscription_pricing.html.markdown
@@ -21,6 +21,28 @@ resource "azurerm_security_center_subscription_pricing" "example" {
 }
 ```
 
+Example for extensions
+```hcl
+resource "azurerm_security_center_subscription_pricing" "test" {
+  tier= "Standard"
+  resource_type = "CloudPosture"
+  extension {
+    name= "SensitiveDataDiscovery"
+    enabled = "True"
+  }
+  extension {
+    name= "AgentlessDiscoveryForKubernetes"
+    enabled = "False"
+  }
+  extension {
+    name= "AgentlessVmScanning"
+    enabled = "True"
+    additional_extension_properties = {
+        ExclusionTags = "[]"
+    }
+  }
+}
+```
 ## Argument Reference
 
 The following arguments are supported:
@@ -28,7 +50,7 @@ The following arguments are supported:
 * `tier` - (Required) The pricing tier to use. Possible values are `Free` and `Standard`.
 * `resource_type` - (Optional) The resource type this setting affects. Possible values are `AppServices`, `ContainerRegistry`, `KeyVaults`, `KubernetesService`, `SqlServers`, `SqlServerVirtualMachines`, `StorageAccounts`, `VirtualMachines`, `Arm`, `Dns`, `OpenSourceRelationalDatabases`, `Containers`, `CosmosDbs` and `CloudPosture`. Defaults to `VirtualMachines`
 * `subplan` - (Optional) Resource type pricing subplan. Contact your MSFT representative for possible values.
-* `extensions` - (Optional) Resource type pricing extensions. Contact your MSFT representative for possible values.
+* `extension` - (Optional) Resource type pricing extensions. Contact your MSFT representative for possible values.
 
 ~> **NOTE:** Changing the pricing tier to `Standard` affects all resources of the given type in the subscription and could be quite costly.
 

--- a/website/docs/r/security_center_subscription_pricing.html.markdown
+++ b/website/docs/r/security_center_subscription_pricing.html.markdown
@@ -36,10 +36,9 @@ A `extension` block supports the following:
 
 * `name` - (Required) The name of extension.
 
-* `enabled` - (Required) enable or disable the extension.
+* `additional_extension_properties` - (Optional) Key/Value pairs that are required for some extensions.
 
-* `additional_extension_properties` - (Optional) Key/Value paris that are required for some extensions.
-
+~> **NOTE:** If an extension is not defined, it will not be enabled. Use `ignore_changes` on the `extension` field if you want to use the default extensions.
 
 ~> **NOTE:** Changing the pricing tier to `Standard` affects all resources of the given type in the subscription and could be quite costly.
 


### PR DESCRIPTION
This PR contains changes to the azurerm_security_center_subscription_pricing resource which adds the extension block to the resource schema, to support for Defender for Cloud Pricing Advanced configuration.

Closes: https://github.com/hashicorp/terraform-provider-azurerm/issues/16217