### PR TITLE
`azurerm_monitor_data_collection_rule` - force a new rule to be created when change a previous set `kind`

### DIFF
--- a/internal/services/monitor/monitor_data_collection_rule_resource.go
+++ b/internal/services/monitor/monitor_data_collection_rule_resource.go
@@ -27,6 +27,9 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
+var _ sdk.ResourceWithUpdate = DataCollectionRuleResource{}
+var _ sdk.ResourceWithCustomizeDiff = DataCollectionRuleResource{}
+
 type DataCollectionRule struct {
 	DataCollectionEndpointId string                 `tfschema:"data_collection_endpoint_id"`
 	DataFlows                []DataFlow             `tfschema:"data_flow"`
@@ -2180,4 +2183,18 @@ func flattenDataCollectionRuleStreamDeclarations(input *map[string]datacollectio
 	}
 
 	return result
+}
+
+func (r DataCollectionRuleResource) CustomizeDiff() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			if oldVal, _ := metadata.ResourceDiff.GetChange("kind"); oldVal.(string) != "" {
+				if err := metadata.ResourceDiff.ForceNew("kind"); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	}
 }

--- a/internal/services/monitor/monitor_data_collection_rule_resource.go
+++ b/internal/services/monitor/monitor_data_collection_rule_resource.go
@@ -2189,7 +2189,7 @@ func (r DataCollectionRuleResource) CustomizeDiff() sdk.ResourceFunc {
 	return sdk.ResourceFunc{
 		Timeout: 5 * time.Minute,
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
-			if oldVal, _ := metadata.ResourceDiff.GetChange("kind"); oldVal.(string) != "" {
+			if oldValue, newValue := metadata.ResourceDiff.GetChange("kind"); oldValue.(string) != newValue.(string) && oldValue.(string) != "" {
 				if err := metadata.ResourceDiff.ForceNew("kind"); err != nil {
 					return err
 				}

--- a/internal/services/monitor/monitor_data_collection_rule_resource_test.go
+++ b/internal/services/monitor/monitor_data_collection_rule_resource_test.go
@@ -411,7 +411,6 @@ resource "azurerm_monitor_data_collection_rule" "test" {
     }
   }
 
-  kind        = "Linux"
   description = "acc test monitor_data_collection_rule"
   tags = {
     ENV = "test"

--- a/website/docs/r/monitor_data_collection_rule.html.markdown
+++ b/website/docs/r/monitor_data_collection_rule.html.markdown
@@ -235,7 +235,7 @@ The following arguments are supported:
 
 * `kind` - (Optional) The kind of the Data Collection Rule. Possible values are `Linux`, `Windows`,and `AgentDirectToStore`. A rule of kind `Linux` does not allow for `windows_event_log` data sources. And a rule of kind `Windows` does not allow for `syslog` data sources. If kind is not specified, all kinds of data sources are allowed.
 
-~> **NOTE** Once `kind` has been set, change it forces a new Data Collection Rule to be created.
+~> **NOTE** Once `kind` has been set, changing it forces a new Data Collection Rule to be created.
 
 * `stream_declaration` - (Optional) A `stream_declaration` block as defined below.
 

--- a/website/docs/r/monitor_data_collection_rule.html.markdown
+++ b/website/docs/r/monitor_data_collection_rule.html.markdown
@@ -234,6 +234,8 @@ The following arguments are supported:
 
 * `kind` - (Optional) The kind of the Data Collection Rule. Possible values are `Linux`, `Windows`,and `AgentDirectToStore`. A rule of kind `Linux` does not allow for `windows_event_log` data sources. And a rule of kind `Windows` does not allow for `syslog` data sources. If kind is not specified, all kinds of data sources are allowed.
 
+~> **NOTE** Once `kind` has been set, change it forces a new Data Collection Rule to be created.
+
 * `stream_declaration` - (Optional) A `stream_declaration` block as defined below.
 
 * `tags` - (Optional) A mapping of tags which should be assigned to the Data Collection Rule.

--- a/website/docs/r/monitor_data_collection_rule.html.markdown
+++ b/website/docs/r/monitor_data_collection_rule.html.markdown
@@ -132,6 +132,7 @@ resource "azurerm_monitor_data_collection_rule" "example" {
       facility_names = ["*"]
       log_levels     = ["*"]
       name           = "example-datasource-syslog"
+      streams        = ["Microsoft-Syslog"]
     }
 
     iis_log {


### PR DESCRIPTION
failure:
```hcl
    testcase.go:113: Step 5/8 error: Error running apply: exit status 1
        Error: updating Data Collection Rule (Subscription: "*******"
        Resource Group Name: "acctestRG-DataCollectionRule-230804003052837407"
        Data Collection Rule Name: "acctestmdcr-230804003052837407"): datacollectionrules.DataCollectionRulesClient#Create: Failure responding to request: StatusCode=400 -- Original Error: autorest/azure: Service returned an error. Status=400 Code="InvalidPayload" Message="The new DCR kind `` is different from the previous one `Linux`. The kind is immutable." Details=[{"code":"InvalidPayload","message":"The new DCR kind `` is different from the previous one `Linux`. The kind is immutable."}]
          with azurerm_monitor_data_collection_rule.test,
          on terraform_plugin_test.tf line 99, in resource "azurerm_monitor_data_collection_rule" "test":
          99: resource "azurerm_monitor_data_collection_rule" "test" {
        updating Data Collection Rule (Subscription:
        "*******"
        Resource Group Name: "acctestRG-DataCollectionRule-230804003052837407"
        Data Collection Rule Name: "acctestmdcr-230804003052837407"):
        datacollectionrules.DataCollectionRulesClient#Create: Failure responding to
        request: StatusCode=400 -- Original Error: autorest/azure: Service returned
        an error. Status=400 Code="InvalidPayload" Message="The new DCR kind `` is
        different from the previous one `Linux`. The kind is immutable."
        Details=[{"code":"InvalidPayload","message":"The new DCR kind `` is different
        from the previous one `Linux`. The kind is immutable."}]
```
