### PR TITLE
[AccTest:] Datasource `azurerm_dns_soa_record` - fixes `TestAccDataSourceDnsSoaRecord_basic`

### DIFF
--- a/internal/services/dns/dns_soa_record_data_source_test.go
+++ b/internal/services/dns/dns_soa_record_data_source_test.go
@@ -54,7 +54,7 @@ resource "azurerm_dns_zone" "test" {
   resource_group_name = azurerm_resource_group.test.name
 
   soa_record {
-    email     = "testemail.com"
+    email = "testemail.com"
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)

--- a/internal/services/dns/dns_soa_record_data_source_test.go
+++ b/internal/services/dns/dns_soa_record_data_source_test.go
@@ -26,7 +26,6 @@ func TestAccDataSourceDnsSoaRecord_basic(t *testing.T) {
 				check.That(data.ResourceName).Key("fqdn").Exists(),
 				check.That(data.ResourceName).Key("name").HasValue("@"),
 				check.That(data.ResourceName).Key("email").HasValue("testemail.com"),
-				check.That(data.ResourceName).Key("host_name").HasValue("testhost.contoso.com"),
 				check.That(data.ResourceName).Key("expire_time").HasValue("2419200"),
 				check.That(data.ResourceName).Key("minimum_ttl").HasValue("300"),
 				check.That(data.ResourceName).Key("refresh_time").HasValue("3600"),
@@ -56,7 +55,6 @@ resource "azurerm_dns_zone" "test" {
 
   soa_record {
     email     = "testemail.com"
-    host_name = "testhost.contoso.com"
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)


### PR DESCRIPTION
`azurerm_dns_soa_record` - fix `TestAccDataSourceDnsSoaRecord_basic`

- according to https://learn.microsoft.com/en-us/azure/dns/dns-zones-records#soa-records, soa_record's hostname is no longer settable. So we need to remove this from datasource test. 
- Quote from resource `azurerm_dns_zone` https://github.com/hashicorp/terraform-provider-azurerm/blob/d20b0e86c867795775fbc882dc6bad627119e5e9/internal/services/dns/dns_zone_resource.go#L95

Testing evidence:

```
GOROOT=C:\Program Files\Go #gosetup
GOPATH=C:\Users\yunliu1\go #gosetup
"C:\Program Files\Go\bin\go.exe" test -c -o C:\Users\yunliu1\AppData\Local\JetBrains\GoLand2023.2\tmp\GoLand\___TestAccDataSourceDnsSoaRecord_basic_in_github_com_hashicorp_terraform_provider_azurerm_internal_services_dns.test.exe github.com/hashicorp/terraform-provider-azurerm/internal/services/dns #gosetup
"C:\Program Files\Go\bin\go.exe" tool test2json -t C:\Users\yunliu1\AppData\Local\JetBrains\GoLand2023.2\tmp\GoLand\___TestAccDataSourceDnsSoaRecord_basic_in_github_com_hashicorp_terraform_provider_azurerm_internal_services_dns.test.exe -test.v -test.paniconexit0 -test.run ^\QTestAccDataSourceDnsSoaRecord_basic\E$ #gosetup
=== RUN   TestAccDataSourceDnsSoaRecord_basic
=== PAUSE TestAccDataSourceDnsSoaRecord_basic
=== CONT  TestAccDataSourceDnsSoaRecord_basic
--- PASS: TestAccDataSourceDnsSoaRecord_basic (141.10s)
PASS


Process finished with the exit code 0
```