### PR TITLE
`azurerm_security_center_assessment_policy` : refactoring to use hashicorp/go-azure-sdk

### DIFF
--- a/internal/services/securitycenter/client/client.go
+++ b/internal/services/securitycenter/client/client.go
@@ -5,14 +5,14 @@ package client
 
 import (
 	"github.com/Azure/azure-sdk-for-go/services/preview/security/mgmt/v3.0/security" // nolint: staticcheck
-	assessmentsmetadata_v2021_06_01 "github.com/hashicorp/go-azure-sdk/resource-manager/security/2021-06-01/assessmentsmetadata"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/security/2021-06-01/assessmentsmetadata"
 	pricings_v2023_01_01 "github.com/hashicorp/go-azure-sdk/resource-manager/security/2023-01-01/pricings"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/common"
 )
 
 type Client struct {
 	AssessmentsClient                   *security.AssessmentsClient
-	AssessmentsMetadataClient           *assessmentsmetadata_v2021_06_01.AssessmentsMetadataClient
+	AssessmentsMetadataClient           *assessmentsmetadata.AssessmentsMetadataClient
 	ContactsClient                      *security.ContactsClient
 	DeviceSecurityGroupsClient          *security.DeviceSecurityGroupsClient
 	IotSecuritySolutionClient           *security.IotSecuritySolutionClient
@@ -31,7 +31,7 @@ func NewClient(o *common.ClientOptions) *Client {
 	AssessmentsClient := security.NewAssessmentsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId, ascLocation)
 	o.ConfigureClient(&AssessmentsClient.Client, o.ResourceManagerAuthorizer)
 
-	AssessmentsMetadataClient := assessmentsmetadata_v2021_06_01.NewAssessmentsMetadataClientWithBaseURI(o.ResourceManagerEndpoint)
+	AssessmentsMetadataClient := assessmentsmetadata.NewAssessmentsMetadataClientWithBaseURI(o.ResourceManagerEndpoint)
 	o.ConfigureClient(&AssessmentsMetadataClient.Client, o.ResourceManagerAuthorizer)
 
 	ContactsClient := security.NewContactsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId, ascLocation)

--- a/internal/services/securitycenter/client/client.go
+++ b/internal/services/securitycenter/client/client.go
@@ -5,13 +5,14 @@ package client
 
 import (
 	"github.com/Azure/azure-sdk-for-go/services/preview/security/mgmt/v3.0/security" // nolint: staticcheck
+	assessmentsmetadata_v2021_06_01 "github.com/hashicorp/go-azure-sdk/resource-manager/security/2021-06-01/assessmentsmetadata"
 	pricings_v2023_01_01 "github.com/hashicorp/go-azure-sdk/resource-manager/security/2023-01-01/pricings"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/common"
 )
 
 type Client struct {
 	AssessmentsClient                   *security.AssessmentsClient
-	AssessmentsMetadataClient           *security.AssessmentsMetadataClient
+	AssessmentsMetadataClient           *assessmentsmetadata_v2021_06_01.AssessmentsMetadataClient
 	ContactsClient                      *security.ContactsClient
 	DeviceSecurityGroupsClient          *security.DeviceSecurityGroupsClient
 	IotSecuritySolutionClient           *security.IotSecuritySolutionClient
@@ -30,7 +31,7 @@ func NewClient(o *common.ClientOptions) *Client {
 	AssessmentsClient := security.NewAssessmentsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId, ascLocation)
 	o.ConfigureClient(&AssessmentsClient.Client, o.ResourceManagerAuthorizer)
 
-	AssessmentsMetadataClient := security.NewAssessmentsMetadataClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId, ascLocation)
+	AssessmentsMetadataClient := assessmentsmetadata_v2021_06_01.NewAssessmentsMetadataClientWithBaseURI(o.ResourceManagerEndpoint)
 	o.ConfigureClient(&AssessmentsMetadataClient.Client, o.ResourceManagerAuthorizer)
 
 	ContactsClient := security.NewContactsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId, ascLocation)

--- a/internal/services/securitycenter/security_center_assessment_policy_resource.go
+++ b/internal/services/securitycenter/security_center_assessment_policy_resource.go
@@ -10,9 +10,11 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/security/mgmt/v3.0/security" // nolint: staticcheck
 	"github.com/google/uuid"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/security/2021-06-01/assessmentsmetadata"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/securitycenter/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
@@ -34,7 +36,7 @@ func resourceArmSecurityCenterAssessmentPolicy() *pluginsdk.Resource {
 		},
 
 		Importer: pluginsdk.ImporterValidatingResourceId(func(id string) error {
-			_, err := parse.AssessmentMetadataID(id)
+			_, err := assessmentsmetadata.ParseProviderAssessmentMetadataID(id)
 			return err
 		}),
 
