### PR TITLE
`azurerm_monitor_alert_prometheus_rule_group` - fix test

### DIFF
--- a/internal/services/monitor/monitor_alert_prometheus_rule_group_resource_test.go
+++ b/internal/services/monitor/monitor_alert_prometheus_rule_group_resource_test.go
@@ -228,9 +228,6 @@ EOF
     severity   = 2
     action {
       action_group_id = azurerm_monitor_action_group.test.id
-      action_properties = {
-        actionName = "actionValue"
-      }
     }
     alert_resolution {
       auto_resolved   = true
@@ -332,15 +329,9 @@ EOF
     severity   = 1
     action {
       action_group_id = azurerm_monitor_action_group.test2.id
-      action_properties = {
-        actionName2 = "actionValue2"
-      }
     }
     action {
       action_group_id = azurerm_monitor_action_group.test.id
-      action_properties = {
-        actionName3 = "actionValue3"
-      }
     }
     alert_resolution {
       auto_resolved   = false

--- a/website/docs/r/monitor_alert_prometheus_rule_group.html.markdown
+++ b/website/docs/r/monitor_alert_prometheus_rule_group.html.markdown
@@ -79,9 +79,6 @@ EOF
 
     action {
       action_group_id = azurerm_monitor_action_group.example.id
-      action_properties = {
-        actionName = "actionValue"
-      }
     }
 
     alert_resolution {
@@ -157,7 +154,7 @@ An `action` block supports the following:
 
 * `action_group_id` - (Required) Specifies the resource id of the monitor action group.
 
-* `action_properties` - (Optional) Specifies the properties of an action group object.
+* `action_properties` - (Optional) Specifies the properties of an action group object. Only available for IcM Connector action group.
 
 ---
 

--- a/website/docs/r/monitor_alert_prometheus_rule_group.html.markdown
+++ b/website/docs/r/monitor_alert_prometheus_rule_group.html.markdown
@@ -154,7 +154,9 @@ An `action` block supports the following:
 
 * `action_group_id` - (Required) Specifies the resource id of the monitor action group.
 
-* `action_properties` - (Optional) Specifies the properties of an action group object. Only available for IcM Connector action group.
+* `action_properties` - (Optional) Specifies the properties of an action group object.
+ 
+-> **Note:** `action_properties` can only be configured for IcM Connector Action Groups for now. Other public features will be supported in the future.
 
 ---
 


### PR DESCRIPTION
`rule.action.action_properties` can only be used with IcM Connector Action Group now.