### PR TITLE
New resource and data source: `azurerm_automation_variable_object`

### DIFF
--- a/internal/services/automation/automation_variable.go
+++ b/internal/services/automation/automation_variable.go
@@ -4,6 +4,7 @@
 package automation
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 	"regexp"
@@ -49,6 +50,9 @@ func ParseAzureAutomationVariableValue(resource string, input *string) (interfac
 		actualResource = "azurerm_automation_variable_int"
 	} else if value, err = strconv.ParseBool(*input); err == nil {
 		actualResource = "azurerm_automation_variable_bool"
+	} else if err := json.Unmarshal([]byte(*input), &value); err == nil {
+		value = *input
+		actualResource = "azurerm_automation_variable_object"
 	}
 
 	if actualResource != resource {
@@ -165,6 +169,9 @@ func resourceAutomationVariableCreateUpdate(d *pluginsdk.ResourceData, meta inte
 		value = strconv.FormatBool(d.Get("value").(bool))
 	case "int":
 		value = strconv.Itoa(d.Get("value").(int))
+	case "object":
+		// We don't quote the object so it gets saved as a JSON object
+		value = d.Get("value").(string)
 	case "string":
 		value = strconv.Quote(d.Get("value").(string))
 	}

--- a/internal/services/automation/automation_variable_object_data_source.go
+++ b/internal/services/automation/automation_variable_object_data_source.go
@@ -1,0 +1,26 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package automation
+
+import (
+	"time"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+func dataSourceAutomationVariableObject() *pluginsdk.Resource {
+	return &pluginsdk.Resource{
+		Read: dataSourceAutomationVariableObjectRead,
+
+		Timeouts: &pluginsdk.ResourceTimeout{
+			Read: pluginsdk.DefaultTimeout(5 * time.Minute),
+		},
+
+		Schema: datasourceAutomationVariableCommonSchema(pluginsdk.TypeString),
+	}
+}
+
+func dataSourceAutomationVariableObjectRead(d *pluginsdk.ResourceData, meta interface{}) error {
+	return dataSourceAutomationVariableRead(d, meta, "Object")
+}

--- a/internal/services/automation/automation_variable_object_data_source_test.go
+++ b/internal/services/automation/automation_variable_object_data_source_test.go
@@ -1,0 +1,40 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package automation_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+)
+
+type AutomationVariableObjectDataSource struct{}
+
+func TestAccDataSourceAzureRMAutomationVariableObject_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "data.azurerm_automation_variable_object", "test")
+	r := AutomationVariableObjectDataSource{}
+
+	data.DataSourceTest(t, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).Key("value").Exists(),
+			),
+		},
+	})
+}
+
+func (AutomationVariableObjectDataSource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_automation_variable_object" "test" {
+  name                    = azurerm_automation_variable_object.test.name
+  resource_group_name     = azurerm_automation_variable_object.test.resource_group_name
+  automation_account_name = azurerm_automation_variable_object.test.automation_account_name
+}
+`, AutomationVariableObjectResource{}.basic(data))
+}

--- a/internal/services/automation/automation_variable_object_resource.go
+++ b/internal/services/automation/automation_variable_object_resource.go
@@ -13,9 +13,9 @@ import (
 
 func resourceAutomationVariableObject() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
-		Create: resourceAutomationVariableObjectCreateUpdate,
+		Create: resourceAutomationVariableObjectCreate,
 		Read:   resourceAutomationVariableObjectRead,
-		Update: resourceAutomationVariableObjectCreateUpdate,
+		Update: resourceAutomationVariableObjectUpdate,
 		Delete: resourceAutomationVariableObjectDelete,
 
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
@@ -35,7 +35,11 @@ func resourceAutomationVariableObject() *pluginsdk.Resource {
 	}
 }
 
-func resourceAutomationVariableObjectCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+func resourceAutomationVariableObjectCreate(d *pluginsdk.ResourceData, meta interface{}) error {
+	return resourceAutomationVariableCreateUpdate(d, meta, "Object")
+}
+
+func resourceAutomationVariableObjectUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
 	return resourceAutomationVariableCreateUpdate(d, meta, "Object")
 }
 

--- a/internal/services/automation/automation_variable_object_resource.go
+++ b/internal/services/automation/automation_variable_object_resource.go
@@ -30,7 +30,6 @@ func resourceAutomationVariableObject() *pluginsdk.Resource {
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 
-		// @TODO Create a validation function to check that we have a JSON object passed to us?
 		Schema: resourceAutomationVariableCommonSchema(pluginsdk.TypeString, validation.StringIsNotEmpty),
 	}
 }

--- a/internal/services/automation/automation_variable_object_resource.go
+++ b/internal/services/automation/automation_variable_object_resource.go
@@ -1,0 +1,48 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package automation
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-sdk/resource-manager/automation/2022-08-08/variable"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+func resourceAutomationVariableObject() *pluginsdk.Resource {
+	return &pluginsdk.Resource{
+		Create: resourceAutomationVariableObjectCreateUpdate,
+		Read:   resourceAutomationVariableObjectRead,
+		Update: resourceAutomationVariableObjectCreateUpdate,
+		Delete: resourceAutomationVariableObjectDelete,
+
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := variable.ParseVariableID(id)
+			return err
+		}),
+
+		Timeouts: &pluginsdk.ResourceTimeout{
+			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
+			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
+			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
+			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
+		},
+
+		// @TODO Create a validation function to check that we have a JSON object passed to us?
+		Schema: resourceAutomationVariableCommonSchema(pluginsdk.TypeString, validation.StringIsNotEmpty),
+	}
+}
+
+func resourceAutomationVariableObjectCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+	return resourceAutomationVariableCreateUpdate(d, meta, "Object")
+}
+
+func resourceAutomationVariableObjectRead(d *pluginsdk.ResourceData, meta interface{}) error {
+	return resourceAutomationVariableRead(d, meta, "Object")
+}
+
+func resourceAutomationVariableObjectDelete(d *pluginsdk.ResourceData, meta interface{}) error {
+	return resourceAutomationVariableDelete(d, meta, "Object")
+}

--- a/internal/services/automation/automation_variable_object_resource_test.go
+++ b/internal/services/automation/automation_variable_object_resource_test.go
@@ -1,0 +1,210 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package automation_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+type AutomationVariableObjectResource struct{}
+
+func TestAccAutomationVariableObject_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_automation_variable_object", "test")
+	r := AutomationVariableObjectResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccAutomationVariableObject_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_automation_variable_object", "test")
+	r := AutomationVariableObjectResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("description").HasValue("This variable is created by Terraform acceptance test."),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccAutomationVariableObject_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_automation_variable_object", "test")
+	r := AutomationVariableObjectResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("description").HasValue("This variable is created by Terraform acceptance test."),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccAutomationVariableObject_encrypted(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_automation_variable_object", "test")
+	r := AutomationVariableObjectResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.encrypted(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("value"),
+	})
+}
+
+func TestAccAutomationVariableObject_encryptedUpdate(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_automation_variable_object", "test")
+	r := AutomationVariableObjectResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.encrypted(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("value"),
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func (t AutomationVariableObjectResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	return testCheckAzureRMAutomationVariableExists(ctx, clients, state, "Object")
+}
+
+func (AutomationVariableObjectResource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-auto-%d"
+  location = "%s"
+}
+
+resource "azurerm_automation_account" "test" {
+  name                = "acctestAutoAcct-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku_name            = "Basic"
+}
+
+resource "azurerm_automation_variable_object" "test" {
+  name                    = "acctestAutoVar-%d"
+  resource_group_name     = azurerm_resource_group.test.name
+  automation_account_name = azurerm_automation_account.test.name
+  value                   = jsonencode({ property = "Hello, Terraform Basic Test." })
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}
+
+func (AutomationVariableObjectResource) complete(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-auto-%d"
+  location = "%s"
+}
+
+resource "azurerm_automation_account" "test" {
+  name                = "acctestAutoAcct-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku_name            = "Basic"
+}
+
+resource "azurerm_automation_variable_object" "test" {
+  name                    = "acctestAutoVar-%d"
+  resource_group_name     = azurerm_resource_group.test.name
+  automation_account_name = azurerm_automation_account.test.name
+  description             = "This variable is created by Terraform acceptance test."
+  value                   = jsonencode({ property = "Hello, Terraform Complete Test." })
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}
+
+func (AutomationVariableObjectResource) encrypted(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-auto-%d"
+  location = "%s"
+}
+
+resource "azurerm_automation_account" "test" {
+  name                = "acctestAutoAcct-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku_name            = "Basic"
+}
+
+resource "azurerm_automation_variable_object" "test" {
+  name                    = "acctestAutoVar-%d"
+  resource_group_name     = azurerm_resource_group.test.name
+  automation_account_name = azurerm_automation_account.test.name
+  description             = "This variable is created by Terraform acceptance test."
+  value                   = jsonencode({ property = "Hello, Terraform Encrypted Test." })
+  encrypted               = true
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger)
+}

--- a/internal/services/automation/automation_variables_data_source.go
+++ b/internal/services/automation/automation_variables_data_source.go
@@ -5,6 +5,7 @@ package automation
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -26,6 +27,7 @@ type AutomationVariablesDataSourceModel struct {
 	EncryptedVariables  []helper.EncryptedVariable `tfschema:"encrypted"`
 	IntegerVariables    []helper.IntegerVariable   `tfschema:"int"`
 	NullVariables       []helper.NullVariable      `tfschema:"null"`
+	ObjectVariables     []helper.ObjectVariable    `tfschema:"object"`
 	StringVariables     []helper.StringVariable    `tfschema:"string"`
 }
 
@@ -95,6 +97,14 @@ func (v AutomationVariablesDataSource) Attributes() map[string]*pluginsdk.Schema
 			},
 		},
 
+		"object": {
+			Type:     pluginsdk.TypeList,
+			Computed: true,
+			Elem: &pluginsdk.Resource{
+				Schema: helper.DataSourceAutomationVariableCommonSchema(pluginsdk.TypeString),
+			},
+		},
+
 		"string": {
 			Type:     pluginsdk.TypeList,
 			Computed: true,
@@ -131,6 +141,7 @@ func (v AutomationVariablesDataSource) Read() sdk.ResourceFunc {
 			var var_encrypt []helper.EncryptedVariable
 			var var_int []helper.IntegerVariable
 			var var_null []helper.NullVariable
+			var var_object []helper.ObjectVariable
 			var var_str []helper.StringVariable
 
 			for _, v := range variableList.Items {
@@ -140,6 +151,7 @@ func (v AutomationVariablesDataSource) Read() sdk.ResourceFunc {
 				}
 
 				datePattern := regexp.MustCompile(`"\\/Date\((-?[0-9]+)\)\\/"`)
+				var objVar map[string]interface{}
 
 				if pointer.From(v.Properties.IsEncrypted) {
 					var_encrypt = append(var_encrypt, helper.EncryptedVariable{
@@ -183,6 +195,14 @@ func (v AutomationVariablesDataSource) Read() sdk.ResourceFunc {
 						IsEncrypted: pointer.From(v.Properties.IsEncrypted),
 						Value:       value,
 					})
+				} else if err := json.Unmarshal([]byte(*v.Properties.Value), &objVar); err == nil {
+					var_object = append(var_object, helper.ObjectVariable{
+						ID:          pointer.From(v.Id),
+						Name:        pointer.From(v.Name),
+						Description: pointer.From(v.Properties.Description),
+						IsEncrypted: pointer.From(v.Properties.IsEncrypted),
+						Value:       pointer.From(v.Properties.Value), //objVar,
+					})
 				} else if s, err := strconv.Unquote(pointer.From(v.Properties.Value)); err == nil {
 					var_str = append(var_str, helper.StringVariable{
 						ID:          pointer.From(v.Id),
@@ -203,6 +223,7 @@ func (v AutomationVariablesDataSource) Read() sdk.ResourceFunc {
 			model.EncryptedVariables = var_encrypt
 			model.IntegerVariables = var_int
 			model.NullVariables = var_null
+			model.ObjectVariables = var_object
 			model.StringVariables = var_str
 			return metadata.Encode(&model)
 		},

--- a/internal/services/automation/automation_variables_data_source.go
+++ b/internal/services/automation/automation_variables_data_source.go
@@ -201,7 +201,7 @@ func (v AutomationVariablesDataSource) Read() sdk.ResourceFunc {
 						Name:        pointer.From(v.Name),
 						Description: pointer.From(v.Properties.Description),
 						IsEncrypted: pointer.From(v.Properties.IsEncrypted),
-						Value:       pointer.From(v.Properties.Value), //objVar,
+						Value:       pointer.From(v.Properties.Value),
 					})
 				} else if s, err := strconv.Unquote(pointer.From(v.Properties.Value)); err == nil {
 					var_str = append(var_str, helper.StringVariable{

--- a/internal/services/automation/helper/automation_variable.go
+++ b/internal/services/automation/helper/automation_variable.go
@@ -42,6 +42,15 @@ type NullVariable struct {
 	IsEncrypted bool   `tfschema:"encrypted"`
 }
 
+type ObjectVariable struct {
+	ID          string `tfschema:"id"`
+	Name        string `tfschema:"name"`
+	Description string `tfschema:"description"`
+	IsEncrypted bool   `tfschema:"encrypted"`
+	Value       string `tfschema:"value"`
+	// Value       map[string]interface{} `tfschema:"value"`
+}
+
 type StringVariable struct {
 	ID          string `tfschema:"id"`
 	Name        string `tfschema:"name"`

--- a/internal/services/automation/helper/automation_variable.go
+++ b/internal/services/automation/helper/automation_variable.go
@@ -48,7 +48,6 @@ type ObjectVariable struct {
 	Description string `tfschema:"description"`
 	IsEncrypted bool   `tfschema:"encrypted"`
 	Value       string `tfschema:"value"`
-	// Value       map[string]interface{} `tfschema:"value"`
 }
 
 type StringVariable struct {

--- a/internal/services/automation/registration.go
+++ b/internal/services/automation/registration.go
@@ -53,6 +53,7 @@ func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
 		"azurerm_automation_variable_bool":     dataSourceAutomationVariableBool(),
 		"azurerm_automation_variable_datetime": dataSourceAutomationVariableDateTime(),
 		"azurerm_automation_variable_int":      dataSourceAutomationVariableInt(),
+		"azurerm_automation_variable_object":   dataSourceAutomationVariableObject(),
 		"azurerm_automation_variable_string":   dataSourceAutomationVariableString(),
 	}
 }

--- a/internal/services/automation/registration.go
+++ b/internal/services/automation/registration.go
@@ -76,6 +76,7 @@ func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 		"azurerm_automation_variable_bool":                  resourceAutomationVariableBool(),
 		"azurerm_automation_variable_datetime":              resourceAutomationVariableDateTime(),
 		"azurerm_automation_variable_int":                   resourceAutomationVariableInt(),
+		"azurerm_automation_variable_object":                resourceAutomationVariableObject(),
 		"azurerm_automation_variable_string":                resourceAutomationVariableString(),
 		"azurerm_automation_webhook":                        resourceAutomationWebhook(),
 	}

--- a/internal/services/automation/validate/variable_name.go
+++ b/internal/services/automation/validate/variable_name.go
@@ -1,0 +1,19 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package validate
+
+import (
+	"regexp"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+// VariableName validates Automation Account variable names
+func VariableName() pluginsdk.SchemaValidateFunc {
+	return validation.StringMatch(
+		regexp.MustCompile(`^[^<>*%&:\\?.+/]{0,127}[^<>*%&:\\?.+/\s]$`),
+		`The name length must be from 1 to 128 characters. The name cannot contain special characters < > * % & : \ ? . + / and cannot end with a whitespace character.`,
+	)
+}

--- a/website/docs/d/automation_variable_object.html.markdown
+++ b/website/docs/d/automation_variable_object.html.markdown
@@ -1,0 +1,53 @@
+---
+subcategory: "Automation"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_automation_variable_object"
+description: |-
+  Gets information about an existing Automation Object Variable
+---
+
+# Data Source: azurerm_automation_variable_object
+
+Use this data source to access information about an existing Automation Object Variable.
+
+## Example Usage
+
+```hcl
+data "azurerm_automation_variable_object" "example" {
+  name                    = "tfex-example-var"
+  resource_group_name     = "tfex-example-rg"
+  automation_account_name = "tfex-example-account"
+}
+
+output "variable" {
+  value = jsondecode(data.azurerm_automation_variable_object.example.value)
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- `name` - The name of the Automation Variable.
+
+- `resource_group_name` - The Name of the Resource Group where the automation account exists.
+
+- `automation_account_name` - The name of the automation account in which the Automation Variable exists.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+- `id` - The ID of the Automation Variable.
+
+- `description` - The description of the Automation Variable.
+
+- `encrypted` - Specifies if the Automation Variable is encrypted. Defaults to `false`.
+
+- `value` - The value of the Automation Variable as a json encoded `string`.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+- `read` - (Defaults to 5 minutes) Used when retrieving the Automation Object Variable.

--- a/website/docs/r/automation_variable_object.html.markdown
+++ b/website/docs/r/automation_variable_object.html.markdown
@@ -1,0 +1,76 @@
+---
+subcategory: "Automation"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_automation_variable_object"
+description: |-
+  Manages a string variable in Azure Automation.
+---
+
+# azurerm_automation_variable_object
+
+Manages a string variable in Azure Automation
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "tfex-example-rg"
+  location = "West Europe"
+}
+
+resource "azurerm_automation_account" "example" {
+  name                = "tfex-example-account"
+  location            = azurerm_resource_group.example.location
+  resource_group_name = azurerm_resource_group.example.name
+  sku_name            = "Basic"
+}
+
+resource "azurerm_automation_variable_object" "example" {
+  name                    = "tfex-example-var"
+  resource_group_name     = azurerm_resource_group.example.name
+  automation_account_name = azurerm_automation_account.example.name
+  value = jsonencode({
+    greeting = "Hello, Terraform Basic Test."
+    language = "en"
+  })
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- `name` - (Required) The name of the Automation Variable. Changing this forces a new resource to be created.
+
+- `resource_group_name` - (Required) The name of the resource group in which to create the Automation Variable. Changing this forces a new resource to be created.
+
+- `automation_account_name` - (Required) The name of the automation account in which the Variable is created. Changing this forces a new resource to be created.
+
+- `description` - (Optional) The description of the Automation Variable.
+
+- `encrypted` - (Optional) Specifies if the Automation Variable is encrypted. Defaults to `false`.
+
+- `value` - (Optional) The value of the Automation Variable as a `jsonencode()` string.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+- `id` - The ID of the Automation Variable.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+- `create` - (Defaults to 30 minutes) Used when creating the Automation Object Variable.
+- `update` - (Defaults to 30 minutes) Used when updating the Automation Object Variable.
+- `read` - (Defaults to 5 minutes) Used when retrieving the Automation Object Variable.
+- `delete` - (Defaults to 30 minutes) Used when deleting the Automation Object Variable.
+
+## Import
+
+Automation Object Variable can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_automation_variable_object.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tfex-example-rg/providers/Microsoft.Automation/automationAccounts/tfex-example-account/variables/tfex-example-var
+```

--- a/website/docs/r/automation_variable_object.html.markdown
+++ b/website/docs/r/automation_variable_object.html.markdown
@@ -3,12 +3,12 @@ subcategory: "Automation"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_automation_variable_object"
 description: |-
-  Manages a string variable in Azure Automation.
+  Manages an object variable in Azure Automation.
 ---
 
 # azurerm_automation_variable_object
 
-Manages a string variable in Azure Automation
+Manages an object variable in Azure Automation
 
 ## Example Usage
 


### PR DESCRIPTION
Add support for object-type variables for Automation Accounts. They cannot be created in the Azure Portal, only via API. They can be viewed in the Azure Portal.

Created as a non-typed resource to match the current variable resource types, and continue to share the parsing code. Also using `resource_group_name` and `automation_account_name` instead of `automation_account_id` to match with the current variable resources.