### PR TITLE
`azurerm_mssql_elasticpool` : fix `license_type` can't be set to null when changing from vCore to DTU model issue

### DIFF
--- a/internal/services/mssql/mssql_elasticpool_resource.go
+++ b/internal/services/mssql/mssql_elasticpool_resource.go
@@ -173,7 +173,6 @@ func resourceMsSqlElasticPool() *pluginsdk.Resource {
 			"license_type": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
-				Computed: true,
 				ValidateFunc: validation.StringInSlice([]string{
 					string(sql.DatabaseLicenseTypeBasePrice),
 					string(sql.DatabaseLicenseTypeLicenseIncluded),

--- a/internal/services/mssql/mssql_elasticpool_resource_test.go
+++ b/internal/services/mssql/mssql_elasticpool_resource_test.go
@@ -538,10 +538,6 @@ resource "azurerm_mssql_elasticpool" "test" {
     min_capacity = %.2[7]f
     max_capacity = %.2[8]f
   }
-
-  lifecycle {
-    ignore_changes = ["license_type"]
-  }
 }
 `, data.RandomInteger, data.Locations.Primary, skuName, skuTier, skuCapacity, skuFamily, databaseSettingsMin, databaseSettingsMax)
 }
@@ -584,10 +580,6 @@ resource "azurerm_mssql_elasticpool" "test" {
     min_capacity = %.2[7]f
     max_capacity = %.2[8]f
   }
-
-  lifecycle {
-    ignore_changes = ["license_type"]
-  }
 }
 `, data.RandomInteger, data.Locations.Primary, skuName, skuTier, skuCapacity, skuFamily, databaseSettingsMin, databaseSettingsMax)
 }
@@ -627,10 +619,6 @@ resource "azurerm_mssql_elasticpool" "test" {
   per_database_settings {
     min_capacity = %.2[7]f
     max_capacity = %.2[8]f
-  }
-
-  lifecycle {
-    ignore_changes = ["license_type"]
   }
 }
 `, data.RandomInteger, data.Locations.Primary, skuName, skuTier, skuCapacity, skuFamily, databaseSettingsMin, databaseSettingsMax)
@@ -674,10 +662,6 @@ resource "azurerm_mssql_elasticpool" "test" {
   per_database_settings {
     min_capacity = 0
     max_capacity = 4
-  }
-
-  lifecycle {
-    ignore_changes = ["license_type"]
   }
 }
 `, data.RandomInteger, data.Locations.Primary)

--- a/internal/services/mssql/mssql_elasticpool_resource_test.go
+++ b/internal/services/mssql/mssql_elasticpool_resource_test.go
@@ -274,7 +274,7 @@ func TestAccMsSqlElasticPool_vCoreToStandardDTU(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.no_licenseType(data),
+			Config: r.noLicenseType(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -624,7 +624,7 @@ resource "azurerm_mssql_elasticpool" "test" {
 `, data.RandomInteger, data.Locations.Primary, skuName, skuTier, skuCapacity, skuFamily, databaseSettingsMin, databaseSettingsMax)
 }
 
-func (MsSqlElasticPoolResource) no_licenseType(data acceptance.TestData) string {
+func (MsSqlElasticPoolResource) noLicenseType(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {}

--- a/internal/services/mssql/mssql_elasticpool_resource_test.go
+++ b/internal/services/mssql/mssql_elasticpool_resource_test.go
@@ -268,6 +268,42 @@ func TestAccMsSqlElasticPool_hyperScale(t *testing.T) {
 	})
 }
 
+func TestAccMsSqlElasticPool_vCoreToStandardDTU(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_mssql_elasticpool", "test")
+	r := MsSqlElasticPoolResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.no_licenseType(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.updateToStandardDTU(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.licenseType(data, "LicenseIncluded"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.updateToStandardDTU(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (MsSqlElasticPoolResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := parse.ElasticPoolID(state.ID)
 	if err != nil {
@@ -328,6 +364,10 @@ func (r MsSqlElasticPoolResource) resizeDTU(data acceptance.TestData) string {
 
 func (r MsSqlElasticPoolResource) basicVCore(data acceptance.TestData) string {
 	return r.templateVCore(data, "GP_Gen5", "GeneralPurpose", 4, "Gen5", 0.25, 4)
+}
+
+func (r MsSqlElasticPoolResource) updateToStandardDTU(data acceptance.TestData) string {
+	return r.templateUpdateToDTU(data, "StandardPool", "Standard", 50, 50, 10, 50, false)
 }
 
 func (r MsSqlElasticPoolResource) fsv2VCore(data acceptance.TestData) string {
@@ -405,6 +445,62 @@ resource "azurerm_mssql_elasticpool" "test" {
 `, data.RandomInteger, data.Locations.Primary, skuName, skuTier, skuCapacity, maxSizeGB, databaseSettingsMin, databaseSettingsMax, zoneRedundant, configName)
 }
 
+func (MsSqlElasticPoolResource) templateUpdateToDTU(data acceptance.TestData, skuName string, skuTier string, skuCapacity int, maxSizeGB float64, databaseSettingsMin int, databaseSettingsMax int, zoneRedundant bool) string {
+	configName := "SQL_Default"
+	if skuTier != "Basic" {
+		switch data.Locations.Primary {
+		case "westeurope":
+			configName = "SQL_WestEurope_DB_2"
+		case "francecentral":
+			configName = "SQL_FranceCentral_DB_1"
+		default:
+			configName = "SQL_Default"
+		}
+	}
+
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_mssql_server" "test" {
+  name                         = "acctest%[1]d"
+  resource_group_name          = azurerm_resource_group.test.name
+  location                     = azurerm_resource_group.test.location
+  version                      = "12.0"
+  administrator_login          = "4dm1n157r470r"
+  administrator_login_password = "4-v3ry-53cr37-p455w0rd"
+}
+
+resource "azurerm_mssql_elasticpool" "test" {
+  name                = "acctest-pool-dtu-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  server_name         = azurerm_mssql_server.test.name
+  max_size_gb         = %.7[6]f
+  zone_redundant      = %[9]t
+
+  maintenance_configuration_name = "%[10]s"
+
+  sku {
+    name     = "%[3]s"
+    tier     = "%[4]s"
+    capacity = %[5]d
+  }
+
+  per_database_settings {
+    min_capacity = %[7]d
+    max_capacity = %[8]d
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, skuName, skuTier, skuCapacity, maxSizeGB, databaseSettingsMin, databaseSettingsMax, zoneRedundant, configName)
+}
+
 func (MsSqlElasticPoolResource) templateVCore(data acceptance.TestData, skuName string, skuTier string, skuCapacity int, skuFamily string, databaseSettingsMin float64, databaseSettingsMax float64) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
@@ -441,6 +537,10 @@ resource "azurerm_mssql_elasticpool" "test" {
   per_database_settings {
     min_capacity = %.2[7]f
     max_capacity = %.2[8]f
+  }
+
+  lifecycle {
+    ignore_changes = ["license_type"]
   }
 }
 `, data.RandomInteger, data.Locations.Primary, skuName, skuTier, skuCapacity, skuFamily, databaseSettingsMin, databaseSettingsMax)
@@ -484,6 +584,10 @@ resource "azurerm_mssql_elasticpool" "test" {
     min_capacity = %.2[7]f
     max_capacity = %.2[8]f
   }
+
+  lifecycle {
+    ignore_changes = ["license_type"]
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, skuName, skuTier, skuCapacity, skuFamily, databaseSettingsMin, databaseSettingsMax)
 }
@@ -524,8 +628,59 @@ resource "azurerm_mssql_elasticpool" "test" {
     min_capacity = %.2[7]f
     max_capacity = %.2[8]f
   }
+
+  lifecycle {
+    ignore_changes = ["license_type"]
+  }
 }
 `, data.RandomInteger, data.Locations.Primary, skuName, skuTier, skuCapacity, skuFamily, databaseSettingsMin, databaseSettingsMax)
