### PR TITLE
feat(azurerm_security_center_subscription_pricing): Support for configuring Defender for APIs

### DIFF
--- a/internal/services/securitycenter/security_center_subscription_pricing_resource.go
+++ b/internal/services/securitycenter/security_center_subscription_pricing_resource.go
@@ -59,6 +59,7 @@ func resourceSecurityCenterSubscriptionPricing() *pluginsdk.Resource {
 				Optional: true,
 				Default:  "VirtualMachines",
 				ValidateFunc: validation.StringInSlice([]string{
+					"Api",
 					"AppServices",
 					"ContainerRegistry",
 					"KeyVaults",

--- a/website/docs/r/security_center_subscription_pricing.html.markdown
+++ b/website/docs/r/security_center_subscription_pricing.html.markdown
@@ -26,7 +26,7 @@ resource "azurerm_security_center_subscription_pricing" "example" {
 The following arguments are supported:
 
 * `tier` - (Required) The pricing tier to use. Possible values are `Free` and `Standard`.
-* `resource_type` - (Optional) The resource type this setting affects. Possible values are `AppServices`, `ContainerRegistry`, `KeyVaults`, `KubernetesService`, `SqlServers`, `SqlServerVirtualMachines`, `StorageAccounts`, `VirtualMachines`, `Arm`, `Dns`, `OpenSourceRelationalDatabases`, `Containers`, `CosmosDbs` and `CloudPosture`. Defaults to `VirtualMachines`
+* `resource_type` - (Optional) The resource type this setting affects. Possible values are `Api`, `AppServices`, `ContainerRegistry`, `KeyVaults`, `KubernetesService`, `SqlServers`, `SqlServerVirtualMachines`, `StorageAccounts`, `VirtualMachines`, `Arm`, `Dns`, `OpenSourceRelationalDatabases`, `Containers`, `CosmosDbs` and `CloudPosture`. Defaults to `VirtualMachines`
 * `subplan` - (Optional) Resource type pricing subplan. Contact your MSFT representative for possible values.
 
 ~> **NOTE:** Changing the pricing tier to `Standard` affects all resources of the given type in the subscription and could be quite costly.


### PR DESCRIPTION
Adds `Api` as option for `azurerm_security_center_subscription_pricing.resource_type`

Example ARM object:
![CleanShot 2023-08-07 at 14 54 26](https://github.com/hashicorp/terraform-provider-azurerm/assets/6249819/c89a8e38-d95e-497c-8e84-deeca3b3fb62)
