### PR TITLE
dependencies: updating to version `v0.20231012.1141427` of `github.com/hashicorp/go-azure-sdk`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.3.1
 	github.com/hashicorp/go-azure-helpers v0.61.0
-	github.com/hashicorp/go-azure-sdk v0.20231011.1091146
+	github.com/hashicorp/go-azure-sdk v0.20231012.1141427
 	github.com/hashicorp/go-hclog v1.5.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -110,8 +110,8 @@ github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brv
 github.com/hashicorp/go-azure-helpers v0.12.0/go.mod h1:Zc3v4DNeX6PDdy7NljlYpnrdac1++qNW0I4U+ofGwpg=
 github.com/hashicorp/go-azure-helpers v0.61.0 h1:dIz23Vp8LdErxuImc6V5QIPtJcWjMgqP75bfp8o1Lro=
 github.com/hashicorp/go-azure-helpers v0.61.0/go.mod h1:BQUQp5udwbJ8pnzl0wByCLVEEyPMAFpJ9vOREiCzObo=
-github.com/hashicorp/go-azure-sdk v0.20231011.1091146 h1:gI1ADgc+DkEh8Ir7K3/wsYC/pWsQm1rIZDxUMDVkah4=
-github.com/hashicorp/go-azure-sdk v0.20231011.1091146/go.mod h1:KSQRt0kuQGxFXo3t0KtQwTXhOWWxso2ZoSbtqQitruY=
+github.com/hashicorp/go-azure-sdk v0.20231012.1141427 h1:WIHCXq+w/hWuv4BX4PuXgtoIMQRzSocW4466eD+oz24=
+github.com/hashicorp/go-azure-sdk v0.20231012.1141427/go.mod h1:n7/QljZviQP/bQF/L1SmkcEgt4KGujaOhQVQpzONW1o=
 github.com/hashicorp/go-checkpoint v0.5.0 h1:MFYpPZCnQqQTE18jFwSII6eUQrD/oxMFp3mlgcqk5mU=
 github.com/hashicorp/go-checkpoint v0.5.0/go.mod h1:7nfLNL10NsxqO4iWuW6tWW0HjZuDrwkBuEQsVcpCOgg=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -156,7 +156,7 @@ github.com/hashicorp/go-azure-helpers/resourcemanager/tags
 github.com/hashicorp/go-azure-helpers/resourcemanager/zones
 github.com/hashicorp/go-azure-helpers/sender
 github.com/hashicorp/go-azure-helpers/storage
-# github.com/hashicorp/go-azure-sdk v0.20231011.1091146
+# github.com/hashicorp/go-azure-sdk v0.20231012.1141427
 ## explicit; go 1.19
 github.com/hashicorp/go-azure-sdk/resource-manager/aad/2021-05-01/domainservices
 github.com/hashicorp/go-azure-sdk/resource-manager/aadb2c/2021-04-01-preview


### PR DESCRIPTION
This version contains no new API Versions - so no upgrades were attempted.

(Upgrade automated [via the `update-go-azure-sdk` tool](https://github.com/hashicorp/terraform-provider-azurerm/tree/main/internal/tools/update-go-azure-sdk) - run locally for now)