### PR TITLE
`data.azurerm_subnet`: use resource id from Get response for `id` field

### DIFF
--- a/internal/services/network/subnet_data_source.go
+++ b/internal/services/network/subnet_data_source.go
@@ -111,6 +111,10 @@ func dataSourceSubnetRead(d *pluginsdk.ResourceData, meta interface{}) error {
 	}
 
 	d.SetId(id.ID())
+	if resp.ID != nil {
+		d.SetId(*resp.ID)
+	}
+
 	d.Set("name", id.SubnetName)
 	d.Set("virtual_network_name", id.VirtualNetworkName)
 	d.Set("resource_group_name", id.ResourceGroupName)

--- a/internal/services/network/subnet_data_source.go
+++ b/internal/services/network/subnet_data_source.go
@@ -112,7 +112,9 @@ func dataSourceSubnetRead(d *pluginsdk.ResourceData, meta interface{}) error {
 
 	d.SetId(id.ID())
 	if resp.ID != nil {
-		d.SetId(*resp.ID)
+		if id, err := commonids.ParseSubnetID(*resp.ID); err == nil {
+			d.SetId(id.ID())
+		}
 	}
 
 	d.Set("name", id.SubnetName)


### PR DESCRIPTION
should fixes #22765 but this may be a breaking change which made a change to the output like below:


```
Changes to Outputs:
  ~ subnetid = "/subscriptions/xxx/resourceGroups/acctestRG-lb-x/providers/Microsoft.Network/virtualNetworks/acctestn/subnets/aaa"
            -> "/subscriptions/xxx/resourceGroups/acctestRG-lb-x/providers/Microsoft.Network/virtualNetworks/acctestn/subnets/AAA"

You can apply this plan to save these new output values to the Terraform state,
without changing any real infrastructure.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: 
```

maybe we should use export a new field like `resource_id` to use the API Responded ID in the data source?  