### PR TITLE
`azurerm_mssql_server_transparent_data_encryption` - Remove `Note` from documentation

### DIFF
--- a/website/docs/r/mssql_managed_instance_transparent_data_encryption.html.markdown
+++ b/website/docs/r/mssql_managed_instance_transparent_data_encryption.html.markdown
@@ -10,8 +10,6 @@ description: |-
 
 Manages the transparent data encryption configuration for a MSSQL Managed Instance
 
-!> **IMPORTANT:** This resource is obsolete and should only be used on pre-existing MS SQL Instances that are over 2 years old. By default all new MS SQL Instances are deployed with System Managed Transparent Data Encryption enabled.
-
 ~> **NOTE:** Once transparent data encryption(TDE) is enabled on a MS SQL instance, it is not possible to remove TDE. You will be able to switch between 'ServiceManaged' and 'CustomerManaged' keys, but will not be able to remove encryption. For safety when this resource is deleted, the TDE mode will automatically be set to 'ServiceManaged'. See `key_vault_uri` for more information on how to specify the key types. As SQL Managed Instance only supports a single configuration for encryption settings, this resource will replace the current encryption settings on the server. 
 
 ~> **Note:** See [documentation](https://docs.microsoft.com/azure/azure-sql/database/transparent-data-encryption-byok-overview) for important information on how handle lifecycle management of the keys to prevent data lockout. 

--- a/website/docs/r/mssql_server_transparent_data_encryption.html.markdown
+++ b/website/docs/r/mssql_server_transparent_data_encryption.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Manages the transparent data encryption configuration for a MSSQL Server
 
+!> **IMPORTANT:** This resource is obsolete and should only be used on pre-existing MS SQL Instances that are over 2 years old. By default all new MS SQL Instances are deployed with System Managed Transparent Data Encryption enabled.
+
 ~> **NOTE:** Once transparent data encryption is enabled on a MS SQL instance, it is not possible to remove TDE. You will be able to switch between 'ServiceManaged' and 'CustomerManaged' keys, but will not be able to remove encryption. For safety when this resource is deleted, the TDE mode will automatically be set to 'ServiceManaged'. See `key_vault_uri` for more information on how to specify the key types. As SQL Server only supports a single configuration for encryption settings, this resource will replace the current encryption settings on the server.
 
 ~> **Note:** See [documentation](https://docs.microsoft.com/azure/azure-sql/database/transparent-data-encryption-byok-overview) for important information on how handle lifecycle management of the keys to prevent data lockout.


### PR DESCRIPTION
Note section was accidently added to `azurerm_mssql_managed_instance_transparent_data_encryption` page when it was meant to be included in the `azurerm_mssql_server_transparent_data_encryption` page.