### PR TITLE
`azurerm_iothub_dps` - fix casing of possible values for `ip_filter_rule.target`

### DIFF
--- a/internal/services/iothub/iothub_dps_resource.go
+++ b/internal/services/iothub/iothub_dps_resource.go
@@ -152,9 +152,9 @@ func resourceIotHubDPS() *pluginsdk.Resource {
 							Type:     pluginsdk.TypeString,
 							Optional: true,
 							ValidateFunc: validation.StringInSlice([]string{
-								azure.TitleCase(string(iotdpsresource.IPFilterTargetTypeAll)),
-								azure.TitleCase(string(iotdpsresource.IPFilterTargetTypeServiceApi)),
-								azure.TitleCase(string(iotdpsresource.IPFilterTargetTypeDeviceApi)),
+								string(iotdpsresource.IPFilterTargetTypeAll),
+								string(iotdpsresource.IPFilterTargetTypeServiceApi),
+								string(iotdpsresource.IPFilterTargetTypeDeviceApi),
 							}, false),
 						},
 					},
@@ -513,7 +513,7 @@ func expandDpsIPFilterRules(d *pluginsdk.ResourceData) *[]iotdpsresource.IPFilte
 
 	for _, r := range ipFilterRuleList {
 		rawRule := r.(map[string]interface{})
-		ipFilterTargetType := iotdpsresource.IPFilterTargetType(azure.TitleCase(rawRule["target"].(string)))
+		ipFilterTargetType := iotdpsresource.IPFilterTargetType(rawRule["target"].(string))
 		rule := &iotdpsresource.IPFilterRule{
 			FilterName: rawRule["name"].(string),
 			Action:     iotdpsresource.IPFilterActionType(rawRule["action"].(string)),

--- a/internal/services/iothub/iothub_dps_resource_test.go
+++ b/internal/services/iothub/iothub_dps_resource_test.go
@@ -135,11 +135,11 @@ func TestAccIotHubDPS_ipFilterRules(t *testing.T) {
 				check.That(data.ResourceName).Key("ip_filter_rule.0.name").HasValue("test"),
 				check.That(data.ResourceName).Key("ip_filter_rule.0.ip_mask").HasValue("10.0.0.0/31"),
 				check.That(data.ResourceName).Key("ip_filter_rule.0.action").HasValue("Accept"),
-				check.That(data.ResourceName).Key("ip_filter_rule.0.target").HasValue("All"),
+				check.That(data.ResourceName).Key("ip_filter_rule.0.target").HasValue("all"),
 				check.That(data.ResourceName).Key("ip_filter_rule.1.name").HasValue("test2"),
 				check.That(data.ResourceName).Key("ip_filter_rule.1.ip_mask").HasValue("10.0.2.0/31"),
 				check.That(data.ResourceName).Key("ip_filter_rule.1.action").HasValue("Accept"),
-				check.That(data.ResourceName).Key("ip_filter_rule.1.target").HasValue("ServiceApi"),
+				check.That(data.ResourceName).Key("ip_filter_rule.1.target").HasValue("serviceApi"),
 			),
 		},
 		{
@@ -149,11 +149,11 @@ func TestAccIotHubDPS_ipFilterRules(t *testing.T) {
 				check.That(data.ResourceName).Key("ip_filter_rule.0.name").HasValue("test"),
 				check.That(data.ResourceName).Key("ip_filter_rule.0.ip_mask").HasValue("10.0.0.0/31"),
 				check.That(data.ResourceName).Key("ip_filter_rule.0.action").HasValue("Reject"),
-				check.That(data.ResourceName).Key("ip_filter_rule.0.target").HasValue("All"),
+				check.That(data.ResourceName).Key("ip_filter_rule.0.target").HasValue("all"),
 				check.That(data.ResourceName).Key("ip_filter_rule.1.name").HasValue("test2"),
 				check.That(data.ResourceName).Key("ip_filter_rule.1.ip_mask").HasValue("10.0.2.0/31"),
 				check.That(data.ResourceName).Key("ip_filter_rule.1.action").HasValue("Reject"),
-				check.That(data.ResourceName).Key("ip_filter_rule.1.target").HasValue("DeviceApi"),
+				check.That(data.ResourceName).Key("ip_filter_rule.1.target").HasValue("deviceApi"),
 				check.That(data.ResourceName).Key("public_network_access_enabled").HasValue("false"),
 			),
 		},
@@ -414,14 +414,14 @@ resource "azurerm_iothub_dps" "test" {
     name    = "test"
     ip_mask = "10.0.0.0/31"
     action  = "Accept"
-    target  = "All"
+    target  = "all"
   }
 
   ip_filter_rule {
     name    = "test2"
     ip_mask = "10.0.2.0/31"
     action  = "Accept"
-    target  = "ServiceApi"
+    target  = "serviceApi"
   }
 
   ip_filter_rule {
@@ -459,14 +459,14 @@ resource "azurerm_iothub_dps" "test" {
     name    = "test"
     ip_mask = "10.0.0.0/31"
     action  = "Reject"
-    target  = "All"
+    target  = "all"
   }
 
   ip_filter_rule {
     name    = "test2"
     ip_mask = "10.0.2.0/31"
     action  = "Reject"
-    target  = "DeviceApi"
+    target  = "deviceApi"
   }
 
   ip_filter_rule {

--- a/website/docs/r/iothub_dps.html.markdown
+++ b/website/docs/r/iothub_dps.html.markdown
@@ -87,7 +87,7 @@ An `ip_filter_rule` block supports the following:
 
 * `action` - (Required) The desired action for requests captured by this rule. Possible values are `Accept`, `Reject`
 
-* `target` - (Optional) Target for requests captured by this rule. Possible values are `All`, `DeviceApi` and `ServiceApi`.
+* `target` - (Optional) Target for requests captured by this rule. Possible values are `all`, `deviceApi` and `serviceApi`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
this resource started using new base layer https://github.com/hashicorp/pandora/pull/2821 which normalizes the returned enum to the one specified in the [swagger](https://github.com/Azure/azure-rest-api-specs/blob/d3edca94ae4ddb854e88142cba6a7337ef1a5eed/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/stable/2022-02-05/iotdps.json#L1977-L1982)
Now the casing matches the swagger, however tests and documents are still with old values:
```
=== CONT  TestAccIotHubDPS_ipFilterRules
    testcase.go:113: Step 1/3 error: Check failed: Check 10/14 error: azurerm_iothub_dps.test: Attribute 'ip_filter_rule.0.target' expected "All", got "all"
```

updating them to the correct values