### PR TITLE
DataSource:`azurerm_container_app_environment`: fix `log_analytics_workspace_name`

### DIFF
--- a/internal/services/containerapps/container_app_environment_data_source.go
+++ b/internal/services/containerapps/container_app_environment_data_source.go
@@ -10,10 +10,12 @@ import (
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/location"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2023-05-01/managedenvironments"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/workspaces"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
@@ -155,7 +157,12 @@ func (r ContainerAppEnvironmentDataSource) Read() sdk.ResourceFunc {
 					}
 
 					if appsLogs := props.AppLogsConfiguration; appsLogs != nil && appsLogs.LogAnalyticsConfiguration != nil {
-						environment.LogAnalyticsWorkspaceName = pointer.From(appsLogs.LogAnalyticsConfiguration.CustomerId)
+						lawClient := metadata.Client.LogAnalytics.SharedKeyWorkspacesClient
+						lawName, err := findLogAnalyticsWorkspaceName(ctx, lawClient, subscriptionId, pointer.From(appsLogs.LogAnalyticsConfiguration.CustomerId))
+						if err != nil {
+							return fmt.Errorf("retrieving Log Analytics Workspace: %+v", err)
+						}
+						environment.LogAnalyticsWorkspaceName = lawName
 					}
 
 					environment.StaticIP = pointer.From(props.StaticIP)
@@ -168,4 +175,29 @@ func (r ContainerAppEnvironmentDataSource) Read() sdk.ResourceFunc {
 			return metadata.Encode(&environment)
 		},
 	}
+}
+
+func findLogAnalyticsWorkspaceName(ctx context.Context, client *workspaces.WorkspacesClient, subscriptionId, targetCustomerId string) (string, error) {
+	parsedSubscriptionId := commonids.NewSubscriptionID(subscriptionId)
+
+	resp, err := client.List(ctx, parsedSubscriptionId)
+	if err != nil {
+		return "", err
+	}
+
+	if resp.Model == nil {
+		return "", fmt.Errorf("model was nil")
+	}
+
+	if resp.Model.Value == nil {
+		return "", fmt.Errorf("value was nil")
+	}
+
+	for _, law := range *resp.Model.Value {
+		if law.Properties != nil && law.Properties.CustomerId != nil && *law.Properties.CustomerId == targetCustomerId && law.Name != nil {
+			return *law.Name, nil
+		}
+	}
+
+	return "", fmt.Errorf("no matching workspace found")
 }

--- a/internal/services/containerapps/container_app_environment_data_source_test.go
+++ b/internal/services/containerapps/container_app_environment_data_source_test.go
@@ -21,7 +21,7 @@ func TestAccContainerAppEnvironmentDataSource_basic(t *testing.T) {
 		{
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
-				check.That(data.ResourceName).Key("log_analytics_workspace_name").IsSet(),
+				check.That(data.ResourceName).Key("log_analytics_workspace_name").HasValue(fmt.Sprintf("acctestLAW-%d", data.RandomInteger)),
 				check.That(data.ResourceName).Key("location").IsSet(),
 				check.That(data.ResourceName).Key("internal_load_balancer_enabled").HasValue("true"),
 			),


### PR DESCRIPTION
`log_analytics_workspace_name` is not consistent with what it really output.

fix #23265

<img width="538" alt="image" src="https://github.com/hashicorp/terraform-provider-azurerm/assets/51212351/589cbbbe-ec5b-4892-993f-bea2ff3486c3">