### PR TITLE
Doc Fix: `azurerm_storage_share` update `quota` section to mention the standard SA can set quota larger than 5TB

### DIFF
--- a/website/docs/r/storage_share.html.markdown
+++ b/website/docs/r/storage_share.html.markdown
@@ -67,7 +67,7 @@ The following arguments are supported:
 
 ~>**NOTE:** For Standard storage accounts, by default this must be `1` GB (or higher) and at most `5120` GB (`5` TB). This can be set to a value larger than `5120` GB if `large_file_share_enabled` is set to `true` in the parent `azurerm_storage_account`.
 
-~>**NOTE:**For Premium FileStorage storage accounts, this must be greater than `100` GB and at most `102400` GB (`100` TB).
+~>**NOTE:** For Premium FileStorage storage accounts, this must be greater than `100` GB and at most `102400` GB (`100` TB).
 
 * `metadata` - (Optional) A mapping of MetaData for this File Share.
 

--- a/website/docs/r/storage_share.html.markdown
+++ b/website/docs/r/storage_share.html.markdown
@@ -65,8 +65,9 @@ The following arguments are supported:
 
 * `quota` - (Required) The maximum size of the share, in gigabytes.
 
-    - For Standard storage accounts, by default this must be `1`GB (or higher) and at most `5120` GB (`5` TB). This can be set to a value larger than `5120` GB if `large_file_share_enabled` is set to `true` in the parent `azurerm_storage_account`.
-    - For Premium FileStorage storage accounts, this must be greater than 100 GB and at most `102400` GB (`100` TB).
+~>**NOTE:** For Standard storage accounts, by default this must be `1` GB (or higher) and at most `5120` GB (`5` TB). This can be set to a value larger than `5120` GB if `large_file_share_enabled` is set to `true` in the parent `azurerm_storage_account`.
+
+~>**NOTE:**For Premium FileStorage storage accounts, this must be greater than `100` GB and at most `102400` GB (`100` TB).
 
 * `metadata` - (Optional) A mapping of MetaData for this File Share.
 

--- a/website/docs/r/storage_share.html.markdown
+++ b/website/docs/r/storage_share.html.markdown
@@ -63,7 +63,10 @@ The following arguments are supported:
 
 ~>**NOTE:** The `Premium` SKU of the `azurerm_storage_account` is required for the `NFS` protocol.
 
-* `quota` - (Required) The maximum size of the share, in gigabytes. For Standard storage accounts, this must be `1`GB (or higher) and at most `5120` GB (`5` TB). For Premium FileStorage storage accounts, this must be greater than 100 GB and at most `102400` GB (`100` TB).
+* `quota` - (Required) The maximum size of the share, in gigabytes.
+
+    - For Standard storage accounts, by default this must be `1`GB (or higher) and at most `5120` GB (`5` TB). This can be set to a value larger than `5120` GB if `large_file_share_enabled` is set to `true` in the parent `azurerm_storage_account`.
+    - For Premium FileStorage storage accounts, this must be greater than 100 GB and at most `102400` GB (`100` TB).
 
 * `metadata` - (Optional) A mapping of MetaData for this File Share.
 


### PR DESCRIPTION
Fix #23016 