### PR TITLE
`azurerm_cdn_endpoint_custom_domain` - pass `nil` as `version` when Certificate/Secret `version` is set to `Latest`

### DIFF
--- a/internal/services/cdn/cdn_endpoint_custom_domain_resource.go
+++ b/internal/services/cdn/cdn_endpoint_custom_domain_resource.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/cdn/mgmt/2020-09-01/cdn" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -481,14 +482,20 @@ func expandArmCdnEndpointCustomDomainUserManagedHttpsSettings(ctx context.Contex
 		return nil, err
 	}
 
+	// Fix for issue #20772
+	var SecretVersion *string
+	if keyVaultSecretId.Version != "" {
+		SecretVersion = pointer.To(keyVaultSecretId.Version)
+	}
+
 	output := &cdn.UserManagedHTTPSParameters{
 		CertificateSourceParameters: &cdn.KeyVaultCertificateSourceParameters{
 			OdataType:         utils.String("#Microsoft.Azure.Cdn.Models.KeyVaultCertificateSourceParameters"),
-			SubscriptionID:    &keyVaultId.SubscriptionId,
-			ResourceGroupName: &keyVaultId.ResourceGroupName,
-			VaultName:         &keyVaultId.VaultName,
-			SecretName:        &keyVaultSecretId.Name,
-			SecretVersion:     &keyVaultSecretId.Version,
+			SubscriptionID:    pointer.To(keyVaultId.SubscriptionId),
+			ResourceGroupName: pointer.To(keyVaultId.ResourceGroupName),
+			VaultName:         pointer.To(keyVaultId.VaultName),
+			SecretName:        pointer.To(keyVaultSecretId.Name),
+			SecretVersion:     SecretVersion,
 			UpdateRule:        utils.String("NoAction"),
 			DeleteRule:        utils.String("NoAction"),
 		},
@@ -556,9 +563,11 @@ func flattenArmCdnEndpointCustomDomainUserManagedHttpsSettings(ctx context.Conte
 	if err != nil {
 		return nil, err
 	}
+
 	if secret.ID == nil {
 		return nil, fmt.Errorf("unexpected null Key Vault Secret retrieved for Key Vault %s / Secret Name %s / Secret Version %s", keyVaultId, secretName, secretVersion)
 	}
+
 	secretId, err := keyvaultParse.ParseOptionallyVersionedNestedItemID(*secret.ID)
 	if err != nil {
 		return nil, err
@@ -589,7 +598,9 @@ func flattenArmCdnEndpointCustomDomainUserManagedHttpsSettings(ctx context.Conte
 			certIdLiteral = certId.VersionlessID()
 		}
 	}
+
 	m["key_vault_certificate_id"] = certIdLiteral
+
 	return []interface{}{m}, nil
 }
 


### PR DESCRIPTION
(fixes #20772)