### PR TITLE
`azurerm_container_app_environment` - support `dapr_application_insights_connection_string`

### DIFF
--- a/internal/services/containerapps/container_app_environment_resource.go
+++ b/internal/services/containerapps/container_app_environment_resource.go
@@ -19,18 +19,20 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/containerapps/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 )
 
 type ContainerAppEnvironmentResource struct{}
 
 type ContainerAppEnvironmentModel struct {
-	Name                        string                 `tfschema:"name"`
-	ResourceGroup               string                 `tfschema:"resource_group_name"`
-	Location                    string                 `tfschema:"location"`
-	LogAnalyticsWorkspaceId     string                 `tfschema:"log_analytics_workspace_id"`
-	InfrastructureSubnetId      string                 `tfschema:"infrastructure_subnet_id"`
-	InternalLoadBalancerEnabled bool                   `tfschema:"internal_load_balancer_enabled"`
-	Tags                        map[string]interface{} `tfschema:"tags"`
+	Name                                    string                 `tfschema:"name"`
+	ResourceGroup                           string                 `tfschema:"resource_group_name"`
+	Location                                string                 `tfschema:"location"`
+	DaprApplicationInsightsConnectionString string                 `tfschema:"dapr_application_insights_connection_string"`
+	LogAnalyticsWorkspaceId                 string                 `tfschema:"log_analytics_workspace_id"`
+	InfrastructureSubnetId                  string                 `tfschema:"infrastructure_subnet_id"`
+	InternalLoadBalancerEnabled             bool                   `tfschema:"internal_load_balancer_enabled"`
+	Tags                                    map[string]interface{} `tfschema:"tags"`
 
 	DefaultDomain         string `tfschema:"default_domain"`
 	DockerBridgeCidr      string `tfschema:"docker_bridge_cidr"`
@@ -66,6 +68,15 @@ func (r ContainerAppEnvironmentResource) Arguments() map[string]*pluginsdk.Schem
 		"location": commonschema.Location(),
 
 		"resource_group_name": commonschema.ResourceGroupName(),
+
+		"dapr_application_insights_connection_string": {
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ForceNew:     true,
+			Sensitive:    true,
+			ValidateFunc: validation.StringIsNotEmpty,
+			Description:  "Application Insights connection string used by Dapr to export Service to Service communication telemetry.",
+		},
 
 		"log_analytics_workspace_id": {
 			Type:         pluginsdk.TypeString,
@@ -165,6 +176,10 @@ func (r ContainerAppEnvironmentResource) Create() sdk.ResourceFunc {
 				Tags: tags.Expand(containerAppEnvironment.Tags),
 			}
 
+			if containerAppEnvironment.DaprApplicationInsightsConnectionString != "" {
+				managedEnvironment.Properties.DaprAIConnectionString = pointer.To(containerAppEnvironment.DaprApplicationInsightsConnectionString)
+			}
+
 			if containerAppEnvironment.LogAnalyticsWorkspaceId != "" {
 				logAnalyticsId, err := workspaces.ParseWorkspaceID(containerAppEnvironment.LogAnalyticsWorkspaceId)
 				if err != nil {
@@ -253,6 +268,11 @@ func (r ContainerAppEnvironmentResource) Read() sdk.ResourceFunc {
 					state.StaticIP = pointer.From(props.StaticIP)
 					state.DefaultDomain = pointer.From(props.DefaultDomain)
 				}
+			}
+
+			// `dapr_application_insights_connection_string` is sensitive and not returned by API
+			if v := metadata.ResourceData.Get("dapr_application_insights_connection_string").(string); v != "" {
+				state.DaprApplicationInsightsConnectionString = v
 			}
 
 			// Reading in log_analytics_workspace_id is not possible, so reading from config. Import will need to ignore_changes unfortunately

--- a/website/docs/r/container_app_environment.html.markdown
+++ b/website/docs/r/container_app_environment.html.markdown
@@ -46,6 +46,8 @@ The following arguments are supported:
 
 ---
 
+* `dapr_application_insights_connection_string` - (Optional) Application Insights connection string used by Dapr to export Service to Service communication telemetry.
+
 * `infrastructure_subnet_id` - (Optional) The existing Subnet to use for the Container Apps Control Plane. Changing this forces a new resource to be created. 
 
 ~> **NOTE:** The Subnet must have a `/21` or larger address space. 


### PR DESCRIPTION
Close #20404
instrumentation key is being superseded by connection string, so adding support for connection string only:
https://learn.microsoft.com/azure/azure-monitor/app/sdk-connection-string?tabs=dotnet5#overview