### PR TITLE
`azurerm_mssql_elasticpool` : fix `Hyperscale` tier `license_type` error

### DIFF
--- a/internal/services/mssql/mssql_elasticpool_resource.go
+++ b/internal/services/mssql/mssql_elasticpool_resource.go
@@ -235,10 +235,10 @@ func resourceMsSqlElasticPoolCreateUpdate(d *pluginsdk.ResourceData, meta interf
 	}
 
 	if _, ok := d.GetOk("license_type"); ok {
-		if sku.Tier != nil && (*sku.Tier == "GeneralPurpose" || *sku.Tier == "BusinessCritical") {
+		if sku.Tier != nil && (*sku.Tier == "GeneralPurpose" || *sku.Tier == "BusinessCritical" || *sku.Tier == "Hyperscale") {
 			elasticPool.ElasticPoolProperties.LicenseType = sql.ElasticPoolLicenseType(d.Get("license_type").(string))
 		} else {
-			return fmt.Errorf("`license_type` can only be configured when `sku.0.tier` is set to `GeneralPurpose` or `BusinessCritical`")
+			return fmt.Errorf("`license_type` can only be configured when `sku.0.tier` is set to `GeneralPurpose`, `Hyperscale` or `BusinessCritical`")
 		}
 	}
 

--- a/internal/services/mssql/mssql_elasticpool_resource_test.go
+++ b/internal/services/mssql/mssql_elasticpool_resource_test.go
@@ -258,6 +258,13 @@ func TestAccMsSqlElasticPool_hyperScale(t *testing.T) {
 			),
 		},
 		data.ImportStep("max_size_gb"),
+		{
+			Config: r.hyperScaleUpdate(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("max_size_gb"),
 	})
 }
 
@@ -376,13 +383,12 @@ resource "azurerm_mssql_server" "test" {
 }
 
 resource "azurerm_mssql_elasticpool" "test" {
-  name                = "acctest-pool-dtu-%[1]d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-  server_name         = azurerm_mssql_server.test.name
-  max_size_gb         = %.7[6]f
-  zone_redundant      = %[9]t
-
+  name                           = "acctest-pool-dtu-%[1]d"
+  resource_group_name            = azurerm_resource_group.test.name
+  location                       = azurerm_resource_group.test.location
+  server_name                    = azurerm_mssql_server.test.name
+  max_size_gb                    = %.7[6]f
+  zone_redundant                 = %[9]t
   maintenance_configuration_name = "%[10]s"
 
   sku {
@@ -425,7 +431,6 @@ resource "azurerm_mssql_elasticpool" "test" {
   location            = azurerm_resource_group.test.location
   server_name         = azurerm_mssql_server.test.name
   max_size_gb         = 5
-
   sku {
     name     = "%[3]s"
     tier     = "%[4]s"
@@ -508,7 +513,6 @@ resource "azurerm_mssql_elasticpool" "test" {
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
   server_name         = azurerm_mssql_server.test.name
-
   sku {
     name     = "%[3]s"
     tier     = "%[4]s"
@@ -571,4 +575,8 @@ resource "azurerm_mssql_elasticpool" "test" {
 
 func (r MsSqlElasticPoolResource) hyperScale(data acceptance.TestData) string {
 	return r.templateHyperScale(data, "HS_Gen5", "Hyperscale", 4, "Gen5", 0.25, 4)
+}
+
+func (r MsSqlElasticPoolResource) hyperScaleUpdate(data acceptance.TestData) string {
+	return r.templateHyperScale(data, "HS_Gen5", "Hyperscale", 4, "Gen5", 0, 4)
 }

--- a/website/docs/r/mssql_elasticpool.html.markdown
+++ b/website/docs/r/mssql_elasticpool.html.markdown
@@ -79,7 +79,7 @@ The following arguments are supported:
 
 * `license_type` - (Optional) Specifies the license type applied to this database. Possible values are `LicenseIncluded` and `BasePrice`.
 
--> **Note:** `license_type` can only be configured when `sku.0.tier` is set to `GeneralPurpose` or `BusinessCritical`
+-> **Note:** `license_type` can only be configured when `sku.0.tier` is set to `GeneralPurpose`, `Hyperscale` or `BusinessCritical`
 
 ---
 


### PR DESCRIPTION
After checking the [API](https://github.com/Azure/azure-rest-api-specs/blob/32c178f2467f792a322f56174be244135d2c907f/specification/sql/resource-manager/Microsoft.Sql/preview/2020-11-01-preview/ElasticPools.json#L118C10-L118C10),  the `Hyperscale` tier supports setting `license_type`. So,  `Hyperscale`  is included to fix issue #23187 .

Fixes #23187 