### PR TITLE
`azurerm_network_interface` - Support `auxiliary_mode`, `auxiliary_sku`

### DIFF
--- a/internal/services/network/network_interface_resource.go
+++ b/internal/services/network/network_interface_resource.go
@@ -132,9 +132,7 @@ func resourceNetworkInterface() *pluginsdk.Resource {
 				ValidateFunc: validation.StringInSlice([]string{
 					string(networkinterfaces.NetworkInterfaceAuxiliaryModeAcceleratedConnections),
 					string(networkinterfaces.NetworkInterfaceAuxiliaryModeFloating),
-					string(networkinterfaces.NetworkInterfaceAuxiliaryModeNone),
 				}, false),
-				Default:      string(networkinterfaces.NetworkInterfaceAuxiliaryModeNone),
 				RequiredWith: []string{"auxiliary_sku"},
 			},
 
@@ -146,9 +144,7 @@ func resourceNetworkInterface() *pluginsdk.Resource {
 					string(networkinterfaces.NetworkInterfaceAuxiliarySkuAFour),
 					string(networkinterfaces.NetworkInterfaceAuxiliarySkuAOne),
 					string(networkinterfaces.NetworkInterfaceAuxiliarySkuATwo),
-					string(networkinterfaces.NetworkInterfaceAuxiliarySkuNone),
 				}, false),
-				Default:      string(networkinterfaces.NetworkInterfaceAuxiliarySkuNone),
 				RequiredWith: []string{"auxiliary_mode"},
 			},
 
@@ -512,8 +508,19 @@ func resourceNetworkInterfaceRead(d *pluginsdk.ResourceData, meta interface{}) e
 				return fmt.Errorf("setting `applied_dns_servers`: %+v", err)
 			}
 
-			d.Set("auxiliary_mode", pointer.From(props.AuxiliaryMode))
-			d.Set("auxiliary_sku", pointer.From(props.AuxiliarySku))
+			auxiliaryMode := ""
+			if props.AuxiliaryMode != nil && *props.AuxiliaryMode != networkinterfaces.NetworkInterfaceAuxiliaryModeNone {
+				auxiliaryMode = string(*props.AuxiliaryMode)
+			}
+
+			d.Set("auxiliary_mode", auxiliaryMode)
+
+			auxiliarySku := ""
+			if props.AuxiliarySku != nil && *props.AuxiliarySku != networkinterfaces.NetworkInterfaceAuxiliarySkuNone {
+				auxiliarySku = string(*props.AuxiliarySku)
+			}
+
+			d.Set("auxiliary_sku", auxiliarySku)
 			d.Set("enable_ip_forwarding", props.EnableIPForwarding)
 			d.Set("enable_accelerated_networking", props.EnableAcceleratedNetworking)
 			d.Set("internal_dns_name_label", internalDnsNameLabel)

--- a/internal/services/network/network_interface_resource.go
+++ b/internal/services/network/network_interface_resource.go
@@ -126,6 +126,32 @@ func resourceNetworkInterface() *pluginsdk.Resource {
 			},
 
 			// Optional
