### PR TITLE
Docs: Clarify meaning of `external_enabled = true` for azurerm_container_app ingress

### DIFF
--- a/website/docs/r/container_app.html.markdown
+++ b/website/docs/r/container_app.html.markdown
@@ -335,7 +335,7 @@ An `ingress` block supports the following:
 
 * `fqdn` -  The FQDN of the ingress.
 
-* `external_enabled` - (Optional) Is this an external Ingress.
+* `external_enabled` - (Optional) Is this an external Ingress? If `internalOnly` is true in the Container Apps Environment, external ingress is limited to the VNet.
 
 * `target_port` - (Required) The target port on the container for the Ingress traffic.
 

--- a/website/docs/r/container_app.html.markdown
+++ b/website/docs/r/container_app.html.markdown
@@ -335,7 +335,7 @@ An `ingress` block supports the following:
 
 * `fqdn` -  The FQDN of the ingress.
 
-* `external_enabled` - (Optional) Is this an external Ingress? If `internalOnly` is true in the Container Apps Environment, external ingress is limited to the VNet.
+* `external_enabled` - (Optional) Are connections to this Ingress from outside the Container App Environment enabled? Defaults to `false`.
 
 * `target_port` - (Required) The target port on the container for the Ingress traffic.
 


### PR DESCRIPTION
I've added a little clarifying note on the documentation of `external_enabled` on an ACA ingress to make clear that external ingress does not always mean public, and can sometimes mean external to the container app environment. The new wording broadly reflects what's in the Azure portal for this setting.

In my team we found the current documentation here a little too ambiguous so I thought I'd suggest a quick change myself.