### PR TITLE
`azurerm_monitor_activity_log_alert` - support setting `HighAvailability` for `recommend_category`

### DIFF
--- a/internal/services/monitor/monitor_activity_log_alert_resource.go
+++ b/internal/services/monitor/monitor_activity_log_alert_resource.go
@@ -222,6 +222,7 @@ func resourceMonitorActivityLogAlert() *pluginsdk.Resource {
 								"Reliability",
 								"OperationalExcellence",
 								"Performance",
+								"HighAvailability",
 							},
 								false,
 							),

--- a/internal/services/monitor/monitor_activity_log_alert_resource_test.go
+++ b/internal/services/monitor/monitor_activity_log_alert_resource_test.go
@@ -568,7 +568,7 @@ resource "azurerm_monitor_activity_log_alert" "test" {
     resource_type           = "Microsoft.Storage/storageAccounts"
     resource_group          = azurerm_resource_group.test.name
     resource_id             = azurerm_storage_account.test.id
-    recommendation_category = "OperationalExcellence"
+    recommendation_category = "HighAvailability"
     recommendation_impact   = "High"
     caller                  = "test email address"
     level                   = "Critical"

--- a/website/docs/r/monitor_activity_log_alert.html.markdown
+++ b/website/docs/r/monitor_activity_log_alert.html.markdown
@@ -122,7 +122,7 @@ A `criteria` block supports the following:
 ~> **NOTE:** `sub_status` and `sub_statuses` are mutually exclusive.
  
 * `recommendation_type` - (Optional) The recommendation type of the event. It is only allowed when `category` is `Recommendation`.
-* `recommendation_category` - (Optional) The recommendation category of the event. Possible values are `Cost`, `Reliability`, `OperationalExcellence` and `Performance`. It is only allowed when `category` is `Recommendation`.
+* `recommendation_category` - (Optional) The recommendation category of the event. Possible values are `Cost`, `Reliability`, `OperationalExcellence`, `HighAvailability` and `Performance`. It is only allowed when `category` is `Recommendation`.
 * `recommendation_impact` - (Optional) The recommendation impact of the event. Possible values are `High`, `Medium` and `Low`. It is only allowed when `category` is `Recommendation`.
 * `resource_health` - (Optional) A block to define fine grain resource health settings.
 * `service_health` - (Optional) A block to define fine grain service health settings.


### PR DESCRIPTION
fix #23569 


GET https://management.azure.com/providers/Microsoft.Advisor/metadata/recommendationCategory?api-version=2023-01-01
{
    "properties": {
        "displayName": "Category",
        "applicableScenarios": [
            "Alerts"
        ],
        "supportedValues": [
            {
                "id": "Cost",
                "displayName": "Cost"
            },
            {
                "id": "Performance",
                "displayName": "Performance"
            },
            {
                **"id": "HighAvailability",**
                "displayName": "High Availability"
            },
            {
                "id": "OperationalExcellence",
                "displayName": "Operational Excellence"
            },
            {
                "id": "Security",
                "displayName": "Security"
            }
        ]
    },
    "id": "/providers/Microsoft.Advisor/metadata/recommendationCategory",
    "type": "Microsoft.Advisor/metadata",
    "name": "recommendationCategory"
}


```
TF_ACC=1 go test -v ./internal/services/monitor -parallel 20 -run TestAccMonitorActivityLogAlert_complete -timeout 2h -ldflags="-X=github.com/hashicorp/terraform-provider-azurerm/version.ProviderVersion=acc"
=== RUN   TestAccMonitorActivityLogAlert_complete
=== PAUSE TestAccMonitorActivityLogAlert_complete
=== CONT  TestAccMonitorActivityLogAlert_complete
--- PASS: TestAccMonitorActivityLogAlert_complete (166.73s)
PASS
ok      github.com/hashicorp/terraform-provider-azurerm/internal/services/monitor       166.744s
```