### PR TITLE
`azurerm_virtual_network_gateway`: increase timeout for create

### DIFF
--- a/internal/services/network/virtual_network_gateway_resource.go
+++ b/internal/services/network/virtual_network_gateway_resource.go
@@ -37,7 +37,7 @@ func resourceVirtualNetworkGateway() *pluginsdk.Resource {
 		}),
 
 		Timeouts: &pluginsdk.ResourceTimeout{
-			Create: pluginsdk.DefaultTimeout(60 * time.Minute),
+			Create: pluginsdk.DefaultTimeout(90 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
 			Update: pluginsdk.DefaultTimeout(60 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(60 * time.Minute),
@@ -315,7 +315,7 @@ func resourceVirtualNetworkGatewaySchema() map[string]*pluginsdk.Schema {
 						},
 					},
 
-					//lintignore:XS003
+					// lintignore:XS003
 					"peering_addresses": {
 						Type:     pluginsdk.TypeList,
 						Computed: true,
@@ -365,7 +365,7 @@ func resourceVirtualNetworkGatewaySchema() map[string]*pluginsdk.Schema {
 			},
 		},
 
-		//lintignore:XS003
+		// lintignore:XS003
 		"custom_route": {
 			Type:     pluginsdk.TypeList,
 			Optional: true,

--- a/website/docs/r/virtual_network_gateway.html.markdown
+++ b/website/docs/r/virtual_network_gateway.html.markdown
@@ -260,7 +260,7 @@ The `peering_addresses` block supports:
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `create` - (Defaults to 60 minutes) Used when creating the Virtual Network Gateway.
+* `create` - (Defaults to 90 minutes) Used when creating the Virtual Network Gateway.
 * `update` - (Defaults to 60 minutes) Used when updating the Virtual Network Gateway.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Virtual Network Gateway.
 * `delete` - (Defaults to 60 minutes) Used when deleting the Virtual Network Gateway.


### PR DESCRIPTION
some acctest may failed occasionally with error we below, try to increase the timeout value.

```
=== CONT  TestAccVirtualNetworkGateway_requiresImport
    testcase.go:113: Step 1/2 error: Error running apply: exit status 1
        Error: waiting for completion of Virtual Network Gateway: (Name "acctestvng-230630050833542667" / Resource Group "acctestRG-230630050833542667"): 
Future#WaitForCompletion: context has been cancelled: StatusCode=200 -- Original Error: context deadline exceeded
```

```
=== CONT  TestAccVirtualNetworkGatewayConnection_natRuleIds
    testcase.go:113: Step 1/2 error: Error running apply: exit status 1
        Error: waiting for completion of Virtual Network Gateway: (Name "acctestvnetgw-230814084927775723" / Resource Group "acctestRG-230814084927775723"): Future#WaitForCompletion: context has been cancelled: StatusCode=200 -- Original Error: context deadline exceeded
```
