### PR TITLE
[Bug:] `azurerm_synapse_sql_pool` - correct the behavior of `geo_backup_policy_enabled`

### DIFF
--- a/internal/services/streamanalytics/stream_analytics_output_synapse_resource_test.go
+++ b/internal/services/streamanalytics/stream_analytics_output_synapse_resource_test.go
@@ -130,8 +130,7 @@ resource "azurerm_synapse_sql_pool" "test" {
   synapse_workspace_id = azurerm_synapse_workspace.test.id
   sku_name             = "DW100c"
   create_mode          = "Default"
-
-  geo_backup_policy_enabled = true
+  storage_account_type = "GRS""
 }
 
 resource "azurerm_stream_analytics_output_synapse" "test" {

--- a/internal/services/streamanalytics/stream_analytics_output_synapse_resource_test.go
+++ b/internal/services/streamanalytics/stream_analytics_output_synapse_resource_test.go
@@ -130,7 +130,7 @@ resource "azurerm_synapse_sql_pool" "test" {
   synapse_workspace_id = azurerm_synapse_workspace.test.id
   sku_name             = "DW100c"
   create_mode          = "Default"
-  storage_account_type = "GRS""
+  storage_account_type = "GRS"
 }
 
 resource "azurerm_stream_analytics_output_synapse" "test" {

--- a/internal/services/streamanalytics/stream_analytics_output_synapse_resource_test.go
+++ b/internal/services/streamanalytics/stream_analytics_output_synapse_resource_test.go
@@ -130,6 +130,8 @@ resource "azurerm_synapse_sql_pool" "test" {
   synapse_workspace_id = azurerm_synapse_workspace.test.id
   sku_name             = "DW100c"
   create_mode          = "Default"
+
+  geo_backup_policy_enabled = true
 }
 
 resource "azurerm_stream_analytics_output_synapse" "test" {

--- a/internal/services/synapse/synapse_sql_pool_extended_auditing_policy_resource_test.go
+++ b/internal/services/synapse/synapse_sql_pool_extended_auditing_policy_resource_test.go
@@ -189,7 +189,7 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestsw%[1]d"
+  name     = "acctestRG-synapse-%[1]d"
   location = "%[2]s"
 }
 

--- a/internal/services/synapse/synapse_sql_pool_extended_auditing_policy_resource_test.go
+++ b/internal/services/synapse/synapse_sql_pool_extended_auditing_policy_resource_test.go
@@ -224,8 +224,7 @@ resource "azurerm_synapse_sql_pool" "test" {
   synapse_workspace_id = azurerm_synapse_workspace.test.id
   sku_name             = "DW100c"
   create_mode          = "Default"
-
-  geo_backup_policy_enabled = true
+  storage_account_type = "GRS"
 }
 
 resource "azurerm_storage_account" "test" {

--- a/internal/services/synapse/synapse_sql_pool_extended_auditing_policy_resource_test.go
+++ b/internal/services/synapse/synapse_sql_pool_extended_auditing_policy_resource_test.go
@@ -224,6 +224,8 @@ resource "azurerm_synapse_sql_pool" "test" {
   synapse_workspace_id = azurerm_synapse_workspace.test.id
   sku_name             = "DW100c"
   create_mode          = "Default"
+
+  geo_backup_policy_enabled = true
 }
 
 resource "azurerm_storage_account" "test" {

--- a/internal/services/synapse/synapse_sql_pool_resource.go
+++ b/internal/services/synapse/synapse_sql_pool_resource.go
@@ -324,11 +324,11 @@ func resourceSynapseSqlPoolUpdate(d *pluginsdk.ResourceData, meta interface{}) e
 		}
 	}
 
-	// NOTE: Per the service team instructions the `geo_backup_policy_enabled` field
+	// NOTE: Per the Synapse service team, the `geo_backup_policy_enabled` field
 	// cannot be changed once it has been created...
 	if !features.FourPointOhBeta() {
 		if d.HasChange("geo_backup_policy_enabled") {
-			return fmt.Errorf("`geo_backup_policy_enabled` field cannot be changed once it has been set")
+			return fmt.Errorf("the `geo_backup_policy_enabled` field cannot be changed once it has been set")
 		}
 	}
 

--- a/internal/services/synapse/synapse_sql_pool_resource_test.go
+++ b/internal/services/synapse/synapse_sql_pool_resource_test.go
@@ -98,33 +98,6 @@ func TestAccSynapseSqlPool_threePointOhUpdate(t *testing.T) {
 	})
 }
 
