### PR TITLE
Update Error Message

### DIFF
--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -2198,7 +2198,7 @@ func resourceStorageAccountRead(d *pluginsdk.ResourceData, meta interface{}) err
 
 		staticWebsiteProps, err := accountsClient.GetServiceProperties(ctx, id.StorageAccountName)
 		if err != nil {
-			return fmt.Errorf("retrieving static website for %s: %+v", *id, err)
+			return fmt.Errorf("retrieving static website properties for %s: %+v", *id, err)
 		}
 		staticWebsite := flattenStaticWebsiteProperties(staticWebsiteProps)
 		if err := d.Set("static_website", staticWebsite); err != nil {


### PR DESCRIPTION
Adds the word "properties" to storage account error message to indicate more clearly this is the service properties and not an actual static website. For storage accounts that do not have a static website enabled and fail this method it could be misleading as to the actual problem.

Fixes #23270 