### PR TITLE
New resource: `azurerm_firewall_policy_application_rule_collection`

### DIFF
--- a/internal/services/firewall/firewall_policy_application_rule_collection_resource.go
+++ b/internal/services/firewall/firewall_policy_application_rule_collection_resource.go
@@ -1,0 +1,378 @@
+package firewall
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/firewall/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/firewall/validate"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+	"github.com/tombuildsstuff/kermit/sdk/network/2022-07-01/network"
+)
+
+func resourceFirewallPolicyApplicationRuleCollection() *pluginsdk.Resource {
+	return &pluginsdk.Resource{
+		Create: resourceFirewallPolicyApplicationRuleCollectionCreateUpdate,
+		Read:   resourceFirewallPolicyApplicationRuleCollectionRead,
+		Update: resourceFirewallPolicyApplicationRuleCollectionCreateUpdate,
+		Delete: resourceFirewallPolicyApplicationRuleCollectionDelete,
+
+		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
+			_, err := parse.FirewallPolicyRuleCollectionID(id)
+			return err
+		}),
+
+		Timeouts: &pluginsdk.ResourceTimeout{
+			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
+			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
+			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
+			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
+		},
+
+		Schema: map[string]*pluginsdk.Schema{
+			"name": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.FirewallPolicyRuleCollectionName(),
+			},
+
+			"rule_collection_group_id": {
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validate.FirewallPolicyRuleCollectionGroupID,
+			},
+
+			"priority": {
+				Type:         pluginsdk.TypeInt,
+				Required:     true,
+				ValidateFunc: validation.IntBetween(100, 65000),
+			},
+
+			"action": {
+				Type:     pluginsdk.TypeString,
+				Required: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					string(network.FirewallPolicyFilterRuleCollectionActionTypeAllow),
+					string(network.FirewallPolicyFilterRuleCollectionActionTypeDeny),
+				}, false),
+			},
+
+			"rule": {
+				Type:     pluginsdk.TypeList,
+				Required: true,
+				MinItems: 1,
+				Elem: &pluginsdk.Resource{
+					Schema: map[string]*pluginsdk.Schema{
+						"name": {
+							Type:         pluginsdk.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+						"description": {
+							Type:         pluginsdk.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringIsNotEmpty,
+						},
+						"protocols": {
+							Type:     pluginsdk.TypeList,
+							Optional: true,
+							Elem: &pluginsdk.Resource{
+								Schema: map[string]*pluginsdk.Schema{
+									"type": {
+										Type:     pluginsdk.TypeString,
+										Required: true,
+										ValidateFunc: validation.StringInSlice([]string{
+											string(network.FirewallPolicyRuleApplicationProtocolTypeHTTP),
+											string(network.FirewallPolicyRuleApplicationProtocolTypeHTTPS),
+											"Mssql",
+										}, false),
+									},
+									"port": {
+										Type:         pluginsdk.TypeInt,
+										Required:     true,
+										ValidateFunc: validation.IntBetween(0, 64000),
+									},
+								},
+							},
+						},
+						"source_addresses": {
+							Type:     pluginsdk.TypeList,
+							Optional: true,
+							Elem: &pluginsdk.Schema{
+								Type: pluginsdk.TypeString,
+								ValidateFunc: validation.Any(
+									validation.IsIPAddress,
+									validation.IsCIDR,
+									validation.StringInSlice([]string{`*`}, false),
+								),
+							},
+						},
+						"source_ip_groups": {
+							Type:     pluginsdk.TypeList,
+							Optional: true,
+							Elem: &pluginsdk.Schema{
+								Type:         pluginsdk.TypeString,
+								ValidateFunc: validation.StringIsNotEmpty,
+							},
+						},
+						"destination_addresses": {
+							Type:     pluginsdk.TypeList,
+							Optional: true,
+							Elem: &pluginsdk.Schema{
+								Type: pluginsdk.TypeString,
+								ValidateFunc: validation.Any(
+									validation.IsIPAddress,
+									validation.IsCIDR,
+									validation.StringInSlice([]string{`*`}, false),
+								),
+							},
+						},
+						"destination_fqdns": {
+							Type:     pluginsdk.TypeList,
+							Optional: true,
+							Elem: &pluginsdk.Schema{
+								Type:         pluginsdk.TypeString,
+								ValidateFunc: validation.StringIsNotEmpty,
+							},
+						},
+						"destination_urls": {
+							Type:     pluginsdk.TypeList,
+							Optional: true,
+							Elem: &pluginsdk.Schema{
+								Type:         pluginsdk.TypeString,
+								ValidateFunc: validation.StringIsNotEmpty,
+							},
+						},
+						"destination_fqdn_tags": {
+							Type:     pluginsdk.TypeList,
+							Optional: true,
+							Elem: &pluginsdk.Schema{
+								Type:         pluginsdk.TypeString,
+								ValidateFunc: validation.StringIsNotEmpty,
+							},
+						},
+						"terminate_tls": {
+							Type:     pluginsdk.TypeBool,
+							Optional: true,
+						},
+						"web_categories": {
+							Type:     pluginsdk.TypeList,
+							Optional: true,
+							Elem: &pluginsdk.Schema{
+								Type:         pluginsdk.TypeString,
+								ValidateFunc: validation.StringIsNotEmpty,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceFirewallPolicyApplicationRuleCollectionCreateUpdate(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Firewall.FirewallPolicyRuleGroupClient
+	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	name := d.Get("name").(string)
+	ruleCollectionGroupId, err := parse.FirewallPolicyRuleCollectionGroupID(d.Get("rule_collection_group_id").(string))
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Get(ctx, ruleCollectionGroupId.ResourceGroup, ruleCollectionGroupId.FirewallPolicyName, ruleCollectionGroupId.RuleCollectionGroupName)
+	if err != nil {
+		if !utils.ResponseWasNotFound(resp.Response) {
+			return fmt.Errorf("checking for existing Firewall Policy Rule Collection Group %q (Resource Group %q / Policy %q): %+v", ruleCollectionGroupId.RuleCollectionGroupName, ruleCollectionGroupId.ResourceGroup, ruleCollectionGroupId.FirewallPolicyName, err)
+		}
+	}
+
+	idx := indexFunc(*resp.RuleCollections, func(ruleCollection network.BasicFirewallPolicyRuleCollection) bool {
+		info, _ := ruleCollection.AsFirewallPolicyFilterRuleCollection()
+		return *info.Name == name
+	})
+
+	if d.IsNewResource() && resp.ID != nil && *resp.ID != "" && idx != -1 {
+		return tf.ImportAsExistsError("azurerm_firewall_policy_application_rule_collection", *resp.ID)
+	}
+
+	locks.ByName(ruleCollectionGroupId.FirewallPolicyName, AzureFirewallPolicyResourceName)
+	defer locks.UnlockByName(ruleCollectionGroupId.FirewallPolicyName, AzureFirewallPolicyResourceName)
+
+	rules := expandFirewallPolicyRuleApplication(d.Get("rule").([]interface{}))
+	ruleCollection := &network.FirewallPolicyFilterRuleCollection{
+		Action: &network.FirewallPolicyFilterRuleCollectionAction{
+			Type: network.FirewallPolicyFilterRuleCollectionActionType(d.Get("action").(string)),
+		},
+		Name:               utils.String(d.Get("name").(string)),
+		Priority:           utils.Int32(int32(d.Get("priority").(int))),
+		RuleCollectionType: network.RuleCollectionTypeFirewallPolicyFilterRuleCollection,
+		Rules:              rules,
+	}
+
+	if idx == -1 {
+		ruleCollections := append(*resp.RuleCollections, ruleCollection)
+		resp.RuleCollections = &ruleCollections
+	} else {
+		(*resp.RuleCollections)[idx] = ruleCollection
+	}
+
+	param := network.FirewallPolicyRuleCollectionGroup{
+		FirewallPolicyRuleCollectionGroupProperties: &network.FirewallPolicyRuleCollectionGroupProperties{
+			Priority:        resp.Priority,
+			RuleCollections: resp.RuleCollections,
+		},
+	}
+
+	future, err := client.CreateOrUpdate(ctx, ruleCollectionGroupId.ResourceGroup, ruleCollectionGroupId.FirewallPolicyName, ruleCollectionGroupId.RuleCollectionGroupName, param)
+	if err != nil {
+		return fmt.Errorf("creating Firewall Policy Rule Collection %q (Resource Group %q / Policy: %q / Rule Collection Group: %q): %+v", name, ruleCollectionGroupId.ResourceGroup, ruleCollectionGroupId.FirewallPolicyName, ruleCollectionGroupId.RuleCollectionGroupName, err)
+	}
+	if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
+		return fmt.Errorf("waiting Firewall Policy Rule Collection Group %q (Resource Group %q / Policy: %q / Rule Collection Group: %q): %+v", name, ruleCollectionGroupId.ResourceGroup, ruleCollectionGroupId.FirewallPolicyName, ruleCollectionGroupId.RuleCollectionGroupName, err)
+	}
+
+	resp, err = client.Get(ctx, ruleCollectionGroupId.ResourceGroup, ruleCollectionGroupId.FirewallPolicyName, ruleCollectionGroupId.RuleCollectionGroupName)
+	if err != nil {
+		return fmt.Errorf("retrieving Firewall Policy Rule Collection Group %q (Resource Group %q / Policy: %q: %+v", ruleCollectionGroupId.RuleCollectionGroupName, ruleCollectionGroupId.ResourceGroup, ruleCollectionGroupId.FirewallPolicyName, err)
+	}
+
+	idx = indexFunc(*resp.RuleCollections, func(ruleCollection network.BasicFirewallPolicyRuleCollection) bool {
+		info, _ := ruleCollection.AsFirewallPolicyFilterRuleCollection()
+		return *info.Name == name
+	})
+
+	if resp.ID == nil || *resp.ID == "" || idx == -1 {
+		return fmt.Errorf("empty or nil ID returned for Firewall Policy Rule Collection %q (Resource Group %q / Policy: %q / Rule Collection Group: %q) ID", name, ruleCollectionGroupId.ResourceGroup, ruleCollectionGroupId.FirewallPolicyName, ruleCollectionGroupId.RuleCollectionGroupName)
+	}
+	ruleCollectionGroupId, err = parse.FirewallPolicyRuleCollectionGroupID(*resp.ID)
+	if err != nil {
+		return err
+	}
+	d.SetId(parse.NewFirewallPolicyRuleCollectionID(ruleCollectionGroupId.SubscriptionId, ruleCollectionGroupId.ResourceGroup, ruleCollectionGroupId.FirewallPolicyName, ruleCollectionGroupId.RuleCollectionGroupName, name).ID())
+
+	return resourceFirewallPolicyApplicationRuleCollectionRead(d, meta)
+}
+
+func resourceFirewallPolicyApplicationRuleCollectionRead(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Firewall.FirewallPolicyRuleGroupClient
+	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.FirewallPolicyRuleCollectionID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Get(ctx, id.ResourceGroup, id.FirewallPolicyName, id.RuleCollectionGroupName)
+	if err != nil {
+		if utils.ResponseWasNotFound(resp.Response) {
+			log.Printf("[DEBUG] Firewall Policy Rule Collection Group %q was not found in Resource Group %q - removing from state!", id.RuleCollectionGroupName, id.ResourceGroup)
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("retrieving Firewall Policy Rule Collection Group %q (Resource Group %q / Policy: %q): %+v", id.RuleCollectionGroupName, id.ResourceGroup, id.FirewallPolicyName, err)
+	}
+
+	idx := indexFunc(*resp.RuleCollections, func(policy network.BasicFirewallPolicyRuleCollection) bool {
+		info, _ := policy.AsFirewallPolicyFilterRuleCollection()
+		return *info.Name == id.RuleCollectionName
+	})
+
+	if idx == -1 {
+		log.Printf("[DEBUG] Firewall Policy Rule Collection %q was not found in Firewall Policy Rule Collection Group %q - removing from state!", id.RuleCollectionName, id.RuleCollectionGroupName)
+		d.SetId("")
+		return nil
+	}
+
+	ruleCollection, _ := (*resp.RuleCollections)[idx].AsFirewallPolicyFilterRuleCollection()
+
+	d.Set("name", *ruleCollection.Name)
+	d.Set("action", ruleCollection.Action.Type)
+	d.Set("priority", *ruleCollection.Priority)
+	d.Set("rule_collection_group_id", parse.NewFirewallPolicyRuleCollectionGroupID(id.SubscriptionId, id.ResourceGroup, id.FirewallPolicyName, id.RuleCollectionGroupName).ID())
+
+	rules, err := flattenFirewallPolicyRuleApplication(ruleCollection.Rules)
+	if err != nil {
+		return fmt.Errorf("flattening Firewall Policy Rule Collections: %+v", err)
+	}
+
+	if err := d.Set("rule", rules); err != nil {
+		return fmt.Errorf("setting `rules`: %+v", err)
+	}
+
+	return nil
+}
+
+func resourceFirewallPolicyApplicationRuleCollectionDelete(d *pluginsdk.ResourceData, meta interface{}) error {
+	client := meta.(*clients.Client).Firewall.FirewallPolicyRuleGroupClient
+	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
+	defer cancel()
+
+	id, err := parse.FirewallPolicyRuleCollectionID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	locks.ByName(id.FirewallPolicyName, AzureFirewallPolicyResourceName)
+	defer locks.UnlockByName(id.FirewallPolicyName, AzureFirewallPolicyResourceName)
+
+	resp, err := client.Get(ctx, id.ResourceGroup, id.FirewallPolicyName, id.RuleCollectionGroupName)
+	if err != nil {
+		if !utils.ResponseWasNotFound(resp.Response) {
+			return fmt.Errorf("checking for existing Firewall Policy Rule Collection Group %q (Resource Group %q / Policy %q): %+v", id.RuleCollectionGroupName, id.ResourceGroup, id.FirewallPolicyName, err)
+		}
+	}
+
+	idx := indexFunc(*resp.RuleCollections, func(policy network.BasicFirewallPolicyRuleCollection) bool {
+		info, _ := policy.AsFirewallPolicyFilterRuleCollection()
+		return *info.Name == id.RuleCollectionName
+	})
+
+	if idx == -1 {
+		log.Printf("[DEBUG] Firewall Policy Rule Collection %q was not found in Firewall Policy Rule Collection Group %q - removing from state!", id.RuleCollectionName, id.RuleCollectionGroupName)
+		return nil
+	}
+
+	param := network.FirewallPolicyRuleCollectionGroup{
+		FirewallPolicyRuleCollectionGroupProperties: &network.FirewallPolicyRuleCollectionGroupProperties{
+			Priority: resp.Priority,
+		},
+	}
+	rulesCollections := *resp.RuleCollections
+	rulesCollections = append(rulesCollections[:idx], rulesCollections[idx+1:]...)
+	param.FirewallPolicyRuleCollectionGroupProperties.RuleCollections = &rulesCollections
+
+	future, err := client.CreateOrUpdate(ctx, id.ResourceGroup, id.FirewallPolicyName, id.RuleCollectionGroupName, param)
+	if err != nil {
+		return fmt.Errorf("deleting Firewall Policy Rule Collection %q (Resource Group %q / Policy: %q / Rule Collection Group: %q): %+v", id.RuleCollectionName, id.ResourceGroup, id.FirewallPolicyName, id.RuleCollectionGroupName, err)
+	}
+	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
+		if !response.WasNotFound(future.Response()) {
+			return fmt.Errorf("waiting for deleting %q (Resource Group %q / Policy: %q / Rule Collection Group: %q): %+v", id.RuleCollectionName, id.ResourceGroup, id.FirewallPolicyName, id.RuleCollectionGroupName, err)
+		}
+	}
+
+	return nil
+}
+
+func indexFunc[T any](s []T, f func(T) bool) int {
+	for i := 0; i < len(s); i++ {
+		if f(s[i]) {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/services/firewall/firewall_policy_application_rule_collection_resource_test.go
+++ b/internal/services/firewall/firewall_policy_application_rule_collection_resource_test.go
@@ -1,0 +1,659 @@
+package firewall_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/firewall/parse"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+	"github.com/tombuildsstuff/kermit/sdk/network/2022-07-01/network"
+)
+
+type FirewallPolicyApplicationRuleCollectionResource struct{}
+
+func TestAccFirewallPolicyApplicationRuleCollection_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_firewall_policy_application_rule_collection", "test")
+	r := FirewallPolicyApplicationRuleCollectionResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccFirewallPolicyApplicationRuleCollection_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_firewall_policy_application_rule_collection", "test")
+	r := FirewallPolicyApplicationRuleCollectionResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccFirewallPolicyApplicationRuleCollection_completePremium(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_firewall_policy_application_rule_collection", "test")
+	r := FirewallPolicyApplicationRuleCollectionResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.completePremium(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccFirewallPolicyApplicationRuleCollection_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_firewall_policy_application_rule_collection", "test")
+	r := FirewallPolicyApplicationRuleCollectionResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.update(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccFirewallPolicyApplicationRuleCollection_updatePremium(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_firewall_policy_application_rule_collection", "test")
+	r := FirewallPolicyApplicationRuleCollectionResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.completePremium(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.updatePremium(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.completePremium(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccFirewallPolicyApplicationRuleCollection_requiresImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_firewall_policy_application_rule_collection", "test")
+	r := FirewallPolicyApplicationRuleCollectionResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.RequiresImportErrorStep(r.requiresImport),
+	})
+}
+
+func (FirewallPolicyApplicationRuleCollectionResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := parse.FirewallPolicyRuleCollectionID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := clients.Firewall.FirewallPolicyRuleGroupClient.Get(ctx, id.ResourceGroup, id.FirewallPolicyName, id.RuleCollectionGroupName)
+	if err != nil {
+		return nil, fmt.Errorf("retrieving %s: %v", id.String(), err)
+	}
+
+	idx := indexFunc(*resp.RuleCollections, func(policy network.BasicFirewallPolicyRuleCollection) bool {
+		info, _ := policy.AsFirewallPolicyFilterRuleCollection()
+		return *info.Name == id.RuleCollectionName
+	})
+
+	return utils.Bool(idx != -1), nil
+}
+
+func (FirewallPolicyApplicationRuleCollectionResource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-fwpolicy-RC-%[1]d"
+  location = "%[2]s"
+  lifecycle {
+    ignore_changes = [tags]
+  }
+}
+resource "azurerm_firewall_policy" "test" {
+  name                = "acctest-fwpolicy-RC-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  lifecycle {
+    ignore_changes = [tags]
+  }
+}
+resource "azurerm_firewall_policy_rule_collection_group" "test" {
+  name               = "acctest-fwpolicy-RC-%[1]d"
+  firewall_policy_id = azurerm_firewall_policy.test.id
+  priority           = 500
+}
+resource "azurerm_firewall_policy_application_rule_collection" "test" {
+  name                     = "acctest-fwpolicy-RC-%[1]d"
+  rule_collection_group_id = azurerm_firewall_policy_rule_collection_group.test.id
+  priority                 = 500
+  action = "Allow"
+  rule {
+    name = "app_rule_collection_rule1"
+    protocols {
+      type = "Https"
+      port = 443
+    }
+    source_addresses  = ["10.0.0.1"]
+    destination_fqdns = ["*.microsoft.com"]
+  }
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func (FirewallPolicyApplicationRuleCollectionResource) complete(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-fwpolicy-RC-%[1]d"
+  location = "%[2]s"
+  lifecycle {
+    ignore_changes = [tags]
+  }
+}
+resource "azurerm_firewall_policy" "test" {
+  name                = "acctest-fwpolicy-RC-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  dns {
+    proxy_enabled = true
+  }
+  lifecycle {
+    ignore_changes = [tags]
+  }
+}
+resource "azurerm_ip_group" "test_source" {
+  name                = "acctestIpGroupForFirewallPolicySource"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  cidrs               = ["1.2.3.4/32", "12.34.56.0/24"]
+  lifecycle {
+    ignore_changes = [tags]
+  }
+}
+resource "azurerm_firewall_policy_rule_collection_group" "test" {
+  name               = "acctest-fwpolicy-RC-%[1]d"
+  firewall_policy_id = azurerm_firewall_policy.test.id
+  priority           = 500
+}
+resource "azurerm_firewall_policy_application_rule_collection" "test" {
+  name                     = "acctest-fwpolicy-RC-%[1]d"
+  rule_collection_group_id = azurerm_firewall_policy_rule_collection_group.test.id
+  priority                 = 500
+  action                   = "Deny"
+  rule {
+    name = "app_rule_collection_rule1"
+    protocols {
+      type = "Http"
+      port = 80
+    }
+    protocols {
+      type = "Https"
+      port = 443
+    }
+    source_addresses  = ["10.0.0.1"]
+    destination_fqdns = ["pluginsdk.io"]
+  }
+  rule {
+    name = "app_rule_collection_rule2"
+    protocols {
+      type = "Http"
+      port = 80
+    }
+    protocols {
+      type = "Https"
+      port = 443
+    }
+    source_ip_groups  = [azurerm_ip_group.test_source.id]
+    destination_fqdns = ["pluginsdk.io"]
+  }
+  rule {
+    name = "app_rule_collection_rule3"
+    protocols {
+      type = "Http"
+      port = 80
+    }
+    protocols {
+      type = "Https"
+      port = 443
+    }
+    protocols {
+      type = "Mssql"
+      port = 1443
+    }
+    source_addresses      = ["10.0.0.1"]
+    destination_fqdn_tags = ["WindowsDiagnostics"]
+  }
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func (FirewallPolicyApplicationRuleCollectionResource) update(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-fwpolicy-RC-%[1]d"
+  location = "%[2]s"
+  lifecycle {
+    ignore_changes = [tags]
+  }
+}
+resource "azurerm_firewall_policy" "test" {
+  name                = "acctest-fwpolicy-RC-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  dns {
+    proxy_enabled = true
+  }
+  lifecycle {
+    ignore_changes = [tags]
+  }
+}
+resource "azurerm_ip_group" "test_source" {
+  name                = "acctestIpGroupForFirewallPolicySource"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  cidrs               = ["1.2.3.4/32", "12.34.56.0/24"]
+  lifecycle {
+    ignore_changes = [tags]
+  }
+}
+resource "azurerm_firewall_policy_rule_collection_group" "test" {
+  name               = "acctest-fwpolicy-RC-%[1]d"
+  firewall_policy_id = azurerm_firewall_policy.test.id
+  priority           = 500
+}
+resource "azurerm_firewall_policy_application_rule_collection" "test" {
+  name                     = "acctest-fwpolicy-RC-%[1]d"
+  rule_collection_group_id = azurerm_firewall_policy_rule_collection_group.test.id
+  priority                 = 500
+  action                   = "Deny"
+  rule {
+    name = "app_rule_collection_rule1"
+    protocols {
+      type = "Http"
+      port = 80
+    }
+    protocols {
+      type = "Https"
+      port = 443
+    }
+    source_addresses  = ["10.0.0.1", "10.0.0.2"]
+    destination_fqdns = ["pluginsdk.io"]
+  }
+  rule {
+    name = "app_rule_collection_rule2"
+    protocols {
+      type = "Http"
+      port = 80
+    }
+    source_ip_groups  = [azurerm_ip_group.test_source.id]
+    destination_fqdns = ["pluginsdk.io"]
+  }
+  rule {
+    name = "app_rule_collection_rule3"
+    protocols {
+      type = "Http"
+      port = 80
+    }
+    protocols {
+      type = "Https"
+      port = 443
+    }
+    source_addresses      = ["10.0.0.1", "10.0.0.2"]
+    destination_fqdn_tags = ["WindowsDiagnostics"]
+  }
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func (FirewallPolicyApplicationRuleCollectionResource) completePremium(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-fwpolicy-RC-%[1]d"
+  location = "%[2]s"
+  lifecycle {
+    ignore_changes = [tags]
+  }
+}
+resource "azurerm_firewall_policy" "test" {
+  name                = "acctest-fwpolicy-RC-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  sku                 = "Premium"
+  dns {
+    proxy_enabled = true
+  }
+  lifecycle {
+    ignore_changes = [tags]
+  }
+}
+resource "azurerm_ip_group" "test_source1" {
+  name                = "acctestIpGroupForFirewallPolicySource1"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  cidrs               = ["1.2.3.4/32", "12.34.56.0/24"]
+  lifecycle {
+    ignore_changes = [tags]
+  }
+}
+resource "azurerm_ip_group" "test_source2" {
+  name                = "acctestIpGroupForFirewallPolicySource2"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  cidrs               = ["4.3.2.1/32", "87.65.43.0/24"]
+  lifecycle {
+    ignore_changes = [tags]
+  }
+}
+resource "azurerm_firewall_policy_rule_collection_group" "test" {
+  name               = "acctest-fwpolicy-RC-%[1]d"
+  firewall_policy_id = azurerm_firewall_policy.test.id
+  priority           = 500
+}
+resource "azurerm_firewall_policy_application_rule_collection" "test" {
+  name                     = "acctest-fwpolicy-RC-%[1]d"
+  rule_collection_group_id = azurerm_firewall_policy_rule_collection_group.test.id
+  priority                 = 500
+  action                   = "Deny"
+  rule {
+    name        = "app_rule_collection_rule1"
+    description = "app_rule_collection_rule1"
+    protocols {
+      type = "Http"
+      port = 80
+    }
+    protocols {
+      type = "Https"
+      port = 443
+    }
+    source_addresses      = ["10.0.0.1"]
+    destination_addresses = ["10.0.0.1"]
+    destination_urls      = ["www.google.com/en"]
+    terminate_tls         = true
+    web_categories        = ["News"]
+  }
+  rule {
+    name        = "app_rule_collection_rule2"
+    description = "app_rule_collection_rule2"
+    protocols {
+      type = "Http"
+      port = 80
+    }
+    protocols {
+      type = "Https"
+      port = 443
+    }
+    source_ip_groups      = [azurerm_ip_group.test_source1.id, azurerm_ip_group.test_source2.id]
+    destination_addresses = ["10.0.0.1"]
+    destination_fqdns     = ["pluginsdk.io"]
+    terminate_tls         = true
+    web_categories        = ["News"]
+  }
+  rule {
+    name        = "app_rule_collection_rule3"
+    description = "app_rule_collection_rule3"
+    protocols {
+      type = "Http"
+      port = 80
+    }
+    protocols {
+      type = "Https"
+      port = 443
+    }
+    source_addresses      = ["10.0.0.1"]
+    destination_addresses = ["10.0.0.1"]
+    destination_urls      = ["www.google.com/en"]
+    terminate_tls         = true
+    web_categories        = ["News"]
+  }
+  rule {
+    name        = "app_rule_collection_rule4"
+    description = "app_rule_collection_rule4"
+    protocols {
+      type = "Http"
+      port = 80
+    }
+    protocols {
+      type = "Https"
+      port = 443
+    }
+    source_addresses      = ["10.0.0.1", "10.0.0.2"]
+    destination_addresses = ["10.0.0.1", "10.0.0.2"]
+    destination_urls      = ["www.google.com/en", "www.google.com/cn"]
+    terminate_tls         = true
+    web_categories        = ["News", "Arts"]
+  }
+  rule {
+    name        = "app_rule_collection_rule5"
+    description = "app_rule_collection_rule5"
+    protocols {
+      type = "Http"
+      port = 80
+    }
+    protocols {
+      type = "Https"
+      port = 443
+    }
+    source_ip_groups      = [azurerm_ip_group.test_source1.id, azurerm_ip_group.test_source2.id]
+    destination_addresses = ["10.0.0.1", "10.0.0.2"]
+    destination_fqdns     = ["pluginsdk.io", "pluginframework.io"]
+    terminate_tls         = true
+    web_categories        = ["News", "Arts"]
+  }
+  rule {
+    name        = "app_rule_collection_rule6"
+    description = "app_rule_collection_rule6"
+    protocols {
+      type = "Http"
+      port = 80
+    }
+    protocols {
+      type = "Https"
+      port = 443
+    }
+    source_addresses      = ["10.0.0.1", "10.0.0.2"]
+    destination_addresses = ["10.0.0.1", "10.0.0.2"]
+    destination_urls      = ["www.google.com/en", "www.google.com/cn"]
+    terminate_tls         = true
+    web_categories        = ["News", "Arts"]
+  }
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func (FirewallPolicyApplicationRuleCollectionResource) updatePremium(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-fwpolicy-RC-%[1]d"
+  location = "%[2]s"
+  lifecycle {
+    ignore_changes = [tags]
+  }
+}
+resource "azurerm_firewall_policy" "test" {
+  name                = "acctest-fwpolicy-RC-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  dns {
+    proxy_enabled = true
+  }
+  lifecycle {
+    ignore_changes = [tags]
+  }
+}
+resource "azurerm_ip_group" "test_source1" {
+  name                = "acctestIpGroupForFirewallPolicySource1"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  cidrs               = ["1.2.3.4/32", "12.34.56.0/24"]
+  lifecycle {
+    ignore_changes = [tags]
+  }
+}
+resource "azurerm_ip_group" "test_source2" {
+  name                = "acctestIpGroupForFirewallPolicySource2"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  cidrs               = ["4.3.2.1/32", "87.65.43.0/24"]
+  lifecycle {
+    ignore_changes = [tags]
+  }
+}
+resource "azurerm_firewall_policy_rule_collection_group" "test" {
+  name               = "acctest-fwpolicy-RC-%[1]d"
+  firewall_policy_id = azurerm_firewall_policy.test.id
+  priority           = 500
+}
+resource "azurerm_firewall_policy_application_rule_collection" "test" {
+  name                     = "acctest-fwpolicy-RC-%[1]d"
+  rule_collection_group_id = azurerm_firewall_policy_rule_collection_group.test.id
+  priority                 = 500
+  action                   = "Deny"
+
+  rule {
+    name        = "app_rule_collection_rule1"
+    description = "app_rule_collection_rule1"
+    protocols {
+      type = "Http"
+      port = 80
+    }
+    protocols {
+      type = "Https"
+      port = 443
+    }
+    source_addresses      = ["10.0.0.1"]
+    destination_addresses = ["10.0.0.1"]
+    destination_urls      = ["www.google.com/en"]
+    terminate_tls         = true
+    web_categories        = ["News"]
+  }
+  rule {
+    name        = "app_rule_collection_rule2"
+    description = "app_rule_collection_rule2"
+    protocols {
+      type = "Http"
+      port = 80
+    }
+    source_ip_groups      = [azurerm_ip_group.test_source1.id]
+    destination_addresses = ["10.0.0.1"]
+    destination_fqdns     = ["pluginsdk.io"]
+    terminate_tls         = true
+    web_categories        = ["News"]
+  }
+  rule {
+    name        = "app_rule_collection_rule3"
+    description = "app_rule_collection_rule3"
+    protocols {
+      type = "Http"
+      port = 80
+    }
+    protocols {
+      type = "Https"
+      port = 443
+    }
+    source_addresses      = ["10.0.0.1", "10.0.0.2"]
+    destination_addresses = ["10.0.0.1", "10.0.0.2"]
+    destination_urls      = ["www.google.com/en"]
+    terminate_tls         = true
+    web_categories        = ["News"]
+  }
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func (FirewallPolicyApplicationRuleCollectionResource) requiresImport(data acceptance.TestData) string {
+	template := FirewallPolicyApplicationRuleCollectionResource{}.basic(data)
+	return fmt.Sprintf(`
+%s
+resource "azurerm_firewall_policy_application_rule_collection" "import" {
+  name                     = azurerm_firewall_policy_application_rule_collection.test.name
+  rule_collection_group_id = azurerm_firewall_policy_application_rule_collection.test.rule_collection_group_id
+  priority                 = azurerm_firewall_policy_application_rule_collection.test.priority
+  action                   = azurerm_firewall_policy_application_rule_collection.test.action
+  rule {
+    name = "app_rule_collection_rule1"
+    protocols {
+      type = "Https"
+      port = 443
+    }
+    source_addresses  = ["10.0.0.1"]
+    destination_fqdns = ["*.microsoft.com"]
+  }
+}
+`, template)
+}
+
+func indexFunc[T any](s []T, f func(T) bool) int {
+	for i := 0; i < len(s); i++ {
+		if f(s[i]) {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/services/firewall/firewall_policy_application_rule_collection_resource_test.go
+++ b/internal/services/firewall/firewall_policy_application_rule_collection_resource_test.go
@@ -161,17 +161,11 @@ provider "azurerm" {
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-fwpolicy-RC-%[1]d"
   location = "%[2]s"
-  lifecycle {
-    ignore_changes = [tags]
-  }
 }
 resource "azurerm_firewall_policy" "test" {
   name                = "acctest-fwpolicy-RC-%[1]d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  lifecycle {
-    ignore_changes = [tags]
-  }
 }
 resource "azurerm_firewall_policy_rule_collection_group" "test" {
   name               = "acctest-fwpolicy-RC-%[1]d"
@@ -182,7 +176,7 @@ resource "azurerm_firewall_policy_application_rule_collection" "test" {
   name                     = "acctest-fwpolicy-RC-%[1]d"
   rule_collection_group_id = azurerm_firewall_policy_rule_collection_group.test.id
   priority                 = 500
-  action = "Allow"
+  action                   = "Allow"
   rule {
     name = "app_rule_collection_rule1"
     protocols {
@@ -204,9 +198,6 @@ provider "azurerm" {
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-fwpolicy-RC-%[1]d"
   location = "%[2]s"
-  lifecycle {
-    ignore_changes = [tags]
-  }
 }
 resource "azurerm_firewall_policy" "test" {
   name                = "acctest-fwpolicy-RC-%[1]d"
@@ -215,18 +206,12 @@ resource "azurerm_firewall_policy" "test" {
   dns {
     proxy_enabled = true
   }
-  lifecycle {
-    ignore_changes = [tags]
-  }
 }
 resource "azurerm_ip_group" "test_source" {
   name                = "acctestIpGroupForFirewallPolicySource"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   cidrs               = ["1.2.3.4/32", "12.34.56.0/24"]
-  lifecycle {
-    ignore_changes = [tags]
-  }
 }
 resource "azurerm_firewall_policy_rule_collection_group" "test" {
   name               = "acctest-fwpolicy-RC-%[1]d"
@@ -293,9 +278,6 @@ provider "azurerm" {
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-fwpolicy-RC-%[1]d"
   location = "%[2]s"
-  lifecycle {
-    ignore_changes = [tags]
-  }
 }
 resource "azurerm_firewall_policy" "test" {
   name                = "acctest-fwpolicy-RC-%[1]d"
@@ -304,18 +286,12 @@ resource "azurerm_firewall_policy" "test" {
   dns {
     proxy_enabled = true
   }
-  lifecycle {
-    ignore_changes = [tags]
-  }
 }
 resource "azurerm_ip_group" "test_source" {
   name                = "acctestIpGroupForFirewallPolicySource"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   cidrs               = ["1.2.3.4/32", "12.34.56.0/24"]
-  lifecycle {
-    ignore_changes = [tags]
-  }
 }
 resource "azurerm_firewall_policy_rule_collection_group" "test" {
   name               = "acctest-fwpolicy-RC-%[1]d"
@@ -374,9 +350,6 @@ provider "azurerm" {
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-fwpolicy-RC-%[1]d"
   location = "%[2]s"
-  lifecycle {
-    ignore_changes = [tags]
-  }
 }
 resource "azurerm_firewall_policy" "test" {
   name                = "acctest-fwpolicy-RC-%[1]d"
@@ -386,27 +359,18 @@ resource "azurerm_firewall_policy" "test" {
   dns {
     proxy_enabled = true
   }
-  lifecycle {
-    ignore_changes = [tags]
-  }
 }
 resource "azurerm_ip_group" "test_source1" {
   name                = "acctestIpGroupForFirewallPolicySource1"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   cidrs               = ["1.2.3.4/32", "12.34.56.0/24"]
-  lifecycle {
-    ignore_changes = [tags]
-  }
 }
 resource "azurerm_ip_group" "test_source2" {
   name                = "acctestIpGroupForFirewallPolicySource2"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   cidrs               = ["4.3.2.1/32", "87.65.43.0/24"]
-  lifecycle {
-    ignore_changes = [tags]
-  }
 }
 resource "azurerm_firewall_policy_rule_collection_group" "test" {
   name               = "acctest-fwpolicy-RC-%[1]d"
@@ -532,9 +496,6 @@ provider "azurerm" {
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-fwpolicy-RC-%[1]d"
   location = "%[2]s"
-  lifecycle {
-    ignore_changes = [tags]
-  }
 }
 resource "azurerm_firewall_policy" "test" {
   name                = "acctest-fwpolicy-RC-%[1]d"
@@ -543,27 +504,18 @@ resource "azurerm_firewall_policy" "test" {
   dns {
     proxy_enabled = true
   }
-  lifecycle {
-    ignore_changes = [tags]
-  }
 }
 resource "azurerm_ip_group" "test_source1" {
   name                = "acctestIpGroupForFirewallPolicySource1"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   cidrs               = ["1.2.3.4/32", "12.34.56.0/24"]
-  lifecycle {
-    ignore_changes = [tags]
-  }
 }
 resource "azurerm_ip_group" "test_source2" {
   name                = "acctestIpGroupForFirewallPolicySource2"
   location            = azurerm_resource_group.test.location
   resource_group_name = azurerm_resource_group.test.name
   cidrs               = ["4.3.2.1/32", "87.65.43.0/24"]
-  lifecycle {
-    ignore_changes = [tags]
-  }
 }
 resource "azurerm_firewall_policy_rule_collection_group" "test" {
   name               = "acctest-fwpolicy-RC-%[1]d"

--- a/internal/services/firewall/firewall_policy_rule_collection_group_resource.go
+++ b/internal/services/firewall/firewall_policy_rule_collection_group_resource.go
@@ -65,6 +65,7 @@ func resourceFirewallPolicyRuleCollectionGroup() *pluginsdk.Resource {
 			"application_rule_collection": {
 				Type:     pluginsdk.TypeList,
 				Optional: true,
+				Computed: true,
 				MinItems: 1,
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{

--- a/internal/services/firewall/parse/firewall_policy_rule_collection.go
+++ b/internal/services/firewall/parse/firewall_policy_rule_collection.go
@@ -1,0 +1,83 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+type FirewallPolicyRuleCollectionId struct {
+	SubscriptionId          string
+	ResourceGroup           string
+	FirewallPolicyName      string
+	RuleCollectionGroupName string
+	RuleCollectionName      string
+}
+
+func NewFirewallPolicyRuleCollectionID(subscriptionId, resourceGroup, firewallPolicyName, ruleCollectionGroupName, ruleCollectionName string) FirewallPolicyRuleCollectionId {
+	return FirewallPolicyRuleCollectionId{
+		SubscriptionId:          subscriptionId,
+		ResourceGroup:           resourceGroup,
+		FirewallPolicyName:      firewallPolicyName,
+		RuleCollectionGroupName: ruleCollectionGroupName,
+		RuleCollectionName:      ruleCollectionName,
+	}
+}
+
+func (id FirewallPolicyRuleCollectionId) String() string {
+	segments := []string{
+		fmt.Sprintf("Rule Collection Group %q", id.RuleCollectionName),
+		fmt.Sprintf("Rule Collection Group Name %q", id.RuleCollectionGroupName),
+		fmt.Sprintf("Firewall Policy Name %q", id.FirewallPolicyName),
+		fmt.Sprintf("Resource Group %q", id.ResourceGroup),
+	}
+	segmentsStr := strings.Join(segments, " / ")
+	return fmt.Sprintf("%s: (%s)", "Firewall Policy Rule Collection", segmentsStr)
+}
+
+func (id FirewallPolicyRuleCollectionId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/firewallPolicies/%s/ruleCollectionGroups/%s/ruleCollections/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroup, id.FirewallPolicyName, id.RuleCollectionGroupName, id.RuleCollectionName)
+}
+
+// FirewallPolicyRuleCollectionID parses a FirewallPolicyRuleCollection ID into an FirewallPolicyRuleCollectionId struct
+func FirewallPolicyRuleCollectionID(input string) (*FirewallPolicyRuleCollectionId, error) {
+	id, err := resourceids.ParseAzureResourceID(input)
+	if err != nil {
+		return nil, err
+	}
+
+	resourceId := FirewallPolicyRuleCollectionId{
+		SubscriptionId: id.SubscriptionID,
+		ResourceGroup:  id.ResourceGroup,
+	}
+
+	if resourceId.SubscriptionId == "" {
+		return nil, fmt.Errorf("ID was missing the 'subscriptions' element")
+	}
+
+	if resourceId.ResourceGroup == "" {
+		return nil, fmt.Errorf("ID was missing the 'resourceGroups' element")
+	}
+
+	if resourceId.FirewallPolicyName, err = id.PopSegment("firewallPolicies"); err != nil {
+		return nil, err
+	}
+
+	if resourceId.RuleCollectionGroupName, err = id.PopSegment("ruleCollectionGroups"); err != nil {
+		return nil, err
+	}
+
+	if resourceId.RuleCollectionName, err = id.PopSegment("ruleCollections"); err != nil {
+		return nil, err
+	}
+
+	if err := id.ValidateNoEmptySegments(input); err != nil {
+		return nil, err
+	}
+
+	return &resourceId, nil
+}

--- a/internal/services/firewall/parse/firewall_policy_rule_collection_test.go
+++ b/internal/services/firewall/parse/firewall_policy_rule_collection_test.go
@@ -1,0 +1,144 @@
+package parse
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+var _ resourceids.Id = FirewallPolicyRuleCollectionId{}
+
+func TestFirewallPolicyRuleCollectionIDFormatter(t *testing.T) {
+	actual := NewFirewallPolicyRuleCollectionID("12345678-1234-9876-4563-123456789012", "resGroup1", "policy1", "ruleCollectionGroup1", "ruleCollection1").ID()
+	expected := "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/firewallPolicies/policy1/ruleCollectionGroups/ruleCollectionGroup1/ruleCollections/ruleCollection1"
+	if actual != expected {
+		t.Fatalf("Expected %q but got %q", expected, actual)
+	}
+}
+
+func TestFirewallPolicyRuleCollectionID(t *testing.T) {
+	testData := []struct {
+		Input    string
+		Error    bool
+		Expected *FirewallPolicyRuleCollectionId
+	}{
+
+		{
+			// empty
+			Input: "",
+			Error: true,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Error: true,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Error: true,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Error: true,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Error: true,
+		},
+
+		{
+			// missing FirewallPolicyName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/",
+			Error: true,
+		},
+
+		{
+			// missing value for FirewallPolicyName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/firewallPolicies/",
+			Error: true,
+		},
+
+		{
+			// missing RuleCollectionGroupName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/firewallPolicies/policy1/",
+			Error: true,
+		},
+
+		{
+			// missing value for RuleCollectionGroupName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/firewallPolicies/policy1/ruleCollectionGroups/",
+			Error: true,
+		},
+
+		{
+			// missing RuleCollectionName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/firewallPolicies/policy1/ruleCollectionGroups/ruleCollectionGroup1/",
+			Error: true,
+		},
+
+		{
+			// missing value for RuleCollectionName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/firewallPolicies/policy1/ruleCollectionGroups/ruleCollectionGroup1/ruleCollections/",
+			Error: true,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/firewallPolicies/policy1/ruleCollectionGroups/ruleCollectionGroup1/ruleCollections/ruleCollection1",
+			Expected: &FirewallPolicyRuleCollectionId{
+				SubscriptionId:          "12345678-1234-9876-4563-123456789012",
+				ResourceGroup:           "resGroup1",
+				FirewallPolicyName:      "policy1",
+				RuleCollectionGroupName: "ruleCollectionGroup1",
+				RuleCollectionName:      "ruleCollection1",
+			},
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.NETWORK/FIREWALLPOLICIES/POLICY1/RULECOLLECTIONGROUPS/RULECOLLECTIONGROUP1/RULECOLLECTIONS/RULECOLLECTION1",
+			Error: true,
+		},
+	}
+
+	for _, v := range testData {
+		t.Logf("[DEBUG] Testing %q", v.Input)
+
+		actual, err := FirewallPolicyRuleCollectionID(v.Input)
+		if err != nil {
+			if v.Error {
+				continue
+			}
+
+			t.Fatalf("Expect a value but got an error: %s", err)
+		}
+		if v.Error {
+			t.Fatal("Expect an error but didn't get one")
+		}
+
+		if actual.SubscriptionId != v.Expected.SubscriptionId {
+			t.Fatalf("Expected %q but got %q for SubscriptionId", v.Expected.SubscriptionId, actual.SubscriptionId)
+		}
+		if actual.ResourceGroup != v.Expected.ResourceGroup {
+			t.Fatalf("Expected %q but got %q for ResourceGroup", v.Expected.ResourceGroup, actual.ResourceGroup)
+		}
+		if actual.FirewallPolicyName != v.Expected.FirewallPolicyName {
+			t.Fatalf("Expected %q but got %q for FirewallPolicyName", v.Expected.FirewallPolicyName, actual.FirewallPolicyName)
+		}
+		if actual.RuleCollectionGroupName != v.Expected.RuleCollectionGroupName {
+			t.Fatalf("Expected %q but got %q for RuleCollectionGroupName", v.Expected.RuleCollectionGroupName, actual.RuleCollectionGroupName)
+		}
+		if actual.RuleCollectionName != v.Expected.RuleCollectionName {
+			t.Fatalf("Expected %q but got %q for RuleCollectionName", v.Expected.RuleCollectionName, actual.RuleCollectionName)
+		}
+	}
+}

--- a/internal/services/firewall/registration.go
+++ b/internal/services/firewall/registration.go
@@ -39,11 +39,12 @@ func (r Registration) SupportedDataSources() map[string]*pluginsdk.Resource {
 // SupportedResources returns the supported Resources supported by this Service
 func (r Registration) SupportedResources() map[string]*pluginsdk.Resource {
 	return map[string]*pluginsdk.Resource{
-		"azurerm_firewall_application_rule_collection":  resourceFirewallApplicationRuleCollection(),
-		"azurerm_firewall_policy":                       resourceFirewallPolicy(),
-		"azurerm_firewall_policy_rule_collection_group": resourceFirewallPolicyRuleCollectionGroup(),
-		"azurerm_firewall_nat_rule_collection":          resourceFirewallNatRuleCollection(),
-		"azurerm_firewall_network_rule_collection":      resourceFirewallNetworkRuleCollection(),
-		"azurerm_firewall":                              resourceFirewall(),
+		"azurerm_firewall_application_rule_collection":        resourceFirewallApplicationRuleCollection(),
+		"azurerm_firewall_policy":                             resourceFirewallPolicy(),
+		"azurerm_firewall_policy_rule_collection_group":       resourceFirewallPolicyRuleCollectionGroup(),
+		"azurerm_firewall_policy_application_rule_collection": resourceFirewallPolicyApplicationRuleCollection(),
+		"azurerm_firewall_nat_rule_collection":                resourceFirewallNatRuleCollection(),
+		"azurerm_firewall_network_rule_collection":            resourceFirewallNetworkRuleCollection(),
+		"azurerm_firewall":                                    resourceFirewall(),
 	}
 }

--- a/internal/services/firewall/validate/firewall_policy_rule_collection_id.go
+++ b/internal/services/firewall/validate/firewall_policy_rule_collection_id.go
@@ -1,0 +1,23 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/firewall/parse"
+)
+
+func FirewallPolicyRuleCollectionID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := parse.FirewallPolicyRuleCollectionID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}

--- a/internal/services/firewall/validate/firewall_policy_rule_collection_id_test.go
+++ b/internal/services/firewall/validate/firewall_policy_rule_collection_id_test.go
@@ -1,0 +1,100 @@
+package validate
+
+// NOTE: this file is generated via 'go:generate' - manual changes will be overwritten
+
+import "testing"
+
+func TestFirewallPolicyRuleCollectionID(t *testing.T) {
+	cases := []struct {
+		Input string
+		Valid bool
+	}{
+
+		{
+			// empty
+			Input: "",
+			Valid: false,
+		},
+
+		{
+			// missing SubscriptionId
+			Input: "/",
+			Valid: false,
+		},
+
+		{
+			// missing value for SubscriptionId
+			Input: "/subscriptions/",
+			Valid: false,
+		},
+
+		{
+			// missing ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/",
+			Valid: false,
+		},
+
+		{
+			// missing value for ResourceGroup
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/",
+			Valid: false,
+		},
+
+		{
+			// missing FirewallPolicyName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/",
+			Valid: false,
+		},
+
+		{
+			// missing value for FirewallPolicyName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/firewallPolicies/",
+			Valid: false,
+		},
+
+		{
+			// missing RuleCollectionGroupName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/firewallPolicies/policy1/",
+			Valid: false,
+		},
+
+		{
+			// missing value for RuleCollectionGroupName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/firewallPolicies/policy1/ruleCollectionGroups/",
+			Valid: false,
+		},
+
+		{
+			// missing RuleCollectionName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/firewallPolicies/policy1/ruleCollectionGroups/ruleCollectionGroup1/",
+			Valid: false,
+		},
+
+		{
+			// missing value for RuleCollectionName
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/firewallPolicies/policy1/ruleCollectionGroups/ruleCollectionGroup1/ruleCollections/",
+			Valid: false,
+		},
+
+		{
+			// valid
+			Input: "/subscriptions/12345678-1234-9876-4563-123456789012/resourceGroups/resGroup1/providers/Microsoft.Network/firewallPolicies/policy1/ruleCollectionGroups/ruleCollectionGroup1/ruleCollections/ruleCollection1",
+			Valid: true,
+		},
+
+		{
+			// upper-cased
+			Input: "/SUBSCRIPTIONS/12345678-1234-9876-4563-123456789012/RESOURCEGROUPS/RESGROUP1/PROVIDERS/MICROSOFT.NETWORK/FIREWALLPOLICIES/POLICY1/RULECOLLECTIONGROUPS/RULECOLLECTIONGROUP1/RULECOLLECTIONS/RULECOLLECTION1",
+			Valid: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Logf("[DEBUG] Testing Value %s", tc.Input)
+		_, errors := FirewallPolicyRuleCollectionID(tc.Input, "test")
+		valid := len(errors) == 0
+
+		if tc.Valid != valid {
+			t.Fatalf("Expected %t but got %t", tc.Valid, valid)
+		}
+	}
+}

--- a/internal/services/firewall/validate/firewall_policy_rule_collection_name.go
+++ b/internal/services/firewall/validate/firewall_policy_rule_collection_name.go
@@ -1,0 +1,12 @@
+package validate
+
+import (
+	"regexp"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+func FirewallPolicyRuleCollectionName() func(i interface{}, k string) (warnings []string, errors []error) {
+	return validation.StringMatch(regexp.MustCompile(`^[^\W_][\w-.]*[\w]$`),
+		"The name must begin with a letter or number, end with a letter, number or underscore, and may contain only letters, numbers, underscores, periods, or hyphens.")
+}

--- a/website/docs/r/firewall_policy_application_rule_collection.html.markdown
+++ b/website/docs/r/firewall_policy_application_rule_collection.html.markdown
@@ -1,0 +1,123 @@
+---
+subcategory: "Network"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_firewall_policy_application_rule_collection"
+description: |-
+  Manages a Firewall Policy Application Rule Collection.
+---
+
+# azurerm_firewall_policy_application_rule_collection
+
+Manages a Firewall Policy Application Rule Collection.
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_firewall_policy" "example" {
+  name                = "example-fwpolicy"
+  resource_group_name = azurerm_resource_group.example.name
+  location            = azurerm_resource_group.example.location
+}
+
+resource "azurerm_firewall_policy_rule_collection_group" "example" {
+  name               = "example-fwpolicy-rcg"
+  firewall_policy_id = azurerm_firewall_policy.example.id
+  priority           = 500
+}
+
+resource "azurerm_firewall_policy_application_rule_collection" "example" {
+  name                     = "example-fwpolicy-arc"
+  rule_collection_group_id = azurerm_firewall_policy_rule_collection_group.example.id
+  priority                 = 500
+  action                   = "Deny"
+  rule {
+    name = "example-fwpolicy-arc-rule1"
+    protocols {
+      type = "Http"
+      port = 80
+    }
+    protocols {
+      type = "Https"
+      port = 443
+    }
+    source_addresses  = ["10.0.0.1"]
+    destination_fqdns = ["*.microsoft.com"]
+  }
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name which should be used for this Firewall Policy Application Rule Collection. Changing this forces a new Firewall Policy Application Rule Collection to be created.
+
+* `rule_collection_group_id` - (Required) The ID of the Firewall Policy Rule Collection Group where the Firewall Policy Application Rule Collection should exist. Changing this forces a new Firewall Policy Application Rule Collection to be created.
+
+* `action` - (Required) The action to take for the application rules in this collection. Possible values are `Allow` and `Deny`.
+
+* `priority` - (Required) The priority of the application rule collection. The range is `100` - `65000`.
+
+* `rule` - (Required) One or more `rule` (application rule) blocks as defined below.
+
+---
+
+A `rule` (application rule) block supports the following:
+
+* `name` - (Required) The name which should be used for this rule.
+
+* `description` - (Optional) The description which should be used for this rule.
+
+* `protocols` - (Optional) One or more `protocols` blocks as defined below. Not required when specifying `destination_fqdn_tags`, but required when specifying `destination_fqdns`.
+
+* `source_addresses` - (Optional) Specifies a list of source IP addresses (including CIDR, IP range and `*`).
+
+* `source_ip_groups` - (Optional) Specifies a list of source IP groups.
+
+* `destination_addresses` - (Optional) Specifies a list of destination IP addresses (including CIDR, IP range and `*`).
+
+* `destination_urls` - (Optional) Specifies a list of destination URLs for which policy should hold. Needs Premium SKU for Firewall Policy. Conflicts with `destination_fqdns`.
+
+* `destination_fqdns` - (Optional) Specifies a list of destination FQDNs. Conflicts with `destination_urls`.
+
+* `destination_fqdn_tags` - (Optional) Specifies a list of destination FQDN tags.
+
+* `terminate_tls` - (Optional) Boolean specifying if TLS shall be terminated (true) or not (false). Must be `true` when using `destination_urls`. Needs Premium SKU for Firewall Policy.
+
+* `web_categories` - (Optional) Specifies a list of web categories to which access is denied or allowed depending on the value of `action` above. Needs Premium SKU for Firewall Policy.
+
+---
+
+A `protocols` block supports the following:
+
+* `type` - (Required) Protocol type. Possible values are `Http` and `Https`.
+
+* `port` - (Required) Port number of the protocol. Range is 0-64000.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported:
+
+* `id` - The ID of the Firewall Policy Application Rule Collection.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Firewall Policy Application Rule Collection.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Firewall Policy Application Rule Collection.
+* `update` - (Defaults to 30 minutes) Used when updating the Firewall Policy Application Rule Collection.
+* `delete` - (Defaults to 30 minutes) Used when deleting the Firewall Policy Application Rule Collection.
+
+## Import
+
+Firewall Policy Application Rule Collections can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_firewall_policy_application_rule_collection.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Network/firewallPolicies/policy1/ruleCollectionGroups/gruop1/ruleCollections/collection1
+```


### PR DESCRIPTION
**New resource: `azurerm_firewall_policy_application_rule_collection`**

This resource allows managing an application rule collection without managing the whole rule collection group (#16586).
The implementation of this resource and associated tests follows the implementation of the `azurerm_firewall_policy_rule_collection_group` resource.

This PR is the first PR of a list of three : the other ones will introduce two new other resources `azurerm_firewall_policy_network_rule_collection` and `azurerm_firewall_policy_nat_rule_collection`. I will push those PRs after merging this one because it uses the same parsing/validation functions. 
Those thee PRs are required to close the issue #16586.

Here are the acceptance tests results : 
``` bash
=== RUN   TestAccFirewallPolicyApplicationRuleCollection_basic
=== PAUSE TestAccFirewallPolicyApplicationRuleCollection_basic
=== RUN   TestAccFirewallPolicyApplicationRuleCollection_complete
=== PAUSE TestAccFirewallPolicyApplicationRuleCollection_complete
=== RUN   TestAccFirewallPolicyApplicationRuleCollection_completePremium
=== PAUSE TestAccFirewallPolicyApplicationRuleCollection_completePremium
=== RUN   TestAccFirewallPolicyApplicationRuleCollection_update
=== PAUSE TestAccFirewallPolicyApplicationRuleCollection_update
=== RUN   TestAccFirewallPolicyApplicationRuleCollection_updatePremium
=== PAUSE TestAccFirewallPolicyApplicationRuleCollection_updatePremium
=== RUN   TestAccFirewallPolicyApplicationRuleCollection_requiresImport
=== PAUSE TestAccFirewallPolicyApplicationRuleCollection_requiresImport
=== CONT  TestAccFirewallPolicyApplicationRuleCollection_basic
=== CONT  TestAccFirewallPolicyApplicationRuleCollection_update
=== CONT  TestAccFirewallPolicyApplicationRuleCollection_requiresImport
=== CONT  TestAccFirewallPolicyApplicationRuleCollection_completePremium
=== CONT  TestAccFirewallPolicyApplicationRuleCollection_complete
=== CONT  TestAccFirewallPolicyApplicationRuleCollection_updatePremium
--- PASS: TestAccFirewallPolicyApplicationRuleCollection_basic (86.76s)
--- PASS: TestAccFirewallPolicyApplicationRuleCollection_completePremium (88.53s)
--- PASS: TestAccFirewallPolicyApplicationRuleCollection_complete (92.10s)
--- PASS: TestAccFirewallPolicyApplicationRuleCollection_requiresImport (94.93s)
--- PASS: TestAccFirewallPolicyApplicationRuleCollection_update (132.94s)
--- PASS: TestAccFirewallPolicyApplicationRuleCollection_updatePremium (134.19s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/firewall      135.454s

```