### PR TITLE
`azurerm_cosmosdb_account` - Add mongodb connection strings

### DIFF
--- a/internal/services/cosmos/cosmosdb_account_resource.go
+++ b/internal/services/cosmos/cosmosdb_account_resource.go
@@ -40,10 +40,14 @@ import (
 var CosmosDbAccountResourceName = "azurerm_cosmosdb_account"
 
 var connStringPropertyMap = map[string]string{
-	"Primary SQL Connection String":             "primary_sql_connection_string",
-	"Secondary SQL Connection String":           "secondary_sql_connection_string",
-	"Primary Read-Only SQL Connection String":   "primary_readonly_sql_connection_string",
-	"Secondary Read-Only SQL Connection String": "secondary_readonly_sql_connection_string",
+	"Primary SQL Connection String":                 "primary_sql_connection_string",
+	"Secondary SQL Connection String":               "secondary_sql_connection_string",
+	"Primary Read-Only SQL Connection String":       "primary_readonly_sql_connection_string",
+	"Secondary Read-Only SQL Connection String":     "secondary_readonly_sql_connection_string",
+	"Primary MongoDB Connection String":             "primary_mongodb_connection_string",
+	"Secondary MongoDB Connection String":           "secondary_mongodb_connection_string",
+	"Primary Read-Only MongoDB Connection String":   "primary_readonly_mongodb_connection_string",
+	"Secondary Read-Only MongoDB Connection String": "secondary_readonly_mongodb_connection_string",
 }
 
 type databaseAccountCapabilities string
@@ -672,6 +676,30 @@ func resourceCosmosDbAccount() *pluginsdk.Resource {
 			},
 
 			"secondary_readonly_sql_connection_string": {
+				Type:      pluginsdk.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+
+			"primary_mongodb_connection_string": {
+				Type:      pluginsdk.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+
+			"secondary_mongodb_connection_string": {
+				Type:      pluginsdk.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+
+			"primary_readonly_mongodb_connection_string": {
+				Type:      pluginsdk.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+
+			"secondary_readonly_mongodb_connection_string": {
 				Type:      pluginsdk.TypeString,
 				Computed:  true,
 				Sensitive: true,

--- a/internal/services/cosmos/cosmosdb_mongo_database_resource_test.go
+++ b/internal/services/cosmos/cosmosdb_mongo_database_resource_test.go
@@ -28,6 +28,7 @@ func TestAccCosmosDbMongoDatabase_basic(t *testing.T) {
 			Config: r.basic(data),
 			Check: acceptance.ComposeAggregateTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				checkAccCosmosDBAccount_mongodb("azurerm_cosmosdb_account.test"),
 			),
 		},
 		data.ImportStep(),
@@ -43,6 +44,7 @@ func TestAccCosmosDbMongoDatabase_complete(t *testing.T) {
 			Config: r.complete(data),
 			Check: acceptance.ComposeAggregateTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				checkAccCosmosDBAccount_mongodb("azurerm_cosmosdb_account.test"),
 			),
 		},
 		data.ImportStep(),
@@ -90,6 +92,7 @@ func TestAccCosmosDbMongoDatabase_serverless(t *testing.T) {
 			Config: r.serverless(data),
 			Check: acceptance.ComposeAggregateTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				checkAccCosmosDBAccount_mongodb("azurerm_cosmosdb_account.test"),
 			),
 		},
 		data.ImportStep(),
@@ -160,4 +163,13 @@ resource "azurerm_cosmosdb_mongo_database" "test" {
   account_name        = azurerm_cosmosdb_account.test.name
 }
 `, CosmosDBAccountResource{}.capabilities(data, documentdb.DatabaseAccountKindMongoDB, []string{"EnableServerless", "mongoEnableDocLevelTTL", "EnableMongo"}), data.RandomInteger)
+}
+
+func checkAccCosmosDBAccount_mongodb(resourceName string) acceptance.TestCheckFunc {
+	return acceptance.ComposeTestCheckFunc(
+		check.That(resourceName).Key("primary_mongodb_connection_string").Exists(),
+		check.That(resourceName).Key("secondary_mongodb_connection_string").Exists(),
+		check.That(resourceName).Key("primary_readonly_mongodb_connection_string").Exists(),
+		check.That(resourceName).Key("secondary_readonly_mongodb_connection_string").Exists(),
+	)
 }

--- a/website/docs/r/cosmosdb_account.html.markdown
+++ b/website/docs/r/cosmosdb_account.html.markdown
@@ -311,6 +311,22 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 * `connection_strings` - A list of connection strings available for this CosmosDB account.
 
+* `primary_sql_connection_string` - Primary SQL connection string for the CosmosDB Account.
+
+* `secondary_sql_connection_string` - Secondary SQL connection string for the CosmosDB Account.
+
+* `primary_readonly_sql_connection_string` - Primary readonly SQL connection string for the CosmosDB Account.
+
+* `secondary_readonly_sql_connection_string` - Secondary readonly SQL connection string for the CosmosDB Account. 
+
+* `primary_mongodb_connection_string` - Primary Mongodb connection string for the CosmosDB Account.
+
+* `secondary_mongodb_connection_string` - Secondary Mongodb connection string for the CosmosDB Account.
+
+* `primary_readonly_mongodb_connection_string` - Primary readonly Mongodb connection string for the CosmosDB Account.
+
+* `secondary_readonly_mongodb_connection_string` - Secondary readonly Mongodb connection string for the CosmosDB Account.
+
 ---
 
 An `identity` block exports the following:


### PR DESCRIPTION
A friend of mine tried to read the mongodb connection string by using `primary_sql_connection_string`, and he was confused when he found this attribute was empty.

The connection strings were outputted via `connection_strings`, but without descriptions, so he cannot figured out which one is the primary connection string.

This pr amended the connection strings for mongodb.