### PR TITLE
Example: storage share `quota` must be >= 100 for premium account

### DIFF
--- a/examples/storage/storage-share/main.tf
+++ b/examples/storage/storage-share/main.tf
@@ -22,5 +22,5 @@ resource "azurerm_storage_account" "example" {
 resource "azurerm_storage_share" "example" {
   name                 = "${var.prefix}storageshare"
   storage_account_name = azurerm_storage_account.example.name
-  quota                = 1
+  quota                = 100
 }


### PR DESCRIPTION
Fix #23526