### PR TITLE
Tooling: limit retention for gha artifacts

### DIFF
--- a/.github/workflows/save-artifacts.yaml
+++ b/.github/workflows/save-artifacts.yaml
@@ -18,3 +18,4 @@ jobs:
         with:
           name: artifact
           path: wr_actions
+          retention-days: 1


### PR DESCRIPTION
These are retained for 90 days by default, limit to 1 day to save space.