### PR TITLE
`DevCenter` - scaffolding the Service Package to enable generation

### DIFF
--- a/.github/labeler-issue-triage.yml
+++ b/.github/labeler-issue-triage.yml
@@ -114,6 +114,8 @@ service/databricks:
 service/datadog:
   - '### (|New or )Affected Resource\(s\)\/Data Source\(s\)((.|\n)*)azurerm_datadog_monitor((.|\n)*)###'
 
+service/dev-center:
+
 service/devtestlabs:
   - '### (|New or )Affected Resource\(s\)\/Data Source\(s\)((.|\n)*)azurerm_dev_test_((.|\n)*)###'
 

--- a/.github/labeler-pull-request-triage.yml
+++ b/.github/labeler-pull-request-triage.yml
@@ -115,6 +115,9 @@ service/databricks:
 service/datadog:
   - internal/services/datadog/**/*
 
+service/dev-center:
+  - internal/services/devcenter/**/*
+
 service/devtestlabs:
   - internal/services/devtestlabs/**/*
 

--- a/.teamcity/components/generated/services.kt
+++ b/.teamcity/components/generated/services.kt
@@ -44,6 +44,7 @@ var services = mapOf(
         "databoxedge" to "Databox Edge",
         "datadog" to "Datadog",
         "desktopvirtualization" to "Desktop Virtualization",
+        "devcenter" to "Dev Center",
         "devtestlabs" to "Dev Test",
         "digitaltwins" to "Digital Twins",
         "disks" to "Disks",

--- a/internal/provider/services_gen.go
+++ b/internal/provider/services_gen.go
@@ -5,6 +5,7 @@ package provider
 import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/containers"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/services/devcenter"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/loadtestservice"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/managedidentity"
 )
@@ -12,6 +13,7 @@ import (
 func autoRegisteredTypedServices() []sdk.TypedServiceRegistration {
 	return []sdk.TypedServiceRegistration{
 		containers.Registration{},
+		devcenter.Registration{},
 		loadtestservice.Registration{},
 		managedidentity.Registration{},
 	}

--- a/internal/services/devcenter/example_gen_test.go
+++ b/internal/services/devcenter/example_gen_test.go
@@ -1,0 +1,8 @@
+package devcenter
+
+import "testing"
+
+func TestAcc(t *testing.T) {
+	// NOTE: this test exists just to keep CI happy until the package is regenerated
+	// hence why this is *_gen.go and not just .go (since it'll be regenerated)
+}

--- a/internal/services/devcenter/registration.go
+++ b/internal/services/devcenter/registration.go
@@ -1,0 +1,31 @@
+package devcenter
+
+import (
+	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+)
+
+var _ sdk.TypedServiceRegistrationWithAGitHubLabel = Registration{}
+
+type Registration struct {
+	autoRegistration
+}
+
+func (r Registration) Name() string {
+	return "Dev Center"
+}
+
+func (r Registration) AssociatedGitHubLabel() string {
+	return "service/dev-center"
+}
+
+func (r Registration) WebsiteCategories() []string {
+	return r.autoRegistration.WebsiteCategories()
+}
+
+func (r Registration) DataSources() []sdk.DataSource {
+	return r.autoRegistration.DataSources()
+}
+
+func (r Registration) Resources() []sdk.Resource {
+	return r.autoRegistration.Resources()
+}

--- a/internal/services/devcenter/registration_gen.go
+++ b/internal/services/devcenter/registration_gen.go
@@ -1,0 +1,28 @@
+package devcenter
+
+// NOTE: this file is temporary to enable the project to compile prior to auto-generation
+
+import "github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
+
+var _ sdk.TypedServiceRegistration = autoRegistration{}
+
+type autoRegistration struct {
+}
+
+func (autoRegistration) Name() string {
+	return "Dev Center"
+}
+
+func (autoRegistration) DataSources() []sdk.DataSource {
+	return []sdk.DataSource{}
+}
+
+func (autoRegistration) Resources() []sdk.Resource {
+	return []sdk.Resource{}
+}
+
+func (autoRegistration) WebsiteCategories() []string {
+	return []string{
+		"Dev Center",
+	}
+}

--- a/internal/tools/generator-services/main.go
+++ b/internal/tools/generator-services/main.go
@@ -380,11 +380,14 @@ func (githubIssueLabelsGenerator) run(outputFileName string, _ map[string]struct
 				prefixes = append(prefixes, strings.TrimPrefix(prefix.CommonPrefix, azurerm))
 			}
 		}
+
 		if len(prefixes) > 1 {
 			out = append(out, fmt.Sprintf("  - '### (|New or )Affected Resource\\(s\\)\\/Data Source\\(s\\)((.|\\n)*)azurerm_(%s)((.|\\n)*)###'", strings.Join(prefixes, "|")))
-		} else {
+		}
+		if len(prefixes) == 1 {
 			out = append(out, fmt.Sprintf("  - '### (|New or )Affected Resource\\(s\\)\\/Data Source\\(s\\)((.|\\n)*)azurerm_%s((.|\\n)*)###'", prefixes[0]))
 		}
+		// NOTE: it's possible for a Service to contain 0 Data Sources/Resources (during initial generation)
 
 		out = append(out, "")
 		output += fmt.Sprintf("\n%s", strings.Join(out, "\n"))

--- a/website/allowed-subcategories
+++ b/website/allowed-subcategories
@@ -43,6 +43,7 @@ Databox Edge
 Databricks
 Datadog
 Desktop Virtualization
+Dev Center
 Dev Test
 Digital Twins
 Disks


### PR DESCRIPTION
The Dev Center resources can be generated via `hashicorp/pandora` - as such this PR lays the foundation for that to happen in https://github.com/hashicorp/pandora/pull/3152.

Supersedes #23522