### PR TITLE
`azurerm_storage_account_customer_managed_key`: fix panic when dereference keyvault id pointer

### DIFF
--- a/internal/services/storage/storage_account_customer_managed_key_resource.go
+++ b/internal/services/storage/storage_account_customer_managed_key_resource.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2021-09-01/storage" // nolint: staticcheck
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/keyvault/2023-02-01/managedhsms"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
@@ -278,7 +279,7 @@ func resourceStorageAccountCustomerManagedKeyRead(d *pluginsdk.ResourceData, met
 		if err != nil {
 			return fmt.Errorf("retrieving Key Vault ID from the Base URI %q: %+v", keyVaultURI, err)
 		}
-		keyVaultID = *tmpKeyVaultID
+		keyVaultID = pointer.From(tmpKeyVaultID)
 	}
 
 	d.Set("storage_account_id", id.ID())


### PR DESCRIPTION
fixes #23587.

`keyVaultsClient.KeyVaultIDFromBaseUrl` may return `(nil, nil)`, so we have to check the pointer before dereference it.

https://github.com/hashicorp/terraform-provider-azurerm/blob/7574d9090cfffcb90c18ea0bac892e453ffe747e/internal/services/keyvault/client/helpers.go#L175-L177