### PR TITLE
`postgresql_database` - Support for `collation` `en-GB`

### DIFF
--- a/internal/services/postgres/validate/postgresql_database_collation.go
+++ b/internal/services/postgres/validate/postgresql_database_collation.go
@@ -21,6 +21,7 @@ func PostgresqlDatabaseCollation(v interface{}, k string) (warnings []string, er
 		"En-US":                      true,
 		"POSIX":                      true,
 		"en-US":                      true,
+		"en-GB":                      true,
 		"aa":                         true,
 		"aa.utf8":                    true,
 		"aa_DJ":                      true,


### PR DESCRIPTION
We got this error after upgrading the provider:
```
Error: collation contains unknown collation en-GB
with module.db-v11.azurerm_postgresql_database.postgres-db,
on .terraform/modules/db-v11/main.tf line 58, in resource "azurerm_postgresql_database" "postgres-db":
```

We tried changing it to en_GB but got this:

```hcl
  # module.db-v11.azurerm_postgresql_database.postgres-db must be replaced
-/+ resource "azurerm_postgresql_database" "postgres-db" {
      ~ charset             = "UTF8" -> "utf8"
      ~ collation           = "en-GB" -> "en_GB" # forces replacement
      ~ id                  = "/subscriptions/1c4f0704-a29e-403d-b719-b90c34ef14c9/resourceGroups/probatemandb-postgres-db-v11-data-aat/providers/Microsoft.DBforPostgreSQL/servers/probatemandb-postgres-db-v11-aat/databases/probatemandb" -> (known after apply)
        name                = "probatemandb"
        # (2 unchanged attributes hidden)
    }

Plan: 1 to add, 0 to change, 1 to destroy.
```

cc @neil-yechenwei @tombuildsstuff

Caused by: https://github.com/hashicorp/terraform-provider-azurerm/pull/22689
