### PR TITLE
dependencies: updating to `v0.20230807.1063129` of `github.com/hashicorp/go-azure-sdk`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-azure-helpers v0.58.0
-	github.com/hashicorp/go-azure-sdk v0.20230804.1110546
+	github.com/hashicorp/go-azure-sdk v0.20230807.1063129
 	github.com/hashicorp/go-hclog v1.4.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -121,8 +121,8 @@ github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brv
 github.com/hashicorp/go-azure-helpers v0.12.0/go.mod h1:Zc3v4DNeX6PDdy7NljlYpnrdac1++qNW0I4U+ofGwpg=
 github.com/hashicorp/go-azure-helpers v0.58.0 h1:P7KMqfBMr872m0PAyyn92IrCoEShOvkMwBVv2fMT4Ms=
 github.com/hashicorp/go-azure-helpers v0.58.0/go.mod h1:BQUQp5udwbJ8pnzl0wByCLVEEyPMAFpJ9vOREiCzObo=
-github.com/hashicorp/go-azure-sdk v0.20230804.1110546 h1:yx4wGSFQdp9mWfFWZVOv9W83VhZa/HzzxKYIuiSNz74=
-github.com/hashicorp/go-azure-sdk v0.20230804.1110546/go.mod h1:iZrpp7qJSZxocEkr4SjslzxpDrhuRLmedyVGGcCPbhk=
+github.com/hashicorp/go-azure-sdk v0.20230807.1063129 h1:WIRtDYuXSw1bnyoSd4GxKsoRZql/RVI6CG50JaykG6o=
+github.com/hashicorp/go-azure-sdk v0.20230807.1063129/go.mod h1:3GK3YHV1vwn/jHHeUyAPWkUyYy91PEzXg0dziKlSMaA=
 github.com/hashicorp/go-checkpoint v0.5.0 h1:MFYpPZCnQqQTE18jFwSII6eUQrD/oxMFp3mlgcqk5mU=
 github.com/hashicorp/go-checkpoint v0.5.0/go.mod h1:7nfLNL10NsxqO4iWuW6tWW0HjZuDrwkBuEQsVcpCOgg=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/alertsmanagement/2021-08-08/alertprocessingrules/model_action.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/alertsmanagement/2021-08-08/alertprocessingrules/model_action.go