-func TestAccSynapseSqlPool_threePointOhStorageAccountError(t *testing.T) {
-	// This error will only happen in the v3.0 of the provider as the
-	// 'storage_account_type' in v4.0 will be ForceNew Required...
-	if features.FourPointOhBeta() {
-		t.Skipf("Skippped as 'storage_account_type' is now a Required field in 4.0")
-	}
-
-	data := acceptance.BuildTestData(t, "azurerm_synapse_sql_pool", "test")
-	r := SynapseSqlPoolResource{}
-
-	data.ResourceTest(t, r, []acceptance.TestStep{
-		{
-			Config: r.geoBackup(data, false, "GRS"),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("geo_backup_policy_enabled").HasValue("false"),
-				check.That(data.ResourceName).Key("storage_account_type").HasValue("GRS"),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config:      r.geoBackup(data, false, "LRS"),
-			ExpectError: regexp.MustCompile("the `storage_account_type` cannot be changed once it has been set, was `GRS` got `LRS`"),
-		},
-	})
-}
-
 func TestAccSynapseSqlPool_utf8(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_synapse_sql_pool", "test")
 	r := SynapseSqlPoolResource{}

--- a/internal/services/synapse/synapse_sql_pool_resource_test.go
+++ b/internal/services/synapse/synapse_sql_pool_resource_test.go
@@ -110,16 +110,16 @@ func TestAccSynapseSqlPool_threePointOhStorageAccountError(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.geoBackupThreePointOhDefault(data),
+			Config: r.geoBackup(data, false, "GRS"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("geo_backup_policy_enabled").HasValue("true"),
+				check.That(data.ResourceName).Key("geo_backup_policy_enabled").HasValue("false"),
 				check.That(data.ResourceName).Key("storage_account_type").HasValue("GRS"),
 			),
 		},
 		data.ImportStep(),
 		{
-			Config:      r.geoBackup(data, true, "LRS"),
+			Config:      r.geoBackup(data, false, "LRS"),
 			ExpectError: regexp.MustCompile("the `storage_account_type` cannot be changed once it has been set, was `GRS` got `LRS`"),
 		},
 	})

