### PR TITLE
`azurerm_kusto_cluster` - remove ForceNew in `virtual_network_configuration`

### DIFF
--- a/internal/services/kusto/kusto_cluster_resource.go
+++ b/internal/services/kusto/kusto_cluster_resource.go
@@ -145,7 +145,6 @@ func resourceKustoCluster() *pluginsdk.Resource {
 			"virtual_network_configuration": {
 				Type:     pluginsdk.TypeList,
 				Optional: true,
-				ForceNew: true,
 				MaxItems: 1,
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{

--- a/website/docs/r/kusto_cluster.html.markdown
+++ b/website/docs/r/kusto_cluster.html.markdown
@@ -68,7 +68,7 @@ The following arguments are supported:
 
 * `purge_enabled` - (Optional) Specifies if the purge operations are enabled.
 
-* `virtual_network_configuration` - (Optional) A `virtual_network_configuration` block as defined below. Changing this forces a new resource to be created.
+* `virtual_network_configuration` - (Optional) A `virtual_network_configuration` block as defined below.
 
 * `language_extensions` - (Optional) An list of `language_extensions` to enable. Valid values are: `PYTHON`, `PYTHON_3.10.8` and `R`. `PYTHON` is used to specify Python 3.6.5 image and `PYTHON_3.10.8` is used to specify Python 3.10.8 image. Note that `PYTHON_3.10.8` is only available in skus which support nested virtualization.
 


### PR DESCRIPTION
Service team is requesting us to remove forceNew of `virtual_network_configuration` in `azurerm_kusto_cluster` to prevent protential data loss.

(Quotes from service team)
```
In 2023-08-15 we will introduce a new property state {“Enbaled”, “Disabled”}.
Consider you have a cluster with virtualNetworkConfiguration and state disabled,  disabled using any SDK\RestCall with version 2023-08-15
Now you are sending HTTP GET request for the cluster, it will look like this:

2023-08-15
"VirtualNetworkConfiguration": {
    "subnetId":  < some value > ,
    "enginePublicIpId":  < some value >
    "dataManagementPublicIpId":  < some value >
    "state": disabled
}

2023-05-02
"VirtualNetworkConfiguration": null

Let’s assume this consumer is using terraform ( and terraform isn’t updated yet to 2023-08-15) what will happen? 

terraform GET:
"VirtualNetworkConfiguration": null

terraform PUT (consumer template):
VirtualNetworkConfiguration": {
    "subnetId":  < some value > ,
    "enginePublicIpId":  < some value >
    "dataManagementPublicIpId":  < some value >
}

VirtualNetworkConfiguration (GET) != VirtualNetworkConfiguration(PUT) -> apply force new

The force new behavior will require the consumer to delete the cluster and create it again (data loss)
If the consumer is using terraform deployment with auto approve variable, he wouldn’t see the “create new” warning and his cluster will be deleted.

If you can help us remove this force new, the scenario above will not happen. 

```

The ultimate solution for azurerm provider could be upgrading to 2023-08-15 and add a new property after its releasing.