### PR TITLE
Doc Fix: Update pim_eligible_role_assignment.html.markdown by removing `principal_type` as required argument.

### DIFF
--- a/website/docs/r/pim_eligible_role_assignment.html.markdown
+++ b/website/docs/r/pim_eligible_role_assignment.html.markdown
@@ -86,8 +86,6 @@ The following arguments are supported:
 
 * `principal_id` - (Required) The principal id. Changing this forces a new Pim Eligible Role Assignment to be created.
 
-* `principal_type` - (Required) The type of principal. Changing this forces a new Pim Eligible Role Assignment to be created.
-
 * `role_definition_id` - (Required) The role definition id. Changing this forces a new Pim Eligible Role Assignment to be created.
 
 * `scope` - (Required) The scope. Changing this forces a new Pim Eligible Role Assignment to be created.


### PR DESCRIPTION
This property is not `required` (anymore). It gets decided automatically.

```
➜ terraform plan 
╷
│ Error: Value for unconfigurable attribute
│ 
│   with azurerm_pim_eligible_role_assignment.mgmt_group_owner_group,
│   on enterprise-maintainers.tf line 93, in resource "azurerm_pim_eligible_role_assignment" "mgmt_group_owner_group":
│   93:   principal_type     = "Group"
│ 
│ Can't configure a value for "principal_type": its value will be decided automatically based on the result of applying this
│ configuration.
```

```
➜ terraform version
Terraform v1.4.2
on linux_amd64
+ provider registry.terraform.io/hashicorp/azuread v2.41.0
+ provider registry.terraform.io/hashicorp/azurerm v3.68.0
+ provider registry.terraform.io/hashicorp/time v0.9.1

Your version of Terraform is out of date! The latest version
is 1.5.7. You can update by downloading from https://www.terraform.io/downloads.html
```