### PR TITLE
Update firewall_policy_rule_collection_group.html.markdown

### DIFF
--- a/website/docs/r/firewall_policy_rule_collection_group.html.markdown
+++ b/website/docs/r/firewall_policy_rule_collection_group.html.markdown
@@ -139,7 +139,7 @@ A `application_rule` (application rule) block supports the following:
 
 * `description` - (Optional) The description which should be used for this rule.
 
-* `protocols` - (Optional) One or more `protocols` blocks as defined below. Not required when specifying `destination_fqdn_tags`, but required when specifying `destination_fqdns`.
+* `protocols` - (Required) One or more `protocols` blocks as defined below.
 
 * `source_addresses` - (Optional) Specifies a list of source IP addresses (including CIDR, IP range and `*`).
 


### PR DESCRIPTION
Azure firewall returns a 500 error when attempting to create an application rule with fqdn tags but without protocol.
This bug is already logged here since Nov '21
https://github.com/hashicorp/terraform-provider-azurerm/issues/14099