### PR TITLE
`azurerm_site_recovery_replicated_vm`: fix `network_interface` diff

### DIFF
--- a/internal/services/recoveryservices/site_recovery_replicated_vm_resource.go
+++ b/internal/services/recoveryservices/site_recovery_replicated_vm_resource.go
@@ -292,7 +292,6 @@ func resourceSiteRecoveryReplicatedVM() *pluginsdk.Resource {
 
 			"network_interface": {
 				Type:       pluginsdk.TypeSet, // use set to avoid diff caused by different orders.
-				Set:        resourceSiteRecoveryReplicatedVMNicHash,
 				ConfigMode: pluginsdk.SchemaConfigModeAttr,
 				Computed:   true,
 				Optional:   true,
@@ -977,19 +976,6 @@ func resourceSiteRecoveryReplicatedVMDiskHash(v interface{}) int {
 
 	if m, ok := v.(map[string]interface{}); ok {
 		if v, ok := m["disk_id"]; ok {
-			buf.WriteString(strings.ToLower(v.(string)))
-		}
-	}
-
-	return pluginsdk.HashString(buf.String())
-}
-
-// the default hash function will not ignore Option + Computed properties, which will cause diff.
-func resourceSiteRecoveryReplicatedVMNicHash(v interface{}) int {
-	var buf bytes.Buffer
-
-	if m, ok := v.(map[string]interface{}); ok {
-		if v, ok := m["source_network_interface_id"]; ok {
 			buf.WriteString(strings.ToLower(v.(string)))
 		}
 	}


### PR DESCRIPTION
fix #23164

<img width="540" alt="Screenshot 2023-09-07 at 4 56 33 PM" src="https://github.com/hashicorp/terraform-provider-azurerm/assets/51212351/312a263f-8977-4a3e-bedd-b914dc970912">
the failed ones are also failing on `main` branch, which is not caused by this PR