### PR TITLE
`azurerm_kubernetes_cluster` - fix `TestAccKubernetesCluster_upgradeChannel`

### DIFF
--- a/internal/services/containers/kubernetes_cluster_other_resource_test.go
+++ b/internal/services/containers/kubernetes_cluster_other_resource_test.go
@@ -461,7 +461,7 @@ func TestAccKubernetesCluster_upgradeChannel(t *testing.T) {
 				check.That(data.ResourceName).Key("automatic_channel_upgrade").HasValue("rapid"),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("node_os_channel_upgrade"),
 		{
 			Config: r.upgradeChannelConfig(data, olderKubernetesVersion, "patch"),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -470,7 +470,7 @@ func TestAccKubernetesCluster_upgradeChannel(t *testing.T) {
 				check.That(data.ResourceName).Key("automatic_channel_upgrade").HasValue("patch"),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("node_os_channel_upgrade"),
 		{
 			Config: r.upgradeChannelConfig(data, olderKubernetesVersion, "node-image"),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -479,7 +479,7 @@ func TestAccKubernetesCluster_upgradeChannel(t *testing.T) {
 				check.That(data.ResourceName).Key("automatic_channel_upgrade").HasValue("node-image"),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("node_os_channel_upgrade"),
 		{
 			// unset = none
 			Config: r.upgradeChannelConfig(data, olderKubernetesVersion, ""),
@@ -489,7 +489,7 @@ func TestAccKubernetesCluster_upgradeChannel(t *testing.T) {
 				check.That(data.ResourceName).Key("automatic_channel_upgrade").HasValue(""),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("node_os_channel_upgrade"),
 		{
 			Config: r.upgradeChannelConfig(data, olderKubernetesVersion, "stable"),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -498,7 +498,7 @@ func TestAccKubernetesCluster_upgradeChannel(t *testing.T) {
 				check.That(data.ResourceName).Key("automatic_channel_upgrade").HasValue("stable"),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep("node_os_channel_upgrade"),
 	})
 }
 


### PR DESCRIPTION
This PR adds `node_os_channel_upgrade` in the ignore step because this field is only set when it's explicitly been set in the config. So during the import step, `node_os_channel_upgrade` should be ignored.

refs: https://github.com/hashicorp/terraform-provider-azurerm/blob/a87e8c0d6d35710889412c6dd5d2ac7952acfeb4/internal/services/containers/kubernetes_cluster_resource.go#L2589-L2593

```
=== RUN   TestAccKubernetesCluster_snapshotId
=== PAUSE TestAccKubernetesCluster_snapshotId
=== CONT  TestAccKubernetesCluster_snapshotId
--- PASS: TestAccKubernetesCluster_snapshotId (1593.10s)
PASS
```