### PR TITLE
`azurerm_linux_virtual_machine`,`azurerm_windows_virtual_machine` - Support `automatic_upgrade_enabled`,`disk_controller_type`,`os_image_notification`,`treat_failure_as_deployment_failure_enabled` and `vm_agent_platform_updates_enabled`

### DIFF
--- a/internal/services/compute/linux_virtual_machine_resource_disk_os_test.go
+++ b/internal/services/compute/linux_virtual_machine_resource_disk_os_test.go
@@ -931,11 +931,11 @@ func (r LinuxVirtualMachineResource) diskOSControllerTypeSCSI(data acceptance.Te
 %s
 
 resource "azurerm_linux_virtual_machine" "test" {
-  name                = "acctestVM-%d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-  size                = "Standard_B1s"
-  admin_username      = "adminuser"
+  name                 = "acctestVM-%d"
+  resource_group_name  = azurerm_resource_group.test.name
+  location             = azurerm_resource_group.test.location
+  size                 = "Standard_B1s"
+  admin_username       = "adminuser"
   disk_controller_type = "SCSI"
 
   network_interface_ids = [
@@ -954,8 +954,8 @@ resource "azurerm_linux_virtual_machine" "test" {
 
   source_image_reference {
     publisher = "Canonical"
-    offer     = "0001-com-ubuntu-server-focal"
-    sku       = "20_04-lts-gen2"
+    offer     = "0001-com-ubuntu-server-jammy"
+    sku       = "22_04-lts-gen2"
     version   = "latest"
   }
 }
@@ -967,11 +967,11 @@ func (r LinuxVirtualMachineResource) diskOSControllerTypeNVMe(data acceptance.Te
 %s
 
 resource "azurerm_linux_virtual_machine" "test" {
-  name                = "acctestVM-%d"
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-  size                = "Standard_E2bds_v5"
-  admin_username      = "adminuser"
+  name                 = "acctestVM-%d"
+  resource_group_name  = azurerm_resource_group.test.name
+  location             = azurerm_resource_group.test.location
+  size                 = "Standard_E2bds_v5"
+  admin_username       = "adminuser"
   disk_controller_type = "NVMe"
 
   network_interface_ids = [
@@ -990,8 +990,8 @@ resource "azurerm_linux_virtual_machine" "test" {
 
   source_image_reference {
     publisher = "Canonical"
-    offer     = "0001-com-ubuntu-server-focal"
-    sku       = "20_04-lts-gen2"
+    offer     = "0001-com-ubuntu-server-jammy"
+    sku       = "22_04-lts-gen2"
     version   = "latest"
   }
 }

--- a/internal/services/compute/linux_virtual_machine_resource_disk_os_test.go
+++ b/internal/services/compute/linux_virtual_machine_resource_disk_os_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/acceptance/check"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 )
 
 func TestAccLinuxVirtualMachine_diskOSBasic(t *testing.T) {
@@ -292,6 +293,39 @@ func TestAccLinuxVirtualMachine_diskOSStorageTypeUpdate(t *testing.T) {
 		data.ImportStep(),
 		{
 			Config: r.diskOSStorageAccountType(data, "Standard_LRS"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccLinuxVirtualMachine_diskOSControllerType(t *testing.T) {
+	if !features.FourPointOhBeta() {
+		t.Skipf("Test applies after 4.0 only")
+	}
+
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+	r := LinuxVirtualMachineResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.diskOSControllerTypeNVMe(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.diskOSControllerTypeSCSI(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.diskOSControllerTypeNVMe(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 			),
@@ -890,6 +924,78 @@ func (r LinuxVirtualMachineResource) diskOSStorageAccountTypeWithRestrictedLocat
 	// Limited regional availability for some storage account type
 	data.Locations.Primary = location
 	return r.diskOSStorageAccountType(data, accountType)
+}
+
+func (r LinuxVirtualMachineResource) diskOSControllerTypeSCSI(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                = "acctestVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_B1s"
+  admin_username      = "adminuser"
+  disk_controller_type = "SCSI"
+
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "0001-com-ubuntu-server-focal"
+    sku       = "20_04-lts-gen2"
+    version   = "latest"
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r LinuxVirtualMachineResource) diskOSControllerTypeNVMe(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                = "acctestVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_E2bds_v5"
+  admin_username      = "adminuser"
+  disk_controller_type = "NVMe"
+
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "0001-com-ubuntu-server-focal"
+    sku       = "20_04-lts-gen2"
+    version   = "latest"
+  }
+}
+`, r.template(data), data.RandomInteger)
 }
 
 func (r LinuxVirtualMachineResource) diskOSWriteAcceleratorEnabled(data acceptance.TestData, enabled bool) string {

--- a/internal/services/compute/linux_virtual_machine_resource_other_test.go
+++ b/internal/services/compute/linux_virtual_machine_resource_other_test.go
@@ -1593,10 +1593,11 @@ resource "azurerm_linux_virtual_machine" "test" {
   }
 
   gallery_application {
-    version_id             = azurerm_gallery_application_version.test2.id
-    order                  = 2
-    configuration_blob_uri = azurerm_storage_blob.test2.id
-    tag                    = "app2"
+    version_id                = azurerm_gallery_application_version.test2.id
+    automatic_upgrade_enabled = true
+    order                     = 2
+    configuration_blob_uri    = azurerm_storage_blob.test2.id
+    tag                       = "app2"
   }
 }
 `, r.otherGalleryApplicationTemplate(data), data.RandomInteger)

--- a/internal/services/compute/linux_virtual_machine_resource_other_test.go
+++ b/internal/services/compute/linux_virtual_machine_resource_other_test.go
@@ -93,6 +93,30 @@ func TestAccLinuxVirtualMachine_otherAllowExtensionOperationsUpdatedWithoutVmAge
 	})
 }
 
+func TestAccLinuxVirtualMachine_otherVmAgentPlatformUpdates(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
+	r := LinuxVirtualMachineResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.otherVmAgentPlatformUpdatesEnabled(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("vm_agent_platform_updates_enabled").HasValue("true"),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.otherVmAgentPlatformUpdatesDisabled(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("vm_agent_platform_updates_enabled").HasValue("false"),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccLinuxVirtualMachine_otherExtensionsTimeBudget(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_linux_virtual_machine", "test")
 	r := LinuxVirtualMachineResource{}
@@ -1122,6 +1146,76 @@ resource "azurerm_linux_virtual_machine" "test" {
   admin_username             = "adminuser"
   allow_extension_operations = true
   provision_vm_agent         = false
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r LinuxVirtualMachineResource) otherVmAgentPlatformUpdatesEnabled(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                              = "acctestVM-%d"
+  resource_group_name               = azurerm_resource_group.test.name
+  location                          = azurerm_resource_group.test.location
+  size                              = "Standard_F2"
+  admin_username                    = "adminuser"
+  vm_agent_platform_updates_enabled = true
+
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = local.first_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+`, r.template(data), data.RandomInteger)
+}
+
+func (r LinuxVirtualMachineResource) otherVmAgentPlatformUpdatesDisabled(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                = "acctestVM-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
   network_interface_ids = [
     azurerm_network_interface.test.id,
   ]

--- a/internal/services/compute/linux_virtual_machine_resource_other_test.go
+++ b/internal/services/compute/linux_virtual_machine_resource_other_test.go
@@ -1236,8 +1236,8 @@ resource "azurerm_linux_virtual_machine" "test" {
 
   source_image_reference {
     publisher = "Canonical"
-    offer     = "UbuntuServer"
-    sku       = "16.04-LTS"
+    offer     = "0001-com-ubuntu-server-jammy"
+    sku       = "22_04-lts"
     version   = "latest"
   }
 }
@@ -1270,8 +1270,8 @@ resource "azurerm_linux_virtual_machine" "test" {
 
   source_image_reference {
     publisher = "Canonical"
-    offer     = "UbuntuServer"
-    sku       = "16.04-LTS"
+    offer     = "0001-com-ubuntu-server-jammy"
+    sku       = "22_04-lts"
     version   = "latest"
   }
 }
@@ -2530,8 +2530,8 @@ resource "azurerm_linux_virtual_machine" "test" {
 
   source_image_reference {
     publisher = "Canonical"
-    offer     = "UbuntuServer"
-    sku       = "16.04-LTS"
+    offer     = "0001-com-ubuntu-server-jammy"
+    sku       = "22_04-lts"
     version   = "latest"
   }
 

--- a/internal/services/compute/linux_virtual_machine_resource_other_test.go
+++ b/internal/services/compute/linux_virtual_machine_resource_other_test.go
@@ -1593,11 +1593,12 @@ resource "azurerm_linux_virtual_machine" "test" {
   }
 
   gallery_application {
-    version_id                = azurerm_gallery_application_version.test2.id
-    automatic_upgrade_enabled = true
-    order                     = 2
-    configuration_blob_uri    = azurerm_storage_blob.test2.id
-    tag                       = "app2"
+    version_id                                  = azurerm_gallery_application_version.test2.id
+    automatic_upgrade_enabled                   = true
+    order                                       = 2
+    configuration_blob_uri                      = azurerm_storage_blob.test2.id
+    tag                                         = "app2"
+    treat_failure_as_deployment_failure_enabled = true
   }
 }
 `, r.otherGalleryApplicationTemplate(data), data.RandomInteger)
@@ -1695,8 +1696,8 @@ resource "azurerm_gallery_application_version" "test" {
   }
 
   manage_action {
-    install = "[install command]"
-    remove  = "[remove command]"
+    install = "echo install"
+    remove  = "echo remove"
   }
 
   target_region {
@@ -1725,8 +1726,8 @@ resource "azurerm_gallery_application_version" "test2" {
   }
 
   manage_action {
-    install = "[install command]"
-    remove  = "[remove command]"
+    install = "echo install"
+    remove  = "echo remove"
   }
 
   target_region {

--- a/internal/services/compute/virtual_machine.go
+++ b/internal/services/compute/virtual_machine.go
@@ -504,6 +504,12 @@ func VirtualMachineGalleryApplicationSchema() *pluginsdk.Schema {
 					ValidateFunc: galleryapplicationversions.ValidateApplicationVersionID,
 				},
 
+				"automatic_upgrade_enabled": {
+					Type:     pluginsdk.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
+
 				// Example: https://mystorageaccount.blob.core.windows.net/configurations/settings.config
 				"configuration_blob_uri": {
 					Type:         pluginsdk.TypeString,
@@ -537,6 +543,7 @@ func expandVirtualMachineGalleryApplication(input []interface{}) *[]compute.VMGa
 
 	for _, v := range input {
 		packageReferenceId := v.(map[string]interface{})["version_id"].(string)
+		automaticUpgradeEnabled := v.(map[string]interface{})["automatic_upgrade_enabled"].(bool)
 		configurationReference := v.(map[string]interface{})["configuration_blob_uri"].(string)
 		order := v.(map[string]interface{})["order"].(int)
 		tag := v.(map[string]interface{})["tag"].(string)
@@ -546,6 +553,7 @@ func expandVirtualMachineGalleryApplication(input []interface{}) *[]compute.VMGa
 			ConfigurationReference: utils.String(configurationReference),
 			Order:                  utils.Int32(int32(order)),
 			Tags:                   utils.String(tag),
+			EnableAutomaticUpgrade: utils.Bool(automaticUpgradeEnabled),
 		}
 
 		out = append(out, *app)
@@ -564,6 +572,7 @@ func flattenVirtualMachineGalleryApplication(input *[]compute.VMGalleryApplicati
 	for _, v := range *input {
 		var packageReferenceId, configurationReference, tag string
 		var order int
+		var automaticUpgradeEnabled bool
 
 		if v.PackageReferenceID != nil {
 			packageReferenceId = *v.PackageReferenceID
@@ -571,6 +580,10 @@ func flattenVirtualMachineGalleryApplication(input *[]compute.VMGalleryApplicati
 
 		if v.ConfigurationReference != nil {
 			configurationReference = *v.ConfigurationReference
+		}
+
+		if v.EnableAutomaticUpgrade != nil {
+			automaticUpgradeEnabled = *v.EnableAutomaticUpgrade
 		}
 
 		if v.Order != nil {
@@ -582,10 +595,11 @@ func flattenVirtualMachineGalleryApplication(input *[]compute.VMGalleryApplicati
 		}
 
 		app := map[string]interface{}{
-			"version_id":             packageReferenceId,
-			"configuration_blob_uri": configurationReference,
-			"order":                  order,
-			"tag":                    tag,
+			"version_id":                packageReferenceId,
+			"automatic_upgrade_enabled": automaticUpgradeEnabled,
+			"configuration_blob_uri":    configurationReference,
+			"order":                     order,
+			"tag":                       tag,
 		}
 
 		out = append(out, app)

--- a/internal/services/compute/virtual_machine.go
+++ b/internal/services/compute/virtual_machine.go
@@ -530,6 +530,12 @@ func VirtualMachineGalleryApplicationSchema() *pluginsdk.Schema {
 					Optional:     true,
 					ValidateFunc: validation.StringIsNotEmpty,
 				},
+
+				"treat_failure_as_deployment_failure_enabled": {
+					Type:     pluginsdk.TypeBool,
+					Optional: true,
+					Default:  false,
+				},
 			},
 		},
 	}
@@ -547,13 +553,15 @@ func expandVirtualMachineGalleryApplication(input []interface{}) *[]compute.VMGa
 		configurationReference := v.(map[string]interface{})["configuration_blob_uri"].(string)
 		order := v.(map[string]interface{})["order"].(int)
 		tag := v.(map[string]interface{})["tag"].(string)
+		treatFailureAsDeploymentFailureEnabled := v.(map[string]interface{})["treat_failure_as_deployment_failure_enabled"].(bool)
 
 		app := &compute.VMGalleryApplication{
-			PackageReferenceID:     utils.String(packageReferenceId),
-			ConfigurationReference: utils.String(configurationReference),
-			Order:                  utils.Int32(int32(order)),
-			Tags:                   utils.String(tag),
-			EnableAutomaticUpgrade: utils.Bool(automaticUpgradeEnabled),
+			PackageReferenceID:              utils.String(packageReferenceId),
+			ConfigurationReference:          utils.String(configurationReference),
+			Order:                           utils.Int32(int32(order)),
+			Tags:                            utils.String(tag),
+			EnableAutomaticUpgrade:          utils.Bool(automaticUpgradeEnabled),
+			TreatFailureAsDeploymentFailure: utils.Bool(treatFailureAsDeploymentFailureEnabled),
 		}
 
 		out = append(out, *app)
@@ -572,7 +580,7 @@ func flattenVirtualMachineGalleryApplication(input *[]compute.VMGalleryApplicati
 	for _, v := range *input {
 		var packageReferenceId, configurationReference, tag string
 		var order int
-		var automaticUpgradeEnabled bool
+		var automaticUpgradeEnabled, treatFailureAsDeploymentFailureEnabled bool
 
 		if v.PackageReferenceID != nil {
 			packageReferenceId = *v.PackageReferenceID
@@ -594,12 +602,17 @@ func flattenVirtualMachineGalleryApplication(input *[]compute.VMGalleryApplicati
 			tag = *v.Tags
 		}
 
+		if v.TreatFailureAsDeploymentFailure != nil {
+			treatFailureAsDeploymentFailureEnabled = *v.TreatFailureAsDeploymentFailure
+		}
+
 		app := map[string]interface{}{
 			"version_id":                packageReferenceId,
 			"automatic_upgrade_enabled": automaticUpgradeEnabled,
 			"configuration_blob_uri":    configurationReference,
 			"order":                     order,
 			"tag":                       tag,
+			"treat_failure_as_deployment_failure_enabled": treatFailureAsDeploymentFailureEnabled,
 		}
 
 		out = append(out, app)

--- a/internal/services/compute/windows_virtual_machine_resource_disk_os_test.go
+++ b/internal/services/compute/windows_virtual_machine_resource_disk_os_test.go
@@ -892,12 +892,12 @@ func (r WindowsVirtualMachineResource) diskOSControllerTypeSCSI(data acceptance.
 %s
 
 resource "azurerm_windows_virtual_machine" "test" {
-  name                = local.vm_name
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-  size                = "Standard_E2bds_v5"
-  admin_username      = "adminuser"
-  admin_password      = "P@$$w0rd1234!"
+  name                 = local.vm_name
+  resource_group_name  = azurerm_resource_group.test.name
+  location             = azurerm_resource_group.test.location
+  size                 = "Standard_E2bds_v5"
+  admin_username       = "adminuser"
+  admin_password       = "P@$$w0rd1234!"
   disk_controller_type = "SCSI"
 
   network_interface_ids = [
@@ -924,12 +924,12 @@ func (r WindowsVirtualMachineResource) diskOSControllerTypeNVMe(data acceptance.
 %s
 
 resource "azurerm_windows_virtual_machine" "test" {
-  name                = local.vm_name
-  resource_group_name = azurerm_resource_group.test.name
-  location            = azurerm_resource_group.test.location
-  size                = "Standard_E2bds_v5"
-  admin_username      = "adminuser"
-  admin_password      = "P@$$w0rd1234!"
+  name                 = local.vm_name
+  resource_group_name  = azurerm_resource_group.test.name
+  location             = azurerm_resource_group.test.location
+  size                 = "Standard_E2bds_v5"
+  admin_username       = "adminuser"
+  admin_password       = "P@$$w0rd1234!"
   disk_controller_type = "NVMe"
 
   network_interface_ids = [

--- a/internal/services/compute/windows_virtual_machine_resource_other_test.go
+++ b/internal/services/compute/windows_virtual_machine_resource_other_test.go
@@ -1947,10 +1947,11 @@ resource "azurerm_windows_virtual_machine" "test" {
   }
 
   gallery_application {
-    version_id             = azurerm_gallery_application_version.test2.id
-    order                  = 2
-    configuration_blob_uri = azurerm_storage_blob.test2.id
-    tag                    = "app2"
+    version_id                = azurerm_gallery_application_version.test2.id
+    automatic_upgrade_enabled = true
+    order                     = 2
+    configuration_blob_uri    = azurerm_storage_blob.test2.id
+    tag                       = "app2"
   }
 }
 `, r.otherGalleryApplicationTemplate(data))

--- a/internal/services/compute/windows_virtual_machine_resource_other_test.go
+++ b/internal/services/compute/windows_virtual_machine_resource_other_test.go
@@ -86,6 +86,30 @@ func TestAccWindowsVirtualMachine_otherPatchModeUpdate(t *testing.T) {
 	})
 }
 
+func TestAccWindowsVirtualMachine_otherVmAgentPlatformUpdates(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
+	r := WindowsVirtualMachineResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.otherVmAgentPlatformUpdatesEnabled(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("vm_agent_platform_updates_enabled").HasValue("true"),
+			),
+		},
+		data.ImportStep("admin_password"),
+		{
+			Config: r.otherVmAgentPlatformUpdatesDisabled(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("vm_agent_platform_updates_enabled").HasValue("false"),
+			),
+		},
+		data.ImportStep("admin_password"),
+	})
+}
+
 func TestAccWindowsVirtualMachine_otherPatchAssessmentModeDefault(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_windows_virtual_machine", "test")
 	r := WindowsVirtualMachineResource{}
@@ -1222,7 +1246,7 @@ resource "azurerm_windows_virtual_machine" "test" {
 `, r.template(data), patchMode)
 }
 
-func (r WindowsVirtualMachineResource) otherPatchModeManual(data acceptance.TestData) string {
+func (r WindowsVirtualMachineResource) otherVmAgentPlatformUpdatesEnabled(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
@@ -1250,8 +1274,40 @@ resource "azurerm_windows_virtual_machine" "test" {
     version   = "latest"
   }
 
-  enable_automatic_updates = false
-  patch_mode               = "Manual"
+  vm_agent_platform_updates_enabled = true
+}
+`, r.template(data))
+}
+
+func (r WindowsVirtualMachineResource) otherVmAgentPlatformUpdatesDisabled(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
+
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+
+  vm_agent_platform_updates_enabled = false
 }
 `, r.template(data))
 }
@@ -1318,6 +1374,40 @@ resource "azurerm_windows_virtual_machine" "test" {
   }
 
   patch_mode = "AutomaticByPlatform"
+}
+`, r.template(data))
+}
+
+func (r WindowsVirtualMachineResource) otherPatchModeManual(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+resource "azurerm_windows_virtual_machine" "test" {
+  name                = local.vm_name
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  size                = "Standard_F2"
+  admin_username      = "adminuser"
+  admin_password      = "P@$$w0rd1234!"
+
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2016-Datacenter"
+    version   = "latest"
+  }
+
+  enable_automatic_updates = false
+  patch_mode               = "Manual"
 }
 `, r.template(data))
 }

--- a/internal/services/compute/windows_virtual_machine_resource_other_test.go
+++ b/internal/services/compute/windows_virtual_machine_resource_other_test.go
@@ -1947,11 +1947,12 @@ resource "azurerm_windows_virtual_machine" "test" {
   }
 
   gallery_application {
-    version_id                = azurerm_gallery_application_version.test2.id
-    automatic_upgrade_enabled = true
-    order                     = 2
-    configuration_blob_uri    = azurerm_storage_blob.test2.id
-    tag                       = "app2"
+    version_id                                  = azurerm_gallery_application_version.test2.id
+    automatic_upgrade_enabled                   = true
+    order                                       = 2
+    configuration_blob_uri                      = azurerm_storage_blob.test2.id
+    tag                                         = "app2"
+    treat_failure_as_deployment_failure_enabled = true
   }
 }
 `, r.otherGalleryApplicationTemplate(data))
@@ -2045,8 +2046,8 @@ resource "azurerm_gallery_application_version" "test" {
   }
 
   manage_action {
-    install = "[install command]"
-    remove  = "[remove command]"
+    install = "echo install"
+    remove  = "echo remove"
   }
 
   target_region {
@@ -2074,8 +2075,8 @@ resource "azurerm_gallery_application_version" "test2" {
   }
 
   manage_action {
-    install = "[install command]"
-    remove  = "[remove command]"
+    install = "echo install"
+    remove  = "echo remove"
   }
 
   target_region {

--- a/website/docs/r/linux_virtual_machine.html.markdown
+++ b/website/docs/r/linux_virtual_machine.html.markdown
@@ -148,6 +148,10 @@ The following arguments are supported:
 
 -> **NOTE:** When an `admin_password` is specified `disable_password_authentication` must be set to `false`.
 
+* `disk_controller_type` - (Optional) Specifies the Disk Controller Type used for this Virtual Machine. Possible values are `SCSI` and `NVMe`.
+
+-> **Note:** This will be available only from the next major version of the Azure Provider (4.0).
+
 * `edge_zone` - (Optional) Specifies the Edge Zone within the Azure Region where this Linux Virtual Machine should exist. Changing this forces a new Linux Virtual Machine to be created.
 
 * `encryption_at_host_enabled` - (Optional) Should all of the disks (including the temp disk) attached to this Virtual Machine be encrypted by enabling Encryption at Host?

--- a/website/docs/r/linux_virtual_machine.html.markdown
+++ b/website/docs/r/linux_virtual_machine.html.markdown
@@ -262,13 +262,15 @@ A `gallery_application` block supports the following:
 
 * `version_id` - (Required) Specifies the Gallery Application Version resource ID.
 
-* `automatic_upgrade_enabled` - (Optional) Whether the version will be automatically updated for the VM when a new Gallery Application version is available in PIR/SIG. Defaults to `false`.
+* `automatic_upgrade_enabled` - (Optional) Specifies whether the version will be automatically updated for the VM when a new Gallery Application version is available in PIR/SIG. Defaults to `false`.
 
 * `configuration_blob_uri` - (Optional) Specifies the URI to an Azure Blob that will replace the default configuration for the package if provided.
 
 * `order` - (Optional) Specifies the order in which the packages have to be installed. Possible values are between `0` and `2,147,483,647`.
 
 * `tag` - (Optional) Specifies a passthrough value for more generic context. This field can be any valid `string` value.
+
+* `treat_failure_as_deployment_failure_enabled` - (Optional) Specifies whether any failure for any operation in the VmApplication will fail the deployment of the VM. Defaults to `false`.
 
 ---
 

--- a/website/docs/r/linux_virtual_machine.html.markdown
+++ b/website/docs/r/linux_virtual_machine.html.markdown
@@ -262,6 +262,8 @@ A `gallery_application` block supports the following:
 
 * `version_id` - (Required) Specifies the Gallery Application Version resource ID.
 
+* `automatic_upgrade_enabled` - (Optional) Whether the version will be automatically updated for the VM when a new Gallery Application version is available in PIR/SIG. Defaults to `false`.
+
 * `configuration_blob_uri` - (Optional) Specifies the URI to an Azure Blob that will replace the default configuration for the package if provided.
 
 * `order` - (Optional) Specifies the order in which the packages have to be installed. Possible values are between `0` and `2,147,483,647`.

--- a/website/docs/r/linux_virtual_machine.html.markdown
+++ b/website/docs/r/linux_virtual_machine.html.markdown
@@ -204,6 +204,8 @@ The following arguments are supported:
 
 * `tags` - (Optional) A mapping of tags which should be assigned to this Virtual Machine.
 
+* `os_image_notification` - (Optional) A `os_image_notification` block as defined below.
+
 * `termination_notification` - (Optional) A `termination_notification` block as defined below.
 
 * `user_data` - (Optional) The Base64-Encoded User Data which should be used for this Virtual Machine.
@@ -349,6 +351,14 @@ The `source_image_reference` block supports the following:
 * `sku` - (Required) Specifies the SKU of the image used to create the virtual machines. Changing this forces a new resource to be created.
 
 * `version` - (Required) Specifies the version of the image used to create the virtual machines. Changing this forces a new resource to be created.
+
+---
+
+A `os_image_notification` block supports the following:
+
+* `enabled` - (Required) Should the OS image notification be enabled on this Virtual Machine?
+
+* `timeout` - (Optional) Length of time a notification to be sent to the VM on the instance metadata server till the VM gets OS upgraded. The only possible value is `PT15M`. Defaults to `PT15M`.
 
 ---
 

--- a/website/docs/r/linux_virtual_machine.html.markdown
+++ b/website/docs/r/linux_virtual_machine.html.markdown
@@ -208,6 +208,8 @@ The following arguments are supported:
 
 * `user_data` - (Optional) The Base64-Encoded User Data which should be used for this Virtual Machine.
 
+* `vm_agent_platform_updates_enabled` - (Optional) Specifies whether VMAgent Platform Updates is enabled. Defaults to `false`.
+
 * `vtpm_enabled` - (Optional) Specifies whether vTPM should be enabled on the virtual machine. Changing this forces a new resource to be created.
 
 * `virtual_machine_scale_set_id` - (Optional) Specifies the Orchestrated Virtual Machine Scale Set that this Virtual Machine should be created within. Changing this forces a new resource to be created.

--- a/website/docs/r/windows_virtual_machine.html.markdown
+++ b/website/docs/r/windows_virtual_machine.html.markdown
@@ -199,6 +199,8 @@ The following arguments are supported:
 
 * `tags` - (Optional) A mapping of tags which should be assigned to this Virtual Machine.
 
+* `os_image_notification` - (Optional) A `os_image_notification` block as defined below.
+
 * `termination_notification` - (Optional) A `termination_notification` block as defined below.
 
 * `timezone` - (Optional) Specifies the Time Zone which should be used by the Virtual Machine, [the possible values are defined here](https://jackstromberg.com/2017/01/list-of-time-zones-consumed-by-azure/). Changing this forces a new resource to be created.
@@ -350,6 +352,14 @@ The `source_image_reference` block supports the following:
 * `sku` - (Required) Specifies the SKU of the image used to create the virtual machines. Changing this forces a new resource to be created.
 
 * `version` - (Required) Specifies the version of the image used to create the virtual machines. Changing this forces a new resource to be created.
+
+---
+
+A `os_image_notification` block supports the following:
+
+* `enabled` - (Required) Should the OS image notification be enabled on this Virtual Machine?
+
+* `timeout` - (Optional) Length of time a notification to be sent to the VM on the instance metadata server till the VM gets OS upgraded. The only possible value is `PT15M`. Defaults to `PT15M`.
 
 ---
 

--- a/website/docs/r/windows_virtual_machine.html.markdown
+++ b/website/docs/r/windows_virtual_machine.html.markdown
@@ -209,6 +209,8 @@ The following arguments are supported:
 
 ~> **NOTE:** Orchestrated Virtual Machine Scale Sets can be provisioned using [the `azurerm_orchestrated_virtual_machine_scale_set` resource](/docs/providers/azurerm/r/orchestrated_virtual_machine_scale_set.html).
 
+* `vm_agent_platform_updates_enabled` - (Optional) Specifies whether VMAgent Platform Updates is enabled. Defaults to `false`.
+
 * `vtpm_enabled` - (Optional) Specifies if vTPM (virtual Trusted Platform Module) and Trusted Launch is enabled for the Virtual Machine. Changing this forces a new resource to be created.
 
 * `winrm_listener` - (Optional) One or more `winrm_listener` blocks as defined below. Changing this forces a new resource to be created.

--- a/website/docs/r/windows_virtual_machine.html.markdown
+++ b/website/docs/r/windows_virtual_machine.html.markdown
@@ -261,6 +261,8 @@ A `gallery_application` block supports the following:
 
 * `version_id` - (Required) Specifies the Gallery Application Version resource ID.
 
+* `automatic_upgrade_enabled` - (Optional) Whether the version will be automatically updated for the VM when a new Gallery Application version is available in PIR/SIG. Defaults to `false`.
+
 * `configuration_blob_uri` - (Optional) Specifies the URI to an Azure Blob that will replace the default configuration for the package if provided.
 
 * `order` - (Optional) Specifies the order in which the packages have to be installed. Possible values are between `0` and `2,147,483,647`.

--- a/website/docs/r/windows_virtual_machine.html.markdown
+++ b/website/docs/r/windows_virtual_machine.html.markdown
@@ -261,13 +261,15 @@ A `gallery_application` block supports the following:
 
 * `version_id` - (Required) Specifies the Gallery Application Version resource ID.
 
-* `automatic_upgrade_enabled` - (Optional) Whether the version will be automatically updated for the VM when a new Gallery Application version is available in PIR/SIG. Defaults to `false`.
+* `automatic_upgrade_enabled` - (Optional) Specifies whether the version will be automatically updated for the VM when a new Gallery Application version is available in PIR/SIG. Defaults to `false`.
 
 * `configuration_blob_uri` - (Optional) Specifies the URI to an Azure Blob that will replace the default configuration for the package if provided.
 
 * `order` - (Optional) Specifies the order in which the packages have to be installed. Possible values are between `0` and `2,147,483,647`.
 
 * `tag` - (Optional) Specifies a passthrough value for more generic context. This field can be any valid `string` value.
+
+* `treat_failure_as_deployment_failure_enabled` - (Optional) Specifies whether any failure for any operation in the VmApplication will fail the deployment of the VM. Defaults to `false`.
 
 ---
 

--- a/website/docs/r/windows_virtual_machine.html.markdown
+++ b/website/docs/r/windows_virtual_machine.html.markdown
@@ -137,6 +137,10 @@ The following arguments are supported:
 
 * `edge_zone` - (Optional) Specifies the Edge Zone within the Azure Region where this Windows Virtual Machine should exist. Changing this forces a new Windows Virtual Machine to be created.
 
+* `disk_controller_type` - (Optional) Specifies the Disk Controller Type used for this Virtual Machine. Possible values are `SCSI` and `NVMe`.
+
+-> **Note:** This will be available only from the next major version of the Azure Provider (4.0).
+
 * `enable_automatic_updates` - (Optional) Specifies if Automatic Updates are Enabled for the Windows Virtual Machine. Changing this forces a new resource to be created. Defaults to `true`.
 
 * `encryption_at_host_enabled` - (Optional) Should all of the disks (including the temp disk) attached to this Virtual Machine be encrypted by enabling Encryption at Host?


### PR DESCRIPTION
## Swagger Link:
https://github.com/Azure/azure-rest-api-specs/tree/main/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2023-03-01

## Test Result

=== RUN   TestAccWindowsVirtualMachine_diskOSControllerType
=== PAUSE TestAccWindowsVirtualMachine_diskOSControllerType
=== CONT  TestAccWindowsVirtualMachine_diskOSControllerType
--- PASS: TestAccWindowsVirtualMachine_diskOSControllerType (683.48s)


=== RUN   TestAccLinuxVirtualMachine_diskOSControllerType
=== PAUSE TestAccLinuxVirtualMachine_diskOSControllerType
=== CONT  TestAccLinuxVirtualMachine_diskOSControllerType
--- PASS: TestAccLinuxVirtualMachine_diskOSControllerType (677.39s)

=== RUN   TestAccLinuxVirtualMachine_otherVmAgentPlatformUpdates
=== PAUSE TestAccLinuxVirtualMachine_otherVmAgentPlatformUpdates
=== CONT  TestAccLinuxVirtualMachine_otherVmAgentPlatformUpdates
--- PASS: TestAccLinuxVirtualMachine_otherVmAgentPlatformUpdates (405.47s)

=== RUN   TestAccLinuxVirtualMachine_otherOsImageNotification
=== PAUSE TestAccLinuxVirtualMachine_otherOsImageNotification
=== CONT  TestAccLinuxVirtualMachine_otherOsImageNotification
--- PASS: TestAccLinuxVirtualMachine_otherOsImageNotification (464.68s)

=== RUN   TestAccWindowsVirtualMachine_otherVmAgentPlatformUpdates
=== PAUSE TestAccWindowsVirtualMachine_otherVmAgentPlatformUpdates
=== CONT  TestAccWindowsVirtualMachine_otherVmAgentPlatformUpdates
--- PASS: TestAccWindowsVirtualMachine_otherVmAgentPlatformUpdates (413.93s)

=== RUN   TestAccWindowsVirtualMachine_otherOsImageNotification
=== PAUSE TestAccWindowsVirtualMachine_otherOsImageNotification
=== CONT  TestAccWindowsVirtualMachine_otherOsImageNotification
--- PASS: TestAccWindowsVirtualMachine_otherOsImageNotification (481.37s)