### PR TITLE
`example` - fix unix const in netapp example

### DIFF
--- a/examples/netapp/nfsv3_volume_with_snapshot_policy/main.tf
+++ b/examples/netapp/nfsv3_volume_with_snapshot_policy/main.tf
@@ -96,7 +96,7 @@ resource "azurerm_netapp_volume" "example" {
   protocols           = ["NFSv3"]
   subnet_id           = azurerm_subnet.example.id
   storage_quota_in_gb = 100
-  security_style      = "Unix"
+  security_style      = "unix"
 
   data_protection_snapshot_policy {
     snapshot_policy_id = azurerm_netapp_snapshot_policy.example.id


### PR DESCRIPTION
valid value has been changed from `Unix` to `unix` in #22721
updating the example as well.