### PR TITLE
`azurerm_policy_set_definition`: fix acceptance test policy set with no parameter

### DIFF
--- a/internal/services/policy/policy_set_definition_resource.go
+++ b/internal/services/policy/policy_set_definition_resource.go
@@ -587,8 +587,9 @@ func expandAzureRMPolicySetDefinitionPolicyDefinitions(input []interface{}) (*[]
 	for _, item := range input {
 		v := item.(map[string]interface{})
 
-		parameters := make(map[string]*policy.ParameterValuesValue)
+		var parameters map[string]*policy.ParameterValuesValue
 		if p, ok := v["parameter_values"].(string); ok && p != "" {
+			parameters = make(map[string]*policy.ParameterValuesValue)
 			if err := json.Unmarshal([]byte(p), &parameters); err != nil {
 				return nil, fmt.Errorf("unmarshalling `parameter_values`: %+v", err)
 			}
@@ -597,6 +598,7 @@ func expandAzureRMPolicySetDefinitionPolicyDefinitions(input []interface{}) (*[]
 			if len(parameters) > 0 && len(p) > 0 {
 				return nil, fmt.Errorf("cannot set both `parameters` and `parameter_values`")
 			}
+			parameters = make(map[string]*policy.ParameterValuesValue)
 			for k, value := range p {
 				parameters[k] = &policy.ParameterValuesValue{
 					Value: value,

--- a/internal/services/policy/policy_set_definition_resource_test.go
+++ b/internal/services/policy/policy_set_definition_resource_test.go
@@ -76,6 +76,13 @@ func TestAccAzureRMPolicySetDefinition_customNoParameter(t *testing.T) {
 			),
 		},
 		data.ImportStep(),
+		{
+			Config: r.customNoParameterUpdate(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
 	})
 }
 
@@ -477,6 +484,24 @@ resource "azurerm_policy_set_definition" "test" {
 
   policy_definition_reference {
     policy_definition_id = azurerm_policy_definition.test.id
+  }
+}
+`, template, data.RandomInteger, data.RandomInteger)
+}
+
+func (r PolicySetDefinitionResource) customNoParameterUpdate(data acceptance.TestData) string {
+	template := r.templateNoParameter(data)
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_policy_set_definition" "test" {
+  name         = "acctestPolSet-%d"
+  policy_type  = "Custom"
+  display_name = "acctestPolSet-display-%d"
+
+  policy_definition_reference {
+    policy_definition_id = azurerm_policy_definition.test.id
+    parameter_values     = "{}"
   }
 }
 `, template, data.RandomInteger, data.RandomInteger)


### PR DESCRIPTION
We should set `Parameters` only when specified in configuration.

current test will fail with: 

```
=== CONT  TestAccAzureRMPolicySetDefinition_customNoParameter
    testcase.go:113: Step 1/2 error: After applying this test step, the plan was not empty.
        stdout:
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place
        Terraform will perform the following actions:
          # azurerm_policy_set_definition.test will be updated in-place
          ~ resource "azurerm_policy_set_definition" "test" {
                id           = "/subscriptions/*******/providers/Microsoft.Authorization/policySetDefinitions/acctestPolSet-230901045501469094"
                name         = "acctestPolSet-230901045501469094"
                # (3 unchanged attributes hidden)
              ~ policy_definition_reference {
                  - parameter_values     = jsonencode({})
                  + policy_group_names   = []
                    # (2 unchanged attributes hidden)
                }
            }
        Plan: 0 to add, 1 to change, 0 to destroy.
--- FAIL: TestAccAzureRMPolicySetDefinition_customNoParameter (218.84s)
```

Test Pass now:

```
=== RUN   TestAccAzureRMPolicySetDefinition_customNoParameter
=== PAUSE TestAccAzureRMPolicySetDefinition_customNoParameter
=== CONT  TestAccAzureRMPolicySetDefinition_customNoParameter
--- PASS: TestAccAzureRMPolicySetDefinition_customNoParameter (243.94s)
```
