### PR TITLE
`azurerm_monitor_action_group` - acctest: fix webhook.service_uri

### DIFF
--- a/internal/services/monitor/monitor_action_group_data_source_test.go
+++ b/internal/services/monitor/monitor_action_group_data_source_test.go
@@ -106,7 +106,7 @@ func TestAccDataSourceMonitorActionGroup_complete(t *testing.T) {
 				check.That(data.ResourceName).Key("sms_receiver.1.phone_number").HasValue("3123456789"),
 				check.That(data.ResourceName).Key("webhook_receiver.#").HasValue("2"),
 				check.That(data.ResourceName).Key("webhook_receiver.0.service_uri").HasValue("http://example.com/alert"),
-				check.That(data.ResourceName).Key("webhook_receiver.1.service_uri").HasValue("https://backup.example.com/warning"),
+				check.That(data.ResourceName).Key("webhook_receiver.1.service_uri").HasValue("https://example.com/warning/backup"),
 				check.That(data.ResourceName).Key("webhook_receiver.1.use_common_alert_schema").HasValue("false"),
 				check.That(data.ResourceName).Key("webhook_receiver.1.aad_auth.#").HasValue("0"),
 				check.That(data.ResourceName).Key("automation_runbook_receiver.#").HasValue("1"),
@@ -250,7 +250,7 @@ resource "azurerm_monitor_action_group" "test" {
 
   webhook_receiver {
     name        = "callmybackupapi"
-    service_uri = "https://backup.example.com/warning"
+    service_uri = "https://example.com/warning/backup"
   }
 
   automation_runbook_receiver {

--- a/internal/services/monitor/monitor_action_group_resource_test.go
+++ b/internal/services/monitor/monitor_action_group_resource_test.go
@@ -1006,7 +1006,7 @@ resource "azurerm_monitor_action_group" "test" {
 
   webhook_receiver {
     name                    = "callmybackupapi"
-    service_uri             = "https://backup.example.com/warning"
+    service_uri             = "https://example.com/warning/backup"
     use_common_alert_schema = true
   }
 


### PR DESCRIPTION
origin failure:
```
------- Stdout: -------
=== RUN   TestAccMonitorActionGroup_multipleReceiversUpdate
=== PAUSE TestAccMonitorActionGroup_multipleReceiversUpdate
=== CONT  TestAccMonitorActionGroup_multipleReceiversUpdate
    testcase.go:113: Step 3/6 error: Error running apply: exit status 1
        Error: creating or updating Action Group (Subscription: "*******"
        Resource Group Name: "acctestRG-230907011804771339"
        Action Group Name: "acctestActionGroup-230907011804771339"): actiongroupsapis.ActionGroupsAPIsClient#ActionGroupsCreateOrUpdate: Failure responding to request: StatusCode=400 -- Original Error: autorest/azure: Service returned an error. Status=400 Code="WebhookServiceUriBlocked" Message="WebhookServiceUriBlocked"
          with azurerm_monitor_action_group.test,
          on terraform_plugin_test.tf line 36, in resource "azurerm_monitor_action_group" "test":
          36: resource "azurerm_monitor_action_group" "test" {
--- FAIL: TestAccMonitorActionGroup_multipleReceiversUpdate (327.71s)
FAIL
```