### PR TITLE
`azurerm_storage_account` - `azure_file_authentication.0.active_directory` supports setting `domain_name` and `domain_guid` when `directory_type` is `AADKERB`

### DIFF
--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -205,24 +205,28 @@ func resourceStorageAccount() *pluginsdk.Resource {
 									"storage_sid": {
 										Type:         pluginsdk.TypeString,
 										Optional:     true,
+										Computed:     true,
 										ValidateFunc: validation.StringIsNotEmpty,
 									},
 
 									"domain_sid": {
 										Type:         pluginsdk.TypeString,
 										Optional:     true,
+										Computed:     true,
 										ValidateFunc: validation.StringIsNotEmpty,
 									},
 
 									"forest_name": {
 										Type:         pluginsdk.TypeString,
 										Optional:     true,
+										Computed:     true,
 										ValidateFunc: validation.StringIsNotEmpty,
 									},
 
 									"netbios_domain_name": {
 										Type:         pluginsdk.TypeString,
 										Optional:     true,
+										Computed:     true,
 										ValidateFunc: validation.StringIsNotEmpty,
 									},
 								},

--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -2483,7 +2483,7 @@ func expandArmStorageAccountAzureFilesAuthentication(input []interface{}) (*stor
 			return nil, fmt.Errorf("`active_directory.0.netbios_domain_name` is required when `directory_type` is `AD`")
 		}
 	case string(storageaccounts.DirectoryServiceOptionsAADKERB):
-		if _, ok := v["azure_active_directory_kerb"]; ok {
+		if _, ok := v["active_directory"]; ok {
 			ad = expandArmStorageAccountActiveDirectoryProperties(v["active_directory"].([]interface{}))
 		}
 	}

