### PR TITLE
`azurerm_cognitive_deployment` - add locks to parent resource to prevent 409 error

### DIFF
--- a/internal/services/cognitive/cognitive_deployment_resource.go
+++ b/internal/services/cognitive/cognitive_deployment_resource.go
@@ -6,6 +6,7 @@ package cognitive
 import (
 	"context"
 	"fmt"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/response"
@@ -220,6 +221,9 @@ func (r CognitiveDeploymentResource) Create() sdk.ResourceFunc {
 
 			client := metadata.Client.Cognitive.DeploymentsClient
 			accountId, err := cognitiveservicesaccounts.ParseAccountID(model.CognitiveAccountId)
+
+			locks.ByID(accountId.ID())
+
 			if err != nil {
 				return err
 			}
@@ -249,6 +253,8 @@ func (r CognitiveDeploymentResource) Create() sdk.ResourceFunc {
 			if err := client.CreateOrUpdateThenPoll(ctx, id, *properties); err != nil {
 				return fmt.Errorf("creating %s: %+v", id, err)
 			}
+
+			locks.UnlockByID(accountId.ID())
 
 			metadata.SetID(id)
 			return nil

--- a/internal/services/cognitive/cognitive_deployment_resource.go
+++ b/internal/services/cognitive/cognitive_deployment_resource.go
@@ -6,13 +6,13 @@ package cognitive
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2023-05-01/cognitiveservicesaccounts"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2023-05-01/deployments"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/22607