### PR TITLE
`azurerm_key_vault`: use Resource Graph API to search keyvault resource from keyvault name

### DIFF
--- a/internal/services/keyvault/client/helpers.go
+++ b/internal/services/keyvault/client/helpers.go
@@ -113,7 +113,7 @@ func (c *Client) Exists(ctx context.Context, keyVaultId commonids.KeyVaultId) (b
 	return true, nil
 }
 
-func (c *Client) KeyVaultIDFromBaseURLByGraph(ctx context.Context, client *graph.ResourcesClient, name string) (string, interface{}) {
+func (c *Client) KeyVaultIDFromBaseURLByGraph(ctx context.Context, client *graph.ResourcesClient, name string) (string, error) {
 	if name == "" {
 		return "", nil
 	}
@@ -136,7 +136,7 @@ func (c *Client) KeyVaultIDFromBaseURLByGraph(ctx context.Context, client *graph
 			}
 		}
 	}
-	return "", fmt.Errorf("no such keyvault in resource graph by query: %s", req.Query)
+	return "", fmt.Errorf("cannot find such keyvault in resource graph by query: %s", req.Query)
 }
 
 func (c *Client) KeyVaultIDFromBaseUrl(ctx context.Context, resourcesClient *resourcesClient.Client, keyVaultBaseUrl string) (*string, error) {

--- a/internal/services/resource/client/client.go
+++ b/internal/services/resource/client/client.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/resources/mgmt/2019-06-01-preview/templatespecs" // nolint: staticcheck
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2020-06-01/resources"                     // nolint: staticcheck
+	graph "github.com/hashicorp/go-azure-sdk/resource-manager/resourcegraph/2022-10-01/resources"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/resources/2020-05-01/managementlocks"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/resources/2020-05-01/resourcemanagementprivatelink"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/resources/2020-10-01/deploymentscripts"
@@ -20,6 +21,7 @@ type Client struct {
 	DeploymentsClient                   *resources.DeploymentsClient
 	DeploymentScriptsClient             *deploymentscripts.DeploymentScriptsClient
 	FeaturesClient                      *features.FeaturesClient
+	GraphResourceClient                 *graph.ResourcesClient
 	GroupsClient                        *resources.GroupsClient
 	LocksClient                         *managementlocks.ManagementLocksClient
 	ResourceManagementPrivateLinkClient *resourcemanagementprivatelink.ResourceManagementPrivateLinkClient
@@ -46,6 +48,12 @@ func NewClient(o *common.ClientOptions) (*Client, error) {
 		return nil, fmt.Errorf("building Features client: %+v", err)
 	}
 	o.Configure(featuresClient.Client, o.Authorizers.ResourceManager)
+
+	graphClient, err := graph.NewResourcesClientWithBaseURI(o.Environment.ResourceManager)
+	if err != nil {
+		return nil, fmt.Errorf("building ResourcesGraph client: %+v", err)
+	}
+	o.Configure(graphClient.Client, o.Authorizers.ResourceManager)
 
 	groupsClient := resources.NewGroupsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&groupsClient.Client, o.ResourceManagerAuthorizer)
@@ -78,6 +86,7 @@ func NewClient(o *common.ClientOptions) (*Client, error) {
 	o.ConfigureClient(&tagsClient.Client, o.ResourceManagerAuthorizer)
 
 	return &Client{
+		GraphResourceClient:                 graphClient,
 		GroupsClient:                        &groupsClient,
 		DeploymentsClient:                   &deploymentsClient,
 		DeploymentScriptsClient:             deploymentScriptsClient,

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resourcegraph/2022-10-01/resources/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resourcegraph/2022-10-01/resources/README.md
@@ -1,0 +1,40 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/resourcegraph/2022-10-01/resources` Documentation
+
+The `resources` SDK allows for interaction with the Azure Resource Manager Service `resourcegraph` (API Version `2022-10-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-sdk/resource-manager/resourcegraph/2022-10-01/resources"
+```
+
+
+### Client Initialization
+
+```go
+client := resources.NewResourcesClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `ResourcesClient.Resources`
+
+```go
+ctx := context.TODO()
+
+payload := resources.QueryRequest{
+	// ...
+}
+
+
+read, err := client.Resources(ctx, payload)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resourcegraph/2022-10-01/resources/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resourcegraph/2022-10-01/resources/client.go
@@ -1,0 +1,26 @@
+package resources
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	sdkEnv "github.com/hashicorp/go-azure-sdk/sdk/environments"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ResourcesClient struct {
+	Client *resourcemanager.Client
+}
+
+func NewResourcesClientWithBaseURI(sdkApi sdkEnv.Api) (*ResourcesClient, error) {
+	client, err := resourcemanager.NewResourceManagerClient(sdkApi, "resources", defaultApiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("instantiating ResourcesClient: %+v", err)
+	}
+
+	return &ResourcesClient{
+		Client: client,
+	}, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resourcegraph/2022-10-01/resources/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resourcegraph/2022-10-01/resources/constants.go
@@ -1,0 +1,180 @@
+package resources
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AuthorizationScopeFilter string
+
+const (
+	AuthorizationScopeFilterAtScopeAboveAndBelow AuthorizationScopeFilter = "AtScopeAboveAndBelow"
+	AuthorizationScopeFilterAtScopeAndAbove      AuthorizationScopeFilter = "AtScopeAndAbove"
+	AuthorizationScopeFilterAtScopeAndBelow      AuthorizationScopeFilter = "AtScopeAndBelow"
+	AuthorizationScopeFilterAtScopeExact         AuthorizationScopeFilter = "AtScopeExact"
+)
+
+func PossibleValuesForAuthorizationScopeFilter() []string {
+	return []string{
+		string(AuthorizationScopeFilterAtScopeAboveAndBelow),
+		string(AuthorizationScopeFilterAtScopeAndAbove),
+		string(AuthorizationScopeFilterAtScopeAndBelow),
+		string(AuthorizationScopeFilterAtScopeExact),
+	}
+}
+
+func (s *AuthorizationScopeFilter) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseAuthorizationScopeFilter(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseAuthorizationScopeFilter(input string) (*AuthorizationScopeFilter, error) {
+	vals := map[string]AuthorizationScopeFilter{
+		"atscopeaboveandbelow": AuthorizationScopeFilterAtScopeAboveAndBelow,
+		"atscopeandabove":      AuthorizationScopeFilterAtScopeAndAbove,
+		"atscopeandbelow":      AuthorizationScopeFilterAtScopeAndBelow,
+		"atscopeexact":         AuthorizationScopeFilterAtScopeExact,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := AuthorizationScopeFilter(input)
+	return &out, nil
+}
+
+type FacetSortOrder string
+
+const (
+	FacetSortOrderAsc  FacetSortOrder = "asc"
+	FacetSortOrderDesc FacetSortOrder = "desc"
+)
+
+func PossibleValuesForFacetSortOrder() []string {
+	return []string{
+		string(FacetSortOrderAsc),
+		string(FacetSortOrderDesc),
+	}
+}
+
+func (s *FacetSortOrder) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseFacetSortOrder(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseFacetSortOrder(input string) (*FacetSortOrder, error) {
+	vals := map[string]FacetSortOrder{
+		"asc":  FacetSortOrderAsc,
+		"desc": FacetSortOrderDesc,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := FacetSortOrder(input)
+	return &out, nil
+}
+
+type ResultFormat string
+
+const (
+	ResultFormatObjectArray ResultFormat = "objectArray"
+	ResultFormatTable       ResultFormat = "table"
+)
+
+func PossibleValuesForResultFormat() []string {
+	return []string{
+		string(ResultFormatObjectArray),
+		string(ResultFormatTable),
+	}
+}
+
+func (s *ResultFormat) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseResultFormat(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseResultFormat(input string) (*ResultFormat, error) {
+	vals := map[string]ResultFormat{
+		"objectarray": ResultFormatObjectArray,
+		"table":       ResultFormatTable,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ResultFormat(input)
+	return &out, nil
+}
+
+type ResultTruncated string
+
+const (
+	ResultTruncatedFalse ResultTruncated = "false"
+	ResultTruncatedTrue  ResultTruncated = "true"
+)
+
+func PossibleValuesForResultTruncated() []string {
+	return []string{
+		string(ResultTruncatedFalse),
+		string(ResultTruncatedTrue),
+	}
+}
+
+func (s *ResultTruncated) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseResultTruncated(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseResultTruncated(input string) (*ResultTruncated, error) {
+	vals := map[string]ResultTruncated{
+		"false": ResultTruncatedFalse,
+		"true":  ResultTruncatedTrue,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ResultTruncated(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resourcegraph/2022-10-01/resources/method_resources.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resourcegraph/2022-10-01/resources/method_resources.go
@@ -1,0 +1,55 @@
+package resources
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ResourcesOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *QueryResponse
+}
+
+// Resources ...
+func (c ResourcesClient) Resources(ctx context.Context, input QueryRequest) (result ResourcesOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       "/providers/Microsoft.ResourceGraph/resources",
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	if err = resp.Unmarshal(&result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resourcegraph/2022-10-01/resources/model_errordetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resourcegraph/2022-10-01/resources/model_errordetails.go
@@ -1,0 +1,9 @@
+package resources
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ErrorDetails struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resourcegraph/2022-10-01/resources/model_facet.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resourcegraph/2022-10-01/resources/model_facet.go
@@ -1,0 +1,61 @@
+package resources
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type Facet interface {
+}
+
+// RawFacetImpl is returned when the Discriminated Value
+// doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawFacetImpl struct {
+	Type   string
+	Values map[string]interface{}
+}
+
+func unmarshalFacetImplementation(input []byte) (Facet, error) {
+	if input == nil {
+		return nil, nil
+	}
+
+	var temp map[string]interface{}
+	if err := json.Unmarshal(input, &temp); err != nil {
+		return nil, fmt.Errorf("unmarshaling Facet into map[string]interface: %+v", err)
+	}
+
+	value, ok := temp["resultType"].(string)
+	if !ok {
+		return nil, nil
+	}
+
+	if strings.EqualFold(value, "FacetError") {
+		var out FacetError
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into FacetError: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "FacetResult") {
+		var out FacetResult
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into FacetResult: %+v", err)
+		}
+		return out, nil
+	}
+
+	out := RawFacetImpl{
+		Type:   value,
+		Values: temp,
+	}
+	return out, nil
+
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resourcegraph/2022-10-01/resources/model_faceterror.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resourcegraph/2022-10-01/resources/model_faceterror.go
@@ -1,0 +1,42 @@
+package resources
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ Facet = FacetError{}
+
+type FacetError struct {
+	Errors []ErrorDetails `json:"errors"`
+
+	// Fields inherited from Facet
+	Expression string `json:"expression"`
+}
+
+var _ json.Marshaler = FacetError{}
+
+func (s FacetError) MarshalJSON() ([]byte, error) {
+	type wrapper FacetError
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling FacetError: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling FacetError: %+v", err)
+	}
+	decoded["resultType"] = "FacetError"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling FacetError: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resourcegraph/2022-10-01/resources/model_facetrequest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resourcegraph/2022-10-01/resources/model_facetrequest.go
@@ -1,0 +1,9 @@
+package resources
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type FacetRequest struct {
+	Expression string               `json:"expression"`
+	Options    *FacetRequestOptions `json:"options,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resourcegraph/2022-10-01/resources/model_facetrequestoptions.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resourcegraph/2022-10-01/resources/model_facetrequestoptions.go
@@ -1,0 +1,11 @@
+package resources
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type FacetRequestOptions struct {
+	Filter    *string         `json:"filter,omitempty"`
+	SortBy    *string         `json:"sortBy,omitempty"`
+	SortOrder *FacetSortOrder `json:"sortOrder,omitempty"`
+	Top       *int64          `json:"$top,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resourcegraph/2022-10-01/resources/model_facetresult.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resourcegraph/2022-10-01/resources/model_facetresult.go
@@ -1,0 +1,44 @@
+package resources
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ Facet = FacetResult{}
+
+type FacetResult struct {
+	Count        int64       `json:"count"`
+	Data         interface{} `json:"data"`
+	TotalRecords int64       `json:"totalRecords"`
+
+	// Fields inherited from Facet
+	Expression string `json:"expression"`
+}
+
+var _ json.Marshaler = FacetResult{}
+
+func (s FacetResult) MarshalJSON() ([]byte, error) {
+	type wrapper FacetResult
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling FacetResult: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling FacetResult: %+v", err)
+	}
+	decoded["resultType"] = "FacetResult"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling FacetResult: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resourcegraph/2022-10-01/resources/model_queryrequest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resourcegraph/2022-10-01/resources/model_queryrequest.go
@@ -1,0 +1,12 @@
+package resources
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type QueryRequest struct {
+	Facets           *[]FacetRequest      `json:"facets,omitempty"`
+	ManagementGroups *[]string            `json:"managementGroups,omitempty"`
+	Options          *QueryRequestOptions `json:"options,omitempty"`
+	Query            string               `json:"query"`
+	Subscriptions    *[]string            `json:"subscriptions,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resourcegraph/2022-10-01/resources/model_queryrequestoptions.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resourcegraph/2022-10-01/resources/model_queryrequestoptions.go
@@ -1,0 +1,13 @@
+package resources
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type QueryRequestOptions struct {
+	AllowPartialScopes       *bool                     `json:"allowPartialScopes,omitempty"`
+	AuthorizationScopeFilter *AuthorizationScopeFilter `json:"authorizationScopeFilter,omitempty"`
+	ResultFormat             *ResultFormat             `json:"resultFormat,omitempty"`
+	Skip                     *int64                    `json:"$skip,omitempty"`
+	SkipToken                *string                   `json:"$skipToken,omitempty"`
+	Top                      *int64                    `json:"$top,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resourcegraph/2022-10-01/resources/model_queryresponse.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resourcegraph/2022-10-01/resources/model_queryresponse.go
@@ -1,0 +1,57 @@
+package resources
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type QueryResponse struct {
+	Count           int64           `json:"count"`
+	Data            interface{}     `json:"data"`
+	Facets          *[]Facet        `json:"facets,omitempty"`
+	ResultTruncated ResultTruncated `json:"resultTruncated"`
+	SkipToken       *string         `json:"$skipToken,omitempty"`
+	TotalRecords    int64           `json:"totalRecords"`
+}
+
+var _ json.Unmarshaler = &QueryResponse{}
+
+func (s *QueryResponse) UnmarshalJSON(bytes []byte) error {
+	type alias QueryResponse
+	var decoded alias
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling into QueryResponse: %+v", err)
+	}
+
+	s.Count = decoded.Count
+	s.Data = decoded.Data
+	s.ResultTruncated = decoded.ResultTruncated
+	s.SkipToken = decoded.SkipToken
+	s.TotalRecords = decoded.TotalRecords
+
+	var temp map[string]json.RawMessage
+	if err := json.Unmarshal(bytes, &temp); err != nil {
+		return fmt.Errorf("unmarshaling QueryResponse into map[string]json.RawMessage: %+v", err)
+	}
+
+	if v, ok := temp["facets"]; ok {
+		var listTemp []json.RawMessage
+		if err := json.Unmarshal(v, &listTemp); err != nil {
+			return fmt.Errorf("unmarshaling Facets into list []json.RawMessage: %+v", err)
+		}
+
+		output := make([]Facet, 0)
+		for i, val := range listTemp {
+			impl, err := unmarshalFacetImplementation(val)
+			if err != nil {
+				return fmt.Errorf("unmarshaling index %d field 'Facets' for 'QueryResponse': %+v", i, err)
+			}
+			output = append(output, impl)
+		}
+		s.Facets = &output
+	}
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resourcegraph/2022-10-01/resources/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/resourcegraph/2022-10-01/resources/version.go
@@ -1,0 +1,12 @@
+package resources
+
+import "fmt"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2022-10-01"
+
+func userAgent() string {
+	return fmt.Sprintf("hashicorp/go-azure-sdk/resources/%s", defaultApiVersion)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -834,6 +834,7 @@ github.com/hashicorp/go-azure-sdk/resource-manager/redisenterprise/2023-07-01/re
 github.com/hashicorp/go-azure-sdk/resource-manager/relay/2021-11-01/hybridconnections
 github.com/hashicorp/go-azure-sdk/resource-manager/relay/2021-11-01/namespaces
 github.com/hashicorp/go-azure-sdk/resource-manager/resourceconnector/2022-10-27/appliances
+github.com/hashicorp/go-azure-sdk/resource-manager/resourcegraph/2022-10-01/resources
 github.com/hashicorp/go-azure-sdk/resource-manager/resources/2020-05-01/managementlocks
 github.com/hashicorp/go-azure-sdk/resource-manager/resources/2020-05-01/resourcemanagementprivatelink
 github.com/hashicorp/go-azure-sdk/resource-manager/resources/2020-10-01/deploymentscripts


### PR DESCRIPTION
Currently the resourceClient.List API is low performance and with high probability of rasing a `context deadline exceeded` if the subscription has over thousands of resources. 

As there are several PRs try to migrate this logic to ARG before (like #13719 but closed at last), this PR is only use ARG as a high pri option and it will fall back to origin logic when ARG fails. And this PR is not to fix the issue of keyvault eventual consistant, but only to improve the performance of the `KeyVaultIDFromBaseUrl` function, Because this function is prone to causing the `context deadline exceed` error on the production environment of our customers.

To avoid breaking the `KeyVaultIDFromBaseUrl` signature, I placed the ResourceGraph Client under `resourcesClient.Client`. This way, we won't have to make changes to multiple files that depend on it.


This should be a long-term fix to #23404.