### PR TITLE
`azurerm_virtual_network_gateway_connection` - `custom_bgp_addresses.secondary` is now `Optional` rather than `Required`

### DIFF
--- a/internal/services/network/virtual_network_gateway_connection_resource.go
+++ b/internal/services/network/virtual_network_gateway_connection_resource.go
@@ -495,11 +495,8 @@ func resourceVirtualNetworkGatewayConnectionRead(d *pluginsdk.ResourceData, meta
 		d.Set("shared_key", conn.SharedKey)
 	}
 
-	if conn.GatewayCustomBgpIPAddresses != nil {
-		adresses := flattenGatewayCustomBgpIPAddresses(conn.GatewayCustomBgpIPAddresses)
-		if err := d.Set("custom_bgp_addresses", adresses); err != nil {
-			return fmt.Errorf("setting `custom_bgp_addresses`: %+v", err)
-		}
+	if err := d.Set("custom_bgp_addresses", flattenGatewayCustomBgpIPAddresses(conn.GatewayCustomBgpIPAddresses)); err != nil {
+		return fmt.Errorf("setting `custom_bgp_addresses`: %+v", err)
 	}
 
 	d.Set("connection_protocol", string(conn.ConnectionProtocol))
@@ -855,8 +852,11 @@ func flattenVirtualNetworkGatewayConnectionIpsecPolicies(ipsecPolicies *[]networ
 
 func flattenGatewayCustomBgpIPAddresses(gatewayCustomBgpIPAddresses *[]network.GatewayCustomBgpIPAddressIPConfiguration) interface{} {
 	customBgpIpAddresses := make([]interface{}, 0)
-	customBgpIpAddress := map[string]interface{}{}
+	if gatewayCustomBgpIPAddresses == nil || len(*gatewayCustomBgpIPAddresses) == 0 {
+		return customBgpIpAddresses
+	}
 
+	customBgpIpAddress := map[string]interface{}{}
 	for k, v := range *gatewayCustomBgpIPAddresses {
 		if k == 0 && v.CustomBgpIPAddress != nil {
 			customBgpIpAddress["primary"] = *v.CustomBgpIPAddress

--- a/internal/services/network/virtual_network_gateway_connection_resource.go
+++ b/internal/services/network/virtual_network_gateway_connection_resource.go
@@ -805,8 +805,8 @@ func expandGatewayCustomBgpIPAddresses(d *pluginsdk.ResourceData, bgpPeeringAddr
 		}
 	}
 
-	if len(primaryIpConfiguration) == 0 && len(secondaryIpConfiguration) == 0 {
-		return &customBgpIpAddresses, fmt.Errorf("primary and secondary address not found at `virtual_network_gateway` configuration `bgp_settings` `peering_addresses`")
+	if len(primaryIpConfiguration) == 0 || (secondaryAddress != "" && len(secondaryIpConfiguration) == 0) {
+		return &customBgpIpAddresses, fmt.Errorf("primary or secondary address not found at `virtual_network_gateway` configuration `bgp_settings` `peering_addresses`")
 	}
 
 	customBgpIpAddresses = append(customBgpIpAddresses, network.GatewayCustomBgpIPAddressIPConfiguration{

--- a/internal/services/network/virtual_network_gateway_connection_resource_test.go
+++ b/internal/services/network/virtual_network_gateway_connection_resource_test.go
@@ -236,6 +236,21 @@ func TestAccVirtualNetworkGatewayConnection_useCustomBgpAddresses(t *testing.T) 
 	})
 }
 
+func TestAccVirtualNetworkGatewayConnection_primaryCustomBgpAddress(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_virtual_network_gateway_connection", "test")
+	r := VirtualNetworkGatewayConnectionResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.primaryCustomBgpAddress(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccVirtualNetworkGatewayConnection_natRuleIds(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_virtual_network_gateway_connection", "test")
 	r := VirtualNetworkGatewayConnectionResource{}
@@ -1373,4 +1388,105 @@ resource "azurerm_virtual_network_gateway_connection" "test" {
   ingress_nat_rule_ids = [azurerm_virtual_network_gateway_nat_rule.test2.id]
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
+}
+
+func (VirtualNetworkGatewayConnectionResource) primaryCustomBgpAddress(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-vnetgwconn-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvn-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  address_space       = ["10.1.0.0/16"]
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "GatewaySubnet"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.1.1.0/24"]
+}
+
+resource "azurerm_public_ip" "test" {
+  name                = "acctestip-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+}
+
+resource "azurerm_virtual_network_gateway" "test" {
+  name                = "acctestgw-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  type                       = "Vpn"
+  vpn_type                   = "RouteBased"
+  enable_bgp                 = true
+  active_active              = true
+  private_ip_address_enabled = false
+  sku                        = "VpnGw2"
+  generation                 = "Generation2"
+
+  ip_configuration {
+    name                          = "default"
+    public_ip_address_id          = azurerm_public_ip.test.id
+    private_ip_address_allocation = "Dynamic"
+    subnet_id                     = azurerm_subnet.test.id
+  }
+
+  bgp_settings {
+    asn = "65000"
+
+    peering_addresses {
+      ip_configuration_name = "default"
+      apipa_addresses = [
+        "169.254.21.2",
+        "169.254.22.2"
+      ]
+    }
+  }
+}
+
+resource "azurerm_local_network_gateway" "test" {
+  name                = "acctestlgw-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  gateway_address = "168.62.225.23"
+
+  bgp_settings {
+    asn                 = "64512"
+    bgp_peering_address = "169.254.21.1"
+  }
+}
+
+resource "azurerm_virtual_network_gateway_connection" "test" {
+  name                           = "acctestgwc-%d"
+  location                       = azurerm_resource_group.test.location
+  resource_group_name            = azurerm_resource_group.test.name
+  local_azure_ip_address_enabled = false
+
+  type                       = "IPsec"
+  virtual_network_gateway_id = azurerm_virtual_network_gateway.test.id
+  local_network_gateway_id   = azurerm_local_network_gateway.test.id
+  dpd_timeout_seconds        = 30
+
+  shared_key = "4-v3ry-53cr37-1p53c-5h4r3d-k3y"
+
+  enable_bgp = true
+
+  custom_bgp_addresses {
+    primary = "169.254.21.2"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger, data.RandomInteger)
 }

--- a/internal/services/network/virtual_network_gateway_connection_resource_test.go
+++ b/internal/services/network/virtual_network_gateway_connection_resource_test.go
@@ -1431,7 +1431,7 @@ resource "azurerm_virtual_network_gateway" "test" {
   type                       = "Vpn"
   vpn_type                   = "RouteBased"
   enable_bgp                 = true
-  active_active              = true
+  active_active              = false
   private_ip_address_enabled = false
   sku                        = "VpnGw2"
   generation                 = "Generation2"

--- a/website/docs/r/virtual_network_gateway_connection.html.markdown
+++ b/website/docs/r/virtual_network_gateway_connection.html.markdown
@@ -263,7 +263,7 @@ The following arguments are supported:
 The `custom_bgp_addresses` block supports:
 
 * `primary` - (Required) single IP address that is part of the `azurerm_virtual_network_gateway` ip_configuration (first one)
-* `secondary` - (Required) single IP address that is part of the `azurerm_virtual_network_gateway` ip_configuration (second one)
+* `secondary` - (Optional) single IP address that is part of the `azurerm_virtual_network_gateway` ip_configuration (second one)
 
 ---
 


### PR DESCRIPTION
fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/22885

![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/19754191/1fa20689-d7de-4798-81e6-23b15b907800)
