### PR TITLE
Doc: Reflect the new id forms for the apimanagement resources

### DIFF
--- a/website/docs/r/api_management_api_operation_policy.html.markdown
+++ b/website/docs/r/api_management_api_operation_policy.html.markdown
@@ -101,5 +101,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 API Management API Operation Policy can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_api_management_api_operation_policy.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.ApiManagement/service/instance1/apis/api1/operations/operation1/policies/policy
+terraform import azurerm_api_management_api_operation_policy.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.ApiManagement/service/instance1/apis/api1/operations/operation1
 ```

--- a/website/docs/r/api_management_api_policy.html.markdown
+++ b/website/docs/r/api_management_api_policy.html.markdown
@@ -69,5 +69,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 API Management API Policy can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_api_management_api_policy.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.ApiManagement/service/service1/apis/exampleId/policies/policy
+terraform import azurerm_api_management_api_policy.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.ApiManagement/service/service1/apis/exampleId
 ```

--- a/website/docs/r/api_management_policy.html.markdown
+++ b/website/docs/r/api_management_policy.html.markdown
@@ -76,5 +76,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 API Management service Policys can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_api_management_policy.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.ApiManagement/service/instance1/policies/policy
+terraform import azurerm_api_management_policy.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.ApiManagement/service/service1
 ```

--- a/website/docs/r/api_management_product_policy.html.markdown
+++ b/website/docs/r/api_management_product_policy.html.markdown
@@ -69,5 +69,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/l
 API Management Product Policy can be imported using the `resource id`, e.g.
 
 ```shell
-terraform import azurerm_api_management_product_policy.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.ApiManagement/service/service1/products/exampleId/policies/policy
+terraform import azurerm_api_management_product_policy.example /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.ApiManagement/service/service1/products/product1
 ```


### PR DESCRIPTION
Complement the document for the migrated new id forms by https://github.com/hashicorp/terraform-provider-azurerm/pull/22783