### PR TITLE
`azurerm_hpc_cache_nfs_target/azurerm_hpc_cache_blob_nfs_target` - update the validation of `usage_model`

### DIFF
--- a/internal/services/hpccache/hpc_cache_blob_nfs_target_resource.go
+++ b/internal/services/hpccache/hpc_cache_blob_nfs_target_resource.go
@@ -78,6 +78,8 @@ func resourceHPCCacheBlobNFSTarget() *pluginsdk.Resource {
 				ValidateFunc: validation.StringInSlice([]string{
 					"READ_HEAVY_INFREQ",
 					"READ_HEAVY_CHECK_180",
+					"READ_ONLY",
+					"READ_WRITE",
 					"WRITE_WORKLOAD_15",
 					"WRITE_AROUND",
 					"WRITE_WORKLOAD_CHECK_30",

--- a/internal/services/hpccache/hpc_cache_blob_nfs_target_resource_test.go
+++ b/internal/services/hpccache/hpc_cache_blob_nfs_target_resource_test.go
@@ -106,6 +106,28 @@ func TestAccHPCCacheBlobNFSTarget_requiresImport(t *testing.T) {
 	})
 }
 
+func TestAccHPCCacheBlobNFSTarget_usageModel(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_hpc_cache_blob_nfs_target", "test")
+	r := HPCCacheBlobNFSTargetResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.usageModel(data, "READ_WRITE"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.usageModel(data, "READ_ONLY"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (HPCCacheBlobNFSTargetResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := storagetargets.ParseStorageTargetID(state.ID)
 	if err != nil {
@@ -352,4 +374,19 @@ resource "azurerm_hpc_cache" "test" {
   ]
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}
+
+func (r HPCCacheBlobNFSTargetResource) usageModel(data acceptance.TestData, modelName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_hpc_cache_blob_nfs_target" "test" {
+  name                 = "acctest-HPCCTGT-%s"
+  resource_group_name  = azurerm_resource_group.test.name
+  cache_name           = azurerm_hpc_cache.test.name
+  storage_container_id = jsondecode(azurerm_resource_group_template_deployment.storage-containers.output_content).id.value
+  namespace_path       = "/p1"
+  usage_model          = "%s"
+}
+`, r.template(data), data.RandomString, modelName)
 }

--- a/internal/services/hpccache/hpc_cache_nfs_target_resource.go
+++ b/internal/services/hpccache/hpc_cache_nfs_target_resource.go
@@ -106,6 +106,8 @@ func resourceHPCCacheNFSTarget() *pluginsdk.Resource {
 				ValidateFunc: validation.StringInSlice([]string{
 					"READ_HEAVY_INFREQ",
 					"READ_HEAVY_CHECK_180",
+					"READ_ONLY",
+					"READ_WRITE",
 					"WRITE_WORKLOAD_15",
 					"WRITE_AROUND",
 					"WRITE_WORKLOAD_CHECK_30",

--- a/internal/services/hpccache/hpc_cache_nfs_target_resource_test.go
+++ b/internal/services/hpccache/hpc_cache_nfs_target_resource_test.go
@@ -46,7 +46,21 @@ func TestAccHPCCacheNFSTarget_usageModel(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
-			Config: r.usageModel(data),
+			Config: r.usageModel(data, "READ_HEAVY_CHECK_180"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.usageModel(data, "READ_WRITE"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.usageModel(data, "READ_ONLY"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -179,7 +193,7 @@ resource "azurerm_hpc_cache_nfs_target" "test" {
 `, r.cacheTemplate(data), data.RandomString)
 }
 
-func (r HPCCacheNFSTargetResource) usageModel(data acceptance.TestData) string {
+func (r HPCCacheNFSTargetResource) usageModel(data acceptance.TestData, modelName string) string {
 	return fmt.Sprintf(`
 %s
 
@@ -188,7 +202,7 @@ resource "azurerm_hpc_cache_nfs_target" "test" {
   resource_group_name = azurerm_resource_group.test.name
   cache_name          = azurerm_hpc_cache.test.name
   target_host_name    = azurerm_linux_virtual_machine.test.private_ip_address
-  usage_model         = "READ_HEAVY_CHECK_180"
+  usage_model         = "%s"
   namespace_junction {
     namespace_path = "/nfs/a1"
     nfs_export     = "/export/a"
@@ -199,7 +213,7 @@ resource "azurerm_hpc_cache_nfs_target" "test" {
     nfs_export     = "/export/b"
   }
 }
-`, r.cacheTemplate(data), data.RandomString)
+`, r.cacheTemplate(data), data.RandomString, modelName)
 }
 
 func (r HPCCacheNFSTargetResource) namespaceJunction(data acceptance.TestData) string {

--- a/website/docs/r/hpc_cache_blob_nfs_target.html.markdown
+++ b/website/docs/r/hpc_cache_blob_nfs_target.html.markdown
@@ -183,7 +183,7 @@ The following arguments are supported:
 
 -> **Note:** This is the Resource Manager ID of the Storage Container, rather than the regular ID - and can be accessed on the `azurerm_storage_container` Data Source/Resource as `resource_manager_id`.
 
-* `usage_model` - (Required) The type of usage of the HPC Cache Blob NFS Target. Possible values are: `READ_HEAVY_INFREQ`, `READ_HEAVY_CHECK_180`, `WRITE_WORKLOAD_15`, `WRITE_AROUND`, `WRITE_WORKLOAD_CHECK_30`, `WRITE_WORKLOAD_CHECK_60` and `WRITE_WORKLOAD_CLOUDWS`.
+* `usage_model` - (Required) The type of usage of the HPC Cache Blob NFS Target. Possible values are: `READ_HEAVY_INFREQ`, `READ_HEAVY_CHECK_180`, `READ_ONLY`, `READ_WRITE`, `WRITE_WORKLOAD_15`, `WRITE_AROUND`, `WRITE_WORKLOAD_CHECK_30`, `WRITE_WORKLOAD_CHECK_60` and `WRITE_WORKLOAD_CLOUDWS`.
 
 ---
 

--- a/website/docs/r/hpc_cache_nfs_target.html.markdown
+++ b/website/docs/r/hpc_cache_nfs_target.html.markdown
@@ -139,7 +139,7 @@ The following arguments are supported:
 
 * `target_host_name` - (Required) The IP address or fully qualified domain name (FQDN) of the HPC Cache NFS target. Changing this forces a new resource to be created.
 
-* `usage_model` - (Required) The type of usage of the HPC Cache NFS Target. Possible values are: `READ_HEAVY_INFREQ`, `READ_HEAVY_CHECK_180`, `WRITE_WORKLOAD_15`, `WRITE_AROUND`, `WRITE_WORKLOAD_CHECK_30`, `WRITE_WORKLOAD_CHECK_60` and `WRITE_WORKLOAD_CLOUDWS`.
+* `usage_model` - (Required) The type of usage of the HPC Cache NFS Target. Possible values are: `READ_HEAVY_INFREQ`, `READ_HEAVY_CHECK_180`, `READ_ONLY`, `READ_WRITE`, `WRITE_WORKLOAD_15`, `WRITE_AROUND`, `WRITE_WORKLOAD_CHECK_30`, `WRITE_WORKLOAD_CHECK_60` and `WRITE_WORKLOAD_CLOUDWS`.
 
 * `namespace_junction` - (Required) Can be specified multiple times to define multiple `namespace_junction`. Each `namespace_juntion` block supports fields documented below.
 


### PR DESCRIPTION
Service team raised a request about supporting new values "READ_ONLY" and "READ_WRITE" for "usage_model".

![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/19754191/10aea3bf-cf66-421a-a284-9279eb10ab27)