### PR TITLE
`azurerm_managed_lustre_file_system` - Add `Microsoft.StorageCache` to required providers list

### DIFF
--- a/internal/resourceproviders/required.go
+++ b/internal/resourceproviders/required.go
@@ -75,6 +75,7 @@ func Required() map[string]struct{} {
 		"Microsoft.ServiceFabric":           {},
 		"Microsoft.Sql":                     {},
 		"Microsoft.Storage":                 {},
+		"Microsoft.StorageCache":            {},
 		"Microsoft.StreamAnalytics":         {},
 		"Microsoft.TimeSeriesInsights":      {},
 		"Microsoft.Web":                     {},


### PR DESCRIPTION
`azurerm_managed_lustre_file_system` resource require provider `Microsoft.StorageCache` been registered before sending requests to API, this pr fixed #23567 by adding this provider to the required providers list.