### PR TITLE
`azurerm_container_group` - Support `sku` and `(init_)container.*.security`

### DIFF
--- a/internal/services/containers/container_group_resource.go
+++ b/internal/services/containers/container_group_resource.go
@@ -149,6 +149,14 @@ func resourceContainerGroup() *pluginsdk.Resource {
 
 			"tags": commonschema.Tags(),
 
+			"sku": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Default:      string(containerinstance.ContainerGroupSkuStandard),
+				ValidateFunc: validation.StringInSlice(containerinstance.PossibleValuesForContainerGroupSku(), false),
+			},
+
 			"restart_policy": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
@@ -261,6 +269,8 @@ func resourceContainerGroup() *pluginsdk.Resource {
 						},
 
 						"volume": containerVolumeSchema(),
+
+						"security": containerSecurityContextSchema(),
 					},
 				},
 			},
@@ -426,6 +436,8 @@ func resourceContainerGroup() *pluginsdk.Resource {
 						},
 
 						"volume": containerVolumeSchema(),
+
+						"security": containerSecurityContextSchema(),
 
 						"liveness_probe": SchemaContainerGroupProbe(),
 
@@ -644,6 +656,23 @@ func containerVolumeSchema() *pluginsdk.Schema {
 	}
 }
 
+func containerSecurityContextSchema() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		ForceNew: true,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"priviledge_enabled": {
+					Type:     pluginsdk.TypeBool,
+					ForceNew: true,
+					Required: true,
+				},
+			},
+		},
+	}
+}
+
 func resourceContainerGroupCreate(d *pluginsdk.ResourceData, meta interface{}) error {
 	client := meta.(*clients.Client).Containers.ContainerInstanceClient
 	subscriptionId := meta.(*clients.Client).Account.SubscriptionId
@@ -700,6 +729,7 @@ func resourceContainerGroupCreate(d *pluginsdk.ResourceData, meta interface{}) e
 		Location: &location,
 		Tags:     tags.Expand(d.Get("tags").(map[string]interface{})),
 		Properties: containerinstance.ContainerGroupPropertiesProperties{
+			Sku:                      pointer.To(containerinstance.ContainerGroupSku(d.Get("sku").(string))),
 			InitContainers:           initContainers,
 			Containers:               containers,
 			Diagnostics:              diagnostics,
@@ -833,6 +863,13 @@ func resourceContainerGroupRead(d *pluginsdk.ResourceData, meta interface{}) err
 		d.Set("zones", zones.FlattenUntyped(model.Zones))
 
 		props := model.Properties
+
+		var sku string
+		if v := props.Sku; v != nil {
+			sku = string(*v)
+		}
+		d.Set("sku", sku)
+
 		containerConfigs := flattenContainerGroupContainers(d, &props.Containers, props.Volumes)
 		if err := d.Set("container", containerConfigs); err != nil {
 			return fmt.Errorf("setting `container`: %+v", err)
@@ -995,7 +1032,8 @@ func expandContainerGroupInitContainers(d *pluginsdk.ResourceData, addedEmptyDir
 		container := containerinstance.InitContainerDefinition{
 			Name: name,
 			Properties: containerinstance.InitContainerPropertiesDefinition{
-				Image: pointer.FromString(image),
+				Image:           pointer.FromString(image),
+				SecurityContext: expandContainerSecurityContext(data["security"].([]interface{})),
 			},
 		}
 
@@ -1049,6 +1087,37 @@ func expandContainerGroupInitContainers(d *pluginsdk.ResourceData, addedEmptyDir
 	return &containers, containerGroupVolumes, nil
 }
 
+func expandContainerSecurityContext(input []interface{}) *containerinstance.SecurityContextDefinition {
+	if len(input) == 0 || input[0] == nil {
+		return nil
+	}
+
+	raw := input[0].(map[string]interface{})
+
+	output := &containerinstance.SecurityContextDefinition{
+		Privileged: pointer.To(raw["priviledge_enabled"].(bool)),
+	}
+
+	return output
+}
+
+func flattenContainerSecurityContext(input *containerinstance.SecurityContextDefinition) []interface{} {
+	if input == nil {
+		return []interface{}{}
+	}
+
+	var priviledged bool
+	if v := input.Privileged; v != nil {
+		priviledged = *v
+	}
+
+	return []interface{}{
+		map[string]interface{}{
+			"priviledge_enabled": priviledged,
+		},
+	}
+}
+
 func expandContainerGroupContainers(d *pluginsdk.ResourceData, addedEmptyDirs map[string]bool) ([]containerinstance.Container, []containerinstance.Port, []containerinstance.Volume, error) {
 	containersConfig := d.Get("container").([]interface{})
 	containers := make([]containerinstance.Container, 0)
@@ -1074,6 +1143,7 @@ func expandContainerGroupContainers(d *pluginsdk.ResourceData, addedEmptyDirs ma
 						Cpu:        cpu,
 					},
 				},
+				SecurityContext: expandContainerSecurityContext(data["security"].([]interface{})),
 			},
 		}
 
@@ -1594,6 +1664,9 @@ func flattenContainerGroupInitContainers(d *pluginsdk.ResourceData, initContaine
 			containersConfigRaw := d.Get("container").([]interface{})
 			flattenContainerVolume(containerConfig, containersConfigRaw, container.Name, container.Properties.VolumeMounts, containerGroupVolumes)
 		}
+
+		containerConfig["security"] = flattenContainerSecurityContext(container.Properties.SecurityContext)
+
 		containerCfg = append(containerCfg, containerConfig)
 	}
 
@@ -1680,6 +1753,7 @@ func flattenContainerGroupContainers(d *pluginsdk.ResourceData, containers *[]co
 
 		containerConfig["liveness_probe"] = flattenContainerProbes(container.Properties.LivenessProbe)
 		containerConfig["readiness_probe"] = flattenContainerProbes(container.Properties.ReadinessProbe)
+		containerConfig["security"] = flattenContainerSecurityContext(container.Properties.SecurityContext)
 
 		containerCfg = append(containerCfg, containerConfig)
 	}

--- a/internal/services/containers/container_group_resource_test.go
+++ b/internal/services/containers/container_group_resource_test.go
@@ -695,6 +695,28 @@ func TestAccContainerGroup_encryption(t *testing.T) {
 	})
 }
 
