### PR TITLE
fix nil panic when `SecurityProfile` is nil

### DIFF
--- a/internal/services/containers/kubernetes_cluster_resource.go
+++ b/internal/services/containers/kubernetes_cluster_resource.go
@@ -2616,6 +2616,9 @@ func resourceKubernetesClusterRead(d *pluginsdk.ResourceData, meta interface{}) 
 				d.Set("node_os_channel_upgrade", nodeOSUpgradeChannel)
 			}
 
+			if props.SecurityProfile == nil {
+				props.SecurityProfile = &managedclusters.ManagedClusterSecurityProfile{}
+			}
 			customCaTrustCertList := flattenCustomCaTrustCerts(props.SecurityProfile.CustomCATrustCertificates)
 			d.Set("custom_ca_trust_certificates_base64", customCaTrustCertList)
 


### PR DESCRIPTION
As not all clusters have property `SecurityProfile`, when `SecurityProfile` is nil, it will panic with nil pointer.