### PR TITLE
Service: `appservice` - rename `win32_status` to `win32_status_code`

### DIFF
--- a/internal/services/appservice/helpers/auto_heal.go
+++ b/internal/services/appservice/helpers/auto_heal.go
@@ -34,7 +34,7 @@ type AutoHealRequestTrigger struct {
 type AutoHealStatusCodeTrigger struct {
 	StatusCodeRange string `tfschema:"status_code_range"` // Conflicts with `StatusCode`, `Win32Code`, and `SubStatus` when not a single value...
 	SubStatus       int    `tfschema:"sub_status"`
-	Win32Status     int    `tfschema:"win32_status"`
+	Win32Status     int    `tfschema:"win32_status_code"`
 	Path            string `tfschema:"path"`
 	Count           int    `tfschema:"count"`
 	Interval        string `tfschema:"interval"` // Format - hh:mm:ss
@@ -240,7 +240,7 @@ func autoHealTriggerSchemaWindows() *pluginsdk.Schema {
 								Optional: true,
 							},
 
-							"win32_status": {
+							"win32_status_code": {
 								Type:     pluginsdk.TypeInt,
 								Optional: true,
 							},
@@ -345,7 +345,7 @@ func autoHealTriggerSchemaWindowsComputed() *pluginsdk.Schema {
 								Computed: true,
 							},
 
-							"win32_status": {
+							"win32_status_code": {
 								Type:     pluginsdk.TypeInt,
 								Computed: true,
 							},

--- a/internal/services/appservice/helpers/linux_web_app_schema.go
+++ b/internal/services/appservice/helpers/linux_web_app_schema.go
@@ -581,7 +581,7 @@ func autoHealTriggerSchemaLinux() *pluginsdk.Schema {
 								ValidateFunc: nil, // TODO - no docs on this, needs investigation
 							},
 
-							"win32_status": {
+							"win32_status_code": {
 								Type:         pluginsdk.TypeInt,
 								Optional:     true,
 								ValidateFunc: nil, // TODO - no docs on this, needs investigation
@@ -682,7 +682,7 @@ func autoHealTriggerSchemaLinuxComputed() *pluginsdk.Schema {
 								Computed: true,
 							},
 
-							"win32_status": {
+							"win32_status_code": {
 								Type:     pluginsdk.TypeInt,
 								Computed: true,
 							},

--- a/internal/services/appservice/windows_web_app_resource_test.go
+++ b/internal/services/appservice/windows_web_app_resource_test.go
@@ -2703,7 +2703,7 @@ resource "azurerm_windows_web_app" "test" {
           count             = 1
           status_code_range = 500
           sub_status        = 30
-          win32_status      = 0
+          win32_status_code = 0
           interval          = "00:10:00"
         }
       }

--- a/website/docs/d/linux_web_app.html.markdown
+++ b/website/docs/d/linux_web_app.html.markdown
@@ -653,7 +653,7 @@ A `status_code` block exports the following:
 
 * `sub_status` - The Request Sub Status of the Status Code.
 
-* `win32_status` - The Win32 Status Code of the Request.
+* `win32_status_code` - The Win32 Status Code of the Request.
 
 ---
 

--- a/website/docs/d/windows_web_app.html.markdown
+++ b/website/docs/d/windows_web_app.html.markdown
@@ -659,7 +659,7 @@ A `status_code` block exports the following:
 
 * `sub_status` - The Request Sub Status of the Status Code.
 
-* `win32_status` - The Win32 Status Code of the Request.
+* `win32_status_code` - The Win32 Status Code of the Request.
 
 ---
 

--- a/website/docs/r/linux_web_app.html.markdown
+++ b/website/docs/r/linux_web_app.html.markdown
@@ -752,7 +752,7 @@ A `status_code` block supports the following:
 
 * `sub_status` - (Optional) The Request Sub Status of the Status Code.
 
-* `win32_status` - (Optional) The Win32 Status Code of the Request.
+* `win32_status_code` - (Optional) The Win32 Status Code of the Request.
 
 ---
 

--- a/website/docs/r/linux_web_app_slot.html.markdown
+++ b/website/docs/r/linux_web_app_slot.html.markdown
@@ -756,7 +756,7 @@ A `status_code` block supports the following:
 
 * `sub_status` - (Optional) The Request Sub Status of the Status Code.
 
-* `win32_status` - (Optional) The Win32 Status Code of the Request.
+* `win32_status_code` - (Optional) The Win32 Status Code of the Request.
 
 ---
 

--- a/website/docs/r/windows_web_app.html.markdown
+++ b/website/docs/r/windows_web_app.html.markdown
@@ -772,7 +772,7 @@ A `status_code` block supports the following:
 
 * `sub_status` - (Optional) The Request Sub Status of the Status Code.
 
-* `win32_status` - (Optional) The Win32 Status Code of the Request.
+* `win32_status_code` - (Optional) The Win32 Status Code of the Request.
 
 ---
 

--- a/website/docs/r/windows_web_app_slot.html.markdown
+++ b/website/docs/r/windows_web_app_slot.html.markdown
@@ -770,7 +770,7 @@ A `status_code` block supports the following:
 
 * `sub_status` - (Optional) The Request Sub Status of the Status Code.
 
-* `win32_status` - (Optional) The Win32 Status Code of the Request.
+* `win32_status_code` - (Optional) The Win32 Status Code of the Request.
 
 ---
 


### PR DESCRIPTION
* `azurerm_linux_web_app`
* `azurerm_linux_web_app_slot`
* `azurerm_windows_web_app`
* `azurerm_windows_web_app_slot`

Due to a change made in the service to the underlying type of the Auto Heal property `win32_status` combined with a prior bug (in 3.62.1 and earlier) causing the value of this property to be stored incorrectly in state as an empty string, the value of this property could not be update or state migrated to accommodate the necessary type change in the state. This results in the resources named above returning an error of `a number is needed` when decoding the state for this value.

Unfortunately a limitation within the `terraform-plugin-sdk` means that it is not possible to introduce an automated migration for this field, and as such we are reluctantly requiring a breaking change for users of this field. The field `win32_status` has been replaced by `win32_status_code` (this remains an `int`, as in 3.63.0 onwards) and will require a breaking change to your Terraform Configuration, if this field is used.