### PR TITLE
azurerm_shared_image_gallery: support directly sharing 

### DIFF
--- a/internal/services/compute/shared_image_gallery_resource.go
+++ b/internal/services/compute/shared_image_gallery_resource.go
@@ -71,6 +71,8 @@ func resourceSharedImageGallery() *pluginsdk.Resource {
 							ForceNew: true,
 							ValidateFunc: validation.StringInSlice([]string{
 								string(galleries.GallerySharingPermissionTypesCommunity),
+								string(galleries.GallerySharingPermissionTypesGroups),
+								string(galleries.GallerySharingPermissionTypesPrivate),
 							}, false),
 						},
 

--- a/internal/services/compute/shared_image_gallery_resource_test.go
+++ b/internal/services/compute/shared_image_gallery_resource_test.go
@@ -111,6 +111,21 @@ func TestAccSharedImageGallery_communityGallery(t *testing.T) {
 	})
 }
 
+func TestAccSharedImageGallery_groupsGallery(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_shared_image_gallery", "test")
+	r := SharedImageGalleryResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.groupsGallery(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (t SharedImageGalleryResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := galleries.ParseGalleryID(state.ID)
 	if err != nil {
@@ -209,6 +224,29 @@ resource "azurerm_shared_image_gallery" "test" {
       publisher_email = "publisher@test.net"
       publisher_uri   = "https://publisher.net"
     }
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (SharedImageGalleryResource) groupsGallery(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_shared_image_gallery" "test" {
+  name                = "acctestsig%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+
+  sharing {
+    permission = "Groups"
   }
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)

--- a/website/docs/r/shared_image_gallery.html.markdown
+++ b/website/docs/r/shared_image_gallery.html.markdown
@@ -52,7 +52,7 @@ The following arguments are supported:
 
 A `sharing` block supports the following:
 
-* `permission` - (Required) The permission of the Shared Image Gallery when sharing. The only possible value now is `Community`. Changing this forces a new resource to be created.
+* `permission` - (Required) The permission of the Shared Image Gallery when sharing. Possible values are `Community`, `Groups` and `Private`. Changing this forces a new resource to be created.
 
 -> **Note:** This requires that the Preview Feature `Microsoft.Compute/CommunityGalleries` is enabled, see [the documentation](https://learn.microsoft.com/azure/virtual-machines/share-gallery-community?tabs=cli) for more information.
 


### PR DESCRIPTION
fix #18326

test
---
```
❯ tftest compute TestAccSharedImageGallery                                            
=== RUN   TestAccSharedImageGallery_basic
=== PAUSE TestAccSharedImageGallery_basic
=== RUN   TestAccSharedImageGallery_requiresImport
=== PAUSE TestAccSharedImageGallery_requiresImport
=== RUN   TestAccSharedImageGallery_complete
=== PAUSE TestAccSharedImageGallery_complete
=== RUN   TestAccSharedImageGallery_update
=== PAUSE TestAccSharedImageGallery_update
=== RUN   TestAccSharedImageGallery_communityGallery
=== PAUSE TestAccSharedImageGallery_communityGallery
=== RUN   TestAccSharedImageGallery_groupsGallery
=== PAUSE TestAccSharedImageGallery_groupsGallery
=== RUN   TestAccSharedImageGallery_privateGallery
=== PAUSE TestAccSharedImageGallery_privateGallery
=== CONT  TestAccSharedImageGallery_basic
=== CONT  TestAccSharedImageGallery_communityGallery
=== CONT  TestAccSharedImageGallery_privateGallery
=== CONT  TestAccSharedImageGallery_groupsGallery
=== CONT  TestAccSharedImageGallery_complete
=== CONT  TestAccSharedImageGallery_update
=== CONT  TestAccSharedImageGallery_requiresImport
--- PASS: TestAccSharedImageGallery_requiresImport (211.83s)
--- PASS: TestAccSharedImageGallery_update (340.38s)
--- PASS: TestAccSharedImageGallery_complete (741.47s)
--- PASS: TestAccSharedImageGallery_privateGallery (774.48s)
--- PASS: TestAccSharedImageGallery_groupsGallery (785.27s)
--- PASS: TestAccSharedImageGallery_communityGallery (817.92s)
--- PASS: TestAccSharedImageGallery_basic (818.13s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/compute       819.789s
```