### PR TITLE
Mysql flexible server iops scaling

### DIFF
--- a/internal/services/mysql/mysql_flexible_server_data_source.go
+++ b/internal/services/mysql/mysql_flexible_server_data_source.go
@@ -139,6 +139,10 @@ func dataSourceMysqlFlexibleServer() *pluginsdk.Resource {
 							Type:     pluginsdk.TypeInt,
 							Computed: true,
 						},
+						"io_scaling_enabled": {
+							Type:     pluginsdk.TypeBool,
+							Computed: true,
+						},
 					},
 				},
 			},
@@ -252,9 +256,10 @@ func flattenDataSourceArmServerStorage(storage *servers.Storage) []interface{} {
 
 	return []interface{}{
 		map[string]interface{}{
-			"size_gb":           size,
-			"iops":              iops,
-			"auto_grow_enabled": *storage.AutoGrow == servers.EnableStatusEnumEnabled,
+			"size_gb":            size,
+			"iops":               iops,
+			"auto_grow_enabled":  *storage.AutoGrow == servers.EnableStatusEnumEnabled,
+			"io_scaling_enabled": *storage.AutoIoScaling == servers.EnableStatusEnumEnabled,
 		},
 	}
 }

--- a/internal/services/mysql/mysql_flexible_server_resource.go
+++ b/internal/services/mysql/mysql_flexible_server_resource.go
@@ -270,7 +270,7 @@ func resourceMysqlFlexibleServer() *pluginsdk.Resource {
 						"io_scaling_enabled": {
 							Type:     pluginsdk.TypeBool,
 							Optional: true,
-							Default:  true,
+							Default:  false,
 						},
 					},
 				},

--- a/internal/services/mysql/mysql_flexible_server_resource.go
+++ b/internal/services/mysql/mysql_flexible_server_resource.go
@@ -267,6 +267,11 @@ func resourceMysqlFlexibleServer() *pluginsdk.Resource {
 							Computed:     true,
 							ValidateFunc: validation.IntBetween(20, 16384),
 						},
+						"io_scaling_enabled": {
+							Type:     pluginsdk.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
 					},
 				},
 			},
@@ -764,8 +769,14 @@ func expandArmServerStorage(inputs []interface{}) *servers.Storage {
 		autoGrow = servers.EnableStatusEnumEnabled
 	}
 
+	autoIoScaling := servers.EnableStatusEnumDisabled
+	if v := input["io_scaling_enabled"].(bool); v {
+		autoIoScaling = servers.EnableStatusEnumEnabled
+	}
+
 	storage := servers.Storage{
-		AutoGrow: &autoGrow,
+		AutoGrow:      &autoGrow,
+		AutoIoScaling: &autoIoScaling,
 	}
 
 	if v := input["size_gb"].(int); v != 0 {
@@ -795,9 +806,10 @@ func flattenArmServerStorage(storage *servers.Storage) []interface{} {
 
 	return []interface{}{
 		map[string]interface{}{
-			"size_gb":           size,
-			"iops":              iops,
-			"auto_grow_enabled": *storage.AutoGrow == servers.EnableStatusEnumEnabled,
+			"size_gb":            size,
+			"iops":               iops,
+			"auto_grow_enabled":  *storage.AutoGrow == servers.EnableStatusEnumEnabled,
+			"io_scaling_enabled": *storage.AutoIoScaling == servers.EnableStatusEnumDisabled,
 		},
 	}
 }

--- a/internal/services/mysql/mysql_flexible_server_resource.go
+++ b/internal/services/mysql/mysql_flexible_server_resource.go
@@ -361,8 +361,10 @@ func resourceMysqlFlexibleServerCreate(d *pluginsdk.ResourceData, meta interface
 	}
 
 	storageSettings := expandArmServerStorage(d.Get("storage").([]interface{}))
-	if storageSettings.Iops != nil && *storageSettings.AutoIoScaling == servers.EnableStatusEnumEnabled {
-		return fmt.Errorf("`iops` can not be set if `io_scaling_enabled` is set to true")
+	if storageSettings != nil {
+		if storageSettings.Iops != nil && *storageSettings.AutoIoScaling == servers.EnableStatusEnumEnabled {
+			return fmt.Errorf("`iops` can not be set if `io_scaling_enabled` is set to true")
+		}
 	}
 
 	sku, err := expandFlexibleServerSku(d.Get("sku_name").(string))

--- a/internal/services/mysql/mysql_flexible_server_resource.go
+++ b/internal/services/mysql/mysql_flexible_server_resource.go
@@ -270,7 +270,7 @@ func resourceMysqlFlexibleServer() *pluginsdk.Resource {
 						"io_scaling_enabled": {
 							Type:     pluginsdk.TypeBool,
 							Optional: true,
-							Default:  false,
+							Default:  true,
 						},
 					},
 				},
@@ -358,6 +358,11 @@ func resourceMysqlFlexibleServerCreate(d *pluginsdk.ResourceData, meta interface
 		if _, ok := d.GetOk("sku_name"); !ok {
 			return fmt.Errorf("`sku_name` is required when `create_mode` is `Default`")
 		}
+	}
+
+	storageSettings := expandArmServerStorage(d.Get("storage").([]interface{}))
+	if storageSettings.Iops != nil && *storageSettings.AutoIoScaling == servers.EnableStatusEnumEnabled {
+		return fmt.Errorf("`iops` can not be set if `io_scaling_enabled` is set to true")
 	}
 
 	sku, err := expandFlexibleServerSku(d.Get("sku_name").(string))
@@ -809,7 +814,7 @@ func flattenArmServerStorage(storage *servers.Storage) []interface{} {
 			"size_gb":            size,
 			"iops":               iops,
 			"auto_grow_enabled":  *storage.AutoGrow == servers.EnableStatusEnumEnabled,
-			"io_scaling_enabled": *storage.AutoIoScaling == servers.EnableStatusEnumDisabled,
+			"io_scaling_enabled": *storage.AutoIoScaling == servers.EnableStatusEnumEnabled,
 		},
 	}
 }

