### PR TITLE
Data source azurerm_virtual_machine - fix power state is null

### DIFF
--- a/internal/services/compute/virtual_machine_data_source.go
+++ b/internal/services/compute/virtual_machine_data_source.go
@@ -84,7 +84,7 @@ func dataSourceVirtualMachineRead(d *pluginsdk.ResourceData, meta interface{}) e
 
 	id := parse.NewVirtualMachineID(subscriptionId, d.Get("resource_group_name").(string), d.Get("name").(string))
 
-	resp, err := client.Get(ctx, id.ResourceGroup, id.Name, "")
+	resp, err := client.Get(ctx, id.ResourceGroup, id.Name, "InstanceView")
 	if err != nil {
 		if utils.ResponseWasNotFound(resp.Response) {
 			return fmt.Errorf("%s was not found", id)


### PR DESCRIPTION
The current version of the `azurerm_virtual_machine` data source returns a `null` value for the `power_state` attribute. This is because the API query against the resource needs to include the `InstanceView` parameter to get the extended attributes that include the power state. 

I have updated the Get function call to include the `InstanceView` parameter and verified that `power_state` is now populated with both the `running` and `deallocated` states.

Fixes #22737