### PR TITLE
`azurerm_api_management_api_policy`, `azurerm_api_management_api_operation_policy`, `azurerm_api_management_product_policy` : fix parsing resource id error

### DIFF
--- a/internal/services/apimanagement/api_management_api_operation_policy_resource.go
+++ b/internal/services/apimanagement/api_management_api_operation_policy_resource.go
@@ -39,9 +39,10 @@ func resourceApiManagementApiOperationPolicy() *pluginsdk.Resource {
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 
-		SchemaVersion: 1,
+		SchemaVersion: 2,
 		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
 			0: migration.ApiManagementApiOperationPolicyV0ToV1{},
+			1: migration.ApiManagementApiOperationPolicyV1ToV2{},
 		}),
 
 		Schema: map[string]*pluginsdk.Schema{

--- a/internal/services/apimanagement/api_management_api_policy_resource.go
+++ b/internal/services/apimanagement/api_management_api_policy_resource.go
@@ -39,9 +39,10 @@ func resourceApiManagementApiPolicy() *pluginsdk.Resource {
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 
-		SchemaVersion: 1,
+		SchemaVersion: 2,
 		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
 			0: migration.ApiManagementApiPolicyV0ToV1{},
+			1: migration.ApiManagementApiPolicyV1ToV2{},
 		}),
 
 		Schema: map[string]*pluginsdk.Schema{

--- a/internal/services/apimanagement/api_management_product_policy_resource.go
+++ b/internal/services/apimanagement/api_management_product_policy_resource.go
@@ -39,9 +39,10 @@ func resourceApiManagementProductPolicy() *pluginsdk.Resource {
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 
-		SchemaVersion: 1,
+		SchemaVersion: 2,
 		StateUpgraders: pluginsdk.StateUpgrades(map[int]pluginsdk.StateUpgrade{
 			0: migration.ApiManagementProductPolicyV0ToV1{},
+			1: migration.ApiManagementProductPolicyV1ToV2{},
 		}),
 
 		Schema: map[string]*pluginsdk.Schema{

--- a/internal/services/apimanagement/migration/api_operation_policy_v1_to_v2.go
+++ b/internal/services/apimanagement/migration/api_operation_policy_v1_to_v2.go
@@ -1,0 +1,71 @@
+package migration
+
+import (
+	"context"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+var _ pluginsdk.StateUpgrade = ApiManagementApiOperationPolicyV1ToV2{}
+
+type ApiManagementApiOperationPolicyV1ToV2 struct{}
+
+func (ApiManagementApiOperationPolicyV1ToV2) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+
+		"resource_group_name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"api_management_name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"api_name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"operation_id": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"xml_content": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			Computed: true,
+		},
+
+		"xml_link": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+		},
+	}
+}
+
+func (ApiManagementApiOperationPolicyV1ToV2) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		// old id : /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.ApiManagement/service/instance1/apis/api1/operations/operation1/policies/policy
+		// new id : /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.ApiManagement/service/instance1/apis/api1/operations/operation1
+		oldId := rawState["id"].(string)
+
+		// Prior to v3.70.0 of Terraform Provider, after importing resource, the id in state file ends with "/policies/policy", the id in state file ends with "/policies/xml" for creating resource by Terraform.
+		// So after migrating pandora SDK (starting from v3.70.0), these two cases need to be migrated.
+		// In ApiManagementApiPolicyV0ToV1, only the case where the ID ends with "/policies/xml" is processed, so the case where the ID ends with "/policies/policy" is processed here to solve the parse id error.
+		newId := strings.TrimSuffix(oldId, "/policies/policy")
+
+		log.Printf("[DEBUG] Updating ID from %q tmakeo %q", oldId, newId)
+		rawState["id"] = newId
+
+		return rawState, nil
+	}
+}

--- a/internal/services/apimanagement/migration/api_operation_policy_v1_to_v2.go
+++ b/internal/services/apimanagement/migration/api_operation_policy_v1_to_v2.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"strings"
 
