### PR TITLE
`azurerm_{linux|windows}_virtual_machine` and `azurerm_managed_disk` - Make the managed Disk creation/deletion in parity with ARM cache

### DIFF
--- a/internal/services/compute/linux_virtual_machine_resource.go
+++ b/internal/services/compute/linux_virtual_machine_resource.go
@@ -762,7 +762,7 @@ func resourceLinuxVirtualMachineCreate(d *pluginsdk.ResourceData, meta interface
 	if diskName == nil {
 		return fmt.Errorf("retrieving Linux %s: `properties.storageProfile.osDisk.name` was nil", id)
 	}
-	if err := waitForVmOsDiskArmCache(
+	if err := waitForManagedDiskArmCache(
 		ctx,
 		meta.(*clients.Client).Resource.ResourcesClient,
 		disks.NewDiskID(id.SubscriptionId, id.ResourceGroupName, *diskName),
@@ -1690,7 +1690,7 @@ func resourceLinuxVirtualMachineDelete(d *pluginsdk.ResourceData, meta interface
 
 			// Post delete polling to ensure the ARM cache of OS disk is in parity with the client's view.
 			// This is to avoid client/RP deleted the OS disk, while ARM cache hasn't reflected that.
-			if err := waitForVmOsDiskArmCache(ctx, meta.(*clients.Client).Resource.ResourcesClient, *diskId, false); err != nil {
+			if err := waitForManagedDiskArmCache(ctx, meta.(*clients.Client).Resource.ResourcesClient, *diskId, false); err != nil {
 				return err
 			}
 

--- a/internal/services/compute/linux_virtual_machine_resource.go
+++ b/internal/services/compute/linux_virtual_machine_resource.go
@@ -742,32 +742,35 @@ func resourceLinuxVirtualMachineCreate(d *pluginsdk.ResourceData, meta interface
 
 	// Post creation polling to ensure the ARM cache of OS disk is in parity with the client's view.
 	// This is to avoid client/RP created the OS disk, while ARM cache hasn't reflected that.
-	resp, err = client.Get(ctx, id.ResourceGroupName, id.VirtualMachineName, compute.InstanceViewTypesUserData)
-	if err != nil {
-		return fmt.Errorf("retrieving Linux %s: %+v", id, err)
-	}
-	if resp.VirtualMachineProperties == nil {
-		return fmt.Errorf("retrieving Linux %s: `properties` was nil", id)
-	}
-	props := *resp.VirtualMachineProperties
-	profile := props.StorageProfile
-	if profile == nil {
-		return fmt.Errorf("retrieving Linux %s: `properties.storageProfile` was nil", id)
-	}
-	osDisk = profile.OsDisk
-	if osDisk == nil {
-		return fmt.Errorf("retrieving Linux %s: `properties.storageProfile.osDisk` was nil", id)
-	}
-	diskName := osDisk.Name
-	if diskName == nil {
-		return fmt.Errorf("retrieving Linux %s: `properties.storageProfile.osDisk.name` was nil", id)
-	}
-	if err := waitForManagedDiskArmCache(
-		ctx,
-		meta.(*clients.Client).Resource.ResourcesClient,
-		disks.NewDiskID(id.SubscriptionId, id.ResourceGroupName, *diskName),
-		true); err != nil {
-		return err
+	// This only applies to non-ephemeral OS disk.
+	if _, ok := d.GetOk("os_disk.0.diff_disk_settings"); !ok {
+		resp, err = client.Get(ctx, id.ResourceGroupName, id.VirtualMachineName, compute.InstanceViewTypesUserData)
+		if err != nil {
+			return fmt.Errorf("retrieving Linux %s: %+v", id, err)
+		}
+		if resp.VirtualMachineProperties == nil {
+			return fmt.Errorf("retrieving Linux %s: `properties` was nil", id)
+		}
+		props := *resp.VirtualMachineProperties
+		profile := props.StorageProfile
+		if profile == nil {
+			return fmt.Errorf("retrieving Linux %s: `properties.storageProfile` was nil", id)
+		}
+		osDisk = profile.OsDisk
+		if osDisk == nil {
+			return fmt.Errorf("retrieving Linux %s: `properties.storageProfile.osDisk` was nil", id)
+		}
+		diskName := osDisk.Name
+		if diskName == nil {
+			return fmt.Errorf("retrieving Linux %s: `properties.storageProfile.osDisk.name` was nil", id)
+		}
+		if err := waitForManagedDiskArmCache(
+			ctx,
+			meta.(*clients.Client).Resource.ResourcesClient,
+			disks.NewDiskID(id.SubscriptionId, id.ResourceGroupName, *diskName),
+			true); err != nil {
+			return err
+		}
 	}
 
 	d.SetId(id.ID())
@@ -1690,8 +1693,11 @@ func resourceLinuxVirtualMachineDelete(d *pluginsdk.ResourceData, meta interface
 
 			// Post delete polling to ensure the ARM cache of OS disk is in parity with the client's view.
 			// This is to avoid client/RP deleted the OS disk, while ARM cache hasn't reflected that.
-			if err := waitForManagedDiskArmCache(ctx, meta.(*clients.Client).Resource.ResourcesClient, *diskId, false); err != nil {
-				return err
+			// This only applies to non-ephemeral OS disk.
+			if _, ok := d.GetOk("os_disk.0.diff_disk_settings"); !ok {
+				if err := waitForManagedDiskArmCache(ctx, meta.(*clients.Client).Resource.ResourcesClient, *diskId, false); err != nil {
+					return err
+				}
 			}
 
 			log.Printf("[DEBUG] Deleted %s for Linux %s", diskId, id)

--- a/internal/services/compute/managed_disk_wait_arm_cache.go
+++ b/internal/services/compute/managed_disk_wait_arm_cache.go
@@ -10,7 +10,9 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 )
 
-func waitForVmOsDiskArmCache(ctx context.Context, client *resources.Client, diskId disks.DiskId, shouldExist bool) error {
+// waitForManagedDiskArmCache repeatedly calls the resource group level list API to query the ARM cache for the specified managed disk,
+// until it (dis)appear in the ARM cache, based on "shouldExist".
+func waitForManagedDiskArmCache(ctx context.Context, client *resources.Client, diskId disks.DiskId, shouldExist bool) error {
 	deadline, ok := ctx.Deadline()
 	if !ok {
 		return fmt.Errorf("context was missing a deadline")
@@ -38,7 +40,6 @@ func waitForVmOsDiskArmCache(ctx context.Context, client *resources.Client, disk
 				}
 			}
 		},
-		MinTimeout:                10 * time.Second,
 		ContinuousTargetOccurence: 5,
 		PollInterval:              5 * time.Second,
 		Timeout:                   time.Until(deadline),

--- a/internal/services/compute/virtual_machine_os_disk_wait.go
+++ b/internal/services/compute/virtual_machine_os_disk_wait.go
@@ -1,0 +1,52 @@
+package compute
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2020-06-01/resources" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2023-04-02/disks"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+)
+
+func waitForVmOsDiskArmCache(ctx context.Context, client *resources.Client, diskId disks.DiskId, shouldExist bool) error {
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return fmt.Errorf("context was missing a deadline")
+	}
+	stateConf := &pluginsdk.StateChangeConf{
+		Pending: []string{"Pending"},
+		Target:  []string{"Done"},
+		Refresh: func() (interface{}, string, error) {
+			filter := fmt.Sprintf("name eq '%s' and resourceType eq 'Microsoft.Compute/disks'", diskId.DiskName)
+			resp, err := client.ListByResourceGroup(ctx, diskId.ResourceGroupName, filter, "", nil)
+			if err != nil {
+				return nil, "", fmt.Errorf("polling for %s within the resource group: %+v", diskId, err)
+			}
+			if shouldExist {
+				if len(resp.Values()) == 0 {
+					return resp, "Pending", nil
+				} else {
+					return resp, "Done", nil
+				}
+			} else {
+				if len(resp.Values()) == 0 {
+					return resp, "Done", nil
+				} else {
+					return resp, "Pending", nil
+				}
+			}
+		},
+		MinTimeout:                10 * time.Second,
+		ContinuousTargetOccurence: 5,
+		PollInterval:              5 * time.Second,
+		Timeout:                   time.Until(deadline),
+	}
+
+	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/services/compute/windows_virtual_machine_resource.go
+++ b/internal/services/compute/windows_virtual_machine_resource.go
@@ -806,7 +806,7 @@ func resourceWindowsVirtualMachineCreate(d *pluginsdk.ResourceData, meta interfa
 	if diskName == nil {
 		return fmt.Errorf("retrieving Windows %s: `properties.storageProfile.osDisk.name` was nil", id)
 	}
-	if err := waitForVmOsDiskArmCache(
+	if err := waitForManagedDiskArmCache(
 		ctx,
 		meta.(*clients.Client).Resource.ResourcesClient,
 		disks.NewDiskID(id.SubscriptionId, id.ResourceGroupName, *diskName),
@@ -1759,7 +1759,7 @@ func resourceWindowsVirtualMachineDelete(d *pluginsdk.ResourceData, meta interfa
 
 			// Post delete polling to ensure the ARM cache of OS disk is in parity with the client's view.
 			// This is to avoid client/RP deleted the OS disk, while ARM cache hasn't reflected that.
-			if err := waitForVmOsDiskArmCache(ctx, meta.(*clients.Client).Resource.ResourcesClient, *diskId, false); err != nil {
+			if err := waitForManagedDiskArmCache(ctx, meta.(*clients.Client).Resource.ResourcesClient, *diskId, false); err != nil {
 				return err
 			}
 


### PR DESCRIPTION
This PR is trying to solve the exact same issue as #8383, by inspecting on the RG list API (which surfaces the ARM cache) to query the specified managed disk, instead of polling the VM itself as is done in #8383. Both OS disk (managed by the VM) and the data disk are involved.