### PR TITLE
Updated `azurerm_nginx_deployment` to support latest API properties

### DIFF
--- a/internal/services/nginx/nginx_deployment_resource_test.go
+++ b/internal/services/nginx/nginx_deployment_resource_test.go
@@ -39,6 +39,8 @@ func TestAccNginxDeployment_basic(t *testing.T) {
 			Config: r.basic(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("capacity").HasValue("10"),
+				check.That(data.ResourceName).Key("email").HasValue("test@test.com"),
 			),
 		},
 		data.ImportStep(),
@@ -84,6 +86,8 @@ func (a DeploymentResource) basic(data acceptance.TestData) string {
 	return fmt.Sprintf(`
 
 
+
+
 %s
 
 resource "azurerm_nginx_deployment" "test" {
@@ -100,6 +104,11 @@ resource "azurerm_nginx_deployment" "test" {
   network_interface {
     subnet_id = azurerm_subnet.test.id
   }
+
+  capacity = 10
+
+  email = "test@test.com"
+
   tags = {
     foo = "bar"
   }
@@ -127,6 +136,10 @@ resource "azurerm_nginx_deployment" "test" {
   network_interface {
     subnet_id = azurerm_subnet.test.id
   }
+
+  capacity = 20
+
+  email = "testing@test.com"
 
   tags = {
     foo = "bar2"
@@ -165,6 +178,10 @@ resource "azurerm_nginx_deployment" "test" {
   network_interface {
     subnet_id = azurerm_subnet.test.id
   }
+
+  capacity = 10
+
+  email = "test@test.com"
 }
 `, a.template(data), data.RandomInteger)
 }

--- a/website/docs/r/nginx_deployment.html.markdown
+++ b/website/docs/r/nginx_deployment.html.markdown
@@ -68,6 +68,10 @@ resource "azurerm_nginx_deployment" "example" {
   network_interface {
     subnet_id = azurerm_subnet.example.id
   }
+
+  capacity = 20
+
+  email = "user@test.com"
 }
 ```
 
@@ -87,7 +91,13 @@ The following arguments are supported:
 
 ---
 
+* `capacity` - (Optional) Specify the number of NGINX capacity units for this NGINX deployment.
+
+-> **Note** For more information on NGINX capacity units, please refer to the [NGINX scaling guidance documentation](https://docs.nginx.com/nginxaas/azure/quickstart/scaling/)
+
 * `diagnose_support_enabled` - (Optional) Should the diagnosis support be enabled?
+
+* `email` - (Optional) Specify the preferred support contact email address of the user used for sending alerts and notification.
 
 * `identity` - (Optional) An `identity` block as defined below.
 
@@ -138,6 +148,7 @@ A `logging_storage_account` block supports the following:
 A `network_interface` block supports the following:
 
 * `subnet_id` - (Required) Specify The SubNet Resource ID to this Nginx Deployment.
+
 
 ## Attributes Reference
 


### PR DESCRIPTION
Adding support for latest published API version which includes additional properties.

Additions:

* Scaling - Allow customers to specify a capacity to scale their NGINXaaS deployment. Validation of values is performed server side.
* UserProfile - Allows customers to specify a preferred primary contact that may be different from SystemData added by Azure

[Swagger Spec](https://github.com/Azure/azure-rest-api-specs/tree/main/specification/nginx/resource-manager/NGINX.NGINXPLUS/stable/2023-04-01)

This PR will follow up [this PR](https://github.com/hashicorp/terraform-provider-azurerm/pull/23583) which provides the api-version and vendoring changes separately per  @catriona-m 's request.