### PR TITLE
`azurerm_key_vault_certificate`: skip wait status when creating certification with Unknown Issuer

### DIFF
--- a/internal/services/keyvault/key_vault_certificate_resource.go
+++ b/internal/services/keyvault/key_vault_certificate_resource.go
@@ -187,7 +187,7 @@ func resourceKeyVaultCertificate() *pluginsdk.Resource {
 											},
 										},
 									},
-									// lintignore:XS003
+									//lintignore:XS003
 									"trigger": {
 										Type:     pluginsdk.TypeList,
 										Required: true,

--- a/internal/services/keyvault/key_vault_certificate_resource.go
+++ b/internal/services/keyvault/key_vault_certificate_resource.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/Azure/go-autorest/autorest"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
@@ -186,7 +187,7 @@ func resourceKeyVaultCertificate() *pluginsdk.Resource {
 											},
 										},
 									},
-									//lintignore:XS003
+									// lintignore:XS003
 									"trigger": {
 										Type:     pluginsdk.TypeList,
 										Required: true,
@@ -653,6 +654,12 @@ func keyVaultCertificateCreationRefreshFunc(ctx context.Context, client *keyvaul
 		}
 
 		if strings.EqualFold(*operation.Status, "inProgress") {
+			if issuer := operation.IssuerParameters; issuer != nil {
+				if strings.EqualFold(pointer.From(issuer.Name), "unknown") {
+					return operation, "Ready", nil
+				}
+			}
+
 			return operation, "Provisioning", nil
 		}
 


### PR DESCRIPTION

https://github.com/hashicorp/terraform-provider-azurerm/pull/20627/files#diff-6663bcb4993480f190a77935d8eb06fbdfda6742cac79c175aea0867c573e3f3L620 removed the special logic for manuallly create a kv certificate with unknown issuer. This PR is to add it back.

doc: [create-a-kv-certificate-manually](https://learn.microsoft.com/en-us/azure/key-vault/certificates/create-certificate-scenarios#create-a-kv-certificate-manually)