@@ -142,57 +144,57 @@ func resourceArmSecurityCenterAssessmentPolicyCreate(d *pluginsdk.ResourceData, 
 
 	name := uuid.New().String()
 
-	id := parse.NewAssessmentMetadataID(subscriptionId, name)
+	id := assessmentsmetadata.NewProviderAssessmentMetadataID(subscriptionId, name)
 
-	existing, err := client.GetInSubscription(ctx, name)
+	existing, err := client.AssessmentsMetadataGetInSubscription(ctx, id)
 	if err != nil {
-		if !utils.ResponseWasNotFound(existing.Response) {
+		if !response.WasNotFound(existing.HttpResponse) {
 			return fmt.Errorf("checking for presence of existing %s: %+v", id, err)
 		}
 	}
 
-	if !utils.ResponseWasNotFound(existing.Response) {
+	if !response.WasNotFound(existing.HttpResponse) {
 		return tf.ImportAsExistsError("azurerm_security_center_assessment_policy", id.ID())
 	}
 
-	params := security.AssessmentMetadata{
-		AssessmentMetadataProperties: &security.AssessmentMetadataProperties{
-			AssessmentType: security.CustomerManaged,
-			Description:    utils.String(d.Get("description").(string)),
-			DisplayName:    utils.String(d.Get("display_name").(string)),
-			Severity:       security.Severity(d.Get("severity").(string)),
+	params := assessmentsmetadata.SecurityAssessmentMetadataResponse{
+		Properties: &assessmentsmetadata.SecurityAssessmentMetadataPropertiesResponse{
+			AssessmentType: assessmentsmetadata.AssessmentTypeCustomerManaged,
+			Description:    pointer.To(d.Get("description").(string)),
+			DisplayName:    d.Get("display_name").(string),
+			Severity:       assessmentsmetadata.Severity(d.Get("severity").(string)),
 		},
 	}
 
 	if v, ok := d.GetOk("categories"); ok {
-		categories := make([]security.Categories, 0)
+		categories := make([]assessmentsmetadata.Categories, 0)
 		for _, item := range v.(*pluginsdk.Set).List() {
-			categories = append(categories, (security.Categories)(item.(string)))
+			categories = append(categories, (assessmentsmetadata.Categories)(item.(string)))
 		}
-		params.AssessmentMetadataProperties.Categories = &categories
+		params.Properties.Categories = &categories
 	}
 
 	if v, ok := d.GetOk("threats"); ok {
-		threats := make([]security.Threats, 0)
+		threats := make([]assessmentsmetadata.Threats, 0)
 		for _, item := range v.(*pluginsdk.Set).List() {
-			threats = append(threats, (security.Threats)(item.(string)))
+			threats = append(threats, (assessmentsmetadata.Threats)(item.(string)))
 		}
-		params.AssessmentMetadataProperties.Threats = &threats
+		params.Properties.Threats = &threats
 	}
 
 	if v, ok := d.GetOk("implementation_effort"); ok {
-		params.AssessmentMetadataProperties.ImplementationEffort = security.ImplementationEffort(v.(string))
+		params.Properties.ImplementationEffort = pointer.To(assessmentsmetadata.ImplementationEffort(v.(string)))
 	}
 
 	if v, ok := d.GetOk("remediation_description"); ok {
-		params.AssessmentMetadataProperties.RemediationDescription = utils.String(v.(string))
+		params.Properties.RemediationDescription = pointer.To(v.(string))
 	}
 
 	if v, ok := d.GetOk("user_impact"); ok {
-		params.AssessmentMetadataProperties.UserImpact = security.UserImpact(v.(string))
+		params.Properties.UserImpact = pointer.To(assessmentsmetadata.UserImpact(v.(string)))
 	}
 
-	if _, err := client.CreateInSubscription(ctx, name, params); err != nil {
+	if _, err := client.AssessmentsMetadataCreateInSubscription(ctx, id, params); err != nil {
 		return fmt.Errorf("creating %s: %+v", id, err)
 	}
 
@@ -206,46 +208,48 @@ func resourceArmSecurityCenterAssessmentPolicyRead(d *pluginsdk.ResourceData, me
 	ctx, cancel := timeouts.ForRead(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := parse.AssessmentMetadataID(d.Id())
+	id, err := assessmentsmetadata.ParseProviderAssessmentMetadataID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	resp, err := client.GetInSubscription(ctx, id.AssessmentMetadataName)
+	resp, err := client.AssessmentsMetadataGetInSubscription(ctx, *id)
 	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
-			log.Printf("[INFO] %s does not exist - removing from state", id)
+		if response.WasNotFound(resp.HttpResponse) {
+			log.Printf("[INFO] %s does not exist - removing from state", *id)
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("retrieving %s: %+v", id, err)
+		return fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
 
 	d.Set("name", id.AssessmentMetadataName)
 
-	if props := resp.AssessmentMetadataProperties; props != nil {
-		d.Set("description", props.Description)
-		d.Set("display_name", props.DisplayName)
-		d.Set("severity", string(props.Severity))
-		d.Set("implementation_effort", string(props.ImplementationEffort))
-		d.Set("remediation_description", props.RemediationDescription)
-		d.Set("user_impact", string(props.UserImpact))
+	if model := resp.Model; model != nil {
+		if props := model.Properties; props != nil {
+			d.Set("description", pointer.From(props.Description))
+			d.Set("display_name", props.DisplayName)
+			d.Set("severity", string(props.Severity))
+			d.Set("implementation_effort", string(pointer.From(props.ImplementationEffort)))
+			d.Set("remediation_description", pointer.From(props.RemediationDescription))
+			d.Set("user_impact", string(pointer.From(props.UserImpact)))
 
-		categories := make([]string, 0)
-		if props.Categories != nil {
-			for _, item := range *props.Categories {
-				categories = append(categories, string(item))
+			categories := make([]string, 0)
+			if props.Categories != nil {
+				for _, item := range *props.Categories {
+					categories = append(categories, string(item))
+				}
 			}
-		}
-		d.Set("categories", utils.FlattenStringSlice(&categories))
+			d.Set("categories", utils.FlattenStringSlice(&categories))
 
-		threats := make([]string, 0)
-		if props.Threats != nil {
-			for _, item := range *props.Threats {
-				threats = append(threats, string(item))
+			threats := make([]string, 0)
+			if props.Threats != nil {
+				for _, item := range *props.Threats {
+					threats = append(threats, string(item))
+				}
 			}
+			d.Set("threats", utils.FlattenStringSlice(&threats))
 		}
-		d.Set("threats", utils.FlattenStringSlice(&threats))
 	}
 
 	return nil
@@ -256,61 +260,61 @@ func resourceArmSecurityCenterAssessmentPolicyUpdate(d *pluginsdk.ResourceData, 
 	ctx, cancel := timeouts.ForCreateUpdate(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := parse.AssessmentMetadataID(d.Id())
+	id, err := assessmentsmetadata.ParseProviderAssessmentMetadataID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	existing, err := client.GetInSubscription(ctx, id.AssessmentMetadataName)
+	existing, err := client.AssessmentsMetadataGetInSubscription(ctx, *id)
 	if err != nil {
-		return fmt.Errorf("retrieving %s: %+v", id, err)
+		return fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
-	if existing.AssessmentMetadataProperties == nil {
-		return fmt.Errorf("retrieving %s: `assessmentMetadataProperties` was nil", id)
+	if existing.Model == nil || &existing.Model.Properties == nil {
+		return fmt.Errorf("retrieving %s: `properties` was nil", *id)
 	}
 
 	if d.HasChange("description") {
-		existing.AssessmentMetadataProperties.Description = utils.String(d.Get("description").(string))
+		existing.Model.Properties.Description = pointer.To(d.Get("description").(string))
 	}
 
 	if d.HasChange("display_name") {
-		existing.AssessmentMetadataProperties.DisplayName = utils.String(d.Get("display_name").(string))
+		existing.Model.Properties.DisplayName = d.Get("display_name").(string)
 	}
 
 	if d.HasChange("severity") {
-		existing.AssessmentMetadataProperties.Severity = security.Severity(d.Get("severity").(string))
+		existing.Model.Properties.Severity = assessmentsmetadata.Severity(d.Get("severity").(string))
 	}
 
 	if d.HasChange("categories") {
-		categories := make([]security.Categories, 0)
+		categories := make([]assessmentsmetadata.Categories, 0)
 		for _, item := range d.Get("categories").(*pluginsdk.Set).List() {
-			categories = append(categories, (security.Categories)(item.(string)))
+			categories = append(categories, (assessmentsmetadata.Categories)(item.(string)))
 		}
-		existing.AssessmentMetadataProperties.Categories = &categories
+		existing.Model.Properties.Categories = &categories
 	}
 
 	if d.HasChange("threats") {
-		threats := make([]security.Threats, 0)
+		threats := make([]assessmentsmetadata.Threats, 0)
 		for _, item := range d.Get("threats").(*pluginsdk.Set).List() {
-			threats = append(threats, (security.Threats)(item.(string)))
+			threats = append(threats, (assessmentsmetadata.Threats)(item.(string)))
 		}
-		existing.AssessmentMetadataProperties.Threats = &threats
+		existing.Model.Properties.Threats = &threats
 	}
 
 	if d.HasChange("implementation_effort") {
-		existing.AssessmentMetadataProperties.ImplementationEffort = security.ImplementationEffort(d.Get("implementation_effort").(string))
+		existing.Model.Properties.ImplementationEffort = pointer.To(assessmentsmetadata.ImplementationEffort(d.Get("implementation_effort").(string)))
 	}
 
 	if d.HasChange("remediation_description") {
-		existing.AssessmentMetadataProperties.RemediationDescription = utils.String(d.Get("remediation_description").(string))
+		existing.Model.Properties.RemediationDescription = utils.String(d.Get("remediation_description").(string))
 	}
 
 	if d.HasChange("user_impact") {
-		existing.AssessmentMetadataProperties.UserImpact = security.UserImpact(d.Get("user_impact").(string))
+		existing.Model.Properties.UserImpact = pointer.To(assessmentsmetadata.UserImpact(d.Get("user_impact").(string)))
 	}
 
-	if _, err := client.CreateInSubscription(ctx, id.AssessmentMetadataName, existing); err != nil {
-		return fmt.Errorf("updating %s: %+v", id, err)
+	if _, err := client.AssessmentsMetadataCreateInSubscription(ctx, *id, *existing.Model); err != nil {
+		return fmt.Errorf("updating %s: %+v", *id, err)
 	}
 
 	return resourceArmSecurityCenterAssessmentPolicyRead(d, meta)
@@ -321,13 +325,13 @@ func resourceArmSecurityCenterAssessmentPolicyDelete(d *pluginsdk.ResourceData, 
 	ctx, cancel := timeouts.ForDelete(meta.(*clients.Client).StopContext, d)
 	defer cancel()
 
-	id, err := parse.AssessmentMetadataID(d.Id())
+	id, err := assessmentsmetadata.ParseProviderAssessmentMetadataID(d.Id())
 	if err != nil {
 		return err
 	}
 
-	if _, err := client.DeleteInSubscription(ctx, id.AssessmentMetadataName); err != nil {
-		return fmt.Errorf("deleting %s: %+v", id, err)
+	if _, err := client.AssessmentsMetadataDeleteInSubscription(ctx, *id); err != nil {
+		return fmt.Errorf("deleting %s: %+v", *id, err)
 	}
 
 	return nil

--- a/internal/services/securitycenter/security_center_assessment_policy_resource.go
+++ b/internal/services/securitycenter/security_center_assessment_policy_resource.go
@@ -177,7 +177,7 @@ func resourceArmSecurityCenterAssessmentPolicyCreate(d *pluginsdk.ResourceData, 
 	if v, ok := d.GetOk("threats"); ok {
 		threats := make([]assessmentsmetadata.Threats, 0)
 		for _, item := range v.(*pluginsdk.Set).List() {
-			threats = append(threats, (assessmentsmetadata.Threats)(item.(string)))
+			threats = append(threats, assessmentsmetadata.Threats(item.(string)))
 		}
 		params.Properties.Threats = &threats
 	}
@@ -288,7 +288,7 @@ func resourceArmSecurityCenterAssessmentPolicyUpdate(d *pluginsdk.ResourceData, 
 	if d.HasChange("categories") {
 		categories := make([]assessmentsmetadata.Categories, 0)
 		for _, item := range d.Get("categories").(*pluginsdk.Set).List() {
-			categories = append(categories, (assessmentsmetadata.Categories)(item.(string)))
+			categories = append(categories, assessmentsmetadata.Categories(item.(string)))
 		}
 		existing.Model.Properties.Categories = &categories
 	}

--- a/internal/services/securitycenter/security_center_assessment_policy_resource.go
+++ b/internal/services/securitycenter/security_center_assessment_policy_resource.go
@@ -269,7 +269,7 @@ func resourceArmSecurityCenterAssessmentPolicyUpdate(d *pluginsdk.ResourceData, 
 	if err != nil {
 		return fmt.Errorf("retrieving %s: %+v", *id, err)
 	}
-	if existing.Model == nil || &existing.Model.Properties == nil {
+	if existing.Model == nil || existing.Model.Properties == nil {
 		return fmt.Errorf("retrieving %s: `properties` was nil", *id)
 	}
 

--- a/internal/services/securitycenter/security_center_assessment_policy_resource_test.go
+++ b/internal/services/securitycenter/security_center_assessment_policy_resource_test.go
@@ -8,10 +8,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/security/2021-06-01/assessmentsmetadata"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/securitycenter/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
@@ -72,21 +74,21 @@ func testAccSecurityCenterAssessmentPolicy_update(t *testing.T) {
 
 func (r SecurityCenterAssessmentPolicyResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	assessmentMetadataClient := client.SecurityCenter.AssessmentsMetadataClient
-	id, err := parse.AssessmentMetadataID(state.ID)
+	id, err := assessmentsmetadata.ParseProviderAssessmentMetadataID(state.ID)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := assessmentMetadataClient.GetInSubscription(ctx, id.AssessmentMetadataName)
+	resp, err := assessmentMetadataClient.AssessmentsMetadataGetInSubscription(ctx, *id)
 	if err != nil {
-		if utils.ResponseWasNotFound(resp.Response) {
+		if response.WasNotFound(resp.HttpResponse) {
 			return utils.Bool(false), nil
 		}
 
-		return nil, fmt.Errorf("retrieving Azure Security Center Assessment Metadata %q: %+v", state.ID, err)
+		return nil, fmt.Errorf("retrieving %q: %+v", *id, err)
 	}
 
-	return utils.Bool(resp.AssessmentMetadataProperties != nil), nil
+	return pointer.To(resp.Model != nil && resp.Model.Properties != nil), nil
 }
 
 func (r SecurityCenterAssessmentPolicyResource) basic() string {

--- a/internal/services/securitycenter/security_center_assessment_policy_resource_test.go
+++ b/internal/services/securitycenter/security_center_assessment_policy_resource_test.go
@@ -88,7 +88,7 @@ func (r SecurityCenterAssessmentPolicyResource) Exists(ctx context.Context, clie
 		return nil, fmt.Errorf("retrieving %q: %+v", *id, err)
 	}
 
-	return pointer.To(resp.Model != nil && resp.Model.Properties != nil), nil
+	return pointer.To(resp.Model != nil), nil
 }
 
 func (r SecurityCenterAssessmentPolicyResource) basic() string {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2021-06-01/assessmentsmetadata/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2021-06-01/assessmentsmetadata/README.md
@@ -1,0 +1,123 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/security/2021-06-01/assessmentsmetadata` Documentation
+
+The `assessmentsmetadata` SDK allows for interaction with the Azure Resource Manager Service `security` (API Version `2021-06-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-sdk/resource-manager/security/2021-06-01/assessmentsmetadata"
+```
+
+
+### Client Initialization
+
+```go
+client := assessmentsmetadata.NewAssessmentsMetadataClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `AssessmentsMetadataClient.AssessmentsMetadataCreateInSubscription`
+
+```go
+ctx := context.TODO()
+id := assessmentsmetadata.NewProviderAssessmentMetadataID("12345678-1234-9876-4563-123456789012", "assessmentMetadataValue")
+
+payload := assessmentsmetadata.SecurityAssessmentMetadataResponse{
+	// ...
+}
+
+
+read, err := client.AssessmentsMetadataCreateInSubscription(ctx, id, payload)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `AssessmentsMetadataClient.AssessmentsMetadataDeleteInSubscription`
+
+```go
+ctx := context.TODO()
+id := assessmentsmetadata.NewProviderAssessmentMetadataID("12345678-1234-9876-4563-123456789012", "assessmentMetadataValue")
+
+read, err := client.AssessmentsMetadataDeleteInSubscription(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `AssessmentsMetadataClient.AssessmentsMetadataGet`
+
+```go
+ctx := context.TODO()
+id := assessmentsmetadata.NewAssessmentMetadataID("assessmentMetadataValue")
+
+read, err := client.AssessmentsMetadataGet(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `AssessmentsMetadataClient.AssessmentsMetadataGetInSubscription`
+
+```go
+ctx := context.TODO()
+id := assessmentsmetadata.NewProviderAssessmentMetadataID("12345678-1234-9876-4563-123456789012", "assessmentMetadataValue")
+
+read, err := client.AssessmentsMetadataGetInSubscription(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `AssessmentsMetadataClient.AssessmentsMetadataList`
+
+```go
+ctx := context.TODO()
+
+
+// alternatively `client.AssessmentsMetadataList(ctx)` can be used to do batched pagination
+items, err := client.AssessmentsMetadataListComplete(ctx)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```
+
+
+### Example Usage: `AssessmentsMetadataClient.AssessmentsMetadataListBySubscription`
+
+```go
+ctx := context.TODO()
+id := assessmentsmetadata.NewSubscriptionID("12345678-1234-9876-4563-123456789012")
+
+// alternatively `client.AssessmentsMetadataListBySubscription(ctx, id)` can be used to do batched pagination
+items, err := client.AssessmentsMetadataListBySubscriptionComplete(ctx, id)
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2021-06-01/assessmentsmetadata/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2021-06-01/assessmentsmetadata/client.go
@@ -1,0 +1,18 @@
+package assessmentsmetadata
+
+import "github.com/Azure/go-autorest/autorest"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AssessmentsMetadataClient struct {
+	Client  autorest.Client
+	baseUri string
+}
+
+func NewAssessmentsMetadataClientWithBaseURI(endpoint string) AssessmentsMetadataClient {
+	return AssessmentsMetadataClient{
+		Client:  autorest.NewClientWithUserAgent(userAgent()),
+		baseUri: endpoint,
+	}
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2021-06-01/assessmentsmetadata/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2021-06-01/assessmentsmetadata/constants.go
@@ -1,0 +1,614 @@
+package assessmentsmetadata
+
+import "strings"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AssessmentType string
+
+const (
+	AssessmentTypeBuiltIn         AssessmentType = "BuiltIn"
+	AssessmentTypeCustomPolicy    AssessmentType = "CustomPolicy"
+	AssessmentTypeCustomerManaged AssessmentType = "CustomerManaged"
+	AssessmentTypeVerifiedPartner AssessmentType = "VerifiedPartner"
+)
+
+func PossibleValuesForAssessmentType() []string {
+	return []string{
+		string(AssessmentTypeBuiltIn),
+		string(AssessmentTypeCustomPolicy),
+		string(AssessmentTypeCustomerManaged),
+		string(AssessmentTypeVerifiedPartner),
+	}
+}
+
+func parseAssessmentType(input string) (*AssessmentType, error) {
+	vals := map[string]AssessmentType{
+		"builtin":         AssessmentTypeBuiltIn,
+		"custompolicy":    AssessmentTypeCustomPolicy,
+		"customermanaged": AssessmentTypeCustomerManaged,
+		"verifiedpartner": AssessmentTypeVerifiedPartner,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := AssessmentType(input)
+	return &out, nil
+}
+
+type Categories string
+
+const (
+	CategoriesCompute           Categories = "Compute"
+	CategoriesData              Categories = "Data"
+	CategoriesIdentityAndAccess Categories = "IdentityAndAccess"
+	CategoriesIoT               Categories = "IoT"
+	CategoriesNetworking        Categories = "Networking"
+)
+
+func PossibleValuesForCategories() []string {
+	return []string{
+		string(CategoriesCompute),
+		string(CategoriesData),
+		string(CategoriesIdentityAndAccess),
+		string(CategoriesIoT),
+		string(CategoriesNetworking),
+	}
+}
+
+func parseCategories(input string) (*Categories, error) {
+	vals := map[string]Categories{
+		"compute":           CategoriesCompute,
+		"data":              CategoriesData,
+		"identityandaccess": CategoriesIdentityAndAccess,
+		"iot":               CategoriesIoT,
+		"networking":        CategoriesNetworking,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := Categories(input)
+	return &out, nil
+}
+
+type ImplementationEffort string
+
+const (
+	ImplementationEffortHigh     ImplementationEffort = "High"
+	ImplementationEffortLow      ImplementationEffort = "Low"
+	ImplementationEffortModerate ImplementationEffort = "Moderate"
+)
+
+func PossibleValuesForImplementationEffort() []string {
+	return []string{
+		string(ImplementationEffortHigh),
+		string(ImplementationEffortLow),
+		string(ImplementationEffortModerate),
+	}
+}
+
+func parseImplementationEffort(input string) (*ImplementationEffort, error) {
+	vals := map[string]ImplementationEffort{
+		"high":     ImplementationEffortHigh,
+		"low":      ImplementationEffortLow,
+		"moderate": ImplementationEffortModerate,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ImplementationEffort(input)
+	return &out, nil
+}
+
+type Severity string
+
+const (
+	SeverityHigh   Severity = "High"
+	SeverityLow    Severity = "Low"
+	SeverityMedium Severity = "Medium"
+)
+
+func PossibleValuesForSeverity() []string {
+	return []string{
+		string(SeverityHigh),
+		string(SeverityLow),
+		string(SeverityMedium),
+	}
+}
+
+func parseSeverity(input string) (*Severity, error) {
+	vals := map[string]Severity{
+		"high":   SeverityHigh,
+		"low":    SeverityLow,
+		"medium": SeverityMedium,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := Severity(input)
+	return &out, nil
+}
+
+type Tactics string
+
+const (
+	TacticsCollection          Tactics = "Collection"
+	TacticsCommandAndControl   Tactics = "Command and Control"
+	TacticsCredentialAccess    Tactics = "Credential Access"
+	TacticsDefenseEvasion      Tactics = "Defense Evasion"
+	TacticsDiscovery           Tactics = "Discovery"
+	TacticsExecution           Tactics = "Execution"
+	TacticsExfiltration        Tactics = "Exfiltration"
+	TacticsImpact              Tactics = "Impact"
+	TacticsInitialAccess       Tactics = "Initial Access"
+	TacticsLateralMovement     Tactics = "Lateral Movement"
+	TacticsPersistence         Tactics = "Persistence"
+	TacticsPrivilegeEscalation Tactics = "Privilege Escalation"
+	TacticsReconnaissance      Tactics = "Reconnaissance"
+	TacticsResourceDevelopment Tactics = "Resource Development"
+)
+
+func PossibleValuesForTactics() []string {
+	return []string{
+		string(TacticsCollection),
+		string(TacticsCommandAndControl),
+		string(TacticsCredentialAccess),
+		string(TacticsDefenseEvasion),
+		string(TacticsDiscovery),
+		string(TacticsExecution),
+		string(TacticsExfiltration),
+		string(TacticsImpact),
+		string(TacticsInitialAccess),
+		string(TacticsLateralMovement),
+		string(TacticsPersistence),
+		string(TacticsPrivilegeEscalation),
+		string(TacticsReconnaissance),
+		string(TacticsResourceDevelopment),
+	}
+}
+
+func parseTactics(input string) (*Tactics, error) {
+	vals := map[string]Tactics{
+		"collection":           TacticsCollection,
+		"command and control":  TacticsCommandAndControl,
+		"credential access":    TacticsCredentialAccess,
+		"defense evasion":      TacticsDefenseEvasion,
+		"discovery":            TacticsDiscovery,
+		"execution":            TacticsExecution,
+		"exfiltration":         TacticsExfiltration,
+		"impact":               TacticsImpact,
+		"initial access":       TacticsInitialAccess,
+		"lateral movement":     TacticsLateralMovement,
+		"persistence":          TacticsPersistence,
+		"privilege escalation": TacticsPrivilegeEscalation,
+		"reconnaissance":       TacticsReconnaissance,
+		"resource development": TacticsResourceDevelopment,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := Tactics(input)
+	return &out, nil
+}
+
+type Techniques string
+
+const (
+	TechniquesAbuseElevationControlMechanism          Techniques = "Abuse Elevation Control Mechanism"
+	TechniquesAccessTokenManipulation                 Techniques = "Access Token Manipulation"
+	TechniquesAccountDiscovery                        Techniques = "Account Discovery"
+	TechniquesAccountManipulation                     Techniques = "Account Manipulation"
+	TechniquesActiveScanning                          Techniques = "Active Scanning"
+	TechniquesApplicationLayerProtocol                Techniques = "Application Layer Protocol"
+	TechniquesAudioCapture                            Techniques = "Audio Capture"
+	TechniquesBootOrLogonAutostartExecution           Techniques = "Boot or Logon Autostart Execution"
+	TechniquesBootOrLogonInitializationScripts        Techniques = "Boot or Logon Initialization Scripts"
+	TechniquesBruteForce                              Techniques = "Brute Force"
+	TechniquesCloudInfrastructureDiscovery            Techniques = "Cloud Infrastructure Discovery"
+	TechniquesCloudServiceDashboard                   Techniques = "Cloud Service Dashboard"
+	TechniquesCloudServiceDiscovery                   Techniques = "Cloud Service Discovery"
+	TechniquesCommandAndScriptingInterpreter          Techniques = "Command and Scripting Interpreter"
+	TechniquesCompromiseClientSoftwareBinary          Techniques = "Compromise Client Software Binary"
+	TechniquesCompromiseInfrastructure                Techniques = "Compromise Infrastructure"
+	TechniquesContainerAndResourceDiscovery           Techniques = "Container and Resource Discovery"
+	TechniquesCreateAccount                           Techniques = "Create Account"
+	TechniquesCreateOrModifySystemProcess             Techniques = "Create or Modify System Process"
+	TechniquesCredentialsFromPasswordStores           Techniques = "Credentials from Password Stores"
+	TechniquesDataDestruction                         Techniques = "Data Destruction"
+	TechniquesDataEncryptedForImpact                  Techniques = "Data Encrypted for Impact"
+	TechniquesDataFromCloudStorageObject              Techniques = "Data from Cloud Storage Object"
+	TechniquesDataFromConfigurationRepository         Techniques = "Data from Configuration Repository"
+	TechniquesDataFromInformationRepositories         Techniques = "Data from Information Repositories"
+	TechniquesDataFromLocalSystem                     Techniques = "Data from Local System"
+	TechniquesDataManipulation                        Techniques = "Data Manipulation"
+	TechniquesDataStaged                              Techniques = "Data Staged"
+	TechniquesDefacement                              Techniques = "Defacement"
+	TechniquesDeobfuscateDecodeFilesOrInformation     Techniques = "Deobfuscate/Decode Files or Information"
+	TechniquesDiskWipe                                Techniques = "Disk Wipe"
+	TechniquesDomainTrustDiscovery                    Techniques = "Domain Trust Discovery"
+	TechniquesDriveNegativebyCompromise               Techniques = "Drive-by Compromise"
+	TechniquesDynamicResolution                       Techniques = "Dynamic Resolution"
+	TechniquesEndpointDenialOfService                 Techniques = "Endpoint Denial of Service"
+	TechniquesEventTriggeredExecution                 Techniques = "Event Triggered Execution"
+	TechniquesExfiltrationOverAlternativeProtocol     Techniques = "Exfiltration Over Alternative Protocol"
+	TechniquesExploitPublicNegativeFacingApplication  Techniques = "Exploit Public-Facing Application"
+	TechniquesExploitationForClientExecution          Techniques = "Exploitation for Client Execution"
+	TechniquesExploitationForCredentialAccess         Techniques = "Exploitation for Credential Access"
+	TechniquesExploitationForDefenseEvasion           Techniques = "Exploitation for Defense Evasion"
+	TechniquesExploitationForPrivilegeEscalation      Techniques = "Exploitation for Privilege Escalation"
+	TechniquesExploitationOfRemoteServices            Techniques = "Exploitation of Remote Services"
+	TechniquesExternalRemoteServices                  Techniques = "External Remote Services"
+	TechniquesFallbackChannels                        Techniques = "Fallback Channels"
+	TechniquesFileAndDirectoryDiscovery               Techniques = "File and Directory Discovery"
+	TechniquesFileAndDirectoryPermissionsModification Techniques = "File and Directory Permissions Modification"
+	TechniquesGatherVictimNetworkInformation          Techniques = "Gather Victim Network Information"
+	TechniquesHideArtifacts                           Techniques = "Hide Artifacts"
+	TechniquesHijackExecutionFlow                     Techniques = "Hijack Execution Flow"
+	TechniquesImpairDefenses                          Techniques = "Impair Defenses"
+	TechniquesImplantContainerImage                   Techniques = "Implant Container Image"
+	TechniquesIndicatorRemovalOnHost                  Techniques = "Indicator Removal on Host"
+	TechniquesIndirectCommandExecution                Techniques = "Indirect Command Execution"
+	TechniquesIngressToolTransfer                     Techniques = "Ingress Tool Transfer"
+	TechniquesInputCapture                            Techniques = "Input Capture"
+	TechniquesInterNegativeProcessCommunication       Techniques = "Inter-Process Communication"
+	TechniquesLateralToolTransfer                     Techniques = "Lateral Tool Transfer"
+	TechniquesManNegativeinNegativetheNegativeMiddle  Techniques = "Man-in-the-Middle"
+	TechniquesMasquerading                            Techniques = "Masquerading"
+	TechniquesModifyAuthenticationProcess             Techniques = "Modify Authentication Process"
+	TechniquesModifyRegistry                          Techniques = "Modify Registry"
+	TechniquesNetworkDenialOfService                  Techniques = "Network Denial of Service"
+	TechniquesNetworkServiceScanning                  Techniques = "Network Service Scanning"
+	TechniquesNetworkSniffing                         Techniques = "Network Sniffing"
+	TechniquesNonNegativeApplicationLayerProtocol     Techniques = "Non-Application Layer Protocol"
+	TechniquesNonNegativeStandardPort                 Techniques = "Non-Standard Port"
+	TechniquesOSCredentialDumping                     Techniques = "OS Credential Dumping"
+	TechniquesObfuscatedFilesOrInformation            Techniques = "Obfuscated Files or Information"
+	TechniquesObtainCapabilities                      Techniques = "Obtain Capabilities"
+	TechniquesOfficeApplicationStartup                Techniques = "Office Application Startup"
+	TechniquesPermissionGroupsDiscovery               Techniques = "Permission Groups Discovery"
+	TechniquesPhishing                                Techniques = "Phishing"
+	TechniquesPreNegativeOSBoot                       Techniques = "Pre-OS Boot"
+	TechniquesProcessDiscovery                        Techniques = "Process Discovery"
+	TechniquesProcessInjection                        Techniques = "Process Injection"
+	TechniquesProtocolTunneling                       Techniques = "Protocol Tunneling"
+	TechniquesProxy                                   Techniques = "Proxy"
+	TechniquesQueryRegistry                           Techniques = "Query Registry"
+	TechniquesRemoteAccessSoftware                    Techniques = "Remote Access Software"
+	TechniquesRemoteServiceSessionHijacking           Techniques = "Remote Service Session Hijacking"
+	TechniquesRemoteServices                          Techniques = "Remote Services"
+	TechniquesRemoteSystemDiscovery                   Techniques = "Remote System Discovery"
+	TechniquesResourceHijacking                       Techniques = "Resource Hijacking"
+	TechniquesSQLStoredProcedures                     Techniques = "SQL Stored Procedures"
+	TechniquesScheduledTaskJob                        Techniques = "Scheduled Task/Job"
+	TechniquesScreenCapture                           Techniques = "Screen Capture"
+	TechniquesSearchVictimNegativeOwnedWebsites       Techniques = "Search Victim-Owned Websites"
+	TechniquesServerSoftwareComponent                 Techniques = "Server Software Component"
+	TechniquesServiceStop                             Techniques = "Service Stop"
+	TechniquesSignedBinaryProxyExecution              Techniques = "Signed Binary Proxy Execution"
+	TechniquesSoftwareDeploymentTools                 Techniques = "Software Deployment Tools"
+	TechniquesStealOrForgeKerberosTickets             Techniques = "Steal or Forge Kerberos Tickets"
+	TechniquesSubvertTrustControls                    Techniques = "Subvert Trust Controls"
+	TechniquesSupplyChainCompromise                   Techniques = "Supply Chain Compromise"
+	TechniquesSystemInformationDiscovery              Techniques = "System Information Discovery"
+	TechniquesTaintSharedContent                      Techniques = "Taint Shared Content"
+	TechniquesTrafficSignaling                        Techniques = "Traffic Signaling"
+	TechniquesTransferDataToCloudAccount              Techniques = "Transfer Data to Cloud Account"
+	TechniquesTrustedRelationship                     Techniques = "Trusted Relationship"
+	TechniquesUnsecuredCredentials                    Techniques = "Unsecured Credentials"
+	TechniquesUserExecution                           Techniques = "User Execution"
+	TechniquesValidAccounts                           Techniques = "Valid Accounts"
+	TechniquesWindowsManagementInstrumentation        Techniques = "Windows Management Instrumentation"
+)
+
+func PossibleValuesForTechniques() []string {
+	return []string{
+		string(TechniquesAbuseElevationControlMechanism),
+		string(TechniquesAccessTokenManipulation),
+		string(TechniquesAccountDiscovery),
+		string(TechniquesAccountManipulation),
+		string(TechniquesActiveScanning),
+		string(TechniquesApplicationLayerProtocol),
+		string(TechniquesAudioCapture),
+		string(TechniquesBootOrLogonAutostartExecution),
+		string(TechniquesBootOrLogonInitializationScripts),
+		string(TechniquesBruteForce),
+		string(TechniquesCloudInfrastructureDiscovery),
+		string(TechniquesCloudServiceDashboard),
+		string(TechniquesCloudServiceDiscovery),
+		string(TechniquesCommandAndScriptingInterpreter),
+		string(TechniquesCompromiseClientSoftwareBinary),
+		string(TechniquesCompromiseInfrastructure),
+		string(TechniquesContainerAndResourceDiscovery),
+		string(TechniquesCreateAccount),
+		string(TechniquesCreateOrModifySystemProcess),
+		string(TechniquesCredentialsFromPasswordStores),
+		string(TechniquesDataDestruction),
+		string(TechniquesDataEncryptedForImpact),
+		string(TechniquesDataFromCloudStorageObject),
+		string(TechniquesDataFromConfigurationRepository),
+		string(TechniquesDataFromInformationRepositories),
+		string(TechniquesDataFromLocalSystem),
+		string(TechniquesDataManipulation),
+		string(TechniquesDataStaged),
+		string(TechniquesDefacement),
+		string(TechniquesDeobfuscateDecodeFilesOrInformation),
+		string(TechniquesDiskWipe),
+		string(TechniquesDomainTrustDiscovery),
+		string(TechniquesDriveNegativebyCompromise),
+		string(TechniquesDynamicResolution),
+		string(TechniquesEndpointDenialOfService),
+		string(TechniquesEventTriggeredExecution),
+		string(TechniquesExfiltrationOverAlternativeProtocol),
+		string(TechniquesExploitPublicNegativeFacingApplication),
+		string(TechniquesExploitationForClientExecution),
+		string(TechniquesExploitationForCredentialAccess),
+		string(TechniquesExploitationForDefenseEvasion),
+		string(TechniquesExploitationForPrivilegeEscalation),
+		string(TechniquesExploitationOfRemoteServices),
+		string(TechniquesExternalRemoteServices),
+		string(TechniquesFallbackChannels),
+		string(TechniquesFileAndDirectoryDiscovery),
+		string(TechniquesFileAndDirectoryPermissionsModification),
+		string(TechniquesGatherVictimNetworkInformation),
+		string(TechniquesHideArtifacts),
+		string(TechniquesHijackExecutionFlow),
+		string(TechniquesImpairDefenses),
+		string(TechniquesImplantContainerImage),
+		string(TechniquesIndicatorRemovalOnHost),
+		string(TechniquesIndirectCommandExecution),
+		string(TechniquesIngressToolTransfer),
+		string(TechniquesInputCapture),
+		string(TechniquesInterNegativeProcessCommunication),
+		string(TechniquesLateralToolTransfer),
+		string(TechniquesManNegativeinNegativetheNegativeMiddle),
+		string(TechniquesMasquerading),
+		string(TechniquesModifyAuthenticationProcess),
+		string(TechniquesModifyRegistry),
+		string(TechniquesNetworkDenialOfService),
+		string(TechniquesNetworkServiceScanning),
+		string(TechniquesNetworkSniffing),
+		string(TechniquesNonNegativeApplicationLayerProtocol),
+		string(TechniquesNonNegativeStandardPort),
+		string(TechniquesOSCredentialDumping),
+		string(TechniquesObfuscatedFilesOrInformation),
+		string(TechniquesObtainCapabilities),
+		string(TechniquesOfficeApplicationStartup),
+		string(TechniquesPermissionGroupsDiscovery),
+		string(TechniquesPhishing),
+		string(TechniquesPreNegativeOSBoot),
+		string(TechniquesProcessDiscovery),
+		string(TechniquesProcessInjection),
+		string(TechniquesProtocolTunneling),
+		string(TechniquesProxy),
+		string(TechniquesQueryRegistry),
+		string(TechniquesRemoteAccessSoftware),
+		string(TechniquesRemoteServiceSessionHijacking),
+		string(TechniquesRemoteServices),
+		string(TechniquesRemoteSystemDiscovery),
+		string(TechniquesResourceHijacking),
+		string(TechniquesSQLStoredProcedures),
+		string(TechniquesScheduledTaskJob),
+		string(TechniquesScreenCapture),
+		string(TechniquesSearchVictimNegativeOwnedWebsites),
+		string(TechniquesServerSoftwareComponent),
+		string(TechniquesServiceStop),
+		string(TechniquesSignedBinaryProxyExecution),
+		string(TechniquesSoftwareDeploymentTools),
+		string(TechniquesStealOrForgeKerberosTickets),
+		string(TechniquesSubvertTrustControls),
+		string(TechniquesSupplyChainCompromise),
+		string(TechniquesSystemInformationDiscovery),
+		string(TechniquesTaintSharedContent),
+		string(TechniquesTrafficSignaling),
+		string(TechniquesTransferDataToCloudAccount),
+		string(TechniquesTrustedRelationship),
+		string(TechniquesUnsecuredCredentials),
+		string(TechniquesUserExecution),
+		string(TechniquesValidAccounts),
+		string(TechniquesWindowsManagementInstrumentation),
+	}
+}
+
+func parseTechniques(input string) (*Techniques, error) {
+	vals := map[string]Techniques{
+		"abuse elevation control mechanism":           TechniquesAbuseElevationControlMechanism,
+		"access token manipulation":                   TechniquesAccessTokenManipulation,
+		"account discovery":                           TechniquesAccountDiscovery,
+		"account manipulation":                        TechniquesAccountManipulation,
+		"active scanning":                             TechniquesActiveScanning,
+		"application layer protocol":                  TechniquesApplicationLayerProtocol,
+		"audio capture":                               TechniquesAudioCapture,
+		"boot or logon autostart execution":           TechniquesBootOrLogonAutostartExecution,
+		"boot or logon initialization scripts":        TechniquesBootOrLogonInitializationScripts,
+		"brute force":                                 TechniquesBruteForce,
+		"cloud infrastructure discovery":              TechniquesCloudInfrastructureDiscovery,
+		"cloud service dashboard":                     TechniquesCloudServiceDashboard,
+		"cloud service discovery":                     TechniquesCloudServiceDiscovery,
+		"command and scripting interpreter":           TechniquesCommandAndScriptingInterpreter,
+		"compromise client software binary":           TechniquesCompromiseClientSoftwareBinary,
+		"compromise infrastructure":                   TechniquesCompromiseInfrastructure,
+		"container and resource discovery":            TechniquesContainerAndResourceDiscovery,
+		"create account":                              TechniquesCreateAccount,
+		"create or modify system process":             TechniquesCreateOrModifySystemProcess,
+		"credentials from password stores":            TechniquesCredentialsFromPasswordStores,
+		"data destruction":                            TechniquesDataDestruction,
+		"data encrypted for impact":                   TechniquesDataEncryptedForImpact,
+		"data from cloud storage object":              TechniquesDataFromCloudStorageObject,
+		"data from configuration repository":          TechniquesDataFromConfigurationRepository,
+		"data from information repositories":          TechniquesDataFromInformationRepositories,
+		"data from local system":                      TechniquesDataFromLocalSystem,
+		"data manipulation":                           TechniquesDataManipulation,
+		"data staged":                                 TechniquesDataStaged,
+		"defacement":                                  TechniquesDefacement,
+		"deobfuscate/decode files or information":     TechniquesDeobfuscateDecodeFilesOrInformation,
+		"disk wipe":                                   TechniquesDiskWipe,
+		"domain trust discovery":                      TechniquesDomainTrustDiscovery,
+		"drive-by compromise":                         TechniquesDriveNegativebyCompromise,
+		"dynamic resolution":                          TechniquesDynamicResolution,
+		"endpoint denial of service":                  TechniquesEndpointDenialOfService,
+		"event triggered execution":                   TechniquesEventTriggeredExecution,
+		"exfiltration over alternative protocol":      TechniquesExfiltrationOverAlternativeProtocol,
+		"exploit public-facing application":           TechniquesExploitPublicNegativeFacingApplication,
+		"exploitation for client execution":           TechniquesExploitationForClientExecution,
+		"exploitation for credential access":          TechniquesExploitationForCredentialAccess,
+		"exploitation for defense evasion":            TechniquesExploitationForDefenseEvasion,
+		"exploitation for privilege escalation":       TechniquesExploitationForPrivilegeEscalation,
+		"exploitation of remote services":             TechniquesExploitationOfRemoteServices,
+		"external remote services":                    TechniquesExternalRemoteServices,
+		"fallback channels":                           TechniquesFallbackChannels,
+		"file and directory discovery":                TechniquesFileAndDirectoryDiscovery,
+		"file and directory permissions modification": TechniquesFileAndDirectoryPermissionsModification,
+		"gather victim network information":           TechniquesGatherVictimNetworkInformation,
+		"hide artifacts":                              TechniquesHideArtifacts,
+		"hijack execution flow":                       TechniquesHijackExecutionFlow,
+		"impair defenses":                             TechniquesImpairDefenses,
+		"implant container image":                     TechniquesImplantContainerImage,
+		"indicator removal on host":                   TechniquesIndicatorRemovalOnHost,
+		"indirect command execution":                  TechniquesIndirectCommandExecution,
+		"ingress tool transfer":                       TechniquesIngressToolTransfer,
+		"input capture":                               TechniquesInputCapture,
+		"inter-process communication":                 TechniquesInterNegativeProcessCommunication,
+		"lateral tool transfer":                       TechniquesLateralToolTransfer,
+		"man-in-the-middle":                           TechniquesManNegativeinNegativetheNegativeMiddle,
+		"masquerading":                                TechniquesMasquerading,
+		"modify authentication process":               TechniquesModifyAuthenticationProcess,
+		"modify registry":                             TechniquesModifyRegistry,
+		"network denial of service":                   TechniquesNetworkDenialOfService,
+		"network service scanning":                    TechniquesNetworkServiceScanning,
+		"network sniffing":                            TechniquesNetworkSniffing,
+		"non-application layer protocol":              TechniquesNonNegativeApplicationLayerProtocol,
+		"non-standard port":                           TechniquesNonNegativeStandardPort,
+		"os credential dumping":                       TechniquesOSCredentialDumping,
+		"obfuscated files or information":             TechniquesObfuscatedFilesOrInformation,
+		"obtain capabilities":                         TechniquesObtainCapabilities,
+		"office application startup":                  TechniquesOfficeApplicationStartup,
+		"permission groups discovery":                 TechniquesPermissionGroupsDiscovery,
+		"phishing":                                    TechniquesPhishing,
+		"pre-os boot":                                 TechniquesPreNegativeOSBoot,
+		"process discovery":                           TechniquesProcessDiscovery,
+		"process injection":                           TechniquesProcessInjection,
+		"protocol tunneling":                          TechniquesProtocolTunneling,
+		"proxy":                                       TechniquesProxy,
+		"query registry":                              TechniquesQueryRegistry,
+		"remote access software":                      TechniquesRemoteAccessSoftware,
+		"remote service session hijacking":            TechniquesRemoteServiceSessionHijacking,
+		"remote services":                             TechniquesRemoteServices,
+		"remote system discovery":                     TechniquesRemoteSystemDiscovery,
+		"resource hijacking":                          TechniquesResourceHijacking,
+		"sql stored procedures":                       TechniquesSQLStoredProcedures,
+		"scheduled task/job":                          TechniquesScheduledTaskJob,
+		"screen capture":                              TechniquesScreenCapture,
+		"search victim-owned websites":                TechniquesSearchVictimNegativeOwnedWebsites,
+		"server software component":                   TechniquesServerSoftwareComponent,
+		"service stop":                                TechniquesServiceStop,
+		"signed binary proxy execution":               TechniquesSignedBinaryProxyExecution,
+		"software deployment tools":                   TechniquesSoftwareDeploymentTools,
+		"steal or forge kerberos tickets":             TechniquesStealOrForgeKerberosTickets,
+		"subvert trust controls":                      TechniquesSubvertTrustControls,
+		"supply chain compromise":                     TechniquesSupplyChainCompromise,
+		"system information discovery":                TechniquesSystemInformationDiscovery,
+		"taint shared content":                        TechniquesTaintSharedContent,
+		"traffic signaling":                           TechniquesTrafficSignaling,
+		"transfer data to cloud account":              TechniquesTransferDataToCloudAccount,
+		"trusted relationship":                        TechniquesTrustedRelationship,
+		"unsecured credentials":                       TechniquesUnsecuredCredentials,
+		"user execution":                              TechniquesUserExecution,
+		"valid accounts":                              TechniquesValidAccounts,
+		"windows management instrumentation":          TechniquesWindowsManagementInstrumentation,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := Techniques(input)
+	return &out, nil
+}
+
+type Threats string
+
+const (
+	ThreatsAccountBreach        Threats = "accountBreach"
+	ThreatsDataExfiltration     Threats = "dataExfiltration"
+	ThreatsDataSpillage         Threats = "dataSpillage"
+	ThreatsDenialOfService      Threats = "denialOfService"
+	ThreatsElevationOfPrivilege Threats = "elevationOfPrivilege"
+	ThreatsMaliciousInsider     Threats = "maliciousInsider"
+	ThreatsMissingCoverage      Threats = "missingCoverage"
+	ThreatsThreatResistance     Threats = "threatResistance"
+)
+
+func PossibleValuesForThreats() []string {
+	return []string{
+		string(ThreatsAccountBreach),
+		string(ThreatsDataExfiltration),
+		string(ThreatsDataSpillage),
+		string(ThreatsDenialOfService),
+		string(ThreatsElevationOfPrivilege),
+		string(ThreatsMaliciousInsider),
+		string(ThreatsMissingCoverage),
+		string(ThreatsThreatResistance),
+	}
+}
+
+func parseThreats(input string) (*Threats, error) {
+	vals := map[string]Threats{
+		"accountbreach":        ThreatsAccountBreach,
+		"dataexfiltration":     ThreatsDataExfiltration,
+		"dataspillage":         ThreatsDataSpillage,
+		"denialofservice":      ThreatsDenialOfService,
+		"elevationofprivilege": ThreatsElevationOfPrivilege,
+		"maliciousinsider":     ThreatsMaliciousInsider,
+		"missingcoverage":      ThreatsMissingCoverage,
+		"threatresistance":     ThreatsThreatResistance,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := Threats(input)
+	return &out, nil
+}
+
+type UserImpact string
+
+const (
+	UserImpactHigh     UserImpact = "High"
+	UserImpactLow      UserImpact = "Low"
+	UserImpactModerate UserImpact = "Moderate"
+)
+
+func PossibleValuesForUserImpact() []string {
+	return []string{
+		string(UserImpactHigh),
+		string(UserImpactLow),
+		string(UserImpactModerate),
+	}
+}
+
+func parseUserImpact(input string) (*UserImpact, error) {
+	vals := map[string]UserImpact{
+		"high":     UserImpactHigh,
+		"low":      UserImpactLow,
+		"moderate": UserImpactModerate,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := UserImpact(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2021-06-01/assessmentsmetadata/id_assessmentmetadata.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2021-06-01/assessmentsmetadata/id_assessmentmetadata.go
@@ -1,0 +1,101 @@
+package assessmentsmetadata
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ resourceids.ResourceId = AssessmentMetadataId{}
+
+// AssessmentMetadataId is a struct representing the Resource ID for a Assessment Metadata
+type AssessmentMetadataId struct {
+	AssessmentMetadataName string
+}
+
+// NewAssessmentMetadataID returns a new AssessmentMetadataId struct
+func NewAssessmentMetadataID(assessmentMetadataName string) AssessmentMetadataId {
+	return AssessmentMetadataId{
+		AssessmentMetadataName: assessmentMetadataName,
+	}
+}
+
+// ParseAssessmentMetadataID parses 'input' into a AssessmentMetadataId
+func ParseAssessmentMetadataID(input string) (*AssessmentMetadataId, error) {
+	parser := resourceids.NewParserFromResourceIdType(AssessmentMetadataId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := AssessmentMetadataId{}
+
+	if id.AssessmentMetadataName, ok = parsed.Parsed["assessmentMetadataName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "assessmentMetadataName", *parsed)
+	}
+
+	return &id, nil
+}
+
+// ParseAssessmentMetadataIDInsensitively parses 'input' case-insensitively into a AssessmentMetadataId
+// note: this method should only be used for API response data and not user input
+func ParseAssessmentMetadataIDInsensitively(input string) (*AssessmentMetadataId, error) {
+	parser := resourceids.NewParserFromResourceIdType(AssessmentMetadataId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := AssessmentMetadataId{}
+
+	if id.AssessmentMetadataName, ok = parsed.Parsed["assessmentMetadataName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "assessmentMetadataName", *parsed)
+	}
+
+	return &id, nil
+}
+
+// ValidateAssessmentMetadataID checks that 'input' can be parsed as a Assessment Metadata ID
+func ValidateAssessmentMetadataID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseAssessmentMetadataID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Assessment Metadata ID
+func (id AssessmentMetadataId) ID() string {
+	fmtString := "/providers/Microsoft.Security/assessmentMetadata/%s"
+	return fmt.Sprintf(fmtString, id.AssessmentMetadataName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Assessment Metadata ID
+func (id AssessmentMetadataId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftSecurity", "Microsoft.Security", "Microsoft.Security"),
+		resourceids.StaticSegment("staticAssessmentMetadata", "assessmentMetadata", "assessmentMetadata"),
+		resourceids.UserSpecifiedSegment("assessmentMetadataName", "assessmentMetadataValue"),
+	}
+}
+
+// String returns a human-readable description of this Assessment Metadata ID
+func (id AssessmentMetadataId) String() string {
+	components := []string{
+		fmt.Sprintf("Assessment Metadata Name: %q", id.AssessmentMetadataName),
+	}
+	return fmt.Sprintf("Assessment Metadata (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2021-06-01/assessmentsmetadata/id_providerassessmentmetadata.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2021-06-01/assessmentsmetadata/id_providerassessmentmetadata.go
@@ -1,0 +1,114 @@
+package assessmentsmetadata
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ resourceids.ResourceId = ProviderAssessmentMetadataId{}
+
+// ProviderAssessmentMetadataId is a struct representing the Resource ID for a Provider Assessment Metadata
+type ProviderAssessmentMetadataId struct {
+	SubscriptionId         string
+	AssessmentMetadataName string
+}
+
+// NewProviderAssessmentMetadataID returns a new ProviderAssessmentMetadataId struct
+func NewProviderAssessmentMetadataID(subscriptionId string, assessmentMetadataName string) ProviderAssessmentMetadataId {
+	return ProviderAssessmentMetadataId{
+		SubscriptionId:         subscriptionId,
+		AssessmentMetadataName: assessmentMetadataName,
+	}
+}
+
+// ParseProviderAssessmentMetadataID parses 'input' into a ProviderAssessmentMetadataId
+func ParseProviderAssessmentMetadataID(input string) (*ProviderAssessmentMetadataId, error) {
+	parser := resourceids.NewParserFromResourceIdType(ProviderAssessmentMetadataId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := ProviderAssessmentMetadataId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
+	}
+
+	if id.AssessmentMetadataName, ok = parsed.Parsed["assessmentMetadataName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "assessmentMetadataName", *parsed)
+	}
+
+	return &id, nil
+}
+
+// ParseProviderAssessmentMetadataIDInsensitively parses 'input' case-insensitively into a ProviderAssessmentMetadataId
+// note: this method should only be used for API response data and not user input
+func ParseProviderAssessmentMetadataIDInsensitively(input string) (*ProviderAssessmentMetadataId, error) {
+	parser := resourceids.NewParserFromResourceIdType(ProviderAssessmentMetadataId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	var ok bool
+	id := ProviderAssessmentMetadataId{}
+
+	if id.SubscriptionId, ok = parsed.Parsed["subscriptionId"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", *parsed)
+	}
+
+	if id.AssessmentMetadataName, ok = parsed.Parsed["assessmentMetadataName"]; !ok {
+		return nil, resourceids.NewSegmentNotSpecifiedError(id, "assessmentMetadataName", *parsed)
+	}
+
+	return &id, nil
+}
+
+// ValidateProviderAssessmentMetadataID checks that 'input' can be parsed as a Provider Assessment Metadata ID
+func ValidateProviderAssessmentMetadataID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseProviderAssessmentMetadataID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Provider Assessment Metadata ID
+func (id ProviderAssessmentMetadataId) ID() string {
+	fmtString := "/subscriptions/%s/providers/Microsoft.Security/assessmentMetadata/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.AssessmentMetadataName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Provider Assessment Metadata ID
+func (id ProviderAssessmentMetadataId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftSecurity", "Microsoft.Security", "Microsoft.Security"),
+		resourceids.StaticSegment("staticAssessmentMetadata", "assessmentMetadata", "assessmentMetadata"),
+		resourceids.UserSpecifiedSegment("assessmentMetadataName", "assessmentMetadataValue"),
+	}
+}
+
+// String returns a human-readable description of this Provider Assessment Metadata ID
+func (id ProviderAssessmentMetadataId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Assessment Metadata Name: %q", id.AssessmentMetadataName),
+	}
+	return fmt.Sprintf("Provider Assessment Metadata (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2021-06-01/assessmentsmetadata/method_assessmentsmetadatacreateinsubscription_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2021-06-01/assessmentsmetadata/method_assessmentsmetadatacreateinsubscription_autorest.go
@@ -1,0 +1,69 @@
+package assessmentsmetadata
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AssessmentsMetadataCreateInSubscriptionOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *SecurityAssessmentMetadataResponse
+}
+
+// AssessmentsMetadataCreateInSubscription ...
+func (c AssessmentsMetadataClient) AssessmentsMetadataCreateInSubscription(ctx context.Context, id ProviderAssessmentMetadataId, input SecurityAssessmentMetadataResponse) (result AssessmentsMetadataCreateInSubscriptionOperationResponse, err error) {
+	req, err := c.preparerForAssessmentsMetadataCreateInSubscription(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "assessmentsmetadata.AssessmentsMetadataClient", "AssessmentsMetadataCreateInSubscription", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "assessmentsmetadata.AssessmentsMetadataClient", "AssessmentsMetadataCreateInSubscription", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForAssessmentsMetadataCreateInSubscription(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "assessmentsmetadata.AssessmentsMetadataClient", "AssessmentsMetadataCreateInSubscription", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForAssessmentsMetadataCreateInSubscription prepares the AssessmentsMetadataCreateInSubscription request.
+func (c AssessmentsMetadataClient) preparerForAssessmentsMetadataCreateInSubscription(ctx context.Context, id ProviderAssessmentMetadataId, input SecurityAssessmentMetadataResponse) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPut(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForAssessmentsMetadataCreateInSubscription handles the response to the AssessmentsMetadataCreateInSubscription request. The method always
+// closes the http.Response Body.
+func (c AssessmentsMetadataClient) responderForAssessmentsMetadataCreateInSubscription(resp *http.Response) (result AssessmentsMetadataCreateInSubscriptionOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2021-06-01/assessmentsmetadata/method_assessmentsmetadatadeleteinsubscription_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2021-06-01/assessmentsmetadata/method_assessmentsmetadatadeleteinsubscription_autorest.go
@@ -1,0 +1,66 @@
+package assessmentsmetadata
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AssessmentsMetadataDeleteInSubscriptionOperationResponse struct {
+	HttpResponse *http.Response
+}
+
+// AssessmentsMetadataDeleteInSubscription ...
+func (c AssessmentsMetadataClient) AssessmentsMetadataDeleteInSubscription(ctx context.Context, id ProviderAssessmentMetadataId) (result AssessmentsMetadataDeleteInSubscriptionOperationResponse, err error) {
+	req, err := c.preparerForAssessmentsMetadataDeleteInSubscription(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "assessmentsmetadata.AssessmentsMetadataClient", "AssessmentsMetadataDeleteInSubscription", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "assessmentsmetadata.AssessmentsMetadataClient", "AssessmentsMetadataDeleteInSubscription", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForAssessmentsMetadataDeleteInSubscription(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "assessmentsmetadata.AssessmentsMetadataClient", "AssessmentsMetadataDeleteInSubscription", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForAssessmentsMetadataDeleteInSubscription prepares the AssessmentsMetadataDeleteInSubscription request.
+func (c AssessmentsMetadataClient) preparerForAssessmentsMetadataDeleteInSubscription(ctx context.Context, id ProviderAssessmentMetadataId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsDelete(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForAssessmentsMetadataDeleteInSubscription handles the response to the AssessmentsMetadataDeleteInSubscription request. The method always
+// closes the http.Response Body.
+func (c AssessmentsMetadataClient) responderForAssessmentsMetadataDeleteInSubscription(resp *http.Response) (result AssessmentsMetadataDeleteInSubscriptionOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2021-06-01/assessmentsmetadata/method_assessmentsmetadataget_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2021-06-01/assessmentsmetadata/method_assessmentsmetadataget_autorest.go
@@ -1,0 +1,68 @@
+package assessmentsmetadata
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AssessmentsMetadataGetOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *SecurityAssessmentMetadataResponse
+}
+
+// AssessmentsMetadataGet ...
+func (c AssessmentsMetadataClient) AssessmentsMetadataGet(ctx context.Context, id AssessmentMetadataId) (result AssessmentsMetadataGetOperationResponse, err error) {
+	req, err := c.preparerForAssessmentsMetadataGet(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "assessmentsmetadata.AssessmentsMetadataClient", "AssessmentsMetadataGet", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "assessmentsmetadata.AssessmentsMetadataClient", "AssessmentsMetadataGet", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForAssessmentsMetadataGet(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "assessmentsmetadata.AssessmentsMetadataClient", "AssessmentsMetadataGet", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForAssessmentsMetadataGet prepares the AssessmentsMetadataGet request.
+func (c AssessmentsMetadataClient) preparerForAssessmentsMetadataGet(ctx context.Context, id AssessmentMetadataId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForAssessmentsMetadataGet handles the response to the AssessmentsMetadataGet request. The method always
+// closes the http.Response Body.
+func (c AssessmentsMetadataClient) responderForAssessmentsMetadataGet(resp *http.Response) (result AssessmentsMetadataGetOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2021-06-01/assessmentsmetadata/method_assessmentsmetadatagetinsubscription_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2021-06-01/assessmentsmetadata/method_assessmentsmetadatagetinsubscription_autorest.go
@@ -1,0 +1,68 @@
+package assessmentsmetadata
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AssessmentsMetadataGetInSubscriptionOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *SecurityAssessmentMetadataResponse
+}
+
+// AssessmentsMetadataGetInSubscription ...
+func (c AssessmentsMetadataClient) AssessmentsMetadataGetInSubscription(ctx context.Context, id ProviderAssessmentMetadataId) (result AssessmentsMetadataGetInSubscriptionOperationResponse, err error) {
+	req, err := c.preparerForAssessmentsMetadataGetInSubscription(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "assessmentsmetadata.AssessmentsMetadataClient", "AssessmentsMetadataGetInSubscription", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "assessmentsmetadata.AssessmentsMetadataClient", "AssessmentsMetadataGetInSubscription", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForAssessmentsMetadataGetInSubscription(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "assessmentsmetadata.AssessmentsMetadataClient", "AssessmentsMetadataGetInSubscription", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForAssessmentsMetadataGetInSubscription prepares the AssessmentsMetadataGetInSubscription request.
+func (c AssessmentsMetadataClient) preparerForAssessmentsMetadataGetInSubscription(ctx context.Context, id ProviderAssessmentMetadataId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForAssessmentsMetadataGetInSubscription handles the response to the AssessmentsMetadataGetInSubscription request. The method always
+// closes the http.Response Body.
+func (c AssessmentsMetadataClient) responderForAssessmentsMetadataGetInSubscription(resp *http.Response) (result AssessmentsMetadataGetInSubscriptionOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2021-06-01/assessmentsmetadata/method_assessmentsmetadatalist_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2021-06-01/assessmentsmetadata/method_assessmentsmetadatalist_autorest.go
@@ -1,0 +1,186 @@
+package assessmentsmetadata
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AssessmentsMetadataListOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *[]SecurityAssessmentMetadataResponse
+
+	nextLink     *string
+	nextPageFunc func(ctx context.Context, nextLink string) (AssessmentsMetadataListOperationResponse, error)
+}
+
+type AssessmentsMetadataListCompleteResult struct {
+	Items []SecurityAssessmentMetadataResponse
+}
+
+func (r AssessmentsMetadataListOperationResponse) HasMore() bool {
+	return r.nextLink != nil
+}
+
+func (r AssessmentsMetadataListOperationResponse) LoadMore(ctx context.Context) (resp AssessmentsMetadataListOperationResponse, err error) {
+	if !r.HasMore() {
+		err = fmt.Errorf("no more pages returned")
+		return
+	}
+	return r.nextPageFunc(ctx, *r.nextLink)
+}
+
+// AssessmentsMetadataList ...
+func (c AssessmentsMetadataClient) AssessmentsMetadataList(ctx context.Context) (resp AssessmentsMetadataListOperationResponse, err error) {
+	req, err := c.preparerForAssessmentsMetadataList(ctx)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "assessmentsmetadata.AssessmentsMetadataClient", "AssessmentsMetadataList", nil, "Failure preparing request")
+		return
+	}
+
+	resp.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "assessmentsmetadata.AssessmentsMetadataClient", "AssessmentsMetadataList", resp.HttpResponse, "Failure sending request")
+		return
+	}
+
+	resp, err = c.responderForAssessmentsMetadataList(resp.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "assessmentsmetadata.AssessmentsMetadataClient", "AssessmentsMetadataList", resp.HttpResponse, "Failure responding to request")
+		return
+	}
+	return
+}
+
+// preparerForAssessmentsMetadataList prepares the AssessmentsMetadataList request.
+func (c AssessmentsMetadataClient) preparerForAssessmentsMetadataList(ctx context.Context) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath("/providers/Microsoft.Security/assessmentMetadata"),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// preparerForAssessmentsMetadataListWithNextLink prepares the AssessmentsMetadataList request with the given nextLink token.
+func (c AssessmentsMetadataClient) preparerForAssessmentsMetadataListWithNextLink(ctx context.Context, nextLink string) (*http.Request, error) {
+	uri, err := url.Parse(nextLink)
+	if err != nil {
+		return nil, fmt.Errorf("parsing nextLink %q: %+v", nextLink, err)
+	}
+	queryParameters := map[string]interface{}{}
+	for k, v := range uri.Query() {
+		if len(v) == 0 {
+			continue
+		}
+		val := v[0]
+		val = autorest.Encode("query", val)
+		queryParameters[k] = val
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(uri.Path),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForAssessmentsMetadataList handles the response to the AssessmentsMetadataList request. The method always
+// closes the http.Response Body.
+func (c AssessmentsMetadataClient) responderForAssessmentsMetadataList(resp *http.Response) (result AssessmentsMetadataListOperationResponse, err error) {
+	type page struct {
+		Values   []SecurityAssessmentMetadataResponse `json:"value"`
+		NextLink *string                              `json:"nextLink"`
+	}
+	var respObj page
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&respObj),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	result.Model = &respObj.Values
+	result.nextLink = respObj.NextLink
+	if respObj.NextLink != nil {
+		result.nextPageFunc = func(ctx context.Context, nextLink string) (result AssessmentsMetadataListOperationResponse, err error) {
+			req, err := c.preparerForAssessmentsMetadataListWithNextLink(ctx, nextLink)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "assessmentsmetadata.AssessmentsMetadataClient", "AssessmentsMetadataList", nil, "Failure preparing request")
+				return
+			}
+
+			result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "assessmentsmetadata.AssessmentsMetadataClient", "AssessmentsMetadataList", result.HttpResponse, "Failure sending request")
+				return
+			}
+
+			result, err = c.responderForAssessmentsMetadataList(result.HttpResponse)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "assessmentsmetadata.AssessmentsMetadataClient", "AssessmentsMetadataList", result.HttpResponse, "Failure responding to request")
+				return
+			}
+
+			return
+		}
+	}
+	return
+}
+
+// AssessmentsMetadataListComplete retrieves all of the results into a single object
+func (c AssessmentsMetadataClient) AssessmentsMetadataListComplete(ctx context.Context) (AssessmentsMetadataListCompleteResult, error) {
+	return c.AssessmentsMetadataListCompleteMatchingPredicate(ctx, SecurityAssessmentMetadataResponseOperationPredicate{})
+}
+
+// AssessmentsMetadataListCompleteMatchingPredicate retrieves all of the results and then applied the predicate
+func (c AssessmentsMetadataClient) AssessmentsMetadataListCompleteMatchingPredicate(ctx context.Context, predicate SecurityAssessmentMetadataResponseOperationPredicate) (resp AssessmentsMetadataListCompleteResult, err error) {
+	items := make([]SecurityAssessmentMetadataResponse, 0)
+
+	page, err := c.AssessmentsMetadataList(ctx)
+	if err != nil {
+		err = fmt.Errorf("loading the initial page: %+v", err)
+		return
+	}
+	if page.Model != nil {
+		for _, v := range *page.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	for page.HasMore() {
+		page, err = page.LoadMore(ctx)
+		if err != nil {
+			err = fmt.Errorf("loading the next page: %+v", err)
+			return
+		}
+
+		if page.Model != nil {
+			for _, v := range *page.Model {
+				if predicate.Matches(v) {
+					items = append(items, v)
+				}
+			}
+		}
+	}
+
+	out := AssessmentsMetadataListCompleteResult{
+		Items: items,
+	}
+	return out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2021-06-01/assessmentsmetadata/method_assessmentsmetadatalistbysubscription_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2021-06-01/assessmentsmetadata/method_assessmentsmetadatalistbysubscription_autorest.go
@@ -1,0 +1,187 @@
+package assessmentsmetadata
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AssessmentsMetadataListBySubscriptionOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *[]SecurityAssessmentMetadataResponse
+
+	nextLink     *string
+	nextPageFunc func(ctx context.Context, nextLink string) (AssessmentsMetadataListBySubscriptionOperationResponse, error)
+}
+
+type AssessmentsMetadataListBySubscriptionCompleteResult struct {
+	Items []SecurityAssessmentMetadataResponse
+}
+
+func (r AssessmentsMetadataListBySubscriptionOperationResponse) HasMore() bool {
+	return r.nextLink != nil
+}
+
+func (r AssessmentsMetadataListBySubscriptionOperationResponse) LoadMore(ctx context.Context) (resp AssessmentsMetadataListBySubscriptionOperationResponse, err error) {
+	if !r.HasMore() {
+		err = fmt.Errorf("no more pages returned")
+		return
+	}
+	return r.nextPageFunc(ctx, *r.nextLink)
+}
+
+// AssessmentsMetadataListBySubscription ...
+func (c AssessmentsMetadataClient) AssessmentsMetadataListBySubscription(ctx context.Context, id commonids.SubscriptionId) (resp AssessmentsMetadataListBySubscriptionOperationResponse, err error) {
+	req, err := c.preparerForAssessmentsMetadataListBySubscription(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "assessmentsmetadata.AssessmentsMetadataClient", "AssessmentsMetadataListBySubscription", nil, "Failure preparing request")
+		return
+	}
+
+	resp.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "assessmentsmetadata.AssessmentsMetadataClient", "AssessmentsMetadataListBySubscription", resp.HttpResponse, "Failure sending request")
+		return
+	}
+
+	resp, err = c.responderForAssessmentsMetadataListBySubscription(resp.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "assessmentsmetadata.AssessmentsMetadataClient", "AssessmentsMetadataListBySubscription", resp.HttpResponse, "Failure responding to request")
+		return
+	}
+	return
+}
+
+// preparerForAssessmentsMetadataListBySubscription prepares the AssessmentsMetadataListBySubscription request.
+func (c AssessmentsMetadataClient) preparerForAssessmentsMetadataListBySubscription(ctx context.Context, id commonids.SubscriptionId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(fmt.Sprintf("%s/providers/Microsoft.Security/assessmentMetadata", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// preparerForAssessmentsMetadataListBySubscriptionWithNextLink prepares the AssessmentsMetadataListBySubscription request with the given nextLink token.
+func (c AssessmentsMetadataClient) preparerForAssessmentsMetadataListBySubscriptionWithNextLink(ctx context.Context, nextLink string) (*http.Request, error) {
+	uri, err := url.Parse(nextLink)
+	if err != nil {
+		return nil, fmt.Errorf("parsing nextLink %q: %+v", nextLink, err)
+	}
+	queryParameters := map[string]interface{}{}
+	for k, v := range uri.Query() {
+		if len(v) == 0 {
+			continue
+		}
+		val := v[0]
+		val = autorest.Encode("query", val)
+		queryParameters[k] = val
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(uri.Path),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForAssessmentsMetadataListBySubscription handles the response to the AssessmentsMetadataListBySubscription request. The method always
+// closes the http.Response Body.
+func (c AssessmentsMetadataClient) responderForAssessmentsMetadataListBySubscription(resp *http.Response) (result AssessmentsMetadataListBySubscriptionOperationResponse, err error) {
+	type page struct {
+		Values   []SecurityAssessmentMetadataResponse `json:"value"`
+		NextLink *string                              `json:"nextLink"`
+	}
+	var respObj page
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&respObj),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	result.Model = &respObj.Values
+	result.nextLink = respObj.NextLink
+	if respObj.NextLink != nil {
+		result.nextPageFunc = func(ctx context.Context, nextLink string) (result AssessmentsMetadataListBySubscriptionOperationResponse, err error) {
+			req, err := c.preparerForAssessmentsMetadataListBySubscriptionWithNextLink(ctx, nextLink)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "assessmentsmetadata.AssessmentsMetadataClient", "AssessmentsMetadataListBySubscription", nil, "Failure preparing request")
+				return
+			}
+
+			result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "assessmentsmetadata.AssessmentsMetadataClient", "AssessmentsMetadataListBySubscription", result.HttpResponse, "Failure sending request")
+				return
+			}
+
+			result, err = c.responderForAssessmentsMetadataListBySubscription(result.HttpResponse)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "assessmentsmetadata.AssessmentsMetadataClient", "AssessmentsMetadataListBySubscription", result.HttpResponse, "Failure responding to request")
+				return
+			}
+
+			return
+		}
+	}
+	return
+}
+
+// AssessmentsMetadataListBySubscriptionComplete retrieves all of the results into a single object
+func (c AssessmentsMetadataClient) AssessmentsMetadataListBySubscriptionComplete(ctx context.Context, id commonids.SubscriptionId) (AssessmentsMetadataListBySubscriptionCompleteResult, error) {
+	return c.AssessmentsMetadataListBySubscriptionCompleteMatchingPredicate(ctx, id, SecurityAssessmentMetadataResponseOperationPredicate{})
+}
+
+// AssessmentsMetadataListBySubscriptionCompleteMatchingPredicate retrieves all of the results and then applied the predicate
+func (c AssessmentsMetadataClient) AssessmentsMetadataListBySubscriptionCompleteMatchingPredicate(ctx context.Context, id commonids.SubscriptionId, predicate SecurityAssessmentMetadataResponseOperationPredicate) (resp AssessmentsMetadataListBySubscriptionCompleteResult, err error) {
+	items := make([]SecurityAssessmentMetadataResponse, 0)
+
+	page, err := c.AssessmentsMetadataListBySubscription(ctx, id)
+	if err != nil {
+		err = fmt.Errorf("loading the initial page: %+v", err)
+		return
+	}
+	if page.Model != nil {
+		for _, v := range *page.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	for page.HasMore() {
+		page, err = page.LoadMore(ctx)
+		if err != nil {
+			err = fmt.Errorf("loading the next page: %+v", err)
+			return
+		}
+
+		if page.Model != nil {
+			for _, v := range *page.Model {
+				if predicate.Matches(v) {
+					items = append(items, v)
+				}
+			}
+		}
+	}
+
+	out := AssessmentsMetadataListBySubscriptionCompleteResult{
+		Items: items,
+	}
+	return out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2021-06-01/assessmentsmetadata/model_securityassessmentmetadatapartnerdata.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2021-06-01/assessmentsmetadata/model_securityassessmentmetadatapartnerdata.go
@@ -1,0 +1,10 @@
+package assessmentsmetadata
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SecurityAssessmentMetadataPartnerData struct {
+	PartnerName string  `json:"partnerName"`
+	ProductName *string `json:"productName,omitempty"`
+	Secret      string  `json:"secret"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2021-06-01/assessmentsmetadata/model_securityassessmentmetadatapropertiesresponse.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2021-06-01/assessmentsmetadata/model_securityassessmentmetadatapropertiesresponse.go
@@ -1,0 +1,23 @@
+package assessmentsmetadata
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SecurityAssessmentMetadataPropertiesResponse struct {
+	AssessmentType         AssessmentType                                            `json:"assessmentType"`
+	Categories             *[]Categories                                             `json:"categories,omitempty"`
+	Description            *string                                                   `json:"description,omitempty"`
+	DisplayName            string                                                    `json:"displayName"`
+	ImplementationEffort   *ImplementationEffort                                     `json:"implementationEffort,omitempty"`
+	PartnerData            *SecurityAssessmentMetadataPartnerData                    `json:"partnerData,omitempty"`
+	PlannedDeprecationDate *string                                                   `json:"plannedDeprecationDate,omitempty"`
+	PolicyDefinitionId     *string                                                   `json:"policyDefinitionId,omitempty"`
+	Preview                *bool                                                     `json:"preview,omitempty"`
+	PublishDates           *SecurityAssessmentMetadataPropertiesResponsePublishDates `json:"publishDates,omitempty"`
+	RemediationDescription *string                                                   `json:"remediationDescription,omitempty"`
+	Severity               Severity                                                  `json:"severity"`
+	Tactics                *[]Tactics                                                `json:"tactics,omitempty"`
+	Techniques             *[]Techniques                                             `json:"techniques,omitempty"`
+	Threats                *[]Threats                                                `json:"threats,omitempty"`
+	UserImpact             *UserImpact                                               `json:"userImpact,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2021-06-01/assessmentsmetadata/model_securityassessmentmetadatapropertiesresponsepublishdates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2021-06-01/assessmentsmetadata/model_securityassessmentmetadatapropertiesresponsepublishdates.go
@@ -1,0 +1,9 @@
+package assessmentsmetadata
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SecurityAssessmentMetadataPropertiesResponsePublishDates struct {
+	GA     *string `json:"GA,omitempty"`
+	Public string  `json:"public"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2021-06-01/assessmentsmetadata/model_securityassessmentmetadataresponse.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2021-06-01/assessmentsmetadata/model_securityassessmentmetadataresponse.go
@@ -1,0 +1,11 @@
+package assessmentsmetadata
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SecurityAssessmentMetadataResponse struct {
+	Id         *string                                       `json:"id,omitempty"`
+	Name       *string                                       `json:"name,omitempty"`
+	Properties *SecurityAssessmentMetadataPropertiesResponse `json:"properties,omitempty"`
+	Type       *string                                       `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2021-06-01/assessmentsmetadata/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2021-06-01/assessmentsmetadata/predicates.go
@@ -1,0 +1,27 @@
+package assessmentsmetadata
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type SecurityAssessmentMetadataResponseOperationPredicate struct {
+	Id   *string
+	Name *string
+	Type *string
+}
+
+func (p SecurityAssessmentMetadataResponseOperationPredicate) Matches(input SecurityAssessmentMetadataResponse) bool {
+
+	if p.Id != nil && (input.Id == nil || *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil || *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil || *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2021-06-01/assessmentsmetadata/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/security/2021-06-01/assessmentsmetadata/version.go
@@ -1,0 +1,12 @@
+package assessmentsmetadata
+
+import "fmt"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2021-06-01"
+
+func userAgent() string {
+	return fmt.Sprintf("hashicorp/go-azure-sdk/assessmentsmetadata/%s", defaultApiVersion)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -808,6 +808,7 @@ github.com/hashicorp/go-azure-sdk/resource-manager/search/2022-09-01/adminkeys
 github.com/hashicorp/go-azure-sdk/resource-manager/search/2022-09-01/querykeys
 github.com/hashicorp/go-azure-sdk/resource-manager/search/2022-09-01/services
 github.com/hashicorp/go-azure-sdk/resource-manager/search/2022-09-01/sharedprivatelinkresources
+github.com/hashicorp/go-azure-sdk/resource-manager/security/2021-06-01/assessmentsmetadata
 github.com/hashicorp/go-azure-sdk/resource-manager/security/2023-01-01/pricings
 github.com/hashicorp/go-azure-sdk/resource-manager/securityinsights/2022-10-01-preview/alertrules
 github.com/hashicorp/go-azure-sdk/resource-manager/securityinsights/2022-10-01-preview/automationrules


### PR DESCRIPTION
Test Result:
```

=== RUN   TestAccServerVulnerabilityAssessment
--- PASS: TestAccServerVulnerabilityAssessment (267.42s)
=== RUN   TestAccServerVulnerabilityAssessment/securityCenterAssessmentPolicy
    --- PASS: TestAccServerVulnerabilityAssessment/securityCenterAssessmentPolicy (267.42s)
=== RUN   TestAccServerVulnerabilityAssessment/securityCenterAssessmentPolicy/basic
        --- PASS: TestAccServerVulnerabilityAssessment/securityCenterAssessmentPolicy/basic (80.27s)
=== RUN   TestAccServerVulnerabilityAssessment/securityCenterAssessmentPolicy/complete
        --- PASS: TestAccServerVulnerabilityAssessment/securityCenterAssessmentPolicy/complete (74.49s)
=== RUN   TestAccServerVulnerabilityAssessment/securityCenterAssessmentPolicy/update
        --- PASS: TestAccServerVulnerabilityAssessment/securityCenterAssessmentPolicy/update (112.67s)
PASS
```