### PR TITLE
`azurerm_monitor_diagnostic_setting` - fix feature flagged schema

### DIFF
--- a/internal/services/monitor/monitor_diagnostic_setting_resource.go
+++ b/internal/services/monitor/monitor_diagnostic_setting_resource.go
@@ -241,6 +241,7 @@ func resourceMonitorDiagnosticSetting() *pluginsdk.Resource {
 		}
 
 		resource.Schema["metric"].AtLeastOneOf = []string{"enabled_log", "log", "metric"}
+		resource.Schema["enabled_log"].AtLeastOneOf = []string{"enabled_log", "log", "metric"}
 		resource.Schema["enabled_log"].ConflictsWith = []string{"log"}
 	}
 


### PR DESCRIPTION
fix #23092
when only `log` is specified in 3.x version, get error: `"enabled_log": one of `enabled_log,metric` must be specified`
related to PR #23024