+			"auxiliary_mode": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					string(networkinterfaces.NetworkInterfaceAuxiliaryModeAcceleratedConnections),
+					string(networkinterfaces.NetworkInterfaceAuxiliaryModeFloating),
+					string(networkinterfaces.NetworkInterfaceAuxiliaryModeNone),
+				}, false),
+				Default:      string(networkinterfaces.NetworkInterfaceAuxiliaryModeNone),
+				RequiredWith: []string{"auxiliary_sku"},
+			},
+
+			"auxiliary_sku": {
+				Type:     pluginsdk.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					string(networkinterfaces.NetworkInterfaceAuxiliarySkuAEight),
+					string(networkinterfaces.NetworkInterfaceAuxiliarySkuAFour),
+					string(networkinterfaces.NetworkInterfaceAuxiliarySkuAOne),
+					string(networkinterfaces.NetworkInterfaceAuxiliarySkuATwo),
+					string(networkinterfaces.NetworkInterfaceAuxiliarySkuNone),
+				}, false),
+				Default:      string(networkinterfaces.NetworkInterfaceAuxiliarySkuNone),
+				RequiredWith: []string{"auxiliary_mode"},
+			},
+
 			"dns_servers": {
 				Type:     pluginsdk.TypeList,
 				Optional: true,
@@ -232,6 +258,14 @@ func resourceNetworkInterfaceCreate(d *pluginsdk.ResourceData, meta interface{})
 	locks.ByName(id.NetworkInterfaceName, networkInterfaceResourceName)
 	defer locks.UnlockByName(id.NetworkInterfaceName, networkInterfaceResourceName)
 
+	if auxiliaryMode, hasAuxiliaryMode := d.GetOk("auxiliary_mode"); hasAuxiliaryMode {
+		properties.AuxiliaryMode = pointer.To(networkinterfaces.NetworkInterfaceAuxiliaryMode(auxiliaryMode.(string)))
+	}
+
+	if auxiliarySku, hasAuxiliarySku := d.GetOk("auxiliary_sku"); hasAuxiliarySku {
+		properties.AuxiliarySku = pointer.To(networkinterfaces.NetworkInterfaceAuxiliarySku(auxiliarySku.(string)))
+	}
+
 	dns, hasDns := d.GetOk("dns_servers")
 	nameLabel, hasNameLabel := d.GetOk("internal_dns_name_label")
 	if hasDns || hasNameLabel {
@@ -323,6 +357,22 @@ func resourceNetworkInterfaceUpdate(d *pluginsdk.ResourceData, meta interface{})
 			EnableAcceleratedNetworking: utils.Bool(d.Get("enable_accelerated_networking").(bool)),
 			DnsSettings:                 &networkinterfaces.NetworkInterfaceDnsSettings{},
 		},
+	}
+
+	if d.HasChange("auxiliary_mode") {
+		if auxiliaryMode, hasAuxiliaryMode := d.GetOk("auxiliary_mode"); hasAuxiliaryMode {
+			update.Properties.AuxiliaryMode = pointer.To(networkinterfaces.NetworkInterfaceAuxiliaryMode(auxiliaryMode.(string)))
+		}
+	} else {
+		update.Properties.AuxiliaryMode = existing.Model.Properties.AuxiliaryMode
+	}
+
+	if d.HasChange("auxiliary_sku") {
+		if auxiliarySku, hasAuxiliarySku := d.GetOk("auxiliary_sku"); hasAuxiliarySku {
+			update.Properties.AuxiliarySku = pointer.To(networkinterfaces.NetworkInterfaceAuxiliarySku(auxiliarySku.(string)))
+		}
+	} else {
+		update.Properties.AuxiliarySku = existing.Model.Properties.AuxiliarySku
 	}
 
 	if d.HasChange("dns_servers") {
@@ -462,6 +512,8 @@ func resourceNetworkInterfaceRead(d *pluginsdk.ResourceData, meta interface{}) e
 				return fmt.Errorf("setting `applied_dns_servers`: %+v", err)
 			}
 
+			d.Set("auxiliary_mode", pointer.From(props.AuxiliaryMode))
+			d.Set("auxiliary_sku", pointer.From(props.AuxiliarySku))
 			d.Set("enable_ip_forwarding", props.EnableIPForwarding)
 			d.Set("enable_accelerated_networking", props.EnableAcceleratedNetworking)
 			d.Set("internal_dns_name_label", internalDnsNameLabel)

--- a/internal/services/network/network_interface_resource.go
+++ b/internal/services/network/network_interface_resource.go
@@ -127,24 +127,16 @@ func resourceNetworkInterface() *pluginsdk.Resource {
 
 			// Optional
 			"auxiliary_mode": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(networkinterfaces.NetworkInterfaceAuxiliaryModeAcceleratedConnections),
-					string(networkinterfaces.NetworkInterfaceAuxiliaryModeFloating),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice(networkinterfaces.PossibleValuesForNetworkInterfaceAuxiliaryMode(), false),
 				RequiredWith: []string{"auxiliary_sku"},
 			},
 
 			"auxiliary_sku": {
-				Type:     pluginsdk.TypeString,
-				Optional: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					string(networkinterfaces.NetworkInterfaceAuxiliarySkuAEight),
-					string(networkinterfaces.NetworkInterfaceAuxiliarySkuAFour),
-					string(networkinterfaces.NetworkInterfaceAuxiliarySkuAOne),
-					string(networkinterfaces.NetworkInterfaceAuxiliarySkuATwo),
-				}, false),
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice(networkinterfaces.PossibleValuesForNetworkInterfaceAuxiliarySku(), false),
 				RequiredWith: []string{"auxiliary_mode"},
 			},
 

