### PR TITLE
New Resource: `azurerm_machine_learning_registry`

### DIFF
--- a/internal/services/machinelearning/client/client.go
+++ b/internal/services/machinelearning/client/client.go
@@ -8,14 +8,16 @@ import (
 
 	"github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/datastore"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/machinelearningcomputes"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/registrymanagement"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/workspaces"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/common"
 )
 
 type Client struct {
-	Datastore               *datastore.DatastoreClient
-	MachineLearningComputes *machinelearningcomputes.MachineLearningComputesClient
-	Workspaces              *workspaces.WorkspacesClient
+	Datastore                *datastore.DatastoreClient
+	MachineLearningComputes  *machinelearningcomputes.MachineLearningComputesClient
+	RegistryManagementClient *registrymanagement.RegistryManagementClient
+	Workspaces               *workspaces.WorkspacesClient
 }
 
 func NewClient(o *common.ClientOptions) (*Client, error) {
@@ -25,21 +27,28 @@ func NewClient(o *common.ClientOptions) (*Client, error) {
 	}
 	o.Configure(datastoreClient.Client, o.Authorizers.ResourceManager)
 
-	workspacesClient, err := workspaces.NewWorkspacesClientWithBaseURI(o.Environment.ResourceManager)
-	if err != nil {
-		return nil, fmt.Errorf("building Workspaces client: %+v", err)
-	}
-	o.Configure(workspacesClient.Client, o.Authorizers.ResourceManager)
-
 	computesClient, err := machinelearningcomputes.NewMachineLearningComputesClientWithBaseURI(o.Environment.ResourceManager)
 	if err != nil {
 		return nil, fmt.Errorf("building MachineLearningComputes client: %+v", err)
 	}
 	o.Configure(computesClient.Client, o.Authorizers.ResourceManager)
 
+	registryClient, err := registrymanagement.NewRegistryManagementClientWithBaseURI(o.Environment.ResourceManager)
+	if err != nil {
+		return nil, fmt.Errorf("building RegistryManagement client: %+v", err)
+	}
+	o.Configure(registryClient.Client, o.Authorizers.ResourceManager)
+
+	workspacesClient, err := workspaces.NewWorkspacesClientWithBaseURI(o.Environment.ResourceManager)
+	if err != nil {
+		return nil, fmt.Errorf("building Workspaces client: %+v", err)
+	}
+	o.Configure(workspacesClient.Client, o.Authorizers.ResourceManager)
+
 	return &Client{
-		MachineLearningComputes: computesClient,
-		Datastore:               datastoreClient,
-		Workspaces:              workspacesClient,
+		Datastore:                datastoreClient,
+		MachineLearningComputes:  computesClient,
+		RegistryManagementClient: registryClient,
+		Workspaces:               workspacesClient,
 	}, nil
 }

