### PR TITLE
azurerm_postgresql_flexible_server_firewall_rule: make locking optional

### DIFF
--- a/internal/services/postgres/postgresql_flexible_server_firewall_rule_resource.go
+++ b/internal/services/postgres/postgresql_flexible_server_firewall_rule_resource.go
@@ -64,6 +64,12 @@ func resourcePostgresqlFlexibleServerFirewallRule() *pluginsdk.Resource {
 				Required:     true,
 				ValidateFunc: validation.IsIPAddress,
 			},
+
+			"resource_lock_enabled": {
+				Type:     pluginsdk.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
 		},
 	}
 }
@@ -81,8 +87,10 @@ func resourcePostgresqlFlexibleServerFirewallRuleCreateUpdate(d *pluginsdk.Resou
 
 	id := firewallrules.NewFirewallRuleID(subscriptionId, serverId.ResourceGroupName, serverId.FlexibleServerName, d.Get("name").(string))
 
-	locks.ByName(id.FlexibleServerName, postgresqlFlexibleServerResourceName)
-	defer locks.UnlockByName(id.FlexibleServerName, postgresqlFlexibleServerResourceName)
+	if d.Get("resource_lock_enabled").(bool) {
+		locks.ByName(id.FlexibleServerName, postgresqlFlexibleServerResourceName)
+		defer locks.UnlockByName(id.FlexibleServerName, postgresqlFlexibleServerResourceName)
+	}
 
 	if d.IsNewResource() {
 		existing, err := client.Get(ctx, id)
@@ -151,8 +159,10 @@ func resourcePostgresqlFlexibleServerFirewallRuleDelete(d *pluginsdk.ResourceDat
 		return err
 	}
 
-	locks.ByName(id.FlexibleServerName, postgresqlFlexibleServerResourceName)
-	defer locks.UnlockByName(id.FlexibleServerName, postgresqlFlexibleServerResourceName)
+	if d.Get("resource_lock_enabled").(bool) {
+		locks.ByName(id.FlexibleServerName, postgresqlFlexibleServerResourceName)
+		defer locks.UnlockByName(id.FlexibleServerName, postgresqlFlexibleServerResourceName)
+	}
 
 	if err = client.DeleteThenPoll(ctx, *id); err != nil {
 		return fmt.Errorf("deleting %q: %+v", id, err)

--- a/website/docs/r/postgresql_flexible_server_firewall_rule.html.markdown
+++ b/website/docs/r/postgresql_flexible_server_firewall_rule.html.markdown
@@ -55,6 +55,8 @@ The following arguments are supported:
 
 * `end_ip_address` - (Required) The End IP Address associated with this PostgreSQL Flexible Server Firewall Rule.
 
+* `resource_locks_enabled` - (Optional) Determines if the PostgreSQL Flexible Server should be locked when creating or updating the Firewall Rule. Defaults to `true`.
+
 ## Attributes Reference
 
 In addition to the Arguments listed above - the following Attributes are exported:


### PR DESCRIPTION
Hey all, first timer here.

My org has a list of firewall rules (> 100), and applying those with the resource locks implemented in #18159 causes it to take close to two hours to add them all. I'm hoping make the locking optional for firewall rule operations. In my testing, disabling the locks cut the apply time significantly - about 5x in my case. (Hopefully) fixes #19953