### PR TITLE
`azurerm_redis_enterprise_cluster` : support for new location `Brazil South`

### DIFF
--- a/internal/services/redisenterprise/validate/redis_enterprise_cluster_location_flash_sku_support.go
+++ b/internal/services/redisenterprise/validate/redis_enterprise_cluster_location_flash_sku_support.go
@@ -37,7 +37,6 @@ func invalidRedisEnterpriseClusterFlashLocations() []string {
 func friendlyInvalidRedisEnterpriseClusterFlashLocations() []string {
 	return []string{
 		"Australia Southeast",
-		"Brazil South",
 		"Central US",
 		"Central US EUAP",
 		"East Asia",


### PR DESCRIPTION
As requested by the service team, removed `Brazil South` from the list of invalid locations since it is already supported.

Note: Because of the comment in [PR](https://github.com/hashicorp/terraform-provider-azurerm/pull/23185), there is no test case for this change, but it is tested locally.