### PR TITLE
`azurerm_synapse_workspace`: fix panic of slice index out-of-range

### DIFF
--- a/internal/services/synapse/synapse_workspace_resource.go
+++ b/internal/services/synapse/synapse_workspace_resource.go
@@ -68,9 +68,10 @@ func resourceSynapseWorkspace() *pluginsdk.Resource {
 			"location": commonschema.Location(),
 
 			"storage_data_lake_gen2_filesystem_id": {
-				Type:     pluginsdk.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.IsURLWithPath,
 			},
 
 			"sql_administrator_login": {

--- a/internal/services/synapse/synapse_workspace_resource.go
+++ b/internal/services/synapse/synapse_workspace_resource.go
@@ -795,7 +795,7 @@ func expandArmWorkspaceDataLakeStorageAccountDetails(storageDataLakeGen2Filesyst
 	uri, _ := url.Parse(storageDataLakeGen2FilesystemId)
 	return &synapse.DataLakeStorageAccountDetails{
 		AccountURL: utils.String(fmt.Sprintf("%s://%s", uri.Scheme, uri.Host)), // https://storageaccountname.dfs.core.windows.net/filesystemname -> https://storageaccountname.dfs.core.windows.net
-		Filesystem: utils.String(uri.Path[1:]),                                 // https://storageaccountname.dfs.core.windows.net/filesystemname -> filesystemname
+		Filesystem: utils.String(strings.TrimPrefix(uri.Path, "/")),            // https://storageaccountname.dfs.core.windows.net/filesystemname -> filesystemname
 	}
 }
 

--- a/internal/tf/validation/pluginsdk.go
+++ b/internal/tf/validation/pluginsdk.go
@@ -5,7 +5,9 @@ package validation
 
 import (
 	"fmt"
+	"net/url"
 	"regexp"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -169,6 +171,33 @@ func IsURLWithHTTPS(i interface{}, k string) ([]string, []error) {
 // IsURLWithScheme is a SchemaValidateFunc which tests if the provided value is of type string and a valid URL with the provided schemas
 func IsURLWithScheme(validSchemes []string) func(interface{}, string) ([]string, []error) {
 	return validation.IsURLWithScheme(validSchemes)
+}
+
+// IsURLWithPath is a SchemaValidateFunc that tests if the provided value is of type string and a valid URL with a path
+func IsURLWithPath(i interface{}, k string) (_ []string, errors []error) {
+	v, ok := i.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected type of %q to be string", k))
+		return
+	}
+
+	if v == "" {
+		errors = append(errors, fmt.Errorf("expected %q url to not be empty, got %v", k, i))
+		return
+	}
+
+	u, err := url.Parse(v)
+	if err != nil {
+		errors = append(errors, fmt.Errorf("expected %q to be a valid url, got %v: %+v", k, v, err))
+		return
+	}
+
+	if strings.TrimPrefix(u.Path, "/") == "" {
+		errors = append(errors, fmt.Errorf("expected %q to have a non empty path got %v", k, v))
+		return
+	}
+
+	return
 }
 
 // IsUUID is a ValidateFunc that ensures a string can be parsed as UUID


### PR DESCRIPTION
Not sure why need a `uri.Path[1:]` here, I guess it want to trim the leading slash (by the comment inline), so change to use `strings.TrimPrefix`

fixes: #23004

