### PR TITLE
azurerm_application_insights_api_key - fix existing key check

### DIFF
--- a/internal/services/applicationinsights/application_insights_api_key_resource.go
+++ b/internal/services/applicationinsights/application_insights_api_key_resource.go
@@ -105,7 +105,6 @@ func resourceApplicationInsightsAPIKeyCreate(d *pluginsdk.ResourceData, meta int
 
 	var existingAPIKeyList insights.ApplicationInsightsComponentAPIKeyListResult
 	var existingAPIKeyId *parse.ApiKeyId
-	var keyId string
 	existingAPIKeyList, err = client.List(ctx, appInsightsId.ResourceGroup, appInsightsId.Name)
 	if err != nil {
 		if !utils.ResponseWasNotFound(existingAPIKeyList.Response) {
@@ -120,24 +119,10 @@ func resourceApplicationInsightsAPIKeyCreate(d *pluginsdk.ResourceData, meta int
 				return err
 			}
 
-			existingAppInsightsName := existingAPIKeyId.ComponentName
-			if appInsightsId.Name == existingAppInsightsName {
-				keyId = existingAPIKeyId.Name
-				break
+			if name == *existingAPIKey.Name {
+				return tf.ImportAsExistsError("azurerm_application_insights_api_key", existingAPIKeyId.ID())
 			}
 		}
-	}
-
-	var existing insights.ApplicationInsightsComponentAPIKey
-	existing, err = client.Get(ctx, appInsightsId.ResourceGroup, appInsightsId.Name, keyId)
-	if err != nil {
-		if !utils.ResponseWasNotFound(existing.Response) {
-			return fmt.Errorf("checking for presence of existing Application Insights API key %q (%s): %s", name, appInsightsId, err)
-		}
-	}
-
-	if !utils.ResponseWasNotFound(existing.Response) && existingAPIKeyId != nil {
-		return tf.ImportAsExistsError("azurerm_application_insights_api_key", existingAPIKeyId.ID())
 	}
 
 	linkedReadProperties := expandApplicationInsightsAPIKeyLinkedProperties(d.Get("read_permissions").(*pluginsdk.Set), appInsightsId.ID())


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/8472


In the current version, when [checking for the existence of an API key](https://github.com/hashicorp/terraform-provider-azurerm/blob/1bd5b7c2a17b1708b23bca84d3ab37b51f5f47bb/internal/services/applicationinsights/application_insights_api_key_resource.go#L125), the name of the Application Insights is compared with the parent Application Insights of the existing key. Obviously, this check is always true. When creating the first key, there are no issues because the list of keys is empty. However, when attempting to add a new key, Terraform incorrectly throws an error stating that a key with this name already exists. Moreover, the subsequent request to retrieve the key is redundant.