### PR TITLE
`azurerm_key_vault_key` - ForceNew when `expiration_date` is removed from the config file

### DIFF
--- a/internal/services/keyvault/key_vault_key_resource.go
+++ b/internal/services/keyvault/key_vault_key_resource.go
@@ -256,6 +256,12 @@ func resourceKeyVaultKey() *pluginsdk.Resource {
 
 			"tags": tags.Schema(),
 		},
+
+		CustomizeDiff: pluginsdk.CustomDiffWithAll(
+			pluginsdk.ForceNewIfChange("expiration_date", func(ctx context.Context, old, new, meta interface{}) bool {
+				return old.(string) != "" && new.(string) == ""
+			}),
+		),
 	}
 }
 


### PR DESCRIPTION
Fixes an issue where `expiration_date` is removed from the config but nothing happens causing during the apply which causes perpetual diff.

The Azure portal also does not allow `expiration_date` to be removed after it has been set (though, it can be changed to a new value)