### PR TITLE
internal/sdk: resource decoding/encoding now parses the struct tags consistently

### DIFF
--- a/internal/sdk/resource_decode.go
+++ b/internal/sdk/resource_decode.go
@@ -6,7 +6,6 @@ package sdk
 import (
 	"fmt"
 	"reflect"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -57,9 +56,13 @@ func decodeReflectedType(input interface{}, stateRetriever stateRetriever, debug
 		field := objType.Field(i)
 		debugLogger.Infof("Field", field)
 
-		if val, exists := field.Tag.Lookup("tfschema"); exists {
-			val = strings.TrimSuffix(val, ",removedInNextMajorVersion")
-			tfschemaValue, valExists := stateRetriever.GetOkExists(val)
+		structTags, err := parseStructTags(field.Tag)
+		if err != nil {
+			return fmt.Errorf("parsing struct tags for %q: %+v", field.Name, err)
+		}
+
+		if structTags != nil {
+			tfschemaValue, valExists := stateRetriever.GetOkExists(structTags.hclPath)
 			if !valExists {
 				continue
 			}
@@ -193,9 +196,13 @@ func setListValue(input interface{}, index int, fieldName string, v []interface{
 					nestedField := elem.Type().Elem().Field(j)
 					debugLogger.Infof("nestedField ", nestedField)
 
-					if val, exists := nestedField.Tag.Lookup("tfschema"); exists {
-						val = strings.TrimSuffix(val, ",removedInNextMajorVersion")
-						nestedTFSchemaValue := test[val]
+					structTags, err := parseStructTags(nestedField.Tag)
+					if err != nil {
+						return fmt.Errorf("parsing struct tags for nested field %q: %+v", nestedField.Name, err)
+					}
+
+					if structTags != nil {
+						nestedTFSchemaValue := test[structTags.hclPath]
 						if err := setValue(elem.Interface(), nestedTFSchemaValue, j, fieldName, debugLogger); err != nil {
 							return err
 						}

--- a/internal/sdk/resource_helpers.go
+++ b/internal/sdk/resource_helpers.go
@@ -1,0 +1,55 @@
+package sdk
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+type decodedStructTags struct {
+	// hclPath defines the path to this field used for this in the Schema for this Resource
+	hclPath string
+
+	// removedInNextMajorVersion specifies whether this field is deprecated and should not
+	// be set into the state in the next major version of the Provider
+	removedInNextMajorVersion bool
+}
+
+// parseStructTags parses the struct tags defined in input into a decodedStructTags object
+// which allows for the consistent parsing of struct tags across the Typed SDK.
+func parseStructTags(input reflect.StructTag) (*decodedStructTags, error) {
+	tag, ok := input.Lookup("tfschema")
+	if !ok {
+		// doesn't exist - ignore it?
+		return nil, nil
+	}
+	if tag == "" {
+		return nil, fmt.Errorf("the `tfschema` struct tag was defined but empty")
+	}
+
+	components := strings.Split(tag, ",")
+	output := &decodedStructTags{
+		// NOTE: `hclPath` has to be the first item in the struct tag
+		hclPath:                   strings.TrimSpace(components[0]),
+		removedInNextMajorVersion: false,
+	}
+	if output.hclPath == "" {
+		return nil, fmt.Errorf("hclPath was empty")
+	}
+
+	if len(components) > 1 {
+		// remove the hcl field name since it's been parsed
+		components = components[1:]
+		for _, item := range components {
+			item = strings.TrimSpace(item) // allowing for both `foo,bar` and `foo, bar` in struct tags
+			if strings.EqualFold(item, "removedInNextMajorVersion") {
+				output.removedInNextMajorVersion = true
+				continue
+			}
+
+			return nil, fmt.Errorf("internal-error: the struct-tag %q is not implemented - struct tags are %q", item, tag)
+		}
+	}
+
+	return output, nil
+}

--- a/internal/sdk/resource_helpers_test.go
+++ b/internal/sdk/resource_helpers_test.go
@@ -1,0 +1,111 @@
+package sdk
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+)
+
+func TestParseStructTags_Empty(t *testing.T) {
+	actual, err := parseStructTags("")
+	if err != nil {
+		t.Fatalf("unexpected error %q", err.Error())
+	}
+
+	if actual != nil {
+		t.Fatalf("expected actual to be nil but got %+v", *actual)
+	}
+}
+
+func TestParseStructTags_WithValue(t *testing.T) {
+	testData := []struct {
+		input    reflect.StructTag
+		expected *decodedStructTags
+		error    *string
+	}{
+		{
+			// empty hclPath
+			input:    `tfschema:""`,
+			expected: nil,
+			error:    pointer.To("the `tfschema` struct tag was defined but empty"),
+		},
+		{
+			// valid, no removedInNextMajorVersion
+			input: `tfschema:"hello"`,
+			expected: &decodedStructTags{
+				hclPath:                   "hello",
+				removedInNextMajorVersion: false,
+			},
+		},
+		{
+			// valid, with removedInNextMajorVersion
+			input: `tfschema:"hello,removedInNextMajorVersion"`,
+			expected: &decodedStructTags{
+				hclPath:                   "hello",
+				removedInNextMajorVersion: true,
+			},
+		},
+		{
+			// valid, with removedInNextMajorVersion and a space before the comma
+			input: `tfschema:"hello, removedInNextMajorVersion"`,
+			expected: &decodedStructTags{
+				hclPath:                   "hello",
+				removedInNextMajorVersion: true,
+			},
+		},
+		{
+			// valid, with removedInNextMajorVersion and a space after the comma
+			//
+			// This would be caught in PR review, but would be a confusing error/experience
+			// during development so it's worth being lenient here since it's non-impactful
+			input: `tfschema:"hello ,removedInNextMajorVersion"`,
+			expected: &decodedStructTags{
+				hclPath:                   "hello",
+				removedInNextMajorVersion: true,
+			},
+		},
+		{
+			// valid, with removedInNextMajorVersion and a space either side
+			//
+			// This would be caught in PR review, but would be a confusing error/experience
+			// during development so it's worth being lenient here since it's non-impactful
+			input: `tfschema:"hello , removedInNextMajorVersion"`,
+			expected: &decodedStructTags{
+				hclPath:                   "hello",
+				removedInNextMajorVersion: true,
+			},
+		},
+		{
+			// invalid, unknown struct tags
+			input:    `tfschema:"hello,world"`,
+			expected: nil,
+			error:    pointer.To(`internal-error: the struct-tag "world" is not implemented - struct tags are "hello,world"`),
+		},
+	}
+	for i, data := range testData {
+		t.Logf("Index %d - Input %q", i, data.input)
+		actual, err := parseStructTags(data.input)
+		if err != nil {
+			if data.error != nil {
+				if err.Error() == *data.error {
+					continue
+				}
+
+				t.Fatalf("expected the error %q but got %q", *data.error, err.Error())
+			}
+
+			t.Fatalf("unexpected error %q", err.Error())
+		}
+		if data.error != nil {
+			t.Fatalf("expected the error %q but didn't get one", *data.error)
+		}
+
+		if actual == nil {
+			t.Fatalf("expected actual to have a value but got nil")
+		}
+		if !reflect.DeepEqual(*data.expected, *actual) {
+			t.Fatalf("expected [%+v] and actual [%+v] didn't match", *data.expected, *actual)
+		}
+	}
+}

--- a/internal/sdk/wrapper_validate.go
+++ b/internal/sdk/wrapper_validate.go
@@ -59,9 +59,13 @@ func validateModelObjectRecursively(prefix string, objType reflect.Type, objVal 
 			}
 		}
 
-		if _, exists := field.Tag.Lookup("tfschema"); !exists {
-			fieldName := strings.TrimPrefix(fmt.Sprintf("%s.%s", prefix, field.Name), ".")
-			return fmt.Errorf("field %q is missing an `tfschema` label", fieldName)
+		fieldName := strings.TrimPrefix(fmt.Sprintf("%s.%s", prefix, field.Name), ".")
+		structTags, err := parseStructTags(field.Tag)
+		if err != nil {
+			return fmt.Errorf("parsing struct tags for %q", fieldName)
+		}
+		if structTags == nil {
+			return fmt.Errorf("field %q is missing a struct tag for `tfschema`", fieldName)
 		}
 	}
 


### PR DESCRIPTION
This means that any future changes can be rolled out consistently, and ensures the struct tags which are parsed contains only the expected segment

```
 $ TF_ACC=1 go test -v ./internal/services/automation/... -run=TestAccSoftwareUpdateConfiguration_withTask -timeout=60m
?   	github.com/hashicorp/terraform-provider-azurerm/internal/services/automation/client	[no test files]
?   	github.com/hashicorp/terraform-provider-azurerm/internal/services/automation/helper	[no test files]
?   	github.com/hashicorp/terraform-provider-azurerm/internal/services/automation/migration	[no test files]
=== RUN   TestAccSoftwareUpdateConfiguration_withTask
=== PAUSE TestAccSoftwareUpdateConfiguration_withTask
=== CONT  TestAccSoftwareUpdateConfiguration_withTask
--- PASS: TestAccSoftwareUpdateConfiguration_withTask (184.17s)
```