### PR TITLE
`azurerm_monitor_log_profile` - mark as deprecated

### DIFF
--- a/internal/services/monitor/monitor_log_profile_data_source.go
+++ b/internal/services/monitor/monitor_log_profile_data_source.go
@@ -18,6 +18,8 @@ func dataSourceMonitorLogProfile() *pluginsdk.Resource {
 	return &pluginsdk.Resource{
 		Read: dataSourceLogProfileRead,
 
+		DeprecationMessage: "Azure Log Profiles will be retired on 30th September 2026 and will be removed in v4.0 of the AzureRM Provider. More information on the deprecation can be found at https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/activity-log?tabs=powershell#legacy-collection-methods",
+
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Read: pluginsdk.DefaultTimeout(5 * time.Minute),
 		},

--- a/internal/services/monitor/monitor_log_profile_resource.go
+++ b/internal/services/monitor/monitor_log_profile_resource.go
@@ -32,6 +32,8 @@ func resourceMonitorLogProfile() *pluginsdk.Resource {
 		Update: resourceLogProfileCreateUpdate,
 		Delete: resourceLogProfileDelete,
 
+		DeprecationMessage: "Azure Log profiles will be retired on 30th September 2026 and will be automatically converted to Diagnostic settings, for more details, please see https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/activity-log?tabs=powershell#legacy-collection-methods",
+
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
 			_, err := logprofiles.ParseLogProfileID(id)
 			return err

--- a/internal/services/monitor/monitor_log_profile_resource.go
+++ b/internal/services/monitor/monitor_log_profile_resource.go
@@ -32,7 +32,7 @@ func resourceMonitorLogProfile() *pluginsdk.Resource {
 		Update: resourceLogProfileCreateUpdate,
 		Delete: resourceLogProfileDelete,
 
-		DeprecationMessage: "Azure Log profiles will be retired on 30th September 2026, for more details, please see https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/activity-log?tabs=powershell#legacy-collection-methods",
+		DeprecationMessage: "Azure Log Profiles will be retired on 30th September 2026 and will be removed in v4.0 of the AzureRM Provider. More information on the deprecation can be found at https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/activity-log?tabs=powershell#legacy-collection-methods",
 
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
 			_, err := logprofiles.ParseLogProfileID(id)

--- a/internal/services/monitor/monitor_log_profile_resource.go
+++ b/internal/services/monitor/monitor_log_profile_resource.go
@@ -32,7 +32,7 @@ func resourceMonitorLogProfile() *pluginsdk.Resource {
 		Update: resourceLogProfileCreateUpdate,
 		Delete: resourceLogProfileDelete,
 
-		DeprecationMessage: "Azure Log profiles will be retired on 30th September 2026 and will be automatically converted to Diagnostic settings, for more details, please see https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/activity-log?tabs=powershell#legacy-collection-methods",
+		DeprecationMessage: "Azure Log profiles will be retired on 30th September 2026, for more details, please see https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/activity-log?tabs=powershell#legacy-collection-methods",
 
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
 			_, err := logprofiles.ParseLogProfileID(id)

--- a/website/docs/d/monitor_log_profile.html.markdown
+++ b/website/docs/d/monitor_log_profile.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Use this data source to access the properties of a Log Profile.
 
+-> **NOTE:** Azure Log profiles will be retired on 30th September 2026 and will be automatically converted to Diagnostic settings, for more details, please see https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/activity-log?tabs=powershell#legacy-collection-methods.
+
 ## Example Usage
 
 ```hcl

--- a/website/docs/d/monitor_log_profile.html.markdown
+++ b/website/docs/d/monitor_log_profile.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Use this data source to access the properties of a Log Profile.
 
--> **NOTE:** Azure Log profiles will be retired on 30th September 2026, for more details, please see the [doc](https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/activity-log?tabs=powershell#legacy-collection-methods).
+!> **NOTE:** Azure Log Profiles will be retired on 30th September 2026 and will be removed in v4.0 of the AzureRM Provider. More information on the deprecation can be found [in the Azure documentation](https://learn.microsoft.com/azure/azure-monitor/essentials/activity-log?tabs=powershell#legacy-collection-methods).
 
 ## Example Usage
 

--- a/website/docs/d/monitor_log_profile.html.markdown
+++ b/website/docs/d/monitor_log_profile.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Use this data source to access the properties of a Log Profile.
 
--> **NOTE:** Azure Log profiles will be retired on 30th September 2026 and will be automatically converted to Diagnostic settings, for more details, please see https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/activity-log?tabs=powershell#legacy-collection-methods.
+-> **NOTE:** Azure Log profiles will be retired on 30th September 2026, for more details, please see the [doc](https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/activity-log?tabs=powershell#legacy-collection-methods).
 
 ## Example Usage
 

--- a/website/docs/r/monitor_log_profile.html.markdown
+++ b/website/docs/r/monitor_log_profile.html.markdown
@@ -12,7 +12,7 @@ Manages a [Log Profile](https://docs.microsoft.com/azure/monitoring-and-diagnost
 
 -> **NOTE:** It's only possible to configure one Log Profile per Subscription. If you are trying to create more than one Log Profile, an error with `StatusCode=409` will occur.
 
--> **NOTE:** Azure Log profiles will be retired on 30th September 2026, for more details, please see the [doc](https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/activity-log?tabs=powershell#legacy-collection-methods).
+!> **NOTE:** Azure Log Profiles will be retired on 30th September 2026 and will be removed in v4.0 of the AzureRM Provider. More information on the deprecation can be found [in the Azure documentation](https://learn.microsoft.com/azure/azure-monitor/essentials/activity-log?tabs=powershell#legacy-collection-methods).
 
 ## Example Usage
 

--- a/website/docs/r/monitor_log_profile.html.markdown
+++ b/website/docs/r/monitor_log_profile.html.markdown
@@ -12,7 +12,7 @@ Manages a [Log Profile](https://docs.microsoft.com/azure/monitoring-and-diagnost
 
 -> **NOTE:** It's only possible to configure one Log Profile per Subscription. If you are trying to create more than one Log Profile, an error with `StatusCode=409` will occur.
 
--> **NOTE:** Azure Log profiles will be retired on 30th September 2026 and will be automatically converted to Diagnostic settings, for more details, please see https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/activity-log?tabs=powershell#legacy-collection-methods.
+-> **NOTE:** Azure Log profiles will be retired on 30th September 2026, for more details, please see the [doc](https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/activity-log?tabs=powershell#legacy-collection-methods).
 
 ## Example Usage
 

--- a/website/docs/r/monitor_log_profile.html.markdown
+++ b/website/docs/r/monitor_log_profile.html.markdown
@@ -12,6 +12,8 @@ Manages a [Log Profile](https://docs.microsoft.com/azure/monitoring-and-diagnost
 
 -> **NOTE:** It's only possible to configure one Log Profile per Subscription. If you are trying to create more than one Log Profile, an error with `StatusCode=409` will occur.
 
+-> **NOTE:** Azure Log profiles will be retired on 30th September 2026 and will be automatically converted to Diagnostic settings, for more details, please see https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/activity-log?tabs=powershell#legacy-collection-methods.
+
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
from https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/activity-log?tabs=powershell#legacy-collection-methods

On 30 September 2026, the legacy solution for forwarding Azure activity logs, known as Log Profiles, will be retired and replaced with diagnostic settings. This transition to diagnostic settings will happen automatically—you don’t need to take any action, and the change won’t cause any disruption in your workflow. 