### PR TITLE
`azurerm_container_app_environment` - Make `log_analytics_workspace_id` an optional argument.

### DIFF
--- a/internal/services/containerapps/container_app_environment_resource.go
+++ b/internal/services/containerapps/container_app_environment_resource.go
@@ -69,7 +69,7 @@ func (r ContainerAppEnvironmentResource) Arguments() map[string]*pluginsdk.Schem
 
 		"log_analytics_workspace_id": {
 			Type:         pluginsdk.TypeString,
-			Required:     true,
+			Optional:     true,
 			ForceNew:     true,
 			ValidateFunc: workspaces.ValidateWorkspaceID,
 			Description:  "The ID for the Log Analytics Workspace to link this Container Apps Managed Environment to.",
@@ -156,47 +156,48 @@ func (r ContainerAppEnvironmentResource) Create() sdk.ResourceFunc {
 				return metadata.ResourceRequiresImport(r.ResourceType(), id)
 			}
 
-			logAnalyticsId, err := workspaces.ParseWorkspaceID(containerAppEnvironment.LogAnalyticsWorkspaceId)
-			if err != nil {
-				return err
-			}
-
-			workspace, err := logAnalyticsClient.Get(ctx, *logAnalyticsId)
-			if err != nil {
-				return fmt.Errorf("retrieving %s for %s: %+v", logAnalyticsId, id, err)
-			}
-
-			if workspace.Model == nil || workspace.Model.Properties == nil {
-				return fmt.Errorf("reading customer ID from %s", logAnalyticsId)
-			}
-
-			if workspace.Model.Properties.CustomerId == nil {
-				return fmt.Errorf("reading customer ID from %s, `customer_id` is nil", logAnalyticsId)
-			}
-
-			keys, err := logAnalyticsClient.SharedKeysGetSharedKeys(ctx, *logAnalyticsId)
-			if err != nil {
-				return fmt.Errorf("retrieving access keys to %s for %s: %+v", logAnalyticsId, id, err)
-			}
-
-			if keys.Model.PrimarySharedKey == nil {
-				return fmt.Errorf("reading shared key for %s in %s", logAnalyticsId, id)
-			}
-
 			managedEnvironment := managedenvironments.ManagedEnvironment{
 				Location: containerAppEnvironment.Location,
 				Name:     pointer.To(containerAppEnvironment.Name),
 				Properties: &managedenvironments.ManagedEnvironmentProperties{
-					AppLogsConfiguration: &managedenvironments.AppLogsConfiguration{
-						Destination: pointer.To("log-analytics"),
-						LogAnalyticsConfiguration: &managedenvironments.LogAnalyticsConfiguration{
-							CustomerId: workspace.Model.Properties.CustomerId,
-							SharedKey:  keys.Model.PrimarySharedKey,
-						},
-					},
 					VnetConfiguration: &managedenvironments.VnetConfiguration{},
 				},
 				Tags: tags.Expand(containerAppEnvironment.Tags),
+			}
+
+			if containerAppEnvironment.LogAnalyticsWorkspaceId != "" {
+				logAnalyticsId, err := workspaces.ParseWorkspaceID(containerAppEnvironment.LogAnalyticsWorkspaceId)
+				if err != nil {
+					return err
+				}
+
+				workspace, err := logAnalyticsClient.Get(ctx, *logAnalyticsId)
+				if err != nil {
+					return fmt.Errorf("retrieving %s for %s: %+v", logAnalyticsId, id, err)
+				}
+
+				if workspace.Model == nil || workspace.Model.Properties == nil {
+					return fmt.Errorf("reading customer ID from %s", logAnalyticsId)
+				}
+
+				if workspace.Model.Properties.CustomerId == nil {
+					return fmt.Errorf("reading customer ID from %s, `customer_id` is nil", logAnalyticsId)
+				}
+
+				keys, err := logAnalyticsClient.SharedKeysGetSharedKeys(ctx, *logAnalyticsId)
+				if err != nil {
+					return fmt.Errorf("retrieving access keys to %s for %s: %+v", logAnalyticsId, id, err)
+				}
+				if keys.Model.PrimarySharedKey == nil {
+					return fmt.Errorf("reading shared key for %s in %s", logAnalyticsId, id)
+				}
+				managedEnvironment.Properties.AppLogsConfiguration = &managedenvironments.AppLogsConfiguration{
+					Destination: pointer.To("log-analytics"),
+					LogAnalyticsConfiguration: &managedenvironments.LogAnalyticsConfiguration{
+						CustomerId: workspace.Model.Properties.CustomerId,
+						SharedKey:  keys.Model.PrimarySharedKey,
+					},
+				}
 			}
 
 			if containerAppEnvironment.InfrastructureSubnetId != "" {

--- a/internal/services/containerapps/container_app_environment_resource_test.go
+++ b/internal/services/containerapps/container_app_environment_resource_test.go
@@ -137,12 +137,13 @@ resource "azurerm_container_app_environment" "test" {
 func (r ContainerAppEnvironmentResource) requiresImport(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 
+
 %[1]s
 
 resource "azurerm_container_app_environment" "import" {
-  name                       = azurerm_container_app_environment.test.name
-  resource_group_name        = azurerm_container_app_environment.test.resource_group_name
-  location                   = azurerm_container_app_environment.test.location
+  name                = azurerm_container_app_environment.test.name
+  resource_group_name = azurerm_container_app_environment.test.resource_group_name
+  location            = azurerm_container_app_environment.test.location
 }
 `, r.basic(data), data.RandomInteger)
 }

--- a/internal/services/containerapps/container_app_environment_resource_test.go
+++ b/internal/services/containerapps/container_app_environment_resource_test.go
@@ -25,7 +25,7 @@ func TestAccContainerAppEnvironment_basic(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.basic(data, true),
+			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -40,7 +40,7 @@ func TestAccContainerAppEnvironment_withoutLogAnalyticsWorkspace(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.basic(data, false),
+			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -55,7 +55,7 @@ func TestAccContainerAppEnvironment_requiresImport(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.basic(data, true),
+			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -118,11 +118,7 @@ func (r ContainerAppEnvironmentResource) Exists(ctx context.Context, client *cli
 	return pointer.To(resp.Model != nil), nil
 }
 
-func (r ContainerAppEnvironmentResource) basic(data acceptance.TestData, bindLogAnalyticsWorkspace bool) string {
-	logAnalyticsWorkspace := "log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id"
-	if !bindLogAnalyticsWorkspace {
-		logAnalyticsWorkspace = ""
-	}
+func (r ContainerAppEnvironmentResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}
@@ -134,9 +130,8 @@ resource "azurerm_container_app_environment" "test" {
   name                = "acctest-CAEnv%[2]d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  %[3]s
 }
-`, r.template(data), data.RandomInteger, logAnalyticsWorkspace)
+`, r.template(data), data.RandomInteger)
 }
 
 func (r ContainerAppEnvironmentResource) requiresImport(data acceptance.TestData) string {
@@ -148,9 +143,8 @@ resource "azurerm_container_app_environment" "import" {
   name                       = azurerm_container_app_environment.test.name
   resource_group_name        = azurerm_container_app_environment.test.resource_group_name
   location                   = azurerm_container_app_environment.test.location
-  log_analytics_workspace_id = azurerm_container_app_environment.test.log_analytics_workspace_id
 }
-`, r.basic(data, true), data.RandomInteger)
+`, r.basic(data), data.RandomInteger)
 }
 
 func (r ContainerAppEnvironmentResource) complete(data acceptance.TestData) string {

--- a/internal/services/containerapps/container_app_environment_resource_test.go
+++ b/internal/services/containerapps/container_app_environment_resource_test.go
@@ -131,9 +131,9 @@ provider "azurerm" {
 %[1]s
 
 resource "azurerm_container_app_environment" "test" {
-  name                       = "acctest-CAEnv%[2]d"
-  resource_group_name        = azurerm_resource_group.test.name
-  location                   = azurerm_resource_group.test.location
+  name                = "acctest-CAEnv%[2]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
   %[3]s
 }
 `, r.template(data), data.RandomInteger, logAnalyticsWorkspace)

--- a/internal/services/containerapps/container_app_environment_resource_test.go
+++ b/internal/services/containerapps/container_app_environment_resource_test.go
@@ -30,21 +30,6 @@ func TestAccContainerAppEnvironment_basic(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep("log_analytics_workspace_id"),
-	})
-}
-
-func TestAccContainerAppEnvironment_withoutLogAnalyticsWorkspace(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_container_app_environment", "test")
-	r := ContainerAppEnvironmentResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.basic(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
 		data.ImportStep(),
 	})
 }

