### PR TITLE
fix acctest: `TestAccSecurityCenterSubscriptionPricing_cloudPostureExtension`

### DIFF
--- a/internal/services/securitycenter/security_center_subscription_pricing_resource_test.go
+++ b/internal/services/securitycenter/security_center_subscription_pricing_resource_test.go
@@ -109,7 +109,7 @@ func TestAccSecurityCenterSubscriptionPricing_cloudPostureExtension(t *testing.T
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("tier").HasValue("Standard"),
 				check.That(data.ResourceName).Key("resource_type").HasValue("CloudPosture"),
-				check.That(data.ResourceName).Key("extension.#").HasValue("2"),
+				check.That(data.ResourceName).Key("extension.#").HasValue("4"),
 			),
 		},
 		data.ImportStep(),
@@ -129,7 +129,7 @@ func TestAccSecurityCenterSubscriptionPricing_cloudPostureExtension(t *testing.T
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("tier").HasValue("Standard"),
 				check.That(data.ResourceName).Key("resource_type").HasValue("CloudPosture"),
-				check.That(data.ResourceName).Key("extension.#").HasValue("2"),
+				check.That(data.ResourceName).Key("extension.#").HasValue("4"),
 			),
 		},
 	})
@@ -197,6 +197,14 @@ resource "azurerm_security_center_subscription_pricing" "test" {
     additional_extension_properties = {
       ExclusionTags = "[]"
     }
+  }
+
+  extension {
+    name = "ContainerRegistriesVulnerabilityAssessments"
+  }
+
+  extension {
+    name = "AgentlessDiscoveryForKubernetes"
   }
 }
 `


### PR DESCRIPTION
test
```
❯ tftest securitycenter TestAccSecurityCenterSubscriptionPricing_cloudPostureExtension
=== RUN   TestAccSecurityCenterSubscriptionPricing_cloudPostureExtension
--- PASS: TestAccSecurityCenterSubscriptionPricing_cloudPostureExtension (208.24s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/securitycenter        208.288s
```