### PR TITLE
Dependency Update: Bump `go-azure-sdk` module version from `v0.20230918.1115907` to `v0.20230922.1111207`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.3.1
 	github.com/hashicorp/go-azure-helpers v0.61.0
-	github.com/hashicorp/go-azure-sdk v0.20230918.1115907
+	github.com/hashicorp/go-azure-sdk v0.20230922.1111207
 	github.com/hashicorp/go-hclog v1.5.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3


### PR DESCRIPTION
Based on review comment on [Kusto API version update PR](https://github.com/hashicorp/terraform-provider-azurerm/pull/23381), this PR is aiming to bump the go-azure-sdk module version to v0.20230922.1111207 which includes the kusto api version 2023-08-15.