### PR TITLE
`azurerm_monitor_data_collection_rule` acctest: change test location to westeurope

### DIFF
--- a/internal/services/monitor/monitor_data_collection_rule_data_source_test.go
+++ b/internal/services/monitor/monitor_data_collection_rule_data_source_test.go
@@ -15,6 +15,8 @@ type MonitorDataCollectionRuleDataSource struct{}
 
 func TestAccMonitorDataCollectionRuleDataSource_complete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "data.azurerm_monitor_data_collection_rule", "test")
+	// https://learn.microsoft.com/en-us/azure/azure-monitor/logs/ingest-logs-event-hub#supported-regions
+	data.Locations.Primary = "westeurope"
 	d := MonitorDataCollectionRuleDataSource{}
 
 	data.DataSourceTest(t, []acceptance.TestStep{

--- a/internal/services/monitor/monitor_data_collection_rule_resource_test.go
+++ b/internal/services/monitor/monitor_data_collection_rule_resource_test.go
@@ -104,6 +104,8 @@ func TestAccMonitorDataCollectionRule_requiresImport(t *testing.T) {
 
 func TestAccMonitorDataCollectionRule_update(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_monitor_data_collection_rule", "test")
+	// https://learn.microsoft.com/en-us/azure/azure-monitor/logs/ingest-logs-event-hub#supported-regions
+	data.Locations.Primary = "westeurope"
 	r := MonitorDataCollectionRuleResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -140,6 +142,8 @@ func TestAccMonitorDataCollectionRule_update(t *testing.T) {
 
 func TestAccMonitorDataCollectionRule_complete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_monitor_data_collection_rule", "test")
+	// https://learn.microsoft.com/en-us/azure/azure-monitor/logs/ingest-logs-event-hub#supported-regions
+	data.Locations.Primary = "westeurope"
 	r := MonitorDataCollectionRuleResource{}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
@@ -734,5 +738,5 @@ resource "azurerm_resource_group" "test" {
   location = "%[2]s"
 }
 
-`, data.RandomInteger, "westeurope")
+`, data.RandomInteger, data.Locations.Primary)
 }

--- a/internal/services/monitor/monitor_data_collection_rule_resource_test.go
+++ b/internal/services/monitor/monitor_data_collection_rule_resource_test.go
@@ -734,5 +734,5 @@ resource "azurerm_resource_group" "test" {
   location = "%[2]s"
 }
 
-`, data.RandomInteger, data.Locations.Primary)
+`, data.RandomInteger, "westeurope")
 }


### PR DESCRIPTION
`westus2` is not applicable for the test, need to change to another location. But seems no way to configure the test location at resource level.

test failure:
```
Resource Group Name: "acctestRG-DataCollectionRule-230728005434411750"
        Data Collection Rule Name: "acctestmdcr-230728005434411750"):
        datacollectionrules.DataCollectionRulesClient#Create: Failure responding to
        request: StatusCode=400 -- Original Error: autorest/azure: Service returned
        an error. Status=400 Code="UnsupportedLocation" Message="'Event Hub Data
        Ingestion' feature is not supported in the Azure region westus2.For a list of
        supported regions, please see ‘Send events from Azure Event Hubs to Azure
        Monitor Logs with a data collection rule'"
        Details=[{"code":"UnsupportedLocation","message":"'Event Hub Data Ingestion'
        feature is not supported in the Azure region westus2.For a list of supported
        regions, please see ‘Send events from Azure Event Hubs to Azure Monitor Logs
        with a data collection rule'"}]
```