### PR TITLE
`azurerm_eventhub_namespace_customer_managed_key`: add infrastructure encryption field

### DIFF
--- a/internal/services/eventhub/eventhub_namespace_customer_managed_key_resource.go
+++ b/internal/services/eventhub/eventhub_namespace_customer_managed_key_resource.go
@@ -77,6 +77,13 @@ func resourceEventHubNamespaceCustomerManagedKey() *pluginsdk.Resource {
 					ValidateFunc: keyVaultValidate.NestedItemIdWithOptionalVersion,
 				},
 			},
+
+			"infrastructure_encryption_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+				Default:  false,
+				ForceNew: true,
+			},
 		},
 	}
 }
@@ -120,6 +127,7 @@ func resourceEventHubNamespaceCustomerManagedKeyCreateUpdate(d *pluginsdk.Resour
 		return err
 	}
 	namespace.Properties.Encryption.KeyVaultProperties = keyVaultProps
+	namespace.Properties.Encryption.RequireInfrastructureEncryption = utils.Bool(d.Get("infrastructure_encryption_enabled").(bool))
 
 	if err := client.CreateOrUpdateThenPoll(ctx, *id, *namespace); err != nil {
 		return fmt.Errorf("creating/updating %s: %+v", *id, err)
@@ -165,6 +173,7 @@ func resourceEventHubNamespaceCustomerManagedKeyRead(d *pluginsdk.ResourceData, 
 		}
 
 		d.Set("key_vault_key_ids", keyVaultKeyIds)
+		d.Set("infrastructure_encryption_enabled", props.Encryption.RequireInfrastructureEncryption)
 	}
 
 	return nil

--- a/internal/services/eventhub/eventhub_namespace_customer_managed_key_resource_test.go
+++ b/internal/services/eventhub/eventhub_namespace_customer_managed_key_resource_test.go
@@ -173,6 +173,7 @@ resource "azurerm_key_vault_key" "test2" {
 resource "azurerm_eventhub_namespace_customer_managed_key" "test" {
   eventhub_namespace_id = azurerm_eventhub_namespace.test.id
   key_vault_key_ids     = [azurerm_key_vault_key.test.id, azurerm_key_vault_key.test2.id]
+  infrastructure_encryption_enabled = true
 }
 `, r.template(data), data.RandomString)
 }

--- a/internal/services/eventhub/eventhub_namespace_customer_managed_key_resource_test.go
+++ b/internal/services/eventhub/eventhub_namespace_customer_managed_key_resource_test.go
@@ -171,8 +171,8 @@ resource "azurerm_key_vault_key" "test2" {
 }
 
 resource "azurerm_eventhub_namespace_customer_managed_key" "test" {
-  eventhub_namespace_id = azurerm_eventhub_namespace.test.id
-  key_vault_key_ids     = [azurerm_key_vault_key.test.id, azurerm_key_vault_key.test2.id]
+  eventhub_namespace_id             = azurerm_eventhub_namespace.test.id
+  key_vault_key_ids                 = [azurerm_key_vault_key.test.id, azurerm_key_vault_key.test2.id]
   infrastructure_encryption_enabled = true
 }
 `, r.template(data), data.RandomString)

--- a/website/docs/r/eventhub_namespace_customer_managed_key.html.markdown
+++ b/website/docs/r/eventhub_namespace_customer_managed_key.html.markdown
@@ -101,6 +101,8 @@ The following arguments are supported:
 
 * `key_vault_key_ids` - (Required) The list of keys of Key Vault.
 
+* `infrastructure_encryption_enabled` - (Optional) Whether to enable Infrastructure Encryption (Double Encryption). Changing this forces a new resource to be created.
+
 ## Attributes Reference
 
 In addition to the Arguments listed above - the following Attributes are exported:


### PR DESCRIPTION
- Added `infrastructure_encryption_enabled` field to the `azurerm_eventhub_namespace_customer_managed_key` resource which is used in eventhub namespace .
- This addresses https://github.com/hashicorp/terraform-provider-azurerm/issues/15629
