### PR TITLE
`azurerm_mysql_server` : Fix acc test `TestAccMySQLServer_createPointInTimeRestore` failing with wrong time format

### DIFF
--- a/internal/services/mysql/mysql_server_resource.go
+++ b/internal/services/mysql/mysql_server_resource.go
@@ -420,11 +420,11 @@ func resourceMySqlServerCreate(d *pluginsdk.ResourceData, meta interface{}) erro
 		if !ok || v.(string) == "" {
 			return fmt.Errorf("restore_point_in_time must be set when create_mode is PointInTimeRestore")
 		}
-		time, _ := time.Parse(time.RFC3339, v.(string)) // should be validated by the schema
+		t, _ := time.Parse(time.RFC3339, v.(string)) // should be validated by the schema
 
 		props = &servers.ServerPropertiesForRestore{
 			SourceServerId:           source,
-			RestorePointInTime:       time.String(),
+			RestorePointInTime:       t.Format(time.RFC3339),
 			InfrastructureEncryption: pointer.To(infraEncrypt),
 			PublicNetworkAccess:      pointer.To(publicAccess),
 			MinimalTlsVersion:        pointer.To(tlsMin),


### PR DESCRIPTION
Test [TestAccMySQLServer_createPointInTimeRestore ](https://hashicorp.teamcity.com/buildConfiguration/TF_AzureRM_AZURERM_SERVICE_PUBLIC_MYSQL/5609?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildTestsSection=true&expandBuildChangesSection=true)fails with error "The 'serverResource.properties.restorePointInTime' segment in the url is invalid." . It seems that the [properties.restorePointInTime](https://learn.microsoft.com/en-us/rest/api/mysql/flexibleserver/servers/create?tabs=HTTP#request-body) should be in ISO8601 format.

Test result:
PASS: TestAccMySQLServer_createPointInTimeRestore (1548.47s)