--- a/internal/services/synapse/synapse_sql_pool_resource_test.go
+++ b/internal/services/synapse/synapse_sql_pool_resource_test.go
@@ -26,7 +26,7 @@ func TestAccSynapseSqlPool_basic(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.geoBackupDefault(data, "GRS"),
+			Config: r.geoBackupDefault(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("geo_backup_policy_enabled").HasValue("true"),
@@ -146,7 +146,7 @@ func TestAccSynapseSqlPool_requiresImport(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.geoBackupDefault(data, "GRS"),
+			Config: r.geoBackupDefault(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -176,7 +176,7 @@ func TestAccSynapseSqlPool_update(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.geoBackupDefault(data, "GRS"),
+			Config: r.geoBackupDefault(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("geo_backup_policy_enabled").HasValue("true"),
@@ -194,7 +194,7 @@ func TestAccSynapseSqlPool_update(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
-			Config: r.geoBackupDefault(data, "GRS"),
+			Config: r.geoBackupDefault(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("geo_backup_policy_enabled").HasValue("true"),
@@ -313,26 +313,26 @@ provider "azurerm" {
 %s
 
 resource "azurerm_synapse_sql_pool" "test" {
-  name                      = "販売管理"
-  synapse_workspace_id      = azurerm_synapse_workspace.test.id
-  sku_name                  = "DW100c"
-  create_mode               = "Default"
-  storage_account_type      = "GRS"
+  name                 = "販売管理"
+  synapse_workspace_id = azurerm_synapse_workspace.test.id
+  sku_name             = "DW100c"
+  create_mode          = "Default"
+  storage_account_type = "GRS"
 }
 `, template)
 }
 
 func (r SynapseSqlPoolResource) requiresImport(data acceptance.TestData) string {
-	config := r.geoBackupDefault(data, "GRS")
+	config := r.geoBackupDefault(data)
 	return fmt.Sprintf(`
 %s
 
 resource "azurerm_synapse_sql_pool" "import" {
-  name                      = azurerm_synapse_sql_pool.test.name
-  synapse_workspace_id      = azurerm_synapse_sql_pool.test.synapse_workspace_id
-  sku_name                  = azurerm_synapse_sql_pool.test.sku_name
-  create_mode               = azurerm_synapse_sql_pool.test.create_mode
-  storage_account_type      = "GRS"
+  name                 = azurerm_synapse_sql_pool.test.name
+  synapse_workspace_id = azurerm_synapse_sql_pool.test.synapse_workspace_id
+  sku_name             = azurerm_synapse_sql_pool.test.sku_name
+  create_mode          = azurerm_synapse_sql_pool.test.create_mode
+  storage_account_type = "GRS"
 }
 `, config)
 }
@@ -381,7 +381,7 @@ resource "azurerm_synapse_sql_pool" "test" {
 `, template, data.RandomString)
 }
 
-func (r SynapseSqlPoolResource) geoBackupDefault(data acceptance.TestData, accountType string) string {
+func (r SynapseSqlPoolResource) geoBackupDefault(data acceptance.TestData) string {
 	template := r.template(data)
 	return fmt.Sprintf(`
 provider "azurerm" {
@@ -395,9 +395,9 @@ resource "azurerm_synapse_sql_pool" "test" {
   synapse_workspace_id = azurerm_synapse_workspace.test.id
   sku_name             = "DW100c"
   create_mode          = "Default"
-  storage_account_type = "%s"
+  storage_account_type = "GRS"
 }
-`, template, data.RandomString, accountType)
+`, template, data.RandomString)
 }
 
 func (r SynapseSqlPoolResource) geoBackup(data acceptance.TestData, geoBackupPolicy bool, accountType string) string {

--- a/internal/services/synapse/synapse_sql_pool_resource_test.go
+++ b/internal/services/synapse/synapse_sql_pool_resource_test.go
@@ -78,7 +78,7 @@ func TestAccSynapseSqlPool_threePointOhUpdate(t *testing.T) {
 		data.ImportStep(),
 		{
 			Config:      r.geoBackupDisabled(data),
-			ExpectError: regexp.MustCompile("`geo_backup_policy_enabled` field cannot be changed once it has been set"),
+			ExpectError: regexp.MustCompile("the `geo_backup_policy_enabled` field cannot be changed once it has been set"),
 		},
 	})
 }

--- a/internal/services/synapse/synapse_sql_pool_resource_test.go
+++ b/internal/services/synapse/synapse_sql_pool_resource_test.go
@@ -27,6 +27,8 @@ func TestAccSynapseSqlPool_basic(t *testing.T) {
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("geo_backup_policy_enabled").HasValue("true"),
+				check.That(data.ResourceName).Key("sql_pool_storage_account_type").HasValue("GRS"),
 			),
 		},
 		data.ImportStep(),
@@ -107,7 +109,7 @@ func TestAccSynapseSqlPool_update(t *testing.T) {
 	})
 }
 
-func TestAccSynapseSqlPool_geoBackupPolicy(t *testing.T) {
+func TestAccSynapseSqlPool_geoBackupPolicyDisabled(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_synapse_sql_pool", "test")
 	r := SynapseSqlPoolResource{}
 
@@ -117,22 +119,7 @@ func TestAccSynapseSqlPool_geoBackupPolicy(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("geo_backup_policy_enabled").HasValue("false"),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.geoBackupEnabled(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("geo_backup_policy_enabled").HasValue("true"),
-			),
-		},
-		data.ImportStep(),
-		{
-			Config: r.geoBackupDisabled(data),
-			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).ExistsInAzure(r),
-				check.That(data.ResourceName).Key("geo_backup_policy_enabled").HasValue("false"),
+				check.That(data.ResourceName).Key("sql_pool_storage_account_type").HasValue("LRS"),
 			),
 		},
 		data.ImportStep(),
@@ -166,10 +153,11 @@ provider "azurerm" {
 %s
 
 resource "azurerm_synapse_sql_pool" "test" {
-  name                 = "acctestSP%s"
-  synapse_workspace_id = azurerm_synapse_workspace.test.id
-  sku_name             = "DW100c"
-  create_mode          = "Default"
+  name                      = "acctestSP%s"
+  synapse_workspace_id      = azurerm_synapse_workspace.test.id
+  sku_name                  = "DW100c"
+  create_mode               = "Default"
+  geo_backup_policy_enabled = true
 }
 `, template, data.RandomString)
 }
@@ -184,10 +172,11 @@ provider "azurerm" {
 %s
 
 resource "azurerm_synapse_sql_pool" "test" {
-  name                 = "販売管理"
-  synapse_workspace_id = azurerm_synapse_workspace.test.id
-  sku_name             = "DW100c"
-  create_mode          = "Default"
+  name                      = "販売管理"
+  synapse_workspace_id      = azurerm_synapse_workspace.test.id
+  sku_name                  = "DW100c"
+  create_mode               = "Default"
+  geo_backup_policy_enabled = true
 }
 `, template)
 }
@@ -198,10 +187,11 @@ func (r SynapseSqlPoolResource) requiresImport(data acceptance.TestData) string 
 %s
 
 resource "azurerm_synapse_sql_pool" "import" {
-  name                 = azurerm_synapse_sql_pool.test.name
-  synapse_workspace_id = azurerm_synapse_sql_pool.test.synapse_workspace_id
-  sku_name             = azurerm_synapse_sql_pool.test.sku_name
-  create_mode          = azurerm_synapse_sql_pool.test.create_mode
+  name                      = azurerm_synapse_sql_pool.test.name
+  synapse_workspace_id      = azurerm_synapse_sql_pool.test.synapse_workspace_id
+  sku_name                  = azurerm_synapse_sql_pool.test.sku_name
+  create_mode               = azurerm_synapse_sql_pool.test.create_mode
+  geo_backup_policy_enabled = true
 }
 `, config)
 }
@@ -216,12 +206,13 @@ provider "azurerm" {
 %s
 
 resource "azurerm_synapse_sql_pool" "test" {
-  name                 = "acctestSP%s"
-  synapse_workspace_id = azurerm_synapse_workspace.test.id
-  sku_name             = "DW500c"
-  create_mode          = "Default"
-  collation            = "SQL_Latin1_General_CP1_CI_AS"
-  data_encrypted       = true
+  name                      = "acctestSP%s"
+  synapse_workspace_id      = azurerm_synapse_workspace.test.id
+  sku_name                  = "DW500c"
+  create_mode               = "Default"
+  collation                 = "SQL_Latin1_General_CP1_CI_AS"
+  data_encrypted            = true
+  geo_backup_policy_enabled = true
 
   tags = {
     ENV = "Test"
@@ -280,25 +271,6 @@ resource "azurerm_synapse_sql_pool" "test" {
   sku_name                  = "DW100c"
   create_mode               = "Default"
   geo_backup_policy_enabled = false
-}
-`, template, data.RandomString)
-}
-
-func (r SynapseSqlPoolResource) geoBackupEnabled(data acceptance.TestData) string {
-	template := r.template(data)
-	return fmt.Sprintf(`
-provider "azurerm" {
-  features {}
-}
-
-%s
-
-resource "azurerm_synapse_sql_pool" "test" {
-  name                      = "acctestSP%s"
-  synapse_workspace_id      = azurerm_synapse_workspace.test.id
-  sku_name                  = "DW100c"
-  create_mode               = "Default"
-  geo_backup_policy_enabled = true
 }
 `, template, data.RandomString)
 }

--- a/internal/services/synapse/synapse_sql_pool_security_alert_policy_resource_test.go
+++ b/internal/services/synapse/synapse_sql_pool_security_alert_policy_resource_test.go
@@ -147,7 +147,7 @@ resource "azurerm_synapse_sql_pool" "test" {
   sku_name             = "DW100c"
   create_mode          = "Default"
 
-  geo_backup_policy_enabled = true
+  storage_account_type = "GRS"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }

--- a/internal/services/synapse/synapse_sql_pool_security_alert_policy_resource_test.go
+++ b/internal/services/synapse/synapse_sql_pool_security_alert_policy_resource_test.go
@@ -146,6 +146,8 @@ resource "azurerm_synapse_sql_pool" "test" {
   synapse_workspace_id = azurerm_synapse_workspace.test.id
   sku_name             = "DW100c"
   create_mode          = "Default"
+
+  geo_backup_policy_enabled = true
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }

--- a/internal/services/synapse/synapse_sql_pool_security_alert_policy_resource_test.go
+++ b/internal/services/synapse/synapse_sql_pool_security_alert_policy_resource_test.go
@@ -146,7 +146,6 @@ resource "azurerm_synapse_sql_pool" "test" {
   synapse_workspace_id = azurerm_synapse_workspace.test.id
   sku_name             = "DW100c"
   create_mode          = "Default"
-
   storage_account_type = "GRS"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)

--- a/internal/services/synapse/synapse_sql_pool_vulnerability_assessment_baseline_resource_test.go
+++ b/internal/services/synapse/synapse_sql_pool_vulnerability_assessment_baseline_resource_test.go
@@ -194,8 +194,7 @@ resource "azurerm_synapse_sql_pool" "test" {
   synapse_workspace_id = azurerm_synapse_workspace.test.id
   sku_name             = "DW100c"
   create_mode          = "Default"
-
-  geo_backup_policy_enabled = true
+  storage_account_type = "GRS"
 }
 
 resource "azurerm_storage_account" "test" {

--- a/internal/services/synapse/synapse_sql_pool_vulnerability_assessment_baseline_resource_test.go
+++ b/internal/services/synapse/synapse_sql_pool_vulnerability_assessment_baseline_resource_test.go
@@ -194,6 +194,8 @@ resource "azurerm_synapse_sql_pool" "test" {
   synapse_workspace_id = azurerm_synapse_workspace.test.id
   sku_name             = "DW100c"
   create_mode          = "Default"
+
+  geo_backup_policy_enabled = true
 }
 
 resource "azurerm_storage_account" "test" {

--- a/internal/services/synapse/synapse_sql_pool_vulnerability_assessment_resource_test.go
+++ b/internal/services/synapse/synapse_sql_pool_vulnerability_assessment_resource_test.go
@@ -147,8 +147,7 @@ resource "azurerm_synapse_sql_pool" "test" {
   synapse_workspace_id = azurerm_synapse_workspace.test.id
   sku_name             = "DW100c"
   create_mode          = "Default"
-
-  geo_backup_policy_enabled = true
+  storage_account_type = "GRS"
 }
 
 resource "azurerm_storage_account" "test" {

--- a/internal/services/synapse/synapse_sql_pool_vulnerability_assessment_resource_test.go
+++ b/internal/services/synapse/synapse_sql_pool_vulnerability_assessment_resource_test.go
@@ -147,6 +147,8 @@ resource "azurerm_synapse_sql_pool" "test" {
   synapse_workspace_id = azurerm_synapse_workspace.test.id
   sku_name             = "DW100c"
   create_mode          = "Default"
+
+  geo_backup_policy_enabled = true
 }
 
 resource "azurerm_storage_account" "test" {

--- a/internal/services/synapse/synapse_sql_pool_workload_classifier_resource_test.go
+++ b/internal/services/synapse/synapse_sql_pool_workload_classifier_resource_test.go
@@ -197,8 +197,7 @@ resource "azurerm_synapse_sql_pool" "test" {
   synapse_workspace_id = azurerm_synapse_workspace.test.id
   sku_name             = "DW100c"
   create_mode          = "Default"
-
-  geo_backup_policy_enabled = true
+  storage_account_type = "GRS"
 }
 
 resource "azurerm_synapse_sql_pool_workload_group" "test" {

--- a/internal/services/synapse/synapse_sql_pool_workload_classifier_resource_test.go
+++ b/internal/services/synapse/synapse_sql_pool_workload_classifier_resource_test.go
@@ -197,6 +197,8 @@ resource "azurerm_synapse_sql_pool" "test" {
   synapse_workspace_id = azurerm_synapse_workspace.test.id
   sku_name             = "DW100c"
   create_mode          = "Default"
+
+  geo_backup_policy_enabled = true
 }
 
 resource "azurerm_synapse_sql_pool_workload_group" "test" {

--- a/internal/services/synapse/synapse_sql_pool_workload_group_resource_test.go
+++ b/internal/services/synapse/synapse_sql_pool_workload_group_resource_test.go
@@ -199,8 +199,7 @@ resource "azurerm_synapse_sql_pool" "test" {
   synapse_workspace_id = azurerm_synapse_workspace.test.id
   sku_name             = "DW100c"
   create_mode          = "Default"
-
-  geo_backup_policy_enabled = true
+  storage_account_type = "GRS"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomInteger, data.RandomInteger, data.RandomString)
 }

--- a/internal/services/synapse/synapse_sql_pool_workload_group_resource_test.go
+++ b/internal/services/synapse/synapse_sql_pool_workload_group_resource_test.go
@@ -199,6 +199,8 @@ resource "azurerm_synapse_sql_pool" "test" {
   synapse_workspace_id = azurerm_synapse_workspace.test.id
   sku_name             = "DW100c"
   create_mode          = "Default"
+
+  geo_backup_policy_enabled = true
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomInteger, data.RandomInteger, data.RandomString)
 }

--- a/internal/services/synapse/synapse_workspace_extended_auditing_policy_resource_test.go
+++ b/internal/services/synapse/synapse_workspace_extended_auditing_policy_resource_test.go
@@ -189,7 +189,7 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "acctestsw%[1]d"
+  name     = "acctestRG-synapse-%[1]d"
   location = "%[2]s"
 }
 

--- a/internal/services/synapse/synapse_workspace_key_resource.go
+++ b/internal/services/synapse/synapse_workspace_key_resource.go
@@ -168,7 +168,7 @@ func resourceSynapseWorkspaceKeysDelete(d *pluginsdk.ResourceData, meta interfac
 	// Fetch the key and check if it's an active key
 	keyresult, err := client.Get(ctx, id.ResourceGroup, id.WorkspaceName, id.KeyName)
 	if err != nil {
-		return fmt.Errorf("Unable to fetch key %s in workspace %s: %v", id.KeyName, id.WorkspaceName, err)
+		return fmt.Errorf("unable to fetch key %s in workspace %s: %v", id.KeyName, id.WorkspaceName, err)
 	}
 
 	// Azure only lets you delete keys that are not active

--- a/internal/services/synapse/synapse_workspace_resource.go
+++ b/internal/services/synapse/synapse_workspace_resource.go
@@ -679,7 +679,7 @@ func resourceSynapseWorkspaceUpdate(d *pluginsdk.ResourceData, meta interface{})
 		}
 		future, err := identitySQLControlClient.CreateOrUpdate(ctx, id.ResourceGroup, id.Name, *sqlControlSettings)
 		if err != nil {
-			return fmt.Errorf("Updating workspace identity control for SQL pool: %+v", err)
+			return fmt.Errorf("updating workspace identity control for SQL pool: %+v", err)
 		}
 		if err := future.WaitForCompletionRef(ctx, client.Client); err != nil {
 			return fmt.Errorf("waiting for update workspace identity control for SQL pool of %q: %+v", id, err)

--- a/website/docs/r/synapse_sql_pool.html.markdown
+++ b/website/docs/r/synapse_sql_pool.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Manages a Synapse SQL Pool.
 
-!> **BREAKING CHANGE:** In v4.0 of the AzureRM Provider the `geo_backup_policy_enabled` field will be `Required` and will force a new Synapse SQL Pool to be created if changed.
+!> **BREAKING CHANGE:** In version 4.0 of the AzureRM Provider, the `geo_backup_policy_enabled` will no longer be an `Optional` field with a preset `default` value. Instead, it be transitioned into a `Required` field, mandating its presence in the configuration file, and subsequently, any modification of the `geo_backup_policy_enabled` field will cause a new Synapse SQL Pool resource to be created.
 
 ## Example Usage
 

--- a/website/docs/r/synapse_sql_pool.html.markdown
+++ b/website/docs/r/synapse_sql_pool.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Manages a Synapse SQL Pool.
 
-!> **BREAKING CHANGE:** In version 4.0 of the AzureRM Provider, the `geo_backup_policy_enabled` will no longer be an `Optional` field with a preset `default` value. Instead, it be transitioned into a `Required` field, mandating its presence in the configuration file, and subsequently, any modification of the `geo_backup_policy_enabled` field will cause a new Synapse SQL Pool resource to be created.
+!> **BREAKING CHANGE:** In version 4.0 of the AzureRM Provider, the `geo_backup_policy_enabled` will no longer be an `Optional` field with a preset `default` value. Instead, it will be transitioned into a `Required` field, mandating its presence in the configuration file, and subsequently, any modification of the `geo_backup_policy_enabled` field will cause a new Synapse SQL Pool resource to be created.
 
 ## Example Usage
 

--- a/website/docs/r/synapse_sql_pool.html.markdown
+++ b/website/docs/r/synapse_sql_pool.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Manages a Synapse SQL Pool.
 
-!> **BREAKING CHANGE:** In version 4.0 of the AzureRM Provider, the `geo_backup_policy_enabled` will no longer be an `Optional` field with a preset `default` value. Instead, it will be transitioned into a `Required` field, mandating its presence in the configuration file, and subsequently, any modification of the `geo_backup_policy_enabled` field will cause a new Synapse SQL Pool resource to be created.
+!> **BREAKING CHANGE:** In v4.0 of the AzureRM Provider, the `storage_account_type` field will be `Required`. Changing the `storage_account_type`, in the v4.0 AzureRM Provider, will force a new Synapse SQL Pool to be created.
 
 ## Example Usage
 
@@ -52,8 +52,7 @@ resource "azurerm_synapse_sql_pool" "example" {
   synapse_workspace_id = azurerm_synapse_workspace.example.id
   sku_name             = "DW100c"
   create_mode          = "Default"
-
-  geo_backup_policy_enabled = true
+  storage_account_type = "GRS"
 }
 ```
 
@@ -77,7 +76,11 @@ The following arguments are supported:
 
 * `restore` - (Optional) A `restore` block as defined below. Only applicable when `create_mode` is set to `PointInTimeRestore`. Changing this forces a new Synapse SQL Pool to be created.
 
-* `geo_backup_policy_enabled` - (Optional) Is geo-backup policy enabled? Defaults to `true`.
+* `geo_backup_policy_enabled` - (Optional) Is geo-backup policy enabled? Possible values include `true` or `false`. Defaults to `true`.
+
+* `storage_account_type` - (Optional) The storage account type that will be used to store backups for this Synapse SQL Pool. Possible values are `LRS` or `GRS`. Defaults to `GRS`.
+
+-> **NOTE:** `storage_account_type` cannot be changed once the Synapse SQL Pool has been created.
 
 * `tags` - (Optional) A mapping of tags which should be assigned to the Synapse SQL Pool.
 
@@ -94,8 +97,6 @@ An `restore` block supports the following:
 In addition to the Arguments listed above - the following Attributes are exported:
 
 * `id` - The ID of the Synapse SQL Pool.
-
-* `sql_pool_storage_account_type` - The Synapse SQL Pool storage account type created, by the service, to store database row data files and transaction log files.
 
 ## Timeouts
 

--- a/website/docs/r/synapse_sql_pool.html.markdown
+++ b/website/docs/r/synapse_sql_pool.html.markdown
@@ -10,8 +10,6 @@ description: |-
 
 Manages a Synapse SQL Pool.
 
-!> **BREAKING CHANGE:** In v4.0 of the AzureRM Provider, the `storage_account_type` field will be `Required`. Changing the `storage_account_type`, in the v4.0 AzureRM Provider, will force a new Synapse SQL Pool to be created.
-
 ## Example Usage
 
 ```hcl
@@ -78,9 +76,7 @@ The following arguments are supported:
 
 * `geo_backup_policy_enabled` - (Optional) Is geo-backup policy enabled? Possible values include `true` or `false`. Defaults to `true`.
 
-* `storage_account_type` - (Optional) The storage account type that will be used to store backups for this Synapse SQL Pool. Possible values are `LRS` or `GRS`. Defaults to `GRS`.
-
--> **NOTE:** `storage_account_type` cannot be changed once the Synapse SQL Pool has been created.
+* `storage_account_type` - (Optional) The storage account type that will be used to store backups for this Synapse SQL Pool. Possible values are `LRS` or `GRS`. Changing this forces a new Synapse SQL Pool to be created.
 
 * `tags` - (Optional) A mapping of tags which should be assigned to the Synapse SQL Pool.
 

--- a/website/docs/r/synapse_sql_pool.html.markdown
+++ b/website/docs/r/synapse_sql_pool.html.markdown
@@ -50,6 +50,8 @@ resource "azurerm_synapse_sql_pool" "example" {
   synapse_workspace_id = azurerm_synapse_workspace.example.id
   sku_name             = "DW100c"
   create_mode          = "Default"
+
+  geo_backup_policy_enabled = true
 }
 ```
 
@@ -57,23 +59,23 @@ resource "azurerm_synapse_sql_pool" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name which should be used for this Synapse SQL Pool. Changing this forces a new synapse SQL Pool to be created.
+* `name` - (Required) The name which should be used for this Synapse SQL Pool. Changing this forces a new Synapse SQL Pool to be created.
 
 * `synapse_workspace_id` - (Required) The ID of Synapse Workspace within which this SQL Pool should be created. Changing this forces a new Synapse SQL Pool to be created.
 
 * `sku_name` - (Required) Specifies the SKU Name for this Synapse SQL Pool. Possible values are `DW100c`, `DW200c`, `DW300c`, `DW400c`, `DW500c`, `DW1000c`, `DW1500c`, `DW2000c`, `DW2500c`, `DW3000c`, `DW5000c`, `DW6000c`, `DW7500c`, `DW10000c`, `DW15000c` or `DW30000c`.
 
-* `create_mode` - (Optional) Specifies how to create the SQL Pool. Valid values are: `Default`, `Recovery` or `PointInTimeRestore`. Must be `Default` to create a new database. Defaults to `Default`. Changing this forces a new resource to be created.
+* `geo_backup_policy_enabled` - (Required) Is geo-backup policy enabled? Changing this forces a new Synapse SQL Pool to be created.
 
-* `collation` - (Optional) The name of the collation to use with this pool, only applicable when `create_mode` is set to `Default`. Azure default is `SQL_LATIN1_GENERAL_CP1_CI_AS`. Changing this forces a new resource to be created.
+* `create_mode` - (Optional) Specifies how to create the SQL Pool. Valid values are: `Default`, `Recovery` or `PointInTimeRestore`. Must be `Default` to create a new database. Defaults to `Default`. Changing this forces a new Synapse SQL Pool to be created.
+
+* `collation` - (Optional) The name of the collation to use with this pool, only applicable when `create_mode` is set to `Default`. Azure default is `SQL_LATIN1_GENERAL_CP1_CI_AS`. Changing this forces a new Synapse SQL Pool to be created.
 
 * `data_encrypted` - (Optional) Is transparent data encryption enabled? 
 
 * `recovery_database_id` - (Optional) The ID of the Synapse SQL Pool or SQL Database which is to back up, only applicable when `create_mode` is set to `Recovery`. Changing this forces a new Synapse SQL Pool to be created.
 
-* `restore` - (Optional) A `restore` block as defined below. only applicable when `create_mode` is set to `PointInTimeRestore`. Changing this forces a new resource to be created.
-
-* `geo_backup_policy_enabled` - (Optional) Is geo-backup policy enabled? Defaults to `true`.
+* `restore` - (Optional) A `restore` block as defined below. Only applicable when `create_mode` is set to `PointInTimeRestore`. Changing this forces a new Synapse SQL Pool to be created.
 
 * `tags` - (Optional) A mapping of tags which should be assigned to the Synapse SQL Pool.
 
@@ -90,6 +92,8 @@ An `restore` block supports the following:
 In addition to the Arguments listed above - the following Attributes are exported:
 
 * `id` - The ID of the Synapse SQL Pool.
+
+* `sql_pool_storage_account_type` - The Synapse SQL Pool storage account type created, by the service, to store database row data files and transaction log files.
 
 ## Timeouts
 

--- a/website/docs/r/synapse_sql_pool.html.markdown
+++ b/website/docs/r/synapse_sql_pool.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Manages a Synapse SQL Pool.
 
+!> **BREAKING CHANGE:** In v4.0 of the AzureRM Provider the `geo_backup_policy_enabled` field will be `Required` and will force a new Synapse SQL Pool to be created if changed.
+
 ## Example Usage
 
 ```hcl
@@ -65,8 +67,6 @@ The following arguments are supported:
 
 * `sku_name` - (Required) Specifies the SKU Name for this Synapse SQL Pool. Possible values are `DW100c`, `DW200c`, `DW300c`, `DW400c`, `DW500c`, `DW1000c`, `DW1500c`, `DW2000c`, `DW2500c`, `DW3000c`, `DW5000c`, `DW6000c`, `DW7500c`, `DW10000c`, `DW15000c` or `DW30000c`.
 
-* `geo_backup_policy_enabled` - (Required) Is geo-backup policy enabled? Changing this forces a new Synapse SQL Pool to be created.
-
 * `create_mode` - (Optional) Specifies how to create the SQL Pool. Valid values are: `Default`, `Recovery` or `PointInTimeRestore`. Must be `Default` to create a new database. Defaults to `Default`. Changing this forces a new Synapse SQL Pool to be created.
 
 * `collation` - (Optional) The name of the collation to use with this pool, only applicable when `create_mode` is set to `Default`. Azure default is `SQL_LATIN1_GENERAL_CP1_CI_AS`. Changing this forces a new Synapse SQL Pool to be created.
@@ -76,6 +76,8 @@ The following arguments are supported:
 * `recovery_database_id` - (Optional) The ID of the Synapse SQL Pool or SQL Database which is to back up, only applicable when `create_mode` is set to `Recovery`. Changing this forces a new Synapse SQL Pool to be created.
 
 * `restore` - (Optional) A `restore` block as defined below. Only applicable when `create_mode` is set to `PointInTimeRestore`. Changing this forces a new Synapse SQL Pool to be created.
+
+* `geo_backup_policy_enabled` - (Optional) Is geo-backup policy enabled? Defaults to `true`.
 
 * `tags` - (Optional) A mapping of tags which should be assigned to the Synapse SQL Pool.
 


### PR DESCRIPTION
Resource behavioral changes in this PR:

* Exposes the new `storage_account_type` field which in v3.0 will inherit the default value of `GRS`, which matches the current resource and the API's behavior. In v4.0 of the provider the `storage_account_type` field will become a `Required` field. In both v3.0 and v4.0 this field is exposed as `ForceNew` which will trigger a `destroy` and `re-create` if the value changes (e.g., `GRS` -> `LRS`).

* The `geo_backup_enabled` field remains unchanged in both v3.0 and v4.0 of the provider and continues to be an `Optional` field with the default value of `GRS`.

* Enables the ability to create a Synapse Sql Pool resource with the `storage_account_type` of `LRS`.

* Prevents the resource, in v3.0 and v4.0, from being created in an invalid state (e.g., `storage_account_type` = "LRS" and `geo_backup_enabled` = true).

* Allows previously existing resources to remain, as is without error, while also enforcing the correct behavior on all net new Synapse Sql Pool resources.

* Allows the toggling of `geo_backup_enabled` field, in both v3.0 and v4.0, if the `storage_account_type`  is `GRS`.

(fixes #23157)