### PR TITLE
`azurerm_shared_image_version` - Support `replicated_region_deletion_enabled` and `target_region.exclude_from_latest_enabled`

### DIFF
--- a/internal/services/compute/shared_image_version_resource.go
+++ b/internal/services/compute/shared_image_version_resource.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/Azure/go-autorest/autorest/date"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
@@ -99,6 +100,12 @@ func resourceSharedImageVersion() *pluginsdk.Resource {
 							ValidateFunc: validate.DiskEncryptionSetID,
 						},
 
+						"exclude_from_latest_enabled": {
+							Type:     pluginsdk.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
+
 						// The Service API doesn't support to update `storage_account_type`. So it has to recreate the resource for updating `storage_account_type`.
 						// However, `ForceNew` cannot be used since resource would be recreated while adding or removing `target_region`.
 						// And `CustomizeDiff` also cannot be used since it doesn't support in a `Set`.
@@ -177,6 +184,13 @@ func resourceSharedImageVersion() *pluginsdk.Resource {
 				Default:  false,
 			},
 
+			"replicated_region_deletion_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+				ForceNew: true,
+				Default:  false,
+			},
+
 			"tags": tags.Schema(),
 		},
 
@@ -221,6 +235,9 @@ func resourceSharedImageVersionCreateUpdate(d *pluginsdk.ResourceData, meta inte
 				ExcludeFromLatest: utils.Bool(d.Get("exclude_from_latest").(bool)),
 				ReplicationMode:   compute.ReplicationMode(d.Get("replication_mode").(string)),
 				TargetRegions:     targetRegions,
+			},
+			SafetyProfile: &compute.GalleryImageVersionSafetyProfile{
+				AllowDeletionOfReplicatedLocations: utils.Bool(d.Get("replicated_region_deletion_enabled").(bool)),
 			},
 			StorageProfile: &compute.GalleryImageVersionStorageProfile{},
 		},
@@ -343,6 +360,10 @@ func resourceSharedImageVersionRead(d *pluginsdk.ResourceData, meta interface{})
 			d.Set("os_disk_snapshot_id", osDiskSnapShotID)
 			d.Set("storage_account_id", storageAccountID)
 		}
+
+		if safetyProfile := props.SafetyProfile; safetyProfile != nil {
+			d.Set("replicated_region_deletion_enabled", pointer.From(safetyProfile.AllowDeletionOfReplicatedLocations))
+		}
 	}
 
 	return tags.FlattenAndSet(d, resp.Tags)
@@ -415,9 +436,11 @@ func expandSharedImageVersionTargetRegions(d *pluginsdk.ResourceData) (*[]comput
 		regionalReplicaCount := input["regional_replica_count"].(int)
 		storageAccountType := input["storage_account_type"].(string)
 		diskEncryptionSetId := input["disk_encryption_set_id"].(string)
+		excludeFromLatest := input["exclude_from_latest_enabled"].(bool)
 
 		output := compute.TargetRegion{
 			Name:                 utils.String(name),
+			ExcludeFromLatest:    utils.Bool(excludeFromLatest),
 			RegionalReplicaCount: utils.Int32(int32(regionalReplicaCount)),
 			StorageAccountType:   compute.StorageAccountType(storageAccountType),
 		}
@@ -462,6 +485,8 @@ func flattenSharedImageVersionTargetRegions(input *[]compute.TargetRegion) []int
 				diskEncryptionSetId = *v.Encryption.OsDiskImage.DiskEncryptionSetID
 			}
 			output["disk_encryption_set_id"] = diskEncryptionSetId
+
+			output["exclude_from_latest_enabled"] = pointer.From(v.ExcludeFromLatest)
 
 			results = append(results, output)
 		}

--- a/internal/services/compute/shared_image_version_resource.go
+++ b/internal/services/compute/shared_image_version_resource.go
@@ -184,7 +184,7 @@ func resourceSharedImageVersion() *pluginsdk.Resource {
 				Default:  false,
 			},
 
