### PR TITLE
azurerm_pim_eligible_role_assignment: fix the context deadline status check

### DIFF
--- a/internal/services/authorization/pim_eligible_role_assignment_resource.go
+++ b/internal/services/authorization/pim_eligible_role_assignment_resource.go
@@ -345,7 +345,7 @@ func (PimEligibleRoleAssignmentResource) Delete() sdk.ResourceFunc {
 			deleteId := roleeligibilityschedulerequests.NewScopedRoleEligibilityScheduleRequestID(id.Scope, uuid)
 
 			deadline, ok := ctx.Deadline()
-			if ok {
+			if !ok {
 				return fmt.Errorf("internal error: context has no deadline")
 			}
 


### PR DESCRIPTION
AzureRM Provider Version: `3.67`

Context deadline check was checking the wrong status value for error. This caused the "Delete" operation to always fail with the error message `internal error: context has no deadline`.