--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -2461,15 +2461,14 @@ func expandArmStorageAccountAzureFilesAuthentication(input []interface{}) (*stor
 
 	v := input[0].(map[string]interface{})
 
+	ad := expandArmStorageAccountActiveDirectoryProperties(v["active_directory"].([]interface{}))
+
 	directoryOption := storage.DirectoryServiceOptions(v["directory_type"].(string))
 
-	var ad *storage.ActiveDirectoryProperties
-	switch string(directoryOption) {
-	case string(storage.DirectoryServiceOptionsAD):
-		if _, ok := v["active_directory"]; !ok {
+	if directoryOption == storage.DirectoryServiceOptionsAD {
+		if ad == nil {
 			return nil, fmt.Errorf("`active_directory` is required when `directory_type` is `AD`")
 		}
-		ad = expandArmStorageAccountActiveDirectoryProperties(v["active_directory"].([]interface{}))
 		if ad.AzureStorageSid == nil {
 			return nil, fmt.Errorf("`active_directory.0.storage_sid` is required when `directory_type` is `AD`")
 		}
@@ -2482,11 +2481,8 @@ func expandArmStorageAccountAzureFilesAuthentication(input []interface{}) (*stor
 		if ad.NetBiosDomainName == nil {
 			return nil, fmt.Errorf("`active_directory.0.netbios_domain_name` is required when `directory_type` is `AD`")
 		}
-	case string(storageaccounts.DirectoryServiceOptionsAADKERB):
-		if _, ok := v["active_directory"]; ok {
-			ad = expandArmStorageAccountActiveDirectoryProperties(v["active_directory"].([]interface{}))
-		}
 	}
+
 	return &storage.AzureFilesIdentityBasedAuthentication{
 		DirectoryServiceOptions:   directoryOption,
 		ActiveDirectoryProperties: ad,

--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -205,28 +205,24 @@ func resourceStorageAccount() *pluginsdk.Resource {
 									"storage_sid": {
 										Type:         pluginsdk.TypeString,
 										Optional:     true,
-										Computed:     true,
 										ValidateFunc: validation.StringIsNotEmpty,
 									},
 
 									"domain_sid": {
 										Type:         pluginsdk.TypeString,
 										Optional:     true,
-										Computed:     true,
 										ValidateFunc: validation.StringIsNotEmpty,
 									},
 
 									"forest_name": {
 										Type:         pluginsdk.TypeString,
 										Optional:     true,
-										Computed:     true,
 										ValidateFunc: validation.StringIsNotEmpty,
 									},
 
 									"netbios_domain_name": {
 										Type:         pluginsdk.TypeString,
 										Optional:     true,
-										Computed:     true,
 										ValidateFunc: validation.StringIsNotEmpty,
 									},
 								},

--- a/internal/services/storage/storage_account_resource_test.go
+++ b/internal/services/storage/storage_account_resource_test.go
@@ -915,7 +915,12 @@ func TestAccAzureRMStorageAccount_azureFilesAuthentication(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
-		data.ImportStep(),
+		data.ImportStep(
+			"azure_files_authentication.0.active_directory.0.storage_sid",
+			"azure_files_authentication.0.active_directory.0.domain_sid",
+			"azure_files_authentication.0.active_directory.0.forest_name",
+			"azure_files_authentication.0.active_directory.0.netbios_domain_name",
+		),
 		{
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
@@ -3322,6 +3327,15 @@ resource "azurerm_storage_account" "test" {
 
   tags = {
     environment = "production"
+  }
+
+  lifecycle {
+	ignore_changes = [
+		azure_files_authentication.0.active_directory.0.storage_sid,
+		azure_files_authentication.0.active_directory.0.domain_sid,
+		azure_files_authentication.0.active_directory.0.forest_name,
+		azure_files_authentication.0.active_directory.0.netbios_domain_name,
+	]
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)

--- a/internal/services/storage/storage_account_resource_test.go
+++ b/internal/services/storage/storage_account_resource_test.go
@@ -3285,10 +3285,6 @@ resource "azurerm_storage_account" "test" {
 
   azure_files_authentication {
     directory_type = "AADKERB"
-    active_directory {
-      domain_name         = "adtest2.com"
-      domain_guid         = "13a20c9a-d491-47e6-8a39-299e7a32ea27"
-    }
   }
 
   tags = {
@@ -3318,6 +3314,10 @@ resource "azurerm_storage_account" "test" {
 
   azure_files_authentication {
     directory_type = "AADKERB"
+    active_directory {
+      domain_name         = "adtest2.com"
+      domain_guid         = "13a20c9a-d491-47e6-8a39-299e7a32ea27"
+    }
   }
 
   tags = {

--- a/internal/services/storage/storage_account_resource_test.go
+++ b/internal/services/storage/storage_account_resource_test.go
@@ -3315,8 +3315,8 @@ resource "azurerm_storage_account" "test" {
   azure_files_authentication {
     directory_type = "AADKERB"
     active_directory {
-      domain_name         = "adtest2.com"
-      domain_guid         = "13a20c9a-d491-47e6-8a39-299e7a32ea27"
+      domain_name = "adtest2.com"
+      domain_guid = "13a20c9a-d491-47e6-8a39-299e7a32ea27"
     }
   }
 

--- a/internal/services/storage/storage_account_resource_test.go
+++ b/internal/services/storage/storage_account_resource_test.go
@@ -3287,7 +3287,7 @@ resource "azurerm_storage_account" "test" {
     directory_type = "AADKERB"
     active_directory {
       domain_name         = "adtest2.com"
-      domain_sid          = "S-1-5-21-2400535526-2334094090-2402026252-1112"
+      domain_guid         = "13a20c9a-d491-47e6-8a39-299e7a32ea27"
     }
   }
 

--- a/internal/services/storage/storage_account_resource_test.go
+++ b/internal/services/storage/storage_account_resource_test.go
@@ -3330,12 +3330,12 @@ resource "azurerm_storage_account" "test" {
   }
 
   lifecycle {
-	ignore_changes = [
-		azure_files_authentication.0.active_directory.0.storage_sid,
-		azure_files_authentication.0.active_directory.0.domain_sid,
-		azure_files_authentication.0.active_directory.0.forest_name,
-		azure_files_authentication.0.active_directory.0.netbios_domain_name,
-	]
+    ignore_changes = [
+      azure_files_authentication.0.active_directory.0.storage_sid,
+      azure_files_authentication.0.active_directory.0.domain_sid,
+      azure_files_authentication.0.active_directory.0.forest_name,
+      azure_files_authentication.0.active_directory.0.netbios_domain_name,
+    ]
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)

--- a/internal/services/storage/storage_account_resource_test.go
+++ b/internal/services/storage/storage_account_resource_test.go
@@ -910,6 +910,13 @@ func TestAccAzureRMStorageAccount_azureFilesAuthentication(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
+			Config: r.azureFilesAuthenticationAADKERBUpdate(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
@@ -3259,6 +3266,39 @@ resource "azurerm_storage_account" "test" {
 }
 
 func (r StorageAccountResource) azureFilesAuthenticationAADKERB(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-storage-%d"
+  location = "%s"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                     = "unlikely23exst2acct%s"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+
+  azure_files_authentication {
+    directory_type = "AADKERB"
+    active_directory {
+      domain_name         = "adtest2.com"
+      domain_sid          = "S-1-5-21-2400535526-2334094090-2402026252-1112"
+    }
+  }
+
+  tags = {
+    environment = "production"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}
+
+func (r StorageAccountResource) azureFilesAuthenticationAADKERBUpdate(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}

--- a/website/docs/r/storage_account.html.markdown
+++ b/website/docs/r/storage_account.html.markdown
@@ -344,23 +344,21 @@ A `azure_files_authentication` block supports the following:
 
 * `active_directory` - (Optional) A `active_directory` block as defined below. Required when `directory_type` is `AD`.
 
-~> **Note:** If `directory_type` is set to `AADKERB`, `active_directory` is not supported. Use [icals](https://learn.microsoft.com/en-us/azure/storage/files/storage-files-identity-auth-azure-active-directory-enable?tabs=azure-portal#configure-directory-and-file-level-permissions) to configure directory and file level permissions.
-
 ---
 
 A `active_directory` block supports the following:
 
-* `storage_sid` - (Required) Specifies the security identifier (SID) for Azure Storage.
-
 * `domain_name` - (Required) Specifies the primary domain that the AD DNS server is authoritative for.
-
-* `domain_sid` - (Required) Specifies the security identifier (SID).
 
 * `domain_guid` - (Required) Specifies the domain GUID.
 
-* `forest_name` - (Required) Specifies the Active Directory forest.
+* `domain_sid` - (Optional) Specifies the security identifier (SID). This is required when `directory_type` is set to `AD`.
 
-* `netbios_domain_name` - (Required) Specifies the NetBIOS domain name.
+* `storage_sid` - (Optional) Specifies the security identifier (SID) for Azure Storage. This is required when `directory_type` is set to `AD`.
+
+* `forest_name` - (Optional) Specifies the Active Directory forest. This is required when `directory_type` is set to `AD`.
+
+* `netbios_domain_name` - (Optional) Specifies the NetBIOS domain name. This is required when `directory_type` is set to `AD`.
 
 ---
 


### PR DESCRIPTION
This PR changes downgrades the following properties in `azure_file_authentication.0.active_directory` block from `Required` to `Optional` + (the unfortunate) `Computed`:

- domain_sid
- storage_sid
- forest_name
- netbios_domain_name

These 4 properties are not needed to be set in the `active_directory` when the `directory_type` is set to `AADKERB` 

The reason to add the `Computed` for them is to align with the current user experience of the whole `active_directory` block (which was set to be `O+C` for now). Since when setting to `AADKERB` with omitting the `domain_name` and `domain_guid`, the whole block is returned back. Otherwise, users might be confused to be asked to explicitly ignore changes for those four properties once they set the `domain_name` and `domain_guid`.

Fix #22784

## Test

![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/7970698/ab5909f9-28ff-4c9c-8f66-1471f5be2e47)
