### PR TITLE
"TypedSDK": Fix the issue with the `removedInNextMajorVersion` tag causing data loss in `Decode`

### DIFF
--- a/internal/sdk/resource_decode.go
+++ b/internal/sdk/resource_decode.go
@@ -6,6 +6,7 @@ package sdk
 import (
 	"fmt"
 	"reflect"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -57,6 +58,7 @@ func decodeReflectedType(input interface{}, stateRetriever stateRetriever, debug
 		debugLogger.Infof("Field", field)
 
 		if val, exists := field.Tag.Lookup("tfschema"); exists {
+			val = strings.TrimSuffix(val, ",removedInNextMajorVersion")
 			tfschemaValue, valExists := stateRetriever.GetOkExists(val)
 			if !valExists {
 				continue
@@ -192,6 +194,7 @@ func setListValue(input interface{}, index int, fieldName string, v []interface{
 					debugLogger.Infof("nestedField ", nestedField)
 
 					if val, exists := nestedField.Tag.Lookup("tfschema"); exists {
+						val = strings.TrimSuffix(val, ",removedInNextMajorVersion")
 						nestedTFSchemaValue := test[val]
 						if err := setValue(elem.Interface(), nestedTFSchemaValue, j, fieldName, debugLogger); err != nil {
 							return err


### PR DESCRIPTION
#23415 does not work with decode method of typed resources which makes many AccTests failed when the tag `removedInNextMajorVersion` added.

Failed Examples: 
1.
![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/2633022/2a866204-2c46-4978-bc16-1044c10e9aa2)
2.
![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/2633022/b2e13fe8-a009-43c5-9acb-438c37a190b3)

Passed in this PR:
```
--- PASS: TestAccSoftwareUpdateConfiguration_withTask (162.60s)
PASS
```