--- a/internal/services/containerapps/container_app_resource_test.go
+++ b/internal/services/containerapps/container_app_resource_test.go
@@ -1326,7 +1326,7 @@ resource "azurerm_container_app" "test" {
 }
 
 func (ContainerAppResource) template(data acceptance.TestData) string {
-	return ContainerAppEnvironmentResource{}.basic(data)
+	return ContainerAppEnvironmentResource{}.basic(data, true)
 }
 
 func (ContainerAppResource) templateWithVnet(data acceptance.TestData) string {

--- a/internal/services/containerapps/container_app_resource_test.go
+++ b/internal/services/containerapps/container_app_resource_test.go
@@ -1326,7 +1326,7 @@ resource "azurerm_container_app" "test" {
 }
 
 func (ContainerAppResource) template(data acceptance.TestData) string {
-	return ContainerAppEnvironmentResource{}.basic(data, true)
+	return ContainerAppEnvironmentResource{}.basic(data)
 }
 
 func (ContainerAppResource) templateWithVnet(data acceptance.TestData) string {

--- a/website/docs/r/container_app_environment.html.markdown
+++ b/website/docs/r/container_app_environment.html.markdown
@@ -44,7 +44,7 @@ The following arguments are supported:
 
 * `location` - (Required) Specifies the supported Azure location where the Container App Environment is to exist. Changing this forces a new resource to be created.
 
-* `log_analytics_workspace_id` - (Required) The ID for the Log Analytics Workspace to link this Container Apps Managed Environment to. Changing this forces a new resource to be created.
+* `log_analytics_workspace_id` - (Optional) The ID for the Log Analytics Workspace to link this Container Apps Managed Environment to. Changing this forces a new resource to be created.
 
 ---
 

--- a/website/docs/r/container_app_environment.html.markdown
+++ b/website/docs/r/container_app_environment.html.markdown
@@ -44,8 +44,6 @@ The following arguments are supported:
 
 * `location` - (Required) Specifies the supported Azure location where the Container App Environment is to exist. Changing this forces a new resource to be created.
 
-* `log_analytics_workspace_id` - (Optional) The ID for the Log Analytics Workspace to link this Container Apps Managed Environment to. Changing this forces a new resource to be created.
-
 ---
 
 * `infrastructure_subnet_id` - (Optional) The existing Subnet to use for the Container Apps Control Plane. Changing this forces a new resource to be created. 
@@ -55,6 +53,8 @@ The following arguments are supported:
 * `internal_load_balancer_enabled` - (Optional) Should the Container Environment operate in Internal Load Balancing Mode? Defaults to `false`. Changing this forces a new resource to be created.
 
 ~> **Note:** can only be set to `true` if `infrastructure_subnet_id` is specified. 
+
+* `log_analytics_workspace_id` - (Optional) The ID for the Log Analytics Workspace to link this Container Apps Managed Environment to. Changing this forces a new resource to be created.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 


### PR DESCRIPTION
We found that `log_analytics_workspace_id` is not required for `azurerm_container_app_environment` anymore, this pr change it to an optional argument so our users could save cost. This pr should solve #20748.

The newly added e2e test passed on my side:

```text
=== RUN   TestAccContainerAppEnvironment_withoutLogAnalyticsWorkspace
=== PAUSE TestAccContainerAppEnvironment_withoutLogAnalyticsWorkspace
=== CONT  TestAccContainerAppEnvironment_withoutLogAnalyticsWorkspace
--- PASS: TestAccContainerAppEnvironment_withoutLogAnalyticsWorkspace (670.33s)
```