### PR TITLE
`azurerm_container_app_environment` - add `zone_redundant_enabled` support

### DIFF
--- a/internal/services/containerapps/container_app_environment_resource.go
+++ b/internal/services/containerapps/container_app_environment_resource.go
@@ -32,6 +32,7 @@ type ContainerAppEnvironmentModel struct {
 	LogAnalyticsWorkspaceId                 string                 `tfschema:"log_analytics_workspace_id"`
 	InfrastructureSubnetId                  string                 `tfschema:"infrastructure_subnet_id"`
 	InternalLoadBalancerEnabled             bool                   `tfschema:"internal_load_balancer_enabled"`
+	ZoneRedundant                           bool                   `tfschema:"zone_redundancy_enabled"`
 	Tags                                    map[string]interface{} `tfschema:"tags"`
 
 	DefaultDomain         string `tfschema:"default_domain"`
@@ -95,11 +96,20 @@ func (r ContainerAppEnvironmentResource) Arguments() map[string]*pluginsdk.Schem
 		},
 
 		"internal_load_balancer_enabled": {
-			Type:        pluginsdk.TypeBool,
-			Optional:    true,
-			ForceNew:    true,
-			Default:     false,
-			Description: "Should the Container Environment operate in Internal Load Balancing Mode? Defaults to `false`. **Note:** can only be set to `true` if `infrastructure_subnet_id` is specified.",
+			Type:         pluginsdk.TypeBool,
+			Optional:     true,
+			ForceNew:     true,
+			Default:      false,
+			RequiredWith: []string{"infrastructure_subnet_id"},
+			Description:  "Should the Container Environment operate in Internal Load Balancing Mode? Defaults to `false`. **Note:** can only be set to `true` if `infrastructure_subnet_id` is specified.",
+		},
+
+		"zone_redundancy_enabled": {
+			Type:         pluginsdk.TypeBool,
+			Optional:     true,
+			ForceNew:     true,
+			Default:      false,
+			RequiredWith: []string{"infrastructure_subnet_id"},
 		},
 
 		"tags": commonschema.Tags(),
@@ -172,6 +182,7 @@ func (r ContainerAppEnvironmentResource) Create() sdk.ResourceFunc {
 				Name:     pointer.To(containerAppEnvironment.Name),
 				Properties: &managedenvironments.ManagedEnvironmentProperties{
 					VnetConfiguration: &managedenvironments.VnetConfiguration{},
+					ZoneRedundant:     pointer.To(containerAppEnvironment.ZoneRedundant),
 				},
 				Tags: tags.Expand(containerAppEnvironment.Tags),
 			}
@@ -265,6 +276,7 @@ func (r ContainerAppEnvironmentResource) Read() sdk.ResourceFunc {
 						state.PlatformReservedDnsIP = pointer.From(vnet.PlatformReservedDnsIP)
 					}
 
+					state.ZoneRedundant = pointer.From(props.ZoneRedundant)
 					state.StaticIP = pointer.From(props.StaticIP)
 					state.DefaultDomain = pointer.From(props.DefaultDomain)
 				}

--- a/internal/services/containerapps/container_app_environment_resource_test.go
+++ b/internal/services/containerapps/container_app_environment_resource_test.go
@@ -101,6 +101,21 @@ func TestAccContainerAppEnvironment_daprApplicationInsightsConnectionString(t *t
 	})
 }
 
+func TestAccContainerAppEnvironment_zoneRedundant(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_container_app_environment", "test")
+	r := ContainerAppEnvironmentResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.completeZoneRedundant(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("log_analytics_workspace_id"),
+	})
+}
+
 func (r ContainerAppEnvironmentResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := managedenvironments.ParseManagedEnvironmentID(state.ID)
 	if err != nil {
@@ -194,6 +209,31 @@ resource "azurerm_container_app_environment" "test" {
 
   tags = {
     Foo = "test"
+  }
+}
+`, r.templateVNet(data), data.RandomInteger)
+}
+
+func (r ContainerAppEnvironmentResource) completeZoneRedundant(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%[1]s
+
+resource "azurerm_container_app_environment" "test" {
+  name                           = "acctest-CAEnv%[2]d"
+  resource_group_name            = azurerm_resource_group.test.name
+  location                       = azurerm_resource_group.test.location
+  log_analytics_workspace_id     = azurerm_log_analytics_workspace.test.id
+  infrastructure_subnet_id       = azurerm_subnet.control.id
+  zone_redundancy_enabled        = true
+  internal_load_balancer_enabled = true
+
+  tags = {
+    Foo    = "Bar"
+    secret = "sauce"
   }
 }
 `, r.templateVNet(data), data.RandomInteger)

--- a/website/docs/r/container_app_environment.html.markdown
+++ b/website/docs/r/container_app_environment.html.markdown
@@ -56,6 +56,10 @@ The following arguments are supported:
 
 ~> **Note:** can only be set to `true` if `infrastructure_subnet_id` is specified. 
 
+* `zone_redundancy_enabled` - (Optional) Should the Container App Environment be created with Zone Redundancy enabled? Defaults to `false`. Changing this forces a new resource to be created.
+
+~> **Note:** can only be set to `true` if `infrastructure_subnet_id` is specified. 
+
 * `log_analytics_workspace_id` - (Optional) The ID for the Log Analytics Workspace to link this Container Apps Managed Environment to. Changing this forces a new resource to be created.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.


### PR DESCRIPTION
Adds support for creating Container App Environments as Zone Redundant.

closes #20538