--- a/internal/services/network/network_interface_resource_test.go
+++ b/internal/services/network/network_interface_resource_test.go
@@ -44,6 +44,34 @@ func TestAccNetworkInterface_disappears(t *testing.T) {
 	})
 }
 
+func TestAccNetworkInterface_auxiliary(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_network_interface", "test")
+	r := NetworkInterfaceResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.auxiliary(data, "", ""),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.auxiliary(data, "AcceleratedConnections", "A2"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.auxiliary(data, "", ""),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccNetworkInterface_dnsServers(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_network_interface", "test")
 	r := NetworkInterfaceResource{}
@@ -386,6 +414,43 @@ resource "azurerm_network_interface" "test" {
   }
 }
 `, r.template(data), data.RandomInteger)
+}
+
+func (r NetworkInterfaceResource) auxiliary(data acceptance.TestData, mode string, sku string) string {
+	// Auxiliary Mode Nic is enabled in specific regions (https://learn.microsoft.com/en-us/azure/networking/nva-accelerated-connections#supported-regions) for now
+	// To not affect other testcases of `Network`, hard-code to that for now
+	data.Locations.Primary = "westus"
+
+	if mode != "" {
+		mode = fmt.Sprintf(`auxiliary_mode = "%s"`, mode)
+	}
+
+	if sku != "" {
+		sku = fmt.Sprintf(`auxiliary_sku = "%s"`, sku)
+	}
+
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_network_interface" "test" {
+  name                = "acctestni-%d"
+  location            = "%s"
+  resource_group_name = azurerm_resource_group.test.name
+  %s
+  %s
+  enable_accelerated_networking = true
+
+  ip_configuration {
+    name                          = "primary"
+    subnet_id                     = azurerm_subnet.test.id
+    private_ip_address_allocation = "Dynamic"
+  }
+
+  tags = {
+    fastpathenabled = "true"
+  }
+}
+`, r.template(data), data.RandomInteger, data.Locations.Primary, mode, sku)
 }
 
 func (r NetworkInterfaceResource) withMultipleParameters(data acceptance.TestData) string {

--- a/website/docs/r/network_interface.html.markdown
+++ b/website/docs/r/network_interface.html.markdown
@@ -60,9 +60,9 @@ The following arguments are supported:
 
 ---
 
-* `auxiliary_mode` - (Optional) The Auxiliary mode of the Network Interface. Possible values are `AcceleratedConnections` and `Floating`.
+* `auxiliary_mode` - (Optional) Specifies auxiliary mode for enabling [Accelerated Connections](https://learn.microsoft.com/en-us/azure/networking/nva-accelerated-connections) to improve networking performance. Possible values are `AcceleratedConnections` and `Floating`.
 
-* `auxiliary_sku` - (Optional) The Auxiliary SKU of the Network Interface. Possible values are `A1`, `A2`, `A4` and `A8`.
+* `auxiliary_sku` - (Optional) Specifies auxiliary SKU for tuning the performance of network connections. Possible values are `A1`, `A2`, `A4` and `A8`.
 
 -> **Note:** `auxiliary_mode` and `auxiliary_sku` require the preview feature is enabled. See the [Prerequisites](https://learn.microsoft.com/en-us/azure/networking/nva-accelerated-connections#prerequisites) for more details.
 

--- a/website/docs/r/network_interface.html.markdown
+++ b/website/docs/r/network_interface.html.markdown
@@ -60,11 +60,11 @@ The following arguments are supported:
 
 ---
 
-* `auxiliary_mode` - (Optional) The Auxiliary mode of the Network Interface. Possible values are `AcceleratedConnections`, `Floating` and `None`. Defaults to `None`.
+* `auxiliary_mode` - (Optional) The Auxiliary mode of the Network Interface. Possible values are `AcceleratedConnections` and `Floating`.
 
--> **Note:** This field requires the preview feature is enabled. See the [Prerequisites](https://learn.microsoft.com/en-us/azure/networking/nva-accelerated-connections#prerequisites) for more details.
+* `auxiliary_sku` - (Optional) The Auxiliary SKU of the Network Interface. Possible values are `A1`, `A2`, `A4` and `A8`.
 
-* `auxiliary_sku` - (Optional) The Auxiliary SKU of the Network Interface. Possible values are `A1`, `A2`, `A4`, `A8` and `None`. Defaults to `None`.
+-> **Note:** `auxiliary_mode` and `auxiliary_sku` require the preview feature is enabled. See the [Prerequisites](https://learn.microsoft.com/en-us/azure/networking/nva-accelerated-connections#prerequisites) for more details.
 
 * `dns_servers` - (Optional) A list of IP Addresses defining the DNS Servers which should be used for this Network Interface.
 

--- a/website/docs/r/network_interface.html.markdown
+++ b/website/docs/r/network_interface.html.markdown
@@ -60,6 +60,12 @@ The following arguments are supported:
 
 ---
 
+* `auxiliary_mode` - (Optional) The Auxiliary mode of the Network Interface. Possible values are `AcceleratedConnections`, `Floating` and `None`. Defaults to `None`.
+
+-> **Note:** This field requires the preview feature is enabled. See the [Prerequisites](https://learn.microsoft.com/en-us/azure/networking/nva-accelerated-connections#prerequisites) for more details.
+
+* `auxiliary_sku` - (Optional) The Auxiliary SKU of the Network Interface. Possible values are `A1`, `A2`, `A4`, `A8` and `None`. Defaults to `None`.
+
 * `dns_servers` - (Optional) A list of IP Addresses defining the DNS Servers which should be used for this Network Interface.
 
 -> **Note:** Configuring DNS Servers on the Network Interface will override the DNS Servers defined on the Virtual Network.

--- a/website/docs/r/network_interface.html.markdown
+++ b/website/docs/r/network_interface.html.markdown
@@ -60,11 +60,13 @@ The following arguments are supported:
 
 ---
 
-* `auxiliary_mode` - (Optional) Specifies auxiliary mode for enabling [Accelerated Connections](https://learn.microsoft.com/en-us/azure/networking/nva-accelerated-connections) to improve networking performance. Possible values are `AcceleratedConnections` and `Floating`.
+* `auxiliary_mode` - (Optional) Specifies the auxiliary mode used to enable network high-performance feature on Network Virtual Appliances (NVAs). This feature offers competitive performance in Connections Per Second (CPS) optimization, along with improvements to handling large amounts of simultaneous connections. Possible values are `AcceleratedConnections` and `Floating`.
 
-* `auxiliary_sku` - (Optional) Specifies auxiliary SKU for tuning the performance of network connections. Possible values are `A1`, `A2`, `A4` and `A8`.
+-> **Note:** `auxiliary_mode` is in **Preview** and requires that the preview is enabled - [more information can be found in the Azure documentation](https://learn.microsoft.com/azure/networking/nva-accelerated-connections#prerequisites).
 
--> **Note:** `auxiliary_mode` and `auxiliary_sku` require the preview feature is enabled. See the [Prerequisites](https://learn.microsoft.com/en-us/azure/networking/nva-accelerated-connections#prerequisites) for more details.
+* `auxiliary_sku` - (Optional) Specifies the SKU used for the network high-performance feature on Network Virtual Appliances (NVAs). Possible values are `A1`, `A2`, `A4` and `A8`.
+
+-> **Note:** `auxiliary_sku` is in **Preview** and requires that the preview is enabled - [more information can be found in the Azure documentation](https://learn.microsoft.com/azure/networking/nva-accelerated-connections#prerequisites).
 
 * `dns_servers` - (Optional) A list of IP Addresses defining the DNS Servers which should be used for this Network Interface.
 


### PR DESCRIPTION
## Swagger Link

https://github.com/Azure/azure-rest-api-specs/blob/1df6d6f671dc5059016fbc2c0a624e01f0b2972c/specification/network/resource-manager/Microsoft.Network/stable/2023-02-01/networkInterface.json#L1212

https://github.com/Azure/azure-rest-api-specs/blob/1df6d6f671dc5059016fbc2c0a624e01f0b2972c/specification/network/resource-manager/Microsoft.Network/stable/2023-02-01/networkInterface.json#L1226C10-L1226C22

## Test Result

<img width="955" alt="image" src="https://github.com/hashicorp/terraform-provider-azurerm/assets/76987228/808f799b-c90b-4344-aaea-d74677637a34">


=== RUN   TestAccNetworkInterface_auxiliary
=== PAUSE TestAccNetworkInterface_auxiliary
=== CONT  TestAccNetworkInterface_auxiliary
--- PASS: TestAccNetworkInterface_auxiliary (360.05s)
PASS