--- a/internal/services/machinelearning/machine_learning_registry_resource.go
+++ b/internal/services/machinelearning/machine_learning_registry_resource.go
@@ -1,0 +1,669 @@
+package machinelearning
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"regexp"
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/containerregistry/2021-08-01-preview/registries"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/registrymanagement"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+// PublicNetworkAccess values not defined as enum, but given in the description
+const (
+	PublicNetworkAccessEnabled  = "Enabled"
+	PublicNetworkAccessDisabled = "Disabled"
+)
+
+func publicNetworkAccessFromBool(b bool) *string {
+	if b {
+		return pointer.To(PublicNetworkAccessEnabled)
+	}
+
+	return pointer.To(PublicNetworkAccessDisabled)
+}
+
+const (
+	ACRAccountSKUPremium = "Premium"
+)
+
+//	type AcrDetails struct {
+//		UserCreatedACRAccountARMResourceID string `tfschema:"user_created_acr_account_arm_resource_id"`
+//	}
+type ArmResourceId string
+
+//
+// type RegionDetails struct {
+// 	Location string `tfschema:"location"`
+//
+// 	AcrDetails            []AcrDetails            `tfschema:"acr_details"`
+// 	StorageAccountDetails []StorageAccountDetails `tfschema:"storage_account_details"`
+// }
+//
+// type StorageAccountDetails struct {
+// 	UserCreatedStorageAccountARMResourceID string `tfschema:"user_created_storage_account_arm_resource_id"`
+//
+// 	StorageAccountType       string        `tfschema:"system_created_storage_account_type"`
+// 	StorageAccountHnsEnabled bool          `tfschema:"system_created_storage_account_hns_enabled"`
+// 	StorageAccountName       string        `tfschema:"system_created_storage_account_name"`
+// 	ArmResourceId            ArmResourceId `tfschema:"system_created_storage_account_arm_resource_id"`
+// }
+//
+// type SystemCreatedAcrAccount struct {
+// 	AcrAccountName string        `tfschema:"acr_account_name"`
+// 	AcrAccountSku  string        `tfschema:"acr_account_sku"`
+// 	ArmResourceId  ArmResourceId `tfschema:"arm_resource_id"`
+// }
+//
+// type SystemCreatedStorageAccount struct {
+// 	StorageAccountName       string        `tfschema:"name"`
+// 	StorageAccountType       string        `tfschema:"type"`
+// 	StorageAccountHnsEnabled bool          `tfschema:"hns_enabled"`
+// 	ArmResourceId            ArmResourceId `tfschema:"arm_resource_id"`
+// }
+
+type ReplicationRegion struct {
+	Location                 string        `tfschema:"location"`
+	ContainerRegistryID      ArmResourceId `tfschema:"container_registry_id"`
+	StorageAccountID         ArmResourceId `tfschema:"storage_account_id"`
+	StorageAccountType       string        `tfschema:"storage_account_type"`
+	StorageAccountHNSEnabled bool          `tfschema:"storage_account_hns_enabled"`
+}
+
+type MachineLearningRegistryModel struct {
+	ResourceGroupName             string                                     `tfschema:"resource_group_name"`
+	Name                          string                                     `tfschema:"name"`
+	Location                      string                                     `tfschema:"location"`
+	DiscoveryUrl                  string                                     `tfschema:"discovery_url"`
+	ContainerRegistryID           ArmResourceId                              `tfschema:"container_registry_id"`
+	StorageAccountID              ArmResourceId                              `tfschema:"storage_account_id"`
+	StorageAccountType            string                                     `tfschema:"storage_account_type"`
+	StorageAccountHNSEnabled      bool                                       `tfschema:"storage_account_hns_enabled"`
+	ReplicationRegions            []ReplicationRegion                        `tfschema:"replication_regions"`
+	MlFlowRegistryUri             string                                     `tfschema:"ml_flow_registry_uri"`
+	IntellectualPropertyPublisher string                                     `tfschema:"intellectual_property_publisher"`
+	PublicNetworkAccess           bool                                       `tfschema:"public_network_access_enabled"`
+	Tags                          map[string]string                          `tfschema:"tags"`
+	Identity                      []identity.ModelSystemAssignedUserAssigned `tfschema:"identity"`
+	ManagedResourceGroup          ArmResourceId                              `tfschema:"managed_resource_group"`
+	// RegionDetails                 []RegionDetails                            `tfschema:"region_details"`
+}
+
+type MachineLearningRegistryResource struct{}
+
+var _ sdk.ResourceWithUpdate = (*MachineLearningRegistryResource)(nil)
+
+func (m MachineLearningRegistryResource) Arguments() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"name": {
+			Type:         pluginsdk.TypeString,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-zA-z0-9][a-zA-z0-9_-]{2,32}$`), "Registry name must be between 3 and 33 characters long. Its first character has to be alphanumeric, and the rest may contain hyphens and underscores. No whitespace is allowed."),
+		},
+
+		"resource_group_name": commonschema.ResourceGroupName(),
+
+		"identity": commonschema.SystemOrUserAssignedIdentityOptionalForceNew(),
+
+		"location": commonschema.Location(),
+
+		"public_network_access_enabled": {
+			Type:     pluginsdk.TypeBool,
+			Optional: true,
+			ForceNew: true,
+			Default:  false,
+		},
+
+		"container_registry_id": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ValidateFunc: registries.ValidateRegistryID,
+		},
+
+		"storage_account_id": {
+			Type:          pluginsdk.TypeString,
+			Optional:      true,
+			ValidateFunc:  commonids.ValidateStorageAccountID,
+			ConflictsWith: []string{"storage_account_type", "storage_account_hns_enabled"},
+		},
+
+		"storage_account_type": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			ValidateFunc: validation.StringInSlice([]string{
+				"Standard_LRS",
+				"Standard_GRS",
+				"Standard_RAGRS",
+				"Standard_ZRS",
+				"Standard_GZRS",
+				"Standard_RAGZRS",
+				"Premium_LRS",
+				"Premium_ZRS",
+			}, false),
+			ConflictsWith: []string{"storage_account_id"},
+		},
+
+		"storage_account_hns_enabled": {
+			Type:          pluginsdk.TypeBool,
+			Optional:      true,
+			Default:       false,
+			ConflictsWith: []string{"storage_account_id"},
+		},
+
+		"replication_regions": {
+			Type:     pluginsdk.TypeList,
+			Optional: true,
+			// This might only be conditionally ForceNew? Please investigate the API to find out
+			// ForceNew: true,
+			Elem: &pluginsdk.Resource{
+				Schema: map[string]*pluginsdk.Schema{
+					"container_registry_id": {
+						Type:         pluginsdk.TypeString,
+						Optional:     true,
+						ForceNew:     true,
+						ValidateFunc: registries.ValidateRegistryID,
+					},
+
+					"location": commonschema.LocationWithoutForceNew(),
+
+					"storage_account_id": {
+						Type:         pluginsdk.TypeString,
+						Optional:     true,
+						ForceNew:     true,
+						ValidateFunc: commonids.ValidateStorageAccountID,
+						// ConflictsWith: []string{
+						// 	"replication_regions.0.system_created_storage_account_type",
+						// 	"replication_regions.0.storage_account_hns_enabled",
+						// },
+					},
+
+					"storage_account_type": {
+						Type:     pluginsdk.TypeString,
+						Optional: true,
+						ForceNew: true,
+						ValidateFunc: validation.StringInSlice([]string{
+							"Standard_LRS",
+							"Standard_GRS",
+							"Standard_RAGRS",
+							"Standard_ZRS",
+							"Standard_GZRS",
+							"Standard_RAGZRS",
+							"Premium_LRS",
+							"Premium_ZRS",
+						}, false),
+						// ConflictsWith: []string{"replication_regions.0.storage_account_id"},
+					},
+
+					"storage_account_hns_enabled": {
+						Type:     pluginsdk.TypeBool,
+						Optional: true,
+						ForceNew: true,
+						Default:  false,
+						// ConflictsWith: []string{"replication_regions.0.storage_account_id"},
+					},
+				},
+			},
+		},
+
+		"tags": commonschema.Tags(),
+	}
+}
+
+func (m MachineLearningRegistryResource) Attributes() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"discovery_url": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"intellectual_property_publisher": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		"ml_flow_registry_uri": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+
+		// API will return a generated mrg even provided in request
+		"managed_resource_group": {
+			Type:     pluginsdk.TypeString,
+			Computed: true,
+		},
+	}
+}
+
+func (m MachineLearningRegistryResource) ModelObject() interface{} {
+	return &MachineLearningRegistryModel{}
+}
+
+func (m MachineLearningRegistryResource) ResourceType() string {
+	return "azurerm_machine_learning_registry"
+}
+
+func (m MachineLearningRegistryResource) Create() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, meta sdk.ResourceMetaData) error {
+			client := meta.Client.MachineLearning.RegistryManagementClient
+
+			var model MachineLearningRegistryModel
+			if err := meta.Decode(&model); err != nil {
+				return err
+			}
+
+			subscriptionID := meta.Client.Account.SubscriptionId
+			id := registrymanagement.NewRegistryID(subscriptionID, model.ResourceGroupName, model.Name)
+			existing, err := client.RegistriesGet(ctx, id)
+			if !response.WasNotFound(existing.HttpResponse) {
+				if err != nil {
+					return fmt.Errorf("retrieving %s: %v", id, err)
+				}
+				return meta.ResourceRequiresImport(m.ResourceType(), id)
+			}
+
+			req := registrymanagement.RegistryTrackedResource{
+				Location: model.Location,
+				Name:     &model.Name,
+				Tags:     &model.Tags,
+			}
+
+			if req.Identity, err = identity.ExpandLegacySystemAndUserAssignedMapFromModel(model.Identity); err != nil {
+				return fmt.Errorf("expand identity: %+v", err)
+			}
+
+			req.Properties = registrymanagement.Registry{
+				PublicNetworkAccess: publicNetworkAccessFromBool(model.PublicNetworkAccess),
+				RegionDetails:       m.expandRegionDetails(&model),
+			}
+
+			if err = client.RegistriesCreateOrUpdateThenPoll(ctx, id, req); err != nil {
+				return fmt.Errorf("creating %s: %v", id, err)
+			}
+
+			meta.SetID(id)
+			return nil
+		},
+	}
+}
+
+func (m MachineLearningRegistryResource) Update() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, meta sdk.ResourceMetaData) error {
+			client := meta.Client.MachineLearning.RegistryManagementClient
+			id, err := registrymanagement.ParseRegistryID(meta.ResourceData.Id())
+			if err != nil {
+				return fmt.Errorf("parsing registry ID: %+V", err)
+			}
+
+			existing, err := client.RegistriesGet(ctx, *id)
+			if response.WasNotFound(existing.HttpResponse) {
+				return fmt.Errorf("registry %s not found to update", *id)
+			}
+			if err != nil {
+				return fmt.Errorf("retrieving %s: %v", id, err)
+			}
+
+			var model MachineLearningRegistryModel
+			if err := meta.Decode(&model); err != nil {
+				return err
+			}
+
+			if meta.ResourceData.HasChange("replication_regions") {
+				o, n := meta.ResourceData.GetChange("replication_regions")
+				remove, add := m.regionsDiff(o, n)
+				// remove first and then update
+				req := registrymanagement.RegistryTrackedResource{
+					Location: model.Location,
+					Name:     &model.Name,
+					Tags:     &model.Tags,
+				}
+				if req.Identity, err = identity.ExpandLegacySystemAndUserAssignedMapFromModel(model.Identity); err != nil {
+					return fmt.Errorf("expand identity: %+v", err)
+				}
+				req.Properties = registrymanagement.Registry{
+					PublicNetworkAccess: publicNetworkAccessFromBool(model.PublicNetworkAccess),
+				}
+
+				if len(remove) > 0 {
+					var regions []registrymanagement.RegistryRegionArmDetails
+					for _, region := range remove {
+						regions = append(regions, m.buildRegionDetail(ReplicationRegion{
+							Location: region.(map[string]interface{})["location"].(string),
+						}))
+					}
+					req.Properties.RegionDetails = &regions
+					if err = client.RegistriesRemoveRegionsThenPoll(ctx, *id, req); err != nil {
+						return fmt.Errorf("remove region: %+v", err)
+					}
+				}
+				if len(add) > 0 {
+					req.Properties.RegionDetails = m.expandRegionDetails(&model)
+					if err = client.RegistriesCreateOrUpdateThenPoll(ctx, *id, req); err != nil {
+						return fmt.Errorf("remove region: %+v", err)
+					}
+				}
+				// region list can be delay, need a wait state
+				stateConf := pluginsdk.StateChangeConf{
+					Delay:   0,
+					Pending: []string{"Pending"},
+					Refresh: func() (result interface{}, state string, err error) {
+						if resp, err := client.RegistriesGet(ctx, *id); err != nil {
+							return resp.Model, "Done", err
+						} else {
+							if getModel := resp.Model; getModel != nil && getModel.Properties.RegionDetails != nil {
+								if len(*getModel.Properties.RegionDetails) == len(model.ReplicationRegions)+1 {
+									return resp.Model, "Done", nil
+								}
+							}
+						}
+						return nil, "Pending", nil
+					},
+					Target:     []string{"Done"},
+					Timeout:    time.Second * 10, // usually it maybe 5-seconds delay under my tests
+					MinTimeout: time.Second * 3,
+				}
+				if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+					return fmt.Errorf("wait update replication regions: %+v", err)
+				}
+			}
+
+			if meta.ResourceData.HasChanges("tags") {
+				req := registrymanagement.PartialRegistryPartialTrackedResource{}
+				req.Tags = pointer.To(model.Tags)
+
+				if _, err = client.RegistriesUpdate(ctx, *id, req); err != nil {
+					return fmt.Errorf("updating %q: %v", *id, err)
+				}
+
+				// remove wait state when issue fixed: https://github.com/Azure/azure-rest-api-specs/issues/25200
+				// with this stateWait, it can still read old value if from different server cluster.
+				deadline, ok := ctx.Deadline()
+				if !ok {
+					return fmt.Errorf("internal error: no deadline for ctx")
+				}
+				stateConf := &pluginsdk.StateChangeConf{
+					Pending: []string{"Pending"},
+					Target:  []string{"Finish"},
+					Refresh: func() (result interface{}, state string, err error) {
+						got, err := client.RegistriesGet(ctx, *id)
+						if err != nil {
+							return nil, "", fmt.Errorf("get updated registry: %+v", err)
+						}
+						state = "Pending"
+						result = got
+						if got.Model != nil {
+							tag := got.Model.Tags
+							if len(model.Tags) == 0 {
+								if tag == nil || len(*tag) == 0 {
+									state = "Finish"
+								}
+							} else if tag != nil && reflect.DeepEqual(model.Tags, *tag) {
+								state = "Finish"
+							}
+						}
+						return
+					},
+					MinTimeout: 10 * time.Second,
+					Timeout:    time.Until(deadline),
+				}
+				if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+					return fmt.Errorf("wait tags updated: %+v", err)
+				}
+			}
+
+			return nil
+		},
+	}
+}
+
+func (m MachineLearningRegistryResource) Read() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 5 * time.Minute,
+		Func: func(ctx context.Context, meta sdk.ResourceMetaData) error {
+			id, err := registrymanagement.ParseRegistryID(meta.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			client := meta.Client.MachineLearning.RegistryManagementClient
+			result, err := client.RegistriesGet(ctx, *id)
+			if err != nil {
+				return err
+			}
+			if result.Model == nil {
+				return fmt.Errorf("retrieving %s got nil model", id)
+			}
+
+			model := result.Model
+			prop := model.Properties
+			output := MachineLearningRegistryModel{
+				ResourceGroupName:             id.ResourceGroupName,
+				Name:                          id.RegistryName,
+				Tags:                          pointer.From(model.Tags),
+				DiscoveryUrl:                  pointer.From(prop.DiscoveryUrl),
+				MlFlowRegistryUri:             pointer.From(prop.MlFlowRegistryUri),
+				PublicNetworkAccess:           pointer.From(prop.PublicNetworkAccess) == PublicNetworkAccessEnabled,
+				IntellectualPropertyPublisher: pointer.From(prop.IntellectualPropertyPublisher),
+				Location:                      model.Location,
+			}
+
+			output.Identity, err = identity.FlattenLegacySystemAndUserAssignedMapToModel(model.Identity)
+			if err != nil {
+				return fmt.Errorf("faltten legacy identity: %+v", err)
+			}
+
+			output.ManagedResourceGroup = m.flattenArmResourceID(prop.ManagedResourceGroup)
+			primary, replicas := m.flattenRegionDetails(model.Location, prop.RegionDetails)
+			output.StorageAccountID = primary.StorageAccountID
+			output.StorageAccountType = primary.StorageAccountType
+			output.StorageAccountHNSEnabled = primary.StorageAccountHNSEnabled
+			output.ContainerRegistryID = primary.ContainerRegistryID
+
+			output.ReplicationRegions = replicas
+
+			return meta.Encode(&output)
+		},
+	}
+}
+
+func (m MachineLearningRegistryResource) Delete() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 10 * time.Minute,
+		Func: func(ctx context.Context, meta sdk.ResourceMetaData) error {
+			id, err := registrymanagement.ParseRegistryID(meta.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+
+			meta.Logger.Infof("deleting %s", id)
+			client := meta.Client.MachineLearning.RegistryManagementClient
+			if err = client.RegistriesDeleteThenPoll(ctx, *id); err != nil {
+				return fmt.Errorf("deleting %s: %v", id, err)
+			}
+
+			return nil
+		},
+	}
+}
+
+func (m MachineLearningRegistryResource) IDValidationFunc() pluginsdk.SchemaValidateFunc {
+	return registrymanagement.ValidateRegistryID
+}
+
+func (m MachineLearningRegistryResource) expandArmResourceID(id ArmResourceId) *registrymanagement.ArmResourceId {
+	if id == "" {
+		return nil
+	}
+
+	return &registrymanagement.ArmResourceId{
+		ResourceId: pointer.To(string(id)),
+	}
+}
+
+func (m MachineLearningRegistryResource) buildRegionDetail(detail ReplicationRegion) registrymanagement.RegistryRegionArmDetails {
+	item := registrymanagement.RegistryRegionArmDetails{
+		Location: pointer.To(detail.Location),
+		// AcrDetails:            m.expandAcrDetails(detail.AcrDetails),
+	}
+
+	if detail.StorageAccountID != "" {
+		item.StorageAccountDetails = &[]registrymanagement.StorageAccountDetails{
+			{
+				UserCreatedStorageAccount: &registrymanagement.UserCreatedStorageAccount{
+					ArmResourceId: m.expandArmResourceID(detail.StorageAccountID),
+				},
+			},
+		}
+	} else {
+		item.StorageAccountDetails = &[]registrymanagement.StorageAccountDetails{
+			{
+				SystemCreatedStorageAccount: &registrymanagement.SystemCreatedStorageAccount{
+					StorageAccountHnsEnabled: pointer.To(detail.StorageAccountHNSEnabled),
+					StorageAccountType:       pointer.To(detail.StorageAccountType),
+				},
+			},
+		}
+	}
+
+	if detail.ContainerRegistryID != "" {
+		item.AcrDetails = &[]registrymanagement.AcrDetails{
+			{
+				UserCreatedAcrAccount: &registrymanagement.UserCreatedAcrAccount{
+					ArmResourceId: m.expandArmResourceID(detail.ContainerRegistryID),
+				},
+			},
+		}
+	} else {
+		item.AcrDetails = &[]registrymanagement.AcrDetails{
+			{
+				SystemCreatedAcrAccount: &registrymanagement.SystemCreatedAcrAccount{
+					AcrAccountSku: pointer.To(ACRAccountSKUPremium),
+				},
+			},
+		}
+	}
+
+	return item
+}
+
+func (m MachineLearningRegistryResource) expandRegionDetails(model *MachineLearningRegistryModel) *[]registrymanagement.RegistryRegionArmDetails {
+	var output []registrymanagement.RegistryRegionArmDetails
+	// add primary location first
+	output = append(output, m.buildRegionDetail(ReplicationRegion{
+		Location:                 model.Location,
+		ContainerRegistryID:      model.ContainerRegistryID,
+		StorageAccountID:         model.StorageAccountID,
+		StorageAccountType:       model.StorageAccountType,
+		StorageAccountHNSEnabled: model.StorageAccountHNSEnabled,
+	}))
+
+	for _, detail := range model.ReplicationRegions {
+		output = append(output, m.buildRegionDetail(detail))
+	}
+
+	return &output
+}
+
+func (m MachineLearningRegistryResource) flattenArmResourceID(id *registrymanagement.ArmResourceId) ArmResourceId {
+	if nil == (id) {
+		return ""
+	}
+
+	return ArmResourceId(pointer.From(id.ResourceId))
+}
+
+func (m MachineLearningRegistryResource) flattenRegion(detail registrymanagement.RegistryRegionArmDetails) ReplicationRegion {
+	var res ReplicationRegion
+	res.Location = pointer.From(detail.Location)
+	if detail.AcrDetails != nil && len(*detail.AcrDetails) > 0 {
+		acr := (*detail.AcrDetails)[0]
+		if acr.UserCreatedAcrAccount != nil {
+			res.ContainerRegistryID = m.flattenArmResourceID(acr.UserCreatedAcrAccount.ArmResourceId)
+		} else if acr.SystemCreatedAcrAccount != nil {
+		}
+	}
+
+	if detail.StorageAccountDetails != nil && len(*detail.StorageAccountDetails) > 0 {
+		storage := (*detail.StorageAccountDetails)[0]
+		if storage.UserCreatedStorageAccount != nil {
+			res.StorageAccountID = m.flattenArmResourceID(storage.UserCreatedStorageAccount.ArmResourceId)
+		} else if storage.SystemCreatedStorageAccount != nil {
+			res.StorageAccountType = pointer.From(storage.SystemCreatedStorageAccount.StorageAccountType)
+			res.StorageAccountHNSEnabled = pointer.From(storage.SystemCreatedStorageAccount.StorageAccountHnsEnabled)
+		}
+	}
+
+	return res
+}
+
+func (m MachineLearningRegistryResource) flattenRegionDetails(primaryLocation string, details *[]registrymanagement.RegistryRegionArmDetails) (
+	primary ReplicationRegion, replicas []ReplicationRegion) {
+	if details == nil || len(*details) == 0 {
+		return ReplicationRegion{}, nil
+	}
+
+	for _, detail := range *details {
+		if pointer.From(detail.Location) == primaryLocation {
+			primary = m.flattenRegion(detail)
+		} else {
+			replicas = append(replicas, m.flattenRegion(detail))
+		}
+	}
+	return primary, replicas
+}
+
+func (m MachineLearningRegistryResource) regionsDiff(old, new interface{}) (remove, add []interface{}) {
+
+	oldRegions := m.regionsToMap(old)
+	newRegions := m.regionsToMap(new)
+
+	// remove if exists in old, but not exists in new
+	for location, v := range oldRegions {
+		if _, ok := newRegions[location]; !ok {
+			remove = append(remove, v)
+		}
+	}
+
+	for location, v := range newRegions {
+		if _, ok := oldRegions[location]; !ok {
+			add = append(add, v)
+		}
+	}
+	return
+}
+
+func (m MachineLearningRegistryResource) regionsToMap(obj interface{}) map[string]interface{} {
+	v, ok := obj.([]interface{})
+	if !ok {
+		return nil
+	}
+
+	if len(v) == 0 {
+		return nil
+	}
+	res := map[string]interface{}{}
+
+	for _, value := range v {
+		if value == nil {
+			continue
+		}
+		if region, ok := value.(map[string]interface{}); ok {
+			res[region["location"].(string)] = value
+		}
+	}
+	return res
+}

--- a/internal/services/machinelearning/machine_learning_registry_resource_test.go
+++ b/internal/services/machinelearning/machine_learning_registry_resource_test.go
@@ -1,0 +1,226 @@
+package machinelearning_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/registrymanagement"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/machinelearning"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/utils"
+)
+
+type MachineLearningRegistryResource struct{}
+
+func (a MachineLearningRegistryResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
+	id, err := registrymanagement.ParseRegistryID(state.ID)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.MachineLearning.RegistryManagementClient.RegistriesGet(ctx, *id)
+	if err != nil {
+		return nil, fmt.Errorf("retrieving MachineLearningRegistry %s: %+v", id, err)
+	}
+	return utils.Bool(resp.Model != nil), nil
+}
+
+func TestAccMachineLearningRegistry_basic(t *testing.T) {
+	data := acceptance.BuildTestData(t, machinelearning.MachineLearningRegistryResource{}.ResourceType(), "test")
+	r := MachineLearningRegistryResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccMachineLearningRegistry_complete(t *testing.T) {
+	data := acceptance.BuildTestData(t, machinelearning.MachineLearningRegistryResource{}.ResourceType(), "test")
+	r := MachineLearningRegistryResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+// update tags still read old value: https://github.com/Azure/azure-rest-api-specs/issues/25200
+func TestAccMachineLearningRegistry_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, machinelearning.MachineLearningRegistryResource{}.ResourceType(), "test")
+	r := MachineLearningRegistryResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basicUpdate(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		// data.ImportStep(),
+		// {
+		// 	Config: r.basicWithNoReplication(data),
+		// 	Check: acceptance.ComposeTestCheckFunc(
+		// 		check.That(data.ResourceName).ExistsInAzure(r),
+		// 	),
+		// },
+		// data.ImportStep(),
+	})
+}
+
+func (a MachineLearningRegistryResource) basic(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+
+
+%s
+
+resource "azurerm_machine_learning_registry" "test" {
+  location            = "%[3]s"
+  resource_group_name = azurerm_resource_group.test.name
+  name                = "accmlc-%[2]d"
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  public_network_access_enabled = true
+  storage_account_type          = "Standard_LRS"
+
+  replication_regions {
+    location = "%[4]s"
+
+    storage_account_type = "Standard_LRS"
+  }
+
+  tags = {
+    key = "example"
+  }
+}
+`, a.template(data), data.RandomInteger, data.Locations.Primary, data.Locations.Secondary)
+}
+
+func (a MachineLearningRegistryResource) basicUpdate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+
+
+
+
+%s
+
+resource "azurerm_machine_learning_registry" "test" {
+  location            = "%[3]s"
+  resource_group_name = azurerm_resource_group.test.name
+  name                = "accmlc-%[2]d"
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  public_network_access_enabled = true
+  storage_account_type          = "Standard_LRS"
+
+  replication_regions {
+    location = "%[4]s"
+
+    storage_account_type = "Standard_LRS"
+  }
+
+  tags = {
+    key = "example"
+  }
+}
+`, a.template(data), data.RandomInteger, data.Locations.Primary, data.Locations.Ternary)
+}
+
+func (a MachineLearningRegistryResource) basicWithNoReplication(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+
+
+%s
+
+resource "azurerm_machine_learning_registry" "test" {
+  location            = "%[3]s"
+  resource_group_name = azurerm_resource_group.test.name
+  name                = "accmlc-%[2]d"
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  public_network_access_enabled = true
+  storage_account_type          = "Standard_LRS"
+
+  tags = {
+    key = "example"
+  }
+}
+`, a.template(data), data.RandomInteger, data.Locations.Primary)
+}
+
+func (a MachineLearningRegistryResource) complete(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_machine_learning_registry" "test" {
+  location            = "%[3]s"
+  resource_group_name = azurerm_resource_group.test.name
+  name                = "accmlc-%[2]d"
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  public_network_access_enabled = true
+  storage_account_type          = "Standard_LRS"
+
+  replication_regions {
+    location = "%[4]s"
+
+    storage_account_type = "Standard_LRS"
+  }
+
+  replication_regions {
+    location = "%[5]s"
+
+    storage_account_type        = "Standard_LRS"
+    storage_account_hns_enabled = true
+  }
+
+  tags = {
+    key = "example2"
+  }
+}
+`, a.template(data), data.RandomInteger, data.Locations.Primary, data.Locations.Secondary, data.Locations.Ternary)
+}
+
+func (a MachineLearningRegistryResource) template(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+`, data.RandomInteger, data.Locations.Primary)
+}

