### PR TITLE
`azurerm_api_management_api` : fix service is unavailable while updating `azurerm_api_management_api` 

### DIFF
--- a/internal/services/apimanagement/api_management_api_resource.go
+++ b/internal/services/apimanagement/api_management_api_resource.go
@@ -420,6 +420,11 @@ func resourceApiManagementApiCreateUpdate(d *pluginsdk.ResourceData, meta interf
 				ApiVersion: pointer.To(version),
 			},
 		}
+
+		if v, ok := d.GetOk("service_url"); ok {
+			apiParams.Properties.ServiceUrl = pointer.To(v.(string))
+		}
+
 		wsdlSelectorVs := importV["wsdl_selector"].([]interface{})
 
 		if len(wsdlSelectorVs) > 0 {

--- a/internal/services/apimanagement/api_management_api_resource_test.go
+++ b/internal/services/apimanagement/api_management_api_resource_test.go
@@ -247,6 +247,44 @@ func TestAccApiManagementApi_importSwagger(t *testing.T) {
 	})
 }
 
+func TestAccApiManagementApi_importSwaggerWithServiceUrl(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_api_management_api", "test")
+	r := ApiManagementApiResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.importSwaggerWithServiceUrl(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		{
+			ResourceName:      data.ResourceName,
+			ImportState:       true,
+			ImportStateVerify: true,
+			ImportStateVerifyIgnore: []string{
+				// not returned from the API
+				"import",
+			},
+		},
+		{
+			Config: r.importSwaggerWithServiceUrlUpdate(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		{
+			ResourceName:      data.ResourceName,
+			ImportState:       true,
+			ImportStateVerify: true,
+			ImportStateVerifyIgnore: []string{
+				// not returned from the API
+				"import",
+			},
+		},
+	})
+}
+
 func TestAccApiManagementApi_importWsdl(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_api_management_api", "test")
 	r := ApiManagementApiResource{}
@@ -597,6 +635,52 @@ resource "azurerm_api_management_api" "test" {
   path                = "api1"
   protocols           = ["https"]
   revision            = "1"
+
+  import {
+    content_value  = file("testdata/api_management_api_swagger.json")
+    content_format = "swagger-json"
+  }
+}
+`, r.template(data, SkuNameConsumption), data.RandomInteger)
+}
+
+func (r ApiManagementApiResource) importSwaggerWithServiceUrl(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_api_management_api" "test" {
+  name                = "acctestapi-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  api_management_name = azurerm_api_management.test.name
+  display_name        = "api1"
+  path                = "api1"
+  protocols           = ["https"]
+  revision            = "1"
+  description         = "import swagger"
+  service_url         = "https://example.com/foo/bar"
+
+  import {
+    content_value  = file("testdata/api_management_api_swagger.json")
+    content_format = "swagger-json"
+  }
+}
+`, r.template(data, SkuNameConsumption), data.RandomInteger)
+}
+
+func (r ApiManagementApiResource) importSwaggerWithServiceUrlUpdate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_api_management_api" "test" {
+  name                = "acctestapi-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  api_management_name = azurerm_api_management.test.name
+  display_name        = "api1"
+  path                = "api1"
+  protocols           = ["https"]
+  revision            = "1"
+  description         = "import swagger update"
+  service_url         = "https://example.com/foo/bar"
 
   import {
     content_value  = file("testdata/api_management_api_swagger.json")


### PR DESCRIPTION
When updating resource `azurerm_api_management_api`, if `import` is set and `service_url` is set, the service will be unavailable for a short time.

This is because if the "import" property is set in configuration, TF sends the properties to the Azure API in two operations. First TF executes import and then updates other properties.

The current TF code does not set the `service_url` property when importing, which will cause `service_url` to be updated to the default value by API, and then TF sets `service_url` to correct value by updating other properties. This causes the service is unavailable while other properties are being updated.

So submit this PR to set `service_url` while importing to fix #22973.

Test result:
PASS: TestAccApiManagementApi_importSwaggerWithServiceUrl (471.20s)