### PR TITLE
azurerm_netapp_volume - update the validation of security_style

### DIFF
--- a/internal/services/netapp/netapp_volume_resource.go
+++ b/internal/services/netapp/netapp_volume_resource.go
@@ -136,14 +136,11 @@ func resourceNetAppVolume() *pluginsdk.Resource {
 			},
 
 			"security_style": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Computed: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					"Unix", // Using hardcoded values instead of SDK enum since no matter what case is passed,
-					"Ntfs", // ANF changes casing to Pascal case in the backend. Please refer to https://github.com/Azure/azure-sdk-for-go/issues/14684
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Computed:     true,
+				ValidateFunc: validation.StringInSlice(volumes.PossibleValuesForSecurityStyle(), false),
 			},
 
 			"storage_quota_in_gb": {

--- a/internal/services/netapp/netapp_volume_resource_test.go
+++ b/internal/services/netapp/netapp_volume_resource_test.go
@@ -355,7 +355,7 @@ resource "azurerm_netapp_volume" "test" {
   service_level       = "Standard"
   subnet_id           = azurerm_subnet.test.id
   protocols           = ["NFSv4.1"]
-  security_style      = "Unix"
+  security_style      = "unix"
   storage_quota_in_gb = 100
   throughput_in_mibps = 1.562
 
@@ -432,7 +432,7 @@ resource "azurerm_netapp_volume" "test" {
   service_level       = "Standard"
   subnet_id           = azurerm_subnet.test.id
   protocols           = ["NFSv3"]
-  security_style      = "Unix"
+  security_style      = "unix"
   storage_quota_in_gb = 100
   throughput_in_mibps = 1.562
 

--- a/website/docs/r/netapp_volume.html.markdown
+++ b/website/docs/r/netapp_volume.html.markdown
@@ -72,7 +72,7 @@ resource "azurerm_netapp_volume" "example" {
   subnet_id                  = azurerm_subnet.example.id
   network_features           = "Basic"
   protocols                  = ["NFSv4.1"]
-  security_style             = "Unix"
+  security_style             = "unix"
   storage_quota_in_gb        = 100
   snapshot_directory_visible = false
 
@@ -120,7 +120,7 @@ The following arguments are supported:
 
 * `protocols` - (Optional) The target volume protocol expressed as a list. Supported single value include `CIFS`, `NFSv3`, or `NFSv4.1`. If argument is not defined it will default to `NFSv3`. Changing this forces a new resource to be created and data will be lost. Dual protocol scenario is supported for CIFS and NFSv3, for more information, please refer to [Create a dual-protocol volume for Azure NetApp Files](https://docs.microsoft.com/azure/azure-netapp-files/create-volumes-dual-protocol) document.
 
-* `security_style` - (Optional) Volume security style, accepted values are `Unix` or `Ntfs`. If not provided, single-protocol volume is created defaulting to `Unix` if it is `NFSv3` or `NFSv4.1` volume, if `CIFS`, it will default to `Ntfs`. In a dual-protocol volume, if not provided, its value will be `Ntfs`. Changing this forces a new resource to be created.
+* `security_style` - (Optional) Volume security style, accepted values are `unix` or `ntfs`. If not provided, single-protocol volume is created defaulting to `unix` if it is `NFSv3` or `NFSv4.1` volume, if `CIFS`, it will default to `ntfs`. In a dual-protocol volume, if not provided, its value will be `ntfs`. Changing this forces a new resource to be created.
 
 * `subnet_id` - (Required) The ID of the Subnet the NetApp Volume resides in, which must have the `Microsoft.NetApp/volumes` delegation. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
This PR is to fix failed test cases "TestAccNetAppVolume_nfsv41" and "TestAccNetAppVolume_snapshotPolicy" in teamcity.

This PR fix is similar with https://github.com/hashicorp/terraform-provider-azurerm/pull/22615 for fixing similar issue.

![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/19754191/5862aa56-ae11-4be1-b73b-0b8afd9820b7)
![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/19754191/3ef49f2f-d699-4e27-949b-d88eb4e4f0e0)