### PR TITLE
`azurerm_storage_account` - Add `properties` literally to the error message when reading static website properties

### DIFF
--- a/internal/services/storage/storage_account_resource.go
+++ b/internal/services/storage/storage_account_resource.go
@@ -2198,7 +2198,7 @@ func resourceStorageAccountRead(d *pluginsdk.ResourceData, meta interface{}) err
 
 		staticWebsiteProps, err := accountsClient.GetServiceProperties(ctx, id.StorageAccountName)
 		if err != nil {
-			return fmt.Errorf("retrieving static website for %s: %+v", *id, err)
+			return fmt.Errorf("retrieving static website properties for %s: %+v", *id, err)
 		}
 		staticWebsite := flattenStaticWebsiteProperties(staticWebsiteProps)
 		if err := d.Set("static_website", staticWebsite); err != nil {


### PR DESCRIPTION
Fix #23270