### PR TITLE
`azurerm_web_application_firewall_policy` - fix handling not found in read

### DIFF
--- a/internal/services/network/web_application_firewall_policy_resource.go
+++ b/internal/services/network/web_application_firewall_policy_resource.go
@@ -537,7 +537,7 @@ func resourceWebApplicationFirewallPolicyRead(d *pluginsdk.ResourceData, meta in
 
 	resp, err := client.Get(ctx, *id)
 	if err != nil {
-		if !response.WasNotFound(resp.HttpResponse) {
+		if response.WasNotFound(resp.HttpResponse) {
 			log.Printf("[INFO] Web Application Firewall Policy %q does not exist - removing from state", d.Id())
 			d.SetId("")
 			return nil


### PR DESCRIPTION
Similar to https://github.com/hashicorp/terraform-provider-azurerm/pull/18619

It looks like a [recent change](https://github.com/hashicorp/terraform-provider-azurerm/pull/22455/files#diff-13f66f44010ebc3540c768ee73c83a2107efd0e11961f8f1a81c10e447414ee2R489) broke this functionality with `azurerm_web_application_firewall_policy`. 

<img width="1242" alt="Screenshot 2023-08-16 at 16 12 04" src="https://github.com/hashicorp/terraform-provider-azurerm/assets/9900707/38ebbbaa-5f09-4dd6-b953-dfcb10dfab27">

Without this fix, terraform plan will fail if resource deleted manually similar to the previously reported issue: https://github.com/hashicorp/terraform-provider-azurerm/issues/18614