+	"github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2021-08-01/apioperationpolicy"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
@@ -62,8 +63,12 @@ func (ApiManagementApiOperationPolicyV1ToV2) UpgradeFunc() pluginsdk.StateUpgrad
 		// So after migrating pandora SDK (starting from v3.70.0), these two cases need to be migrated.
 		// In ApiManagementApiPolicyV0ToV1, only the case where the ID ends with "/policies/xml" is processed, so the case where the ID ends with "/policies/policy" is processed here to solve the parse id error.
 		newId := strings.TrimSuffix(oldId, "/policies/policy")
-
-		log.Printf("[DEBUG] Updating ID from %q tmakeo %q", oldId, newId)
+		parsed, err := apioperationpolicy.ParseOperationID(newId)
+		if err != nil {
+			return rawState, err
+		}
+		newId = parsed.ID()
+		log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newId)
 		rawState["id"] = newId
 
 		return rawState, nil

--- a/internal/services/apimanagement/migration/api_policy_v1_to_v2.go
+++ b/internal/services/apimanagement/migration/api_policy_v1_to_v2.go
@@ -1,0 +1,65 @@
+package migration
+
+import (
+	"context"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+var _ pluginsdk.StateUpgrade = ApiManagementApiPolicyV1ToV2{}
+
+type ApiManagementApiPolicyV1ToV2 struct{}
+
+func (ApiManagementApiPolicyV1ToV2) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+
+		"resource_group_name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"api_management_name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"api_name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"xml_content": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			Computed: true,
+		},
+
+		"xml_link": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+		},
+	}
+}
+
+func (ApiManagementApiPolicyV1ToV2) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		// old id : /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.ApiManagement/service/service1/apis/exampleId/policies/policy
+		// new id : /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.ApiManagement/service/service1/apis/exampleId
+		oldId := rawState["id"].(string)
+
+		// Prior to v3.70.0 of Terraform Provider, after importing resource, the id in state file ends with "/policies/policy", the id in state file ends with "/policies/xml" for creating resource by Terraform.
+		// So after migrating pandora SDK (starting from v3.70.0), these two cases need to be migrated.
+		// In ApiManagementApiPolicyV0ToV1, only the case where the ID ends with "/policies/xml" is processed, so the case where the ID ends with "/policies/policy" is processed here to solve the parse id error.
+		newId := strings.TrimSuffix(oldId, "/policies/policy")
+
+		log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newId)
+		rawState["id"] = newId
+
+		return rawState, nil
+	}
+}

--- a/internal/services/apimanagement/migration/api_policy_v1_to_v2.go
+++ b/internal/services/apimanagement/migration/api_policy_v1_to_v2.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"strings"
 
+	"github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2021-08-01/apipolicy"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
@@ -56,7 +57,11 @@ func (ApiManagementApiPolicyV1ToV2) UpgradeFunc() pluginsdk.StateUpgraderFunc {
 		// So after migrating pandora SDK (starting from v3.70.0), these two cases need to be migrated.
 		// In ApiManagementApiPolicyV0ToV1, only the case where the ID ends with "/policies/xml" is processed, so the case where the ID ends with "/policies/policy" is processed here to solve the parse id error.
 		newId := strings.TrimSuffix(oldId, "/policies/policy")
-
+		parsed, err := apipolicy.ParseApiID(newId)
+		if err != nil {
+			return rawState, err
+		}
+		newId = parsed.ID()
 		log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newId)
 		rawState["id"] = newId
 

--- a/internal/services/apimanagement/migration/api_product_policy_v1_to_v2.go
+++ b/internal/services/apimanagement/migration/api_product_policy_v1_to_v2.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"strings"
 
