### PR TITLE
fix(azurerm_subnet): grammar error in docs

### DIFF
--- a/website/docs/r/subnet.html.markdown
+++ b/website/docs/r/subnet.html.markdown
@@ -11,9 +11,9 @@ description: |-
 
 Manages a subnet. Subnets represent network segments within the IP space defined by the virtual network.
 
-~> **NOTE on Virtual Networks and Subnet's:** Terraform currently
+~> **NOTE on Virtual Networks and Subnets:** Terraform currently
 provides both a standalone [Subnet resource](subnet.html), and allows for Subnets to be defined in-line within the [Virtual Network resource](virtual_network.html).
-At this time you cannot use a Virtual Network with in-line Subnets in conjunction with any Subnet resources. Doing so will cause a conflict of Subnet configurations and will overwrite Subnet's.
+At this time you cannot use a Virtual Network with in-line Subnets in conjunction with any Subnet resources. Doing so will cause a conflict of Subnet configurations and will overwrite Subnets.
 
 ## Example Usage
 


### PR DESCRIPTION
Minor fix to grammar error in docs for `azurerm_subnet` resource.