### PR TITLE
`data` `azurerm_images` - support and fix issue with `disk_encryption_set_id`

### DIFF
--- a/website/docs/d/images.html.markdown
+++ b/website/docs/d/images.html.markdown
@@ -65,6 +65,8 @@ The `os_disk` block exports the following:
 
 * `size_gb` - the size of the OS Disk in GB.
 
+* `disk_encryption_set_id` -  the ID of the Disk Encryption Set used to encrypt this image.
+
 ---
 
 The `data_disk` block exports the following:


### PR DESCRIPTION
`d\azurerm_images` uses the flatten function in `r\azurerm_image`, and when adding new property in #22642, there is a schema mismatch in this data source. Fixing the schema and copying the functions out to avoid potential mistake in the future.

Currently the tests are failing due to the issue.
=== CONT  TestAccDataSourceAzureRMImages_basic
------- Stderr: -------
panic: Invalid address to set: []string{"images", "0", "os_disk", "0", "disk_encryption_set_id"}