### PR TITLE
`azurerm_maps_account` - Support for `local_authentication_enabled`

### DIFF
--- a/internal/services/maps/maps_account_resource_test.go
+++ b/internal/services/maps/maps_account_resource_test.go
@@ -100,6 +100,30 @@ func TestAccMapsAccount_tags(t *testing.T) {
 	})
 }
 
+func TestAccMapsAccount_disableLocalAuth(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_maps_account", "test")
+	r := MapsAccountResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.disableLocalAuth(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("local_authentication_enabled").HasValue("false"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.enableLocalAuth(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("local_authentication_enabled").HasValue("true"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (MapsAccountResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := accounts.ParseAccountID(state.ID)
 	if err != nil {
@@ -171,6 +195,46 @@ resource "azurerm_maps_account" "test" {
   tags = {
     environment = "testing"
   }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (MapsAccountResource) disableLocalAuth(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_maps_account" "test" {
+  name                         = "accMapsAccount-%d"
+  resource_group_name          = azurerm_resource_group.test.name
+  sku_name                     = "S0"
+  local_authentication_enabled = false
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (MapsAccountResource) enableLocalAuth(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_maps_account" "test" {
+  name                         = "accMapsAccount-%d"
+  resource_group_name          = azurerm_resource_group.test.name
+  sku_name                     = "S0"
+  local_authentication_enabled = true
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }

--- a/website/docs/r/maps_account.html.markdown
+++ b/website/docs/r/maps_account.html.markdown
@@ -19,9 +19,10 @@ resource "azurerm_resource_group" "example" {
 }
 
 resource "azurerm_maps_account" "example" {
-  name                = "example-maps-account"
-  resource_group_name = azurerm_resource_group.example.name
-  sku_name            = "S1"
+  name                         = "example-maps-account"
+  resource_group_name          = azurerm_resource_group.example.name
+  sku_name                     = "S1"
+  local_authentication_enabled = true
 
   tags = {
     environment = "Test"
@@ -38,6 +39,8 @@ The following arguments are supported:
 * `resource_group_name` - (Required) The name of the Resource Group in which the Azure Maps Account should exist. Changing this forces a new resource to be created.
 
 * `sku_name` - (Required) The SKU of the Azure Maps Account. Possible values are `S0`, `S1` and `G2`. Changing this forces a new resource to be created.
+
+* `local_authentication_enabled` - (Optional) Is local authentication enabled for this Azure Maps Account? When `false`, all authentication to the Azure Maps data-plane REST API is disabled, except Azure AD authentication. Defaults to `true`.
 
 * `tags` - (Optional) A mapping of tags to assign to the Azure Maps Account.
 


### PR DESCRIPTION
Fixes #22856

```
TF_ACC=1 go test -v ./internal/services/maps -run=TestAccMapsAccount_basic -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"                   
=== RUN   TestAccMapsAccount_basic
=== PAUSE TestAccMapsAccount_basic
=== CONT  TestAccMapsAccount_basic
--- PASS: TestAccMapsAccount_basic (39.55s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/maps  41.995s
```

```
TF_ACC=1 go test -v ./internal/services/maps -run=TestAccMapsAccount_disableLocalAuth -timeout 60m -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"  
=== RUN   TestAccMapsAccount_disableLocalAuth
=== PAUSE TestAccMapsAccount_disableLocalAuth
=== CONT  TestAccMapsAccount_disableLocalAuth
--- PASS: TestAccMapsAccount_disableLocalAuth (55.66s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/maps  58.027s
```