### PR TITLE
Fix provider example in documentation

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -47,9 +47,8 @@ terraform {
 
 # Configure the Microsoft Azure Provider
 provider "azurerm" {
-  features {
-    skip_provider_registration = true # This is only required when the User, Service Principal, or Identity running Terraform lacks the permissions to register Azure Resource Providers.
-  }
+  skip_provider_registration = true # This is only required when the User, Service Principal, or Identity running Terraform lacks the permissions to register Azure Resource Providers.
+  features {}
 }
 
 # Create a resource group


### PR DESCRIPTION
The example in the doc shows that the `skip_provider_registration` property needs to be set under `features`. Doing that causes an error when running the terraform script:
```bash
╷
│ Error: Unsupported argument
│ 
│   on main.tf line 24, in provider "azurerm":
│   24:     skip_provider_registration = true
│ 
│ An argument named "skip_provider_registration" is not expected here.
╵
```
Moving it outside of the `features` block fixes the issue.