### PR TITLE
`azurerm_mobile_network_packet_core_control_plane`: fix acctest

### DIFF
--- a/internal/services/mobilenetwork/mobile_network_packet_core_control_plane_resource_test.go
+++ b/internal/services/mobilenetwork/mobile_network_packet_core_control_plane_resource_test.go
@@ -332,7 +332,7 @@ resource "azurerm_mobile_network_packet_core_control_plane" "test" {
   }
 
   interoperability_settings_json = jsonencode({
-    "mtu" = 1440
+    "unknownuser-causecode" = "eps-and-non-eps-service-not-allowed-8"
   })
 
   depends_on = [azurerm_mobile_network.test]
@@ -489,7 +489,7 @@ resource "azurerm_mobile_network_packet_core_control_plane" "test" {
   control_plane_access_ipv4_subnet  = "192.168.1.0/25"
 
   interoperability_settings_json = jsonencode({
-    "mtu" = 1440
+    "unknownuser-causecode" = "eps-and-non-eps-service-not-allowed-8"
   })
 
   local_diagnostics_access {


### PR DESCRIPTION
<del>
If `user_equipment_mtu_in_bytes` and `mtu` in `interoperability_settings_json` are both specified, the service will return the following error.
```
ResourceCreationValidateFailed: Validation failed: MTU cannot be set in interop settings when UeMtu value is provided. Set MTU in one place only.
```
to avoid breaking change, made it possible to set `user_equipment_mtu_in_bytes` to `0`. 
</del>

test
---
```
❯ tftest mobilenetwork TestAccMobileNetworkPacketCoreControlPlane
=== RUN   TestAccMobileNetworkPacketCoreControlPlane_basic
=== PAUSE TestAccMobileNetworkPacketCoreControlPlane_basic
=== RUN   TestAccMobileNetworkPacketCoreControlPlane_withAccessInterface
=== PAUSE TestAccMobileNetworkPacketCoreControlPlane_withAccessInterface
=== RUN   TestAccMobileNetworkPacketCoreControlPlane_withInteropJSON
=== PAUSE TestAccMobileNetworkPacketCoreControlPlane_withInteropJSON
=== RUN   TestAccMobileNetworkPacketCoreControlPlane_withUeMTU
=== PAUSE TestAccMobileNetworkPacketCoreControlPlane_withUeMTU
=== RUN   TestAccMobileNetworkPacketCoreControlPlane_withCertificateUserAssignedIdentity
=== PAUSE TestAccMobileNetworkPacketCoreControlPlane_withCertificateUserAssignedIdentity
=== RUN   TestAccMobileNetworkPacketCoreControlPlane_requiresImport
=== PAUSE TestAccMobileNetworkPacketCoreControlPlane_requiresImport
=== RUN   TestAccMobileNetworkPacketCoreControlPlane_update
=== PAUSE TestAccMobileNetworkPacketCoreControlPlane_update
=== RUN   TestAccMobileNetworkPacketCoreControlPlane_complete
=== PAUSE TestAccMobileNetworkPacketCoreControlPlane_complete
=== CONT  TestAccMobileNetworkPacketCoreControlPlane_basic
=== CONT  TestAccMobileNetworkPacketCoreControlPlane_withCertificateUserAssignedIdentity
=== CONT  TestAccMobileNetworkPacketCoreControlPlane_withInteropJSON
=== CONT  TestAccMobileNetworkPacketCoreControlPlane_withAccessInterface
=== CONT  TestAccMobileNetworkPacketCoreControlPlane_withUeMTU
=== CONT  TestAccMobileNetworkPacketCoreControlPlane_update
=== CONT  TestAccMobileNetworkPacketCoreControlPlane_complete
=== CONT  TestAccMobileNetworkPacketCoreControlPlane_requiresImport
--- PASS: TestAccMobileNetworkPacketCoreControlPlane_withUeMTU (866.31s)
--- PASS: TestAccMobileNetworkPacketCoreControlPlane_withAccessInterface (946.18s)
--- PASS: TestAccMobileNetworkPacketCoreControlPlane_requiresImport (1020.02s)
--- PASS: TestAccMobileNetworkPacketCoreControlPlane_basic (1081.86s)
--- PASS: TestAccMobileNetworkPacketCoreControlPlane_update (1087.75s)
--- PASS: TestAccMobileNetworkPacketCoreControlPlane_withInteropJSON (1091.40s)
--- PASS: TestAccMobileNetworkPacketCoreControlPlane_complete (1148.65s)
--- PASS: TestAccMobileNetworkPacketCoreControlPlane_withCertificateUserAssignedIdentity (1231.24s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/mobilenetwork 1232.856s
```