### PR TITLE
`azurerm_container_app` - Correct commands issue with multiple containers (#22984)

### DIFF
--- a/internal/services/containerapps/container_app_resource_test.go
+++ b/internal/services/containerapps/container_app_resource_test.go
@@ -221,6 +221,27 @@ func TestAccContainerAppResource_completeWithSidecar(t *testing.T) {
 	})
 }
 
+func TestAccContainerAppResource_completeWithMultipleContainers(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_container_app", "test")
+	r := ContainerAppResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.completeWithMultipleContainers(data, "rev1"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("template.0.container.0.command.0").HasValue("sh"),
+				check.That(data.ResourceName).Key("template.0.container.0.command.1").HasValue("-c"),
+				check.That(data.ResourceName).Key("template.0.container.0.command.2").HasValue("CONTAINER=one python3 -m flask run --host=0.0.0.0"),
+				check.That(data.ResourceName).Key("template.0.container.1.command.0").HasValue("sh"),
+				check.That(data.ResourceName).Key("template.0.container.1.command.1").HasValue("-c"),
+				check.That(data.ResourceName).Key("template.0.container.1.command.2").HasValue("CONTAINER=two python3 -m flask run --host=0.0.0.0"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccContainerAppResource_completeUpdate(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_container_app", "test")
 	r := ContainerAppResource{}
@@ -1049,6 +1070,143 @@ resource "azurerm_container_app" "test" {
   secret {
     name  = "registry-password"
     value = azurerm_container_registry.test.admin_password
+  }
+
+  tags = {
+    foo     = "Bar"
+    accTest = "1"
+  }
+}
+`, r.templatePlusExtras(data), data.RandomInteger, revisionSuffix)
+}
+
+func (r ContainerAppResource) completeWithMultipleContainers(data acceptance.TestData, revisionSuffix string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_container_app" "test" {
+  name                         = "acctest-capp-%[2]d"
+  resource_group_name          = azurerm_resource_group.test.name
+  container_app_environment_id = azurerm_container_app_environment.test.id
+  revision_mode                = "Single"
+
+  template {
+    container {
+      name   = "acctest-cont1-%[2]d"
+      image  = "jackofallops/azure-containerapps-python-acctest:v0.0.1"
+      cpu    = 0.25
+      memory = "0.5Gi"
+      command = ["sh", "-c", "CONTAINER=one python3 -m flask run --host=0.0.0.0"]
+
+      readiness_probe {
+        transport = "HTTP"
+        port      = 5000
+      }
+
+      liveness_probe {
+        transport = "HTTP"
+        port      = 5000
+        path      = "/health"
+
+        header {
+          name  = "Cache-Control"
+          value = "no-cache"
+        }
+
+        initial_delay           = 5
+        interval_seconds        = 20
+        timeout                 = 2
+        failure_count_threshold = 1
+      }
+
+      startup_probe {
+        transport = "TCP"
+        port      = 5000
+      }
+
+      volume_mounts {
+        name = azurerm_container_app_environment_storage.test.name
+        path = "/tmp/testdata"
+      }
+    }
+
+    container {
+      name   = "acctest-cont2-%[2]d"
+      image  = "jackofallops/azure-containerapps-python-acctest:v0.0.1"
+      cpu    = 0.25
+      memory = "0.5Gi"
+      command = ["sh", "-c", "CONTAINER=two python3 -m flask run --host=0.0.0.0"]
+
+      readiness_probe {
+        transport = "HTTP"
+        port      = 5000
+      }
+
+      liveness_probe {
+        transport = "HTTP"
+        port      = 5000
+        path      = "/health"
+
+        header {
+          name  = "Cache-Control"
+          value = "no-cache"
+        }
+
+        initial_delay           = 5
+        interval_seconds        = 20
+        timeout                 = 2
+        failure_count_threshold = 1
+      }
+
+      startup_probe {
+        transport = "TCP"
+        port      = 5000
+      }
+
+      volume_mounts {
+        name = azurerm_container_app_environment_storage.test.name
+        path = "/tmp/testdata"
+      }
+    }
+
+    volume {
+      name         = azurerm_container_app_environment_storage.test.name
+      storage_type = "AzureFile"
+      storage_name = azurerm_container_app_environment_storage.test.name
+    }
+
+    min_replicas = 2
+    max_replicas = 3
+
+    revision_suffix = "%[3]s"
+  }
+
+  ingress {
+    allow_insecure_connections = true
+    external_enabled           = true
+    target_port                = 5000
+    transport                  = "http"
+    traffic_weight {
+      latest_revision = true
+      percentage      = 100
+    }
+  }
+
+  registry {
+    server               = azurerm_container_registry.test.login_server
+    username             = azurerm_container_registry.test.admin_username
+    password_secret_name = "registry-password"
+  }
+
+  secret {
+    name  = "registry-password"
+    value = azurerm_container_registry.test.admin_password
+  }
+
+  dapr {
+    app_id       = "acctest-cont-%[2]d"
+    app_port     = 5000
+    app_protocol = "http"
   }
 
   tags = {

--- a/internal/services/containerapps/container_app_resource_test.go
+++ b/internal/services/containerapps/container_app_resource_test.go
@@ -1092,10 +1092,10 @@ resource "azurerm_container_app" "test" {
 
   template {
     container {
-      name   = "acctest-cont1-%[2]d"
-      image  = "jackofallops/azure-containerapps-python-acctest:v0.0.1"
-      cpu    = 0.25
-      memory = "0.5Gi"
+      name    = "acctest-cont1-%[2]d"
+      image   = "jackofallops/azure-containerapps-python-acctest:v0.0.1"
+      cpu     = 0.25
+      memory  = "0.5Gi"
       command = ["sh", "-c", "CONTAINER=one python3 -m flask run --host=0.0.0.0"]
 
       readiness_probe {
@@ -1131,10 +1131,10 @@ resource "azurerm_container_app" "test" {
     }
 
     container {
-      name   = "acctest-cont2-%[2]d"
-      image  = "jackofallops/azure-containerapps-python-acctest:v0.0.1"
-      cpu    = 0.25
-      memory = "0.5Gi"
+      name    = "acctest-cont2-%[2]d"
+      image   = "jackofallops/azure-containerapps-python-acctest:v0.0.1"
+      cpu     = 0.25
+      memory  = "0.5Gi"
       command = ["sh", "-c", "CONTAINER=two python3 -m flask run --host=0.0.0.0"]
 
       readiness_probe {

--- a/internal/services/containerapps/helpers/container_apps.go
+++ b/internal/services/containerapps/helpers/container_apps.go
@@ -1014,9 +1014,7 @@ func expandContainerAppContainers(input []Container) *[]containerapps.Container 
 			args := pointer.To(v.Args)
 		}
 		if len(v.Command) != 0 {
-			commandCopy := make([]string, len(v.Command))
-			copy(commandCopy, v.Command)
-			container.Command = &commandCopy
+			container.Command = pointer.To(v.Command)
 		}
 
 		result = append(result, container)

--- a/internal/services/containerapps/helpers/container_apps.go
+++ b/internal/services/containerapps/helpers/container_apps.go
@@ -1011,9 +1011,7 @@ func expandContainerAppContainers(input []Container) *[]containerapps.Container 
 			VolumeMounts: expandContainerVolumeMounts(v.VolumeMounts),
 		}
 		if len(v.Args) != 0 {
-			argsCopy := make([]string, len(v.Args))
-			copy(argsCopy, v.Args)
-			container.Args = &argsCopy
+			args := pointer.To(v.Args)
 		}
 		if len(v.Command) != 0 {
 			commandCopy := make([]string, len(v.Command))

--- a/internal/services/containerapps/helpers/container_apps.go
+++ b/internal/services/containerapps/helpers/container_apps.go
@@ -1011,10 +1011,14 @@ func expandContainerAppContainers(input []Container) *[]containerapps.Container 
 			VolumeMounts: expandContainerVolumeMounts(v.VolumeMounts),
 		}
 		if len(v.Args) != 0 {
-			container.Args = &v.Args
+			argsCopy := make([]string, len(v.Args))
+			copy(argsCopy, v.Args)
+			container.Args = &argsCopy
 		}
 		if len(v.Command) != 0 {
-			container.Command = &v.Command
+			commandCopy := make([]string, len(v.Command))
+			copy(commandCopy, v.Command)
+			container.Command = &commandCopy
 		}
 
 		result = append(result, container)

--- a/internal/services/containerapps/helpers/container_apps.go
+++ b/internal/services/containerapps/helpers/container_apps.go
@@ -1011,7 +1011,7 @@ func expandContainerAppContainers(input []Container) *[]containerapps.Container 
 			VolumeMounts: expandContainerVolumeMounts(v.VolumeMounts),
 		}
 		if len(v.Args) != 0 {
-			args := pointer.To(v.Args)
+			container.Args = pointer.To(v.Args)
 		}
 		if len(v.Command) != 0 {
 			container.Command = pointer.To(v.Command)


### PR DESCRIPTION
When defining multiple containers with unique `command`, it was observed that all containers were being assigned the same command, despite the plan being correct. This behavior resulted in incorrect configurations being applied to Azure.

Upon investigation, it was determined that the issue stems from shared slice references in the ExpandContainerAppTemplate function of the helpers/container_apps.go file. The Command and Args slices for individual containers are being assigned directly to the corresponding fields of the containerapps.Container, leading to shared references. As a result, any change in one container's Command or Args inadvertently affects all other containers.

To address this issue, instead of directly assigning the slice references, this PR implements a deep copy of the Command and Args slices for each container.

I have also created an acceptance test for this scenario, as the existing tests don't cover multiple containers or commands.

New to the project, so apologies in advance for anything that needs correcting.

Fixes #22984 