### PR TITLE
Adding azd as auth Authorizer

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -313,6 +313,15 @@ func azureProvider(supportLegacyTestSuite bool) *schema.Provider {
 				Description: "Allow Azure CLI to be used for Authentication.",
 			},
 
+			// Azure Developer CLI specific fields
+			"use_azd": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				DefaultFunc: schema.EnvDefaultFunc("ARM_USE_AZD", true),
+				Description: "Allow Azure Developer CLI to be used for Authentication.",
+			},
+
 			// Managed Tracking GUID for User-agent
 			"partner_id": {
 				Type:         schema.TypeString,
@@ -417,6 +426,7 @@ func providerConfigure(p *schema.Provider) schema.ConfigureContextFunc {
 
 		var (
 			enableAzureCli        = d.Get("use_cli").(bool)
+			enableAzd             = d.Get("use_azd").(bool)
 			enableManagedIdentity = d.Get("use_msi").(bool)
 			enableOidc            = d.Get("use_oidc").(bool)
 		)
@@ -441,6 +451,7 @@ func providerConfigure(p *schema.Provider) schema.ConfigureContextFunc {
 			EnableAuthenticatingUsingClientCertificate: true,
 			EnableAuthenticatingUsingClientSecret:      true,
 			EnableAuthenticatingUsingAzureCLI:          enableAzureCli,
+			EnableAuthenticatingUsingAzureDeveloperCLI: enableAzd,
 			EnableAuthenticatingUsingManagedIdentity:   enableManagedIdentity,
 			EnableAuthenticationUsingOIDC:              enableOidc,
 			EnableAuthenticationUsingGitHubOIDC:        enableOidc,

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -160,6 +160,46 @@ func TestAccProvider_cliAuth(t *testing.T) {
 	}
 }
 
+func TestAccProvider_azdAuth(t *testing.T) {
+	if os.Getenv("TF_ACC") == "" {
+		t.Skip("TF_ACC not set")
+	}
+
+	logging.SetOutput(t)
+
+	provider := TestAzureProvider()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	// Support only Azure Developer CLI authentication
+	provider.ConfigureContextFunc = func(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
+		envName := d.Get("environment").(string)
+		env, err := environments.FromName(envName)
+		if err != nil {
+			t.Fatalf("configuring environment %q: %v", envName, err)
+		}
+
+		authConfig := &auth.Credentials{
+			Environment:                                *env,
+			EnableAuthenticatingUsingAzureCLI:          false,
+			EnableAuthenticatingUsingAzureDeveloperCLI: true,
+		}
+
+		return buildClient(ctx, provider, d, authConfig)
+	}
+
+	d := provider.Configure(ctx, terraform.NewResourceConfigRaw(nil))
+	if d != nil && d.HasError() {
+		t.Fatalf("err: %+v", d)
+	}
+
+	if errs := testCheckProvider(provider); len(errs) > 0 {
+		for _, err := range errs {
+			t.Error(err)
+		}
+	}
+}
+
 func TestAccProvider_clientCertificateAuth(t *testing.T) {
 	if os.Getenv("TF_ACC") == "" {
 		t.Skip("TF_ACC not set")

--- a/vendor/github.com/hashicorp/go-azure-sdk/sdk/auth/auth.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/sdk/auth/auth.go
@@ -19,6 +19,7 @@ import (
 // - GitHub OIDC authentication
 // - MSI authentication
 // - Azure CLI authentication
+// - Azure Developer CLI (azd) authentication
 //
 // Whether one of these is returned depends on whether it is enabled in the Credentials, and whether sufficient
 // configuration fields are set to enable that authentication method.
@@ -28,7 +29,8 @@ import (
 // For OIDC authentication, specify TenantID, ClientID and OIDCAssertionToken.
 // For GitHub OIDC authentication, specify TenantID, ClientID, GitHubOIDCTokenRequestURL and GitHubOIDCTokenRequestToken.
 // MSI authentication (if enabled) using the Azure Metadata Service is then attempted
-// Azure CLI authentication (if enabled) is attempted last
+// Azure CLI authentication (if enabled) is then attempted
+// Azure Developer CLI authentication (if enabled) is attempted last
 //
 // It's recommended to only enable the mechanisms you have configured and are known to work in the execution
 // environment. If any authentication mechanism fails due to misconfiguration or some other error, the function
@@ -133,6 +135,21 @@ func NewAuthorizerFromCredentials(ctx context.Context, c Credentials, api enviro
 		a, err := NewAzureCliAuthorizer(ctx, opts)
 		if err != nil {
 			return nil, fmt.Errorf("could not configure AzureCli Authorizer: %s", err)
+		}
+		if a != nil {
+			return a, nil
+		}
+	}
+
+	if c.EnableAuthenticatingUsingAzureDeveloperCLI {
+		opts := AzureDeveloperCliAuthorizerOptions{
+			Api:          api,
+			TenantId:     c.TenantID,
+			AuxTenantIds: c.AuxiliaryTenantIDs,
+		}
+		a, err := NewAzureDeveloperCliAuthorizer(ctx, opts)
+		if err != nil {
+			return nil, fmt.Errorf("could not configure AzureDeveloperCli Authorizer: %s", err)
 		}
 		if a != nil {
 			return a, nil

--- a/vendor/github.com/hashicorp/go-azure-sdk/sdk/auth/azure_cli_authorizer.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/sdk/auth/azure_cli_authorizer.go
@@ -39,7 +39,7 @@ func NewAzureCliAuthorizer(ctx context.Context, options AzureCliAuthorizerOption
 	return conf.TokenSource(ctx)
 }
 
-var _ Authorizer = &AzureDeveloperCliAuthorizer{}
+var _ Authorizer = &AzureCliAuthorizer{}
 
 // AzureCliAuthorizer is an Authorizer which supports the Azure CLI.
 type AzureCliAuthorizer struct {
@@ -85,7 +85,7 @@ func (a *AzureCliAuthorizer) Token(_ context.Context, _ *http.Request) (*oauth2.
 	var expiry time.Time
 	if token.ExpiresOn != "" {
 		if expiry, err = time.ParseInLocation("2006-01-02 15:04:05.999999", token.ExpiresOn, time.Local); err != nil {
-			return nil, fmt.Errorf("internal-error: parsing expiresOn value for azd-cli auth token")
+			return nil, fmt.Errorf("internal-error: parsing expiresOn value for az-cli token")
 		}
 	}
 

--- a/vendor/github.com/hashicorp/go-azure-sdk/sdk/auth/azure_cli_authorizer.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/sdk/auth/azure_cli_authorizer.go
@@ -39,7 +39,7 @@ func NewAzureCliAuthorizer(ctx context.Context, options AzureCliAuthorizerOption
 	return conf.TokenSource(ctx)
 }
 
-var _ Authorizer = &AzureCliAuthorizer{}
+var _ Authorizer = &AzureDeveloperCliAuthorizer{}
 
 // AzureCliAuthorizer is an Authorizer which supports the Azure CLI.
 type AzureCliAuthorizer struct {
@@ -85,7 +85,7 @@ func (a *AzureCliAuthorizer) Token(_ context.Context, _ *http.Request) (*oauth2.
 	var expiry time.Time
 	if token.ExpiresOn != "" {
 		if expiry, err = time.ParseInLocation("2006-01-02 15:04:05.999999", token.ExpiresOn, time.Local); err != nil {
-			return nil, fmt.Errorf("internal-error: parsing expiresOn value for az-cli token")
+			return nil, fmt.Errorf("internal-error: parsing expiresOn value for azd-cli auth token")
 		}
 	}
 

--- a/vendor/github.com/hashicorp/go-azure-sdk/sdk/auth/azure_developer_cli_authorizer.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/sdk/auth/azure_developer_cli_authorizer.go
@@ -38,7 +38,7 @@ func NewAzureDeveloperCliAuthorizer(ctx context.Context, options AzureDeveloperC
 	return conf.TokenSource(ctx)
 }
 
-var _ Authorizer = &AzureCliAuthorizer{}
+var _ Authorizer = &AzureDeveloperCliAuthorizer{}
 
 // AzureDeveloperCliAuthorizer is an Authorizer which supports the Azure Developer CLI (azd).
 type AzureDeveloperCliAuthorizer struct {
@@ -76,7 +76,7 @@ func (a *AzureDeveloperCliAuthorizer) Token(_ context.Context, _ *http.Request) 
 	var expiry time.Time
 	if token.ExpiresOn != "" {
 		if expiry, err = time.ParseInLocation("2006-01-02T15:04:05Z", token.ExpiresOn, time.Local); err != nil {
-			return nil, fmt.Errorf("internal-error: parsing expiresOn value for az-cli token")
+			return nil, fmt.Errorf("internal-error: parsing expiresOn value for azd-cli auth token")
 		}
 	}
 

--- a/vendor/github.com/hashicorp/go-azure-sdk/sdk/auth/azure_developer_cli_authorizer.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/sdk/auth/azure_developer_cli_authorizer.go
@@ -1,0 +1,164 @@
+// Copyright (c) HashiCorp Inc. All rights reserved.
+// Licensed under the MPL-2.0 License. See NOTICE.txt in the project root for license information.
+
+package auth
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/environments"
+	"github.com/hashicorp/go-azure-sdk/sdk/internal/azuredevelopercli"
+	"golang.org/x/oauth2"
+)
+
+type AzureDeveloperCliAuthorizerOptions struct {
+	// TenantId is the tenant to authenticate against
+	TenantId string
+
+	// AuxTenantIds lists additional tenants to authenticate against, currently only
+	// used for Resource Manager when auxiliary tenants are needed.
+	// e.g. https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/authenticate-multi-tenant
+	AuxTenantIds []string
+
+	// Api describes the Azure API being used
+	Api environments.Api
+}
+
+// NewAzureDeveloperCliAuthorizer returns an Authorizer which authenticates using the Azure Developer CLI.
+func NewAzureDeveloperCliAuthorizer(ctx context.Context, options AzureDeveloperCliAuthorizerOptions) (Authorizer, error) {
+	conf, err := newAzureDeveloperCliConfig(options.Api, options.TenantId, options.AuxTenantIds)
+	if err != nil {
+		return nil, err
+	}
+	return conf.TokenSource(ctx)
+}
+
+var _ Authorizer = &AzureCliAuthorizer{}
+
+// AzureDeveloperCliAuthorizer is an Authorizer which supports the Azure Developer CLI (azd).
+type AzureDeveloperCliAuthorizer struct {
+	// TenantID is the specified tenant ID, or the auto-detected tenant ID if none was specified
+	TenantID string
+
+	conf *azureDeveloperCliConfig
+}
+
+// Token returns an access token using the Azure Developer CLI as an authentication mechanism.
+func (a *AzureDeveloperCliAuthorizer) Token(_ context.Context, _ *http.Request) (*oauth2.Token, error) {
+	if a.conf == nil {
+		return nil, fmt.Errorf("could not request token: conf is nil")
+	}
+
+	azArgs := []string{"auth", "token"}
+
+	scope, err := environments.Scope(a.conf.Api)
+	if err != nil {
+		return nil, fmt.Errorf("determining scope for %q: %+v", a.conf.Api.Name(), err)
+	}
+	azArgs = append(azArgs, "--scope", *scope)
+
+	// Try to detect if we're running in Cloud Shell
+	if cloudShell := os.Getenv("AZUREPS_HOST_ENVIRONMENT"); !strings.HasPrefix(cloudShell, "cloud-shell/") {
+		// Seemingly not, so we'll append the tenant ID to the az args
+		azArgs = append(azArgs, "--tenant-id", a.conf.TenantID)
+	}
+
+	var token azureDeveloperCliToken
+	if err := azuredevelopercli.JSONUnmarshalAzdCmd(&token, azArgs...); err != nil {
+		return nil, err
+	}
+
+	var expiry time.Time
+	if token.ExpiresOn != "" {
+		if expiry, err = time.ParseInLocation("2006-01-02T15:04:05Z", token.ExpiresOn, time.Local); err != nil {
+			return nil, fmt.Errorf("internal-error: parsing expiresOn value for az-cli token")
+		}
+	}
+
+	return &oauth2.Token{
+		AccessToken: token.AccessToken,
+		Expiry:      expiry,
+		TokenType:   "Bearer",
+	}, nil
+}
+
+// AuxiliaryTokens returns additional tokens for auxiliary tenant IDs, for use in multi-tenant scenarios
+func (a *AzureDeveloperCliAuthorizer) AuxiliaryTokens(_ context.Context, _ *http.Request) ([]*oauth2.Token, error) {
+	if a.conf == nil {
+		return nil, fmt.Errorf("could not request token: conf is nil")
+	}
+
+	// Return early if no auxiliary tenants are configured
+	if len(a.conf.AuxiliaryTenantIDs) == 0 {
+		return []*oauth2.Token{}, nil
+	}
+
+	// Try to detect if we're running in Cloud Shell
+	if cloudShell := os.Getenv("AZUREPS_HOST_ENVIRONMENT"); strings.HasPrefix(cloudShell, "cloud-shell/") {
+		return nil, fmt.Errorf("auxiliary tokens not supported in Cloud Shell")
+	}
+
+	azArgs := []string{"auth", "token"}
+
+	scope, err := environments.Scope(a.conf.Api)
+	if err != nil {
+		return nil, fmt.Errorf("determining scope for %q: %+v", a.conf.Api.Name(), err)
+	}
+	azArgs = append(azArgs, "--scope", *scope)
+
+	tokens := make([]*oauth2.Token, 0)
+	for _, tenantId := range a.conf.AuxiliaryTenantIDs {
+		argsWithTenant := append(azArgs, "--tenant-id", tenantId)
+
+		var token azureDeveloperCliToken
+		if err := azuredevelopercli.JSONUnmarshalAzdCmd(&token, argsWithTenant...); err != nil {
+			return nil, err
+		}
+
+		tokens = append(tokens, &oauth2.Token{
+			AccessToken: token.AccessToken,
+			TokenType:   "Bearer",
+		})
+	}
+
+	return tokens, nil
+}
+
+// azureDeveloperCliConfig configures an AzureDeveloperCliAuthorizer.
+type azureDeveloperCliConfig struct {
+	Api environments.Api
+
+	// TenantID is the required tenant ID for the primary token
+	TenantID string
+
+	// AuxiliaryTenantIDs is an optional list of tenant IDs for which to obtain additional tokens
+	AuxiliaryTenantIDs []string
+}
+
+// newAzureDeveloperCliConfig returns a new azureDeveloperCliConfig.
+func newAzureDeveloperCliConfig(api environments.Api, tenantId string, auxiliaryTenantIds []string) (*azureDeveloperCliConfig, error) {
+	return &azureDeveloperCliConfig{
+		Api:                api,
+		TenantID:           tenantId,
+		AuxiliaryTenantIDs: auxiliaryTenantIds,
+	}, nil
+}
+
+// TokenSource provides a source for obtaining access tokens using AzureDeveloperCliAuthorizer.
+func (c *azureDeveloperCliConfig) TokenSource(ctx context.Context) (Authorizer, error) {
+	// Cache access tokens internally to avoid unnecessary `azd` invocations
+	return NewCachedAuthorizer(&AzureDeveloperCliAuthorizer{
+		TenantID: c.TenantID,
+		conf:     c,
+	})
+}
+
+type azureDeveloperCliToken struct {
+	AccessToken string `json:"token"`
+	ExpiresOn   string `json:"expiresOn"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/sdk/auth/config.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/sdk/auth/config.go
@@ -22,6 +22,9 @@ type Credentials struct {
 	// EnableAuthenticatingUsingAzureCLI specifies whether Azure CLI authentication should be checked.
 	EnableAuthenticatingUsingAzureCLI bool
 
+	// EnableAuthenticatingUsingAzureDeveloperCLI specifies whether Azure Developer CLI authentication should be checked.
+	EnableAuthenticatingUsingAzureDeveloperCLI bool
+
 	// EnableAuthenticatingUsingClientCertificate specifies whether Client Certificate authentication should be checked.
 	EnableAuthenticatingUsingClientCertificate bool
 	// ClientCertificateData specifies the contents of a Client Certificate PKCS#12 bundle.

--- a/vendor/github.com/hashicorp/go-azure-sdk/sdk/internal/azuredevelopercli/azd.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/sdk/internal/azuredevelopercli/azd.go
@@ -1,0 +1,45 @@
+// Copyright (c) HashiCorp Inc. All rights reserved.
+// Licensed under the MPL-2.0 License. See NOTICE.txt in the project root for license information.
+
+package azuredevelopercli
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// JSONUnmarshalAzdCmd executes an Azure Developer CLI command and unmarshalls the JSON output.
+func JSONUnmarshalAzdCmd(i interface{}, arg ...string) error {
+	var stderr bytes.Buffer
+	var stdout bytes.Buffer
+
+	arg = append(arg, "-o=json")
+	cmd := exec.Command("azd", arg...)
+	cmd.Stderr = &stderr
+	cmd.Stdout = &stdout
+
+	if err := cmd.Start(); err != nil {
+		err := fmt.Errorf("launching Azure Developer CLI: %+v", err)
+		if stdErrStr := stderr.String(); stdErrStr != "" {
+			err = fmt.Errorf("%s: %s", err, strings.TrimSpace(stdErrStr))
+		}
+		return err
+	}
+
+	if err := cmd.Wait(); err != nil {
+		err := fmt.Errorf("running Azure Developer CLI: %+v", err)
+		if stdErrStr := stderr.String(); stdErrStr != "" {
+			err = fmt.Errorf("%s: %s", err, strings.TrimSpace(stdErrStr))
+		}
+		return err
+	}
+
+	if err := json.Unmarshal(stdout.Bytes(), &i); err != nil {
+		return fmt.Errorf("unmarshaling the output of Azure Developer CLI: %v", err)
+	}
+
+	return nil
+}

--- a/website/docs/guides/azure_cli.html.markdown
+++ b/website/docs/guides/azure_cli.html.markdown
@@ -15,6 +15,7 @@ Terraform supports a number of different methods for authenticating to Azure:
 * [Authenticating to Azure using a Service Principal and a Client Certificate](service_principal_client_certificate.html)
 * [Authenticating to Azure using a Service Principal and a Client Secret](service_principal_client_secret.html)
 * [Authenticating to Azure using a Service Principal and Open ID Connect](service_principal_oidc.html)
+* [Authenticating to Azure using the Azure Developer CLI (azd)](azure_developer_cli.html)
 
 ---
 

--- a/website/docs/guides/azure_developer_cli.html.markdown
+++ b/website/docs/guides/azure_developer_cli.html.markdown
@@ -1,0 +1,63 @@
+---
+layout: "azurerm"
+page_title: "Azure Provider: Authenticating via the Azure Developer CLI (azd)"
+description: |-
+  This guide will cover how to use the Azure Developer CLI as authentication for the Azure Provider.
+
+---
+
+# Azure Provider: Authenticating using the Azure Developer CLI (azd)
+
+Terraform supports a number of different methods for authenticating to Azure:
+
+* Authenticating to Azure using the Azure Developer CLI (which is covered in this guide)
+* [Authenticating to Azure using the Azure CLI](azure_cli.html)
+* [Authenticating to Azure using Managed Service Identity](managed_service_identity.html)
+* [Authenticating to Azure using a Service Principal and a Client Certificate](service_principal_client_certificate.html)
+* [Authenticating to Azure using a Service Principal and a Client Secret](service_principal_client_secret.html)
+* [Authenticating to Azure using a Service Principal and Open ID Connect](service_principal_oidc.html)
+
+---
+
+Use the [Azure Developer CLI](https://learn.microsoft.com/azure/developer/azure-developer-cli/overview) to extend the `azd` authentication for terraform. This is convenience for terraform templates.
+
+---
+
+## Logging into the Azure Developer CLI
+
+Login to the Azure CLI using:
+
+```shell
+azd auth login
+```
+---
+
+## Configuring Azure Developer CLI authentication in Terraform
+
+Now that we're logged into the Azure Developer CLI - we can configure Terraform to use these credentials.
+
+```hcl
+# We strongly recommend using the required_providers block to set the
+# Azure Provider source and version being used
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "=3.0.0"
+    }
+  }
+}
+
+# Configure the Microsoft Azure Provider
+provider "azurerm" {
+  features {}
+}
+```
+
+More information on [the fields supported in the Provider block can be found here](../index.html#argument-reference).
+
+At this point running either `terraform plan` or `terraform apply` should allow Terraform to run using the Azure Developer CLI to authenticate.
+
+---
+
+The Azure Developer CLI uses the selected Azure subscription during `azd provision` or `azd up`. 

--- a/website/docs/guides/managed_service_identity.html.markdown
+++ b/website/docs/guides/managed_service_identity.html.markdown
@@ -14,6 +14,7 @@ Terraform supports a number of different methods for authenticating to Azure:
 - [Authenticating to Azure using a Service Principal and a Client Certificate](service_principal_client_certificate.html)
 - [Authenticating to Azure using a Service Principal and a Client Secret](service_principal_client_secret.html)
 - [Authenticating to Azure using OpenID Connect](service_principal_oidc.html)
+- [Authenticating to Azure using the Azure Developer CLI (azd)](azure_developer_cli.html)
 
 ---
 

--- a/website/docs/guides/service_principal_client_certificate.html.markdown
+++ b/website/docs/guides/service_principal_client_certificate.html.markdown
@@ -15,6 +15,7 @@ Terraform supports a number of different methods for authenticating to Azure:
 * Authenticating to Azure using a Service Principal and a Client Certificate (which is covered in this guide)
 * [Authenticating to Azure using a Service Principal and a Client Secret](service_principal_client_secret.html)
 * [Authenticating to Azure using a Service Principal and OpenID Connect](service_principal_oidc.html)
+* [Authenticating to Azure using the Azure Developer CLI (azd)](azure_developer_cli.html)
 
 ---
 

--- a/website/docs/guides/service_principal_client_secret.html.markdown
+++ b/website/docs/guides/service_principal_client_secret.html.markdown
@@ -15,6 +15,7 @@ Terraform supports a number of different methods for authenticating to Azure:
 * [Authenticating to Azure using a Service Principal and a Client Certificate](service_principal_client_certificate.html)
 * Authenticating to Azure using a Service Principal and a Client Secret (which is covered in this guide)
 * [Authenticating to Azure using a Service Principal and OpenID Connect](service_principal_oidc.html)
+* [Authenticating to Azure using the Azure Developer CLI (azd)](azure_developer_cli.html)
 
 ---
 

--- a/website/docs/guides/service_principal_oidc.html.markdown
+++ b/website/docs/guides/service_principal_oidc.html.markdown
@@ -14,6 +14,7 @@ Terraform supports a number of different methods for authenticating to Azure:
 * [Authenticating to Azure using a Service Principal and a Client Certificate](service_principal_client_certificate.html)
 * [Authenticating to Azure using a Service Principal and a Client Secret](service_principal_client_secret.html)
 * Authenticating to Azure using a Service Principal and OpenID Connect (which is covered in this guide)
+* [Authenticating to Azure using the Azure Developer CLI (azd)](azure_developer_cli.html)
 
 ---
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -24,6 +24,7 @@ Terraform supports a number of different methods for authenticating to Azure:
 * [Authenticating to Azure using a Service Principal and a Client Certificate](guides/service_principal_client_certificate.html)
 * [Authenticating to Azure using a Service Principal and a Client Secret](guides/service_principal_client_secret.html)
 * [Authenticating to Azure using OpenID Connect](guides/service_principal_oidc.html)
+* [Authenticating to Azure using the Azure Developer CLI (azd)](guides/azure_developer_cli.html)
 
 ---
 


### PR DESCRIPTION
Adding `azd` as auth Authorizer.

This allows folks using azd-terraform templates to use `azd` as authentication source. 

fix: https://github.com/Azure/azure-dev/issues/1530