### PR TITLE
Correct identity block statement for aws_synapse_workspace doc

### DIFF
--- a/website/docs/r/synapse_workspace.html.markdown
+++ b/website/docs/r/synapse_workspace.html.markdown
@@ -253,11 +253,11 @@ A `customer_managed_key` block supports the following:
 
 The `identity` block supports the following:
 
-* `type` - (Required) Specifies the type of Managed Service Identity that should be associated with this Synapse Workspace. Possible values are `SystemAssigned`, `UserAssigned` and `SystemAssigned, UserAssigned` (to enable both).
+* `type` - (Required) Specifies the type of Managed Service Identity that should be associated with this Synapse Workspace. Possible values are `SystemAssigned` and `SystemAssigned, UserAssigned` (to enable both).
 
 * `identity_ids` - (Optional) Specifies a list of User Assigned Managed Identity IDs to be assigned to this Synapse Workspace.
 
-~> **NOTE:** This is required when `type` is set to `UserAssigned` or `SystemAssigned, UserAssigned`.
+~> **NOTE:** `identity_ids` is required when `type` is set to `SystemAssigned, UserAssigned`.
 
 ---
 


### PR DESCRIPTION
1. Remove `UserAssigned` as a viable option that can be configured, as per https://learn.microsoft.com/en-us/rest/api/synapse/workspaces/create-or-update?tabs=HTTP#resourceidentitytype, this is not currently possible.

2. Add clarity to the note statement, where it specifies which exact argument in the identity block it's referring to