### PR TITLE
`azurerm_automation_account`: fix automation account local_authentication_enabled  logic

### DIFF
--- a/internal/services/automation/automation_account_resource.go
+++ b/internal/services/automation/automation_account_resource.go
@@ -195,9 +195,7 @@ func resourceAutomationAccountCreate(d *pluginsdk.ResourceData, meta interface{}
 		},
 	}
 
-	if localAuth := d.Get("local_authentication_enabled").(bool); !localAuth {
-		parameters.Properties.DisableLocalAuth = utils.Bool(true)
-	}
+	parameters.Properties.DisableLocalAuth = utils.Bool(!d.Get("local_authentication_enabled").(bool))
 
 	// for create account do not set identity property (even TypeNone is not allowed), or api will response error
 	if identityVal.Type != identity.TypeNone {
@@ -247,8 +245,8 @@ func resourceAutomationAccountUpdate(d *pluginsdk.ResourceData, meta interface{}
 		},
 	}
 
-	if localAuth := d.Get("local_authentication_enabled").(bool); !localAuth {
-		parameters.Properties.DisableLocalAuth = utils.Bool(true)
+	if d.HasChange("local_authentication_enabled") {
+		parameters.Properties.DisableLocalAuth = utils.Bool(!d.Get("local_authentication_enabled").(bool))
 	}
 
 	if tagsVal := tags.Expand(d.Get("tags").(map[string]interface{})); tagsVal != nil {

--- a/internal/services/automation/automation_account_resource_test.go
+++ b/internal/services/automation/automation_account_resource_test.go
@@ -67,6 +67,34 @@ func TestAccAutomationAccount_complete(t *testing.T) {
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("sku_name").HasValue("Basic"),
 				check.That(data.ResourceName).Key("tags.hello").HasValue("world"),
+				check.That(data.ResourceName).Key("local_authentication_enabled").HasValue("true"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccAutomationAccount_update(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_automation_account", "test")
+	r := AutomationAccountResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("sku_name").HasValue("Basic"),
+				check.That(data.ResourceName).Key("local_authentication_enabled").HasValue("false"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("sku_name").HasValue("Basic"),
+				check.That(data.ResourceName).Key("tags.hello").HasValue("world"),
+				check.That(data.ResourceName).Key("local_authentication_enabled").HasValue("true"),
 			),
 		},
 		data.ImportStep(),
@@ -206,10 +234,11 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_automation_account" "test" {
-  name                = "acctest-%[1]d"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
-  sku_name            = "Basic"
+  name                         = "acctest-%[1]d"
+  location                     = azurerm_resource_group.test.location
+  resource_group_name          = azurerm_resource_group.test.name
+  sku_name                     = "Basic"
+  local_authentication_enabled = false
 }
 `, data.RandomInteger, data.Locations.Primary)
 }
@@ -246,6 +275,7 @@ resource "azurerm_automation_account" "test" {
   resource_group_name           = azurerm_resource_group.test.name
   sku_name                      = "Basic"
   public_network_access_enabled = false
+  local_authentication_enabled  = true
   tags = {
     "hello" = "world"
   }


### PR DESCRIPTION
fixes #23053

always set `local_authentication_enabled` when create/update, not only when it is `false`.

```
--- PASS: TestAccAutomationAccount_complete (136.36s)
--- PASS: TestAccAutomationAccount_update (163.60s)
PASS
```