### PR TITLE
`azurerm_recovery_services_vault_resource_guard_association`: fix acctest

### DIFF
--- a/internal/services/recoveryservices/recovery_services_vault_resource_guard_association_resource.go
+++ b/internal/services/recoveryservices/recovery_services_vault_resource_guard_association_resource.go
@@ -48,10 +48,13 @@ func (r VaultGuardProxyResource) ResourceType() string {
 
 func (r VaultGuardProxyResource) Arguments() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		// todo 4.0: remove the `name` field as the service only allow create `VaultProxy`
 		"name": {
+			Deprecated:   "The `name` field will be removed in v4.0 of the AzureRM Provider.",
 			Type:         pluginsdk.TypeString,
-			Required:     true,
+			Optional:     true,
 			ForceNew:     true,
+			Default:      "VaultProxy",
 			ValidateFunc: validation.StringIsNotEmpty,
 		},
 

--- a/internal/services/recoveryservices/recovery_services_vault_resource_guard_association_resource_test.go
+++ b/internal/services/recoveryservices/recovery_services_vault_resource_guard_association_resource_test.go
@@ -60,7 +60,7 @@ resource "azurerm_data_protection_resource_guard" "test" {
 }
 
 resource "azurerm_recovery_services_vault_resource_guard_association" "test" {
-  name              = "tftest"
+  name              = "VaultProxy"
   vault_id          = azurerm_recovery_services_vault.test.id
   resource_guard_id = azurerm_data_protection_resource_guard.test.id
 }

--- a/website/docs/r/recovery_services_vault_resource_guard_association.html.markdown
+++ b/website/docs/r/recovery_services_vault_resource_guard_association.html.markdown
@@ -34,7 +34,7 @@ resource "azurerm_recovery_services_vault" "vault" {
 }
 
 resource "azurerm_recovery_services_vault_resource_guard_association" "test" {
-  name              = "example-guard-proxy"
+  name              = "VaultProxy"
   vault_id          = azurerm_recovery_services_vault.test.id
   resource_guard_id = azurerm_data_protection_resource_guard.test.id
 }

--- a/website/docs/r/recovery_services_vault_resource_guard_association.html.markdown
+++ b/website/docs/r/recovery_services_vault_resource_guard_association.html.markdown
@@ -44,7 +44,9 @@ resource "azurerm_recovery_services_vault_resource_guard_association" "test" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name of the Recovery Services Vault Resource Guard Association. Changing this forces a new resource to be created.
+* `name` - (Optional) Specifies the name of the Recovery Services Vault Resource Guard Association. Changing this forces a new resource to be created.
+
+-> **NOTE:** `name` has been deprecated and will be removed in version 4.0 of the provider.
 
 * `vault_id` - (Required) ID of the Recovery Services Vault which should be associated with. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
The service start to return error if the name is not `VaultProxy`.
While removing the property will bring breaking change.

test
---
```
❯ tftest recoveryservices TestAccSiteRecoveryVaultResourceGuardAssociation_basic 
=== RUN   TestAccSiteRecoveryVaultResourceGuardAssociation_basic
=== PAUSE TestAccSiteRecoveryVaultResourceGuardAssociation_basic
=== CONT  TestAccSiteRecoveryVaultResourceGuardAssociation_basic
--- PASS: TestAccSiteRecoveryVaultResourceGuardAssociation_basic (316.99s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/recoveryservices      317.046s
```