### PR TITLE
`azurerm_application_gateway` - support for `verify_client_certificate_revocation` in `ssl_profile` block

### DIFF
--- a/internal/services/network/application_gateway_resource.go
+++ b/internal/services/network/application_gateway_resource.go
@@ -4289,7 +4289,7 @@ func flattenApplicationGatewaySslProfiles(input *[]network.ApplicationGatewaySsl
 		output["name"] = name
 
 		verifyClientCertIssuerDn := false
-		verifyClientCertRevocation := "None"
+		verifyClientCertRevocation := ""
 		if v.ClientAuthConfiguration != nil {
 			verifyClientCertIssuerDn = pointer.From(v.ClientAuthConfiguration.VerifyClientCertIssuerDN)
 			verifyClientCertRevocation = string(v.ClientAuthConfiguration.VerifyClientRevocation)

--- a/internal/services/network/application_gateway_resource.go
+++ b/internal/services/network/application_gateway_resource.go
@@ -1240,19 +1240,18 @@ func resourceApplicationGateway() *pluginsdk.Resource {
 							},
 						},
 
+						// TODO: replace cert by certificate in 4.0
 						"verify_client_cert_issuer_dn": {
 							Type:     pluginsdk.TypeBool,
 							Optional: true,
 							Default:  false,
 						},
 
-						"verify_client_cert_revocation": {
+						"verify_client_certificate_revocation": {
 							Type:     pluginsdk.TypeString,
 							Optional: true,
-							Default:  string(network.ApplicationGatewayClientRevocationOptionsNone),
 							ValidateFunc: validation.StringInSlice([]string{
 								string(network.ApplicationGatewayClientRevocationOptionsOCSP),
-								string(network.ApplicationGatewayClientRevocationOptionsNone),
 							}, false),
 						},
 
@@ -4229,14 +4228,14 @@ func expandApplicationGatewaySslProfiles(d *pluginsdk.ResourceData, gatewayID st
 
 		name := v["name"].(string)
 		verifyClientCertIssuerDn := v["verify_client_cert_issuer_dn"].(bool)
-		verifyClientCertRevocation := v["verify_client_cert_revocation"].(string)
+		verifyClientCertificateRevocation := v["verify_client_certificate_revocation"].(string)
 
 		output := network.ApplicationGatewaySslProfile{
 			Name: pointer.To(name),
 			ApplicationGatewaySslProfilePropertiesFormat: &network.ApplicationGatewaySslProfilePropertiesFormat{
 				ClientAuthConfiguration: &network.ApplicationGatewayClientAuthConfiguration{
 					VerifyClientCertIssuerDN: pointer.To(verifyClientCertIssuerDn),
-					VerifyClientRevocation:   network.ApplicationGatewayClientRevocationOptions(verifyClientCertRevocation),
+					VerifyClientRevocation:   network.ApplicationGatewayClientRevocationOptions(verifyClientCertificateRevocation),
 				},
 			},
 		}
@@ -4289,13 +4288,15 @@ func flattenApplicationGatewaySslProfiles(input *[]network.ApplicationGatewaySsl
 		output["name"] = name
 
 		verifyClientCertIssuerDn := false
-		verifyClientCertRevocation := ""
+		verifyClientCertificateRevocation := ""
 		if v.ClientAuthConfiguration != nil {
 			verifyClientCertIssuerDn = pointer.From(v.ClientAuthConfiguration.VerifyClientCertIssuerDN)
-			verifyClientCertRevocation = string(v.ClientAuthConfiguration.VerifyClientRevocation)
+			if v.ClientAuthConfiguration.VerifyClientRevocation != network.ApplicationGatewayClientRevocationOptionsNone {
+				verifyClientCertificateRevocation = string(v.ClientAuthConfiguration.VerifyClientRevocation)
+			}
 		}
 		output["verify_client_cert_issuer_dn"] = verifyClientCertIssuerDn
-		output["verify_client_cert_revocation"] = verifyClientCertRevocation
+		output["verify_client_certificate_revocation"] = verifyClientCertificateRevocation
 
 		output["ssl_policy"] = flattenApplicationGatewaySslPolicy(v.SslPolicy)
 

--- a/internal/services/network/application_gateway_resource.go
+++ b/internal/services/network/application_gateway_resource.go
@@ -4228,14 +4228,17 @@ func expandApplicationGatewaySslProfiles(d *pluginsdk.ResourceData, gatewayID st
 
 		name := v["name"].(string)
 		verifyClientCertIssuerDn := v["verify_client_cert_issuer_dn"].(bool)
-		verifyClientCertificateRevocation := v["verify_client_certificate_revocation"].(string)
+		verifyClientCertificateRevocation := network.ApplicationGatewayClientRevocationOptionsNone
+		if v["verify_client_certificate_revocation"].(string) != "" {
+			verifyClientCertificateRevocation = network.ApplicationGatewayClientRevocationOptions(v["verify_client_certificate_revocation"].(string))
+		}
 
 		output := network.ApplicationGatewaySslProfile{
 			Name: pointer.To(name),
 			ApplicationGatewaySslProfilePropertiesFormat: &network.ApplicationGatewaySslProfilePropertiesFormat{
 				ClientAuthConfiguration: &network.ApplicationGatewayClientAuthConfiguration{
 					VerifyClientCertIssuerDN: pointer.To(verifyClientCertIssuerDn),
-					VerifyClientRevocation:   network.ApplicationGatewayClientRevocationOptions(verifyClientCertificateRevocation),
+					VerifyClientRevocation:   verifyClientCertificateRevocation,
 				},
 			},
 		}

--- a/internal/services/network/application_gateway_resource_test.go
+++ b/internal/services/network/application_gateway_resource_test.go
@@ -7257,8 +7257,9 @@ resource "azurerm_application_gateway" "test" {
   }
 
   ssl_profile {
-    name                         = local.ssl_profile_name
-    verify_client_cert_issuer_dn = true
+    name                          = local.ssl_profile_name
+    verify_client_cert_issuer_dn  = true
+    verify_client_cert_revocation = "OCSP"
     ssl_policy {
       policy_type = "Predefined"
       policy_name = "AppGwSslPolicy20170401"

--- a/internal/services/network/application_gateway_resource_test.go
+++ b/internal/services/network/application_gateway_resource_test.go
@@ -7257,9 +7257,9 @@ resource "azurerm_application_gateway" "test" {
   }
 
   ssl_profile {
-    name                          = local.ssl_profile_name
-    verify_client_cert_issuer_dn  = true
-    verify_client_cert_revocation = "OCSP"
+    name                                 = local.ssl_profile_name
+    verify_client_cert_issuer_dn         = true
+    verify_client_certificate_revocation = "OCSP"
     ssl_policy {
       policy_type = "Predefined"
       policy_name = "AppGwSslPolicy20170401"

--- a/website/docs/r/application_gateway.html.markdown
+++ b/website/docs/r/application_gateway.html.markdown
@@ -508,7 +508,7 @@ A `ssl_profile` block supports the following:
 
 * `verify_client_cert_issuer_dn` - (Optional) Should client certificate issuer DN be verified? Defaults to `false`.
  
-* `verify_client_cert_revocation` - (Optional) Specify the method to check client certificate revocation status. Possible values are `OCSP` and `None`. Default to `None`.
+* `verify_client_certificate_revocation` - (Optional) Specify the method to check client certificate revocation status. Possible value is `OCSP`.
 
 * `ssl_policy` - (Optional) a `ssl_policy` block as defined below.
 

--- a/website/docs/r/application_gateway.html.markdown
+++ b/website/docs/r/application_gateway.html.markdown
@@ -507,6 +507,8 @@ A `ssl_profile` block supports the following:
 * `trusted_client_certificate_names` - (Optional) The name of the Trusted Client Certificate that will be used to authenticate requests from clients.
 
 * `verify_client_cert_issuer_dn` - (Optional) Should client certificate issuer DN be verified? Defaults to `false`.
+ 
+* `verify_client_cert_revocation` - (Optional) Specify the method to check client certificate revocation status. Possible values are `OCSP` and `None`. Default to `None`.
 
 * `ssl_policy` - (Optional) a `ssl_policy` block as defined below.
 


### PR DESCRIPTION
- [Certificate Revocation doc](https://learn.microsoft.com/en-us/azure/application-gateway/mutual-authentication-overview?tabs=powershell#certificate-revocation)
- [REST API](https://github.com/Azure/azure-rest-api-specs/blob/c320f58d8643a309c126dd4ec5fdc6737fccd981/specification/network/resource-manager/Microsoft.Network/stable/2022-07-01/applicationGateway.json#L1371)
