### PR TITLE
`azurerm_virtual_hub_connection` - support for `inbound_route_map_id`, `outbound_route_map_id` and `static_vnet_local_route_override_criteria`

### DIFF
--- a/internal/services/network/virtual_hub_connection_resource.go
+++ b/internal/services/network/virtual_hub_connection_resource.go
@@ -89,6 +89,18 @@ func resourceVirtualHubConnectionSchema() map[string]*pluginsdk.Schema {
 						AtLeastOneOf: []string{"routing.0.associated_route_table_id", "routing.0.propagated_route_table", "routing.0.static_vnet_route"},
 					},
 
+					"inbound_route_map_id": {
+						Type:         pluginsdk.TypeString,
+						Optional:     true,
+						ValidateFunc: validate.RouteMapID,
+					},
+
+					"outbound_route_map_id": {
+						Type:         pluginsdk.TypeString,
+						Optional:     true,
+						ValidateFunc: validate.RouteMapID,
+					},
+
 					"propagated_route_table": {
 						Type:     pluginsdk.TypeList,
 						Optional: true,
@@ -312,6 +324,18 @@ func expandVirtualHubConnectionRouting(input []interface{}) *network.RoutingConf
 		}
 	}
 
+	if inboundRouteMapId := v["inbound_route_map_id"].(string); inboundRouteMapId != "" {
+		result.InboundRouteMap = &network.SubResource{
+			ID: utils.String(inboundRouteMapId),
+		}
+	}
+
+	if outboundRouteMapId := v["outbound_route_map_id"].(string); outboundRouteMapId != "" {
+		result.OutboundRouteMap = &network.SubResource{
+			ID: utils.String(outboundRouteMapId),
+		}
+	}
+
 	if vnetStaticRoute := v["static_vnet_route"].([]interface{}); len(vnetStaticRoute) != 0 {
 		result.VnetRoutes = expandVirtualHubConnectionVnetStaticRoute(vnetStaticRoute)
 	}
@@ -401,9 +425,21 @@ func flattenVirtualHubConnectionRouting(input *network.RoutingConfiguration) []i
 		associatedRouteTableId = *input.AssociatedRouteTable.ID
 	}
 
