### PR TITLE
New Tool: `update-api-version`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-azure-helpers v0.57.0
 	github.com/hashicorp/go-azure-sdk v0.20230731.1122530
+	github.com/hashicorp/go-hclog v1.4.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/go-version v1.6.0
@@ -30,6 +31,7 @@ require (
 	github.com/tombuildsstuff/kermit v0.20230703.1101016
 	golang.org/x/crypto v0.9.0
 	golang.org/x/net v0.10.0
+	golang.org/x/tools v0.6.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -46,7 +48,6 @@ require (
 	github.com/hashicorp/go-checkpoint v0.5.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320 // indirect
-	github.com/hashicorp/go-hclog v1.4.0 // indirect
 	github.com/hashicorp/go-plugin v1.4.8 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.4 // indirect
 	github.com/hashicorp/hc-install v0.5.0 // indirect
@@ -76,7 +77,6 @@ require (
 	golang.org/x/oauth2 v0.4.0 // indirect
 	golang.org/x/sys v0.8.0 // indirect
 	golang.org/x/text v0.9.0 // indirect
-	golang.org/x/tools v0.6.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f // indirect
 	google.golang.org/grpc v1.53.0 // indirect

--- a/internal/tools/update-api-version/.gitignore
+++ b/internal/tools/update-api-version/.gitignore
@@ -1,0 +1,1 @@
+update-api-version

--- a/internal/tools/update-api-version/README.md
+++ b/internal/tools/update-api-version/README.md
@@ -1,0 +1,33 @@
+## Tool: `update-api-version`
+
+This tool automatically updates import references from one API version to another API version when using `hashicorp/go-azure-sdk`.
+
+This works against a Service and takes both the old and the new API versions, for example:
+
+```sh
+./update-api-version -service=advisor -old-api-version=2020-01-01 -new-api-version=2022-01-01
+```
+
+The arguments are:
+
+* `service` - the name of the Service Package (e.g. `compute`, `network` etc).
+* `old-api-version` - the existing API version (for example `2020-01-01` or `2020-01-01-preview`) which should be replaced.
+* `new-api-version` - the new API version which should be used in place of the value for `old-api-version`.
+
+---
+
+This tool supports updating both explicit SDK references, that is:
+
+```
+import (
+    "github.com/hashicorp/go-azure-sdk/resource-manager/{service}/{api-version}/{sdk}"
+)
+```
+
+as well as Meta Clients (which includes updating the import alias):
+
+```
+import (
+    service_api_version "github.com/hashicorp/go-azure-sdk/resource-manager/{service}/{api-version}"
+)
+```

--- a/internal/tools/update-api-version/README.md
+++ b/internal/tools/update-api-version/README.md
@@ -5,7 +5,7 @@ This tool automatically updates import references from one API version to anothe
 This works against a Service and takes both the old and the new API versions, for example:
 
 ```sh
-./update-api-version -service=advisor -old-api-version=2020-01-01 -new-api-version=2022-01-01
+./update-api-version -service="advisor" -old-api-version="2020-01-01" -new-api-version="2022-01-01"
 ```
 
 The arguments are:

--- a/internal/tools/update-api-version/main.go
+++ b/internal/tools/update-api-version/main.go
@@ -92,7 +92,7 @@ func updateImportsWithinDirectory(serviceName string, oldApiVersion string, newA
 			if err = format.Node(&buf, fileSet, file); err != nil {
 				return fmt.Errorf("error formatting new code: %w", err)
 			}
-			os.WriteFile(fileName, buf.Bytes(), 0644)
+			_ = os.WriteFile(fileName, buf.Bytes(), 0644)
 		}
 	}
 	return nil

--- a/internal/tools/update-api-version/main.go
+++ b/internal/tools/update-api-version/main.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"go/ast"
+	"go/format"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/hashicorp/go-hclog"
+	"golang.org/x/tools/go/ast/astutil"
+)
+
+var logger hclog.Logger
+
+func main() {
+	logger = hclog.New(hclog.DefaultOptions)
+	if os.Getenv("DEBUG") != "" {
+		logger.SetLevel(hclog.Debug)
+	}
+
+	f := flag.NewFlagSet("update-api-version", flag.ExitOnError)
+	serviceName := f.String("service", "", "-service=compute")
+	oldApiVersion := f.String("old-api-version", "", "-old-api-version=2019-01-01")
+	newApiVersion := f.String("new-api-version", "", "-new-api-version=2023-06-01")
+	_ = f.Parse(os.Args[1:])
+
+	if err := f.Parse(os.Args); err != nil {
+		log.Fatalf("parsing arguments: %+v", err)
+	}
+
+	workingDirectory := fmt.Sprintf("../../services/%s", *serviceName)
+	if err := run(*serviceName, *oldApiVersion, *newApiVersion, workingDirectory); err != nil {
+		log.Fatalf("error: %+v", err)
+	}
+}
+
+func run(serviceName string, oldApiVersion string, newApiVersion string, workingDirectory string) error {
+	logger.Debug(fmt.Sprintf("Updating Imports in the top-level directory %q..", workingDirectory))
+	if err := updateImportsWithinDirectory(serviceName, oldApiVersion, newApiVersion, workingDirectory); err != nil {
+		return fmt.Errorf("updating the imports within the top-level directory %q: %+v", workingDirectory, err)
+	}
+
+	logger.Debug(fmt.Sprintf("Updating Imports in the directories within directory %q..", workingDirectory))
+	entries, err := os.ReadDir(workingDirectory)
+	if err != nil {
+		return fmt.Errorf("opening the working directory at %q: %+v", workingDirectory, err)
+	}
+	directories := make([]string, 0)
+	for _, entry := range entries {
+		info, err := entry.Info()
+		if err != nil {
+			return fmt.Errorf("retrieving information for %q: %+v", entry.Name(), err)
+		}
+		if info.IsDir() {
+			directories = append(directories, info.Name())
+		}
+	}
+	for _, directory := range directories {
+		path := filepath.Join(workingDirectory, directory)
+		logger.Debug(fmt.Sprintf("Updating Imports within the nested directory %q..", path))
+		if err := updateImportsWithinDirectory(serviceName, oldApiVersion, newApiVersion, path); err != nil {
+			return fmt.Errorf("updating the imports within %q: %+v", path, err)
+		}
+	}
+
+	return nil
+}
+
+func updateImportsWithinDirectory(serviceName string, oldApiVersion string, newApiVersion string, workingDirectory string) error {
+	fileSet := token.NewFileSet()
+	files, err := parser.ParseDir(fileSet, workingDirectory, func(info fs.FileInfo) bool {
+		return true
+	}, parser.ParseComments)
+	if err != nil {
+		return fmt.Errorf("parsing files within %q: %+v", workingDirectory, err)
+	}
+	for pkgName, pkg := range files {
+		fmt.Printf("Package %q", pkgName)
+		for fileName, file := range pkg.Files {
+			logger.Info(fmt.Sprintf("Updating imports for File %q..", fileName))
+			updateImportsForFile(fileSet, file, serviceName, oldApiVersion, newApiVersion)
+
+			var buf bytes.Buffer
+			if err = format.Node(&buf, fileSet, file); err != nil {
+				return fmt.Errorf("error formatting new code: %w", err)
+			}
+			os.WriteFile(fileName, buf.Bytes(), 0644)
+		}
+	}
+	return nil
+}
+
+func updateImportsForFile(fileSet *token.FileSet, file *ast.File, serviceName string, oldApiVersion string, newApiVersion string) {
+	importLineForPreviousApiVersion := fmt.Sprintf("github.com/hashicorp/go-azure-sdk/resource-manager/%s/%s", serviceName, oldApiVersion)
+	importLineForNewApiVersion := fmt.Sprintf("github.com/hashicorp/go-azure-sdk/resource-manager/%s/%s", serviceName, newApiVersion)
+
+	existingImports := astutil.Imports(fileSet, file)
+	for _, val := range existingImports {
+		for _, item := range val {
+			logger.Debug(fmt.Sprintf("Processing Import %q", item.Path.Value))
+			existingImportLine := item.Path.Value
+			if !strings.Contains(existingImportLine, importLineForPreviousApiVersion) {
+				continue
+			}
+
+			updatedImportLine := strings.Replace(existingImportLine, importLineForPreviousApiVersion, importLineForNewApiVersion, 1)
+			logger.Debug(fmt.Sprintf("Updating Import URI from %q to %q", existingImportLine, updatedImportLine))
+			item.Path.Value = updatedImportLine
+
+			// if we're importing the meta client (e.g. the api version directly) then we also need to update the alias
+			importsMetaClient := existingImportLine == importLineForPreviousApiVersion
+			if importsMetaClient && item.Name != nil {
+				if existingAlias := item.Name.Name; existingAlias != "" {
+					updatedAlias := strings.ToLower(fmt.Sprintf("%s_%s", serviceName, strings.ReplaceAll(newApiVersion, "-", "_")))
+					logger.Debug(fmt.Sprintf("Updating Import Alias from %q to %q", existingAlias, updatedAlias))
+					item.Name.Name = updatedAlias
+				}
+			}
+
+			// finally, remove any comments which will be stragglers/lintignores which shouldn't be present
+			if item.Comment != nil {
+				item.Comment.List = []*ast.Comment{}
+			}
+		}
+	}
+}

--- a/internal/tools/update-api-version/main.go
+++ b/internal/tools/update-api-version/main.go
@@ -30,10 +30,20 @@ func main() {
 	serviceName := f.String("service", "", "-service=compute")
 	oldApiVersion := f.String("old-api-version", "", "-old-api-version=2019-01-01")
 	newApiVersion := f.String("new-api-version", "", "-new-api-version=2023-06-01")
-	_ = f.Parse(os.Args[1:])
-
-	if err := f.Parse(os.Args); err != nil {
+	if len(os.Args) == 1 { // 0 is the app name
+		log.Fatalf("expected multiple arguments but didn't get any")
+	}
+	if err := f.Parse(os.Args[1:]); err != nil {
 		log.Fatalf("parsing arguments: %+v", err)
+	}
+	if serviceName == nil || *serviceName == "" {
+		log.Fatalf("missing `-service`")
+	}
+	if oldApiVersion == nil || *oldApiVersion == "" {
+		log.Fatalf("missing `-old-api-version`")
+	}
+	if newApiVersion == nil || *newApiVersion == "" {
+		log.Fatalf("missing `-new-api-version`")
 	}
 
 	workingDirectory := fmt.Sprintf("../../services/%s", *serviceName)


### PR DESCRIPTION
This PR introduces a new tool `update-api-version` which will update the import references to one API version used within `hashicorp/go-azure-sdk` to another API version.

Whilst this tool can be run standalone, this is primarily intended to be run in automation so that API versions can be updated automatically.