### PR TITLE
`azurerm_logic_app_standard` - Move the attribute `auto_swap_slot_name` under `site_config`

### DIFF
--- a/internal/services/logic/logic_app_standard_data_source.go
+++ b/internal/services/logic/logic_app_standard_data_source.go
@@ -53,11 +53,6 @@ func dataSourceLogicAppStandard() *pluginsdk.Resource {
 				},
 			},
 
-			"auto_swap_slot_name": {
-				Type:     pluginsdk.TypeString,
-				Computed: true,
-			},
-
 			"use_extension_bundle": {
 				Type:     pluginsdk.TypeBool,
 				Computed: true,

--- a/internal/services/logic/logic_app_standard_resource.go
+++ b/internal/services/logic/logic_app_standard_resource.go
@@ -229,11 +229,6 @@ func resourceLogicAppStandard() *pluginsdk.Resource {
 				Optional:     true,
 				ValidateFunc: commonids.ValidateSubnetID,
 			},
-
-			"auto_swap_slot_name": {
-				Type:     pluginsdk.TypeString,
-				Computed: true,
-			},
 		},
 	}
 }
@@ -870,6 +865,11 @@ func schemaLogicAppStandardSiteConfig() *pluginsdk.Schema {
 				"vnet_route_all_enabled": {
 					Type:     pluginsdk.TypeBool,
 					Optional: true,
+					Computed: true,
+				},
+
+				"auto_swap_slot_name": {
+					Type:     pluginsdk.TypeString,
 					Computed: true,
 				},
 			},

--- a/website/docs/d/logic_app_standard.html.markdown
+++ b/website/docs/d/logic_app_standard.html.markdown
@@ -41,8 +41,6 @@ The following attributes are exported:
 
 * `identity` - An `identity` block as defined below.
 
-* `auto_swap_slot_name` - The Auto-swap slot name.
-
 ---
 
 The `identity` block exports the following:

--- a/website/docs/r/logic_app_standard.html.markdown
+++ b/website/docs/r/logic_app_standard.html.markdown
@@ -298,8 +298,6 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `id` - The ID of the Logic App
 
-* `auto_swap_slot_name` - The Auto-swap slot name.
-
 * `custom_domain_verification_id` - An identifier used by App Service to perform domain ownership verification via DNS TXT record.
 
 * `default_hostname` - The default hostname associated with the Logic App - such as `mysite.azurewebsites.net`
@@ -331,6 +329,12 @@ The `site_credential` block exports the following:
 * `username` - The username which can be used to publish to this App Service
 
 * `password` - The password associated with the username, which can be used to publish to this App Service.
+
+---
+
+The `site_config` block exports the following:
+
+* `auto_swap_slot_name` - The Auto-swap slot name.
 
 ## Timeouts
 


### PR DESCRIPTION
https://github.com/hashicorp/terraform-provider-azurerm/pull/22525 adds up the missing `auto_swap_slot_name` incorrectly under the root level, where it should be under `site_config`.