### PR TITLE
`lint` fix website lint

### DIFF
--- a/website/docs/r/palo_alto_local_rulestack_fqdn_list.html.markdown
+++ b/website/docs/r/palo_alto_local_rulestack_fqdn_list.html.markdown
@@ -25,10 +25,10 @@ resource "azurerm_palo_alto_local_rulestack" "example" {
 }
 
 resource "azurerm_palo_alto_local_rulestack_fqdn_list" "example" {
-  name          = "example"
+  name         = "example"
   rulestack_id = azurerm_palo_alto_local_rulestack.example.id
-  
-  fully_qualified_domain_names = [ "contoso.com" ]
+
+  fully_qualified_domain_names = ["contoso.com"]
 }
 ```
 

--- a/website/docs/r/palo_alto_local_rulestack_prefix_list.html.markdown
+++ b/website/docs/r/palo_alto_local_rulestack_prefix_list.html.markdown
@@ -27,7 +27,7 @@ resource "azurerm_palo_alto_local_rulestack" "example" {
 resource "azurerm_palo_alto_local_rulestack_prefix_list" "example" {
   name         = "example"
   rulestack_id = azurerm_palo_alto_local_rulestack.example.id
-  prefix_list  = [ "10.0.1.0/24" ]
+  prefix_list  = ["10.0.1.0/24"]
 }
 ```
 