+func TestAccContainerGroup_securityContext(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_container_group", "test")
+	r := ContainerGroupResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.securityContextPriviledged(data, false),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.securityContextPriviledged(data, true),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (ContainerGroupResource) SystemAssignedIdentity(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
@@ -2465,4 +2487,40 @@ resource "azurerm_container_group" "test" {
   depends_on       = [azurerm_key_vault_access_policy.test]
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (ContainerGroupResource) securityContextPriviledged(data acceptance.TestData, v bool) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_container_group" "test" {
+  name                = "acctestcontainergroup-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  ip_address_type     = "Public"
+  os_type             = "Linux"
+  sku                 = "Confidential"
+
+  container {
+    name   = "hw"
+    image  = "ubuntu:20.04"
+    cpu    = "0.5"
+    memory = "0.5"
+    ports {
+      port     = 80
+      protocol = "TCP"
+    }
+    security {
+      priviledge_enabled = %[3]t
+    }
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, v)
 }

--- a/website/docs/r/container_group.html.markdown
+++ b/website/docs/r/container_group.html.markdown
@@ -65,6 +65,8 @@ The following arguments are supported:
 
 * `location` - (Required) Specifies the supported Azure location where the resource exists. Changing this forces a new resource to be created.
 
+* `sku` - (Optional) Specifies the sku of the Container Group. Possible values are `Confidential`, `Dedicated` and `Standard`. Defaults to `Standard`. Changing this forces a new resource to be created.
+
 * `identity` - (Optional) An `identity` block as defined below.
 
 * `init_container` - (Optional) The definition of an init container that is part of the group as documented in the `init_container` block below. Changing this forces a new resource to be created.
@@ -137,6 +139,8 @@ An `init_container` block supports:
 
 * `volume` - (Optional) The definition of a volume mount for this container as documented in the `volume` block below. Changing this forces a new resource to be created.
 
+* `security` - (Optional) The definition of the security context for this container as documented in the `security` block below. Changing this forces a new resource to be created.
+
 ---
 
 A `container` block supports:
@@ -172,6 +176,8 @@ A `container` block supports:
 * `commands` - (Optional) A list of commands which should be run on the container. Changing this forces a new resource to be created.
 
 * `volume` - (Optional) The definition of a volume mount for this container as documented in the `volume` block below. Changing this forces a new resource to be created.
+
+* `security` - (Optional) The definition of the security context for this container as documented in the `security` block below. Changing this forces a new resource to be created.
 
 ---
 
@@ -334,6 +340,12 @@ The `dns_config` block supports:
 * `search_domains` - (Optional) A list of search domains that DNS requests will search along. Changing this forces a new resource to be created.
 
 * `options` - (Optional) A list of [resolver configuration options](https://man7.org/linux/man-pages/man5/resolv.conf.5.html). Changing this forces a new resource to be created.
+
+---
+
+The `security` block supports:
+
+* `priviledge_enabled` - (Required) Whether the container's permission is elevated to priviledged? Currently, this only applies when the `os_type` is `Linux` and the `sku` is `Confidential`. Changing this forces a new resource to be created.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Support the `sku` and `(init_)container.*.security` for the `azurerm_container_group`.

For `sku`, by default (on absent) it is set to `Standard` for the existing resources. This meets the most use cases, whilst in order to support the `securityContext`, it needs to be set to `Confidential`.

For `security` block, there are several properties defined in the API. Whilst, currently only the `priviledge_enabled` is supported for all users, the others are behind a feature flag and are only experimental at the current API version (the latest one). Keeping the properties in the `security` block is a sane choice for the future support once those experimental properties are exposed to public.

## Test

```shell
💤  TF_ACC=1 go test -v -timeout=20h -run='TestAccContainerGroup_securityContext' ./internal/services/containers
=== RUN   TestAccContainerGroup_securityContext
=== PAUSE TestAccContainerGroup_securityContext
=== CONT  TestAccContainerGroup_securityContext
--- PASS: TestAccContainerGroup_securityContext (279.61s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/containers    279.625s
```