### PR TITLE
Update API Management website documentation

### DIFF
--- a/website/docs/r/api_management.html.markdown
+++ b/website/docs/r/api_management.html.markdown
@@ -97,7 +97,9 @@ The following arguments are supported:
 
 ~> **NOTE:** Custom public IPs are only supported on the `Premium` and `Developer` tiers when deployed in a virtual network.
 
-* `public_network_access_enabled` - (Optional) Is public access to the service allowed?. Defaults to `true`
+* `public_network_access_enabled` - (Optional) Is public access to the service allowed? Defaults to `true`.
+
+~> **NOTE:** This option is applicable only to the Management plane, not the API gateway or Developer portal. It is required to be `true` on the creation.
 
 * `virtual_network_type` - (Optional) The type of virtual network you want to use, valid values include: `None`, `External`, `Internal`.
 


### PR DESCRIPTION
The documentation about API Management service is a bit misleading. Especially the part about public network access. 

According to the Microsoft [documentation ](https://learn.microsoft.com/en-us/rest/api/apimanagement/current-ga/api-management-service/create-or-update?tabs=HTTP#publicnetworkaccess) and [answers](https://github.com/Azure/azure-rest-api-specs/issues/23683#issuecomment-1524768462), the `public_network_access_enabled` parameter is responsible for public access to only Management plane, not the API Gateway or the Developer Portal (which can be public or private, when injected into VNet).

Also it is pretty important to mention, that `public_network_access_enabled` must be set to `true` on the initial creation of an API Management instance - which is pretty obvious, because it is about public_access to the management endpoint and management endpoint is used for the interaction with API providers (like Terraform).