### PR TITLE
automation: opening a PR when a branch named `auto-pr/deps/updating-go-azure-sdk-to-{version}` is pushed

### DIFF
--- a/.github/workflows/automation-open-pull-request-go-sdk.yaml
+++ b/.github/workflows/automation-open-pull-request-go-sdk.yaml
@@ -18,7 +18,7 @@ jobs:
         id: open-pr
         run: |
           version="$(echo {{ github.ref_name }} | sed "s/auto-pr\/deps\/updating-go-azure-sdk-to-//")"
-          title="dependencies: updating `hashicorp/go-azure-sdk` to `${version}"
+          title="dependencies: updating `hashicorp/go-azure-sdk` to `${version}`"
           
           # this runs everytime the PR gets pushed too, whilst you can only create a PR a single time
           # so we should be smarter, but piping this to /dev/null is a fine workaround for MVP

--- a/.github/workflows/automation-open-pull-request-go-sdk.yaml
+++ b/.github/workflows/automation-open-pull-request-go-sdk.yaml
@@ -17,8 +17,8 @@ jobs:
       - name: "open a pull request"
         id: open-pr
         run: |
-          $version=$(echo {{ github.ref_name }} | sed "s/auto-pr\/deps\/updating-go-azure-sdk-to-//")
-          $title="dependencies: updating `hashicorp/go-azure-sdk` to `${version}"
+          version="$(echo {{ github.ref_name }} | sed "s/auto-pr\/deps\/updating-go-azure-sdk-to-//")"
+          title="dependencies: updating `hashicorp/go-azure-sdk` to `${version}"
           
           # this runs everytime the PR gets pushed too, whilst you can only create a PR a single time
           # so we should be smarter, but piping this to /dev/null is a fine workaround for MVP

--- a/.github/workflows/automation-open-pull-request-go-sdk.yaml
+++ b/.github/workflows/automation-open-pull-request-go-sdk.yaml
@@ -1,10 +1,10 @@
 ---
-name: Open Pull Request when an `auto-pr` is pushed
+name: Open Pull Request when an `auto-pr` is pushed for go-azure-sdk
 
 on:
   push:
     branches:
-      - 'auto-pr/**'
+      - 'auto-pr/deps/updating-go-azure-sdk-to-**'
 
 jobs:
   open-pull-request:
@@ -17,12 +17,14 @@ jobs:
       - name: "open a pull request"
         id: open-pr
         run: |
+          $version=$(echo {{ github.ref_name }} | sed "s/auto-pr\/deps\/updating-go-azure-sdk-to-//")
+          $title="dependencies: updating `hashicorp/go-azure-sdk` to `${version}"
+          
           # this runs everytime the PR gets pushed too, whilst you can only create a PR a single time
           # so we should be smarter, but piping this to /dev/null is a fine workaround for MVP
-          gh pr create --title "$PR_TITLE" --body "$PR_BODY" -B "$PR_TARGET" > /dev/null
+          gh pr create --title "$title" --body "$PR_BODY" -B "$PR_TARGET" > /dev/null
 
         env:
-          PR_TITLE: "Auto PR: Regenerating based on (${{ github.sha }})"
-          PR_BODY: "Regenerating the Terraform Provider based on the latest changes"
+          PR_BODY: "This PR updates `hashicorp/go-azure-sdk` - further details can be found in a comment."
           PR_TARGET: "main"
           GH_TOKEN: ${{ secrets.SERVICE_ACCOUNT_TERRAFORM_TOKEN }}

--- a/.github/workflows/automation-open-pull-request-pandora.yaml
+++ b/.github/workflows/automation-open-pull-request-pandora.yaml
@@ -1,0 +1,30 @@
+---
+name: Open Pull Request when an `auto-pr` is pushed for Pandora
+
+on:
+  push:
+    branches:
+      - 'auto-pr/**'
+    branches-ignore:
+      - 'auto-pr/deps/updating-go-azure-sdk-to-**'
+
+jobs:
+  open-pull-request:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+
+      - name: "open a pull request"
+        id: open-pr
+        run: |
+          # this runs everytime the PR gets pushed too, whilst you can only create a PR a single time
+          # so we should be smarter, but piping this to /dev/null is a fine workaround for MVP
+          gh pr create --title "$PR_TITLE" --body "$PR_BODY" -B "$PR_TARGET" > /dev/null
+
+        env:
+          PR_TITLE: "Auto PR: Regenerating based on (${{ github.sha }})"
+          PR_BODY: "Regenerating the Terraform Provider based on the latest changes"
+          PR_TARGET: "main"
+          GH_TOKEN: ${{ secrets.SERVICE_ACCOUNT_TERRAFORM_TOKEN }}


### PR DESCRIPTION
This enables the `update-go-azure-sdk` tool to be run automagically

Related https://github.com/hashicorp/terraform-provider-azurerm/pull/23498
Related https://github.com/hashicorp/go-azure-sdk/pull/673