--- a/internal/services/mysql/mysql_flexible_server_resource_test.go
+++ b/internal/services/mysql/mysql_flexible_server_resource_test.go
@@ -374,6 +374,13 @@ func TestAccMySqlFlexibleServer_updateStorage(t *testing.T) {
 			),
 		},
 		data.ImportStep("administrator_password"),
+		{
+			Config: r.updateStorage(data, 34, nil, false, true),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("administrator_password"),
 	})
 }
 

--- a/internal/services/mysql/mysql_flexible_server_resource_test.go
+++ b/internal/services/mysql/mysql_flexible_server_resource_test.go
@@ -361,14 +361,14 @@ func TestAccMySqlFlexibleServer_updateStorage(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.updateStorage(data, 20, 360, true),
+			Config: r.updateStorage(data, 20, 360, true, false),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep("administrator_password"),
 		{
-			Config: r.updateStorage(data, 34, 402, false),
+			Config: r.updateStorage(data, 34, 402, false, false),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -701,9 +701,10 @@ resource "azurerm_mysql_flexible_server" "test" {
   geo_redundant_backup_enabled = false
 
   storage {
-    size_gb           = 32
-    iops              = 400
-    auto_grow_enabled = false
+    size_gb                 = 32
+    iops                    = 400
+    auto_grow_enabled       = false
+	auto_io_scaling_enabled = false
   }
 
   delegated_subnet_id = azurerm_subnet.test.id
@@ -970,7 +971,7 @@ resource "azurerm_mysql_flexible_server" "geo_restore" {
 `, r.geoRestoreSource(data), data.RandomInteger, os.Getenv("ARM_GEO_RESTORE_LOCATION"))
 }
 
-func (r MySqlFlexibleServerResource) updateStorage(data acceptance.TestData, sizeGB int, iops int, enabled bool) string {
+func (r MySqlFlexibleServerResource) updateStorage(data acceptance.TestData, sizeGB int, iops int, autoGrowEnabled bool, ioScalingEnabled bool) string {
 	return fmt.Sprintf(`
 %s
 
@@ -986,12 +987,13 @@ resource "azurerm_mysql_flexible_server" "test" {
   zone                         = "1"
 
   storage {
-    size_gb           = %d
-    iops              = %d
-    auto_grow_enabled = %t
+    size_gb                 = %d
+    iops                    = %d
+    auto_grow_enabled       = %t
+	auto_io_scaling_enabled = %t
   }
 }
-`, r.template(data), data.RandomInteger, sizeGB, iops, enabled)
+`, r.template(data), data.RandomInteger, sizeGB, iops, autoGrowEnabled, ioScalingEnabled)
 }
 
 func (r MySqlFlexibleServerResource) failover(data acceptance.TestData, primaryZone string, standbyZone string) string {

--- a/internal/services/mysql/mysql_flexible_server_resource_test.go
+++ b/internal/services/mysql/mysql_flexible_server_resource_test.go
@@ -375,7 +375,7 @@ func TestAccMySqlFlexibleServer_updateStorage(t *testing.T) {
 		},
 		data.ImportStep("administrator_password"),
 		{
-			Config: r.updateStorage(data, 34, nil, false, true),
+			Config: r.updateStorageNoIOPS(data, 34, false, true),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -1001,6 +1001,30 @@ resource "azurerm_mysql_flexible_server" "test" {
   }
 }
 `, r.template(data), data.RandomInteger, sizeGB, iops, autoGrowEnabled, ioScalingEnabled)
+}
+
+func (r MySqlFlexibleServerResource) updateStorageNoIOPS(data acceptance.TestData, sizeGB int, autoGrowEnabled bool, ioScalingEnabled bool) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_mysql_flexible_server" "test" {
+  name                         = "acctest-fs-%d"
+  resource_group_name          = azurerm_resource_group.test.name
+  location                     = azurerm_resource_group.test.location
+  administrator_login          = "adminTerraform"
+  administrator_password       = "QAZwsx123"
+  sku_name                     = "GP_Standard_D4ds_v4"
+  geo_redundant_backup_enabled = true
+  version                      = "8.0.21"
+  zone                         = "1"
+
+  storage {
+    size_gb            = %d
+    auto_grow_enabled  = %t
+	io_scaling_enabled = %t
+  }
+}
+`, r.template(data), data.RandomInteger, sizeGB, autoGrowEnabled, ioScalingEnabled)
 }
 
 func (r MySqlFlexibleServerResource) failover(data acceptance.TestData, primaryZone string, standbyZone string) string {

--- a/internal/services/mysql/mysql_flexible_server_resource_test.go
+++ b/internal/services/mysql/mysql_flexible_server_resource_test.go
@@ -708,10 +708,10 @@ resource "azurerm_mysql_flexible_server" "test" {
   geo_redundant_backup_enabled = false
 
   storage {
-    size_gb                 = 32
-    iops                    = 400
-    auto_grow_enabled       = false
-	io_scaling_enabled      = false
+    size_gb            = 32
+    iops               = 400
+    auto_grow_enabled  = false
+	io_scaling_enabled = false
   }
 
   delegated_subnet_id = azurerm_subnet.test.id
@@ -994,10 +994,10 @@ resource "azurerm_mysql_flexible_server" "test" {
   zone                         = "1"
 
   storage {
-    size_gb                 = %d
-    iops                    = %d
-    auto_grow_enabled       = %t
-	io_scaling_enabled      = %t
+    size_gb            = %d
+    iops               = %d
+    auto_grow_enabled  = %t
+	io_scaling_enabled = %t
   }
 }
 `, r.template(data), data.RandomInteger, sizeGB, iops, autoGrowEnabled, ioScalingEnabled)

--- a/internal/services/mysql/mysql_flexible_server_resource_test.go
+++ b/internal/services/mysql/mysql_flexible_server_resource_test.go
@@ -704,7 +704,7 @@ resource "azurerm_mysql_flexible_server" "test" {
     size_gb                 = 32
     iops                    = 400
     auto_grow_enabled       = false
-	auto_io_scaling_enabled = false
+	io_scaling_enabled      = false
   }
 
   delegated_subnet_id = azurerm_subnet.test.id
@@ -990,7 +990,7 @@ resource "azurerm_mysql_flexible_server" "test" {
     size_gb                 = %d
     iops                    = %d
     auto_grow_enabled       = %t
-	auto_io_scaling_enabled = %t
+	io_scaling_enabled      = %t
   }
 }
 `, r.template(data), data.RandomInteger, sizeGB, iops, autoGrowEnabled, ioScalingEnabled)

--- a/internal/services/mysql/mysql_flexible_server_resource_test.go
+++ b/internal/services/mysql/mysql_flexible_server_resource_test.go
@@ -711,7 +711,7 @@ resource "azurerm_mysql_flexible_server" "test" {
     size_gb            = 32
     iops               = 400
     auto_grow_enabled  = false
-	io_scaling_enabled = false
+    io_scaling_enabled = false
   }
 
   delegated_subnet_id = azurerm_subnet.test.id
@@ -997,7 +997,7 @@ resource "azurerm_mysql_flexible_server" "test" {
     size_gb            = %d
     iops               = %d
     auto_grow_enabled  = %t
-	io_scaling_enabled = %t
+    io_scaling_enabled = %t
   }
 }
 `, r.template(data), data.RandomInteger, sizeGB, iops, autoGrowEnabled, ioScalingEnabled)
@@ -1021,7 +1021,7 @@ resource "azurerm_mysql_flexible_server" "test" {
   storage {
     size_gb            = %d
     auto_grow_enabled  = %t
-	io_scaling_enabled = %t
+    io_scaling_enabled = %t
   }
 }
 `, r.template(data), data.RandomInteger, sizeGB, autoGrowEnabled, ioScalingEnabled)

