### PR TITLE
[TestCase] fix TestAccPortalTenantConfiguration

### DIFF
--- a/internal/services/portal/portal_tenant_configuration_resource_test.go
+++ b/internal/services/portal/portal_tenant_configuration_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
@@ -91,6 +92,22 @@ func (r PortalTenantConfigurationResource) Exists(ctx context.Context, client *c
 	}
 
 	return utils.Bool(resp.Model != nil), nil
+}
+
+func (r PortalTenantConfigurationResource) Destroy(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := parse.PortalTenantConfigurationID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.Portal.TenantConfigurationsClient.Delete(ctx)
+	if err != nil {
+		if !response.WasNotFound(resp.HttpResponse) {
+			return nil, fmt.Errorf("deleting %s: %+v", *id, err)
+		}
+	}
+
+	return utils.Bool(true), nil
 }
 
 func (r PortalTenantConfigurationResource) basic(enforcePrivateMarkdownStorage bool) string {


### PR DESCRIPTION
As the portal tenant configuration is global resource and it wouldn't be destroyed when the running acctest in Teamcity is canceled, so it would fail in the next run due to the resource existing in the Azure. So I submitted this PR to fix this issue.

![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/19754191/8b85e014-56a6-476c-92d8-e62b370d3c0d)