-			"replicated_region_deletion_enabled": {
+			"deletion_of_replicated_locations_enabled": {
 				Type:     pluginsdk.TypeBool,
 				Optional: true,
 				ForceNew: true,
@@ -237,7 +237,7 @@ func resourceSharedImageVersionCreateUpdate(d *pluginsdk.ResourceData, meta inte
 				TargetRegions:     targetRegions,
 			},
 			SafetyProfile: &compute.GalleryImageVersionSafetyProfile{
-				AllowDeletionOfReplicatedLocations: utils.Bool(d.Get("replicated_region_deletion_enabled").(bool)),
+				AllowDeletionOfReplicatedLocations: utils.Bool(d.Get("deletion_of_replicated_locations_enabled").(bool)),
 			},
 			StorageProfile: &compute.GalleryImageVersionStorageProfile{},
 		},
@@ -362,7 +362,7 @@ func resourceSharedImageVersionRead(d *pluginsdk.ResourceData, meta interface{})
 		}
 
 		if safetyProfile := props.SafetyProfile; safetyProfile != nil {
-			d.Set("replicated_region_deletion_enabled", pointer.From(safetyProfile.AllowDeletionOfReplicatedLocations))
+			d.Set("deletion_of_replicated_locations_enabled", pointer.From(safetyProfile.AllowDeletionOfReplicatedLocations))
 		}
 	}
 

