### PR TITLE
azurerm_datadog_monitor_tag_rule - remove nil check

### DIFF
--- a/internal/services/datadog/datadog_monitor_tag_rule_resource.go
+++ b/internal/services/datadog/datadog_monitor_tag_rule_resource.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/datadog/2021-03-01/monitorsresource"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/datadog/2021-03-01/rules"
-	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
@@ -145,15 +144,6 @@ func resourceDatadogTagRulesCreate(d *pluginsdk.ResourceData, meta interface{}) 
 	}
 
 	id := rules.NewTagRuleID(monitorId.SubscriptionId, monitorId.ResourceGroupName, monitorId.MonitorName, d.Get("name").(string))
-	existing, err := client.TagRulesGet(ctx, id)
-	if err != nil {
-		if !response.WasNotFound(existing.HttpResponse) {
-			return fmt.Errorf("checking for an existing %s: %+v", id, err)
-		}
-	}
-	if !response.WasNotFound(existing.HttpResponse) {
-		return tf.ImportAsExistsError("azurerm_datadog_monitor_tag_rule", id.ID())
-	}
 
 	payload := rules.MonitoringTagRules{
 		Properties: &rules.MonitoringTagRulesProperties{

--- a/internal/services/datadog/datadog_monitor_tag_rule_resource_test.go
+++ b/internal/services/datadog/datadog_monitor_tag_rule_resource_test.go
@@ -48,21 +48,6 @@ func TestAccDatadogMonitorTagRules_basic(t *testing.T) {
 	})
 }
 
-func TestAccDatadogMonitorTagRules_requiresImport(t *testing.T) {
-	data := acceptance.BuildTestData(t, "azurerm_datadog_monitor_tag_rule", "test")
-	r := TagRulesDatadogMonitorResource{}
-	r.populateFromEnvironment(t)
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.basic(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-			),
-		},
-		data.RequiresImportErrorStep(r.requiresImport),
-	})
-}
-
 func TestAccDatadogMonitorTagRules_update(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_datadog_monitor_tag_rule", "test")
 	r := TagRulesDatadogMonitorResource{}
@@ -139,10 +124,6 @@ resource "azurerm_datadog_monitor" "test" {
 
 func (r TagRulesDatadogMonitorResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
 %s
 
 resource "azurerm_datadog_monitor_tag_rule" "test" {
@@ -161,33 +142,8 @@ resource "azurerm_datadog_monitor_tag_rule" "test" {
 `, r.template(data))
 }
 
-func (r TagRulesDatadogMonitorResource) requiresImport(data acceptance.TestData) string {
-	return fmt.Sprintf(`
-%s
-
-resource "azurerm_datadog_monitor_tag_rule" "import" {
-  datadog_monitor_id = azurerm_datadog_monitor_tag_rule.test.datadog_monitor_id
-  name               = azurerm_datadog_monitor_tag_rule.test.name
-  log {
-    subscription_log_enabled = true
-  }
-  metric {
-    filter {
-      name   = "Test"
-      value  = "Testing-Logs"
-      action = "Include"
-    }
-  }
-}
-`, r.basic(data))
-}
-
 func (r TagRulesDatadogMonitorResource) update(data acceptance.TestData) string {
 	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
 %s
 
 resource "azurerm_datadog_monitor_tag_rule" "test" {


### PR DESCRIPTION
fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/22793

As datadog monitor tag rule is always there, so we don't need to check if it exists.

--- PASS: TestAccDatadogMonitorTagRules_basic (221.01s)
--- PASS: TestAccDatadogMonitorTagRules_update (340.70s)