+	inboundRouteMapId := ""
+	if input.InboundRouteMap != nil && input.InboundRouteMap.ID != nil {
+		inboundRouteMapId = *input.InboundRouteMap.ID
+	}
+
+	outboundRouteMapId := ""
+	if input.OutboundRouteMap != nil && input.OutboundRouteMap.ID != nil {
+		outboundRouteMapId = *input.OutboundRouteMap.ID
+	}
+
 	return []interface{}{
 		map[string]interface{}{
 			"associated_route_table_id": associatedRouteTableId,
+			"inbound_route_map_id":      inboundRouteMapId,
+			"outbound_route_map_id":     outboundRouteMapId,
 			"propagated_route_table":    flattenVirtualHubConnectionPropagatedRouteTable(input.PropagatedRouteTables),
 			"static_vnet_route":         flattenVirtualHubConnectionVnetStaticRoute(input.VnetRoutes),
 		},

--- a/internal/services/network/virtual_hub_connection_resource_test.go
+++ b/internal/services/network/virtual_hub_connection_resource_test.go
@@ -579,9 +579,6 @@ resource "azurerm_virtual_hub_connection" "test" {
   remote_virtual_network_id = azurerm_virtual_network.test.id
 
   routing {
-    inbound_route_map_id  = azurerm_route_map.test.id
-    outbound_route_map_id = azurerm_route_map.test2.id
-
     propagated_route_table {
       labels = ["label3"]
     }

--- a/internal/services/network/virtual_hub_connection_resource_test.go
+++ b/internal/services/network/virtual_hub_connection_resource_test.go
@@ -239,7 +239,6 @@ func TestAccVirtualHubConnection_requiresLocking(t *testing.T) {
 func TestAccVirtualHubConnection_updateRoutingConfiguration(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_virtual_hub_connection", "test")
 	r := VirtualHubConnectionResource{}
-	nameSuffix := randString()
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -249,7 +248,23 @@ func TestAccVirtualHubConnection_updateRoutingConfiguration(t *testing.T) {
 			),
 		},
 		{
-			Config: r.updateRoutingConfiguration(data, nameSuffix),
+			Config: r.updateRoutingConfiguration(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccVirtualHubConnection_routeMapAndStaticVnetLocalRouteOverrideCriteria(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_virtual_hub_connection", "test")
+	r := VirtualHubConnectionResource{}
+	nameSuffix := randString()
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.routeMapAndStaticVnetLocalRouteOverrideCriteria(data, nameSuffix),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -554,7 +569,34 @@ resource "azurerm_virtual_hub_connection" "test" {
 `, r.template(data), data.RandomInteger)
 }
 
-func (r VirtualHubConnectionResource) updateRoutingConfiguration(data acceptance.TestData, nameSuffix string) string {
+func (r VirtualHubConnectionResource) updateRoutingConfiguration(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "azurerm_virtual_hub_connection" "test" {
+  name                      = "acctest-vhubconn-%[2]d"
+  virtual_hub_id            = azurerm_virtual_hub.test.id
+  remote_virtual_network_id = azurerm_virtual_network.test.id
+
+  routing {
+    inbound_route_map_id  = azurerm_route_map.test.id
+    outbound_route_map_id = azurerm_route_map.test2.id
+
+    propagated_route_table {
+      labels = ["label3"]
+    }
+
+    static_vnet_route {
+      name                = "testvnetroute6"
+      address_prefixes    = ["10.0.6.0/24", "10.0.7.0/24"]
+      next_hop_ip_address = "10.0.6.5"
+    }
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r VirtualHubConnectionResource) routeMapAndStaticVnetLocalRouteOverrideCriteria(data acceptance.TestData, nameSuffix string) string {
 	return fmt.Sprintf(`
 %[1]s
 

--- a/internal/services/network/virtual_hub_connection_resource_test.go
+++ b/internal/services/network/virtual_hub_connection_resource_test.go
@@ -242,12 +242,12 @@ func TestAccVirtualHubConnection_updateRoutingConfiguration(t *testing.T) {
 	nameSuffix := randString()
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
-		//{
-		//	Config: r.withRoutingConfiguration(data),
-		//	Check: acceptance.ComposeTestCheckFunc(
-		//		check.That(data.ResourceName).ExistsInAzure(r),
-		//	),
-		//},
+		{
+			Config: r.withRoutingConfiguration(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
 		{
 			Config: r.updateRoutingConfiguration(data, nameSuffix),
 			Check: acceptance.ComposeTestCheckFunc(

--- a/internal/services/network/virtual_hub_connection_resource_test.go
+++ b/internal/services/network/virtual_hub_connection_resource_test.go
@@ -649,8 +649,9 @@ resource "azurerm_virtual_hub_connection" "test" {
   remote_virtual_network_id = azurerm_virtual_network.test.id
 
   routing {
-    inbound_route_map_id  = azurerm_route_map.test.id
-    outbound_route_map_id = azurerm_route_map.test2.id
+    inbound_route_map_id                      = azurerm_route_map.test.id
+    outbound_route_map_id                     = azurerm_route_map.test2.id
+    static_vnet_local_route_override_criteria = "Equal"
 
     propagated_route_table {
       labels = ["label3"]

--- a/website/docs/r/virtual_hub_connection.html.markdown
+++ b/website/docs/r/virtual_hub_connection.html.markdown
@@ -68,6 +68,10 @@ A `routing` block supports the following:
 
 * `associated_route_table_id` - (Optional) The ID of the route table associated with this Virtual Hub connection.
 
+* `inbound_route_map_id` - (Optional) The resource ID of the Route Map associated with this Routing Configuration for inbound learned routes.
+
+* `outbound_route_map_id` - (Optional) The resource ID of the Route Map associated with this Routing Configuration for outbound advertised routes.
+
 * `propagated_route_table` - (Optional) A `propagated_route_table` block as defined below.
 
 * `static_vnet_route` - (Optional) A `static_vnet_route` block as defined below.

--- a/website/docs/r/virtual_hub_connection.html.markdown
+++ b/website/docs/r/virtual_hub_connection.html.markdown
@@ -74,6 +74,8 @@ A `routing` block supports the following:
 
 * `propagated_route_table` - (Optional) A `propagated_route_table` block as defined below.
 
+* `static_vnet_local_route_override_criteria` - (Optional) The static VNet local route override criteria that is used to determine whether NVA in spoke VNet is bypassed for traffic with destination in spoke VNet. Possible values are `Contains` and `Equal`. Defaults to `Contains`. Changing this forces a new resource to be created.
+
 * `static_vnet_route` - (Optional) A `static_vnet_route` block as defined below.
 
 ---


### PR DESCRIPTION
![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/19754191/ef86f571-ff67-43b5-ab7b-20f2a69f1a0c)
