### PR TITLE
Doc Fix:  Fix incorrect IoTHub categories 

### DIFF
--- a/website/docs/r/iothub_endpoint_eventhub.html.markdown
+++ b/website/docs/r/iothub_endpoint_eventhub.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Messaging"
+subcategory: "IoT Hub"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_iothub_endpoint_eventhub"
 description: |-

--- a/website/docs/r/iothub_endpoint_servicebus_queue.html.markdown
+++ b/website/docs/r/iothub_endpoint_servicebus_queue.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Messaging"
+subcategory: "IoT Hub"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_iothub_endpoint_servicebus_queue"
 description: |-

--- a/website/docs/r/iothub_endpoint_servicebus_topic.html.markdown
+++ b/website/docs/r/iothub_endpoint_servicebus_topic.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Messaging"
+subcategory: "IoT Hub"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_iothub_endpoint_servicebus_topic"
 description: |-

--- a/website/docs/r/iothub_endpoint_storage_container.html.markdown
+++ b/website/docs/r/iothub_endpoint_storage_container.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Messaging"
+subcategory: "IoT Hub"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_iothub_endpoint_storage_container"
 description: |-

--- a/website/docs/r/iothub_enrichment.html.markdown
+++ b/website/docs/r/iothub_enrichment.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Messaging"
+subcategory: "IoT Hub"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_iothub_enrichment"
 description: |-

--- a/website/docs/r/iothub_fallback_route.html.markdown
+++ b/website/docs/r/iothub_fallback_route.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Messaging"
+subcategory: "IoT Hub"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_iothub_fallback_route"
 description: |-

--- a/website/docs/r/iothub_route.html.markdown
+++ b/website/docs/r/iothub_route.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Messaging"
+subcategory: "IoT Hub"
 layout: "azurerm"
 page_title: "Azure Resource Manager: azurerm_iothub_route"
 description: |-


### PR DESCRIPTION
Fixing the wrong category of `iothub_*` resources
Ref:
https://github.com/hashicorp/terraform-provider-azurerm/blob/a75bf648cea026110b096168284920616ac3a12c/website/docs/r/iothub.html.markdown?plain=1#L2-L4