@@ -12,6 +12,15 @@ import (
 type Action interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawActionImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalActionImplementation(input []byte) (Action, error) {
 	if input == nil {
 		return nil, nil
@@ -43,10 +52,6 @@ func unmarshalActionImplementation(input []byte) (Action, error) {
 		return out, nil
 	}
 
-	type RawActionImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawActionImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/alertsmanagement/2021-08-08/alertprocessingrules/model_recurrence.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/alertsmanagement/2021-08-08/alertprocessingrules/model_recurrence.go
@@ -12,6 +12,15 @@ import (
 type Recurrence interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawRecurrenceImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalRecurrenceImplementation(input []byte) (Recurrence, error) {
 	if input == nil {
 		return nil, nil
@@ -51,10 +60,6 @@ func unmarshalRecurrenceImplementation(input []byte) (Recurrence, error) {
 		return out, nil
 	}
 
-	type RawRecurrenceImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawRecurrenceImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2019-06-01-preview/registries/model_runrequest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2019-06-01-preview/registries/model_runrequest.go
@@ -12,6 +12,15 @@ import (
 type RunRequest interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawRunRequestImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalRunRequestImplementation(input []byte) (RunRequest, error) {
 	if input == nil {
 		return nil, nil
@@ -59,10 +68,6 @@ func unmarshalRunRequestImplementation(input []byte) (RunRequest, error) {
 		return out, nil
 	}
 
-	type RawRunRequestImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawRunRequestImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2019-06-01-preview/taskruns/model_runrequest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2019-06-01-preview/taskruns/model_runrequest.go
@@ -12,6 +12,15 @@ import (
 type RunRequest interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawRunRequestImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalRunRequestImplementation(input []byte) (RunRequest, error) {
 	if input == nil {
 		return nil, nil
@@ -59,10 +68,6 @@ func unmarshalRunRequestImplementation(input []byte) (RunRequest, error) {
 		return out, nil
 	}
 
-	type RawRunRequestImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawRunRequestImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2019-06-01-preview/tasks/model_taskstepproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2019-06-01-preview/tasks/model_taskstepproperties.go
@@ -12,6 +12,15 @@ import (
 type TaskStepProperties interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawTaskStepPropertiesImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalTaskStepPropertiesImplementation(input []byte) (TaskStepProperties, error) {
 	if input == nil {
 		return nil, nil
@@ -51,10 +60,6 @@ func unmarshalTaskStepPropertiesImplementation(input []byte) (TaskStepProperties
 		return out, nil
 	}
 
-	type RawTaskStepPropertiesImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawTaskStepPropertiesImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2019-06-01-preview/tasks/model_taskstepupdateparameters.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2019-06-01-preview/tasks/model_taskstepupdateparameters.go
@@ -12,6 +12,15 @@ import (
 type TaskStepUpdateParameters interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawTaskStepUpdateParametersImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalTaskStepUpdateParametersImplementation(input []byte) (TaskStepUpdateParameters, error) {
 	if input == nil {
 		return nil, nil
@@ -51,10 +60,6 @@ func unmarshalTaskStepUpdateParametersImplementation(input []byte) (TaskStepUpda
 		return out, nil
 	}
 
-	type RawTaskStepUpdateParametersImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawTaskStepUpdateParametersImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-05-15/cosmosdb/model_backuppolicy.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-05-15/cosmosdb/model_backuppolicy.go
@@ -12,6 +12,15 @@ import (
 type BackupPolicy interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawBackupPolicyImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalBackupPolicyImplementation(input []byte) (BackupPolicy, error) {
 	if input == nil {
 		return nil, nil
@@ -43,10 +52,6 @@ func unmarshalBackupPolicyImplementation(input []byte) (BackupPolicy, error) {
 		return out, nil
 	}
 
-	type RawBackupPolicyImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawBackupPolicyImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-05-15/sqldedicatedgateway/model_serviceresourceproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2022-05-15/sqldedicatedgateway/model_serviceresourceproperties.go
@@ -12,6 +12,15 @@ import (
 type ServiceResourceProperties interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawServiceResourcePropertiesImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalServiceResourcePropertiesImplementation(input []byte) (ServiceResourceProperties, error) {
 	if input == nil {
 		return nil, nil
@@ -59,10 +68,6 @@ func unmarshalServiceResourcePropertiesImplementation(input []byte) (ServiceReso
 		return out, nil
 	}
 
-	type RawServiceResourcePropertiesImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawServiceResourcePropertiesImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2023-04-15/cosmosdb/model_backuppolicy.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/cosmosdb/2023-04-15/cosmosdb/model_backuppolicy.go
@@ -12,6 +12,15 @@ import (
 type BackupPolicy interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawBackupPolicyImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalBackupPolicyImplementation(input []byte) (BackupPolicy, error) {
 	if input == nil {
 		return nil, nil
@@ -43,10 +52,6 @@ func unmarshalBackupPolicyImplementation(input []byte) (BackupPolicy, error) {
 		return out, nil
 	}
 
-	type RawBackupPolicyImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawBackupPolicyImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datafactory/2018-06-01/factories/model_factoryrepoconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datafactory/2018-06-01/factories/model_factoryrepoconfiguration.go
@@ -12,6 +12,15 @@ import (
 type FactoryRepoConfiguration interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawFactoryRepoConfigurationImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalFactoryRepoConfigurationImplementation(input []byte) (FactoryRepoConfiguration, error) {
 	if input == nil {
 		return nil, nil
@@ -43,10 +52,6 @@ func unmarshalFactoryRepoConfigurationImplementation(input []byte) (FactoryRepoC
 		return out, nil
 	}
 
-	type RawFactoryRepoConfigurationImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawFactoryRepoConfigurationImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dataprotection/2022-04-01/backupinstances/model_authcredentials.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dataprotection/2022-04-01/backupinstances/model_authcredentials.go
@@ -12,6 +12,15 @@ import (
 type AuthCredentials interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawAuthCredentialsImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalAuthCredentialsImplementation(input []byte) (AuthCredentials, error) {
 	if input == nil {
 		return nil, nil
@@ -35,10 +44,6 @@ func unmarshalAuthCredentialsImplementation(input []byte) (AuthCredentials, erro
 		return out, nil
 	}
 
-	type RawAuthCredentialsImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawAuthCredentialsImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dataprotection/2022-04-01/backupinstances/model_azurebackuprestorerequest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dataprotection/2022-04-01/backupinstances/model_azurebackuprestorerequest.go
@@ -12,6 +12,15 @@ import (
 type AzureBackupRestoreRequest interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawAzureBackupRestoreRequestImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalAzureBackupRestoreRequestImplementation(input []byte) (AzureBackupRestoreRequest, error) {
 	if input == nil {
 		return nil, nil
@@ -51,10 +60,6 @@ func unmarshalAzureBackupRestoreRequestImplementation(input []byte) (AzureBackup
 		return out, nil
 	}
 
-	type RawAzureBackupRestoreRequestImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawAzureBackupRestoreRequestImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dataprotection/2022-04-01/backupinstances/model_datastoreparameters.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dataprotection/2022-04-01/backupinstances/model_datastoreparameters.go
@@ -12,6 +12,15 @@ import (
 type DataStoreParameters interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawDataStoreParametersImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalDataStoreParametersImplementation(input []byte) (DataStoreParameters, error) {
 	if input == nil {
 		return nil, nil
@@ -35,10 +44,6 @@ func unmarshalDataStoreParametersImplementation(input []byte) (DataStoreParamete
 		return out, nil
 	}
 
-	type RawDataStoreParametersImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawDataStoreParametersImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dataprotection/2022-04-01/backupinstances/model_itemlevelrestorecriteria.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dataprotection/2022-04-01/backupinstances/model_itemlevelrestorecriteria.go
@@ -12,6 +12,15 @@ import (
 type ItemLevelRestoreCriteria interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawItemLevelRestoreCriteriaImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalItemLevelRestoreCriteriaImplementation(input []byte) (ItemLevelRestoreCriteria, error) {
 	if input == nil {
 		return nil, nil
@@ -51,10 +60,6 @@ func unmarshalItemLevelRestoreCriteriaImplementation(input []byte) (ItemLevelRes
 		return out, nil
 	}
 
-	type RawItemLevelRestoreCriteriaImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawItemLevelRestoreCriteriaImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dataprotection/2022-04-01/backupinstances/model_operationextendedinfo.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dataprotection/2022-04-01/backupinstances/model_operationextendedinfo.go
@@ -12,6 +12,15 @@ import (
 type OperationExtendedInfo interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawOperationExtendedInfoImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalOperationExtendedInfoImplementation(input []byte) (OperationExtendedInfo, error) {
 	if input == nil {
 		return nil, nil
@@ -35,10 +44,6 @@ func unmarshalOperationExtendedInfoImplementation(input []byte) (OperationExtend
 		return out, nil
 	}
 
-	type RawOperationExtendedInfoImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawOperationExtendedInfoImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dataprotection/2022-04-01/backupinstances/model_restoretargetinfobase.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dataprotection/2022-04-01/backupinstances/model_restoretargetinfobase.go
@@ -12,6 +12,15 @@ import (
 type RestoreTargetInfoBase interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawRestoreTargetInfoBaseImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalRestoreTargetInfoBaseImplementation(input []byte) (RestoreTargetInfoBase, error) {
 	if input == nil {
 		return nil, nil
@@ -51,10 +60,6 @@ func unmarshalRestoreTargetInfoBaseImplementation(input []byte) (RestoreTargetIn
 		return out, nil
 	}
 
-	type RawRestoreTargetInfoBaseImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawRestoreTargetInfoBaseImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dataprotection/2022-04-01/backuppolicies/model_backupcriteria.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dataprotection/2022-04-01/backuppolicies/model_backupcriteria.go
@@ -12,6 +12,15 @@ import (
 type BackupCriteria interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawBackupCriteriaImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalBackupCriteriaImplementation(input []byte) (BackupCriteria, error) {
 	if input == nil {
 		return nil, nil
@@ -35,10 +44,6 @@ func unmarshalBackupCriteriaImplementation(input []byte) (BackupCriteria, error)
 		return out, nil
 	}
 
-	type RawBackupCriteriaImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawBackupCriteriaImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dataprotection/2022-04-01/backuppolicies/model_backupparameters.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dataprotection/2022-04-01/backuppolicies/model_backupparameters.go
@@ -12,6 +12,15 @@ import (
 type BackupParameters interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawBackupParametersImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalBackupParametersImplementation(input []byte) (BackupParameters, error) {
 	if input == nil {
 		return nil, nil
@@ -35,10 +44,6 @@ func unmarshalBackupParametersImplementation(input []byte) (BackupParameters, er
 		return out, nil
 	}
 
-	type RawBackupParametersImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawBackupParametersImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dataprotection/2022-04-01/backuppolicies/model_basebackuppolicy.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dataprotection/2022-04-01/backuppolicies/model_basebackuppolicy.go
@@ -12,6 +12,15 @@ import (
 type BaseBackupPolicy interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawBaseBackupPolicyImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalBaseBackupPolicyImplementation(input []byte) (BaseBackupPolicy, error) {
 	if input == nil {
 		return nil, nil
@@ -35,10 +44,6 @@ func unmarshalBaseBackupPolicyImplementation(input []byte) (BaseBackupPolicy, er
 		return out, nil
 	}
 
-	type RawBaseBackupPolicyImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawBaseBackupPolicyImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dataprotection/2022-04-01/backuppolicies/model_basepolicyrule.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dataprotection/2022-04-01/backuppolicies/model_basepolicyrule.go
@@ -12,6 +12,15 @@ import (
 type BasePolicyRule interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawBasePolicyRuleImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalBasePolicyRuleImplementation(input []byte) (BasePolicyRule, error) {
 	if input == nil {
 		return nil, nil
@@ -43,10 +52,6 @@ func unmarshalBasePolicyRuleImplementation(input []byte) (BasePolicyRule, error)
 		return out, nil
 	}
 
-	type RawBasePolicyRuleImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawBasePolicyRuleImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dataprotection/2022-04-01/backuppolicies/model_copyoption.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dataprotection/2022-04-01/backuppolicies/model_copyoption.go
@@ -12,6 +12,15 @@ import (
 type CopyOption interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawCopyOptionImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalCopyOptionImplementation(input []byte) (CopyOption, error) {
 	if input == nil {
 		return nil, nil
@@ -51,10 +60,6 @@ func unmarshalCopyOptionImplementation(input []byte) (CopyOption, error) {
 		return out, nil
 	}
 
-	type RawCopyOptionImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawCopyOptionImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dataprotection/2022-04-01/backuppolicies/model_deleteoption.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dataprotection/2022-04-01/backuppolicies/model_deleteoption.go
@@ -12,6 +12,15 @@ import (
 type DeleteOption interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawDeleteOptionImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalDeleteOptionImplementation(input []byte) (DeleteOption, error) {
 	if input == nil {
 		return nil, nil
@@ -35,10 +44,6 @@ func unmarshalDeleteOptionImplementation(input []byte) (DeleteOption, error) {
 		return out, nil
 	}
 
-	type RawDeleteOptionImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawDeleteOptionImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dataprotection/2022-04-01/backuppolicies/model_triggercontext.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/dataprotection/2022-04-01/backuppolicies/model_triggercontext.go
@@ -12,6 +12,15 @@ import (
 type TriggerContext interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawTriggerContextImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalTriggerContextImplementation(input []byte) (TriggerContext, error) {
 	if input == nil {
 		return nil, nil
@@ -43,10 +52,6 @@ func unmarshalTriggerContextImplementation(input []byte) (TriggerContext, error)
 		return out, nil
 	}
 
-	type RawTriggerContextImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawTriggerContextImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datashare/2019-11-01/dataset/model_dataset.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datashare/2019-11-01/dataset/model_dataset.go
@@ -12,6 +12,15 @@ import (
 type DataSet interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawDataSetImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalDataSetImplementation(input []byte) (DataSet, error) {
 	if input == nil {
 		return nil, nil
@@ -123,10 +132,6 @@ func unmarshalDataSetImplementation(input []byte) (DataSet, error) {
 		return out, nil
 	}
 
-	type RawDataSetImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawDataSetImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datashare/2019-11-01/synchronizationsetting/model_synchronizationsetting.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/datashare/2019-11-01/synchronizationsetting/model_synchronizationsetting.go
@@ -12,6 +12,15 @@ import (
 type SynchronizationSetting interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawSynchronizationSettingImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalSynchronizationSettingImplementation(input []byte) (SynchronizationSetting, error) {
 	if input == nil {
 		return nil, nil
@@ -35,10 +44,6 @@ func unmarshalSynchronizationSettingImplementation(input []byte) (Synchronizatio
 		return out, nil
 	}
 
-	type RawSynchronizationSettingImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawSynchronizationSettingImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/digitaltwins/2023-01-31/endpoints/model_digitaltwinsendpointresourceproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/digitaltwins/2023-01-31/endpoints/model_digitaltwinsendpointresourceproperties.go
@@ -12,6 +12,15 @@ import (
 type DigitalTwinsEndpointResourceProperties interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawDigitalTwinsEndpointResourcePropertiesImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalDigitalTwinsEndpointResourcePropertiesImplementation(input []byte) (DigitalTwinsEndpointResourceProperties, error) {
 	if input == nil {
 		return nil, nil
@@ -51,10 +60,6 @@ func unmarshalDigitalTwinsEndpointResourcePropertiesImplementation(input []byte)
 		return out, nil
 	}
 
-	type RawDigitalTwinsEndpointResourcePropertiesImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawDigitalTwinsEndpointResourcePropertiesImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/digitaltwins/2023-01-31/timeseriesdatabaseconnections/model_timeseriesdatabaseconnectionproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/digitaltwins/2023-01-31/timeseriesdatabaseconnections/model_timeseriesdatabaseconnectionproperties.go
@@ -12,6 +12,15 @@ import (
 type TimeSeriesDatabaseConnectionProperties interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawTimeSeriesDatabaseConnectionPropertiesImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalTimeSeriesDatabaseConnectionPropertiesImplementation(input []byte) (TimeSeriesDatabaseConnectionProperties, error) {
 	if input == nil {
 		return nil, nil
@@ -35,10 +44,6 @@ func unmarshalTimeSeriesDatabaseConnectionPropertiesImplementation(input []byte)
 		return out, nil
 	}
 
-	type RawTimeSeriesDatabaseConnectionPropertiesImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawTimeSeriesDatabaseConnectionPropertiesImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2022-06-15/domains/model_inputschemamapping.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2022-06-15/domains/model_inputschemamapping.go
@@ -12,6 +12,15 @@ import (
 type InputSchemaMapping interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawInputSchemaMappingImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalInputSchemaMappingImplementation(input []byte) (InputSchemaMapping, error) {
 	if input == nil {
 		return nil, nil
@@ -35,10 +44,6 @@ func unmarshalInputSchemaMappingImplementation(input []byte) (InputSchemaMapping
 		return out, nil
 	}
 
-	type RawInputSchemaMappingImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawInputSchemaMappingImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2022-06-15/eventsubscriptions/model_advancedfilter.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2022-06-15/eventsubscriptions/model_advancedfilter.go
@@ -12,6 +12,15 @@ import (
 type AdvancedFilter interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawAdvancedFilterImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalAdvancedFilterImplementation(input []byte) (AdvancedFilter, error) {
 	if input == nil {
 		return nil, nil
@@ -179,10 +188,6 @@ func unmarshalAdvancedFilterImplementation(input []byte) (AdvancedFilter, error)
 		return out, nil
 	}
 
-	type RawAdvancedFilterImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawAdvancedFilterImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2022-06-15/eventsubscriptions/model_deadletterdestination.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2022-06-15/eventsubscriptions/model_deadletterdestination.go
@@ -12,6 +12,15 @@ import (
 type DeadLetterDestination interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawDeadLetterDestinationImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalDeadLetterDestinationImplementation(input []byte) (DeadLetterDestination, error) {
 	if input == nil {
 		return nil, nil
@@ -35,10 +44,6 @@ func unmarshalDeadLetterDestinationImplementation(input []byte) (DeadLetterDesti
 		return out, nil
 	}
 
-	type RawDeadLetterDestinationImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawDeadLetterDestinationImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2022-06-15/eventsubscriptions/model_deliveryattributemapping.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2022-06-15/eventsubscriptions/model_deliveryattributemapping.go
@@ -12,6 +12,15 @@ import (
 type DeliveryAttributeMapping interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawDeliveryAttributeMappingImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalDeliveryAttributeMappingImplementation(input []byte) (DeliveryAttributeMapping, error) {
 	if input == nil {
 		return nil, nil
@@ -43,10 +52,6 @@ func unmarshalDeliveryAttributeMappingImplementation(input []byte) (DeliveryAttr
 		return out, nil
 	}
 
-	type RawDeliveryAttributeMappingImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawDeliveryAttributeMappingImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2022-06-15/eventsubscriptions/model_eventsubscriptiondestination.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2022-06-15/eventsubscriptions/model_eventsubscriptiondestination.go
@@ -12,6 +12,15 @@ import (
 type EventSubscriptionDestination interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawEventSubscriptionDestinationImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalEventSubscriptionDestinationImplementation(input []byte) (EventSubscriptionDestination, error) {
 	if input == nil {
 		return nil, nil
@@ -83,10 +92,6 @@ func unmarshalEventSubscriptionDestinationImplementation(input []byte) (EventSub
 		return out, nil
 	}
 
-	type RawEventSubscriptionDestinationImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawEventSubscriptionDestinationImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2022-06-15/topics/model_inputschemamapping.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/eventgrid/2022-06-15/topics/model_inputschemamapping.go
@@ -12,6 +12,15 @@ import (
 type InputSchemaMapping interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawInputSchemaMappingImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalInputSchemaMappingImplementation(input []byte) (InputSchemaMapping, error) {
 	if input == nil {
 		return nil, nil
@@ -35,10 +44,6 @@ func unmarshalInputSchemaMappingImplementation(input []byte) (InputSchemaMapping
 		return out, nil
 	}
 
-	type RawInputSchemaMappingImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawInputSchemaMappingImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2020-05-01/frontdoors/model_routeconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/frontdoor/2020-05-01/frontdoors/model_routeconfiguration.go
@@ -12,6 +12,15 @@ import (
 type RouteConfiguration interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawRouteConfigurationImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalRouteConfigurationImplementation(input []byte) (RouteConfiguration, error) {
 	if input == nil {
 		return nil, nil
@@ -43,10 +52,6 @@ func unmarshalRouteConfigurationImplementation(input []byte) (RouteConfiguration
 		return out, nil
 	}
 
-	type RawRouteConfigurationImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawRouteConfigurationImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2018-03-01/metricalerts/model_metricalertcriteria.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2018-03-01/metricalerts/model_metricalertcriteria.go
@@ -12,6 +12,15 @@ import (
 type MetricAlertCriteria interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawMetricAlertCriteriaImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalMetricAlertCriteriaImplementation(input []byte) (MetricAlertCriteria, error) {
 	if input == nil {
 		return nil, nil
@@ -51,10 +60,6 @@ func unmarshalMetricAlertCriteriaImplementation(input []byte) (MetricAlertCriter
 		return out, nil
 	}
 
-	type RawMetricAlertCriteriaImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawMetricAlertCriteriaImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2018-03-01/metricalerts/model_multimetriccriteria.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2018-03-01/metricalerts/model_multimetriccriteria.go
@@ -12,6 +12,15 @@ import (
 type MultiMetricCriteria interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawMultiMetricCriteriaImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalMultiMetricCriteriaImplementation(input []byte) (MultiMetricCriteria, error) {
 	if input == nil {
 		return nil, nil
@@ -43,10 +52,6 @@ func unmarshalMultiMetricCriteriaImplementation(input []byte) (MultiMetricCriter
 		return out, nil
 	}
 
-	type RawMultiMetricCriteriaImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawMultiMetricCriteriaImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2018-04-16/scheduledqueryrules/model_action.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/insights/2018-04-16/scheduledqueryrules/model_action.go
@@ -12,6 +12,15 @@ import (
 type Action interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawActionImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalActionImplementation(input []byte) (Action, error) {
 	if input == nil {
 		return nil, nil
@@ -43,10 +52,6 @@ func unmarshalActionImplementation(input []byte) (Action, error) {
 		return out, nil
 	}
 
-	type RawActionImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawActionImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2023-05-02/databases/model_database.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2023-05-02/databases/model_database.go
@@ -12,6 +12,15 @@ import (
 type Database interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawDatabaseImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalDatabaseImplementation(input []byte) (Database, error) {
 	if input == nil {
 		return nil, nil
@@ -43,10 +52,6 @@ func unmarshalDatabaseImplementation(input []byte) (Database, error) {
 		return out, nil
 	}
 
-	type RawDatabaseImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawDatabaseImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2023-05-02/dataconnections/model_dataconnection.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/kusto/2023-05-02/dataconnections/model_dataconnection.go
@@ -12,6 +12,15 @@ import (
 type DataConnection interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawDataConnectionImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalDataConnectionImplementation(input []byte) (DataConnection, error) {
 	if input == nil {
 		return nil, nil
@@ -59,10 +68,6 @@ func unmarshalDataConnectionImplementation(input []byte) (DataConnection, error)
 		return out, nil
 	}
 
-	type RawDataConnectionImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawDataConnectionImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/datastore/model_datastore.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/datastore/model_datastore.go
@@ -12,6 +12,15 @@ import (
 type Datastore interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawDatastoreImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalDatastoreImplementation(input []byte) (Datastore, error) {
 	if input == nil {
 		return nil, nil
@@ -59,10 +68,6 @@ func unmarshalDatastoreImplementation(input []byte) (Datastore, error) {
 		return out, nil
 	}
 
-	type RawDatastoreImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawDatastoreImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/datastore/model_datastorecredentials.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/datastore/model_datastorecredentials.go
@@ -12,6 +12,15 @@ import (
 type DatastoreCredentials interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawDatastoreCredentialsImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalDatastoreCredentialsImplementation(input []byte) (DatastoreCredentials, error) {
 	if input == nil {
 		return nil, nil
@@ -67,10 +76,6 @@ func unmarshalDatastoreCredentialsImplementation(input []byte) (DatastoreCredent
 		return out, nil
 	}
 
-	type RawDatastoreCredentialsImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawDatastoreCredentialsImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/datastore/model_datastoresecrets.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/datastore/model_datastoresecrets.go
@@ -12,6 +12,15 @@ import (
 type DatastoreSecrets interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawDatastoreSecretsImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalDatastoreSecretsImplementation(input []byte) (DatastoreSecrets, error) {
 	if input == nil {
 		return nil, nil
@@ -59,10 +68,6 @@ func unmarshalDatastoreSecretsImplementation(input []byte) (DatastoreSecrets, er
 		return out, nil
 	}
 
-	type RawDatastoreSecretsImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawDatastoreSecretsImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/machinelearningcomputes/model_compute.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/machinelearningcomputes/model_compute.go
@@ -12,6 +12,15 @@ import (
 type Compute interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawComputeImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalComputeImplementation(input []byte) (Compute, error) {
 	if input == nil {
 		return nil, nil
@@ -107,10 +116,6 @@ func unmarshalComputeImplementation(input []byte) (Compute, error) {
 		return out, nil
 	}
 
-	type RawComputeImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawComputeImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/machinelearningcomputes/model_computesecrets.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/machinelearningcomputes/model_computesecrets.go
@@ -12,6 +12,15 @@ import (
 type ComputeSecrets interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawComputeSecretsImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalComputeSecretsImplementation(input []byte) (ComputeSecrets, error) {
 	if input == nil {
 		return nil, nil
@@ -51,10 +60,6 @@ func unmarshalComputeSecretsImplementation(input []byte) (ComputeSecrets, error)
 		return out, nil
 	}
 
-	type RawComputeSecretsImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawComputeSecretsImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mariadb/2018-06-01/servers/model_serverpropertiesforcreate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mariadb/2018-06-01/servers/model_serverpropertiesforcreate.go
@@ -12,6 +12,15 @@ import (
 type ServerPropertiesForCreate interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawServerPropertiesForCreateImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalServerPropertiesForCreateImplementation(input []byte) (ServerPropertiesForCreate, error) {
 	if input == nil {
 		return nil, nil
@@ -59,10 +68,6 @@ func unmarshalServerPropertiesForCreateImplementation(input []byte) (ServerPrope
 		return out, nil
 	}
 
-	type RawServerPropertiesForCreateImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawServerPropertiesForCreateImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/assetsandassetfilters/model_trackbase.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/assetsandassetfilters/model_trackbase.go
@@ -12,6 +12,15 @@ import (
 type TrackBase interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawTrackBaseImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalTrackBaseImplementation(input []byte) (TrackBase, error) {
 	if input == nil {
 		return nil, nil
@@ -51,10 +60,6 @@ func unmarshalTrackBaseImplementation(input []byte) (TrackBase, error) {
 		return out, nil
 	}
 
-	type RawTrackBaseImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawTrackBaseImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/contentkeypolicies/model_contentkeypolicyconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/contentkeypolicies/model_contentkeypolicyconfiguration.go
@@ -12,6 +12,15 @@ import (
 type ContentKeyPolicyConfiguration interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawContentKeyPolicyConfigurationImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalContentKeyPolicyConfigurationImplementation(input []byte) (ContentKeyPolicyConfiguration, error) {
 	if input == nil {
 		return nil, nil
@@ -67,10 +76,6 @@ func unmarshalContentKeyPolicyConfigurationImplementation(input []byte) (Content
 		return out, nil
 	}
 
-	type RawContentKeyPolicyConfigurationImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawContentKeyPolicyConfigurationImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/contentkeypolicies/model_contentkeypolicyplayreadycontentkeylocation.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/contentkeypolicies/model_contentkeypolicyplayreadycontentkeylocation.go
@@ -12,6 +12,15 @@ import (
 type ContentKeyPolicyPlayReadyContentKeyLocation interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawContentKeyPolicyPlayReadyContentKeyLocationImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalContentKeyPolicyPlayReadyContentKeyLocationImplementation(input []byte) (ContentKeyPolicyPlayReadyContentKeyLocation, error) {
 	if input == nil {
 		return nil, nil
@@ -43,10 +52,6 @@ func unmarshalContentKeyPolicyPlayReadyContentKeyLocationImplementation(input []
 		return out, nil
 	}
 
-	type RawContentKeyPolicyPlayReadyContentKeyLocationImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawContentKeyPolicyPlayReadyContentKeyLocationImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/contentkeypolicies/model_contentkeypolicyrestriction.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/contentkeypolicies/model_contentkeypolicyrestriction.go
@@ -12,6 +12,15 @@ import (
 type ContentKeyPolicyRestriction interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawContentKeyPolicyRestrictionImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalContentKeyPolicyRestrictionImplementation(input []byte) (ContentKeyPolicyRestriction, error) {
 	if input == nil {
 		return nil, nil
@@ -51,10 +60,6 @@ func unmarshalContentKeyPolicyRestrictionImplementation(input []byte) (ContentKe
 		return out, nil
 	}
 
-	type RawContentKeyPolicyRestrictionImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawContentKeyPolicyRestrictionImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/contentkeypolicies/model_contentkeypolicyrestrictiontokenkey.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/contentkeypolicies/model_contentkeypolicyrestrictiontokenkey.go
@@ -12,6 +12,15 @@ import (
 type ContentKeyPolicyRestrictionTokenKey interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawContentKeyPolicyRestrictionTokenKeyImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalContentKeyPolicyRestrictionTokenKeyImplementation(input []byte) (ContentKeyPolicyRestrictionTokenKey, error) {
 	if input == nil {
 		return nil, nil
@@ -51,10 +60,6 @@ func unmarshalContentKeyPolicyRestrictionTokenKeyImplementation(input []byte) (C
 		return out, nil
 	}
 
-	type RawContentKeyPolicyRestrictionTokenKeyImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawContentKeyPolicyRestrictionTokenKeyImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/encodings/model_cliptime.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/encodings/model_cliptime.go
@@ -12,6 +12,15 @@ import (
 type ClipTime interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawClipTimeImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalClipTimeImplementation(input []byte) (ClipTime, error) {
 	if input == nil {
 		return nil, nil
@@ -43,10 +52,6 @@ func unmarshalClipTimeImplementation(input []byte) (ClipTime, error) {
 		return out, nil
 	}
 
-	type RawClipTimeImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawClipTimeImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/encodings/model_codec.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/encodings/model_codec.go
@@ -12,6 +12,15 @@ import (
 type Codec interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawCodecImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalCodecImplementation(input []byte) (Codec, error) {
 	if input == nil {
 		return nil, nil
@@ -107,10 +116,6 @@ func unmarshalCodecImplementation(input []byte) (Codec, error) {
 		return out, nil
 	}
 
-	type RawCodecImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawCodecImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/encodings/model_format.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/encodings/model_format.go
@@ -12,6 +12,15 @@ import (
 type Format interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawFormatImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalFormatImplementation(input []byte) (Format, error) {
 	if input == nil {
 		return nil, nil
@@ -75,10 +84,6 @@ func unmarshalFormatImplementation(input []byte) (Format, error) {
 		return out, nil
 	}
 
-	type RawFormatImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawFormatImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/encodings/model_inputdefinition.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/encodings/model_inputdefinition.go
@@ -12,6 +12,15 @@ import (
 type InputDefinition interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawInputDefinitionImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalInputDefinitionImplementation(input []byte) (InputDefinition, error) {
 	if input == nil {
 		return nil, nil
@@ -51,10 +60,6 @@ func unmarshalInputDefinitionImplementation(input []byte) (InputDefinition, erro
 		return out, nil
 	}
 
-	type RawInputDefinitionImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawInputDefinitionImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/encodings/model_jobinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/encodings/model_jobinput.go
@@ -12,6 +12,15 @@ import (
 type JobInput interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawJobInputImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalJobInputImplementation(input []byte) (JobInput, error) {
 	if input == nil {
 		return nil, nil
@@ -67,10 +76,6 @@ func unmarshalJobInputImplementation(input []byte) (JobInput, error) {
 		return out, nil
 	}
 
-	type RawJobInputImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawJobInputImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/encodings/model_joboutput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/encodings/model_joboutput.go
@@ -12,6 +12,15 @@ import (
 type JobOutput interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawJobOutputImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalJobOutputImplementation(input []byte) (JobOutput, error) {
 	if input == nil {
 		return nil, nil
@@ -35,10 +44,6 @@ func unmarshalJobOutputImplementation(input []byte) (JobOutput, error) {
 		return out, nil
 	}
 
-	type RawJobOutputImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawJobOutputImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/encodings/model_overlay.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/encodings/model_overlay.go
@@ -12,6 +12,15 @@ import (
 type Overlay interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawOverlayImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalOverlayImplementation(input []byte) (Overlay, error) {
 	if input == nil {
 		return nil, nil
@@ -43,10 +52,6 @@ func unmarshalOverlayImplementation(input []byte) (Overlay, error) {
 		return out, nil
 	}
 
-	type RawOverlayImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawOverlayImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/encodings/model_preset.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/encodings/model_preset.go
@@ -12,6 +12,15 @@ import (
 type Preset interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawPresetImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalPresetImplementation(input []byte) (Preset, error) {
 	if input == nil {
 		return nil, nil
@@ -67,10 +76,6 @@ func unmarshalPresetImplementation(input []byte) (Preset, error) {
 		return out, nil
 	}
 
-	type RawPresetImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawPresetImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/encodings/model_trackdescriptor.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2021-11-01/encodings/model_trackdescriptor.go
@@ -12,6 +12,15 @@ import (
 type TrackDescriptor interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawTrackDescriptorImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalTrackDescriptorImplementation(input []byte) (TrackDescriptor, error) {
 	if input == nil {
 		return nil, nil
@@ -75,10 +84,6 @@ func unmarshalTrackDescriptorImplementation(input []byte) (TrackDescriptor, erro
 		return out, nil
 	}
 
-	type RawTrackDescriptorImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawTrackDescriptorImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-07-01/encodings/model_cliptime.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-07-01/encodings/model_cliptime.go
@@ -12,6 +12,15 @@ import (
 type ClipTime interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawClipTimeImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalClipTimeImplementation(input []byte) (ClipTime, error) {
 	if input == nil {
 		return nil, nil
@@ -43,10 +52,6 @@ func unmarshalClipTimeImplementation(input []byte) (ClipTime, error) {
 		return out, nil
 	}
 
-	type RawClipTimeImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawClipTimeImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-07-01/encodings/model_codec.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-07-01/encodings/model_codec.go
@@ -12,6 +12,15 @@ import (
 type Codec interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawCodecImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalCodecImplementation(input []byte) (Codec, error) {
 	if input == nil {
 		return nil, nil
@@ -115,10 +124,6 @@ func unmarshalCodecImplementation(input []byte) (Codec, error) {
 		return out, nil
 	}
 
-	type RawCodecImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawCodecImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-07-01/encodings/model_format.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-07-01/encodings/model_format.go
@@ -12,6 +12,15 @@ import (
 type Format interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawFormatImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalFormatImplementation(input []byte) (Format, error) {
 	if input == nil {
 		return nil, nil
@@ -75,10 +84,6 @@ func unmarshalFormatImplementation(input []byte) (Format, error) {
 		return out, nil
 	}
 
-	type RawFormatImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawFormatImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-07-01/encodings/model_inputdefinition.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-07-01/encodings/model_inputdefinition.go
@@ -12,6 +12,15 @@ import (
 type InputDefinition interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawInputDefinitionImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalInputDefinitionImplementation(input []byte) (InputDefinition, error) {
 	if input == nil {
 		return nil, nil
@@ -51,10 +60,6 @@ func unmarshalInputDefinitionImplementation(input []byte) (InputDefinition, erro
 		return out, nil
 	}
 
-	type RawInputDefinitionImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawInputDefinitionImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-07-01/encodings/model_jobinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-07-01/encodings/model_jobinput.go
@@ -12,6 +12,15 @@ import (
 type JobInput interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawJobInputImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalJobInputImplementation(input []byte) (JobInput, error) {
 	if input == nil {
 		return nil, nil
@@ -67,10 +76,6 @@ func unmarshalJobInputImplementation(input []byte) (JobInput, error) {
 		return out, nil
 	}
 
-	type RawJobInputImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawJobInputImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-07-01/encodings/model_joboutput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-07-01/encodings/model_joboutput.go
@@ -12,6 +12,15 @@ import (
 type JobOutput interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawJobOutputImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalJobOutputImplementation(input []byte) (JobOutput, error) {
 	if input == nil {
 		return nil, nil
@@ -35,10 +44,6 @@ func unmarshalJobOutputImplementation(input []byte) (JobOutput, error) {
 		return out, nil
 	}
 
-	type RawJobOutputImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawJobOutputImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-07-01/encodings/model_overlay.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-07-01/encodings/model_overlay.go
@@ -12,6 +12,15 @@ import (
 type Overlay interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawOverlayImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalOverlayImplementation(input []byte) (Overlay, error) {
 	if input == nil {
 		return nil, nil
@@ -43,10 +52,6 @@ func unmarshalOverlayImplementation(input []byte) (Overlay, error) {
 		return out, nil
 	}
 
-	type RawOverlayImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawOverlayImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-07-01/encodings/model_preset.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-07-01/encodings/model_preset.go
@@ -12,6 +12,15 @@ import (
 type Preset interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawPresetImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalPresetImplementation(input []byte) (Preset, error) {
 	if input == nil {
 		return nil, nil
@@ -67,10 +76,6 @@ func unmarshalPresetImplementation(input []byte) (Preset, error) {
 		return out, nil
 	}
 
-	type RawPresetImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawPresetImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-07-01/encodings/model_trackdescriptor.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-07-01/encodings/model_trackdescriptor.go
@@ -12,6 +12,15 @@ import (
 type TrackDescriptor interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawTrackDescriptorImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalTrackDescriptorImplementation(input []byte) (TrackDescriptor, error) {
 	if input == nil {
 		return nil, nil
@@ -75,10 +84,6 @@ func unmarshalTrackDescriptorImplementation(input []byte) (TrackDescriptor, erro
 		return out, nil
 	}
 
-	type RawTrackDescriptorImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawTrackDescriptorImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-08-01/assetsandassetfilters/model_trackbase.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-08-01/assetsandassetfilters/model_trackbase.go
@@ -12,6 +12,15 @@ import (
 type TrackBase interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawTrackBaseImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalTrackBaseImplementation(input []byte) (TrackBase, error) {
 	if input == nil {
 		return nil, nil
@@ -51,10 +60,6 @@ func unmarshalTrackBaseImplementation(input []byte) (TrackBase, error) {
 		return out, nil
 	}
 
-	type RawTrackBaseImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawTrackBaseImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-08-01/contentkeypolicies/model_contentkeypolicyconfiguration.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-08-01/contentkeypolicies/model_contentkeypolicyconfiguration.go
@@ -12,6 +12,15 @@ import (
 type ContentKeyPolicyConfiguration interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawContentKeyPolicyConfigurationImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalContentKeyPolicyConfigurationImplementation(input []byte) (ContentKeyPolicyConfiguration, error) {
 	if input == nil {
 		return nil, nil
@@ -67,10 +76,6 @@ func unmarshalContentKeyPolicyConfigurationImplementation(input []byte) (Content
 		return out, nil
 	}
 
-	type RawContentKeyPolicyConfigurationImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawContentKeyPolicyConfigurationImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-08-01/contentkeypolicies/model_contentkeypolicyplayreadycontentkeylocation.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-08-01/contentkeypolicies/model_contentkeypolicyplayreadycontentkeylocation.go
@@ -12,6 +12,15 @@ import (
 type ContentKeyPolicyPlayReadyContentKeyLocation interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawContentKeyPolicyPlayReadyContentKeyLocationImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalContentKeyPolicyPlayReadyContentKeyLocationImplementation(input []byte) (ContentKeyPolicyPlayReadyContentKeyLocation, error) {
 	if input == nil {
 		return nil, nil
@@ -43,10 +52,6 @@ func unmarshalContentKeyPolicyPlayReadyContentKeyLocationImplementation(input []
 		return out, nil
 	}
 
-	type RawContentKeyPolicyPlayReadyContentKeyLocationImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawContentKeyPolicyPlayReadyContentKeyLocationImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-08-01/contentkeypolicies/model_contentkeypolicyrestriction.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-08-01/contentkeypolicies/model_contentkeypolicyrestriction.go
@@ -12,6 +12,15 @@ import (
 type ContentKeyPolicyRestriction interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawContentKeyPolicyRestrictionImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalContentKeyPolicyRestrictionImplementation(input []byte) (ContentKeyPolicyRestriction, error) {
 	if input == nil {
 		return nil, nil
@@ -51,10 +60,6 @@ func unmarshalContentKeyPolicyRestrictionImplementation(input []byte) (ContentKe
 		return out, nil
 	}
 
-	type RawContentKeyPolicyRestrictionImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawContentKeyPolicyRestrictionImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-08-01/contentkeypolicies/model_contentkeypolicyrestrictiontokenkey.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/media/2022-08-01/contentkeypolicies/model_contentkeypolicyrestrictiontokenkey.go
@@ -12,6 +12,15 @@ import (
 type ContentKeyPolicyRestrictionTokenKey interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawContentKeyPolicyRestrictionTokenKeyImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalContentKeyPolicyRestrictionTokenKeyImplementation(input []byte) (ContentKeyPolicyRestrictionTokenKey, error) {
 	if input == nil {
 		return nil, nil
@@ -51,10 +60,6 @@ func unmarshalContentKeyPolicyRestrictionTokenKeyImplementation(input []byte) (C
 		return out, nil
 	}
 
-	type RawContentKeyPolicyRestrictionTokenKeyImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawContentKeyPolicyRestrictionTokenKeyImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mysql/2017-12-01/servers/model_serverpropertiesforcreate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/mysql/2017-12-01/servers/model_serverpropertiesforcreate.go
@@ -12,6 +12,15 @@ import (
 type ServerPropertiesForCreate interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawServerPropertiesForCreateImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalServerPropertiesForCreateImplementation(input []byte) (ServerPropertiesForCreate, error) {
 	if input == nil {
 		return nil, nil
@@ -59,10 +68,6 @@ func unmarshalServerPropertiesForCreateImplementation(input []byte) (ServerPrope
 		return out, nil
 	}
 
-	type RawServerPropertiesForCreateImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawServerPropertiesForCreateImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-04-01/adminrules/model_baseadminrule.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-04-01/adminrules/model_baseadminrule.go
@@ -12,6 +12,15 @@ import (
 type BaseAdminRule interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawBaseAdminRuleImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalBaseAdminRuleImplementation(input []byte) (BaseAdminRule, error) {
 	if input == nil {
 		return nil, nil
@@ -43,10 +52,6 @@ func unmarshalBaseAdminRuleImplementation(input []byte) (BaseAdminRule, error) {
 		return out, nil
 	}
 
-	type RawBaseAdminRuleImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawBaseAdminRuleImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-04-01/firewallpolicyrulecollectiongroups/model_firewallpolicyrule.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-04-01/firewallpolicyrulecollectiongroups/model_firewallpolicyrule.go
@@ -12,6 +12,15 @@ import (
 type FirewallPolicyRule interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawFirewallPolicyRuleImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalFirewallPolicyRuleImplementation(input []byte) (FirewallPolicyRule, error) {
 	if input == nil {
 		return nil, nil
@@ -51,10 +60,6 @@ func unmarshalFirewallPolicyRuleImplementation(input []byte) (FirewallPolicyRule
 		return out, nil
 	}
 
-	type RawFirewallPolicyRuleImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawFirewallPolicyRuleImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-04-01/firewallpolicyrulecollectiongroups/model_firewallpolicyrulecollection.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-04-01/firewallpolicyrulecollectiongroups/model_firewallpolicyrulecollection.go
@@ -12,6 +12,15 @@ import (
 type FirewallPolicyRuleCollection interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawFirewallPolicyRuleCollectionImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalFirewallPolicyRuleCollectionImplementation(input []byte) (FirewallPolicyRuleCollection, error) {
 	if input == nil {
 		return nil, nil
@@ -43,10 +52,6 @@ func unmarshalFirewallPolicyRuleCollectionImplementation(input []byte) (Firewall
 		return out, nil
 	}
 
-	type RawFirewallPolicyRuleCollectionImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawFirewallPolicyRuleCollectionImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-04-01/networkmanageractiveconfigurations/model_activebasesecurityadminrule.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-04-01/networkmanageractiveconfigurations/model_activebasesecurityadminrule.go
@@ -12,6 +12,15 @@ import (
 type ActiveBaseSecurityAdminRule interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawActiveBaseSecurityAdminRuleImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalActiveBaseSecurityAdminRuleImplementation(input []byte) (ActiveBaseSecurityAdminRule, error) {
 	if input == nil {
 		return nil, nil
@@ -43,10 +52,6 @@ func unmarshalActiveBaseSecurityAdminRuleImplementation(input []byte) (ActiveBas
 		return out, nil
 	}
 
-	type RawActiveBaseSecurityAdminRuleImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawActiveBaseSecurityAdminRuleImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-04-01/networkmanagereffectivesecurityadminrules/model_effectivebasesecurityadminrule.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/network/2023-04-01/networkmanagereffectivesecurityadminrules/model_effectivebasesecurityadminrule.go
@@ -12,6 +12,15 @@ import (
 type EffectiveBaseSecurityAdminRule interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawEffectiveBaseSecurityAdminRuleImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalEffectiveBaseSecurityAdminRuleImplementation(input []byte) (EffectiveBaseSecurityAdminRule, error) {
 	if input == nil {
 		return nil, nil
@@ -43,10 +52,6 @@ func unmarshalEffectiveBaseSecurityAdminRuleImplementation(input []byte) (Effect
 		return out, nil
 	}
 
-	type RawEffectiveBaseSecurityAdminRuleImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawEffectiveBaseSecurityAdminRuleImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2017-12-01/servers/model_serverpropertiesforcreate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/postgresql/2017-12-01/servers/model_serverpropertiesforcreate.go
@@ -12,6 +12,15 @@ import (
 type ServerPropertiesForCreate interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawServerPropertiesForCreateImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalServerPropertiesForCreateImplementation(input []byte) (ServerPropertiesForCreate, error) {
 	if input == nil {
 		return nil, nil
@@ -59,10 +68,6 @@ func unmarshalServerPropertiesForCreateImplementation(input []byte) (ServerPrope
 		return out, nil
 	}
 
-	type RawServerPropertiesForCreateImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawServerPropertiesForCreateImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservices/2022-10-01/vaultcertificates/model_resourcecertificatedetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservices/2022-10-01/vaultcertificates/model_resourcecertificatedetails.go
@@ -12,6 +12,15 @@ import (
 type ResourceCertificateDetails interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawResourceCertificateDetailsImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalResourceCertificateDetailsImplementation(input []byte) (ResourceCertificateDetails, error) {
 	if input == nil {
 		return nil, nil
@@ -43,10 +52,6 @@ func unmarshalResourceCertificateDetailsImplementation(input []byte) (ResourceCe
 		return out, nil
 	}
 
-	type RawResourceCertificateDetailsImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawResourceCertificateDetailsImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2023-02-01/backupprotectableitems/model_workloadprotectableitem.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2023-02-01/backupprotectableitems/model_workloadprotectableitem.go
@@ -12,6 +12,15 @@ import (
 type WorkloadProtectableItem interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawWorkloadProtectableItemImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalWorkloadProtectableItemImplementation(input []byte) (WorkloadProtectableItem, error) {
 	if input == nil {
 		return nil, nil
@@ -131,10 +140,6 @@ func unmarshalWorkloadProtectableItemImplementation(input []byte) (WorkloadProte
 		return out, nil
 	}
 
-	type RawWorkloadProtectableItemImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawWorkloadProtectableItemImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2023-02-01/backupprotecteditems/model_protecteditem.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2023-02-01/backupprotecteditems/model_protecteditem.go
@@ -12,6 +12,15 @@ import (
 type ProtectedItem interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawProtectedItemImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalProtectedItemImplementation(input []byte) (ProtectedItem, error) {
 	if input == nil {
 		return nil, nil
@@ -131,10 +140,6 @@ func unmarshalProtectedItemImplementation(input []byte) (ProtectedItem, error) {
 		return out, nil
 	}
 
-	type RawProtectedItemImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawProtectedItemImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2023-02-01/protecteditems/model_protecteditem.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2023-02-01/protecteditems/model_protecteditem.go
@@ -12,6 +12,15 @@ import (
 type ProtectedItem interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawProtectedItemImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalProtectedItemImplementation(input []byte) (ProtectedItem, error) {
 	if input == nil {
 		return nil, nil
@@ -131,10 +140,6 @@ func unmarshalProtectedItemImplementation(input []byte) (ProtectedItem, error) {
 		return out, nil
 	}
 
-	type RawProtectedItemImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawProtectedItemImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2023-02-01/protectioncontainers/model_protectioncontainer.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2023-02-01/protectioncontainers/model_protectioncontainer.go
@@ -12,6 +12,15 @@ import (
 type ProtectionContainer interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawProtectionContainerImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalProtectionContainerImplementation(input []byte) (ProtectionContainer, error) {
 	if input == nil {
 		return nil, nil
@@ -123,10 +132,6 @@ func unmarshalProtectionContainerImplementation(input []byte) (ProtectionContain
 		return out, nil
 	}
 
-	type RawProtectionContainerImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawProtectionContainerImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2023-02-01/protectionpolicies/model_protectionpolicy.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2023-02-01/protectionpolicies/model_protectionpolicy.go
@@ -12,6 +12,15 @@ import (
 type ProtectionPolicy interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawProtectionPolicyImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalProtectionPolicyImplementation(input []byte) (ProtectionPolicy, error) {
 	if input == nil {
 		return nil, nil
@@ -75,10 +84,6 @@ func unmarshalProtectionPolicyImplementation(input []byte) (ProtectionPolicy, er
 		return out, nil
 	}
 
-	type RawProtectionPolicyImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawProtectionPolicyImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2023-02-01/protectionpolicies/model_retentionpolicy.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2023-02-01/protectionpolicies/model_retentionpolicy.go
@@ -12,6 +12,15 @@ import (
 type RetentionPolicy interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawRetentionPolicyImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalRetentionPolicyImplementation(input []byte) (RetentionPolicy, error) {
 	if input == nil {
 		return nil, nil
@@ -43,10 +52,6 @@ func unmarshalRetentionPolicyImplementation(input []byte) (RetentionPolicy, erro
 		return out, nil
 	}
 
-	type RawRetentionPolicyImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawRetentionPolicyImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2023-02-01/protectionpolicies/model_schedulepolicy.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2023-02-01/protectionpolicies/model_schedulepolicy.go
@@ -12,6 +12,15 @@ import (
 type SchedulePolicy interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawSchedulePolicyImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalSchedulePolicyImplementation(input []byte) (SchedulePolicy, error) {
 	if input == nil {
 		return nil, nil
@@ -59,10 +68,6 @@ func unmarshalSchedulePolicyImplementation(input []byte) (SchedulePolicy, error)
 		return out, nil
 	}
 
-	type RawSchedulePolicyImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawSchedulePolicyImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_fabricspecificcreationinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_fabricspecificcreationinput.go
@@ -12,6 +12,15 @@ import (
 type FabricSpecificCreationInput interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawFabricSpecificCreationInputImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalFabricSpecificCreationInputImplementation(input []byte) (FabricSpecificCreationInput, error) {
 	if input == nil {
 		return nil, nil
@@ -51,10 +60,6 @@ func unmarshalFabricSpecificCreationInputImplementation(input []byte) (FabricSpe
 		return out, nil
 	}
 
-	type RawFabricSpecificCreationInputImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawFabricSpecificCreationInputImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_fabricspecificdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationfabrics/model_fabricspecificdetails.go
@@ -12,6 +12,15 @@ import (
 type FabricSpecificDetails interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawFabricSpecificDetailsImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalFabricSpecificDetailsImplementation(input []byte) (FabricSpecificDetails, error) {
 	if input == nil {
 		return nil, nil
@@ -75,10 +84,6 @@ func unmarshalFabricSpecificDetailsImplementation(input []byte) (FabricSpecificD
 		return out, nil
 	}
 
-	type RawFabricSpecificDetailsImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawFabricSpecificDetailsImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/model_fabricspecificcreatenetworkmappinginput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/model_fabricspecificcreatenetworkmappinginput.go
@@ -12,6 +12,15 @@ import (
 type FabricSpecificCreateNetworkMappingInput interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawFabricSpecificCreateNetworkMappingInputImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalFabricSpecificCreateNetworkMappingInputImplementation(input []byte) (FabricSpecificCreateNetworkMappingInput, error) {
 	if input == nil {
 		return nil, nil
@@ -51,10 +60,6 @@ func unmarshalFabricSpecificCreateNetworkMappingInputImplementation(input []byte
 		return out, nil
 	}
 
-	type RawFabricSpecificCreateNetworkMappingInputImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawFabricSpecificCreateNetworkMappingInputImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/model_fabricspecificupdatenetworkmappinginput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/model_fabricspecificupdatenetworkmappinginput.go
@@ -12,6 +12,15 @@ import (
 type FabricSpecificUpdateNetworkMappingInput interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawFabricSpecificUpdateNetworkMappingInputImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalFabricSpecificUpdateNetworkMappingInputImplementation(input []byte) (FabricSpecificUpdateNetworkMappingInput, error) {
 	if input == nil {
 		return nil, nil
@@ -51,10 +60,6 @@ func unmarshalFabricSpecificUpdateNetworkMappingInputImplementation(input []byte
 		return out, nil
 	}
 
-	type RawFabricSpecificUpdateNetworkMappingInputImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawFabricSpecificUpdateNetworkMappingInputImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/model_networkmappingfabricspecificsettings.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationnetworkmappings/model_networkmappingfabricspecificsettings.go
@@ -12,6 +12,15 @@ import (
 type NetworkMappingFabricSpecificSettings interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawNetworkMappingFabricSpecificSettingsImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalNetworkMappingFabricSpecificSettingsImplementation(input []byte) (NetworkMappingFabricSpecificSettings, error) {
 	if input == nil {
 		return nil, nil
@@ -51,10 +60,6 @@ func unmarshalNetworkMappingFabricSpecificSettingsImplementation(input []byte) (
 		return out, nil
 	}
 
-	type RawNetworkMappingFabricSpecificSettingsImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawNetworkMappingFabricSpecificSettingsImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/model_policyproviderspecificdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/model_policyproviderspecificdetails.go
@@ -12,6 +12,15 @@ import (
 type PolicyProviderSpecificDetails interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawPolicyProviderSpecificDetailsImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalPolicyProviderSpecificDetailsImplementation(input []byte) (PolicyProviderSpecificDetails, error) {
 	if input == nil {
 		return nil, nil
@@ -115,10 +124,6 @@ func unmarshalPolicyProviderSpecificDetailsImplementation(input []byte) (PolicyP
 		return out, nil
 	}
 
-	type RawPolicyProviderSpecificDetailsImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawPolicyProviderSpecificDetailsImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/model_policyproviderspecificinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationpolicies/model_policyproviderspecificinput.go
@@ -12,6 +12,15 @@ import (
 type PolicyProviderSpecificInput interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawPolicyProviderSpecificInputImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalPolicyProviderSpecificInputImplementation(input []byte) (PolicyProviderSpecificInput, error) {
 	if input == nil {
 		return nil, nil
@@ -99,10 +108,6 @@ func unmarshalPolicyProviderSpecificInputImplementation(input []byte) (PolicyPro
 		return out, nil
 	}
 
-	type RawPolicyProviderSpecificInputImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawPolicyProviderSpecificInputImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_adddisksproviderspecificinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_adddisksproviderspecificinput.go
@@ -12,6 +12,15 @@ import (
 type AddDisksProviderSpecificInput interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawAddDisksProviderSpecificInputImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalAddDisksProviderSpecificInputImplementation(input []byte) (AddDisksProviderSpecificInput, error) {
 	if input == nil {
 		return nil, nil
@@ -35,10 +44,6 @@ func unmarshalAddDisksProviderSpecificInputImplementation(input []byte) (AddDisk
 		return out, nil
 	}
 
-	type RawAddDisksProviderSpecificInputImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawAddDisksProviderSpecificInputImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_applyrecoverypointproviderspecificinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_applyrecoverypointproviderspecificinput.go
@@ -12,6 +12,15 @@ import (
 type ApplyRecoveryPointProviderSpecificInput interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawApplyRecoveryPointProviderSpecificInputImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalApplyRecoveryPointProviderSpecificInputImplementation(input []byte) (ApplyRecoveryPointProviderSpecificInput, error) {
 	if input == nil {
 		return nil, nil
@@ -67,10 +76,6 @@ func unmarshalApplyRecoveryPointProviderSpecificInputImplementation(input []byte
 		return out, nil
 	}
 
-	type RawApplyRecoveryPointProviderSpecificInputImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawApplyRecoveryPointProviderSpecificInputImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_disableprotectionproviderspecificinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_disableprotectionproviderspecificinput.go
@@ -12,6 +12,15 @@ import (
 type DisableProtectionProviderSpecificInput interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawDisableProtectionProviderSpecificInputImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalDisableProtectionProviderSpecificInputImplementation(input []byte) (DisableProtectionProviderSpecificInput, error) {
 	if input == nil {
 		return nil, nil
@@ -35,10 +44,6 @@ func unmarshalDisableProtectionProviderSpecificInputImplementation(input []byte)
 		return out, nil
 	}
 
-	type RawDisableProtectionProviderSpecificInputImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawDisableProtectionProviderSpecificInputImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_enableprotectionproviderspecificinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_enableprotectionproviderspecificinput.go
@@ -12,6 +12,15 @@ import (
 type EnableProtectionProviderSpecificInput interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawEnableProtectionProviderSpecificInputImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalEnableProtectionProviderSpecificInputImplementation(input []byte) (EnableProtectionProviderSpecificInput, error) {
 	if input == nil {
 		return nil, nil
@@ -75,10 +84,6 @@ func unmarshalEnableProtectionProviderSpecificInputImplementation(input []byte) 
 		return out, nil
 	}
 
-	type RawEnableProtectionProviderSpecificInputImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawEnableProtectionProviderSpecificInputImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_plannedfailoverproviderspecificfailoverinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_plannedfailoverproviderspecificfailoverinput.go
@@ -12,6 +12,15 @@ import (
 type PlannedFailoverProviderSpecificFailoverInput interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawPlannedFailoverProviderSpecificFailoverInputImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalPlannedFailoverProviderSpecificFailoverInputImplementation(input []byte) (PlannedFailoverProviderSpecificFailoverInput, error) {
 	if input == nil {
 		return nil, nil
@@ -51,10 +60,6 @@ func unmarshalPlannedFailoverProviderSpecificFailoverInputImplementation(input [
 		return out, nil
 	}
 
-	type RawPlannedFailoverProviderSpecificFailoverInputImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawPlannedFailoverProviderSpecificFailoverInputImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_removedisksproviderspecificinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_removedisksproviderspecificinput.go
@@ -12,6 +12,15 @@ import (
 type RemoveDisksProviderSpecificInput interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawRemoveDisksProviderSpecificInputImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalRemoveDisksProviderSpecificInputImplementation(input []byte) (RemoveDisksProviderSpecificInput, error) {
 	if input == nil {
 		return nil, nil
@@ -35,10 +44,6 @@ func unmarshalRemoveDisksProviderSpecificInputImplementation(input []byte) (Remo
 		return out, nil
 	}
 
-	type RawRemoveDisksProviderSpecificInputImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawRemoveDisksProviderSpecificInputImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_replicationproviderspecificsettings.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_replicationproviderspecificsettings.go
@@ -12,6 +12,15 @@ import (
 type ReplicationProviderSpecificSettings interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawReplicationProviderSpecificSettingsImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalReplicationProviderSpecificSettingsImplementation(input []byte) (ReplicationProviderSpecificSettings, error) {
 	if input == nil {
 		return nil, nil
@@ -107,10 +116,6 @@ func unmarshalReplicationProviderSpecificSettingsImplementation(input []byte) (R
 		return out, nil
 	}
 
-	type RawReplicationProviderSpecificSettingsImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawReplicationProviderSpecificSettingsImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_reversereplicationproviderspecificinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_reversereplicationproviderspecificinput.go
@@ -12,6 +12,15 @@ import (
 type ReverseReplicationProviderSpecificInput interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawReverseReplicationProviderSpecificInputImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalReverseReplicationProviderSpecificInputImplementation(input []byte) (ReverseReplicationProviderSpecificInput, error) {
 	if input == nil {
 		return nil, nil
@@ -75,10 +84,6 @@ func unmarshalReverseReplicationProviderSpecificInputImplementation(input []byte
 		return out, nil
 	}
 
-	type RawReverseReplicationProviderSpecificInputImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawReverseReplicationProviderSpecificInputImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_switchproviderproviderspecificinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_switchproviderproviderspecificinput.go
@@ -12,6 +12,15 @@ import (
 type SwitchProviderProviderSpecificInput interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawSwitchProviderProviderSpecificInputImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalSwitchProviderProviderSpecificInputImplementation(input []byte) (SwitchProviderProviderSpecificInput, error) {
 	if input == nil {
 		return nil, nil
@@ -35,10 +44,6 @@ func unmarshalSwitchProviderProviderSpecificInputImplementation(input []byte) (S
 		return out, nil
 	}
 
-	type RawSwitchProviderProviderSpecificInputImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawSwitchProviderProviderSpecificInputImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_testfailoverproviderspecificinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_testfailoverproviderspecificinput.go
@@ -12,6 +12,15 @@ import (
 type TestFailoverProviderSpecificInput interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawTestFailoverProviderSpecificInputImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalTestFailoverProviderSpecificInputImplementation(input []byte) (TestFailoverProviderSpecificInput, error) {
 	if input == nil {
 		return nil, nil
@@ -67,10 +76,6 @@ func unmarshalTestFailoverProviderSpecificInputImplementation(input []byte) (Tes
 		return out, nil
 	}
 
-	type RawTestFailoverProviderSpecificInputImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawTestFailoverProviderSpecificInputImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_unplannedfailoverproviderspecificinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_unplannedfailoverproviderspecificinput.go
@@ -12,6 +12,15 @@ import (
 type UnplannedFailoverProviderSpecificInput interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawUnplannedFailoverProviderSpecificInputImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalUnplannedFailoverProviderSpecificInputImplementation(input []byte) (UnplannedFailoverProviderSpecificInput, error) {
 	if input == nil {
 		return nil, nil
@@ -67,10 +76,6 @@ func unmarshalUnplannedFailoverProviderSpecificInputImplementation(input []byte)
 		return out, nil
 	}
 
-	type RawUnplannedFailoverProviderSpecificInputImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawUnplannedFailoverProviderSpecificInputImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_updateapplianceforreplicationprotecteditemproviderspecificinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_updateapplianceforreplicationprotecteditemproviderspecificinput.go
@@ -12,6 +12,15 @@ import (
 type UpdateApplianceForReplicationProtectedItemProviderSpecificInput interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawUpdateApplianceForReplicationProtectedItemProviderSpecificInputImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalUpdateApplianceForReplicationProtectedItemProviderSpecificInputImplementation(input []byte) (UpdateApplianceForReplicationProtectedItemProviderSpecificInput, error) {
 	if input == nil {
 		return nil, nil
@@ -35,10 +44,6 @@ func unmarshalUpdateApplianceForReplicationProtectedItemProviderSpecificInputImp
 		return out, nil
 	}
 
-	type RawUpdateApplianceForReplicationProtectedItemProviderSpecificInputImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawUpdateApplianceForReplicationProtectedItemProviderSpecificInputImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_updatereplicationprotecteditemproviderinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotecteditems/model_updatereplicationprotecteditemproviderinput.go
@@ -12,6 +12,15 @@ import (
 type UpdateReplicationProtectedItemProviderInput interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawUpdateReplicationProtectedItemProviderInputImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalUpdateReplicationProtectedItemProviderInputImplementation(input []byte) (UpdateReplicationProtectedItemProviderInput, error) {
 	if input == nil {
 		return nil, nil
@@ -59,10 +68,6 @@ func unmarshalUpdateReplicationProtectedItemProviderInputImplementation(input []
 		return out, nil
 	}
 
-	type RawUpdateReplicationProtectedItemProviderInputImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawUpdateReplicationProtectedItemProviderInputImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/model_protectioncontainermappingproviderspecificdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/model_protectioncontainermappingproviderspecificdetails.go
@@ -12,6 +12,15 @@ import (
 type ProtectionContainerMappingProviderSpecificDetails interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawProtectionContainerMappingProviderSpecificDetailsImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalProtectionContainerMappingProviderSpecificDetailsImplementation(input []byte) (ProtectionContainerMappingProviderSpecificDetails, error) {
 	if input == nil {
 		return nil, nil
@@ -51,10 +60,6 @@ func unmarshalProtectionContainerMappingProviderSpecificDetailsImplementation(in
 		return out, nil
 	}
 
-	type RawProtectionContainerMappingProviderSpecificDetailsImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawProtectionContainerMappingProviderSpecificDetailsImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/model_replicationproviderspecificcontainermappinginput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/model_replicationproviderspecificcontainermappinginput.go
@@ -12,6 +12,15 @@ import (
 type ReplicationProviderSpecificContainerMappingInput interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawReplicationProviderSpecificContainerMappingInputImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalReplicationProviderSpecificContainerMappingInputImplementation(input []byte) (ReplicationProviderSpecificContainerMappingInput, error) {
 	if input == nil {
 		return nil, nil
@@ -43,10 +52,6 @@ func unmarshalReplicationProviderSpecificContainerMappingInputImplementation(inp
 		return out, nil
 	}
 
-	type RawReplicationProviderSpecificContainerMappingInputImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawReplicationProviderSpecificContainerMappingInputImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/model_replicationproviderspecificupdatecontainermappinginput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainermappings/model_replicationproviderspecificupdatecontainermappinginput.go
@@ -12,6 +12,15 @@ import (
 type ReplicationProviderSpecificUpdateContainerMappingInput interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawReplicationProviderSpecificUpdateContainerMappingInputImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalReplicationProviderSpecificUpdateContainerMappingInputImplementation(input []byte) (ReplicationProviderSpecificUpdateContainerMappingInput, error) {
 	if input == nil {
 		return nil, nil
@@ -43,10 +52,6 @@ func unmarshalReplicationProviderSpecificUpdateContainerMappingInputImplementati
 		return out, nil
 	}
 
-	type RawReplicationProviderSpecificUpdateContainerMappingInputImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawReplicationProviderSpecificUpdateContainerMappingInputImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/model_replicationproviderspecificcontainercreationinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/model_replicationproviderspecificcontainercreationinput.go
@@ -12,6 +12,15 @@ import (
 type ReplicationProviderSpecificContainerCreationInput interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawReplicationProviderSpecificContainerCreationInputImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalReplicationProviderSpecificContainerCreationInputImplementation(input []byte) (ReplicationProviderSpecificContainerCreationInput, error) {
 	if input == nil {
 		return nil, nil
@@ -51,10 +60,6 @@ func unmarshalReplicationProviderSpecificContainerCreationInputImplementation(in
 		return out, nil
 	}
 
-	type RawReplicationProviderSpecificContainerCreationInputImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawReplicationProviderSpecificContainerCreationInputImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/model_switchprotectionproviderspecificinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationprotectioncontainers/model_switchprotectionproviderspecificinput.go
@@ -12,6 +12,15 @@ import (
 type SwitchProtectionProviderSpecificInput interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawSwitchProtectionProviderSpecificInputImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalSwitchProtectionProviderSpecificInputImplementation(input []byte) (SwitchProtectionProviderSpecificInput, error) {
 	if input == nil {
 		return nil, nil
@@ -35,10 +44,6 @@ func unmarshalSwitchProtectionProviderSpecificInputImplementation(input []byte) 
 		return out, nil
 	}
 
-	type RawSwitchProtectionProviderSpecificInputImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawSwitchProtectionProviderSpecificInputImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_recoveryplanactiondetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_recoveryplanactiondetails.go
@@ -12,6 +12,15 @@ import (
 type RecoveryPlanActionDetails interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawRecoveryPlanActionDetailsImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalRecoveryPlanActionDetailsImplementation(input []byte) (RecoveryPlanActionDetails, error) {
 	if input == nil {
 		return nil, nil
@@ -51,10 +60,6 @@ func unmarshalRecoveryPlanActionDetailsImplementation(input []byte) (RecoveryPla
 		return out, nil
 	}
 
-	type RawRecoveryPlanActionDetailsImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawRecoveryPlanActionDetailsImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_recoveryplanproviderspecificdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_recoveryplanproviderspecificdetails.go
@@ -12,6 +12,15 @@ import (
 type RecoveryPlanProviderSpecificDetails interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawRecoveryPlanProviderSpecificDetailsImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalRecoveryPlanProviderSpecificDetailsImplementation(input []byte) (RecoveryPlanProviderSpecificDetails, error) {
 	if input == nil {
 		return nil, nil
@@ -35,10 +44,6 @@ func unmarshalRecoveryPlanProviderSpecificDetailsImplementation(input []byte) (R
 		return out, nil
 	}
 
-	type RawRecoveryPlanProviderSpecificDetailsImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawRecoveryPlanProviderSpecificDetailsImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_recoveryplanproviderspecificfailoverinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_recoveryplanproviderspecificfailoverinput.go
@@ -12,6 +12,15 @@ import (
 type RecoveryPlanProviderSpecificFailoverInput interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawRecoveryPlanProviderSpecificFailoverInputImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalRecoveryPlanProviderSpecificFailoverInputImplementation(input []byte) (RecoveryPlanProviderSpecificFailoverInput, error) {
 	if input == nil {
 		return nil, nil
@@ -83,10 +92,6 @@ func unmarshalRecoveryPlanProviderSpecificFailoverInputImplementation(input []by
 		return out, nil
 	}
 
-	type RawRecoveryPlanProviderSpecificFailoverInputImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawRecoveryPlanProviderSpecificFailoverInputImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_recoveryplanproviderspecificinput.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicessiterecovery/2022-10-01/replicationrecoveryplans/model_recoveryplanproviderspecificinput.go
@@ -12,6 +12,15 @@ import (
 type RecoveryPlanProviderSpecificInput interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawRecoveryPlanProviderSpecificInputImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalRecoveryPlanProviderSpecificInputImplementation(input []byte) (RecoveryPlanProviderSpecificInput, error) {
 	if input == nil {
 		return nil, nil
@@ -35,10 +44,6 @@ func unmarshalRecoveryPlanProviderSpecificInputImplementation(input []byte) (Rec
 		return out, nil
 	}
 
-	type RawRecoveryPlanProviderSpecificInputImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawRecoveryPlanProviderSpecificInputImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2020-10-01/deploymentscripts/model_deploymentscript.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resources/2020-10-01/deploymentscripts/model_deploymentscript.go
@@ -12,6 +12,15 @@ import (
 type DeploymentScript interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawDeploymentScriptImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalDeploymentScriptImplementation(input []byte) (DeploymentScript, error) {
 	if input == nil {
 		return nil, nil
@@ -43,10 +52,6 @@ func unmarshalDeploymentScriptImplementation(input []byte) (DeploymentScript, er
 		return out, nil
 	}
 
-	type RawDeploymentScriptImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawDeploymentScriptImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/securityinsights/2022-10-01-preview/alertrules/model_alertrule.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/securityinsights/2022-10-01-preview/alertrules/model_alertrule.go
@@ -12,6 +12,15 @@ import (
 type AlertRule interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawAlertRuleImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalAlertRuleImplementation(input []byte) (AlertRule, error) {
 	if input == nil {
 		return nil, nil
@@ -75,10 +84,6 @@ func unmarshalAlertRuleImplementation(input []byte) (AlertRule, error) {
 		return out, nil
 	}
 
-	type RawAlertRuleImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawAlertRuleImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/securityinsights/2022-10-01-preview/automationrules/model_automationruleaction.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/securityinsights/2022-10-01-preview/automationrules/model_automationruleaction.go
@@ -12,6 +12,15 @@ import (
 type AutomationRuleAction interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawAutomationRuleActionImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalAutomationRuleActionImplementation(input []byte) (AutomationRuleAction, error) {
 	if input == nil {
 		return nil, nil
@@ -43,10 +52,6 @@ func unmarshalAutomationRuleActionImplementation(input []byte) (AutomationRuleAc
 		return out, nil
 	}
 
-	type RawAutomationRuleActionImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawAutomationRuleActionImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/securityinsights/2022-10-01-preview/automationrules/model_automationrulecondition.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/securityinsights/2022-10-01-preview/automationrules/model_automationrulecondition.go
@@ -12,6 +12,15 @@ import (
 type AutomationRuleCondition interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawAutomationRuleConditionImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalAutomationRuleConditionImplementation(input []byte) (AutomationRuleCondition, error) {
 	if input == nil {
 		return nil, nil
@@ -67,10 +76,6 @@ func unmarshalAutomationRuleConditionImplementation(input []byte) (AutomationRul
 		return out, nil
 	}
 
-	type RawAutomationRuleConditionImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawAutomationRuleConditionImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicelinker/2022-05-01/links/model_authinfobase.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicelinker/2022-05-01/links/model_authinfobase.go
@@ -12,6 +12,15 @@ import (
 type AuthInfoBase interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawAuthInfoBaseImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalAuthInfoBaseImplementation(input []byte) (AuthInfoBase, error) {
 	if input == nil {
 		return nil, nil
@@ -67,10 +76,6 @@ func unmarshalAuthInfoBaseImplementation(input []byte) (AuthInfoBase, error) {
 		return out, nil
 	}
 
-	type RawAuthInfoBaseImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawAuthInfoBaseImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicelinker/2022-05-01/links/model_azureresourcepropertiesbase.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicelinker/2022-05-01/links/model_azureresourcepropertiesbase.go
@@ -12,6 +12,15 @@ import (
 type AzureResourcePropertiesBase interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawAzureResourcePropertiesBaseImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalAzureResourcePropertiesBaseImplementation(input []byte) (AzureResourcePropertiesBase, error) {
 	if input == nil {
 		return nil, nil
@@ -35,10 +44,6 @@ func unmarshalAzureResourcePropertiesBaseImplementation(input []byte) (AzureReso
 		return out, nil
 	}
 
-	type RawAzureResourcePropertiesBaseImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawAzureResourcePropertiesBaseImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicelinker/2022-05-01/links/model_secretinfobase.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicelinker/2022-05-01/links/model_secretinfobase.go
@@ -12,6 +12,15 @@ import (
 type SecretInfoBase interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawSecretInfoBaseImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalSecretInfoBaseImplementation(input []byte) (SecretInfoBase, error) {
 	if input == nil {
 		return nil, nil
@@ -51,10 +60,6 @@ func unmarshalSecretInfoBaseImplementation(input []byte) (SecretInfoBase, error)
 		return out, nil
 	}
 
-	type RawSecretInfoBaseImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawSecretInfoBaseImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicelinker/2022-05-01/links/model_targetservicebase.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicelinker/2022-05-01/links/model_targetservicebase.go
@@ -12,6 +12,15 @@ import (
 type TargetServiceBase interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawTargetServiceBaseImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalTargetServiceBaseImplementation(input []byte) (TargetServiceBase, error) {
 	if input == nil {
 		return nil, nil
@@ -51,10 +60,6 @@ func unmarshalTargetServiceBaseImplementation(input []byte) (TargetServiceBase, 
 		return out, nil
 	}
 
-	type RawTargetServiceBaseImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawTargetServiceBaseImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicelinker/2022-05-01/servicelinker/model_authinfobase.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicelinker/2022-05-01/servicelinker/model_authinfobase.go
@@ -12,6 +12,15 @@ import (
 type AuthInfoBase interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawAuthInfoBaseImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalAuthInfoBaseImplementation(input []byte) (AuthInfoBase, error) {
 	if input == nil {
 		return nil, nil
@@ -67,10 +76,6 @@ func unmarshalAuthInfoBaseImplementation(input []byte) (AuthInfoBase, error) {
 		return out, nil
 	}
 
-	type RawAuthInfoBaseImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawAuthInfoBaseImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicelinker/2022-05-01/servicelinker/model_azureresourcepropertiesbase.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicelinker/2022-05-01/servicelinker/model_azureresourcepropertiesbase.go
@@ -12,6 +12,15 @@ import (
 type AzureResourcePropertiesBase interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawAzureResourcePropertiesBaseImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalAzureResourcePropertiesBaseImplementation(input []byte) (AzureResourcePropertiesBase, error) {
 	if input == nil {
 		return nil, nil
@@ -35,10 +44,6 @@ func unmarshalAzureResourcePropertiesBaseImplementation(input []byte) (AzureReso
 		return out, nil
 	}
 
-	type RawAzureResourcePropertiesBaseImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawAzureResourcePropertiesBaseImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicelinker/2022-05-01/servicelinker/model_secretinfobase.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicelinker/2022-05-01/servicelinker/model_secretinfobase.go
@@ -12,6 +12,15 @@ import (
 type SecretInfoBase interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawSecretInfoBaseImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalSecretInfoBaseImplementation(input []byte) (SecretInfoBase, error) {
 	if input == nil {
 		return nil, nil
@@ -51,10 +60,6 @@ func unmarshalSecretInfoBaseImplementation(input []byte) (SecretInfoBase, error)
 		return out, nil
 	}
 
-	type RawSecretInfoBaseImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawSecretInfoBaseImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicelinker/2022-05-01/servicelinker/model_targetservicebase.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/servicelinker/2022-05-01/servicelinker/model_targetservicebase.go
@@ -12,6 +12,15 @@ import (
 type TargetServiceBase interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawTargetServiceBaseImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalTargetServiceBaseImplementation(input []byte) (TargetServiceBase, error) {
 	if input == nil {
 		return nil, nil
@@ -51,10 +60,6 @@ func unmarshalTargetServiceBaseImplementation(input []byte) (TargetServiceBase, 
 		return out, nil
 	}
 
-	type RawTargetServiceBaseImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawTargetServiceBaseImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagemover/2023-03-01/endpoints/model_endpointbaseproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagemover/2023-03-01/endpoints/model_endpointbaseproperties.go
@@ -12,6 +12,15 @@ import (
 type EndpointBaseProperties interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawEndpointBasePropertiesImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalEndpointBasePropertiesImplementation(input []byte) (EndpointBaseProperties, error) {
 	if input == nil {
 		return nil, nil
@@ -43,10 +52,6 @@ func unmarshalEndpointBasePropertiesImplementation(input []byte) (EndpointBasePr
 		return out, nil
 	}
 
-	type RawEndpointBasePropertiesImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawEndpointBasePropertiesImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/functions/model_functionbinding.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/functions/model_functionbinding.go
@@ -12,6 +12,15 @@ import (
 type FunctionBinding interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawFunctionBindingImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalFunctionBindingImplementation(input []byte) (FunctionBinding, error) {
 	if input == nil {
 		return nil, nil
@@ -43,10 +52,6 @@ func unmarshalFunctionBindingImplementation(input []byte) (FunctionBinding, erro
 		return out, nil
 	}
 
-	type RawFunctionBindingImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawFunctionBindingImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/functions/model_functionproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/functions/model_functionproperties.go
@@ -12,6 +12,15 @@ import (
 type FunctionProperties interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawFunctionPropertiesImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalFunctionPropertiesImplementation(input []byte) (FunctionProperties, error) {
 	if input == nil {
 		return nil, nil
@@ -43,10 +52,6 @@ func unmarshalFunctionPropertiesImplementation(input []byte) (FunctionProperties
 		return out, nil
 	}
 
-	type RawFunctionPropertiesImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawFunctionPropertiesImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/functions/model_functionretrievedefaultdefinitionparameters.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/functions/model_functionretrievedefaultdefinitionparameters.go
@@ -12,6 +12,15 @@ import (
 type FunctionRetrieveDefaultDefinitionParameters interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawFunctionRetrieveDefaultDefinitionParametersImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalFunctionRetrieveDefaultDefinitionParametersImplementation(input []byte) (FunctionRetrieveDefaultDefinitionParameters, error) {
 	if input == nil {
 		return nil, nil
@@ -43,10 +52,6 @@ func unmarshalFunctionRetrieveDefaultDefinitionParametersImplementation(input []
 		return out, nil
 	}
 
-	type RawFunctionRetrieveDefaultDefinitionParametersImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawFunctionRetrieveDefaultDefinitionParametersImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/inputs/model_inputproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/inputs/model_inputproperties.go
@@ -12,6 +12,15 @@ import (
 type InputProperties interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawInputPropertiesImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalInputPropertiesImplementation(input []byte) (InputProperties, error) {
 	if input == nil {
 		return nil, nil
@@ -43,10 +52,6 @@ func unmarshalInputPropertiesImplementation(input []byte) (InputProperties, erro
 		return out, nil
 	}
 
-	type RawInputPropertiesImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawInputPropertiesImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/inputs/model_referenceinputdatasource.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/inputs/model_referenceinputdatasource.go
@@ -12,6 +12,15 @@ import (
 type ReferenceInputDataSource interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawReferenceInputDataSourceImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalReferenceInputDataSourceImplementation(input []byte) (ReferenceInputDataSource, error) {
 	if input == nil {
 		return nil, nil
@@ -51,10 +60,6 @@ func unmarshalReferenceInputDataSourceImplementation(input []byte) (ReferenceInp
 		return out, nil
 	}
 
-	type RawReferenceInputDataSourceImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawReferenceInputDataSourceImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/inputs/model_serialization.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/inputs/model_serialization.go
@@ -12,6 +12,15 @@ import (
 type Serialization interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawSerializationImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalSerializationImplementation(input []byte) (Serialization, error) {
 	if input == nil {
 		return nil, nil
@@ -59,10 +68,6 @@ func unmarshalSerializationImplementation(input []byte) (Serialization, error) {
 		return out, nil
 	}
 
-	type RawSerializationImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawSerializationImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/inputs/model_streaminputdatasource.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/inputs/model_streaminputdatasource.go
@@ -12,6 +12,15 @@ import (
 type StreamInputDataSource interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawStreamInputDataSourceImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalStreamInputDataSourceImplementation(input []byte) (StreamInputDataSource, error) {
 	if input == nil {
 		return nil, nil
@@ -67,10 +76,6 @@ func unmarshalStreamInputDataSourceImplementation(input []byte) (StreamInputData
 		return out, nil
 	}
 
-	type RawStreamInputDataSourceImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawStreamInputDataSourceImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/streamingjobs/model_functionbinding.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/streamingjobs/model_functionbinding.go
@@ -12,6 +12,15 @@ import (
 type FunctionBinding interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawFunctionBindingImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalFunctionBindingImplementation(input []byte) (FunctionBinding, error) {
 	if input == nil {
 		return nil, nil
@@ -43,10 +52,6 @@ func unmarshalFunctionBindingImplementation(input []byte) (FunctionBinding, erro
 		return out, nil
 	}
 
-	type RawFunctionBindingImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawFunctionBindingImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/streamingjobs/model_functionproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/streamingjobs/model_functionproperties.go
@@ -12,6 +12,15 @@ import (
 type FunctionProperties interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawFunctionPropertiesImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalFunctionPropertiesImplementation(input []byte) (FunctionProperties, error) {
 	if input == nil {
 		return nil, nil
@@ -43,10 +52,6 @@ func unmarshalFunctionPropertiesImplementation(input []byte) (FunctionProperties
 		return out, nil
 	}
 
-	type RawFunctionPropertiesImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawFunctionPropertiesImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/streamingjobs/model_inputproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/streamingjobs/model_inputproperties.go
@@ -12,6 +12,15 @@ import (
 type InputProperties interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawInputPropertiesImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalInputPropertiesImplementation(input []byte) (InputProperties, error) {
 	if input == nil {
 		return nil, nil
@@ -43,10 +52,6 @@ func unmarshalInputPropertiesImplementation(input []byte) (InputProperties, erro
 		return out, nil
 	}
 
-	type RawInputPropertiesImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawInputPropertiesImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/streamingjobs/model_outputdatasource.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/streamingjobs/model_outputdatasource.go
@@ -12,6 +12,15 @@ import (
 type OutputDataSource interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawOutputDataSourceImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalOutputDataSourceImplementation(input []byte) (OutputDataSource, error) {
 	if input == nil {
 		return nil, nil
@@ -131,10 +140,6 @@ func unmarshalOutputDataSourceImplementation(input []byte) (OutputDataSource, er
 		return out, nil
 	}
 
-	type RawOutputDataSourceImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawOutputDataSourceImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/streamingjobs/model_referenceinputdatasource.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/streamingjobs/model_referenceinputdatasource.go
@@ -12,6 +12,15 @@ import (
 type ReferenceInputDataSource interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawReferenceInputDataSourceImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalReferenceInputDataSourceImplementation(input []byte) (ReferenceInputDataSource, error) {
 	if input == nil {
 		return nil, nil
@@ -51,10 +60,6 @@ func unmarshalReferenceInputDataSourceImplementation(input []byte) (ReferenceInp
 		return out, nil
 	}
 
-	type RawReferenceInputDataSourceImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawReferenceInputDataSourceImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/streamingjobs/model_serialization.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/streamingjobs/model_serialization.go
@@ -12,6 +12,15 @@ import (
 type Serialization interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawSerializationImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalSerializationImplementation(input []byte) (Serialization, error) {
 	if input == nil {
 		return nil, nil
@@ -59,10 +68,6 @@ func unmarshalSerializationImplementation(input []byte) (Serialization, error) {
 		return out, nil
 	}
 
-	type RawSerializationImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawSerializationImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/streamingjobs/model_streaminputdatasource.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2020-03-01/streamingjobs/model_streaminputdatasource.go
@@ -12,6 +12,15 @@ import (
 type StreamInputDataSource interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawStreamInputDataSourceImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalStreamInputDataSourceImplementation(input []byte) (StreamInputDataSource, error) {
 	if input == nil {
 		return nil, nil
@@ -67,10 +76,6 @@ func unmarshalStreamInputDataSourceImplementation(input []byte) (StreamInputData
 		return out, nil
 	}
 
-	type RawStreamInputDataSourceImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawStreamInputDataSourceImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2021-10-01-preview/outputs/model_outputdatasource.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2021-10-01-preview/outputs/model_outputdatasource.go
@@ -12,6 +12,15 @@ import (
 type OutputDataSource interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawOutputDataSourceImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalOutputDataSourceImplementation(input []byte) (OutputDataSource, error) {
 	if input == nil {
 		return nil, nil
@@ -155,10 +164,6 @@ func unmarshalOutputDataSourceImplementation(input []byte) (OutputDataSource, er
 		return out, nil
 	}
 
-	type RawOutputDataSourceImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawOutputDataSourceImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2021-10-01-preview/outputs/model_serialization.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/streamanalytics/2021-10-01-preview/outputs/model_serialization.go
@@ -12,6 +12,15 @@ import (
 type Serialization interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawSerializationImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalSerializationImplementation(input []byte) (Serialization, error) {
 	if input == nil {
 		return nil, nil
@@ -75,10 +84,6 @@ func unmarshalSerializationImplementation(input []byte) (Serialization, error) {
 		return out, nil
 	}
 
-	type RawSerializationImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawSerializationImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/timeseriesinsights/2020-05-15/environments/model_environmentcreateorupdateparameters.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/timeseriesinsights/2020-05-15/environments/model_environmentcreateorupdateparameters.go
@@ -12,6 +12,15 @@ import (
 type EnvironmentCreateOrUpdateParameters interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawEnvironmentCreateOrUpdateParametersImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalEnvironmentCreateOrUpdateParametersImplementation(input []byte) (EnvironmentCreateOrUpdateParameters, error) {
 	if input == nil {
 		return nil, nil
@@ -43,10 +52,6 @@ func unmarshalEnvironmentCreateOrUpdateParametersImplementation(input []byte) (E
 		return out, nil
 	}
 
-	type RawEnvironmentCreateOrUpdateParametersImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawEnvironmentCreateOrUpdateParametersImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/timeseriesinsights/2020-05-15/environments/model_environmentresource.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/timeseriesinsights/2020-05-15/environments/model_environmentresource.go
@@ -12,6 +12,15 @@ import (
 type EnvironmentResource interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawEnvironmentResourceImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalEnvironmentResourceImplementation(input []byte) (EnvironmentResource, error) {
 	if input == nil {
 		return nil, nil
@@ -43,10 +52,6 @@ func unmarshalEnvironmentResourceImplementation(input []byte) (EnvironmentResour
 		return out, nil
 	}
 
-	type RawEnvironmentResourceImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawEnvironmentResourceImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/timeseriesinsights/2020-05-15/environments/model_environmentupdateparameters.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/timeseriesinsights/2020-05-15/environments/model_environmentupdateparameters.go
@@ -12,6 +12,15 @@ import (
 type EnvironmentUpdateParameters interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawEnvironmentUpdateParametersImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalEnvironmentUpdateParametersImplementation(input []byte) (EnvironmentUpdateParameters, error) {
 	if input == nil {
 		return nil, nil
@@ -43,10 +52,6 @@ func unmarshalEnvironmentUpdateParametersImplementation(input []byte) (Environme
 		return out, nil
 	}
 
-	type RawEnvironmentUpdateParametersImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawEnvironmentUpdateParametersImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/timeseriesinsights/2020-05-15/eventsources/model_eventsourcecreateorupdateparameters.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/timeseriesinsights/2020-05-15/eventsources/model_eventsourcecreateorupdateparameters.go
@@ -12,6 +12,15 @@ import (
 type EventSourceCreateOrUpdateParameters interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawEventSourceCreateOrUpdateParametersImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalEventSourceCreateOrUpdateParametersImplementation(input []byte) (EventSourceCreateOrUpdateParameters, error) {
 	if input == nil {
 		return nil, nil
@@ -43,10 +52,6 @@ func unmarshalEventSourceCreateOrUpdateParametersImplementation(input []byte) (E
 		return out, nil
 	}
 
-	type RawEventSourceCreateOrUpdateParametersImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawEventSourceCreateOrUpdateParametersImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/timeseriesinsights/2020-05-15/eventsources/model_eventsourceresource.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/timeseriesinsights/2020-05-15/eventsources/model_eventsourceresource.go
@@ -12,6 +12,15 @@ import (
 type EventSourceResource interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawEventSourceResourceImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalEventSourceResourceImplementation(input []byte) (EventSourceResource, error) {
 	if input == nil {
 		return nil, nil
@@ -43,10 +52,6 @@ func unmarshalEventSourceResourceImplementation(input []byte) (EventSourceResour
 		return out, nil
 	}
 
-	type RawEventSourceResourceImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawEventSourceResourceImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/timeseriesinsights/2020-05-15/eventsources/model_eventsourceupdateparameters.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/timeseriesinsights/2020-05-15/eventsources/model_eventsourceupdateparameters.go
@@ -12,6 +12,15 @@ import (
 type EventSourceUpdateParameters interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawEventSourceUpdateParametersImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalEventSourceUpdateParametersImplementation(input []byte) (EventSourceUpdateParameters, error) {
 	if input == nil {
 		return nil, nil
@@ -43,10 +52,6 @@ func unmarshalEventSourceUpdateParametersImplementation(input []byte) (EventSour
 		return out, nil
 	}
 
-	type RawEventSourceUpdateParametersImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawEventSourceUpdateParametersImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/webpubsub/2023-02-01/webpubsub/model_eventlistenerendpoint.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/webpubsub/2023-02-01/webpubsub/model_eventlistenerendpoint.go
@@ -12,6 +12,15 @@ import (
 type EventListenerEndpoint interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawEventListenerEndpointImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalEventListenerEndpointImplementation(input []byte) (EventListenerEndpoint, error) {
 	if input == nil {
 		return nil, nil
@@ -35,10 +44,6 @@ func unmarshalEventListenerEndpointImplementation(input []byte) (EventListenerEn
 		return out, nil
 	}
 
-	type RawEventListenerEndpointImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawEventListenerEndpointImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/webpubsub/2023-02-01/webpubsub/model_eventlistenerfilter.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/webpubsub/2023-02-01/webpubsub/model_eventlistenerfilter.go
@@ -12,6 +12,15 @@ import (
 type EventListenerFilter interface {
 }
 
+// RawModeOfTransitImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawEventListenerFilterImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
 func unmarshalEventListenerFilterImplementation(input []byte) (EventListenerFilter, error) {
 	if input == nil {
 		return nil, nil
@@ -35,10 +44,6 @@ func unmarshalEventListenerFilterImplementation(input []byte) (EventListenerFilt
 		return out, nil
 	}
 
-	type RawEventListenerFilterImpl struct {
-		Type   string                 `json:"-"`
-		Values map[string]interface{} `json:"-"`
-	}
 	out := RawEventListenerFilterImpl{
 		Type:   value,
 		Values: temp,

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -129,7 +129,7 @@ github.com/hashicorp/go-azure-helpers/resourcemanager/tags
 github.com/hashicorp/go-azure-helpers/resourcemanager/zones
 github.com/hashicorp/go-azure-helpers/sender
 github.com/hashicorp/go-azure-helpers/storage
-# github.com/hashicorp/go-azure-sdk v0.20230804.1110546
+# github.com/hashicorp/go-azure-sdk v0.20230807.1063129
 ## explicit; go 1.19
 github.com/hashicorp/go-azure-sdk/resource-manager/aad/2021-05-01/domainservices
 github.com/hashicorp/go-azure-sdk/resource-manager/aadb2c/2021-04-01-preview


### PR DESCRIPTION
This update to the SDK updates the `Raw{DiscriminatorType}Impl` method to be public, so it's a bit noisy but this is otherwise a noop.