### PR TITLE
`azurerm_management_lock` - Add post-create/delete polling to tolerate RP propagation

### DIFF
--- a/internal/services/resource/management_lock_resource.go
+++ b/internal/services/resource/management_lock_resource.go
@@ -100,6 +100,11 @@ func resourceManagementLockCreate(d *pluginsdk.ResourceData, meta interface{}) e
 		return fmt.Errorf("creating %s: %+v", id, err)
 	}
 
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return fmt.Errorf("internal-error: context was missing a deadline")
+	}
+
 	stateConf := &pluginsdk.StateChangeConf{
 		Target: []string{
 			"OK",
@@ -107,7 +112,7 @@ func resourceManagementLockCreate(d *pluginsdk.ResourceData, meta interface{}) e
 		Refresh:                   managementLockStateRefreshFunc(ctx, client, id),
 		MinTimeout:                10 * time.Second,
 		ContinuousTargetOccurence: 12,
-		Timeout:                   d.Timeout(pluginsdk.TimeoutUpdate),
+		Timeout:                   time.Until(deadline),
 	}
 	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
 		return fmt.Errorf("waiting for %s to finish create replication", id)
@@ -168,6 +173,11 @@ func resourceManagementLockDelete(d *pluginsdk.ResourceData, meta interface{}) e
 		return fmt.Errorf("deleting %s: %+v", *id, err)
 	}
 
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return fmt.Errorf("internal-error: context was missing a deadline")
+	}
+
 	stateConf := &pluginsdk.StateChangeConf{
 		Target: []string{
 			"NotFound",
@@ -175,7 +185,7 @@ func resourceManagementLockDelete(d *pluginsdk.ResourceData, meta interface{}) e
 		Refresh:                   managementLockStateRefreshFunc(ctx, client, *id),
 		MinTimeout:                10 * time.Second,
 		ContinuousTargetOccurence: 12,
-		Timeout:                   d.Timeout(pluginsdk.TimeoutUpdate),
+		Timeout:                   time.Until(deadline),
 	}
 	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
 		return fmt.Errorf("waiting for %s to finish delete replication", id)

--- a/internal/services/resource/management_lock_resource.go
+++ b/internal/services/resource/management_lock_resource.go
@@ -4,6 +4,7 @@
 package resource
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -32,7 +33,6 @@ func resourceManagementLock() *pluginsdk.Resource {
 		Timeouts: &pluginsdk.ResourceTimeout{
 			Create: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Read:   pluginsdk.DefaultTimeout(5 * time.Minute),
-			Update: pluginsdk.DefaultTimeout(30 * time.Minute),
 			Delete: pluginsdk.DefaultTimeout(30 * time.Minute),
 		},
 
@@ -100,6 +100,19 @@ func resourceManagementLockCreate(d *pluginsdk.ResourceData, meta interface{}) e
 		return fmt.Errorf("creating %s: %+v", id, err)
 	}
 
+	stateConf := &pluginsdk.StateChangeConf{
+		Target: []string{
+			"OK",
+		},
+		Refresh:                   managementLockStateRefreshFunc(ctx, client, id),
+		MinTimeout:                10 * time.Second,
+		ContinuousTargetOccurence: 12,
+		Timeout:                   d.Timeout(pluginsdk.TimeoutUpdate),
+	}
+	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+		return fmt.Errorf("waiting for %s to finish create replication", id)
+	}
+
 	d.SetId(id.ID())
 	return resourceManagementLockRead(d, meta)
 }
@@ -155,5 +168,31 @@ func resourceManagementLockDelete(d *pluginsdk.ResourceData, meta interface{}) e
 		return fmt.Errorf("deleting %s: %+v", *id, err)
 	}
 
+	stateConf := &pluginsdk.StateChangeConf{
+		Target: []string{
+			"NotFound",
+		},
+		Refresh:                   managementLockStateRefreshFunc(ctx, client, *id),
+		MinTimeout:                10 * time.Second,
+		ContinuousTargetOccurence: 12,
+		Timeout:                   d.Timeout(pluginsdk.TimeoutUpdate),
+	}
+	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+		return fmt.Errorf("waiting for %s to finish delete replication", id)
+	}
+
 	return nil