--- a/internal/services/machinelearning/registration.go
+++ b/internal/services/machinelearning/registration.go
@@ -57,5 +57,6 @@ func (r Registration) Resources() []sdk.Resource {
 		MachineLearningDataStoreBlobStorage{},
 		MachineLearningDataStoreDataLakeGen2{},
 		MachineLearningDataStoreFileShare{},
+		MachineLearningRegistryResource{},
 	}
 }

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/registrymanagement/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/registrymanagement/README.md
@@ -1,0 +1,137 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/registrymanagement` Documentation
+
+The `registrymanagement` SDK allows for interaction with the Azure Resource Manager Service `machinelearningservices` (API Version `2023-04-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/registrymanagement"
+```
+
+
+### Client Initialization
+
+```go
+client := registrymanagement.NewRegistryManagementClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `RegistryManagementClient.RegistriesCreateOrUpdate`
+
+```go
+ctx := context.TODO()
+id := registrymanagement.NewRegistryID("12345678-1234-9876-4563-123456789012", "example-resource-group", "registryValue")
+
+payload := registrymanagement.RegistryTrackedResource{
+	// ...
+}
+
+
+if err := client.RegistriesCreateOrUpdateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `RegistryManagementClient.RegistriesDelete`
+
+```go
+ctx := context.TODO()
+id := registrymanagement.NewRegistryID("12345678-1234-9876-4563-123456789012", "example-resource-group", "registryValue")
+
+if err := client.RegistriesDeleteThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `RegistryManagementClient.RegistriesGet`
+
+```go
+ctx := context.TODO()
+id := registrymanagement.NewRegistryID("12345678-1234-9876-4563-123456789012", "example-resource-group", "registryValue")
+
+read, err := client.RegistriesGet(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `RegistryManagementClient.RegistriesList`
+
+```go
+ctx := context.TODO()
+id := registrymanagement.NewResourceGroupID("12345678-1234-9876-4563-123456789012", "example-resource-group")
+
+// alternatively `client.RegistriesList(ctx, id)` can be used to do batched pagination
+items, err := client.RegistriesListComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `RegistryManagementClient.RegistriesListBySubscription`
+
+```go
+ctx := context.TODO()
+id := registrymanagement.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+
+// alternatively `client.RegistriesListBySubscription(ctx, id)` can be used to do batched pagination
+items, err := client.RegistriesListBySubscriptionComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `RegistryManagementClient.RegistriesRemoveRegions`
+
+```go
+ctx := context.TODO()
+id := registrymanagement.NewRegistryID("12345678-1234-9876-4563-123456789012", "example-resource-group", "registryValue")
+
+payload := registrymanagement.RegistryTrackedResource{
+	// ...
+}
+
+
+if err := client.RegistriesRemoveRegionsThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `RegistryManagementClient.RegistriesUpdate`
+
+```go
+ctx := context.TODO()
+id := registrymanagement.NewRegistryID("12345678-1234-9876-4563-123456789012", "example-resource-group", "registryValue")
+
+payload := registrymanagement.PartialRegistryPartialTrackedResource{
+	// ...
+}
+
+
+read, err := client.RegistriesUpdate(ctx, id, payload)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/registrymanagement/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/registrymanagement/client.go
@@ -1,0 +1,26 @@
+package registrymanagement
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	sdkEnv "github.com/hashicorp/go-azure-sdk/sdk/environments"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RegistryManagementClient struct {
+	Client *resourcemanager.Client
+}
+
+func NewRegistryManagementClientWithBaseURI(sdkApi sdkEnv.Api) (*RegistryManagementClient, error) {
+	client, err := resourcemanager.NewResourceManagerClient(sdkApi, "registrymanagement", defaultApiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("instantiating RegistryManagementClient: %+v", err)
+	}
+
+	return &RegistryManagementClient{
+		Client: client,
+	}, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/registrymanagement/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/registrymanagement/constants.go
@@ -1,0 +1,104 @@
+package registrymanagement
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type EndpointServiceConnectionStatus string
+
+const (
+	EndpointServiceConnectionStatusApproved     EndpointServiceConnectionStatus = "Approved"
+	EndpointServiceConnectionStatusDisconnected EndpointServiceConnectionStatus = "Disconnected"
+	EndpointServiceConnectionStatusPending      EndpointServiceConnectionStatus = "Pending"
+	EndpointServiceConnectionStatusRejected     EndpointServiceConnectionStatus = "Rejected"
+)
+
+func PossibleValuesForEndpointServiceConnectionStatus() []string {
+	return []string{
+		string(EndpointServiceConnectionStatusApproved),
+		string(EndpointServiceConnectionStatusDisconnected),
+		string(EndpointServiceConnectionStatusPending),
+		string(EndpointServiceConnectionStatusRejected),
+	}
+}
+
+func (s *EndpointServiceConnectionStatus) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseEndpointServiceConnectionStatus(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseEndpointServiceConnectionStatus(input string) (*EndpointServiceConnectionStatus, error) {
+	vals := map[string]EndpointServiceConnectionStatus{
+		"approved":     EndpointServiceConnectionStatusApproved,
+		"disconnected": EndpointServiceConnectionStatusDisconnected,
+		"pending":      EndpointServiceConnectionStatusPending,
+		"rejected":     EndpointServiceConnectionStatusRejected,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := EndpointServiceConnectionStatus(input)
+	return &out, nil
+}
+
+type SkuTier string
+
+const (
+	SkuTierBasic    SkuTier = "Basic"
+	SkuTierFree     SkuTier = "Free"
+	SkuTierPremium  SkuTier = "Premium"
+	SkuTierStandard SkuTier = "Standard"
+)
+
+func PossibleValuesForSkuTier() []string {
+	return []string{
+		string(SkuTierBasic),
+		string(SkuTierFree),
+		string(SkuTierPremium),
+		string(SkuTierStandard),
+	}
+}
+
+func (s *SkuTier) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseSkuTier(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseSkuTier(input string) (*SkuTier, error) {
+	vals := map[string]SkuTier{
+		"basic":    SkuTierBasic,
+		"free":     SkuTierFree,
+		"premium":  SkuTierPremium,
+		"standard": SkuTierStandard,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := SkuTier(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/registrymanagement/id_registry.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/registrymanagement/id_registry.go
@@ -1,0 +1,127 @@
+package registrymanagement
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ resourceids.ResourceId = RegistryId{}
+
+// RegistryId is a struct representing the Resource ID for a Registry
+type RegistryId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	RegistryName      string
+}
+
+// NewRegistryID returns a new RegistryId struct
+func NewRegistryID(subscriptionId string, resourceGroupName string, registryName string) RegistryId {
+	return RegistryId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		RegistryName:      registryName,
+	}
+}
+
+// ParseRegistryID parses 'input' into a RegistryId
+func ParseRegistryID(input string) (*RegistryId, error) {
+	parser := resourceids.NewParserFromResourceIdType(RegistryId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := RegistryId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
+	}
+
+	if id.RegistryName, ok = parsed.Parsed["registryName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "registryName", *parsed)
+	}
+
+	return &id, nil
+}
+
+// ParseRegistryIDInsensitively parses 'input' case-insensitively into a RegistryId
+// note: this method should only be used for API response data and not user input
+func ParseRegistryIDInsensitively(input string) (*RegistryId, error) {
+	parser := resourceids.NewParserFromResourceIdType(RegistryId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := RegistryId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
+	}
+
+	if id.ResourceGroupName, ok = parsed.Parsed["resourceGroupName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", *parsed)
+	}
+
+	if id.RegistryName, ok = parsed.Parsed["registryName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "registryName", *parsed)
+	}
+
+	return &id, nil
+}
+
+// ValidateRegistryID checks that 'input' can be parsed as a Registry ID
+func ValidateRegistryID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseRegistryID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Registry ID
+func (id RegistryId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.MachineLearningServices/registries/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.RegistryName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Registry ID
+func (id RegistryId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftMachineLearningServices", "Microsoft.MachineLearningServices", "Microsoft.MachineLearningServices"),
+		resourceids.StaticSegment("staticRegistries", "registries", "registries"),
+		resourceids.UserSpecifiedSegment("registryName", "registryValue"),
+	}
+}
+
+// String returns a human-readable description of this Registry ID
+func (id RegistryId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Registry Name: %q", id.RegistryName),
+	}
+	return fmt.Sprintf("Registry (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/registrymanagement/method_registriescreateorupdate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/registrymanagement/method_registriescreateorupdate.go
@@ -1,0 +1,75 @@
+package registrymanagement
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RegistriesCreateOrUpdateOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// RegistriesCreateOrUpdate ...
+func (c RegistryManagementClient) RegistriesCreateOrUpdate(ctx context.Context, id RegistryId, input RegistryTrackedResource) (result RegistriesCreateOrUpdateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusCreated,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPut,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// RegistriesCreateOrUpdateThenPoll performs RegistriesCreateOrUpdate then polls until it's completed
+func (c RegistryManagementClient) RegistriesCreateOrUpdateThenPoll(ctx context.Context, id RegistryId, input RegistryTrackedResource) error {
+	result, err := c.RegistriesCreateOrUpdate(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing RegistriesCreateOrUpdate: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after RegistriesCreateOrUpdate: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/registrymanagement/method_registriesdelete.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/registrymanagement/method_registriesdelete.go
@@ -1,0 +1,71 @@
+package registrymanagement
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RegistriesDeleteOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// RegistriesDelete ...
+func (c RegistryManagementClient) RegistriesDelete(ctx context.Context, id RegistryId) (result RegistriesDeleteOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusNoContent,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodDelete,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// RegistriesDeleteThenPoll performs RegistriesDelete then polls until it's completed
+func (c RegistryManagementClient) RegistriesDeleteThenPoll(ctx context.Context, id RegistryId) error {
+	result, err := c.RegistriesDelete(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing RegistriesDelete: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after RegistriesDelete: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/registrymanagement/method_registriesget.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/registrymanagement/method_registriesget.go
@@ -1,0 +1,51 @@
+package registrymanagement
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RegistriesGetOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *RegistryTrackedResource
+}
+
+// RegistriesGet ...
+func (c RegistryManagementClient) RegistriesGet(ctx context.Context, id RegistryId) (result RegistriesGetOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	if err = resp.Unmarshal(&result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/registrymanagement/method_registrieslist.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/registrymanagement/method_registrieslist.go
@@ -1,0 +1,90 @@
+package registrymanagement
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RegistriesListOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]RegistryTrackedResource
+}
+
+type RegistriesListCompleteResult struct {
+	Items []RegistryTrackedResource
+}
+
+// RegistriesList ...
+func (c RegistryManagementClient) RegistriesList(ctx context.Context, id commonids.ResourceGroupId) (result RegistriesListOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       fmt.Sprintf("%s/providers/Microsoft.MachineLearningServices/registries", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]RegistryTrackedResource `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// RegistriesListComplete retrieves all the results into a single object
+func (c RegistryManagementClient) RegistriesListComplete(ctx context.Context, id commonids.ResourceGroupId) (RegistriesListCompleteResult, error) {
+	return c.RegistriesListCompleteMatchingPredicate(ctx, id, RegistryTrackedResourceOperationPredicate{})
+}
+
+// RegistriesListCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c RegistryManagementClient) RegistriesListCompleteMatchingPredicate(ctx context.Context, id commonids.ResourceGroupId, predicate RegistryTrackedResourceOperationPredicate) (result RegistriesListCompleteResult, err error) {
+	items := make([]RegistryTrackedResource, 0)
+
+	resp, err := c.RegistriesList(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = RegistriesListCompleteResult{
+		Items: items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/registrymanagement/method_registrieslistbysubscription.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/registrymanagement/method_registrieslistbysubscription.go
@@ -1,0 +1,90 @@
+package registrymanagement
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RegistriesListBySubscriptionOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *[]RegistryTrackedResource
+}
+
+type RegistriesListBySubscriptionCompleteResult struct {
+	Items []RegistryTrackedResource
+}
+
+// RegistriesListBySubscription ...
+func (c RegistryManagementClient) RegistriesListBySubscription(ctx context.Context, id commonids.SubscriptionId) (result RegistriesListBySubscriptionOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       fmt.Sprintf("%s/providers/Microsoft.MachineLearningServices/registries", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.ExecutePaged(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var values struct {
+		Values *[]RegistryTrackedResource `json:"value"`
+	}
+	if err = resp.Unmarshal(&values); err != nil {
+		return
+	}
+
+	result.Model = values.Values
+
+	return
+}
+
+// RegistriesListBySubscriptionComplete retrieves all the results into a single object
+func (c RegistryManagementClient) RegistriesListBySubscriptionComplete(ctx context.Context, id commonids.SubscriptionId) (RegistriesListBySubscriptionCompleteResult, error) {
+	return c.RegistriesListBySubscriptionCompleteMatchingPredicate(ctx, id, RegistryTrackedResourceOperationPredicate{})
+}
+
+// RegistriesListBySubscriptionCompleteMatchingPredicate retrieves all the results and then applies the predicate
+func (c RegistryManagementClient) RegistriesListBySubscriptionCompleteMatchingPredicate(ctx context.Context, id commonids.SubscriptionId, predicate RegistryTrackedResourceOperationPredicate) (result RegistriesListBySubscriptionCompleteResult, err error) {
+	items := make([]RegistryTrackedResource, 0)
+
+	resp, err := c.RegistriesListBySubscription(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading results: %+v", err)
+		return
+	}
+	if resp.Model != nil {
+		for _, v := range *resp.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	result = RegistriesListBySubscriptionCompleteResult{
+		Items: items,
+	}
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/registrymanagement/method_registriesremoveregions.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/registrymanagement/method_registriesremoveregions.go
@@ -1,0 +1,74 @@
+package registrymanagement
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RegistriesRemoveRegionsOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// RegistriesRemoveRegions ...
+func (c RegistryManagementClient) RegistriesRemoveRegions(ctx context.Context, id RegistryId, input RegistryTrackedResource) (result RegistriesRemoveRegionsOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/removeRegions", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// RegistriesRemoveRegionsThenPoll performs RegistriesRemoveRegions then polls until it's completed
+func (c RegistryManagementClient) RegistriesRemoveRegionsThenPoll(ctx context.Context, id RegistryId, input RegistryTrackedResource) error {
+	result, err := c.RegistriesRemoveRegions(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing RegistriesRemoveRegions: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after RegistriesRemoveRegions: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/registrymanagement/method_registriesupdate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/registrymanagement/method_registriesupdate.go
@@ -1,0 +1,55 @@
+package registrymanagement
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RegistriesUpdateOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *RegistryTrackedResource
+}
+
+// RegistriesUpdate ...
+func (c RegistryManagementClient) RegistriesUpdate(ctx context.Context, id RegistryId, input PartialRegistryPartialTrackedResource) (result RegistriesUpdateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPatch,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	if err = resp.Unmarshal(&result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/registrymanagement/model_acrdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/registrymanagement/model_acrdetails.go
@@ -1,0 +1,9 @@
+package registrymanagement
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AcrDetails struct {
+	SystemCreatedAcrAccount *SystemCreatedAcrAccount `json:"systemCreatedAcrAccount,omitempty"`
+	UserCreatedAcrAccount   *UserCreatedAcrAccount   `json:"userCreatedAcrAccount,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/registrymanagement/model_armresourceid.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/registrymanagement/model_armresourceid.go
@@ -1,0 +1,8 @@
+package registrymanagement
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ArmResourceId struct {
+	ResourceId *string `json:"resourceId,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/registrymanagement/model_partialregistrypartialtrackedresource.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/registrymanagement/model_partialregistrypartialtrackedresource.go
@@ -1,0 +1,14 @@
+package registrymanagement
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PartialRegistryPartialTrackedResource struct {
+	Identity *identity.LegacySystemAndUserAssignedMap `json:"identity,omitempty"`
+	Sku      *PartialSku                              `json:"sku,omitempty"`
+	Tags     *map[string]string                       `json:"tags,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/registrymanagement/model_partialsku.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/registrymanagement/model_partialsku.go
@@ -1,0 +1,12 @@
+package registrymanagement
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PartialSku struct {
+	Capacity *int64   `json:"capacity,omitempty"`
+	Family   *string  `json:"family,omitempty"`
+	Name     *string  `json:"name,omitempty"`
+	Size     *string  `json:"size,omitempty"`
+	Tier     *SkuTier `json:"tier,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/registrymanagement/model_privateendpointresource.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/registrymanagement/model_privateendpointresource.go
@@ -1,0 +1,9 @@
+package registrymanagement
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type PrivateEndpointResource struct {
+	Id          *string `json:"id,omitempty"`
+	SubnetArmId *string `json:"subnetArmId,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/registrymanagement/model_registry.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/registrymanagement/model_registry.go
@@ -1,0 +1,14 @@
+package registrymanagement
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type Registry struct {
+	DiscoveryUrl                  *string                              `json:"discoveryUrl,omitempty"`
+	IntellectualPropertyPublisher *string                              `json:"intellectualPropertyPublisher,omitempty"`
+	ManagedResourceGroup          *ArmResourceId                       `json:"managedResourceGroup,omitempty"`
+	MlFlowRegistryUri             *string                              `json:"mlFlowRegistryUri,omitempty"`
+	PrivateEndpointConnections    *[]RegistryPrivateEndpointConnection `json:"privateEndpointConnections,omitempty"`
+	PublicNetworkAccess           *string                              `json:"publicNetworkAccess,omitempty"`
+	RegionDetails                 *[]RegistryRegionArmDetails          `json:"regionDetails,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/registrymanagement/model_registryprivateendpointconnection.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/registrymanagement/model_registryprivateendpointconnection.go
@@ -1,0 +1,10 @@
+package registrymanagement
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RegistryPrivateEndpointConnection struct {
+	Id         *string                                      `json:"id,omitempty"`
+	Location   *string                                      `json:"location,omitempty"`
+	Properties *RegistryPrivateEndpointConnectionProperties `json:"properties,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/registrymanagement/model_registryprivateendpointconnectionproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/registrymanagement/model_registryprivateendpointconnectionproperties.go
@@ -1,0 +1,11 @@
+package registrymanagement
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RegistryPrivateEndpointConnectionProperties struct {
+	GroupIds                          *[]string                                  `json:"groupIds,omitempty"`
+	PrivateEndpoint                   *PrivateEndpointResource                   `json:"privateEndpoint,omitempty"`
+	PrivateLinkServiceConnectionState *RegistryPrivateLinkServiceConnectionState `json:"privateLinkServiceConnectionState,omitempty"`
+	ProvisioningState                 *string                                    `json:"provisioningState,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/registrymanagement/model_registryprivatelinkserviceconnectionstate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/registrymanagement/model_registryprivatelinkserviceconnectionstate.go
@@ -1,0 +1,10 @@
+package registrymanagement
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RegistryPrivateLinkServiceConnectionState struct {
+	ActionsRequired *string                          `json:"actionsRequired,omitempty"`
+	Description     *string                          `json:"description,omitempty"`
+	Status          *EndpointServiceConnectionStatus `json:"status,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/registrymanagement/model_registryregionarmdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/registrymanagement/model_registryregionarmdetails.go
@@ -1,0 +1,10 @@
+package registrymanagement
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RegistryRegionArmDetails struct {
+	AcrDetails            *[]AcrDetails            `json:"acrDetails,omitempty"`
+	Location              *string                  `json:"location,omitempty"`
+	StorageAccountDetails *[]StorageAccountDetails `json:"storageAccountDetails,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/registrymanagement/model_registrytrackedresource.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/registrymanagement/model_registrytrackedresource.go
@@ -1,0 +1,22 @@
+package registrymanagement
+
+import (
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/identity"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/systemdata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RegistryTrackedResource struct {
+	Id         *string                                  `json:"id,omitempty"`
+	Identity   *identity.LegacySystemAndUserAssignedMap `json:"identity,omitempty"`
+	Kind       *string                                  `json:"kind,omitempty"`
+	Location   string                                   `json:"location"`
+	Name       *string                                  `json:"name,omitempty"`
+	Properties Registry                                 `json:"properties"`
+	Sku        *Sku                                     `json:"sku,omitempty"`
+	SystemData *systemdata.SystemData                   `json:"systemData,omitempty"`
+	Tags       *map[string]string                       `json:"tags,omitempty"`
+	Type       *string                                  `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/registrymanagement/model_sku.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/registrymanagement/model_sku.go
@@ -1,0 +1,12 @@
+package registrymanagement
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type Sku struct {
+	Capacity *int64   `json:"capacity,omitempty"`
+	Family   *string  `json:"family,omitempty"`
+	Name     string   `json:"name"`
+	Size     *string  `json:"size,omitempty"`
+	Tier     *SkuTier `json:"tier,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/registrymanagement/model_storageaccountdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/registrymanagement/model_storageaccountdetails.go
@@ -1,0 +1,9 @@
+package registrymanagement
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type StorageAccountDetails struct {
+	SystemCreatedStorageAccount *SystemCreatedStorageAccount `json:"systemCreatedStorageAccount,omitempty"`
+	UserCreatedStorageAccount   *UserCreatedStorageAccount   `json:"userCreatedStorageAccount,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/registrymanagement/model_systemcreatedacraccount.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/registrymanagement/model_systemcreatedacraccount.go
@@ -1,0 +1,10 @@
+package registrymanagement
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SystemCreatedAcrAccount struct {
+	AcrAccountName *string        `json:"acrAccountName,omitempty"`
+	AcrAccountSku  *string        `json:"acrAccountSku,omitempty"`
+	ArmResourceId  *ArmResourceId `json:"armResourceId,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/registrymanagement/model_systemcreatedstorageaccount.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/registrymanagement/model_systemcreatedstorageaccount.go
@@ -1,0 +1,12 @@
+package registrymanagement
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SystemCreatedStorageAccount struct {
+	AllowBlobPublicAccess    *bool          `json:"allowBlobPublicAccess,omitempty"`
+	ArmResourceId            *ArmResourceId `json:"armResourceId,omitempty"`
+	StorageAccountHnsEnabled *bool          `json:"storageAccountHnsEnabled,omitempty"`
+	StorageAccountName       *string        `json:"storageAccountName,omitempty"`
+	StorageAccountType       *string        `json:"storageAccountType,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/registrymanagement/model_usercreatedacraccount.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/registrymanagement/model_usercreatedacraccount.go
@@ -1,0 +1,8 @@
+package registrymanagement
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UserCreatedAcrAccount struct {
+	ArmResourceId *ArmResourceId `json:"armResourceId,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/registrymanagement/model_usercreatedstorageaccount.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/registrymanagement/model_usercreatedstorageaccount.go
@@ -1,0 +1,8 @@
+package registrymanagement
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UserCreatedStorageAccount struct {
+	ArmResourceId *ArmResourceId `json:"armResourceId,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/registrymanagement/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/registrymanagement/predicates.go
@@ -1,0 +1,37 @@
+package registrymanagement
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RegistryTrackedResourceOperationPredicate struct {
+	Id       *string
+	Kind     *string
+	Location *string
+	Name     *string
+	Type     *string
+}
+
+func (p RegistryTrackedResourceOperationPredicate) Matches(input RegistryTrackedResource) bool {
+
+	if p.Id != nil && (input.Id == nil || *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Kind != nil && (input.Kind == nil || *p.Kind != *input.Kind) {
+		return false
+	}
+
+	if p.Location != nil && *p.Location != input.Location {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil || *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil || *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/registrymanagement/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/registrymanagement/version.go
@@ -1,0 +1,12 @@
+package registrymanagement
+
+import "fmt"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2023-04-01"
+
+func userAgent() string {
+	return fmt.Sprintf("hashicorp/go-azure-sdk/registrymanagement/%s", defaultApiVersion)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -534,6 +534,7 @@ github.com/hashicorp/go-azure-sdk/resource-manager/logz/2020-10-01/subaccount
 github.com/hashicorp/go-azure-sdk/resource-manager/logz/2020-10-01/tagrules
 github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/datastore
 github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/machinelearningcomputes
+github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/registrymanagement
 github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01/workspaces
 github.com/hashicorp/go-azure-sdk/resource-manager/maintenance/2022-07-01-preview/configurationassignments
 github.com/hashicorp/go-azure-sdk/resource-manager/maintenance/2022-07-01-preview/maintenanceconfigurations

--- a/website/docs/r/machine_learning_registry.html.markdown
+++ b/website/docs/r/machine_learning_registry.html.markdown
@@ -1,0 +1,180 @@
+---
+subcategory: "Machine Learning"
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_machine_learning_registry"
+description: |-
+  Manages a Machine Learning Registry.
+---
+
+# azurerm_machine_learning_registry
+
+Manages a Machine Learning Registry.
+
+## Example Usage
+
+```hcl
+resource "azurerm_resource_group" "example" {
+  name     = "rg-example"
+  location = "WestEurope"
+}
+
+
+resource "azurerm_machine_learning_registry" "example" {
+  location            = "WestEurope"
+  resource_group_name = azurerm_resource_group.example.name
+  name                = "mlr-example"
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  public_network_access_enabled = true
+
+  region_details {
+    location = "WestEurope"
+    storage_account_details {
+      system_created_storage_account {
+        storage_account_type = "Standard_LRS"
+      }
+    }
+
+    acr_details {
+      system_created_acr_account {
+        acr_account_sku = "Premium"
+      }
+    }
+  }
+
+  region_details {
+    location = "EastUS2"
+    storage_account_details {
+      system_created_storage_account {
+        storage_account_type = "Standard_LRS"
+      }
+    }
+
+    acr_details {
+      system_created_acr_account {
+        acr_account_sku = "Premium"
+      }
+    }
+  }
+
+  tags = {
+    key = "example"
+  }
+}
+```
+
+## Arguments Reference
+
+The following arguments are supported:
+
+* `location` - (Required) The Azure Region where the Machine Learning Registry should exist. Changing this forces a new Machine Learning Registry to be created.
+
+* `name` - (Required) The name which should be used for this Machine Learning Registry. Changing this forces a new Machine Learning Registry to be created.
+
+* `region_details` - (Required) One or more `region_details` blocks as defined below. Changing this forces a new Machine Learning Registry to be created.
+
+* `resource_group_name` - (Required) The name of the Resource Group where the Machine Learning Registry should exist. Changing this forces a new Machine Learning Registry to be created.
+
+---
+
+* `identity` - (Optional) A `identity` block as defined below. Changing this forces a new Machine Learning Registry to be created.
+
+* `public_network_access_enabled` - (Optional) Should the public network access be enabled? Defaults to `false`. Changing this forces a new Machine Learning Registry to be created.
+
+* `tags` - (Optional) A mapping of tags which should be assigned to the Machine Learning Registry.
+
+---
+
+A `acr_details` block supports the following:
+
+* `system_created_acr_account` - (Optional) One or more `system_created_acr_account` blocks as defined below.
+
+* `user_created_acr_account` - (Optional) One or more `user_created_acr_account` blocks as defined below.
+
+---
+
+A `identity` block supports the following:
+
+* `type` - (Required) Specifies the type of Managed Service Identity. Possible values are `SystemAssigned`, `UserAssigned`. Changing this forces a new resource to be created.
+
+* `identity_ids` - (Optional) Specifies the list of User Assigned Managed Service Identity IDs which should be assigned to this Machine Learning Registry. Changing this forces a new Machine Learning Registry to be created.
+
+---
+
+A `region_details` block supports the following:
+
+* `location` - (Required) The Azure Region where the Machine Learning Registry should exist.
+
+* `acr_details` - (Optional) One or more `acr_details` blocks as defined above.
+
+* `storage_account_details` - (Optional) One or more `storage_account_details` blocks as defined below.
+
+---
+
+A `storage_account_details` block supports the following:
+
+* `system_created_storage_account` - (Optional) One or more `system_created_storage_account` blocks as defined below.
+
+* `user_created_storage_account` - (Optional) One or more `user_created_storage_account` blocks as defined below.
+
+---
+
+A `system_created_acr_account` block supports the following:
+
+* `acr_account_sku` - (Optional) The SKU of the ACR account. The only possible value is `Premium`.
+
+---
+
+A `system_created_storage_account` block supports the following:
+
+* `blob_public_access_allowed` - (Optional) Whether public blob access allowed. Defaults to `false`.
+
+* `storage_account_hns_enabled` - (Optional) Should the HNS be enabled for storage account? Defaults to `false`.
+
+* `storage_account_type` - (Optional) Specify the storage account type. Possible values are `Standard_LRS`, `Standard_GRS`, `Standard_RAGRS`, `Standard_ZRS`, `Standard_GZRS`, `Standard_RAGZRS`, `Premium_LRS` and `Premium_ZRS`.
+
+---
+
+A `user_created_acr_account` block supports the following:
+
+* `arm_resource_id` - (Optional) The ID of the user created ACR account.
+
+---
+
+A `user_created_storage_account` block supports the following:
+
+* `arm_resource_id` - (Optional) The ID of the user created ACR account.
+
+## Attributes Reference
+
+In addition to the Arguments listed above - the following Attributes are exported: 
+
+* `id` - The ID of the Machine Learning Registry.
+
+* `discovery_url` - The discovery URL for this Registry.
+
+* `intellectual_property_publisher` - The intellectual property publisher.
+
+* `managed_resource_group` -The resource ID of the managed resource group if the Registry has system created resources.
+
+* `ml_flow_registry_uri` - The MLFlow registry URI for this registry.
+
+## Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
+
+* `create` - (Defaults to 30 minutes) Used when creating the Machine Learning Registry.
+* `read` - (Defaults to 5 minutes) Used when retrieving the Machine Learning Registry.
+* `update` - (Defaults to 30 minutes) Used when updating the Machine Learning Registry.
+* `delete` - (Defaults to 10 minutes) Used when deleting the Machine Learning Registry.
+
+## Import
+
+Machine Learning Registries can be imported using the `resource id`, e.g.
+
+```shell
+terraform import azurerm_machine_learning_registry.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.MachineLearningServices/registries/reg1
+```


### PR DESCRIPTION
**Draft for swagger API Issue**

Fixes #22565

there is a [cache inconsistency issue](https://github.com/Azure/azure-rest-api-specs/issues/25200) in the UPDATE, <del>so it may still read the old value after updating the `tags` field. but only the tags field can be updated. is this acceptable for this resource?</del>

there are eventually consistency issues in Update/RemoveRegions API. This resource can be merged once the issue addressed by service team. I have reach out to service team but I am still waiting for their response.

```
--- PASS: TestAccMachineLearningRegistry_basic (795.53s)
--- PASS: TestAccMachineLearningRegistry_complete (843.55s)
--- PASS: TestAccMachineLearningRegistry_update (989.24s)
```