### PR TITLE
`azurerm_resource_provider_registration` - fix test: add timeout for custom importer

### DIFF
--- a/internal/services/resource/resource_provider_registration_resource.go
+++ b/internal/services/resource/resource_provider_registration_resource.go
@@ -336,8 +336,11 @@ func (r ResourceProviderRegistrationResource) CustomImporter() sdk.ResourceRunFu
 		client := metadata.Client.Resource.ResourceProvidersClient
 		account := metadata.Client.Account
 
-		ctx, cancel := context.WithDeadline(ctx, time.Now().Add(5*time.Minute))
-		defer cancel()
+		if _, ok := ctx.Deadline(); !ok {
+			var cancelFunc context.CancelFunc
+			ctx, cancelFunc = context.WithDeadline(ctx, time.Now().Add(5*time.Minute))
+			defer cancelFunc()
+		}
 
 		id, err := providers.ParseSubscriptionProviderID(metadata.ResourceData.Id())
 		if err != nil {

--- a/internal/services/resource/resource_provider_registration_resource.go
+++ b/internal/services/resource/resource_provider_registration_resource.go
@@ -294,6 +294,7 @@ func (r ResourceProviderRegistrationResource) Delete() sdk.ResourceFunc {
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
 			client := metadata.Client.Resource.ResourceProvidersClient
 			account := metadata.Client.Account
+			featureClient := metadata.Client.Resource.FeaturesClient
 
 			id, err := providers.ParseSubscriptionProviderID(metadata.ResourceData.Id())
 			if err != nil {
@@ -304,7 +305,28 @@ func (r ResourceProviderRegistrationResource) Delete() sdk.ResourceFunc {
 				return err
 			}
 
-			err = r.applyFeatures(ctx, metadata, *id, metadata.ResourceData.Get("feature").(*pluginsdk.Set).List(), make([]interface{}, 0))
+			existingFeatures := make([]interface{}, 0)
+			result, err := featureClient.ListComplete(ctx, id.ProviderName)
+			if err != nil {
+				return fmt.Errorf("retrieving features for %s: %+v", *id, err)
+			}
+			for result.NotDone() {
+				value := result.Value()
+				if value.Properties != nil && value.Properties.State != nil && value.Name != nil {
+					featureName := (*value.Name)[len(id.ProviderName)+1:]
+					switch *value.Properties.State {
+					case Registering, Registered:
+						existingFeatures = append(existingFeatures, map[string]interface{}{"name": featureName, "registered": true})
+					case Unregistering, Unregistered:
+						existingFeatures = append(existingFeatures, map[string]interface{}{"name": featureName, "registered": false})
+					}
+				}
+				if err := result.NextWithContext(ctx); err != nil {
+					return fmt.Errorf("enumerating features: %+v", err)
+				}
+			}
+
+			err = r.applyFeatures(ctx, metadata, *id, existingFeatures, make([]interface{}, 0))
 			if err != nil {
 				return fmt.Errorf("applying features for %s: %+v", *id, err)
 			}

--- a/internal/services/resource/resource_provider_registration_resource.go
+++ b/internal/services/resource/resource_provider_registration_resource.go
@@ -336,6 +336,9 @@ func (r ResourceProviderRegistrationResource) CustomImporter() sdk.ResourceRunFu
 		client := metadata.Client.Resource.ResourceProvidersClient
 		account := metadata.Client.Account
 
+		ctx, cancel := context.WithDeadline(ctx, time.Now().Add(5*time.Minute))
+		defer cancel()
+
 		id, err := providers.ParseSubscriptionProviderID(metadata.ResourceData.Id())
 		if err != nil {
 			return err


### PR DESCRIPTION
original failure:
```
------- Stdout: -------
=== RUN   TestAccResourceProviderRegistration_basic
=== PAUSE TestAccResourceProviderRegistration_basic
=== CONT  TestAccResourceProviderRegistration_basic
    testcase.go:113: Step 2/2 error running import: exit status 1
        Error: retrieving Subscription Provider (Subscription: "*******"
        Provider Name: "Microsoft.BlockchainTokens"): the context used must have a deadline attached for polling purposes, but got no deadline
--- FAIL: TestAccResourceProviderRegistration_basic (45.71s)
FAIL
```

test:
```
TF_ACC=1 go test -v ./internal/services/resource -parallel 20 -test.run='TestAccResourceProviderRegistration_' -timeout 1440m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccResourceProviderRegistration_basic
=== PAUSE TestAccResourceProviderRegistration_basic
=== RUN   TestAccResourceProviderRegistration_requiresImport
=== PAUSE TestAccResourceProviderRegistration_requiresImport
=== RUN   TestAccResourceProviderRegistration_feature
=== PAUSE TestAccResourceProviderRegistration_feature
=== CONT  TestAccResourceProviderRegistration_basic
=== CONT  TestAccResourceProviderRegistration_feature
=== CONT  TestAccResourceProviderRegistration_requiresImport
--- PASS: TestAccResourceProviderRegistration_requiresImport (53.87s)
--- PASS: TestAccResourceProviderRegistration_basic (56.66s)
--- PASS: TestAccResourceProviderRegistration_feature (4976.44s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/resource      4976.489s

```