### PR TITLE
Fix Azure Machine Learning Compute Location 

### DIFF
--- a/internal/services/machinelearning/machine_learning_compute_cluster_resource.go
+++ b/internal/services/machinelearning/machine_learning_compute_cluster_resource.go
@@ -227,7 +227,7 @@ func resourceComputeClusterCreate(d *pluginsdk.ResourceData, meta interface{}) e
 	computeClusterParameters := machinelearningcomputes.ComputeResource{
 		Properties: computeClusterProperties,
 		Identity:   identity,
-		Location:   computeClusterProperties.ComputeLocation,
+		Location:   workspace.Location,
 		Tags:       tags.Expand(d.Get("tags").(map[string]interface{})),
 		Sku: &machinelearningcomputes.Sku{
 			Name: workspace.Model.Sku.Name,

--- a/internal/services/machinelearning/machine_learning_compute_cluster_resource.go
+++ b/internal/services/machinelearning/machine_learning_compute_cluster_resource.go
@@ -227,7 +227,7 @@ func resourceComputeClusterCreate(d *pluginsdk.ResourceData, meta interface{}) e
 	computeClusterParameters := machinelearningcomputes.ComputeResource{
 		Properties: computeClusterProperties,
 		Identity:   identity,
-		Location:   workspace.Location,
+		Location:   workspace.Model.Location,
 		Tags:       tags.Expand(d.Get("tags").(map[string]interface{})),
 		Sku: &machinelearningcomputes.Sku{
 			Name: workspace.Model.Sku.Name,

--- a/internal/services/machinelearning/machine_learning_compute_instance_resource.go
+++ b/internal/services/machinelearning/machine_learning_compute_instance_resource.go
@@ -215,10 +215,15 @@ func resourceComputeInstanceCreate(d *pluginsdk.ResourceData, meta interface{}) 
 		computeInstance.Properties.ComputeInstanceAuthorizationType = utils.ToPtr(machinelearningcomputes.ComputeInstanceAuthorizationType(authType))
 	}
 
+	workspace, err := mlWorkspacesClient.Get(ctx, *workspaceID)
+	if err != nil {
+		return err
+	}
+
 	parameters := machinelearningcomputes.ComputeResource{
 		Properties: computeInstance,
 		Identity:   identity,
-		Location:   utils.String(location.Normalize(d.Get("location").(string))),
+		Location:   workspace.Location,
 		Tags:       tags.Expand(d.Get("tags").(map[string]interface{})),
 	}
 

--- a/internal/services/machinelearning/machine_learning_compute_instance_resource.go
+++ b/internal/services/machinelearning/machine_learning_compute_instance_resource.go
@@ -215,6 +215,7 @@ func resourceComputeInstanceCreate(d *pluginsdk.ResourceData, meta interface{}) 
 		computeInstance.Properties.ComputeInstanceAuthorizationType = utils.ToPtr(machinelearningcomputes.ComputeInstanceAuthorizationType(authType))
 	}
 
+	mlWorkspacesClient := meta.(*clients.Client).MachineLearning.Workspaces
 	workspace, err := mlWorkspacesClient.Get(ctx, *workspaceID)
 	if err != nil {
 		return err
@@ -223,7 +224,7 @@ func resourceComputeInstanceCreate(d *pluginsdk.ResourceData, meta interface{}) 
 	parameters := machinelearningcomputes.ComputeResource{
 		Properties: computeInstance,
 		Identity:   identity,
-		Location:   workspace.Location,
+		Location:   workspace.Model.Location,
 		Tags:       tags.Expand(d.Get("tags").(map[string]interface{})),
 	}
 


### PR DESCRIPTION
The Location on the ARM proxy resource should always be the parent resource's location. computeLocation determines which location the underlying compute will be created