--- a/internal/services/compute/shared_image_version_resource_test.go
+++ b/internal/services/compute/shared_image_version_resource_test.go
@@ -727,13 +727,13 @@ func (r SharedImageVersionResource) replicatedRegionDeletion(data acceptance.Tes
 %s
 
 resource "azurerm_shared_image_version" "test" {
-  name                               = "0.0.1"
-  gallery_name                       = azurerm_shared_image_gallery.test.name
-  image_name                         = azurerm_shared_image.test.name
-  resource_group_name                = azurerm_resource_group.test.name
-  location                           = azurerm_resource_group.test.location
-  managed_image_id                   = azurerm_image.test.id
-  replicated_region_deletion_enabled = true
+  name                                     = "0.0.1"
+  gallery_name                             = azurerm_shared_image_gallery.test.name
+  image_name                               = azurerm_shared_image.test.name
+  resource_group_name                      = azurerm_resource_group.test.name
+  location                                 = azurerm_resource_group.test.location
+  managed_image_id                         = azurerm_image.test.id
+  deletion_of_replicated_locations_enabled = true
 
   target_region {
     name                        = azurerm_resource_group.test.location

--- a/internal/services/compute/shared_image_version_resource_test.go
+++ b/internal/services/compute/shared_image_version_resource_test.go
@@ -234,6 +234,29 @@ func TestAccSharedImageVersion_replicationMode(t *testing.T) {
 	})
 }
 
+func TestAccSharedImageVersion_replicatedRegionDeletion(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_shared_image_version", "test")
+	r := SharedImageVersionResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			// need to create a vm and then reference it in the image creation
+			Config: r.setup(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				data.CheckWithClientForResource(ImageResource{}.virtualMachineExists, "azurerm_virtual_machine.testsource"),
+				data.CheckWithClientForResource(ImageResource{}.generalizeVirtualMachine(data), "azurerm_virtual_machine.testsource"),
+			),
+		},
+		{
+			Config: r.replicatedRegionDeletion(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccSharedImageVersion_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_shared_image_version", "test")
 	r := SharedImageVersionResource{}
@@ -693,6 +716,29 @@ resource "azurerm_shared_image_version" "test" {
   target_region {
     name                   = azurerm_resource_group.test.location
     regional_replica_count = 1
+  }
+}
+`, template)
+}
+
+func (r SharedImageVersionResource) replicatedRegionDeletion(data acceptance.TestData) string {
+	template := r.provision(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_shared_image_version" "test" {
+  name                               = "0.0.1"
+  gallery_name                       = azurerm_shared_image_gallery.test.name
+  image_name                         = azurerm_shared_image.test.name
+  resource_group_name                = azurerm_resource_group.test.name
+  location                           = azurerm_resource_group.test.location
+  managed_image_id                   = azurerm_image.test.id
+  replicated_region_deletion_enabled = true
+
+  target_region {
+    name                        = azurerm_resource_group.test.location
+    regional_replica_count      = 1
+    exclude_from_latest_enabled = true
   }
 }
 `, template)

--- a/website/docs/r/shared_image_version.html.markdown
+++ b/website/docs/r/shared_image_version.html.markdown
@@ -77,6 +77,8 @@ The following arguments are supported:
 
 -> **NOTE:** You must specify exact one of `blob_uri`, `managed_image_id` and `os_disk_snapshot_id`.
 
+* `replicated_region_deletion_enabled` - (Optional)  Whether removing this Gallery Image Version from replicated regions is allowed. Defaults to `false`. Changing this forces a new resource to be created.
+
 * `replication_mode` - (Optional) Mode to be used for replication. Possible values are `Full` and `Shallow`. Defaults to `Full`. Changing this forces a new resource to be created.
 
 * `storage_account_id` - (Optional) The ID of the Storage Account where the Blob exists. Changing this forces a new resource to be created.
@@ -94,6 +96,8 @@ The `target_region` block supports the following:
 * `regional_replica_count` - (Required) The number of replicas of the Image Version to be created per region.
 
 * `disk_encryption_set_id` - (Optional) The ID of the Disk Encryption Set to encrypt the Image Version in the target region. Changing this forces a new resource to be created.
+
+* `exclude_from_latest_enabled` - (Optional) Whether excluding this Image Version from the `latest` filter. If set to `true` this Image Version won't be returned for the `latest` version. Defaults to `false`.
 
 * `storage_account_type` - (Optional) The storage account type for the image version. Possible values are `Standard_LRS`, `Premium_LRS` and `Standard_ZRS`. Defaults to `Standard_LRS`. You can store all of your image version replicas in Zone Redundant Storage by specifying `Standard_ZRS`.
 

--- a/website/docs/r/shared_image_version.html.markdown
+++ b/website/docs/r/shared_image_version.html.markdown
@@ -77,7 +77,7 @@ The following arguments are supported:
 
 -> **NOTE:** You must specify exact one of `blob_uri`, `managed_image_id` and `os_disk_snapshot_id`.
 
-* `replicated_region_deletion_enabled` - (Optional)  Whether removing this Gallery Image Version from replicated regions is allowed. Defaults to `false`. Changing this forces a new resource to be created.
+* `deletion_of_replicated_locations_enabled` - (Optional)  Specifies whether this Shared Image Version can be deleted from the Azure Regions this is replicated to. Defaults to `false`. Changing this forces a new resource to be created.
 
 * `replication_mode` - (Optional) Mode to be used for replication. Possible values are `Full` and `Shallow`. Defaults to `Full`. Changing this forces a new resource to be created.
 
@@ -97,7 +97,7 @@ The `target_region` block supports the following:
 
 * `disk_encryption_set_id` - (Optional) The ID of the Disk Encryption Set to encrypt the Image Version in the target region. Changing this forces a new resource to be created.
 
-* `exclude_from_latest_enabled` - (Optional) Whether excluding this Image Version from the `latest` filter. If set to `true` this Image Version won't be returned for the `latest` version. Defaults to `false`.
+* `exclude_from_latest_enabled` - (Optional) Specifies whether this Shared Image Version should be excluded when querying for the `latest` version. Defaults to `false`.
 
 * `storage_account_type` - (Optional) The storage account type for the image version. Possible values are `Standard_LRS`, `Premium_LRS` and `Standard_ZRS`. Defaults to `Standard_LRS`. You can store all of your image version replicas in Zone Redundant Storage by specifying `Standard_ZRS`.
 


### PR DESCRIPTION
## Swagger Link
https://github.com/Azure/azure-rest-api-specs/blob/d99cad13db6f16e55ddf4e45879980c9e1aaf178/specification/compute/resource-manager/Microsoft.Compute/GalleryRP/stable/2022-03-03/gallery.json#L2838

https://github.com/Azure/azure-rest-api-specs/blob/d99cad13db6f16e55ddf4e45879980c9e1aaf178/specification/compute/resource-manager/Microsoft.Compute/GalleryRP/stable/2022-03-03/gallery.json#L2454C10-L2454C27

## Test Result

![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/76987228/7173b433-0f15-465a-b92f-0079c4ce218a)