### PR TITLE
`azurerm_cdn_frontdoor_security_policy` - fix `resourceID` casing for associated `ActivatedResourceReference` resources on `READ` from Azure

### DIFF
--- a/internal/services/cdn/cdn_frontdoor_security_policy_resource.go
+++ b/internal/services/cdn/cdn_frontdoor_security_policy_resource.go
@@ -243,7 +243,7 @@ func resourceCdnFrontdoorSecurityPolicyRead(d *pluginsdk.ResourceData, meta inte
 			for _, item := range *waf.Associations {
 				domain, err := cdnfrontdoorsecurityparams.FlattenSecurityPoliciesActivatedResourceReference(item.Domains)
 				if err != nil {
-					return fmt.Errorf("flattening `domain`: %+v", err)
+					return fmt.Errorf("flattening `ActivatedResourceReference`: %+v", err)
 				}
 
 				associations = append(associations, map[string]interface{}{

--- a/internal/services/cdn/cdn_frontdoor_security_policy_resource.go
+++ b/internal/services/cdn/cdn_frontdoor_security_policy_resource.go
@@ -232,13 +232,22 @@ func resourceCdnFrontdoorSecurityPolicyRead(d *pluginsdk.ResourceData, meta inte
 
 		wafPolicyId := ""
 		if waf.WafPolicy != nil && waf.WafPolicy.ID != nil {
-			wafPolicyId = *waf.WafPolicy.ID
+			parsedId, err := parse.FrontDoorFirewallPolicyIDInsensitively(*waf.WafPolicy.ID)
+			if err != nil {
+				return fmt.Errorf("flattening `cdn_frontdoor_firewall_policy_id`: %+v", err)
+			}
+			wafPolicyId = parsedId.ID()
 		}
 
 		if waf.Associations != nil {
 			for _, item := range *waf.Associations {
+				domain, err := cdnfrontdoorsecurityparams.FlattenSecurityPoliciesActivatedResourceReference(item.Domains)
+				if err != nil {
+					return fmt.Errorf("flattening `domain`: %+v", err)
+				}
+
 				associations = append(associations, map[string]interface{}{
-					"domain":            cdnfrontdoorsecurityparams.FlattenSecurityPoliciesActivatedResourceReference(item.Domains),
+					"domain":            domain,
 					"patterns_to_match": utils.FlattenStringSlice(item.PatternsToMatch),
 				})
 			}

--- a/internal/services/cdn/frontdoorsecurityparams/cdn_frontdoor_security_params.go
+++ b/internal/services/cdn/frontdoorsecurityparams/cdn_frontdoor_security_params.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/Azure/azure-sdk-for-go/services/cdn/mgmt/2021-06-01/cdn" // nolint: staticcheck
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/cdn/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
@@ -86,16 +87,22 @@ func expandSecurityPoliciesActivatedResourceReference(input []interface{}) *[]cd
 	return &results
 }
 
-func FlattenSecurityPoliciesActivatedResourceReference(input *[]cdn.ActivatedResourceReference) []interface{} {
+func FlattenSecurityPoliciesActivatedResourceReference(input *[]cdn.ActivatedResourceReference) ([]interface{}, error) {
 	results := make([]interface{}, 0)
 	if input == nil {
-		return results
+		return results, nil
 	}
 
 	for _, item := range *input {
 		frontDoorDomainId := ""
 		if item.ID != nil {
-			frontDoorDomainId = *item.ID
+			if parsedFrontDoorCustomDomainId, frontDoorCustomDomainIdErr := parse.FrontDoorCustomDomainIDInsensitively(*item.ID); frontDoorCustomDomainIdErr == nil {
+				frontDoorDomainId = parsedFrontDoorCustomDomainId.ID()
+			} else if parsedFrontDoorEndpointId, frontDoorEndpointIdErr := parse.FrontDoorEndpointIDInsensitively(*item.ID); frontDoorEndpointIdErr == nil {
+				frontDoorDomainId = parsedFrontDoorEndpointId.ID()
+			} else {
+				return nil, fmt.Errorf("flattening `cdn_frontdoor_domain_id`: %+v; %+v", frontDoorCustomDomainIdErr, frontDoorEndpointIdErr)
+			}
 		}
 
 		active := false
@@ -109,5 +116,5 @@ func FlattenSecurityPoliciesActivatedResourceReference(input *[]cdn.ActivatedRes
 		})
 	}
 
-	return results
+	return results, nil
 }


### PR DESCRIPTION
Fix #22666
For this resource created out of Terraform, the ID of these properties may not be aligned within the provider, normalizing them on read