### PR TITLE
`azurerm_analysis_services_server`, `azurerm_mariadb_configuration` : Fix acc tests failing on context no deadline issue

### DIFF
--- a/internal/services/analysisservices/analysis_services_server_resource_test.go
+++ b/internal/services/analysisservices/analysis_services_server_resource_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/go-azure-sdk/resource-manager/analysisservices/2017-08-01/servers"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
@@ -521,7 +522,10 @@ func (t AnalysisServicesServerResource) suspend(ctx context.Context, clients *cl
 		return err
 	}
 
-	if err := client.SuspendThenPoll(ctx, *id); err != nil {
+	ctx2, cancel := context.WithTimeout(ctx, 15*time.Minute)
+	defer cancel()
+
+	if err := client.SuspendThenPoll(ctx2, *id); err != nil {
 		return fmt.Errorf("suspending %s: %+v", *id, err)
 	}
 
@@ -537,7 +541,10 @@ func (t AnalysisServicesServerResource) checkState(expectedState servers.State) 
 			return err
 		}
 
-		resp, err := client.GetDetails(ctx, *id)
+		ctx2, cancel := context.WithTimeout(ctx, 15*time.Minute)
+		defer cancel()
+
+		resp, err := client.GetDetails(ctx2, *id)
 		if err != nil {
 			return fmt.Errorf("retrieving %s to check the state: %+v", *id, err)
 		}

--- a/internal/services/analysisservices/analysis_services_server_resource_test.go
+++ b/internal/services/analysisservices/analysis_services_server_resource_test.go
@@ -522,10 +522,10 @@ func (t AnalysisServicesServerResource) suspend(ctx context.Context, clients *cl
 		return err
 	}
 
-	ctx2, cancel := context.WithTimeout(ctx, 15*time.Minute)
+	timeout, cancel := context.WithTimeout(ctx, 15*time.Minute)
 	defer cancel()
 
-	if err := client.SuspendThenPoll(ctx2, *id); err != nil {
+	if err := client.SuspendThenPoll(timeout, *id); err != nil {
 		return fmt.Errorf("suspending %s: %+v", *id, err)
 	}
 
@@ -541,10 +541,10 @@ func (t AnalysisServicesServerResource) checkState(expectedState servers.State) 
 			return err
 		}
 
-		ctx2, cancel := context.WithTimeout(ctx, 15*time.Minute)
+		timeout, cancel := context.WithTimeout(ctx, 15*time.Minute)
 		defer cancel()
 
-		resp, err := client.GetDetails(ctx2, *id)
+		resp, err := client.GetDetails(timeout, *id)
 		if err != nil {
 			return fmt.Errorf("retrieving %s to check the state: %+v", *id, err)
 		}

--- a/internal/services/mariadb/mariadb_configuration_resource_test.go
+++ b/internal/services/mariadb/mariadb_configuration_resource_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/go-azure-sdk/resource-manager/mariadb/2018-06-01/configurations"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/mariadb/2018-06-01/servers"
@@ -108,7 +109,10 @@ func checkValueIs(value string) acceptance.ClientCheckFunc {
 			return err
 		}
 
-		resp, err := clients.MariaDB.ConfigurationsClient.Get(ctx, *id)
+		ctx2, cancel := context.WithTimeout(ctx, 5*time.Minute)
+		defer cancel()
+
+		resp, err := clients.MariaDB.ConfigurationsClient.Get(ctx2, *id)
 		if err != nil {
 			return fmt.Errorf("retrieving %s: %v", *id, err)
 		}
@@ -138,7 +142,10 @@ func checkValueIsReset(configurationName string) acceptance.ClientCheckFunc {
 
 		id := configurations.NewConfigurationID(serverId.SubscriptionId, serverId.ResourceGroupName, serverId.ServerName, configurationName)
 
-		resp, err := clients.MariaDB.ConfigurationsClient.Get(ctx, id)
+		ctx2, cancel := context.WithTimeout(ctx, 5*time.Minute)
+		defer cancel()
+
+		resp, err := clients.MariaDB.ConfigurationsClient.Get(ctx2, id)
 		if err != nil {
 			return fmt.Errorf("retrieving %s: %v", id, err)
 		}

--- a/internal/services/mariadb/mariadb_configuration_resource_test.go
+++ b/internal/services/mariadb/mariadb_configuration_resource_test.go
@@ -109,10 +109,10 @@ func checkValueIs(value string) acceptance.ClientCheckFunc {
 			return err
 		}
 
-		ctx2, cancel := context.WithTimeout(ctx, 5*time.Minute)
+		timeout, cancel := context.WithTimeout(ctx, 5*time.Minute)
 		defer cancel()
 
-		resp, err := clients.MariaDB.ConfigurationsClient.Get(ctx2, *id)
+		resp, err := clients.MariaDB.ConfigurationsClient.Get(timeout, *id)
 		if err != nil {
 			return fmt.Errorf("retrieving %s: %v", *id, err)
 		}
@@ -142,10 +142,10 @@ func checkValueIsReset(configurationName string) acceptance.ClientCheckFunc {
 
 		id := configurations.NewConfigurationID(serverId.SubscriptionId, serverId.ResourceGroupName, serverId.ServerName, configurationName)
 
-		ctx2, cancel := context.WithTimeout(ctx, 5*time.Minute)
+		timeout, cancel := context.WithTimeout(ctx, 5*time.Minute)
 		defer cancel()
 
-		resp, err := clients.MariaDB.ConfigurationsClient.Get(ctx2, id)
+		resp, err := clients.MariaDB.ConfigurationsClient.Get(timeout, id)
 		if err != nil {
 			return fmt.Errorf("retrieving %s: %v", id, err)
 		}


### PR DESCRIPTION
Fix tests [TestAccAzureRMAnalysisServicesServer_suspended ](https://hashicorp.teamcity.com/buildConfiguration/TF_AzureRM_AZURERM_SERVICE_PUBLIC_ANALYSISSERVICES/4980?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildTestsSection=true&expandBuildChangesSection=true) and [TestAccMariaDbConfiguration_](https://hashicorp.teamcity.com/buildConfiguration/TF_AzureRM_AZURERM_SERVICE_PUBLIC_MARIADB/5005?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildTestsSection=true&expandBuildChangesSection=true) failing with error "the context used must have a deadline attached for polling purposes, but got no deadline".

Note: For test `TestAccAzureRMAnalysisServicesServer_suspended ` , the test pass also depends on  [go-azure-sdk PR](https://github.com/hashicorp/go-azure-sdk/pull/606).