--- a/website/docs/r/palo_alto_local_rulestack_rule.html.markdown
+++ b/website/docs/r/palo_alto_local_rulestack_rule.html.markdown
@@ -25,11 +25,11 @@ resource "azurerm_palo_alto_local_rulestack" "example" {
 }
 
 resource "azurerm_palo_alto_local_rulestack_rule" "example" {
-  name          = "example-rule"
+  name         = "example-rule"
   rulestack_id = azurerm_palo_alto_local_rulestack.example.id
-  priority      = 1000
-  
-  applications  = ["any"]
+  priority     = 1000
+
+  applications = ["any"]
 
   source {
     cidrs = ["10.0.0.0/8"]

--- a/website/docs/r/palo_alto_network_virtual_appliance.html.markdown
+++ b/website/docs/r/palo_alto_network_virtual_appliance.html.markdown
@@ -30,7 +30,7 @@ resource "azurerm_virtual_hub" "example" {
   location            = azurerm_resource_group.example.location
   virtual_wan_id      = azurerm_virtual_wan.example.id
   address_prefix      = "10.0.0.0/23"
-  
+
   tags = {
     "hubSaaSPreview" = "true"
   }

--- a/website/docs/r/palo_alto_next_generation_firewall_vhub_local_rulestack.html.markdown
+++ b/website/docs/r/palo_alto_next_generation_firewall_vhub_local_rulestack.html.markdown
@@ -19,9 +19,9 @@ resource "azurerm_palo_alto_next_generation_firewall_virtual_hub_local_rulestack
   rulestack_id        = "TODO"
 
   network_profile {
-    virtual_hub_id = "TODO"
+    virtual_hub_id               = "TODO"
     network_virtual_appliance_id = "TODO"
-    public_ip_address_ids = [ "example" ]
+    public_ip_address_ids        = ["example"]
   }
 }
 ```

--- a/website/docs/r/palo_alto_next_generation_firewall_vhub_panorama.html.markdown
+++ b/website/docs/r/palo_alto_next_generation_firewall_vhub_panorama.html.markdown
@@ -58,11 +58,11 @@ resource "azurerm_palo_alto_next_generation_firewall_vhub_panorama" "example" {
   location            = azurerm_resource_group.example.location
 
   network_profile {
-    public_ip_address_ids                = [ azurerm_public_ip.example.id ]
+    public_ip_address_ids        = [azurerm_public_ip.example.id]
     virtual_hub_id               = azurerm_virtual_hub.example.id
-    network_virtual_appliance_id = azurerm_palo_alto_virtual_network_appliance.example.id    
+    network_virtual_appliance_id = azurerm_palo_alto_virtual_network_appliance.example.id
   }
-  
+
   panorama_base64_config = "VGhpcyBpcyBub3QgYSByZWFsIGNvbmZpZywgcGxlYXNlIHVzZSB5b3VyIFBhbm9yYW1hIHNlcnZlciB0byBnZW5lcmF0ZSBhIHJlYWwgdmFsdWUgZm9yIHRoaXMgcHJvcGVydHkhCg=="
 }
 ```

--- a/website/docs/r/palo_alto_next_generation_firewall_virtual_network_local_rulestack.html.markdown
+++ b/website/docs/r/palo_alto_next_generation_firewall_virtual_network_local_rulestack.html.markdown
@@ -44,7 +44,7 @@ resource "azurerm_virtual_network" "example" {
 }
 
 resource "azurerm_subnet" "trust" {
-  name                 = "exmaple-trust-subnet"
+  name                 = "example-trust-subnet"
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
   address_prefixes     = ["10.0.1.0/24"]
@@ -96,7 +96,7 @@ resource "azurerm_palo_alto_local_rulestack" "example" {
 }
 
 resource "azurerm_palo_alto_local_rulestack_rule" "example" {
-  name         = "exmaple-rulestack-rule"
+  name         = "example-rulestack-rule"
   rulestack_id = azurerm_palo_alto_local_rulestack.example.id
   priority     = 1001
   action       = "Allow"

--- a/website/docs/r/palo_alto_next_generation_firewall_virtual_network_panorama.html.markdown
+++ b/website/docs/r/palo_alto_next_generation_firewall_virtual_network_panorama.html.markdown
@@ -44,7 +44,7 @@ resource "azurerm_virtual_network" "example" {
 }
 
 resource "azurerm_subnet" "trust" {
-  name                 = "exmaple-trust-subnet"
+  name                 = "example-trust-subnet"
   resource_group_name  = azurerm_resource_group.example.name
   virtual_network_name = azurerm_virtual_network.example.name
   address_prefixes     = ["10.0.1.0/24"]
@@ -96,13 +96,13 @@ resource "azurerm_palo_alto_next_generation_firewall_virtual_network_panorama" "
   panorama_base64_config = "e2RnbmFtZTogY25nZnctYXotZXhhbXBsZSwgdHBsbmFtZTogY25nZnctZXhhbXBsZS10ZW1wbGF0ZS1zdGFjaywgZXhhbXBsZS1wYW5vcmFtYS1zZXJ2ZXI6IDE5Mi4xNjguMC4xLCB2bS1hdXRoLWtleTogMDAwMDAwMDAwMDAwMDAwLCBleHBpcnk6IDIwMjQvMDcvMzF9Cg=="
 
   network_profile {
-    public_ip_address_ids = [ azurerm_public_ip.example.id ]
+    public_ip_address_ids = [azurerm_public_ip.example.id]
 
     vnet_configuration {
       virtual_network_id  = azurerm_virtual_network.example.id
       trusted_subnet_id   = azurerm_subnet.trust.id
       untrusted_subnet_id = azurerm_subnet.untrust.id
-    }    
+    }
   }
 }
 ```


### PR DESCRIPTION
```
==> Checking documentation spelling...
website/docs/r/palo_alto_next_generation_firewall_virtual_network_local_rulestack.html.markdown:47:2[6](https://github.com/hashicorp/terraform-provider-azurerm/actions/runs/5818883739/job/15776175732?pr=22808#step:6:7): "exmaple" is a misspelling of "example"
website/docs/r/palo_alto_next_generation_firewall_virtual_network_local_rulestack.html.markdown:99:18: "exmaple" is a misspelling of "example"
website/docs/r/palo_alto_next_generation_firewall_virtual_network_panorama.html.markdown:4[7](https://github.com/hashicorp/terraform-provider-azurerm/actions/runs/5818883739/job/15776175732?pr=22808#step:6:8):26: "exmaple" is a misspelling of "example"
make: *** [GNUmakefile:114: website-lint] Error 2
Error: Process completed with exit code 2.
```
```
==> Checking documentation terraform blocks are formatted...
./website/docs/r/palo_alto_network_virtual_appliance.html.markdown:15
./website/docs/r/palo_alto_next_generation_firewall_virtual_network_panorama.html.markdown:15
./website/docs/r/palo_alto_next_generation_firewall_vhub_panorama.html.markdown:15
./website/docs/r/palo_alto_next_generation_firewall_vhub_local_rulestack.html.markdown:15
./website/docs/r/palo_alto_local_rulestack_fqdn_list.html.markdown:15
./website/docs/r/palo_alto_local_rulestack_rule.html.markdown:15
./website/docs/r/palo_alto_local_rulestack_prefix_list.html.markdown:15
```