### PR TITLE
`azurerm_key_vault_certificate`: fix `createCertificate` lost `http.Response` which is used to check if should recover this certificate

### DIFF
--- a/internal/services/keyvault/key_vault_certificate_resource.go
+++ b/internal/services/keyvault/key_vault_certificate_resource.go
@@ -186,7 +186,7 @@ func resourceKeyVaultCertificate() *pluginsdk.Resource {
 											},
 										},
 									},
-									// lintignore:XS003
+									//lintignore:XS003
 									"trigger": {
 										Type:     pluginsdk.TypeList,
 										Required: true,

--- a/internal/services/keyvault/key_vault_certificate_resource.go
+++ b/internal/services/keyvault/key_vault_certificate_resource.go
@@ -186,7 +186,7 @@ func resourceKeyVaultCertificate() *pluginsdk.Resource {
 											},
 										},
 									},
-									//lintignore:XS003
+									// lintignore:XS003
 									"trigger": {
 										Type:     pluginsdk.TypeList,
 										Required: true,
@@ -514,7 +514,7 @@ func resourceKeyVaultCertificateCreate(d *pluginsdk.ResourceData, meta interface
 		if err != nil {
 			if meta.(*clients.Client).Features.KeyVault.RecoverSoftDeletedCerts && utils.ResponseWasConflict(newCert.Response) {
 				if err = recoverDeletedCertificate(ctx, d, meta, *keyVaultBaseUrl, name); err != nil {
-					return fmt.Errorf("recover deleted certificqate: %+v", err)
+					return fmt.Errorf("recover deleted certificate: %+v", err)
 				}
 				newCert, err = client.ImportCertificate(ctx, *keyVaultBaseUrl, name, importParameters)
 				if err != nil {
@@ -530,7 +530,7 @@ func resourceKeyVaultCertificateCreate(d *pluginsdk.ResourceData, meta interface
 		if err != nil {
 			if meta.(*clients.Client).Features.KeyVault.RecoverSoftDeletedCerts && utils.ResponseWasConflict(newCert.Response) {
 				if err = recoverDeletedCertificate(ctx, d, meta, *keyVaultBaseUrl, name); err != nil {
-					return fmt.Errorf("recover deleted certificqate: %+v", err)
+					return fmt.Errorf("recover deleted certificate: %+v", err)
 				}
 				// after we recovered the existing certificate we still have to apply our changes
 				newCert, err = createCertificate(d, meta)

--- a/internal/services/keyvault/key_vault_certificate_resource_test.go
+++ b/internal/services/keyvault/key_vault_certificate_resource_test.go
@@ -138,8 +138,7 @@ func TestAccKeyVaultCertificate_softDeleteRecovery(t *testing.T) {
 			),
 		},
 		{
-			Config:  r.softDeleteRecovery(data, false),
-			Destroy: true,
+			Config: r.softDeleteCertificate(data, false),
 		},
 		{
 			Config: r.softDeleteRecovery(data, true),
@@ -1171,13 +1170,27 @@ resource "azurerm_key_vault_certificate" "test" {
 `, r.template(data), data.RandomString)
 }
 
+func (r KeyVaultCertificateResource) softDeleteCertificate(data acceptance.TestData, purge bool) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {
+    key_vault {
+      purge_soft_deleted_certificates_on_destroy = %t
+      recover_soft_deleted_key_vaults = true
+    }
+  }
+}
+
+%s`, purge, r.template(data))
+}
+
 func (r KeyVaultCertificateResource) softDeleteRecovery(data acceptance.TestData, purge bool) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {
     key_vault {
-      purge_soft_delete_on_destroy    = "%t"
-      recover_soft_deleted_key_vaults = true
+      purge_soft_deleted_certificates_on_destroy = %t
+      recover_soft_deleted_key_vaults            = true
     }
   }
 }


### PR DESCRIPTION
should fixes: #23177.

the failed `TestAccKeyVaultCertificate_basicGenerateUnknownIssuer` should not related to this PR. it has been failed for some time. I'll submit a separate PR(#23214)to fix it.

![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/2633022/c5fded52-4801-4ef4-96b3-94869ef0830f)

