### PR TITLE
`azurerm_container_app_environment`: Add support for `workload_profile`

### DIFF
--- a/internal/services/containerapps/container_app_environment_resource.go
+++ b/internal/services/containerapps/container_app_environment_resource.go
@@ -6,6 +6,7 @@ package containerapps
 import (
 	"context"
 	"fmt"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/containerapps/helpers"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -25,15 +26,16 @@ import (
 type ContainerAppEnvironmentResource struct{}
 
 type ContainerAppEnvironmentModel struct {
-	Name                                    string                 `tfschema:"name"`
-	ResourceGroup                           string                 `tfschema:"resource_group_name"`
-	Location                                string                 `tfschema:"location"`
-	DaprApplicationInsightsConnectionString string                 `tfschema:"dapr_application_insights_connection_string"`
-	LogAnalyticsWorkspaceId                 string                 `tfschema:"log_analytics_workspace_id"`
-	InfrastructureSubnetId                  string                 `tfschema:"infrastructure_subnet_id"`
-	InternalLoadBalancerEnabled             bool                   `tfschema:"internal_load_balancer_enabled"`
-	ZoneRedundant                           bool                   `tfschema:"zone_redundancy_enabled"`
-	Tags                                    map[string]interface{} `tfschema:"tags"`
+	Name                                    string                         `tfschema:"name"`
+	ResourceGroup                           string                         `tfschema:"resource_group_name"`
+	Location                                string                         `tfschema:"location"`
+	DaprApplicationInsightsConnectionString string                         `tfschema:"dapr_application_insights_connection_string"`
+	LogAnalyticsWorkspaceId                 string                         `tfschema:"log_analytics_workspace_id"`
+	InfrastructureSubnetId                  string                         `tfschema:"infrastructure_subnet_id"`
+	InternalLoadBalancerEnabled             bool                           `tfschema:"internal_load_balancer_enabled"`
+	ZoneRedundant                           bool                           `tfschema:"zone_redundancy_enabled"`
+	Tags                                    map[string]interface{}         `tfschema:"tags"`
+	WorkloadProfiles                        []helpers.WorkloadProfileModel `tfschema:"workload_profile"`
 
 	DefaultDomain         string `tfschema:"default_domain"`
 	DockerBridgeCidr      string `tfschema:"docker_bridge_cidr"`
@@ -103,6 +105,8 @@ func (r ContainerAppEnvironmentResource) Arguments() map[string]*pluginsdk.Schem
 			RequiredWith: []string{"infrastructure_subnet_id"},
 			Description:  "Should the Container Environment operate in Internal Load Balancing Mode? Defaults to `false`. **Note:** can only be set to `true` if `infrastructure_subnet_id` is specified.",
 		},
+
+		"workload_profile": helpers.WorkloadProfileSchema(),
 
 		"zone_redundancy_enabled": {
 			Type:         pluginsdk.TypeBool,
@@ -231,6 +235,8 @@ func (r ContainerAppEnvironmentResource) Create() sdk.ResourceFunc {
 				managedEnvironment.Properties.VnetConfiguration.Internal = pointer.To(containerAppEnvironment.InternalLoadBalancerEnabled)
 			}
 
+			managedEnvironment.Properties.WorkloadProfiles = helpers.ExpandWorkloadProfiles(containerAppEnvironment.WorkloadProfiles)
+
 			if err := client.CreateOrUpdateThenPoll(ctx, id, managedEnvironment); err != nil {
 				return fmt.Errorf("creating %s: %+v", id, err)
 			}
@@ -279,6 +285,7 @@ func (r ContainerAppEnvironmentResource) Read() sdk.ResourceFunc {
 					state.ZoneRedundant = pointer.From(props.ZoneRedundant)
 					state.StaticIP = pointer.From(props.StaticIP)
 					state.DefaultDomain = pointer.From(props.DefaultDomain)
+					state.WorkloadProfiles = helpers.FlattenWorkloadProfiles(props.WorkloadProfiles)
 				}
 			}
 

--- a/internal/services/containerapps/container_app_environment_resource.go
+++ b/internal/services/containerapps/container_app_environment_resource.go
@@ -6,7 +6,6 @@ package containerapps
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-provider-azurerm/internal/services/containerapps/helpers"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
@@ -18,6 +17,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2023-05-01/managedenvironments"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/operationalinsights/2020-08-01/workspaces"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/containerapps/helpers"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/containerapps/validate"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"

--- a/internal/services/containerapps/container_app_environment_resource_test.go
+++ b/internal/services/containerapps/container_app_environment_resource_test.go
@@ -246,11 +246,6 @@ resource "azurerm_container_app_environment" "test" {
     workload_profile_type = "D4"
   }
 
-  workload_profile {
-    name                  = "Consumption"
-    workload_profile_type = "Consumption"
-  }
-
   zone_redundancy_enabled = true
 
   tags = {

--- a/internal/services/containerapps/container_app_environment_resource_test.go
+++ b/internal/services/containerapps/container_app_environment_resource_test.go
@@ -206,6 +206,14 @@ resource "azurerm_container_app_environment" "test" {
 
 func (r ContainerAppEnvironmentResource) completeWithWorkloadProfile(data acceptance.TestData) string {
 	return fmt.Sprintf(`
+provider "azurerm" {
+  features {
+	resource_group {
+	  prevent_deletion_if_contains_resources = false
+	}
+  }
+}
+
 %[1]s
 
 resource "azurerm_virtual_network" "test" {
@@ -233,18 +241,21 @@ resource "azurerm_container_app_environment" "test" {
   name                       = "acctest-CAEnv%[2]d"
   resource_group_name        = azurerm_resource_group.test.name
   location                   = azurerm_resource_group.test.location
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.test.id
-
   infrastructure_subnet_id = azurerm_subnet.control.id
 
-  internal_load_balancer_enabled = true
+  workload_profile {
+    maximum_count = 2
+    minimum_count = 0
+    name = "My-GP-01"
+    workload_profile_type = "D4"
+  }
 
   workload_profile {
-	maximum_count = 2
-	minimum_count = 0
-	name = "My-GP--01"
-	workload_profile_type = "D4"
+    name = "Consumption"
+    workload_profile_type = "Consumption"
   }
+
+  zone_redundancy_enabled = true
 
   tags = {
     Foo    = "Bar"

--- a/internal/services/containerapps/container_app_environment_resource_test.go
+++ b/internal/services/containerapps/container_app_environment_resource_test.go
@@ -208,9 +208,9 @@ func (r ContainerAppEnvironmentResource) completeWithWorkloadProfile(data accept
 	return fmt.Sprintf(`
 provider "azurerm" {
   features {
-	resource_group {
-	  prevent_deletion_if_contains_resources = false
-	}
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
   }
 }
 
@@ -229,29 +229,29 @@ resource "azurerm_subnet" "control" {
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["10.0.0.0/23"]
   delegation {
-	name = "acctestdelegation%[2]d" 
-	service_delegation {
-	  actions = ["Microsoft.Network/virtualNetworks/subnets/join/action"]
-	  name = "Microsoft.App/environments"
-	}
+    name = "acctestdelegation%[2]d"
+    service_delegation {
+      actions = ["Microsoft.Network/virtualNetworks/subnets/join/action"]
+      name    = "Microsoft.App/environments"
+    }
   }
 }
 
 resource "azurerm_container_app_environment" "test" {
-  name                       = "acctest-CAEnv%[2]d"
-  resource_group_name        = azurerm_resource_group.test.name
-  location                   = azurerm_resource_group.test.location
+  name                     = "acctest-CAEnv%[2]d"
+  resource_group_name      = azurerm_resource_group.test.name
+  location                 = azurerm_resource_group.test.location
   infrastructure_subnet_id = azurerm_subnet.control.id
 
   workload_profile {
-    maximum_count = 2
-    minimum_count = 0
-    name = "My-GP-01"
+    maximum_count         = 2
+    minimum_count         = 0
+    name                  = "My-GP-01"
     workload_profile_type = "D4"
   }
 
   workload_profile {
-    name = "Consumption"
+    name                  = "Consumption"
     workload_profile_type = "Consumption"
   }
 

--- a/internal/services/containerapps/container_app_environment_resource_test.go
+++ b/internal/services/containerapps/container_app_environment_resource_test.go
@@ -207,11 +207,7 @@ resource "azurerm_container_app_environment" "test" {
 func (r ContainerAppEnvironmentResource) completeWithWorkloadProfile(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 provider "azurerm" {
-  features {
-    resource_group {
-      prevent_deletion_if_contains_resources = false
-    }
-  }
+  features {}
 }
 
 %[1]s

--- a/internal/services/containerapps/container_app_environment_resource_test.go
+++ b/internal/services/containerapps/container_app_environment_resource_test.go
@@ -79,6 +79,35 @@ func TestAccContainerAppEnvironment_withWorkloadProfile(t *testing.T) {
 	})
 }
 
+func TestAccContainerAppEnvironment_updateWorkloadProfile(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_container_app_environment", "test")
+	r := ContainerAppEnvironmentResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.complete(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("log_analytics_workspace_id"),
+		{
+			Config: r.completeWithWorkloadProfile(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("log_analytics_workspace_id"),
+		{
+			Config: r.completeUpdate(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep("log_analytics_workspace_id"),
+	})
+}
+
 func TestAccContainerAppEnvironment_completeUpdate(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_container_app_environment", "test")
 	r := ContainerAppEnvironmentResource{}

--- a/internal/services/containerapps/helpers/container_app_environment.go
+++ b/internal/services/containerapps/helpers/container_app_environment.go
@@ -48,12 +48,12 @@ func WorkloadProfileSchema() *pluginsdk.Schema {
 
 				"maximum_count": {
 					Type:     pluginsdk.TypeInt,
-					Optional: true,
+					Required: true,
 				},
 
 				"minimum_count": {
 					Type:     pluginsdk.TypeInt,
-					Optional: true,
+					Required: true,
 				},
 			},
 		},

--- a/internal/services/containerapps/helpers/container_app_environment.go
+++ b/internal/services/containerapps/helpers/container_app_environment.go
@@ -1,0 +1,111 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package helpers
+
+import (
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2023-05-01/managedenvironments"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
+)
+
+const consumption = "Consumption"
+
+type WorkloadProfileModel struct {
+	MaximumCount        int    `tfschema:"maximum_count"`
+	MinimumCount        int    `tfschema:"minimum_count"`
+	Name                string `tfschema:"name"`
+	WorkloadProfileType string `tfschema:"workload_profile_type"`
+}
+
+func WorkloadProfileSchema() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeSet,
+		Optional: true,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"name": {
+					Type:         pluginsdk.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+
+				"workload_profile_type": {
+					Type:     pluginsdk.TypeString,
+					Required: true,
+					ValidateFunc: validation.StringInSlice([]string{
+						"D4",
+						"D8",
+						"D16",
+						"D32",
+						"E4",
+						"E8",
+						"E16",
+						"E32",
+					}, false),
+				},
+
+				"maximum_count": {
+					Type:     pluginsdk.TypeInt,
+					Optional: true,
+				},
+
+				"minimum_count": {
+					Type:     pluginsdk.TypeInt,
+					Optional: true,
+				},
+			},
+		},
+	}
+}
+
+func ExpandWorkloadProfiles(input []WorkloadProfileModel) *[]managedenvironments.WorkloadProfile {
+	if len(input) == 0 {
+		return nil
+	}
+
+	result := make([]managedenvironments.WorkloadProfile, 0)
+
+	for _, v := range input {
+		r := managedenvironments.WorkloadProfile{
+			Name:                v.Name,
+			WorkloadProfileType: v.WorkloadProfileType,
+		}
+
+		if v.Name != consumption {
+			r.MaximumCount = pointer.To(int64(v.MaximumCount))
+			r.MinimumCount = pointer.To(int64(v.MinimumCount))
+		}
+
+		result = append(result, r)
+	}
+
+	result = append(result, managedenvironments.WorkloadProfile{
+		Name:                consumption,
+		WorkloadProfileType: consumption,
+	})
+
+	return &result
+}
+
+func FlattenWorkloadProfiles(input *[]managedenvironments.WorkloadProfile) []WorkloadProfileModel {
+	if input == nil || len(*input) == 0 {
+		return []WorkloadProfileModel{}
+	}
+	result := make([]WorkloadProfileModel, 0)
+
+	for _, v := range *input {
+		if v.Name == consumption {
+			continue
+		}
+		result = append(result, WorkloadProfileModel{
+			Name:                v.Name,
+			MaximumCount:        int(pointer.From(v.MaximumCount)),
+			MinimumCount:        int(pointer.From(v.MinimumCount)),
+			WorkloadProfileType: v.WorkloadProfileType,
+		})
+	}
+
+	return result
+}

--- a/internal/services/containerapps/helpers/container_app_environment.go
+++ b/internal/services/containerapps/helpers/container_app_environment.go
@@ -4,6 +4,8 @@
 package helpers
 
 import (
+	"strings"
+
 	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/containerapps/2023-05-01/managedenvironments"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
@@ -96,7 +98,7 @@ func FlattenWorkloadProfiles(input *[]managedenvironments.WorkloadProfile) []Wor
 	result := make([]WorkloadProfileModel, 0)
 
 	for _, v := range *input {
-		if v.Name == consumption {
+		if strings.EqualFold(v.WorkloadProfileType, consumption) {
 			continue
 		}
 		result = append(result, WorkloadProfileModel{

--- a/internal/services/containerapps/helpers/container_apps.go
+++ b/internal/services/containerapps/helpers/container_apps.go
@@ -17,8 +17,6 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 )
 
-const consumption = "Consumption"
-
 type Registry struct {
 	PasswordSecretRef string `tfschema:"password_secret_name"`
 	Server            string `tfschema:"server"`
@@ -3015,85 +3013,4 @@ func (c *ContainerTemplate) flattenContainerAppScaleRules(input *[]containerapps
 		c.HTTPScaleRules = httpScaleRules
 		c.TCPScaleRules = tcpScaleRules
 	}
-}
-
-type WorkloadProfileModel struct {
-	MaximumCount        int64  `tfschema:"maximum_count"`
-	MinimumCount        int64  `tfschema:"minimum_count"`
-	Name                string `tfschema:"name"`
-	WorkloadProfileType string `tfschema:"workload_profile_type"`
-}
-
-func WorkloadProfileSchema() *pluginsdk.Schema {
-	return &pluginsdk.Schema{
-		Type:     pluginsdk.TypeSet,
-		Optional: true,
-		Elem: &pluginsdk.Resource{
-			Schema: map[string]*pluginsdk.Schema{
-				"name": {
-					Type:         pluginsdk.TypeString,
-					Required:     true,
-					ValidateFunc: validation.StringIsNotEmpty,
-				},
-
-				"workload_profile_type": {
-					Type:         pluginsdk.TypeString,
-					Required:     true,
-					ValidateFunc: validation.StringIsNotEmpty,
-				},
-
-				"maximum_count": {
-					Type:     pluginsdk.TypeInt,
-					Optional: true,
-				},
-
-				"minimum_count": {
-					Type:     pluginsdk.TypeInt,
-					Optional: true,
-				},
-			},
-		},
-	}
-}
-
-func ExpandWorkloadProfiles(input []WorkloadProfileModel) *[]managedenvironments.WorkloadProfile {
-	if len(input) == 0 {
-		return nil
-	}
-
-	result := make([]managedenvironments.WorkloadProfile, 0)
-
-	for _, v := range input {
-		r := managedenvironments.WorkloadProfile{
-			Name:                v.Name,
-			WorkloadProfileType: v.WorkloadProfileType,
-		}
-
-		if v.Name != consumption {
-			r.MaximumCount = pointer.To(v.MaximumCount)
-			r.MinimumCount = pointer.To(v.MinimumCount)
-		}
-
-		result = append(result, r)
-	}
-
-	return &result
-}
-
-func FlattenWorkloadProfiles(input *[]managedenvironments.WorkloadProfile) []WorkloadProfileModel {
-	if input == nil || len(*input) == 0 {
-		return []WorkloadProfileModel{}
-	}
-	result := make([]WorkloadProfileModel, 0)
-
-	for _, v := range *input {
-		result = append(result, WorkloadProfileModel{
-			Name:                v.Name,
-			MaximumCount:        pointer.From(v.MaximumCount),
-			MinimumCount:        pointer.From(v.MinimumCount),
-			WorkloadProfileType: v.WorkloadProfileType,
-		})
-	}
-
-	return result
 }

--- a/internal/services/containerapps/helpers/container_apps.go
+++ b/internal/services/containerapps/helpers/container_apps.go
@@ -3014,3 +3014,82 @@ func (c *ContainerTemplate) flattenContainerAppScaleRules(input *[]containerapps
 		c.TCPScaleRules = tcpScaleRules
 	}
 }
+
+type WorkloadProfileModel struct {
+	MaximumCount        int    `tfschema:"maximum_count"`
+	MinimumCount        int    `tfschema:"minimum_count"`
+	Name                string `tfschema:"name"`
+	WorkloadProfileType string `tfschema:"workload_profile_type"`
+}
+
+func WorkloadProfileSchema() *pluginsdk.Schema {
+	return &pluginsdk.Schema{
+		Type:     pluginsdk.TypeList,
+		Optional: true,
+		Elem: &pluginsdk.Resource{
+			Schema: map[string]*pluginsdk.Schema{
+				"maximum_count": {
+					Type:         pluginsdk.TypeInt,
+					Required:     true,
+					ValidateFunc: validation.IntAtLeast(1),
+				},
+
+				"minimum_count": {
+					Type:         pluginsdk.TypeInt,
+					Required:     true,
+					ValidateFunc: validation.IntAtLeast(0),
+				},
+
+				"name": {
+					Type:         pluginsdk.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+
+				"workload_profile_type": {
+					Type:         pluginsdk.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringIsNotEmpty,
+				},
+			},
+		},
+	}
+}
+
+func ExpandWorkloadProfiles(input []WorkloadProfileModel) *[]managedenvironments.WorkloadProfile {
+	if len(input) == 0 {
+		return nil
+	}
+
+	result := make([]managedenvironments.WorkloadProfile, 0)
+
+	for _, v := range input {
+		result = append(result, managedenvironments.WorkloadProfile{
+			Name:                v.Name,
+			MaximumCount:        pointer.To(int64(v.MaximumCount)),
+			MinimumCount:        pointer.To(int64(v.MinimumCount)),
+			WorkloadProfileType: v.WorkloadProfileType,
+		})
+	}
+
+	return &result
+}
+
+func FlattenWorkloadProfiles(input *[]managedenvironments.WorkloadProfile) []WorkloadProfileModel {
+	if input == nil || len(*input) == 0 {
+		return []WorkloadProfileModel{}
+	}
+
+	result := make([]WorkloadProfileModel, 0)
+
+	for _, v := range *input {
+		result = append(result, WorkloadProfileModel{
+			Name:                v.Name,
+			MaximumCount:        int(pointer.From(v.MaximumCount)),
+			MinimumCount:        int(pointer.From(v.MinimumCount)),
+			WorkloadProfileType: v.WorkloadProfileType,
+		})
+	}
+
+	return result
+}

--- a/internal/services/paloalto/local_rulestack_data_source_test.go
+++ b/internal/services/paloalto/local_rulestack_data_source_test.go
@@ -29,7 +29,7 @@ func (d LocalRulestackDataSource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 %s
 
-data "azurerm_palo_alto_local_rulestack" "test"{
+data "azurerm_palo_alto_local_rulestack" "test" {
   name                = azurerm_palo_alto_local_rulestack.test.name
   resource_group_name = azurerm_palo_alto_local_rulestack.test.resource_group_name
 }

--- a/website/docs/r/container_app_environment.html.markdown
+++ b/website/docs/r/container_app_environment.html.markdown
@@ -74,9 +74,9 @@ A `workload_profile` block supports the following:
 
 * `workload_profile_type` - (Required) Workload profile type for the workloads to run on. 
 
-* `maximum_count` - (Optional) The maximum number of containers that can be deployed in the Container App Environment.
+* `maximum_container_count` - (Optional) The maximum number of containers that can be deployed in the Container App Environment.
 
-* `minimum_count` - (Optional) The minimum number of containers that can be deployed in the Container App Environment.
+* `minimum_container_count` - (Optional) The minimum number of containers that can be deployed in the Container App Environment.
 
 ## Attributes Reference
 

--- a/website/docs/r/container_app_environment.html.markdown
+++ b/website/docs/r/container_app_environment.html.markdown
@@ -72,7 +72,7 @@ A `workload_profile` block supports the following:
 
 * `name` - (Required) The name of the workload profile.
 
-* `workload_profile_type` - (Required) Workload profile type for the workloads to run on. 
+* `workload_profile_type` - (Required) Workload profile type for the workloads to run on. Possible values include `D4`, `D8`, `D16`, `D32`, `E4`, `E8`, `E16` and `E32`.
 
 * `maximum_container_count` - (Optional) The maximum number of instances of workload profile that can be deployed in the Container App Environment.
 

--- a/website/docs/r/container_app_environment.html.markdown
+++ b/website/docs/r/container_app_environment.html.markdown
@@ -62,7 +62,21 @@ The following arguments are supported:
 
 * `log_analytics_workspace_id` - (Optional) The ID for the Log Analytics Workspace to link this Container Apps Managed Environment to. Changing this forces a new resource to be created.
 
+* `workload_profile` - (Optional) The profile of the workload to scope the container app execution. A `workload_profile` block as defined below.
+
 * `tags` - (Optional) A mapping of tags to assign to the resource.
+
+---
+
+A `workload_profile` block supports the following:
+
+* `name` - (Required) The name of the workload profile.
+
+* `workload_profile_type` - (Required) Workload profile type for the workloads to run on. 
+
+* `maximum_count` - (Optional) The maximum number of containers that can be deployed in the Container App Environment.
+
+* `minimum_count` - (Optional) The minimum number of containers that can be deployed in the Container App Environment.
 
 ## Attributes Reference
 

--- a/website/docs/r/container_app_environment.html.markdown
+++ b/website/docs/r/container_app_environment.html.markdown
@@ -74,9 +74,9 @@ A `workload_profile` block supports the following:
 
 * `workload_profile_type` - (Required) Workload profile type for the workloads to run on. 
 
-* `maximum_container_count` - (Optional) The maximum number of containers that can be deployed in the Container App Environment.
+* `maximum_container_count` - (Optional) The maximum number of instances of workload profile that can be deployed in the Container App Environment.
 
-* `minimum_container_count` - (Optional) The minimum number of containers that can be deployed in the Container App Environment.
+* `minimum_container_count` - (Optional) The minimum number of instances of workload profile that can be deployed in the Container App Environment.
 
 ## Attributes Reference
 


### PR DESCRIPTION
* All related test passed.

```
TestAccContainerAppEnvironment_withWorkloadProfile
    === RUN   TestAccContainerAppEnvironment_withWorkloadProfile
    === PAUSE TestAccContainerAppEnvironment_withWorkloadProfile
    === CONT  TestAccContainerAppEnvironment_withWorkloadProfile
    --- PASS: TestAccContainerAppEnvironment_withWorkloadProfile (2083.54s)
    PASS
```

![Screenshot 2023-11-21 095151](https://github.com/hashicorp/terraform-provider-azurerm/assets/100274846/67547800-f36e-4b30-bf2c-5775ef193a98)