+}
+
+func managementLockStateRefreshFunc(ctx context.Context, client *managementlocks.ManagementLocksClient, id managementlocks.ScopedLockId) pluginsdk.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		resp, err := client.GetByScope(ctx, id)
+		if err != nil {
+			if response.WasNotFound(resp.HttpResponse) {
+				return resp, "NotFound", nil
+			}
+			return nil, "Error", err
+		}
+		return "OK", "OK", nil
+	}
 }


### PR DESCRIPTION
This PR adds post-create/delete polling to mitigate issues caused by slow RP propagation, e.g. a GET after creation returned 404 when the GET hits a different Azure regional endpoint.

There are currently a couple of (random) test failures in the daily test suite are failing due to this, e.g.:

```shell
=== RUN   TestAccManagementLock_resourceGroupReadOnlyBasic
=== PAUSE TestAccManagementLock_resourceGroupReadOnlyBasic
=== CONT  TestAccManagementLock_resourceGroupReadOnlyBasic
    testcase.go:113: Step 1/2 error: Error running apply: exit status 1
        Error: Provider produced inconsistent result after apply
        When applying changes to azurerm_management_lock.test, provider
        "provider[\"registry.terraform.io/hashicorp/azurerm\"]" produced an
        unexpected new value: Root resource was present, but now absent.
        This is a bug in the provider, which should be reported in the provider's own
        issue tracker.
```

## Test

```shell
💤  TF_ACC=1 go test -v -timeout=20h -run='TestAccManagementLock_' ./internal/services/resource
=== RUN   TestAccManagementLock_resourceGroupReadOnlyBasic
=== PAUSE TestAccManagementLock_resourceGroupReadOnlyBasic
=== RUN   TestAccManagementLock_requiresImport
=== PAUSE TestAccManagementLock_requiresImport
=== RUN   TestAccManagementLock_resourceGroupReadOnlyComplete
=== PAUSE TestAccManagementLock_resourceGroupReadOnlyComplete
=== RUN   TestAccManagementLock_resourceGroupCanNotDeleteBasic
=== PAUSE TestAccManagementLock_resourceGroupCanNotDeleteBasic
=== RUN   TestAccManagementLock_resourceGroupCanNotDeleteComplete
=== PAUSE TestAccManagementLock_resourceGroupCanNotDeleteComplete
=== RUN   TestAccManagementLock_publicIPReadOnlyBasic
=== PAUSE TestAccManagementLock_publicIPReadOnlyBasic
=== RUN   TestAccManagementLock_publicIPCanNotDeleteBasic
=== PAUSE TestAccManagementLock_publicIPCanNotDeleteBasic
=== RUN   TestAccManagementLock_subscriptionReadOnlyBasic
    management_lock_resource_test.go:130: `TF_ACC_SUBSCRIPTION_PARALLEL_LOCK` isn't specified - skipping since this test can't be run in Parallel
--- SKIP: TestAccManagementLock_subscriptionReadOnlyBasic (0.00s)
=== RUN   TestAccManagementLock_subscriptionCanNotDeleteBasic
    management_lock_resource_test.go:150: `TF_ACC_SUBSCRIPTION_PARALLEL_LOCK` isn't specified - skipping since this test can't be run in Parallel
--- SKIP: TestAccManagementLock_subscriptionCanNotDeleteBasic (0.00s)
=== CONT  TestAccManagementLock_resourceGroupReadOnlyBasic
=== CONT  TestAccManagementLock_resourceGroupCanNotDeleteComplete
=== CONT  TestAccManagementLock_publicIPCanNotDeleteBasic
=== CONT  TestAccManagementLock_resourceGroupReadOnlyComplete
=== CONT  TestAccManagementLock_resourceGroupCanNotDeleteBasic
=== CONT  TestAccManagementLock_publicIPReadOnlyBasic
=== CONT  TestAccManagementLock_requiresImport
--- PASS: TestAccManagementLock_resourceGroupCanNotDeleteBasic (288.93s)
--- PASS: TestAccManagementLock_publicIPReadOnlyBasic (322.27s)
--- PASS: TestAccManagementLock_resourceGroupReadOnlyComplete (352.41s)
--- PASS: TestAccManagementLock_resourceGroupCanNotDeleteComplete (353.01s)
--- PASS: TestAccManagementLock_requiresImport (353.93s)
--- PASS: TestAccManagementLock_resourceGroupReadOnlyBasic (356.80s)
--- PASS: TestAccManagementLock_publicIPCanNotDeleteBasic (395.21s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/resource      395.238s
```