### PR TITLE
`azurerm_key_vault_*`: add `TryCacheKeyvaultID` function to speed up get keyvault id from keyvault URL

### DIFF
--- a/internal/services/keyvault/key_vault_certificate_contacts_resource.go
+++ b/internal/services/keyvault/key_vault_certificate_contacts_resource.go
@@ -155,6 +155,8 @@ func (r KeyVaultCertificateContactsResource) Read() sdk.ResourceFunc {
 				return err
 			}
 
+			_ = vaultClient.TryCacheWithKeyVaultID(ctx, metadata.ResourceData.Get("key_vault_id").(string))
+
 			keyVaultIdRaw, err := vaultClient.KeyVaultIDFromBaseUrl(ctx, resourcesClient, id.KeyVaultBaseUrl)
 			if err != nil {
 				return fmt.Errorf("retrieving resource ID of the Key Vault at URL %s: %+v", id.KeyVaultBaseUrl, err)

--- a/internal/services/keyvault/key_vault_certificate_resource.go
+++ b/internal/services/keyvault/key_vault_certificate_resource.go
@@ -685,6 +685,8 @@ func resourceKeyVaultCertificateRead(d *pluginsdk.ResourceData, meta interface{}
 		return err
 	}
 
+	_ = keyVaultsClient.TryCacheWithKeyVaultID(ctx, d.Get("key_vault_id").(string))
+
 	keyVaultIdRaw, err := keyVaultsClient.KeyVaultIDFromBaseUrl(ctx, resourcesClient, id.KeyVaultBaseUrl)
 	if err != nil {
 		return fmt.Errorf("retrieving the Resource ID the Key Vault at URL %q: %s", id.KeyVaultBaseUrl, err)

--- a/internal/services/keyvault/key_vault_key_resource.go
+++ b/internal/services/keyvault/key_vault_key_resource.go
@@ -17,6 +17,8 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/crypto/ssh"
+
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/date"
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -34,7 +36,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 	"github.com/tombuildsstuff/kermit/sdk/keyvault/7.4/keyvault"
-	"golang.org/x/crypto/ssh"
 )
 
 func resourceKeyVaultKey() *pluginsdk.Resource {
@@ -468,6 +469,8 @@ func resourceKeyVaultKeyRead(d *pluginsdk.ResourceData, meta interface{}) error 
 	if err != nil {
 		return err
 	}
+
+	_ = keyVaultsClient.TryCacheWithKeyVaultID(ctx, d.Get("key_vault_id").(string))
 
 	keyVaultIdRaw, err := keyVaultsClient.KeyVaultIDFromBaseUrl(ctx, resourcesClient, id.KeyVaultBaseUrl)
 	if err != nil {

--- a/internal/services/keyvault/key_vault_managed_storage_account.go
+++ b/internal/services/keyvault/key_vault_managed_storage_account.go
@@ -191,6 +191,8 @@ func resourceKeyVaultManagedStorageAccountRead(d *pluginsdk.ResourceData, meta i
 		return err
 	}
 
+	_ = keyVaultsClient.TryCacheWithKeyVaultID(ctx, d.Get("key_vault_id").(string))
+
 	keyVaultIdRaw, err := keyVaultsClient.KeyVaultIDFromBaseUrl(ctx, resourcesClient, id.KeyVaultBaseUrl)
 	if err != nil {
 		return fmt.Errorf("retrieving the Resource ID of the Key Vault at URL %q: %s", id.KeyVaultBaseUrl, err)

--- a/internal/services/keyvault/key_vault_secret_resource.go
+++ b/internal/services/keyvault/key_vault_secret_resource.go
@@ -313,6 +313,8 @@ func resourceKeyVaultSecretRead(d *pluginsdk.ResourceData, meta interface{}) err
 		return err
 	}
 
+	_ = keyVaultsClient.TryCacheWithKeyVaultID(ctx, d.Get("key_vault_id").(string))
+
 	keyVaultIdRaw, err := keyVaultsClient.KeyVaultIDFromBaseUrl(ctx, resourcesClient, id.KeyVaultBaseUrl)
 	if err != nil {
 		return fmt.Errorf("retrieving the Resource ID the Key Vault at URL %q: %s", id.KeyVaultBaseUrl, err)


### PR DESCRIPTION
This is a short-term fixes #23404.

[KeyVaultIDFromBaseUrl](https://github.com/hashicorp/terraform-provider-azurerm/blob/09cadb0753157b6b581e198e8c405e4a2c551d8f/internal/services/keyvault/client/helpers.go#L114C32-L114C32) is time-consuming for listing almost all pages of the resources of the subscription to find the keyvault resource by name. This PR is trying to cache the mapping beween the keyvault URL and keyvault at first to void the `ResourcesClient.List` operation.

The process of finding the KeyVault resource by name using [KeyVaultIDFromBaseUrl](https://github.com/hashicorp/terraform-provider-azurerm/blob/09cadb0753157b6b581e198e8c405e4a2c551d8f/internal/services/keyvault/client/helpers.go#L114C32-L114C32) is time-consuming as it requires listing almost all pages of subscription resources. This PR aims to improve performance by caching the mapping between the KeyVault URL and its corresponding resource before the `KeyVaultIDFromBaseUrl` calls, thereby avoiding the need for a `ResourcesClient.List` operation. This PR won't speed up the `terraform import`.