--- a/website/docs/d/mysql_flexible_server.html.markdown
+++ b/website/docs/d/mysql_flexible_server.html.markdown
@@ -93,7 +93,7 @@ A `storage` block exports the following:
 
 * `auto_grow_enabled` - Is Storage Auto Grow enabled?
 
-* `io_scaling_enabled` - Should iops be scaled automatically?
+* `io_scaling_enabled` - Should IOPS be scaled automatically?
 
 * `iops` - The storage IOPS of the MySQL Flexible Server.
 

--- a/website/docs/d/mysql_flexible_server.html.markdown
+++ b/website/docs/d/mysql_flexible_server.html.markdown
@@ -93,6 +93,8 @@ A `storage` block exports the following:
 
 * `auto_grow_enabled` - Is Storage Auto Grow enabled?
 
+* `io_scaling_enabled` - Should iops be scaled automatically?
+
 * `iops` - The storage IOPS of the MySQL Flexible Server.
 
 * `size_gb` - The max storage allowed for the MySQL Flexible Server.

--- a/website/docs/r/mysql_flexible_server.html.markdown
+++ b/website/docs/r/mysql_flexible_server.html.markdown
@@ -189,7 +189,7 @@ A `storage` block supports the following:
 
 * `auto_grow_enabled` - (Optional) Should Storage Auto Grow be enabled? Defaults to `true`.
 
