### PR TITLE
fixed security_group_association for bastion example

### DIFF
--- a/examples/virtual-machines/virtual_machine/bastion-box/1-dependencies.tf
+++ b/examples/virtual-machines/virtual_machine/bastion-box/1-dependencies.tf
@@ -37,7 +37,11 @@ resource "azurerm_subnet" "bastion" {
   virtual_network_name      = "${azurerm_virtual_network.example.name}"
   resource_group_name       = "${azurerm_resource_group.example.name}"
   address_prefixes          = ["10.0.0.128/25"]
-  network_security_group_id = "${azurerm_network_security_group.bastion.id}"
+}
+
+resource "azurerm_subnet_network_security_group_association" "bastion" {
+  subnet_id                 = azurerm_subnet.bastion.id
+  network_security_group_id = azurerm_network_security_group.bastion.id
 }
 
 resource "azurerm_network_security_group" "web" {
@@ -77,5 +81,9 @@ resource "azurerm_subnet" "web" {
   virtual_network_name      = "${azurerm_virtual_network.example.name}"
   resource_group_name       = "${azurerm_resource_group.example.name}"
   address_prefixes          = ["10.0.1.0/24"]
-  network_security_group_id = "${azurerm_network_security_group.web.id}"
+}
+
+resource "azurerm_subnet_network_security_group_association" "web" {
+  subnet_id                 = azurerm_subnet.web.id
+  network_security_group_id = azurerm_network_security_group.web.id
 }

--- a/examples/virtual-machines/virtual_machine/bastion-box/main.tf
+++ b/examples/virtual-machines/virtual_machine/bastion-box/main.tf
@@ -14,7 +14,6 @@ resource "azurerm_network_interface" "example" {
   name                      = "${azurerm_resource_group.example.name}-nic"
   location                  = "${azurerm_resource_group.example.location}"
   resource_group_name       = "${azurerm_resource_group.example.name}"
-  network_security_group_id = "${azurerm_network_security_group.bastion.id}"
 
   ip_configuration {
     name                          = "internal"
@@ -22,6 +21,11 @@ resource "azurerm_network_interface" "example" {
     private_ip_address_allocation = "Dynamic"
     public_ip_address_id          = "${azurerm_public_ip.example.id}"
   }
+}
+
+resource "azurerm_network_interface_security_group_association" "example" {
+  network_interface_id      = azurerm_network_interface.example.id
+  network_security_group_id = azurerm_network_security_group.bastion.id
 }
 
 resource "azurerm_public_ip" "example" {


### PR DESCRIPTION
Hi - I was having an issue with the examples/virtual-machines/virtual-machine/bastion example using haschicorp/azurerm v3.71.0.

Looks like you can no longer associate a network_security_group directly with a subnet or a network_interface. Have added a azurerm_subnet_network_security_group_association and azurerm_network_interface_security_group_association to fix.