### PR TITLE
`azurerm_windows_web_app` : fix the issue of incorrect application stack setting after updating the web app without changing the `application_stack` configuration

### DIFF
--- a/internal/services/appservice/helpers/windows_web_app_schema.go
+++ b/internal/services/appservice/helpers/windows_web_app_schema.go
@@ -617,34 +617,46 @@ func (s *SiteConfigWindows) ExpandForUpdate(metadata sdk.ResourceMetaData, exist
 	if metadata.ResourceData.HasChange("site_config.0.application_stack") {
 		if len(s.ApplicationStack) == 1 {
 			winAppStack := s.ApplicationStack[0]
-			if winAppStack.NetFrameworkVersion != "" {
-				expanded.NetFrameworkVersion = pointer.To(winAppStack.NetFrameworkVersion)
+			if metadata.ResourceData.HasChanges("site_config.0.application_stack.0.dotnet_version", "site_config.0.application_stack.0.dotnet_core_version") {
+				switch {
+				case winAppStack.NetFrameworkVersion != "":
+					expanded.NetFrameworkVersion = pointer.To(winAppStack.NetFrameworkVersion)
+				case winAppStack.NetCoreVersion != "":
+					expanded.NetFrameworkVersion = pointer.To(winAppStack.NetCoreVersion)
+				default:
+					expanded.NetFrameworkVersion = nil
+				}
 			}
-			if winAppStack.NetCoreVersion != "" {
-				expanded.NetFrameworkVersion = pointer.To(winAppStack.NetCoreVersion)
-			}
-			if winAppStack.PhpVersion != "" {
-				if winAppStack.PhpVersion != PhpVersionOff {
-					expanded.PhpVersion = pointer.To(winAppStack.PhpVersion)
-				} else {
-					expanded.PhpVersion = pointer.To("")
+			if metadata.ResourceData.HasChange("site_config.0.application_stack.0.php_version") {
+				if winAppStack.PhpVersion != "" {
+					if winAppStack.PhpVersion != PhpVersionOff {
+						expanded.PhpVersion = pointer.To(winAppStack.PhpVersion)
+					} else {
+						expanded.PhpVersion = pointer.To("")
+					}
 				}
 			}
 			if winAppStack.PythonVersion != "" || winAppStack.Python {
 				expanded.PythonVersion = pointer.To(winAppStack.PythonVersion)
 			}
-			if winAppStack.JavaVersion != "" {
-				expanded.JavaVersion = pointer.To(winAppStack.JavaVersion)
-				switch {
-				case winAppStack.JavaEmbeddedServer:
-					expanded.JavaContainer = pointer.To(JavaContainerEmbeddedServer)
-					expanded.JavaContainerVersion = pointer.To(JavaContainerEmbeddedServerVersion)
-				case winAppStack.TomcatVersion != "":
-					expanded.JavaContainer = pointer.To(JavaContainerTomcat)
-					expanded.JavaContainerVersion = pointer.To(winAppStack.TomcatVersion)
-				case winAppStack.JavaContainer != "":
-					expanded.JavaContainer = pointer.To(winAppStack.JavaContainer)
-					expanded.JavaContainerVersion = pointer.To(winAppStack.JavaContainerVersion)
+			if metadata.ResourceData.HasChange("site_config.0.application_stack.0.java_version") {
+				if winAppStack.JavaVersion != "" {
+					expanded.JavaVersion = pointer.To(winAppStack.JavaVersion)
+					switch {
+					case winAppStack.JavaEmbeddedServer:
+						expanded.JavaContainer = pointer.To(JavaContainerEmbeddedServer)
+						expanded.JavaContainerVersion = pointer.To(JavaContainerEmbeddedServerVersion)
+					case winAppStack.TomcatVersion != "":
+						expanded.JavaContainer = pointer.To(JavaContainerTomcat)
+						expanded.JavaContainerVersion = pointer.To(winAppStack.TomcatVersion)
+					case winAppStack.JavaContainer != "":
+						expanded.JavaContainer = pointer.To(winAppStack.JavaContainer)
+						expanded.JavaContainerVersion = pointer.To(winAppStack.JavaContainerVersion)
+					}
+				} else {
+					expanded.JavaVersion = nil
+					expanded.JavaContainer = nil
+					expanded.JavaContainerVersion = nil
 				}
 			}
 			if !features.FourPointOhBeta() {
@@ -807,10 +819,10 @@ func (s *SiteConfigWindows) Flatten(appSiteConfig *web.SiteConfig, currentStack 
 	var winAppStack ApplicationStackWindows
 	if currentStack == CurrentStackDotNetCore {
 		winAppStack.NetCoreVersion = pointer.From(appSiteConfig.NetFrameworkVersion)
-	}
-	if currentStack == CurrentStackDotNet {
+	} else {
 		winAppStack.NetFrameworkVersion = pointer.From(appSiteConfig.NetFrameworkVersion)
 	}
+
 	winAppStack.PhpVersion = pointer.From(appSiteConfig.PhpVersion)
 	if winAppStack.PhpVersion == "" {
 		winAppStack.PhpVersion = PhpVersionOff
@@ -824,9 +836,11 @@ func (s *SiteConfigWindows) Flatten(appSiteConfig *web.SiteConfig, currentStack 
 	}
 	switch pointer.From(appSiteConfig.JavaContainer) {
 	case JavaContainerTomcat:
-		winAppStack.TomcatVersion = *appSiteConfig.JavaContainerVersion
+		winAppStack.TomcatVersion = pointer.From(appSiteConfig.JavaContainerVersion)
+		winAppStack.JavaVersion = pointer.From(appSiteConfig.JavaVersion)
 	case JavaContainerEmbeddedServer:
 		winAppStack.JavaEmbeddedServer = true
+		winAppStack.JavaVersion = pointer.From(appSiteConfig.JavaVersion)
 	}
 
 	s.WindowsFxVersion = pointer.From(appSiteConfig.WindowsFxVersion)

--- a/internal/services/appservice/helpers/windows_web_app_schema.go
+++ b/internal/services/appservice/helpers/windows_web_app_schema.go
@@ -817,7 +817,11 @@ func (s *SiteConfigWindows) Flatten(appSiteConfig *web.SiteConfig, currentStack 
 	}
 	winAppStack.PythonVersion = pointer.From(appSiteConfig.PythonVersion) // This _should_ always be `""`
 	winAppStack.Python = currentStack == CurrentStackPython
-	winAppStack.JavaVersion = pointer.From(appSiteConfig.JavaVersion)
+
+	// we should only set JavaVersion when  currentStack is java since the API will return the JavaVersion that was once set
+	if currentStack == "java" {
+		winAppStack.JavaVersion = pointer.From(appSiteConfig.JavaVersion)
+	}
 	switch pointer.From(appSiteConfig.JavaContainer) {
 	case JavaContainerTomcat:
 		winAppStack.TomcatVersion = *appSiteConfig.JavaContainerVersion

--- a/internal/services/appservice/helpers/windows_web_app_schema.go
+++ b/internal/services/appservice/helpers/windows_web_app_schema.go
@@ -818,7 +818,7 @@ func (s *SiteConfigWindows) Flatten(appSiteConfig *web.SiteConfig, currentStack 
 	winAppStack.PythonVersion = pointer.From(appSiteConfig.PythonVersion) // This _should_ always be `""`
 	winAppStack.Python = currentStack == CurrentStackPython
 
-	// we should only set JavaVersion when  currentStack is java since the API will return the JavaVersion that was once set
+	// we should only set JavaVersion when  currentStack is java since the API will return the value of JavaVersion that was once set
 	if currentStack == "java" {
 		winAppStack.JavaVersion = pointer.From(appSiteConfig.JavaVersion)
 	}

--- a/internal/services/appservice/windows_web_app_resource.go
+++ b/internal/services/appservice/windows_web_app_resource.go
@@ -788,6 +788,13 @@ func (r WindowsWebAppResource) Update() sdk.ResourceFunc {
 				return fmt.Errorf("reading Windows %s: %v", id, err)
 			}
 
+			// Despite being part of the defined `Get` response model, site_config is always nil so we get it explicitly
+			webAppSiteConfig, err := client.GetConfiguration(ctx, id.ResourceGroup, id.SiteName)
+			if err != nil {
+				return fmt.Errorf("reading Site Config for Windows %s: %+v", id, err)
+			}
+			existing.SiteConfig = webAppSiteConfig.SiteConfig
+
 			var serviceFarmId string
 			servicePlanChange := false
 			if existing.SiteProperties.ServerFarmID != nil {

--- a/internal/services/appservice/windows_web_app_resource_test.go
+++ b/internal/services/appservice/windows_web_app_resource_test.go
@@ -2645,18 +2645,17 @@ resource "azurerm_windows_web_app" "test" {
 
   site_config {
     application_stack {
-      dotnet_version         = "%s"
-      php_version            = "%s"
-      python                 = "%t"
-      java_version           = "%s"
-      java_container         = "%s"
-      java_container_version = "%s"
+      dotnet_version = "%s"
+      php_version    = "%s"
+      python         = "%t"
+      java_version   = "%s"
+      tomcat_version = "%s"
 
       current_stack = "python"
     }
   }
 }
-`, r.baseTemplate(data), data.RandomInteger, "v4.0", "7.4", true, "1.8", "TOMCAT", "9.0")
+`, r.baseTemplate(data), data.RandomInteger, "v4.0", "7.4", true, "1.8", "9.0")
 }
 
 func (r WindowsWebAppResource) withLogsHttpBlob(data acceptance.TestData) string {

--- a/internal/services/appservice/windows_web_app_resource_test.go
+++ b/internal/services/appservice/windows_web_app_resource_test.go
@@ -1020,6 +1020,13 @@ func TestAccWindowsWebApp_updateAppStack(t *testing.T) {
 		},
 		data.ImportStep(),
 		{
+			Config: r.healthCheckUpdate(data, "11"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
 			Config: r.dotNet(data, "v5.0"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
@@ -2563,6 +2570,34 @@ resource "azurerm_windows_web_app" "test" {
       current_stack                = "java"
       java_version                 = "%s"
       java_embedded_server_enabled = "true"
+    }
+  }
+}
+`, r.baseTemplate(data), data.RandomInteger, javaVersion)
+}
+
+//nolint:unparam
+func (r WindowsWebAppResource) healthCheckUpdate(data acceptance.TestData, javaVersion string) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+
+resource "azurerm_windows_web_app" "test" {
+  name                = "acctestWA-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  service_plan_id     = azurerm_service_plan.test.id
+
+  site_config {
+    health_check_path                 = "/health"
+    health_check_eviction_time_in_min = 5
+    application_stack {
+      current_stack                   = "java"
+      java_version                    = "%s"
+      java_embedded_server_enabled    = "true"
     }
   }
 }

--- a/internal/services/appservice/windows_web_app_resource_test.go
+++ b/internal/services/appservice/windows_web_app_resource_test.go
@@ -2595,9 +2595,9 @@ resource "azurerm_windows_web_app" "test" {
     health_check_path                 = "/health"
     health_check_eviction_time_in_min = 5
     application_stack {
-      current_stack                   = "java"
-      java_version                    = "%s"
-      java_embedded_server_enabled    = "true"
+      current_stack                = "java"
+      java_version                 = "%s"
+      java_embedded_server_enabled = "true"
     }
   }
 }

--- a/website/docs/r/windows_web_app.html.markdown
+++ b/website/docs/r/windows_web_app.html.markdown
@@ -150,6 +150,8 @@ An `application_stack` block supports the following:
 
 ~> **NOTE:** Whilst this property is Optional omitting it can cause unexpected behaviour, in particular for display of settings in the Azure Portal.
 
+~> **NOTE:** Windows Web apps can configure multiple `app_stack` properties, it is recommended to always configure this `Optional` value and set it to the primary application stack of your app to ensure correct operation of this resource and display the correct metadata in the Azure Portal.
+
 * `docker_image_name` - (Optional) The docker image, including tag, to be used. e.g. `azure-app-service/windows/parkingpage:latest`.
 
 * `docker_registry_url` - (Optional) The URL of the container registry where the `docker_image_name` is located. e.g. `https://index.docker.io` or `https://mcr.microsoft.com`. This value is required with `docker_image_name`.


### PR DESCRIPTION
Two purposes of this PR:

- Application stack is incorrectly updated

 Symptom: 

> 1. Creating `azurerm_windows_web_app` with `site_config` as shown below.
> 
>   ```
> site_config {
> 	health_check_path           = "/health"
> 	load_balancing_mode="LeastRequests"
>     application_stack {
>         current_stack                = "java"
> 	    java_embedded_server_enabled = true
>         java_version                 = "11"
>       } 
> }
> ```
> 2. Update `azurerm_windows_web_app` and only change `health_check_eviction_time_in_min ` from null to 5 as follows.
>  
> ```
> site_config {
>         health_check_eviction_time_in_min = 5
> 	health_check_path           = "/health"
> 	load_balancing_mode="LeastRequests"
>         application_stack {
>            current_stack                = "java"
> 	    java_embedded_server_enabled = true
>             java_version                 = "11"
>         }
> }
> ```
> 
> Actual:
> <img width="392" alt="image" src="https://github.com/hashicorp/terraform-provider-azurerm/assets/39109137/b7ae270c-3200-437c-b124-dcefeef2da17">
> Expected:
> <img width="386" alt="image" src="https://github.com/hashicorp/terraform-provider-azurerm/assets/39109137/939fb0d4-fe19-4db0-8db8-c2353966136e">
> 
> Per the following code in the [existing](https://github.com/hashicorp/terraform-provider-azurerm/blob/6f8b827b654f0145d7f9f39b57b8784abb2b5df5/internal/services/appservice/windows_web_app_resource.go#L511C4-L511C4) in Read(), I assume this should also be added to Update() function to solve the above issue.
> 
> ```
> // Despite being part of the defined `Get` response model, site_config is always nil so we get it explicitly
> webAppSiteConfig, err := client.GetConfiguration(ctx, id.ResourceGroup, id.SiteName)
> if err != nil {
>    return fmt.Errorf("reading Site Config for Windows %s: %+v", id, err)
> }
> ```

- I assume that we should only set `JavaVersion` in Read() function when `currentStack` is `java`  since the API will return the value of `JavaVersion` that was once set.

Test result:
PASS: TestAccWindowsWebApp_updateAppStack (611.57s)