### PR TITLE
`azurerm_kusto_cosmosdb_data_connection_resource` - fix cosmosdb account id

### DIFF
--- a/internal/services/kusto/kusto_cosmosdb_data_connection_resource.go
+++ b/internal/services/kusto/kusto_cosmosdb_data_connection_resource.go
@@ -118,6 +118,7 @@ func (r CosmosDBDataConnectionResource) Create() sdk.ResourceFunc {
 				return err
 			}
 
+			// SubscriptionId and ResourceGroupName need to align with the CosmosDB container, and those could be different from the Kusto database
 			cosmosDbAccountResourceId := cosmosdb.NewDatabaseAccountID(cosmosDbContainerId.SubscriptionId, cosmosDbContainerId.ResourceGroupName, cosmosDbContainerId.DatabaseAccountName)
 
 			id := dataconnections.NewDataConnectionID(kustoDatabaseId.SubscriptionId, kustoDatabaseId.ResourceGroupName, kustoDatabaseId.ClusterName, kustoDatabaseId.DatabaseName, model.Name)

--- a/internal/services/kusto/kusto_cosmosdb_data_connection_resource.go
+++ b/internal/services/kusto/kusto_cosmosdb_data_connection_resource.go
@@ -119,7 +119,7 @@ func (r CosmosDBDataConnectionResource) Create() sdk.ResourceFunc {
 				return err
 			}
 
-			cosmosDbAccountResourceId := cosmosdb.NewDatabaseAccountID(subscriptionId, kustoDatabaseId.ResourceGroupName, cosmosDbContainerId.DatabaseAccountName)
+			cosmosDbAccountResourceId := cosmosdb.NewDatabaseAccountID(subscriptionId, cosmosDbContainerId.ResourceGroupName, cosmosDbContainerId.DatabaseAccountName)
 
 			id := dataconnections.NewDataConnectionID(subscriptionId, kustoDatabaseId.ResourceGroupName, kustoDatabaseId.ClusterName, kustoDatabaseId.DatabaseName, model.Name)
 

--- a/internal/services/kusto/kusto_cosmosdb_data_connection_resource.go
+++ b/internal/services/kusto/kusto_cosmosdb_data_connection_resource.go
@@ -107,7 +107,6 @@ func (r CosmosDBDataConnectionResource) Create() sdk.ResourceFunc {
 			}
 
 			client := metadata.Client.Kusto.DataConnectionsClient
