### PR TITLE
[Documentation]: update example usage for `azurerm_cdn_frontdoor_route`, `azurerm_cdn_frontdoor_rule`, `azurerm_cdn_frontdoor_secret` and `azurerm_cdn_frontdoor_security_policy`

### DIFF
--- a/website/docs/r/cdn_frontdoor_route.html.markdown
+++ b/website/docs/r/cdn_frontdoor_route.html.markdown
@@ -26,11 +26,18 @@ resource "azurerm_dns_zone" "example" {
 resource "azurerm_cdn_frontdoor_profile" "example" {
   name                = "example-profile"
   resource_group_name = azurerm_resource_group.example.name
+  sku_name            = "Standard_AzureFrontDoor"
 }
 
 resource "azurerm_cdn_frontdoor_origin_group" "example" {
   name                     = "example-originGroup"
   cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.example.id
+
+  load_balancing {
+    additional_latency_in_milliseconds = 0
+    sample_size                        = 16
+    successful_samples_required        = 3
+  }
 }
 
 resource "azurerm_cdn_frontdoor_origin" "example" {
@@ -50,6 +57,11 @@ resource "azurerm_cdn_frontdoor_origin" "example" {
 
 resource "azurerm_cdn_frontdoor_endpoint" "example" {
   name                     = "example-endpoint"
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.example.id
+}
+
+resource "azurerm_cdn_frontdoor_rule_set" "example" {
+  name                     = "ExampleRuleSet"
   cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.example.id
 }
 

--- a/website/docs/r/cdn_frontdoor_rule.html.markdown
+++ b/website/docs/r/cdn_frontdoor_rule.html.markdown
@@ -23,6 +23,7 @@ resource "azurerm_resource_group" "example" {
 resource "azurerm_cdn_frontdoor_profile" "example" {
   name                = "example-profile"
   resource_group_name = azurerm_resource_group.example.name
+  sku_name            = "Premium_AzureFrontDoor"
 }
 
 resource "azurerm_cdn_frontdoor_endpoint" "example" {

--- a/website/docs/r/cdn_frontdoor_secret.html.markdown
+++ b/website/docs/r/cdn_frontdoor_secret.html.markdown
@@ -34,6 +34,11 @@ data "azuread_service_principal" "frontdoor" {
   display_name = "Microsoft.Azure.Cdn"
 }
 
+resource "azurerm_resource_group" "example" {
+  name     = "example-cdn-frontdoor"
+  location = "West Europe"
+}
+
 resource "azurerm_key_vault" "example" {
   name                       = "example-keyvault"
   location                   = azurerm_resource_group.example.location
@@ -78,20 +83,26 @@ resource "azurerm_key_vault" "example" {
 
 resource "azurerm_key_vault_certificate" "example" {
   name         = "example-cert"
-  key_vault_id = azurerm_key_vault.test.id
+  key_vault_id = azurerm_key_vault.example.id
 
   certificate {
     contents = filebase64("my-certificate.pfx")
   }
 }
 
+resource "azurerm_cdn_frontdoor_profile" "example" {
+  name                = "example-cdn-profile"
+  resource_group_name = azurerm_resource_group.example.name
+  sku_name            = "Standard_AzureFrontDoor"
+}
+
 resource "azurerm_cdn_frontdoor_secret" "example" {
   name                     = "example-customer-managed-secret"
-  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.test.id
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.example.id
 
   secret {
     customer_certificate {
-      key_vault_certificate_id = azurerm_key_vault_certificate.test.id
+      key_vault_certificate_id = azurerm_key_vault_certificate.example.id
     }
   }
 }

--- a/website/docs/r/cdn_frontdoor_security_policy.html.markdown
+++ b/website/docs/r/cdn_frontdoor_security_policy.html.markdown
@@ -21,6 +21,7 @@ resource "azurerm_resource_group" "example" {
 resource "azurerm_cdn_frontdoor_profile" "example" {
   name                = "example-profile"
   resource_group_name = azurerm_resource_group.example.name
+  sku_name            = "Standard_AzureFrontDoor"
 }
 
 resource "azurerm_cdn_frontdoor_firewall_policy" "example" {
@@ -51,6 +52,23 @@ resource "azurerm_cdn_frontdoor_firewall_policy" "example" {
   }
 }
 
+resource "azurerm_dns_zone" "example" {
+  name                = "sub-domain.domain.com"
+  resource_group_name = azurerm_resource_group.example.name
+}
+
+resource "azurerm_cdn_frontdoor_custom_domain" "example" {
+  name                     = "example-customDomain"
+  cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.example.id
+  dns_zone_id              = azurerm_dns_zone.example.id
+  host_name                = "contoso.fabrikam.com"
+
+  tls {
+    certificate_type    = "ManagedCertificate"
+    minimum_tls_version = "TLS12"
+  }
+}
+
 resource "azurerm_cdn_frontdoor_security_policy" "example" {
   name                     = "Example-Security-Policy"
   cdn_frontdoor_profile_id = azurerm_cdn_frontdoor_profile.example.id
@@ -61,7 +79,7 @@ resource "azurerm_cdn_frontdoor_security_policy" "example" {
 
       association {
         domain {
-          cdn_frontdoor_domain_id = azurerm_cdn_frontdoor_custom_domain.domain1.id
+          cdn_frontdoor_domain_id = azurerm_cdn_frontdoor_custom_domain.example.id
         }
         patterns_to_match = ["/*"]
       }


### PR DESCRIPTION
Update examples to be valid HCL.
