### PR TITLE
`azurerm_management_group_subscription_association` - correctly mark as gone if not found during read

### DIFF
--- a/internal/services/managementgroup/subscription_association_resource.go
+++ b/internal/services/managementgroup/subscription_association_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2020-05-01/managementgroups" // nolint: staticcheck
@@ -87,7 +88,7 @@ func resourceManagementGroupSubscriptionAssociationCreate(d *pluginsdk.ResourceD
 
 	if props.Children != nil {
 		for _, v := range *props.Children {
-			if v.Type == managementgroups.Type1Subscriptions && v.Name != nil && *v.Name == id.SubscriptionId {
+			if v.Type == managementgroups.Type1Subscriptions && v.Name != nil && strings.EqualFold(*v.Name, id.SubscriptionId) {
 				return tf.ImportAsExistsError("azurerm_management_group_subscription_association", id.ID())
 			}
 		}
@@ -121,7 +122,7 @@ func resourceManagementGroupSubscriptionAssociationRead(d *pluginsdk.ResourceDat
 	if props := managementGroup.Properties; props != nil {
 		if props.Children != nil {
 			for _, v := range *props.Children {
-				if v.Type == managementgroups.Type1Subscriptions && v.Name != nil && *v.Name == id.SubscriptionId {
+				if v.Type == managementgroups.Type1Subscriptions && v.Name != nil && strings.EqualFold(*v.Name, id.SubscriptionId) {
 					found = true
 				}
 			}
@@ -192,7 +193,7 @@ func subscriptionAssociationRefreshFunc(ctx context.Context, client *managementg
 		if props := managementGroup.Properties; props != nil && props.Children != nil {
 			for _, v := range *props.Children {
 				if v.Type == managementgroups.Type1Subscriptions {
-					if v.Name != nil && *v.Name == id.SubscriptionId {
+					if v.Name != nil && strings.EqualFold(*v.Name, id.SubscriptionId) {
 						return managementGroup, "Exists", nil
 					}
 				}

--- a/internal/services/managementgroup/subscription_association_resource.go
+++ b/internal/services/managementgroup/subscription_association_resource.go
@@ -119,13 +119,9 @@ func resourceManagementGroupSubscriptionAssociationRead(d *pluginsdk.ResourceDat
 	}
 	found := false
 	if props := managementGroup.Properties; props != nil {
-		if props.Children == nil {
-			return fmt.Errorf("could not read properties for Management Group %q", id.ManagementGroup)
-		}
-
-		for _, v := range *props.Children {
-			if v.Type == managementgroups.Type1Subscriptions {
-				if v.Name != nil && *v.Name == id.SubscriptionId {
+		if props.Children != nil {
+			for _, v := range *props.Children {
+				if v.Type == managementgroups.Type1Subscriptions && v.Name != nil && *v.Name == id.SubscriptionId {
 					found = true
 				}
 			}

--- a/internal/services/managementgroup/subscription_association_resource_test.go
+++ b/internal/services/managementgroup/subscription_association_resource_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2020-05-01/managementgroups" // nolint: staticcheck
@@ -124,7 +125,7 @@ func (r ManagementGroupSubscriptionAssociation) Exists(ctx context.Context, clie
 
 	present := false
 	for _, v := range *resp.Children {
-		if v.Type == managementgroups.Type1Subscriptions && v.Name != nil && *v.Name == id.SubscriptionId {
+		if v.Type == managementgroups.Type1Subscriptions && v.Name != nil && strings.EqualFold(*v.Name, id.SubscriptionId) {
 			present = true
 		}
 	}


### PR DESCRIPTION
fix #23323