### PR TITLE
dependencies: updating to `v0.20230802.1115742` of `github.com/hashicorp/go-azure-sdk`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-azure-helpers v0.57.0
-	github.com/hashicorp/go-azure-sdk v0.20230801.1155153
+	github.com/hashicorp/go-azure-sdk v0.20230802.1115742
 	github.com/hashicorp/go-hclog v1.4.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -121,8 +121,8 @@ github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brv
 github.com/hashicorp/go-azure-helpers v0.12.0/go.mod h1:Zc3v4DNeX6PDdy7NljlYpnrdac1++qNW0I4U+ofGwpg=
 github.com/hashicorp/go-azure-helpers v0.57.0 h1:85CWEUtIjMtx8DaXisFbEb2GCWR4S2UZlYvJpSPYoZ4=
 github.com/hashicorp/go-azure-helpers v0.57.0/go.mod h1:BQUQp5udwbJ8pnzl0wByCLVEEyPMAFpJ9vOREiCzObo=
-github.com/hashicorp/go-azure-sdk v0.20230801.1155153 h1:k4OhnT1J16enTWvOovShWRLXhArcm4eQpp0EEtip0js=
-github.com/hashicorp/go-azure-sdk v0.20230801.1155153/go.mod h1:iZrpp7qJSZxocEkr4SjslzxpDrhuRLmedyVGGcCPbhk=
+github.com/hashicorp/go-azure-sdk v0.20230802.1115742 h1:/2W3xmkxhcT+VkZqYITlHv2dbhIo1nMgcxXMLaFFBNk=
+github.com/hashicorp/go-azure-sdk v0.20230802.1115742/go.mod h1:iZrpp7qJSZxocEkr4SjslzxpDrhuRLmedyVGGcCPbhk=
 github.com/hashicorp/go-checkpoint v0.5.0 h1:MFYpPZCnQqQTE18jFwSII6eUQrD/oxMFp3mlgcqk5mU=
 github.com/hashicorp/go-checkpoint v0.5.0/go.mod h1:7nfLNL10NsxqO4iWuW6tWW0HjZuDrwkBuEQsVcpCOgg=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=

--- a/vendor/github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager/poller.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager/poller.go
@@ -6,6 +6,7 @@ package resourcemanager
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/hashicorp/go-azure-sdk/sdk/client"
@@ -17,11 +18,14 @@ func PollerFromResponse(response *client.Response, client *Client) (poller polle
 		return pollers.Poller{}, fmt.Errorf("no HTTP Response was returned")
 	}
 
+	originalRequestUri := response.Request.URL.String()
+
 	// If this is a LRO we should either have a 201/202 with a Polling URI header
 	isLroStatus := response.StatusCode == http.StatusCreated || response.StatusCode == http.StatusAccepted
 	methodIsDelete := strings.EqualFold(response.Request.Method, "DELETE")
 	lroPollingUri := pollingUriForLongRunningOperation(response)
-	if isLroStatus && lroPollingUri != "" && !methodIsDelete {
+	lroIsSelfReference := isLROSelfReference(lroPollingUri, originalRequestUri)
+	if isLroStatus && lroPollingUri != "" && !methodIsDelete && !lroIsSelfReference {
 		lro, lroErr := longRunningOperationPollerFromResponse(response, client.Client)
 		if lroErr != nil {
 			err = lroErr
@@ -62,4 +66,21 @@ func PollerFromResponse(response *client.Response, client *Client) (poller polle
 	}
 
 	return pollers.Poller{}, fmt.Errorf("no applicable pollers were found for the response")
+}
+
+func isLROSelfReference(lroPollingUri, originalRequestUri string) bool {
+	// Some APIs return a LRO URI of themselves, meaning that we should be checking a 200 OK is returned rather
+	// than polling as usual. Automation@2022-08-08 - DSCNodeConfiguration CreateOrUpdate is one such example.
+	first, err := url.Parse(lroPollingUri)
+	if err != nil {
+		return false
+	}
+	second, err := url.Parse(originalRequestUri)
+	if err != nil {
+		return false
+	}
+
+	// The Query String can be a different API version / options and in some cases the Host
+	// is returned with `:443` - so the path should be sufficient as a check.
+	return strings.EqualFold(first.Path, second.Path)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -131,7 +131,7 @@ github.com/hashicorp/go-azure-helpers/resourcemanager/tags
 github.com/hashicorp/go-azure-helpers/resourcemanager/zones
 github.com/hashicorp/go-azure-helpers/sender
 github.com/hashicorp/go-azure-helpers/storage
-# github.com/hashicorp/go-azure-sdk v0.20230801.1155153
+# github.com/hashicorp/go-azure-sdk v0.20230802.1115742
 ## explicit; go 1.19
 github.com/hashicorp/go-azure-sdk/resource-manager/aad/2021-05-01/domainservices
 github.com/hashicorp/go-azure-sdk/resource-manager/aadb2c/2021-04-01-preview


### PR DESCRIPTION
Includes a fix to polling which'll enable https://github.com/hashicorp/terraform-provider-azurerm/pull/22781

Supersedes https://github.com/hashicorp/terraform-provider-azurerm/pull/22787