### PR TITLE
`azurerm_key_vault` - add support for the `NestedItemTypeStorageKey` to key vault `nested_item`

### DIFF
--- a/internal/services/keyvault/parse/nested_item.go
+++ b/internal/services/keyvault/parse/nested_item.go
@@ -22,11 +22,13 @@ const (
 	NestedItemTypeSecret NestedItemObjectType = "secrets"
 	// KeyVaultObjectType Certificates...
 	NestedItemTypeCertificate NestedItemObjectType = "certificates"
+	// KeyVaultObjectType Storage Keys...
+	NestedItemTypeStorageKey NestedItemObjectType = "storage"
 )
 
 // PossibleNestedItemObjectTypeValues returns a string slice of possible "NestedItemObjectType" values.
 func PossibleNestedItemObjectTypeValues() []string {
-	return []string{string(NestedItemTypeKey), string(NestedItemTypeSecret), string(NestedItemTypeCertificate)}
+	return []string{string(NestedItemTypeKey), string(NestedItemTypeSecret), string(NestedItemTypeCertificate), string(NestedItemTypeStorageKey)}
 }
 
 var _ resourceids.Id = NestedItemId{}


### PR DESCRIPTION
(fixes #22694 and #22757)