### PR TITLE
`azurerm_dedicated_host` - Fix failed tests

### DIFF
--- a/internal/services/compute/dedicated_host_resource_test.go
+++ b/internal/services/compute/dedicated_host_resource_test.go
@@ -190,7 +190,7 @@ resource "azurerm_dedicated_host" "test" {
   name                    = "acctest-DH-%d"
   location                = azurerm_resource_group.test.location
   dedicated_host_group_id = azurerm_dedicated_host_group.test.id
-  sku_name                = "DSv3-Type1"
+  sku_name                = "DSv3-Type3"
   platform_fault_domain   = 1
 }
 `, r.template(data), data.RandomInteger)
@@ -218,7 +218,7 @@ resource "azurerm_dedicated_host" "test" {
   name                    = "acctest-DH-%d"
   location                = azurerm_resource_group.test.location
   dedicated_host_group_id = azurerm_dedicated_host_group.test.id
-  sku_name                = "DSv3-Type1"
+  sku_name                = "FSv2-Type2"
   platform_fault_domain   = 1
   auto_replace_on_failure = %t
 }
@@ -233,7 +233,7 @@ resource "azurerm_dedicated_host" "test" {
   name                    = "acctest-DH-%d"
   location                = azurerm_resource_group.test.location
   dedicated_host_group_id = azurerm_dedicated_host_group.test.id
-  sku_name                = "DSv3-Type1"
+  sku_name                = "FSv2-Type2"
   platform_fault_domain   = 1
   license_type            = %q
 }
@@ -248,7 +248,7 @@ resource "azurerm_dedicated_host" "test" {
   name                    = "acctest-DH-%d"
   location                = azurerm_resource_group.test.location
   dedicated_host_group_id = azurerm_dedicated_host_group.test.id
-  sku_name                = "DSv3-Type1"
+  sku_name                = "DSv3-Type3"
   platform_fault_domain   = 1
   license_type            = "Windows_Server_Hybrid"
   auto_replace_on_failure = false

--- a/internal/services/compute/linux_virtual_machine_resource_scaling_test.go
+++ b/internal/services/compute/linux_virtual_machine_resource_scaling_test.go
@@ -661,7 +661,7 @@ resource "azurerm_dedicated_host" "test" {
   name                    = "acctestDH-%d"
   dedicated_host_group_id = azurerm_dedicated_host_group.test.id
   location                = azurerm_resource_group.test.location
-  sku_name                = "DSv3-Type1"
+  sku_name                = "DSv3-Type3"
   platform_fault_domain   = 1
 }
 
@@ -711,7 +711,7 @@ resource "azurerm_dedicated_host" "test" {
   name                    = "acctestDH-%d"
   dedicated_host_group_id = azurerm_dedicated_host_group.test.id
   location                = azurerm_resource_group.test.location
-  sku_name                = "DSv3-Type1"
+  sku_name                = "DSv3-Type3"
   platform_fault_domain   = 1
 }
 
@@ -719,7 +719,7 @@ resource "azurerm_dedicated_host" "second" {
   name                    = "acctestDH2-%d"
   dedicated_host_group_id = azurerm_dedicated_host_group.test.id
   location                = azurerm_resource_group.test.location
-  sku_name                = "DSv3-Type1"
+  sku_name                = "DSv3-Type3"
   platform_fault_domain   = 1
 }
 
@@ -769,7 +769,7 @@ resource "azurerm_dedicated_host" "second" {
   name                    = "acctestDH2-%d"
   dedicated_host_group_id = azurerm_dedicated_host_group.test.id
   location                = azurerm_resource_group.test.location
-  sku_name                = "DSv3-Type1"
+  sku_name                = "DSv3-Type3"
   platform_fault_domain   = 1
 }
 
@@ -853,7 +853,7 @@ resource "azurerm_dedicated_host" "test" {
   name                    = "acctestDH-%d"
   dedicated_host_group_id = azurerm_dedicated_host_group.test.id
   location                = azurerm_resource_group.test.location
-  sku_name                = "DSv3-Type1"
+  sku_name                = "DSv3-Type3"
   platform_fault_domain   = 1
 }
 
@@ -908,7 +908,7 @@ resource "azurerm_dedicated_host" "test" {
   name                    = "acctestDH-%d"
   dedicated_host_group_id = azurerm_dedicated_host_group.test.id
   location                = azurerm_resource_group.test.location
-  sku_name                = "DSv3-Type1"
+  sku_name                = "DSv3-Type3"
   platform_fault_domain   = 1
 }
 
@@ -924,7 +924,7 @@ resource "azurerm_dedicated_host" "second" {
   name                    = "acctestDH2-%d"
   dedicated_host_group_id = azurerm_dedicated_host_group.second.id
   location                = azurerm_resource_group.test.location
-  sku_name                = "DSv3-Type1"
+  sku_name                = "DSv3-Type3"
   platform_fault_domain   = 1
 }
 
@@ -979,7 +979,7 @@ resource "azurerm_dedicated_host" "second" {
   name                    = "acctestDH2-%d"
   dedicated_host_group_id = azurerm_dedicated_host_group.second.id
   location                = azurerm_resource_group.test.location
-  sku_name                = "DSv3-Type1"
+  sku_name                = "DSv3-Type3"
   platform_fault_domain   = 1
 }
 

--- a/internal/services/compute/linux_virtual_machine_scale_set_resource_scaling_test.go
+++ b/internal/services/compute/linux_virtual_machine_scale_set_resource_scaling_test.go
@@ -444,7 +444,7 @@ resource "azurerm_dedicated_host" "test" {
   name                    = "acctestDH-%[2]d"
   dedicated_host_group_id = azurerm_dedicated_host_group.test.id
   location                = azurerm_resource_group.test.location
-  sku_name                = "DSv3-Type1"
+  sku_name                = "DSv3-Type3"
   platform_fault_domain   = 1
 }
 

--- a/internal/services/compute/windows_virtual_machine_resource_scaling_test.go
+++ b/internal/services/compute/windows_virtual_machine_resource_scaling_test.go
@@ -633,7 +633,7 @@ resource "azurerm_dedicated_host" "test" {
   name                    = "acctestDH-%d"
   dedicated_host_group_id = azurerm_dedicated_host_group.test.id
   location                = azurerm_resource_group.test.location
-  sku_name                = "DSv3-Type1"
+  sku_name                = "DSv3-Type3"
   platform_fault_domain   = 1
 }
 
@@ -679,7 +679,7 @@ resource "azurerm_dedicated_host" "test" {
   name                    = "acctestDH-%d"
   dedicated_host_group_id = azurerm_dedicated_host_group.test.id
   location                = azurerm_resource_group.test.location
-  sku_name                = "DSv3-Type1"
+  sku_name                = "DSv3-Type3"
   platform_fault_domain   = 1
 }
 
@@ -687,7 +687,7 @@ resource "azurerm_dedicated_host" "second" {
   name                    = "acctestDH2-%d"
   dedicated_host_group_id = azurerm_dedicated_host_group.test.id
   location                = azurerm_resource_group.test.location
-  sku_name                = "DSv3-Type1"
+  sku_name                = "DSv3-Type3"
   platform_fault_domain   = 1
 }
 
@@ -733,7 +733,7 @@ resource "azurerm_dedicated_host" "second" {
   name                    = "acctestDH2-%d"
   dedicated_host_group_id = azurerm_dedicated_host_group.test.id
   location                = azurerm_resource_group.test.location
-  sku_name                = "DSv3-Type1"
+  sku_name                = "DSv3-Type3"
   platform_fault_domain   = 1
 }
 
@@ -809,7 +809,7 @@ resource "azurerm_dedicated_host" "test" {
   name                    = "acctestDH-%d"
   dedicated_host_group_id = azurerm_dedicated_host_group.test.id
   location                = azurerm_resource_group.test.location
-  sku_name                = "DSv3-Type1"
+  sku_name                = "DSv3-Type3"
   platform_fault_domain   = 1
 }
 
@@ -860,7 +860,7 @@ resource "azurerm_dedicated_host" "test" {
   name                    = "acctestDH-%d"
   dedicated_host_group_id = azurerm_dedicated_host_group.test.id
   location                = azurerm_resource_group.test.location
-  sku_name                = "DSv3-Type1"
+  sku_name                = "DSv3-Type3"
   platform_fault_domain   = 1
 }
 
@@ -876,7 +876,7 @@ resource "azurerm_dedicated_host" "second" {
   name                    = "acctestDH2-%d"
   dedicated_host_group_id = azurerm_dedicated_host_group.second.id
   location                = azurerm_resource_group.test.location
-  sku_name                = "DSv3-Type1"
+  sku_name                = "DSv3-Type3"
   platform_fault_domain   = 1
 }
 
@@ -927,7 +927,7 @@ resource "azurerm_dedicated_host" "second" {
   name                    = "acctestDH2-%d"
   dedicated_host_group_id = azurerm_dedicated_host_group.second.id
   location                = azurerm_resource_group.test.location
-  sku_name                = "DSv3-Type1"
+  sku_name                = "DSv3-Type3"
   platform_fault_domain   = 1
 }
 

--- a/internal/services/compute/windows_virtual_machine_scale_set_resource_scaling_test.go
+++ b/internal/services/compute/windows_virtual_machine_scale_set_resource_scaling_test.go
@@ -425,7 +425,7 @@ resource "azurerm_dedicated_host" "test" {
   name                    = "acctestDH-%[2]d"
   dedicated_host_group_id = azurerm_dedicated_host_group.test.id
   location                = azurerm_resource_group.test.location
-  sku_name                = "DSv3-Type1"
+  sku_name                = "DSv3-Type3"
   platform_fault_domain   = 1
 }
 


### PR DESCRIPTION
## Test Result

--- PASS: TestAccDedicatedHost_basic (390.70s)
--- PASS: TestAccDedicatedHost_basicNewSku (391.64s)
--- PASS: TestAccDedicatedHost_complete (391.72s)
--- PASS: TestAccDedicatedHost_requiresImport (392.76s)
--- PASS: TestAccDedicatedHost_update (442.04s)
--- PASS: TestAccDedicatedHost_autoReplaceOnFailure (499.65s)
--- PASS: TestAccDedicatedHost_licenseType (553.80s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/compute       578.353s

--- PASS: TestAccLinuxVirtualMachine_scalingDedicatedHost (532.76s)
--- PASS: TestAccLinuxVirtualMachine_scalingDedicatedHostGroup (559.83s)
--- PASS: TestAccLinuxVirtualMachine_scalingDedicatedHostGroupUpdate (965.82s)
--- PASS: TestAccLinuxVirtualMachine_scalingDedicatedHostUpdate (1044.67s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/compute       1070.139s

--- PASS: TestAccWindowsVirtualMachine_scalingDedicatedHost (550.45s)
--- PASS: TestAccWindowsVirtualMachine_scalingDedicatedHostGroup (564.71s)
--- PASS: TestAccWindowsVirtualMachine_scalingDedicatedHostUpdate (1075.53s)
--- PASS: TestAccWindowsVirtualMachine_scalingDedicatedHostGroupUpdate (1098.21s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/compute       1123.386s

--- PASS: TestAccLinuxVirtualMachineScaleSet_scalingHostGroupId (713.60s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/compute       718.690s

--- PASS: TestAccWindowsVirtualMachineScaleSet_scalingHostGroupId (582.28s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/compute       587.567s

--- PASS: TestAccOrchestratedVirtualMachineScaleSet_AutomaticVMGuestPatchingUpdateLinux (334.08s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/compute       339.589s