### PR TITLE
`azurerm_storage_management_policy` - Add existance check

### DIFF
--- a/internal/services/storage/storage_management_policy_resource.go
+++ b/internal/services/storage/storage_management_policy_resource.go
@@ -10,7 +10,9 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2021-09-01/storage" // nolint: staticcheck
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -285,7 +287,21 @@ func resourceStorageManagementPolicyCreateOrUpdate(d *pluginsdk.ResourceData, me
 	// The name of the Storage Account Management Policy. It should always be 'default' (from https://docs.microsoft.com/en-us/rest/api/storagerp/managementpolicies/createorupdate)
 	mgmtPolicyId := parse.NewStorageAccountManagementPolicyID(rid.SubscriptionId, rid.ResourceGroupName, rid.StorageAccountName, "default")
 
-	// TODO: support Requires Import
+	if d.IsNewResource() {
+		// This lock is to protect the existance checking when two storage mgmt policies are being created at the same time.
+		locks.ByID(mgmtPolicyId.ID())
+		defer locks.UnlockByID(mgmtPolicyId.ID())
+
+		existing, err := client.Get(ctx, rid.ResourceGroupName, rid.StorageAccountName)
+		if err != nil {
+			if !utils.ResponseWasNotFound(existing.Response) {
+				return fmt.Errorf("checking for presence of existing %s: %s", mgmtPolicyId, err)
+			}
+		}
+		if !utils.ResponseWasNotFound(existing.Response) {
+			return tf.ImportAsExistsError("azurerm_storage_management_policy", mgmtPolicyId.ID())
+		}
+	}
 
 	parameters := storage.ManagementPolicy{
 		Name: &mgmtPolicyId.ManagementPolicyName,

--- a/internal/services/storage/storage_management_policy_resource.go
+++ b/internal/services/storage/storage_management_policy_resource.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/storage/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -288,10 +287,6 @@ func resourceStorageManagementPolicyCreateOrUpdate(d *pluginsdk.ResourceData, me
 	mgmtPolicyId := parse.NewStorageAccountManagementPolicyID(rid.SubscriptionId, rid.ResourceGroupName, rid.StorageAccountName, "default")
 
 	if d.IsNewResource() {
-		// This lock is to protect the existence checking when two storage mgmt policies are being created at the same time.
-		locks.ByID(mgmtPolicyId.ID())
-		defer locks.UnlockByID(mgmtPolicyId.ID())
-
 		existing, err := client.Get(ctx, rid.ResourceGroupName, rid.StorageAccountName)
 		if err != nil {
 			if !utils.ResponseWasNotFound(existing.Response) {

--- a/internal/services/storage/storage_management_policy_resource.go
+++ b/internal/services/storage/storage_management_policy_resource.go
@@ -288,7 +288,7 @@ func resourceStorageManagementPolicyCreateOrUpdate(d *pluginsdk.ResourceData, me
 	mgmtPolicyId := parse.NewStorageAccountManagementPolicyID(rid.SubscriptionId, rid.ResourceGroupName, rid.StorageAccountName, "default")
 
 	if d.IsNewResource() {
-		// This lock is to protect the existance checking when two storage mgmt policies are being created at the same time.
+		// This lock is to protect the existence checking when two storage mgmt policies are being created at the same time.
 		locks.ByID(mgmtPolicyId.ID())
 		defer locks.UnlockByID(mgmtPolicyId.ID())
 

--- a/internal/services/storage/storage_management_policy_resource_test.go
+++ b/internal/services/storage/storage_management_policy_resource_test.go
@@ -46,7 +46,7 @@ func TestAccStorageManagementPolicy_basic(t *testing.T) {
 	})
 }
 
-func TestAccStorageManagementPolicy_requiersImport(t *testing.T) {
+func TestAccStorageManagementPolicy_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_storage_management_policy", "test")
 	r := StorageManagementPolicyResource{}
 

--- a/internal/services/storage/storage_management_policy_resource_test.go
+++ b/internal/services/storage/storage_management_policy_resource_test.go
@@ -46,6 +46,21 @@ func TestAccStorageManagementPolicy_basic(t *testing.T) {
 	})
 }
 
+func TestAccStorageManagementPolicy_requiersImport(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_storage_management_policy", "test")
+	r := StorageManagementPolicyResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.RequiresImportErrorStep(r.requiresImport),
+	})
+}
+
 func TestAccStorageManagementPolicy_singleAction(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_storage_management_policy", "test")
 	r := StorageManagementPolicyResource{}
@@ -470,6 +485,16 @@ resource "azurerm_storage_management_policy" "test" {
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}
+
+func (r StorageManagementPolicyResource) requiresImport(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_storage_management_policy" "import" {
+  storage_account_id = azurerm_storage_management_policy.test.storage_account_id
+}
+`, r.basic(data))
 }
 
 func (r StorageManagementPolicyResource) singleAction(data acceptance.TestData) string {


### PR DESCRIPTION
The concern is whether the lock here is necessary, as if that is the case, then I believe almost all of the existing resources should add that. But at least, it is needed for the use case in #18583.

Fix #18583 

## Test

```shell
💤  TF_ACC=1 go test -v -timeout=20h -run='TestAccStorageManagementPolicy_requiersImport' ./internal/services/storage
=== RUN   TestAccStorageManagementPolicy_requiersImport
=== PAUSE TestAccStorageManagementPolicy_requiersImport
=== CONT  TestAccStorageManagementPolicy_requiersImport
--- PASS: TestAccStorageManagementPolicy_requiersImport (152.71s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/storage       152.721s
```