-* `io_scaling_enabled` - (Optional) Should IOPS be scaled automatically? If `true`, `iops` can not be set. Defaults to `true`.
+* `io_scaling_enabled` - (Optional) Should IOPS be scaled automatically? If `true`, `iops` can not be set. Defaults to `false`.
 
 * `iops` - (Optional) The storage IOPS for the MySQL Flexible Server. Possible values are between `360` and `20000`.
 

--- a/website/docs/r/mysql_flexible_server.html.markdown
+++ b/website/docs/r/mysql_flexible_server.html.markdown
@@ -189,7 +189,7 @@ A `storage` block supports the following:
 
 * `auto_grow_enabled` - (Optional) Should Storage Auto Grow be enabled? Defaults to `true`.
 
-* `io_scaling_enabled` - (Optional) Should iops be scaled automatically? If `true`, `iops` can not be set. Defaults to `true`.
+* `io_scaling_enabled` - (Optional) Should IOPS be scaled automatically? If `true`, `iops` can not be set. Defaults to `true`.
 
 * `iops` - (Optional) The storage IOPS for the MySQL Flexible Server. Possible values are between `360` and `20000`.
 

--- a/website/docs/r/mysql_flexible_server.html.markdown
+++ b/website/docs/r/mysql_flexible_server.html.markdown
@@ -189,6 +189,8 @@ A `storage` block supports the following:
 
 * `auto_grow_enabled` - (Optional) Should Storage Auto Grow be enabled? Defaults to `true`.
 
+* `io_scaling_enabled` - (Optional) Should iops be scaled automatically? If `true`, `iops` can not be set. Defaults to `true`.
+
 * `iops` - (Optional) The storage IOPS for the MySQL Flexible Server. Possible values are between `360` and `20000`.
 
 * `size_gb` - (Optional) The max storage allowed for the MySQL Flexible Server. Possible values are between `20` and `16384`.


### PR DESCRIPTION
Related to https://github.com/hashicorp/terraform-provider-azurerm/issues/19125

Adds support for the `autoIoScaling` field in the `storage` block of the `mysql flexible-server` resource. This is a new field introduced in the `2022-01-01` version of the API

I have been a bit unsure about the following:
- Should the arguments in the storage block be constrained/validated? I have added a check in the `resourceMysqlFlexibleServerCreate` function, where `iops` can not be set, if `io_scaling_enabled` is `true`. Not sure if we want this?
- I have named the field `io_scaling_enabled`, but not quite sure i like that name. Maybe you have some other suggestion?