+}
+
+func (MsSqlElasticPoolResource) no_licenseType(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%[2]s"
+}
+
+resource "azurerm_mssql_server" "test" {
+  name                         = "acctest%[1]d"
+  resource_group_name          = azurerm_resource_group.test.name
+  location                     = azurerm_resource_group.test.location
+  version                      = "12.0"
+  administrator_login          = "4dm1n157r470r"
+  administrator_login_password = "4-v3ry-53cr37-p455w0rd"
+}
+
+resource "azurerm_mssql_elasticpool" "test" {
+  name                = "acctest-pool-dtu-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  server_name         = azurerm_mssql_server.test.name
+  max_size_gb         = 50
+  zone_redundant      = false
+
+  sku {
+    name     = "GP_Gen5"
+    tier     = "GeneralPurpose"
+    capacity = 4
+    family   = "Gen5"
+  }
+
+  per_database_settings {
+    min_capacity = 0
+    max_capacity = 4
+  }
+
+  lifecycle {
+    ignore_changes = ["license_type"]
+  }
+}
+`, data.RandomInteger, data.Locations.Primary)
 }
 
 func (MsSqlElasticPoolResource) licenseType(data acceptance.TestData, licenseType string) string {
@@ -568,7 +723,6 @@ resource "azurerm_mssql_elasticpool" "test" {
     min_capacity = 0
     max_capacity = 4
   }
-
 }
 `, data.RandomInteger, data.Locations.Primary, licenseType)
 }

--- a/website/docs/r/mssql_elasticpool.html.markdown
+++ b/website/docs/r/mssql_elasticpool.html.markdown
@@ -79,8 +79,6 @@ The following arguments are supported:
 
 * `license_type` - (Optional) Specifies the license type applied to this database. Possible values are `LicenseIncluded` and `BasePrice`.
 
--> **Note:** `license_type` can only be configured when `sku.0.tier` is set to `GeneralPurpose`, `Hyperscale` or `BusinessCritical`
-
 ---
 
 The `sku` block supports the following:


### PR DESCRIPTION
Per the following behavior of the [API](https://github.com/Azure/azure-rest-api-specs/blob/32c178f2467f792a322f56174be244135d2c907f/specification/sql/resource-manager/Microsoft.Sql/preview/2020-11-01-preview/ElasticPools.json#L118C10-L118C10), removed the check of TF. Also set a default value when the API does not return a value for license type property to fix issue #22311.

The behavior of the API:
<img width="407" alt="image" src="https://github.com/hashicorp/terraform-provider-azurerm/assets/39109137/8151ee3f-2632-42dd-849a-f8ce1bd291bc">


Test results:
<img width="484" alt="image" src="https://github.com/hashicorp/terraform-provider-azurerm/assets/39109137/9e2af91f-26ee-44c6-9c81-ab7b520f4040">