-			subscriptionId := metadata.Client.Account.SubscriptionId
 
 			cosmosDbContainerId, err := cosmosdb.ParseContainerID(model.CosmosDbContainerId)
 			if err != nil {
@@ -119,9 +118,9 @@ func (r CosmosDBDataConnectionResource) Create() sdk.ResourceFunc {
 				return err
 			}
 
-			cosmosDbAccountResourceId := cosmosdb.NewDatabaseAccountID(subscriptionId, cosmosDbContainerId.ResourceGroupName, cosmosDbContainerId.DatabaseAccountName)
+			cosmosDbAccountResourceId := cosmosdb.NewDatabaseAccountID(cosmosDbContainerId.SubscriptionId, cosmosDbContainerId.ResourceGroupName, cosmosDbContainerId.DatabaseAccountName)
 
-			id := dataconnections.NewDataConnectionID(subscriptionId, kustoDatabaseId.ResourceGroupName, kustoDatabaseId.ClusterName, kustoDatabaseId.DatabaseName, model.Name)
+			id := dataconnections.NewDataConnectionID(kustoDatabaseId.SubscriptionId, kustoDatabaseId.ResourceGroupName, kustoDatabaseId.ClusterName, kustoDatabaseId.DatabaseName, model.Name)
 
 			existing, err := client.Get(ctx, id)
 			if err != nil && !response.WasNotFound(existing.HttpResponse) {
@@ -199,7 +198,7 @@ func (r CosmosDBDataConnectionResource) Read() sdk.ResourceFunc {
 					if err != nil {
 						return err
 					}
-					cosmosDbContainerId := cosmosdb.NewContainerID(id.SubscriptionId, id.ResourceGroupName, cosmosdbAccountId.DatabaseAccountName, properties.CosmosDbDatabase, properties.CosmosDbContainer)
+					cosmosDbContainerId := cosmosdb.NewContainerID(cosmosdbAccountId.SubscriptionId, cosmosdbAccountId.ResourceGroupName, cosmosdbAccountId.DatabaseAccountName, properties.CosmosDbDatabase, properties.CosmosDbContainer)
 					state.CosmosDbContainerId = cosmosDbContainerId.ID()
 					state.TableName = properties.TableName
 					state.ManagedIdentityId = properties.ManagedIdentityResourceId

--- a/internal/services/kusto/kusto_cosmosdb_data_connection_resource_test.go
+++ b/internal/services/kusto/kusto_cosmosdb_data_connection_resource_test.go
@@ -92,6 +92,26 @@ func TestAccKustoCosmosDBDataConnection_requiresImport(t *testing.T) {
 	})
 }
 
+func TestAccKustoCosmosDBDataConnection_diffResourceGroups(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_kusto_cosmosdb_data_connection", "test")
+	r := KustoCosmosDBDataConnectionResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.diffResourceGroups(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("cosmosdb_container_id").Exists(),
+				check.That(data.ResourceName).Key("kusto_database_id").Exists(),
+				check.That(data.ResourceName).Key("table_name").Exists(),
+				check.That(data.ResourceName).Key("managed_identity_id").Exists(),
+				check.That(data.ResourceName).Key("table_name").HasValue("TestTable"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (k KustoCosmosDBDataConnectionResource) basic(data acceptance.TestData) string {
 	template := k.template(data)
 	return fmt.Sprintf(`
@@ -143,6 +163,133 @@ resource "azurerm_kusto_cosmosdb_data_connection" "import" {
     ignore_changes = [retrieval_start_date]
   }
 }`, template)
+}
+
+func (k KustoCosmosDBDataConnectionResource) diffResourceGroups(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_resource_group" "test2" {
+  name     = "acctestSecRG-%d"
+  location = "%s"
+}
+
+data "azurerm_role_definition" "builtin" {
+  role_definition_id = "fbdf93bf-df7d-467e-a4d2-9458aa1360c8"
+}
+
+resource "azurerm_role_assignment" "test" {
+  scope                = azurerm_resource_group.test.id
+  role_definition_name = data.azurerm_role_definition.builtin.name
+  principal_id         = azurerm_kusto_cluster.test.identity[0].principal_id
+}
+
+resource "azurerm_cosmosdb_account" "test" {
+  name                = "acctest-ca-%d"
+  location            = azurerm_resource_group.test2.location
+  resource_group_name = azurerm_resource_group.test2.name
+  offer_type          = "Standard"
+  kind                = "GlobalDocumentDB"
+
+  consistency_policy {
+    consistency_level       = "Session"
+    max_interval_in_seconds = 5
+    max_staleness_prefix    = 100
+  }
+
+  geo_location {
+    location          = azurerm_resource_group.test2.location
+    failover_priority = 0
+  }
+}
+
+resource "azurerm_cosmosdb_sql_database" "test" {
+  name                = "acctestcosmosdbsqldb-%d"
+  resource_group_name = azurerm_cosmosdb_account.test.resource_group_name
+  account_name        = azurerm_cosmosdb_account.test.name
+}
+
+resource "azurerm_cosmosdb_sql_container" "test" {
+  name                = "acctestcosmosdbsqlcon-%d"
+  resource_group_name = azurerm_cosmosdb_account.test.resource_group_name
+  account_name        = azurerm_cosmosdb_account.test.name
+  database_name       = azurerm_cosmosdb_sql_database.test.name
+  partition_key_path  = "/part"
+  throughput          = 400
+}
+
+data "azurerm_cosmosdb_sql_role_definition" "test" {
+  role_definition_id  = "00000000-0000-0000-0000-000000000001"
+  resource_group_name = azurerm_resource_group.test2.name
+  account_name        = azurerm_cosmosdb_account.test.name
+}
+
+
+resource "azurerm_cosmosdb_sql_role_assignment" "test" {
+  resource_group_name = azurerm_resource_group.test2.name
+  account_name        = azurerm_cosmosdb_account.test.name
+  role_definition_id  = data.azurerm_cosmosdb_sql_role_definition.test.id
+  principal_id        = azurerm_kusto_cluster.test.identity[0].principal_id
+  scope               = azurerm_cosmosdb_account.test.id
+}
+
+resource "azurerm_kusto_cluster" "test" {
+  name                = "acctestkc%s"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku {
+    name     = "Dev(No SLA)_Standard_D11_v2"
+    capacity = 1
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+
+resource "azurerm_kusto_database" "test" {
+  name                = "acctestkd-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  cluster_name        = azurerm_kusto_cluster.test.name
+}
+
+resource "azurerm_kusto_script" "test" {
+  name           = "create-table-script"
+  database_id    = azurerm_kusto_database.test.id
+  script_content = <<SCRIPT
+.create table TestTable(Id:string, Name:string, _ts:long, _timestamp:datetime)
+.create table TestTable ingestion json mapping "TestMapping"
+'['
+'    {"column":"Id","path":"$.id"},'
+'    {"column":"Name","path":"$.name"},'
+'    {"column":"_ts","path":"$._ts"},'
+'    {"column":"_timestamp","path":"$._ts", "transform":"DateTimeFromUnixSeconds"}'
+']'
+.alter table TestTable policy ingestionbatching "{'MaximumBatchingTimeSpan': '0:0:10', 'MaximumNumberOfItems': 10000}"
+SCRIPT
+}
+
+resource "azurerm_kusto_cosmosdb_data_connection" "test" {
+  name                  = "acctestkcd%s"
+  location              = azurerm_resource_group.test.location
+  cosmosdb_container_id = azurerm_cosmosdb_sql_container.test.id
+  kusto_database_id     = azurerm_kusto_database.test.id
+  managed_identity_id   = azurerm_kusto_cluster.test.id
+  table_name            = "TestTable"
+  lifecycle {
+    ignore_changes = [retrieval_start_date]
+  }
+}`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomString, data.RandomInteger, data.RandomString)
 }
 
 func (k KustoCosmosDBDataConnectionResource) template(data acceptance.TestData) string {

--- a/internal/services/kusto/kusto_cosmosdb_data_connection_resource_test.go
+++ b/internal/services/kusto/kusto_cosmosdb_data_connection_resource_test.go
@@ -158,11 +158,6 @@ resource "azurerm_resource_group" "test" {
   location = "%s"
 }
 
-resource "azurerm_resource_group" "test2" {
-  name     = "acctestRG-%d"
-  location = "%s"
-}
-
 data "azurerm_role_definition" "builtin" {
   role_definition_id = "fbdf93bf-df7d-467e-a4d2-9458aa1360c8"
 }
@@ -175,8 +170,8 @@ resource "azurerm_role_assignment" "test" {
 
 resource "azurerm_cosmosdb_account" "test" {
   name                = "acctest-ca-%d"
-  location            = azurerm_resource_group.test2.location
-  resource_group_name = azurerm_resource_group.test2.name
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
   offer_type          = "Standard"
   kind                = "GlobalDocumentDB"
 
@@ -187,7 +182,7 @@ resource "azurerm_cosmosdb_account" "test" {
   }
 
   geo_location {
-    location          = azurerm_resource_group.test2.location
+    location          = azurerm_resource_group.test.location
     failover_priority = 0
   }
 }
@@ -209,13 +204,13 @@ resource "azurerm_cosmosdb_sql_container" "test" {
 
 data "azurerm_cosmosdb_sql_role_definition" "test" {
   role_definition_id  = "00000000-0000-0000-0000-000000000001"
-  resource_group_name = azurerm_resource_group.test2.name
+  resource_group_name = azurerm_resource_group.test.name
   account_name        = azurerm_cosmosdb_account.test.name
 }
 
 
 resource "azurerm_cosmosdb_sql_role_assignment" "test" {
-  resource_group_name = azurerm_resource_group.test2.name
+  resource_group_name = azurerm_resource_group.test.name
   account_name        = azurerm_cosmosdb_account.test.name
   role_definition_id  = data.azurerm_cosmosdb_sql_role_definition.test.id
   principal_id        = azurerm_kusto_cluster.test.identity[0].principal_id
@@ -258,5 +253,5 @@ resource "azurerm_kusto_script" "test" {
 .alter table TestTable policy ingestionbatching "{'MaximumBatchingTimeSpan': '0:0:10', 'MaximumNumberOfItems': 10000}"
 SCRIPT
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomString, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomString, data.RandomInteger)
 }

--- a/internal/services/kusto/kusto_cosmosdb_data_connection_resource_test.go
+++ b/internal/services/kusto/kusto_cosmosdb_data_connection_resource_test.go
@@ -158,6 +158,11 @@ resource "azurerm_resource_group" "test" {
   location = "%s"
 }
 
+resource "azurerm_resource_group" "test2" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
 data "azurerm_role_definition" "builtin" {
   role_definition_id = "fbdf93bf-df7d-467e-a4d2-9458aa1360c8"
 }
@@ -170,8 +175,8 @@ resource "azurerm_role_assignment" "test" {
 
 resource "azurerm_cosmosdb_account" "test" {
   name                = "acctest-ca-%d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test2.location
+  resource_group_name = azurerm_resource_group.test2.name
   offer_type          = "Standard"
   kind                = "GlobalDocumentDB"
 
@@ -182,7 +187,7 @@ resource "azurerm_cosmosdb_account" "test" {
   }
 
   geo_location {
-    location          = azurerm_resource_group.test.location
+    location          = azurerm_resource_group.test2.location
     failover_priority = 0
   }
 }
@@ -204,13 +209,13 @@ resource "azurerm_cosmosdb_sql_container" "test" {
 
 data "azurerm_cosmosdb_sql_role_definition" "test" {
   role_definition_id  = "00000000-0000-0000-0000-000000000001"
-  resource_group_name = azurerm_resource_group.test.name
+  resource_group_name = azurerm_resource_group.test2.name
   account_name        = azurerm_cosmosdb_account.test.name
 }
 
 
 resource "azurerm_cosmosdb_sql_role_assignment" "test" {
-  resource_group_name = azurerm_resource_group.test.name
+  resource_group_name = azurerm_resource_group.test2.name
   account_name        = azurerm_cosmosdb_account.test.name
   role_definition_id  = data.azurerm_cosmosdb_sql_role_definition.test.id
   principal_id        = azurerm_kusto_cluster.test.identity[0].principal_id
@@ -253,5 +258,5 @@ resource "azurerm_kusto_script" "test" {
 .alter table TestTable policy ingestionbatching "{'MaximumBatchingTimeSpan': '0:0:10', 'MaximumNumberOfItems': 10000}"
 SCRIPT
 }
-`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomString, data.RandomInteger)
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomString, data.RandomInteger)
 }


### PR DESCRIPTION
`azurerm_kusto_cosmosdb_data_connection_resource` - fix cosmosdb account id

Testing evidence:

```
Generating script.
Script contents:
TF_ACC=1 go test -parallel 10 -v ./internal/services/kusto -run=TestAccKustoCosmosDBDataConnection_ -timeout '720m' -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
========================== Starting Command Output ===========================
/usr/bin/bash /mnt/vss/_work/_temp/7c97feb5-ceef-47af-86db-78972d877efe.sh
=== RUN   TestAccKustoCosmosDBDataConnection_basic
=== PAUSE TestAccKustoCosmosDBDataConnection_basic
=== RUN   TestAccKustoCosmosDBDataConnection_complete
=== PAUSE TestAccKustoCosmosDBDataConnection_complete
=== RUN   TestAccKustoCosmosDBDataConnection_requiresImport
=== PAUSE TestAccKustoCosmosDBDataConnection_requiresImport
=== CONT  TestAccKustoCosmosDBDataConnection_basic
=== CONT  TestAccKustoCosmosDBDataConnection_requiresImport
=== CONT  TestAccKustoCosmosDBDataConnection_complete
--- PASS: TestAccKustoCosmosDBDataConnection_requiresImport (1418.40s)
--- PASS: TestAccKustoCosmosDBDataConnection_complete (1422.67s)
--- PASS: TestAccKustoCosmosDBDataConnection_basic (1460.38s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/kusto	1460.403s
Finishing: Run test in parallel

```