### PR TITLE
`azurerm_log_analytics_workspace`: support `data_collection_rule_id`

### DIFF
--- a/internal/services/loganalytics/log_analytics_workspace_resource.go
+++ b/internal/services/loganalytics/log_analytics_workspace_resource.go
@@ -453,7 +453,12 @@ func resourceLogAnalyticsWorkspaceRead(d *pluginsdk.ResourceData, meta interface
 
 			defaultDataCollectionRuleResourceId := ""
 			if props.DefaultDataCollectionRuleResourceId != nil {
-				defaultDataCollectionRuleResourceId = *props.DefaultDataCollectionRuleResourceId
+				dataCollectionId, err := datacollectionrules.ParseDataCollectionRuleID(*props.DefaultDataCollectionRuleResourceId)
+				if err != nil {
+					return fmt.Errorf("parsing %s: %+v", *props.DefaultDataCollectionRuleResourceId, err)
+				}
+
+				defaultDataCollectionRuleResourceId = dataCollectionId.ID()
 			}
 			d.Set("data_collection_rule_id", defaultDataCollectionRuleResourceId)
 

--- a/internal/services/loganalytics/log_analytics_workspace_resource.go
+++ b/internal/services/loganalytics/log_analytics_workspace_resource.go
@@ -455,7 +455,7 @@ func resourceLogAnalyticsWorkspaceRead(d *pluginsdk.ResourceData, meta interface
 			if props.DefaultDataCollectionRuleResourceId != nil {
 				dataCollectionId, err := datacollectionrules.ParseDataCollectionRuleID(*props.DefaultDataCollectionRuleResourceId)
 				if err != nil {
-					return fmt.Errorf("parsing %s: %+v", *props.DefaultDataCollectionRuleResourceId, err)
+					return err
 				}
 
 				defaultDataCollectionRuleResourceId = dataCollectionId.ID()

--- a/internal/services/loganalytics/log_analytics_workspace_resource.go
+++ b/internal/services/loganalytics/log_analytics_workspace_resource.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/insights/2022-06-01/datacollectionrules"
 	sharedKeyWorkspaces "github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/workspaces"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2022-10-01/workspaces"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/azure"
@@ -142,6 +143,12 @@ func resourceLogAnalyticsWorkspace() *pluginsdk.Resource {
 				Default:          -1.0,
 				DiffSuppressFunc: dailyQuotaGbDiffSuppressFunc,
 				ValidateFunc:     validation.FloatAtLeast(-1.0),
+			},
+
+			"default_data_collection_rule_id": {
+				Type:         pluginsdk.TypeString,
+				Optional:     true,
+				ValidateFunc: datacollectionrules.ValidateDataCollectionRuleID,
 			},
 
 			"workspace_id": {
@@ -311,6 +318,12 @@ func resourceLogAnalyticsWorkspaceCreateUpdate(d *pluginsdk.ResourceData, meta i
 		return err
 	}
 
+	// `default_data_collection_rule_id` also needs an additional update.
+	// error message: Default dcr is not applicable on workspace creation, please provide it on update.
+	if v, ok := d.GetOk("default_data_collection_rule_id"); ok {
+		parameters.Properties.DefaultDataCollectionRuleResourceId = pointer.To(v.(string))
+	}
+
 	// `allow_resource_only_permissions` needs an additional update, tacked on https://github.com/Azure/azure-rest-api-specs/issues/21591
 	err = client.CreateOrUpdateThenPoll(ctx, id, parameters)
 	if err != nil {
@@ -437,6 +450,12 @@ func resourceLogAnalyticsWorkspaceRead(d *pluginsdk.ResourceData, meta interface
 			}
 			d.Set("allow_resource_only_permissions", allowResourceOnlyPermissions)
 			d.Set("local_authentication_disabled", disableLocalAuth)
+
+			defaultDataCollectionRuleResourceId := ""
+			if props.DefaultDataCollectionRuleResourceId != nil {
+				defaultDataCollectionRuleResourceId = *props.DefaultDataCollectionRuleResourceId
+			}
+			d.Set("default_data_collection_rule_id", defaultDataCollectionRuleResourceId)
 
 			sharedKeyId := sharedKeyWorkspaces.WorkspaceId{
 				SubscriptionId:    id.SubscriptionId,

--- a/internal/services/loganalytics/log_analytics_workspace_resource.go
+++ b/internal/services/loganalytics/log_analytics_workspace_resource.go
@@ -145,7 +145,7 @@ func resourceLogAnalyticsWorkspace() *pluginsdk.Resource {
 				ValidateFunc:     validation.FloatAtLeast(-1.0),
 			},
 
-			"default_data_collection_rule_id": {
+			"data_collection_rule_id": {
 				Type:         pluginsdk.TypeString,
 				Optional:     true,
 				ValidateFunc: datacollectionrules.ValidateDataCollectionRuleID,
@@ -318,9 +318,9 @@ func resourceLogAnalyticsWorkspaceCreateUpdate(d *pluginsdk.ResourceData, meta i
 		return err
 	}
 
-	// `default_data_collection_rule_id` also needs an additional update.
+	// `data_collection_rule_id` also needs an additional update.
 	// error message: Default dcr is not applicable on workspace creation, please provide it on update.
-	if v, ok := d.GetOk("default_data_collection_rule_id"); ok {
+	if v, ok := d.GetOk("data_collection_rule_id"); ok {
 		parameters.Properties.DefaultDataCollectionRuleResourceId = pointer.To(v.(string))
 	}
 
@@ -455,7 +455,7 @@ func resourceLogAnalyticsWorkspaceRead(d *pluginsdk.ResourceData, meta interface
 			if props.DefaultDataCollectionRuleResourceId != nil {
 				defaultDataCollectionRuleResourceId = *props.DefaultDataCollectionRuleResourceId
 			}
-			d.Set("default_data_collection_rule_id", defaultDataCollectionRuleResourceId)
+			d.Set("data_collection_rule_id", defaultDataCollectionRuleResourceId)
 
 			sharedKeyId := sharedKeyWorkspaces.WorkspaceId{
 				SubscriptionId:    id.SubscriptionId,

--- a/internal/services/loganalytics/log_analytics_workspace_resource_test.go
+++ b/internal/services/loganalytics/log_analytics_workspace_resource_test.go
@@ -811,12 +811,12 @@ resource "azurerm_monitor_data_collection_rule" "test" {
 }
 
 resource "azurerm_log_analytics_workspace" "test" {
-  name                            = "acctestLAW-%[1]d"
-  location                        = azurerm_resource_group.test.location
-  resource_group_name             = azurerm_resource_group.test.name
-  sku                             = "PerGB2018"
-  retention_in_days               = 30
-  default_data_collection_rule_id = "%[3]s"
+  name                    = "acctestLAW-%[1]d"
+  location                = azurerm_resource_group.test.location
+  resource_group_name     = azurerm_resource_group.test.name
+  sku                     = "PerGB2018"
+  retention_in_days       = 30
+  data_collection_rule_id = "%[3]s"
 }
 `, data.RandomInteger, data.Locations.Primary, ruleID)
 }

--- a/internal/services/loganalytics/log_analytics_workspace_resource_test.go
+++ b/internal/services/loganalytics/log_analytics_workspace_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/go-azure-sdk/resource-manager/insights/2022-06-01/datacollectionrules"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/workspaces"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
@@ -348,6 +349,30 @@ func TestAccLogAnalyticsWorkspace_updateSku(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("reservation_capacity_in_gb_per_day").HasValue("100"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccLogAnalyticsWorkspace_withDefaultDataCollectionRule(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_log_analytics_workspace", "test")
+	r := LogAnalyticsWorkspaceResource{}
+
+	// the default data collection rule could only be set during update,
+	// and to avoid the dependency cycle, we do an additional update here.
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.withDataCollectionRule(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.withDefaultDataCollectionRule(data, datacollectionrules.NewDataCollectionRuleID(data.Subscriptions.Primary, fmt.Sprintf("acctestRG-%d", data.RandomInteger), fmt.Sprintf("acctestmdcr-%d", data.RandomInteger)).ID()),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
 			),
 		},
 		data.ImportStep(),
@@ -715,4 +740,83 @@ resource "azurerm_log_analytics_workspace" "test" {
   local_authentication_disabled = %[4]t
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger, disableLocalAuth)
+}
+
+func (LogAnalyticsWorkspaceResource) withDataCollectionRule(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%s"
+}
+
+resource "azurerm_monitor_data_collection_rule" "test" {
+  name                = "acctestmdcr-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  destinations {
+    log_analytics {
+      workspace_resource_id = azurerm_log_analytics_workspace.test.id
+      name                  = "test-destination"
+    }
+  }
+
+  data_flow {
+    streams      = ["Microsoft-InsightsMetrics"]
+    destinations = ["test-destination"]
+  }
+}
+
+resource "azurerm_log_analytics_workspace" "test" {
+  name                = "acctestLAW-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "PerGB2018"
+  retention_in_days   = 30
+}
+`, data.RandomInteger, data.Locations.Primary)
+}
+
+func (LogAnalyticsWorkspaceResource) withDefaultDataCollectionRule(data acceptance.TestData, ruleID string) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%[1]d"
+  location = "%s"
+}
+
+resource "azurerm_monitor_data_collection_rule" "test" {
+  name                = "acctestmdcr-%[1]d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  destinations {
+    log_analytics {
+      workspace_resource_id = azurerm_log_analytics_workspace.test.id
+      name                  = "test-destination"
+    }
+  }
+
+  data_flow {
+    streams      = ["Microsoft-InsightsMetrics"]
+    destinations = ["test-destination"]
+  }
+}
+
+resource "azurerm_log_analytics_workspace" "test" {
+  name                            = "acctestLAW-%[1]d"
+  location                        = azurerm_resource_group.test.location
+  resource_group_name             = azurerm_resource_group.test.name
+  sku                             = "PerGB2018"
+  retention_in_days               = 30
+  default_data_collection_rule_id = "%[3]s"
+}
+`, data.RandomInteger, data.Locations.Primary, ruleID)
 }

--- a/website/docs/r/log_analytics_workspace.html.markdown
+++ b/website/docs/r/log_analytics_workspace.html.markdown
@@ -65,7 +65,7 @@ The following arguments are supported:
 
 ~> **NOTE:** `reservation_capacity_in_gb_per_day` can only be used when the `sku` is set to `CapacityReservation`.
 
-* `default_data_collection_rule_id` - (Optional) The ID of the default Data Collection Rule to use for this workspace.
+* `data_collection_rule_id` - (Optional) The ID of the Data Collection Rule to use for this workspace.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 

--- a/website/docs/r/log_analytics_workspace.html.markdown
+++ b/website/docs/r/log_analytics_workspace.html.markdown
@@ -65,6 +65,8 @@ The following arguments are supported:
 
 ~> **NOTE:** `reservation_capacity_in_gb_per_day` can only be used when the `sku` is set to `CapacityReservation`.
 
+* `default_data_collection_rule_id` - (Optional) The ID of the default Data Collection Rule to use for this workspace.
+
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
 ~> **NOTE:** If a `azurerm_log_analytics_workspace` is connected to a `azurerm_log_analytics_cluster` via a `azurerm_log_analytics_linked_service` you will not be able to modify the workspaces `sku` field until the link between the workspace and the cluster has been broken by deleting the `azurerm_log_analytics_linked_service` resource. All other fields are modifiable while the workspace is linked to a cluster.


### PR DESCRIPTION
test
---
```
❯ tftest loganalytics TestAccLogAnalyticsWorkspace                              
=== RUN   TestAccLogAnalyticsWorkspace_basic
=== PAUSE TestAccLogAnalyticsWorkspace_basic
=== RUN   TestAccLogAnalyticsWorkspace_requiresImport
=== PAUSE TestAccLogAnalyticsWorkspace_requiresImport
=== RUN   TestAccLogAnalyticsWorkspace_complete
=== PAUSE TestAccLogAnalyticsWorkspace_complete
=== RUN   TestAccLogAnalyticsWorkspace_freeTier
    log_analytics_workspace_resource_test.go:96: `TestAccLogAnalyticsWorkspace_freeTier` due to subscription pricing tier configuration (e.g. Pricing tier doesn't match the subscription's billing model.)
--- SKIP: TestAccLogAnalyticsWorkspace_freeTier (0.00s)
=== RUN   TestAccLogAnalyticsWorkspace_withDefaultSku
=== PAUSE TestAccLogAnalyticsWorkspace_withDefaultSku
=== RUN   TestAccLogAnalyticsWorkspace_withVolumeCap
=== PAUSE TestAccLogAnalyticsWorkspace_withVolumeCap
=== RUN   TestAccLogAnalyticsWorkspace_removeVolumeCap
=== PAUSE TestAccLogAnalyticsWorkspace_removeVolumeCap
=== RUN   TestAccLogAnalyticsWorkspace_withInternetIngestionEnabled
=== PAUSE TestAccLogAnalyticsWorkspace_withInternetIngestionEnabled
=== RUN   TestAccLogAnalyticsWorkspace_withInternetQueryEnabled
=== PAUSE TestAccLogAnalyticsWorkspace_withInternetQueryEnabled
=== RUN   TestAccLogAnalyticsWorkspace_withCapacityReservation
=== PAUSE TestAccLogAnalyticsWorkspace_withCapacityReservation
=== RUN   TestAccLogAnalyticsWorkspace_negativeOne
=== PAUSE TestAccLogAnalyticsWorkspace_negativeOne
=== RUN   TestAccLogAnalyticsWorkspace_cmkForQueryForced
=== PAUSE TestAccLogAnalyticsWorkspace_cmkForQueryForced
=== RUN   TestAccLogAnalyticsWorkspace_ToggleAllowOnlyResourcePermission
=== PAUSE TestAccLogAnalyticsWorkspace_ToggleAllowOnlyResourcePermission
=== RUN   TestAccLogAnalyticsWorkspace_ToggleDisableLocalAuth
=== PAUSE TestAccLogAnalyticsWorkspace_ToggleDisableLocalAuth
=== RUN   TestAccLogAnalyticsWorkspace_updateSku
=== PAUSE TestAccLogAnalyticsWorkspace_updateSku
=== RUN   TestAccLogAnalyticsWorkspace_withDefaultDataCollectionRule
=== PAUSE TestAccLogAnalyticsWorkspace_withDefaultDataCollectionRule
=== CONT  TestAccLogAnalyticsWorkspace_basic
=== CONT  TestAccLogAnalyticsWorkspace_withCapacityReservation
=== CONT  TestAccLogAnalyticsWorkspace_ToggleDisableLocalAuth
=== CONT  TestAccLogAnalyticsWorkspace_withVolumeCap
=== CONT  TestAccLogAnalyticsWorkspace_withInternetQueryEnabled
=== CONT  TestAccLogAnalyticsWorkspace_cmkForQueryForced
=== CONT  TestAccLogAnalyticsWorkspace_complete
=== CONT  TestAccLogAnalyticsWorkspace_withDefaultDataCollectionRule
--- PASS: TestAccLogAnalyticsWorkspace_basic (160.71s)
=== CONT  TestAccLogAnalyticsWorkspace_withDefaultSku
--- PASS: TestAccLogAnalyticsWorkspace_complete (172.69s)
=== CONT  TestAccLogAnalyticsWorkspace_negativeOne
--- PASS: TestAccLogAnalyticsWorkspace_withVolumeCap (202.16s)
=== CONT  TestAccLogAnalyticsWorkspace_updateSku
--- PASS: TestAccLogAnalyticsWorkspace_withCapacityReservation (220.42s)
=== CONT  TestAccLogAnalyticsWorkspace_requiresImport
--- PASS: TestAccLogAnalyticsWorkspace_cmkForQueryForced (235.00s)
=== CONT  TestAccLogAnalyticsWorkspace_ToggleAllowOnlyResourcePermission
--- PASS: TestAccLogAnalyticsWorkspace_withInternetQueryEnabled (244.63s)
=== CONT  TestAccLogAnalyticsWorkspace_withInternetIngestionEnabled
--- PASS: TestAccLogAnalyticsWorkspace_ToggleDisableLocalAuth (251.34s)
=== CONT  TestAccLogAnalyticsWorkspace_removeVolumeCap
--- PASS: TestAccLogAnalyticsWorkspace_withDefaultDataCollectionRule (272.18s)
--- PASS: TestAccLogAnalyticsWorkspace_negativeOne (155.94s)
--- PASS: TestAccLogAnalyticsWorkspace_withDefaultSku (179.47s)
--- PASS: TestAccLogAnalyticsWorkspace_requiresImport (156.11s)
--- PASS: TestAccLogAnalyticsWorkspace_removeVolumeCap (148.63s)
--- PASS: TestAccLogAnalyticsWorkspace_updateSku (205.75s)
--- PASS: TestAccLogAnalyticsWorkspace_withInternetIngestionEnabled (191.49s)
--- PASS: TestAccLogAnalyticsWorkspace_ToggleAllowOnlyResourcePermission (233.25s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/loganalytics  468.326s


```