### PR TITLE
[TestCase] azurerm_maps_account - update sku_name value in the test case

### DIFF
--- a/internal/services/maps/maps_account_data_source_test.go
+++ b/internal/services/maps/maps_account_data_source_test.go
@@ -26,7 +26,7 @@ func TestAccMapsAccountDataSource_basic(t *testing.T) {
 				check.That(data.ResourceName).Key("resource_group_name").Exists(),
 				check.That(data.ResourceName).Key("tags.%").HasValue("1"),
 				check.That(data.ResourceName).Key("tags.environment").HasValue("testing"),
-				check.That(data.ResourceName).Key("sku_name").HasValue("S0"),
+				check.That(data.ResourceName).Key("sku_name").HasValue("G2"),
 				check.That(data.ResourceName).Key("x_ms_client_id").Exists(),
 				check.That(data.ResourceName).Key("primary_access_key").Exists(),
 				check.That(data.ResourceName).Key("secondary_access_key").Exists(),

--- a/internal/services/maps/maps_account_resource_test.go
+++ b/internal/services/maps/maps_account_resource_test.go
@@ -30,7 +30,7 @@ func TestAccMapsAccount_basic(t *testing.T) {
 				check.That(data.ResourceName).Key("x_ms_client_id").Exists(),
 				check.That(data.ResourceName).Key("primary_access_key").Exists(),
 				check.That(data.ResourceName).Key("secondary_access_key").Exists(),
-				check.That(data.ResourceName).Key("sku_name").HasValue("S0"),
+				check.That(data.ResourceName).Key("sku_name").HasValue("G2"),
 			),
 		},
 		data.ImportStep(),
@@ -43,13 +43,13 @@ func TestAccMapsAccount_sku(t *testing.T) {
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.sku(data, "S1"),
+			Config: r.sku(data, "G2"),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).Key("name").Exists(),
 				check.That(data.ResourceName).Key("x_ms_client_id").Exists(),
 				check.That(data.ResourceName).Key("primary_access_key").Exists(),
 				check.That(data.ResourceName).Key("secondary_access_key").Exists(),
-				check.That(data.ResourceName).Key("sku_name").HasValue("S1"),
+				check.That(data.ResourceName).Key("sku_name").HasValue("G2"),
 			),
 		},
 		data.ImportStep(),
@@ -152,7 +152,7 @@ resource "azurerm_resource_group" "test" {
 resource "azurerm_maps_account" "test" {
   name                = "accMapsAccount-%d"
   resource_group_name = azurerm_resource_group.test.name
-  sku_name            = "S0"
+  sku_name            = "G2"
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
 }
@@ -190,7 +190,7 @@ resource "azurerm_resource_group" "test" {
 resource "azurerm_maps_account" "test" {
   name                = "accMapsAccount-%d"
   resource_group_name = azurerm_resource_group.test.name
-  sku_name            = "S0"
+  sku_name            = "G2"
 
   tags = {
     environment = "testing"
@@ -213,7 +213,7 @@ resource "azurerm_resource_group" "test" {
 resource "azurerm_maps_account" "test" {
   name                         = "accMapsAccount-%d"
   resource_group_name          = azurerm_resource_group.test.name
-  sku_name                     = "S0"
+  sku_name                     = "G2"
   local_authentication_enabled = false
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
@@ -233,7 +233,7 @@ resource "azurerm_resource_group" "test" {
 resource "azurerm_maps_account" "test" {
   name                         = "accMapsAccount-%d"
   resource_group_name          = azurerm_resource_group.test.name
-  sku_name                     = "S0"
+  sku_name                     = "G2"
   local_authentication_enabled = true
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)

--- a/website/docs/r/maps_account.html.markdown
+++ b/website/docs/r/maps_account.html.markdown
@@ -40,7 +40,7 @@ The following arguments are supported:
 
 * `sku_name` - (Required) The SKU of the Azure Maps Account. Possible values are `S0`, `S1` and `G2`. Changing this forces a new resource to be created.
 
-~> **Note:** `S0` and `S1` are deprecated by Service API. Suggest to use `G2`. Please see more at this [document](https://learn.microsoft.com/azure/azure-maps/how-to-manage-pricing-tier).
+~> **Note:** Gen1 SKUs (`S0` and `S1`) are deprecated and can no longer be used for new deployments, which should instead use a Gen2 SKU (`G2`) - more information can be found [in the Azure documentation](https://learn.microsoft.com/azure/azure-maps/how-to-manage-pricing-tier).
 
 * `local_authentication_enabled` - (Optional) Is local authentication enabled for this Azure Maps Account? When `false`, all authentication to the Azure Maps data-plane REST API is disabled, except Azure AD authentication. Defaults to `true`.
 

--- a/website/docs/r/maps_account.html.markdown
+++ b/website/docs/r/maps_account.html.markdown
@@ -40,7 +40,7 @@ The following arguments are supported:
 
 * `sku_name` - (Required) The SKU of the Azure Maps Account. Possible values are `S0`, `S1` and `G2`. Changing this forces a new resource to be created.
 
-~> **Note:** `S0` and `S1` is deprecated by Service API. Suggest to use `G2`. Please see more at this [document](https://learn.microsoft.com/azure/azure-maps/how-to-manage-pricing-tier).
+~> **Note:** `S0` and `S1` are deprecated by Service API. Suggest to use `G2`. Please see more at this [document](https://learn.microsoft.com/azure/azure-maps/how-to-manage-pricing-tier).
 
 * `local_authentication_enabled` - (Optional) Is local authentication enabled for this Azure Maps Account? When `false`, all authentication to the Azure Maps data-plane REST API is disabled, except Azure AD authentication. Defaults to `true`.
 

--- a/website/docs/r/maps_account.html.markdown
+++ b/website/docs/r/maps_account.html.markdown
@@ -40,6 +40,8 @@ The following arguments are supported:
 
 * `sku_name` - (Required) The SKU of the Azure Maps Account. Possible values are `S0`, `S1` and `G2`. Changing this forces a new resource to be created.
 
+~> **Note:** `S0` and `S1` is deprecated by Service API. Suggest to use `G2`. Please see more at this [document](https://learn.microsoft.com/azure/azure-maps/how-to-manage-pricing-tier).
+
 * `local_authentication_enabled` - (Optional) Is local authentication enabled for this Azure Maps Account? When `false`, all authentication to the Azure Maps data-plane REST API is disabled, except Azure AD authentication. Defaults to `true`.
 
 * `tags` - (Optional) A mapping of tags to assign to the Azure Maps Account.


### PR DESCRIPTION
Recently, test cases about Maps Account in Teamcity are failed. After investigated, I found that skus `S0` and `S1` and kind `Gen1` are deprecated. So I updated test cases.

Note: I didn't remove the deprecated skus from the validation since we shouldn't block the user who is using the existing resource with S0 and S1.

![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/19754191/41a93702-d077-4284-9801-b5e18bdd893d)
![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/19754191/cbbf430d-5f8d-48e4-8ee8-6f36b2de84a6)
