### PR TITLE
docs: fix mssql reference in elasticpool

### DIFF
--- a/website/docs/r/mssql_elasticpool.html.markdown
+++ b/website/docs/r/mssql_elasticpool.html.markdown
@@ -18,7 +18,7 @@ resource "azurerm_resource_group" "example" {
   location = "West Europe"
 }
 
-resource "azurerm_sql_server" "example" {
+resource "azurerm_mssql_server" "example" {
   name                         = "my-sql-server"
   resource_group_name          = azurerm_resource_group.example.name
   location                     = azurerm_resource_group.example.location
@@ -31,7 +31,7 @@ resource "azurerm_mssql_elasticpool" "example" {
   name                = "test-epool"
   resource_group_name = azurerm_resource_group.example.name
   location            = azurerm_resource_group.example.location
-  server_name         = azurerm_sql_server.example.name
+  server_name         = azurerm_mssql_server.example.name
   license_type        = "LicenseIncluded"
   max_size_gb         = 756
 


### PR DESCRIPTION
This PR fixes the old reference to the `azurerm_sql_server` resource and uses `azurerm_mssql_server` now for the mssql elasticpool.