### PR TITLE
`azurerm_postgresql_server` : fix acc tests fail with context no deadline issue

### DIFF
--- a/internal/services/postgres/postgresql_server_resource.go
+++ b/internal/services/postgres/postgresql_server_resource.go
@@ -76,7 +76,10 @@ func resourcePostgreSQLServer() *pluginsdk.Resource {
 				return []*pluginsdk.ResourceData{d}, err
 			}
 
-			resp, err := client.Get(ctx, *id)
+			timeout, cancel := context.WithTimeout(ctx, 5*time.Minute)
+			defer cancel()
+
+			resp, err := client.Get(timeout, *id)
 			if err != nil {
 				return []*pluginsdk.ResourceData{d}, fmt.Errorf("reading %s: %+v", id, err)
 			}


### PR DESCRIPTION
Submit this PR to fix some tests in postgresql server RP failing due to context without deadline, see below for more details:

https://hashicorp.teamcity.com/buildConfiguration/TF_AzureRM_AZURERM_SERVICE_PUBLIC_POSTGRES/8377?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildTestsSection=true&expandBuildChangesSection=true


Submit this PR to fix some test cases in postgresql server RP failing due to context without deadline, see below for more details: