### PR TITLE
`azurerm_cognitive_deployment` - remove ForceNew tag for property 'capacity'

### DIFF
--- a/internal/services/cognitive/cognitive_deployment_resource.go
+++ b/internal/services/cognitive/cognitive_deployment_resource.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2023-05-01/cognitiveservicesaccounts"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/cognitive/2023-05-01/deployments"
@@ -115,7 +116,6 @@ func (r CognitiveDeploymentResource) Arguments() map[string]*pluginsdk.Schema {
 		arguments["scale"] = &pluginsdk.Schema{
 			Type:     pluginsdk.TypeList,
 			Required: true,
-			ForceNew: true,
 			MaxItems: 1,
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*pluginsdk.Schema{
@@ -160,7 +160,6 @@ func (r CognitiveDeploymentResource) Arguments() map[string]*pluginsdk.Schema {
 		arguments["sku"] = &pluginsdk.Schema{
 			Type:     pluginsdk.TypeList,
 			Required: true,
-			ForceNew: true,
 			MaxItems: 1,
 			Elem: &pluginsdk.Resource{
 				Schema: map[string]*pluginsdk.Schema{
@@ -194,7 +193,6 @@ func (r CognitiveDeploymentResource) Arguments() map[string]*pluginsdk.Schema {
 					"capacity": {
 						Type:         pluginsdk.TypeInt,
 						Optional:     true,
-						ForceNew:     true,
 						Default:      1,
 						ValidateFunc: validation.IntAtLeast(1),
 					},
@@ -220,13 +218,12 @@ func (r CognitiveDeploymentResource) Create() sdk.ResourceFunc {
 
 			client := metadata.Client.Cognitive.DeploymentsClient
 			accountId, err := cognitiveservicesaccounts.ParseAccountID(model.CognitiveAccountId)
-
-			locks.ByID(accountId.ID())
-			defer locks.UnlockByID(accountId.ID())
-
 			if err != nil {
 				return err
 			}
+
+			locks.ByID(accountId.ID())
+			defer locks.UnlockByID(accountId.ID())
 
 			id := deployments.NewDeploymentID(accountId.SubscriptionId, accountId.ResourceGroupName, accountId.AccountName, model.Name)
 			existing, err := client.Get(ctx, id)
@@ -251,6 +248,49 @@ func (r CognitiveDeploymentResource) Create() sdk.ResourceFunc {
 			properties.Sku = expandDeploymentSkuModel(model.ScaleSettings)
 
 			if err := client.CreateOrUpdateThenPoll(ctx, id, *properties); err != nil {
+				return fmt.Errorf("creating %s: %+v", id, err)
+			}
+
+			metadata.SetID(id)
+			return nil
+		},
+	}
+}
+
+func (r CognitiveDeploymentResource) Update() sdk.ResourceFunc {
+	return sdk.ResourceFunc{
+		Timeout: 30 * time.Minute,
+		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
+			var model cognitiveDeploymentModel
+			if err := metadata.Decode(&model); err != nil {
+				return fmt.Errorf("decoding: %+v", err)
+			}
+
+			client := metadata.Client.Cognitive.DeploymentsClient
+			accountId, err := cognitiveservicesaccounts.ParseAccountID(model.CognitiveAccountId)
+			if err != nil {
+				return err
+			}
+
+			locks.ByID(accountId.ID())
+			defer locks.UnlockByID(accountId.ID())
+
+			id, err := deployments.ParseDeploymentID(metadata.ResourceData.Id())
+			if err != nil {
+				return err
+			}
+			resp, err := client.Get(ctx, *id)
+			if err != nil {
+				return err
+			}
+
+			properties := resp.Model
+
+			if metadata.ResourceData.HasChange("scale.0.capacity") {
+				properties.Sku.Capacity = pointer.To(model.ScaleSettings[0].Capacity)
+			}
+
+			if err := client.CreateOrUpdateThenPoll(ctx, *id, *properties); err != nil {
 				return fmt.Errorf("creating %s: %+v", id, err)
 			}
 

--- a/internal/services/cognitive/cognitive_deployment_resource.go
+++ b/internal/services/cognitive/cognitive_deployment_resource.go
@@ -149,7 +149,6 @@ func (r CognitiveDeploymentResource) Arguments() map[string]*pluginsdk.Schema {
 					"capacity": {
 						Type:         pluginsdk.TypeInt,
 						Optional:     true,
-						ForceNew:     true,
 						Default:      1,
 						ValidateFunc: validation.IntAtLeast(1),
 					},

--- a/internal/services/cognitive/cognitive_deployment_resource_test.go
+++ b/internal/services/cognitive/cognitive_deployment_resource_test.go
@@ -206,6 +206,8 @@ func (r CognitiveDeploymentTestResource) update(data acceptance.TestData) string
 	return fmt.Sprintf(`
 
 
+
+
 %s
 
 resource "azurerm_cognitive_deployment" "test" {
@@ -217,7 +219,7 @@ resource "azurerm_cognitive_deployment" "test" {
     version = "2"
   }
   scale {
-    type = "Standard"
+    type     = "Standard"
     capacity = 2
   }
 }


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/23226

Remove this forcenew tag since by testing this is not a force new property.

Testing evidence using AzAPI provider:
```hcl
terraform {
  required_providers {
    azapi = {
      source = "azure/azapi"
    }
  }
}

provider "azapi" {
}

provider "azurerm" {
  features {}
}
resource "azurerm_resource_group" "example" {
  name     = "yunliutest2222"
  location = "eastus"
}

resource "azurerm_cognitive_account" "example" {
  name                = "yunliutest222"
  location            = azurerm_resource_group.example.location
  resource_group_name = azurerm_resource_group.example.name
  kind                = "OpenAI"
  sku_name            = "S0"
}

resource "azapi_resource" "example" {
  type      = "Microsoft.CognitiveServices/accounts/deployments@2023-05-01"
  name      = "testdeployment"
  parent_id = azurerm_cognitive_account.example.id

  body = jsonencode({
    sku = {
      name     = "Standard"
      capacity = 2 // Change from 1->2
    }
    properties = {

      model = {
        format  = "OpenAI"
        name    = "gpt-35-turbo"
        version = "0301"
      }
    }
  })
}
```
Output
```
PS C:\Users\yunliu1\Documents\terraformtest\cognitive> terraform apply -auto-approve
azurerm_resource_group.example: Refreshing state... [id=/subscriptions/85b3dbca-5974-4067-9669-67a141095a76/resourceGroups/yunliutest2222]
azurerm_cognitive_account.example: Refreshing state... [id=/subscriptions/85b3dbca-5974-4067-9669-67a141095a76/resourceGroups/yunliutest2222/providers/Microsoft.CognitiveServices/accounts/yunliutest222]
azapi_resource.example: Refreshing state... [id=/subscriptions/85b3dbca-5974-4067-9669-67a141095a76/resourceGroups/yunliutest2222/providers/Microsoft.CognitiveServices/accounts/yunliutest222/deployments/testdeployment]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # azapi_resource.example will be updated in-place
  ~ resource "azapi_resource" "example" {
      ~ body                      = jsonencode(
          ~ {
              ~ sku        = {
                  ~ capacity = 1 -> 2
                    name     = "Standard"
                }
                # (1 unchanged attribute hidden)
            }
        )
        id                        = "/subscriptions/85b3dbca-5974-4067-9669-67a141095a76/resourceGroups/yunliutest2222/providers/Microsoft.CognitiveServices/accounts/yunliutest222/deployments/testdeployment"
        name                      = "testdeployment"
      ~ output                    = jsonencode({}) -> (known after apply)
        tags                      = {}
        # (6 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
azapi_resource.example: Modifying... [id=/subscriptions/85b3dbca-5974-4067-9669-67a141095a76/resourceGroups/yunliutest2222/providers/Microsoft.CognitiveServices/accounts/yunliutest222/deployments/testdeployment]
azapi_resource.example: Modifications complete after 3s [id=/subscriptions/85b3dbca-5974-4067-9669-67a141095a76/resourceGroups/yunliutest2222/providers/Microsoft.CognitiveServices/accounts/yunliutest222/deployments/testdeployment]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```