+	"github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2021-08-01/productpolicy"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
@@ -55,8 +56,12 @@ func (ApiManagementProductPolicyV1ToV2) UpgradeFunc() pluginsdk.StateUpgraderFun
 		// So after migrating pandora SDK (starting from v3.70.0), these two cases need to be migrated.
 		// In ApiManagementApiPolicyV0ToV1, only the case where the ID ends with "/policies/xml" is processed, so the case where the ID ends with "/policies/policy" is processed here to solve the parse id error.
 		newId := strings.TrimSuffix(oldId, "/policies/policy")
-
-		log.Printf("[DEBUG] Updating ID from %q tmakeo %q", oldId, newId)
+		parsed, err := productpolicy.ParseProductID(newId)
+		if err != nil {
+			return rawState, err
+		}
+		newId = parsed.ID()
+		log.Printf("[DEBUG] Updating ID from %q to %q", oldId, newId)
 		rawState["id"] = newId
 
 		return rawState, nil

--- a/internal/services/apimanagement/migration/api_product_policy_v1_to_v2.go
+++ b/internal/services/apimanagement/migration/api_product_policy_v1_to_v2.go
@@ -1,0 +1,64 @@
+package migration
+
+import (
+	"context"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+var _ pluginsdk.StateUpgrade = ApiManagementProductPolicyV1ToV2{}
+
+type ApiManagementProductPolicyV1ToV2 struct{}
+
+func (ApiManagementProductPolicyV1ToV2) Schema() map[string]*pluginsdk.Schema {
+	return map[string]*pluginsdk.Schema{
+		"resource_group_name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"api_management_name": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"product_id": {
+			Type:     pluginsdk.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+
+		"xml_content": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+			Computed: true,
+		},
+
+		"xml_link": {
+			Type:     pluginsdk.TypeString,
+			Optional: true,
+		},
+	}
+}
+
+func (ApiManagementProductPolicyV1ToV2) UpgradeFunc() pluginsdk.StateUpgraderFunc {
+	return func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+		// old id : /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.ApiManagement/service/service1/products/exampleId/policies/policy
+		// new id : /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.ApiManagement/service/service1/products/exampleId
+		oldId := rawState["id"].(string)
+
+		// Prior to v3.70.0 of Terraform Provider, after importing resource, the id in state file ends with "/policies/policy", the id in state file ends with "/policies/xml" for creating resource by Terraform.
+		// So after migrating pandora SDK (starting from v3.70.0), these two cases need to be migrated.
+		// In ApiManagementApiPolicyV0ToV1, only the case where the ID ends with "/policies/xml" is processed, so the case where the ID ends with "/policies/policy" is processed here to solve the parse id error.
+		newId := strings.TrimSuffix(oldId, "/policies/policy")
+
+		log.Printf("[DEBUG] Updating ID from %q tmakeo %q", oldId, newId)
+		rawState["id"] = newId
+
+		return rawState, nil
+	}
+}


### PR DESCRIPTION
For resources `azurerm_api_management_api_policy`, `azurerm_api_management_api_operation_policy`, `azurerm_api_management_product_policy`, after importing the resource using a version before v3.70.0 of Terraform Provider,  the id in state file ends with "/policies/policy", and the id in state file ends with "/policies/xml" when creating resource by Terraform. Therefore, when migrating Pandora SDK, both cases need to be migrated.

 In [PR #22783](https://github.com/hashicorp/terraform-provider-azurerm/pull/22783) only the case where the ID ends with "/policies/xml" is processed, so submit this PR to process the case where the ID ends with "/policies/policy" to solve the parsing id error.

Might fix issue #23112, #23095.

Local manual testing, the steps are as follows:
	

> 1. Import  the existing resources `azurerm_api_management_api_policy`, `azurerm_api_management_api_operation_policy`, `azurerm_api_management_product_policy` using TF provider v3.69.0. 
> 	2. Upgrade TF provider to v3.71.0.
> 	3. Run "terraform plan" => The parsing id error occurred.
> 	4. Upgrade the TF provider to the current PR build version.
> 	5.  Run "terraform plan"  => No error.
