### PR TITLE
`azurerm_batch_pool` - add new property `accelerated_networking_enabled`

### DIFF
--- a/internal/services/batch/batch_pool.go
+++ b/internal/services/batch/batch_pool.go
@@ -1312,11 +1312,6 @@ func flattenBatchPoolNetworkConfiguration(input *pool.NetworkConfiguration) []in
 		dynamicVNetAssignmentScope = string(*input.DynamicVnetAssignmentScope)
 	}
 
-	acceleratedNetworkingEnabled := false
-	if input.EnableAcceleratedNetworking != nil && *input.EnableAcceleratedNetworking {
-		acceleratedNetworkingEnabled = true
-	}
-
 	return []interface{}{
 		map[string]interface{}{
 			"dynamic_vnet_assignment_scope":    dynamicVNetAssignmentScope,

--- a/internal/services/batch/batch_pool.go
+++ b/internal/services/batch/batch_pool.go
@@ -1114,6 +1114,10 @@ func ExpandBatchPoolNetworkConfiguration(list []interface{}) (*pool.NetworkConfi
 		networkConfiguration.DynamicVnetAssignmentScope = pointer.To(pool.DynamicVNetAssignmentScope(v.(string)))
 	}
 
+	if v, ok := networkConfigValue["accelerated_networking_enabled"]; ok {
+		networkConfiguration.EnableAcceleratedNetworking = pointer.FromBool(v.(bool))
+	}
+
 	if v, ok := networkConfigValue["subnet_id"]; ok {
 		if value := v.(string); value != "" {
 			networkConfiguration.SubnetId = &value
@@ -1308,9 +1312,15 @@ func flattenBatchPoolNetworkConfiguration(input *pool.NetworkConfiguration) []in
 		dynamicVNetAssignmentScope = string(*input.DynamicVnetAssignmentScope)
 	}
 
+	acceleratedNetworkingEnabled := false
+	if input.EnableAcceleratedNetworking != nil && *input.EnableAcceleratedNetworking {
+		acceleratedNetworkingEnabled = true
+	}
+
 	return []interface{}{
 		map[string]interface{}{
 			"dynamic_vnet_assignment_scope":    dynamicVNetAssignmentScope,
+			"accelerated_networking_enabled":   acceleratedNetworkingEnabled,
 			"endpoint_configuration":           endpointConfigs,
 			"public_address_provisioning_type": publicAddressProvisioningType,
 			"public_ips":                       pluginsdk.NewSet(pluginsdk.HashString, publicIPAddressIds),

--- a/internal/services/batch/batch_pool.go
+++ b/internal/services/batch/batch_pool.go
@@ -1320,7 +1320,7 @@ func flattenBatchPoolNetworkConfiguration(input *pool.NetworkConfiguration) []in
 	return []interface{}{
 		map[string]interface{}{
 			"dynamic_vnet_assignment_scope":    dynamicVNetAssignmentScope,
-			"accelerated_networking_enabled":   acceleratedNetworkingEnabled,
+			"accelerated_networking_enabled":   pointer.From(input.EnableAcceleratedNetworking),
 			"endpoint_configuration":           endpointConfigs,
 			"public_address_provisioning_type": publicAddressProvisioningType,
 			"public_ips":                       pluginsdk.NewSet(pluginsdk.HashString, publicIPAddressIds),

--- a/internal/services/batch/batch_pool_data_source.go
+++ b/internal/services/batch/batch_pool_data_source.go
@@ -478,6 +478,10 @@ func dataSourceBatchPool() *pluginsdk.Resource {
 							Type:     pluginsdk.TypeString,
 							Computed: true,
 						},
+						"accelerated_networking_enabled": {
+							Type:     pluginsdk.TypeBool,
+							Computed: true,
+						},
 						"subnet_id": {
 							Type:     pluginsdk.TypeString,
 							Computed: true,

--- a/internal/services/batch/batch_pool_resource.go
+++ b/internal/services/batch/batch_pool_resource.go
@@ -463,9 +463,15 @@ func resourceBatchPool() *pluginsdk.Resource {
 								string(pool.DynamicVNetAssignmentScopeJob),
 							}, false),
 						},
+						"accelerated_networking_enabled": {
+							Type:     pluginsdk.TypeBool,
+							Optional: true,
+							Default:  false,
+							ForceNew: true,
+						},
 						"subnet_id": {
 							Type:         pluginsdk.TypeString,
-							Required:     true,
+							Optional:     true,
 							ForceNew:     true,
 							ValidateFunc: validation.StringIsNotEmpty,
 						},

--- a/internal/services/batch/batch_pool_resource_test.go
+++ b/internal/services/batch/batch_pool_resource_test.go
@@ -44,6 +44,22 @@ func TestAccBatchPool_basic(t *testing.T) {
 	})
 }
 
+func TestAccBatchPool_acceleratedNetworkingEnabled(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_batch_pool", "test")
+	r := BatchPoolResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.acceleratedNetworkingEnabled(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("network_configuration.0.accelerated_networking_enabled").HasValue("true"),
+			),
+		},
+		data.ImportStep("stop_pending_resize_operation"),
+	})
+}
+
 func TestAccBatchPool_identity(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_batch_pool", "test")
 	r := BatchPoolResource{}
@@ -990,6 +1006,48 @@ resource "azurerm_batch_pool" "test" {
     offer     = "UbuntuServer"
     sku       = "18.04-lts"
     version   = "latest"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString)
+}
+
+func (BatchPoolResource) acceleratedNetworkingEnabled(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-batch-%d"
+  location = "%s"
+}
+
+resource "azurerm_batch_account" "test" {
+  name                = "testaccbatch%s"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_batch_pool" "test" {
+  name                = "testaccpool%s"
+  resource_group_name = azurerm_resource_group.test.name
+  account_name        = azurerm_batch_account.test.name
+  node_agent_sku_id   = "batch.node.windows amd64"
+  vm_size             = "Standard_D1_v2"
+
+  fixed_scale {
+    target_dedicated_nodes = 2
+  }
+
+  storage_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-datacenter-smalldisk"
+    version   = "latest"
+  }
+  
+  network_configuration {
+	accelerated_networking_enabled = true
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString)

--- a/internal/services/batch/batch_pool_resource_test.go
+++ b/internal/services/batch/batch_pool_resource_test.go
@@ -1045,9 +1045,9 @@ resource "azurerm_batch_pool" "test" {
     sku       = "2016-datacenter-smalldisk"
     version   = "latest"
   }
-  
+
   network_configuration {
-	accelerated_networking_enabled = true
+    accelerated_networking_enabled = true
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString)

--- a/website/docs/r/batch_pool.html.markdown
+++ b/website/docs/r/batch_pool.html.markdown
@@ -462,6 +462,8 @@ A `network_configuration` block supports the following:
 
 * `dynamic_vnet_assignment_scope` - (Optional) The scope of dynamic vnet assignment. Allowed values: `none`, `job`. Changing this forces a new resource to be created.
 
+* `accelerated_networking_enabled` - (Optional) Whether to enable accelerated networking. Possible values are `true` and `false`. Defaults to `false`. Changing this forces a new resource to be created.
+
 * `public_ips` - (Optional) A list of public IP ids that will be allocated to nodes. Changing this forces a new resource to be created.
 
 * `endpoint_configuration` - (Optional) A list of inbound NAT pools that can be used to address specific ports on an individual compute node externally. Set as documented in the inbound_nat_pools block below. Changing this forces a new resource to be created.

--- a/website/docs/r/batch_pool.html.markdown
+++ b/website/docs/r/batch_pool.html.markdown
@@ -458,7 +458,7 @@ A `nfs_mount` block supports the following:
 
 A `network_configuration` block supports the following:
 
-* `subnet_id` - (Required) The ARM resource identifier of the virtual network subnet which the compute nodes of the pool will join. Changing this forces a new resource to be created.
+* `subnet_id` - (Optional) The ARM resource identifier of the virtual network subnet which the compute nodes of the pool will join. Changing this forces a new resource to be created.
 
 * `dynamic_vnet_assignment_scope` - (Optional) The scope of dynamic vnet assignment. Allowed values: `none`, `job`. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
`azurerm_batch_pool` 
- add new property `accelerated_networking_enabled`
- add related document
- since this property can be used independently, removing `Required` from `subnet_id`

Testing evidence:
![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/17947406/42a7aa5b-03c5-41fb-8bb1-5f8e517222f0)

The failed one is not due to this PR and I will try to fix that in a new one.