### PR TITLE
`azurerm_batch_pool`  - add new subproperty `automatic_upgrade_enabled`

### DIFF
--- a/internal/services/batch/batch_pool.go
+++ b/internal/services/batch/batch_pool.go
@@ -859,6 +859,10 @@ func expandBatchPoolExtension(ref map[string]interface{}) (*pool.VmExtension, er
 		result.AutoUpgradeMinorVersion = utils.Bool(autoUpgradeMinorVersion.(bool))
 	}
 
+	if autoUpgradeEnabled, ok := ref["automatic_upgrade_enabled"]; ok {
+		result.EnableAutomaticUpgrade = utils.Bool(autoUpgradeEnabled.(bool))
+	}
+
 	if typeHandlerVersion, ok := ref["type_handler_version"]; ok {
 		result.TypeHandlerVersion = utils.String(typeHandlerVersion.(string))
 	}

--- a/internal/services/batch/batch_pool_resource.go
+++ b/internal/services/batch/batch_pool_resource.go
@@ -652,6 +652,10 @@ func resourceBatchPool() *pluginsdk.Resource {
 							Type:     pluginsdk.TypeBool,
 							Optional: true,
 						},
+						"automatic_upgrade_enabled": {
+							Type:     pluginsdk.TypeBool,
+							Optional: true,
+						},
 						"settings_json": {
 							Type:         pluginsdk.TypeString,
 							Optional:     true,
@@ -860,11 +864,11 @@ func resourceBatchPoolCreate(d *pluginsdk.ResourceData, meta interface{}) error 
 	}
 	parameters.Properties.TaskSchedulingPolicy = taskSchedulingPolicy
 
-	identity, err := identity.ExpandUserAssignedMap(d.Get("identity").([]interface{}))
+	identityResult, err := identity.ExpandUserAssignedMap(d.Get("identity").([]interface{}))
 	if err != nil {
 		return fmt.Errorf(`expanding "identity": %v`, err)
 	}
-	parameters.Identity = identity
+	parameters.Identity = identityResult
 
 	scaleSettings, err := expandBatchPoolScaleSettings(d)
 	if err != nil {
@@ -1100,11 +1104,11 @@ func resourceBatchPoolRead(d *pluginsdk.ResourceData, meta interface{}) error {
 	d.Set("resource_group_name", id.ResourceGroupName)
 
 	if model := resp.Model; model != nil {
-		identity, err := identity.FlattenUserAssignedMap(model.Identity)
+		identityResult, err := identity.FlattenUserAssignedMap(model.Identity)
 		if err != nil {
 			return fmt.Errorf("flattening `identity`: %+v", err)
 		}
-		if err := d.Set("identity", identity); err != nil {
+		if err := d.Set("identity", identityResult); err != nil {
 			return fmt.Errorf("setting `identity`: %+v", err)
 		}
 
@@ -1193,6 +1197,9 @@ func resourceBatchPoolRead(d *pluginsdk.ResourceData, meta interface{}) error {
 							}
 							if item.AutoUpgradeMinorVersion != nil {
 								extension["auto_upgrade_minor_version"] = *item.AutoUpgradeMinorVersion
+							}
+							if item.EnableAutomaticUpgrade != nil {
+								extension["automatic_upgrade_enabled"] = *item.EnableAutomaticUpgrade
 							}
 							if item.Settings != nil {
 								extension["settings_json"] = item.Settings

--- a/internal/services/batch/batch_pool_resource_test.go
+++ b/internal/services/batch/batch_pool_resource_test.go
@@ -681,6 +681,7 @@ func TestAccBatchPool_extensions(t *testing.T) {
 				check.That(data.ResourceName).Key("extensions.0.type").HasValue("KeyVaultForLinux"),
 				check.That(data.ResourceName).Key("extensions.0.type_handler_version").HasValue("2.0"),
 				check.That(data.ResourceName).Key("extensions.0.auto_upgrade_minor_version").HasValue("true"),
+				check.That(data.ResourceName).Key("extensions.0.automatic_upgrade_enabled").HasValue("true"),
 				check.That(data.ResourceName).Key("extensions.0.settings_json").HasValue("{}"),
 				check.That(data.ResourceName).Key("extensions.0.protected_settings").HasValue("sensitive"),
 				check.That(data.ResourceName).Key("extensions.0.provision_after_extensions.0").HasValue("newProv1"),
@@ -2313,6 +2314,7 @@ resource "azurerm_batch_pool" "test" {
     type                       = "KeyVaultForLinux"
     type_handler_version       = "2.0"
     auto_upgrade_minor_version = true
+    automatic_upgrade_enabled  = true
     settings_json              = "{}"
     protected_settings         = "sensitive"
     provision_after_extensions = ["newProv1"]

--- a/website/docs/r/batch_pool.html.markdown
+++ b/website/docs/r/batch_pool.html.markdown
@@ -222,6 +222,10 @@ If specified, the extensions mentioned in this configuration will be installed o
 
 * `auto_upgrade_minor_version` - (Optional) Indicates whether the extension should use a newer minor version if one is available at deployment time. Once deployed, however, the extension will not upgrade minor versions unless redeployed, even with this property set to true.
 
+* `automatic_upgrade_enabled` - (Optional) Indicates whether the extension should be automatically upgraded by the platform if there is a newer version available. Supported values are `true` and `false`.
+
+**NOTE:** When `automatic_upgrade_enabled` is set to `true`, the `type_handler_version` is automatically updated by the Azure platform when a new version is available and any change in `type_handler_version` should be manually ignored by user.
+
 * `settings_json` - (Optional) JSON formatted public settings for the extension.
 
 * `protected_settings` - (Optional) The extension can contain either `protected_settings` or `provision_after_extensions` or no protected settings at all.


### PR DESCRIPTION
`azurerm_batch_pool`  
- add new subproperty `automatic_upgrade_enabled`.
- update an local variable to avoid collision with imported package name.
- update doc.

Testing Evidence:

![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/17947406/9237c7e3-488e-4764-92fa-4054db6ac80b)