### PR TITLE
[Bug:] `azurerm_cdn_frontdoor_rule` - make `match_values` optional if `operator` is set to `Any` for the `url_filename_condition`

### DIFF
--- a/internal/services/cdn/cdn_frontdoor_rule_resource.go
+++ b/internal/services/cdn/cdn_frontdoor_rule_resource.go
@@ -487,8 +487,9 @@ func resourceCdnFrontDoorRule() *pluginsdk.Resource {
 								Schema: map[string]*pluginsdk.Schema{
 									"operator":         schemaCdnFrontDoorOperator(),
 									"negate_condition": schemaCdnFrontDoorNegateCondition(),
-									"match_values":     schemaCdnFrontDoorMatchValuesRequired(),
-									"transforms":       schemaCdnFrontDoorRuleTransforms(),
+									// making optional for issue #23504
+									"match_values": schemaCdnFrontDoorMatchValues(),
+									"transforms":   schemaCdnFrontDoorRuleTransforms(),
 								},
 							},
 						},

--- a/internal/services/cdn/cdn_frontdoor_rule_resource_test.go
+++ b/internal/services/cdn/cdn_frontdoor_rule_resource_test.go
@@ -392,6 +392,34 @@ func TestAccCdnFrontDoorRule_allowForwardSlashUrlConditionMatchValue(t *testing.
 	})
 }
 
+func TestAccCdnFrontDoorRule_urlFilenameConditionOperatorAny(t *testing.T) {
+	// NOTE: Regression test case for issue #23504
+	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_rule", "test")
+	r := CdnFrontDoorRuleResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.urlFilenameConditionOperator(data, "Any"),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
+func TestAccCdnFrontDoorRule_urlFilenameConditionOperatorError(t *testing.T) {
+	// NOTE: Regression test case for issue #23504
+	data := acceptance.BuildTestData(t, "azurerm_cdn_frontdoor_rule", "test")
+	r := CdnFrontDoorRuleResource{}
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config:      r.urlFilenameConditionOperator(data, "Contains"),
+			ExpectError: regexp.MustCompile(`the 'match_values' field must be set if the conditions 'operator' is not set to 'Any'`),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (r CdnFrontDoorRuleResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := parse.FrontDoorRuleID(state.ID)
 	if err != nil {
@@ -1318,4 +1346,37 @@ resource "azurerm_cdn_frontdoor_rule" "test" {
   }
 }
 `, template, data.RandomInteger)
+}
+
+func (r CdnFrontDoorRuleResource) urlFilenameConditionOperator(data acceptance.TestData, operator string) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+%s
+resource "azurerm_cdn_frontdoor_rule" "test" {
+  depends_on = [azurerm_cdn_frontdoor_origin_group.repro, azurerm_cdn_frontdoor_origin.repro]
+
+  name                      = "accTestRule%d"
+  cdn_frontdoor_rule_set_id = azurerm_cdn_frontdoor_rule_set.test.id
+  order                     = 1
+  behavior_on_match         = "Stop"
+
+  actions {
+    url_rewrite_action {
+      source_pattern          = "/"
+      destination             = "/index.html"
+      preserve_unmatched_path = false
+    }
+  }
+
+  conditions {
+    url_filename_condition {
+      operator = "%s"
+    }
+  }
+}
+`, template, data.RandomInteger, operator)
 }

--- a/internal/services/cdn/frontdoorruleconditions/cdn_frontdoor_rule_conditions.go
+++ b/internal/services/cdn/frontdoorruleconditions/cdn_frontdoor_rule_conditions.go
@@ -235,6 +235,11 @@ func validateCdnFrontDoorExpandConditionOperatorValues(operator string, matchVal
 		return fmt.Errorf("%q is invalid: the 'match_values' field must not be set if the conditions 'operator' is set to 'Any'", m.ConfigName)
 	}
 
+	// make the 'match_values' field required if the operator is not set to 'Any'...
+	if operator != string(cdn.OperatorAny) && len(*matchValues) == 0 {
+		return fmt.Errorf("%q is invalid: the 'match_values' field must be set if the conditions 'operator' is not set to 'Any'", m.ConfigName)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
(Fixes #23504)