### PR TITLE
`azurerm_palo_alto_next_generation_firewall_virtual_network_local_rulestack`: add lock of `ruleStackID` in creating

### DIFF
--- a/internal/services/paloalto/next_generation_firewall_vhub_local_rulestack_resource.go
+++ b/internal/services/paloalto/next_generation_firewall_vhub_local_rulestack_resource.go
@@ -80,7 +80,7 @@ func (r NextGenerationFirewallVHubLocalRuleStackResource) Attributes() map[strin
 
 func (r NextGenerationFirewallVHubLocalRuleStackResource) Create() sdk.ResourceFunc {
 	return sdk.ResourceFunc{
-		Timeout: 2 * time.Hour,
+		Timeout: 3 * time.Hour,
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
 			client := metadata.Client.PaloAlto.Client.Firewalls
 			localRuleStackClient := metadata.Client.PaloAlto.Client.LocalRulestacks
@@ -222,7 +222,7 @@ func (r NextGenerationFirewallVHubLocalRuleStackResource) Delete() sdk.ResourceF
 
 func (r NextGenerationFirewallVHubLocalRuleStackResource) Update() sdk.ResourceFunc {
 	return sdk.ResourceFunc{
-		Timeout: 2 * time.Hour,
+		Timeout: 3 * time.Hour,
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
 			client := metadata.Client.PaloAlto.Client.Firewalls
 
@@ -278,6 +278,12 @@ func (r NextGenerationFirewallVHubLocalRuleStackResource) Update() sdk.ResourceF
 
 			if metadata.ResourceData.HasChange("tags") {
 				firewall.Tags = tags.Expand(model.Tags)
+			}
+
+			if metadata.ResourceData.HasChange("rulestack_id") {
+				ruleStackID, _ := localrulestacks.ParseLocalRulestackID(model.RuleStackId)
+				locks.ByID(ruleStackID.ID())
+				defer locks.UnlockByID(ruleStackID.ID())
 			}
 
 			if err = client.CreateOrUpdateThenPoll(ctx, *id, firewall); err != nil {

--- a/internal/services/paloalto/next_generation_firewall_vhub_local_rulestack_resource.go
+++ b/internal/services/paloalto/next_generation_firewall_vhub_local_rulestack_resource.go
@@ -281,7 +281,10 @@ func (r NextGenerationFirewallVHubLocalRuleStackResource) Update() sdk.ResourceF
 			}
 
 			if metadata.ResourceData.HasChange("rulestack_id") {
-				ruleStackID, _ := localrulestacks.ParseLocalRulestackID(model.RuleStackId)
+				ruleStackID, err := localrulestacks.ParseLocalRulestackID(model.RuleStackId)
+				if err != nil {
+					return fmt.Errorf("parsing rulestack_id %s: %+v", model.RuleStackId, err)
+				}
 				locks.ByID(ruleStackID.ID())
 				defer locks.UnlockByID(ruleStackID.ID())
 			}

--- a/internal/services/paloalto/next_generation_firewall_vhub_local_rulestack_resource.go
+++ b/internal/services/paloalto/next_generation_firewall_vhub_local_rulestack_resource.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/paloaltonetworks/2022-08-29/firewalls"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/paloaltonetworks/2022-08-29/localrulestacks"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/paloalto/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/paloalto/validate"
@@ -136,6 +137,9 @@ func (r NextGenerationFirewallVHubLocalRuleStackResource) Create() sdk.ResourceF
 
 				Tags: tags.Expand(model.Tags),
 			}
+
+			locks.ByID(ruleStackID.ID())
+			defer locks.UnlockByID(ruleStackID.ID())
 
 			if err = client.CreateOrUpdateThenPoll(ctx, id, firewall); err != nil {
 				return err

--- a/internal/services/paloalto/next_generation_firewall_vhub_local_rulestack_resource.go
+++ b/internal/services/paloalto/next_generation_firewall_vhub_local_rulestack_resource.go
@@ -260,6 +260,8 @@ func (r NextGenerationFirewallVHubLocalRuleStackResource) Update() sdk.ResourceF
 				}
 
 				props.AssociatedRulestack = ruleStack
+				locks.ByID(ruleStackID.ID())
+				defer locks.UnlockByID(ruleStackID.ID())
 			}
 
 			if metadata.ResourceData.HasChange("network_profile") {
@@ -278,15 +280,6 @@ func (r NextGenerationFirewallVHubLocalRuleStackResource) Update() sdk.ResourceF
 
 			if metadata.ResourceData.HasChange("tags") {
 				firewall.Tags = tags.Expand(model.Tags)
-			}
-
-			if metadata.ResourceData.HasChange("rulestack_id") {
-				ruleStackID, err := localrulestacks.ParseLocalRulestackID(model.RuleStackId)
-				if err != nil {
-					return fmt.Errorf("parsing rulestack_id %s: %+v", model.RuleStackId, err)
-				}
-				locks.ByID(ruleStackID.ID())
-				defer locks.UnlockByID(ruleStackID.ID())
 			}
 
 			if err = client.CreateOrUpdateThenPoll(ctx, *id, firewall); err != nil {

--- a/internal/services/paloalto/next_generation_firewall_vnet_local_rulestack_resource.go
+++ b/internal/services/paloalto/next_generation_firewall_vnet_local_rulestack_resource.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/tags"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/paloaltonetworks/2022-08-29/firewalls"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/paloaltonetworks/2022-08-29/localrulestacks"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/locks"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/sdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/paloalto/schema"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/paloalto/validate"
@@ -130,6 +131,9 @@ func (r NextGenerationFirewallVNetLocalRulestackResource) Create() sdk.ResourceF
 				},
 				Tags: tags.Expand(model.Tags),
 			}
+
+			locks.ByID(ruleStackID.ID())
+			defer locks.UnlockByID(ruleStackID.ID())
 
 			if err = client.CreateOrUpdateThenPoll(ctx, id, firewall); err != nil {
 				return fmt.Errorf("creating %s: %+v", id, err)

--- a/internal/services/paloalto/next_generation_firewall_vnet_local_rulestack_resource.go
+++ b/internal/services/paloalto/next_generation_firewall_vnet_local_rulestack_resource.go
@@ -276,7 +276,10 @@ func (r NextGenerationFirewallVNetLocalRulestackResource) Update() sdk.ResourceF
 			}
 
 			if metadata.ResourceData.HasChange("rulestack_id") {
-				ruleStackID, _ := localrulestacks.ParseLocalRulestackID(model.RuleStackId)
+				ruleStackID, err := localrulestacks.ParseLocalRulestackID(model.RuleStackId)
+				if err != nil {
+					return fmt.Errorf("parsing rulestack_id %s: %+v", model.RuleStackId, err)
+				}
 				locks.ByID(ruleStackID.ID())
 				defer locks.UnlockByID(ruleStackID.ID())
 			}

--- a/internal/services/paloalto/next_generation_firewall_vnet_local_rulestack_resource.go
+++ b/internal/services/paloalto/next_generation_firewall_vnet_local_rulestack_resource.go
@@ -255,6 +255,8 @@ func (r NextGenerationFirewallVNetLocalRulestackResource) Update() sdk.ResourceF
 				}
 
 				props.AssociatedRulestack = ruleStack
+				locks.ByID(ruleStackID.ID())
+				defer locks.UnlockByID(ruleStackID.ID())
 			}
 
 			if metadata.ResourceData.HasChange("network_profile") {
@@ -273,15 +275,6 @@ func (r NextGenerationFirewallVNetLocalRulestackResource) Update() sdk.ResourceF
 
 			if metadata.ResourceData.HasChange("tags") {
 				firewall.Tags = tags.Expand(model.Tags)
-			}
-
-			if metadata.ResourceData.HasChange("rulestack_id") {
-				ruleStackID, err := localrulestacks.ParseLocalRulestackID(model.RuleStackId)
-				if err != nil {
-					return fmt.Errorf("parsing rulestack_id %s: %+v", model.RuleStackId, err)
-				}
-				locks.ByID(ruleStackID.ID())
-				defer locks.UnlockByID(ruleStackID.ID())
 			}
 
 			if err = client.CreateOrUpdateThenPoll(ctx, *id, firewall); err != nil {

--- a/internal/services/paloalto/next_generation_firewall_vnet_local_rulestack_resource.go
+++ b/internal/services/paloalto/next_generation_firewall_vnet_local_rulestack_resource.go
@@ -75,7 +75,7 @@ func (r NextGenerationFirewallVNetLocalRulestackResource) ResourceType() string 
 
 func (r NextGenerationFirewallVNetLocalRulestackResource) Create() sdk.ResourceFunc {
 	return sdk.ResourceFunc{
-		Timeout: 2 * time.Hour,
+		Timeout: 3 * time.Hour,
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
 			client := metadata.Client.PaloAlto.Client.Firewalls
 			localRulestackClient := metadata.Client.PaloAlto.Client.LocalRulestacks
@@ -216,7 +216,7 @@ func (r NextGenerationFirewallVNetLocalRulestackResource) IDValidationFunc() plu
 
 func (r NextGenerationFirewallVNetLocalRulestackResource) Update() sdk.ResourceFunc {
 	return sdk.ResourceFunc{
-		Timeout: 2 * time.Hour,
+		Timeout: 3 * time.Hour,
 		Func: func(ctx context.Context, metadata sdk.ResourceMetaData) error {
 			client := metadata.Client.PaloAlto.Client.Firewalls
 
@@ -273,6 +273,12 @@ func (r NextGenerationFirewallVNetLocalRulestackResource) Update() sdk.ResourceF
 
 			if metadata.ResourceData.HasChange("tags") {
 				firewall.Tags = tags.Expand(model.Tags)
+			}
+
+			if metadata.ResourceData.HasChange("rulestack_id") {
+				ruleStackID, _ := localrulestacks.ParseLocalRulestackID(model.RuleStackId)
+				locks.ByID(ruleStackID.ID())
+				defer locks.UnlockByID(ruleStackID.ID())
 			}
 
 			if err = client.CreateOrUpdateThenPoll(ctx, *id, firewall); err != nil {

--- a/website/docs/r/palo_alto_next_generation_firewall_vhub_local_rulestack.html.markdown
+++ b/website/docs/r/palo_alto_next_generation_firewall_vhub_local_rulestack.html.markdown
@@ -148,9 +148,9 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `create` - (Defaults to 2 hours) Used when creating the Palo Alto Next Generation Firewall VHub Local Rulestack.
+* `create` - (Defaults to 3 hours) Used when creating the Palo Alto Next Generation Firewall VHub Local Rulestack.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Palo Alto Next Generation Firewall VHub Local Rulestack.
-* `update` - (Defaults to 2 hours) Used when updating the Palo Alto Next Generation Firewall VHub Local Rulestack.
+* `update` - (Defaults to 3 hours) Used when updating the Palo Alto Next Generation Firewall VHub Local Rulestack.
 * `delete` - (Defaults to 2 hours) Used when deleting the Palo Alto Next Generation Firewall VHub Local Rulestack.
 
 ## Import

--- a/website/docs/r/palo_alto_next_generation_firewall_virtual_network_local_rulestack.html.markdown
+++ b/website/docs/r/palo_alto_next_generation_firewall_virtual_network_local_rulestack.html.markdown
@@ -217,9 +217,9 @@ In addition to the Arguments listed above - the following Attributes are exporte
 
 The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/language/resources/syntax#operation-timeouts) for certain actions:
 
-* `create` - (Defaults to 2 hours) Used when creating the Palo Alto Next Generation Firewall Virtual Network Local Rulestack.
+* `create` - (Defaults to 3 hours) Used when creating the Palo Alto Next Generation Firewall Virtual Network Local Rulestack.
 * `read` - (Defaults to 5 minutes) Used when retrieving the Palo Alto Next Generation Firewall Virtual Network Local Rulestack.
-* `update` - (Defaults to 2 hours) Used when updating the Palo Alto Next Generation Firewall Virtual Network Local Rulestack.
+* `update` - (Defaults to 3 hours) Used when updating the Palo Alto Next Generation Firewall Virtual Network Local Rulestack.
 * `delete` - (Defaults to 2 hours) Used when deleting the Palo Alto Next Generation Firewall Virtual Network Local Rulestack.
 
 ## Import


### PR DESCRIPTION
fixes #23472.

Firewall Creating should be sequentialized with other rule create operation, so we should add a lock for it (also extend timeout value).

![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/2633022/1a2f20af-90c3-422d-a1e2-a89e16a30d4a)