### PR TITLE
`azurerm_kusto_cluster` - add `state` and remove `forceNew` from `zones` and `virtual_network_configuration`

### DIFF
--- a/internal/services/kusto/kusto_cluster_resource.go
+++ b/internal/services/kusto/kusto_cluster_resource.go
@@ -145,24 +145,32 @@ func resourceKustoCluster() *pluginsdk.Resource {
 			"virtual_network_configuration": {
 				Type:     pluginsdk.TypeList,
 				Optional: true,
-				ForceNew: true,
 				MaxItems: 1,
 				Elem: &pluginsdk.Resource{
 					Schema: map[string]*pluginsdk.Schema{
 						"subnet_id": {
 							Type:         pluginsdk.TypeString,
 							Required:     true,
+							ForceNew:     true,
 							ValidateFunc: commonids.ValidateSubnetID,
 						},
 						"engine_public_ip_id": {
 							Type:         pluginsdk.TypeString,
 							Required:     true,
+							ForceNew:     true,
 							ValidateFunc: networkValidate.PublicIpAddressID,
 						},
 						"data_management_public_ip_id": {
 							Type:         pluginsdk.TypeString,
 							Required:     true,
+							ForceNew:     true,
 							ValidateFunc: networkValidate.PublicIpAddressID,
+						},
+						"state": {
+							Type:         pluginsdk.TypeString,
+							Optional:     true,
+							Default:      clusters.VnetStateEnabled,
+							ValidateFunc: validation.StringInSlice(clusters.PossibleValuesForVnetState(), false),
 						},
 					},
 				},
@@ -234,7 +242,7 @@ func resourceKustoCluster() *pluginsdk.Resource {
 				Default:  false,
 			},
 
-			"zones": commonschema.ZonesMultipleOptionalForceNew(),
+			"zones": commonschema.ZonesMultipleOptional(),
 
 			"tags": commonschema.Tags(),
 		},
@@ -575,11 +583,13 @@ func expandKustoClusterVNET(input []interface{}) *clusters.VirtualNetworkConfigu
 	subnetID := vnet["subnet_id"].(string)
 	enginePublicIPID := vnet["engine_public_ip_id"].(string)
 	dataManagementPublicIPID := vnet["data_management_public_ip_id"].(string)
+	state := clusters.VnetState(vnet["state"].(string))
 
 	return &clusters.VirtualNetworkConfiguration{
 		SubnetId:                 subnetID,
 		EnginePublicIPId:         enginePublicIPID,
 		DataManagementPublicIPId: dataManagementPublicIPID,
+		State:                    pointer.To(state),
 	}
 }
 
@@ -666,6 +676,7 @@ func flattenKustoClusterVNET(vnet *clusters.VirtualNetworkConfiguration) []inter
 		"subnet_id":                    vnet.SubnetId,
 		"engine_public_ip_id":          vnet.EnginePublicIPId,
 		"data_management_public_ip_id": vnet.DataManagementPublicIPId,
+		"state":                        string(*vnet.State),
 	}
 
 	return []interface{}{output}

--- a/internal/services/kusto/kusto_cluster_resource_test.go
+++ b/internal/services/kusto/kusto_cluster_resource_test.go
@@ -170,6 +170,14 @@ func TestAccKustoCluster_zones(t *testing.T) {
 				check.That(data.ResourceName).Key("zones.0").HasValue("1"),
 			),
 		},
+		{
+			Config: r.withZonesUpdate(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("zones.#").HasValue("1"),
+				check.That(data.ResourceName).Key("zones.0").HasValue("2"),
+			),
+		},
 	})
 }
 
@@ -238,6 +246,18 @@ func TestAccKustoCluster_vnet(t *testing.T) {
 				check.That(data.ResourceName).Key("virtual_network_configuration.0.subnet_id").Exists(),
 				check.That(data.ResourceName).Key("virtual_network_configuration.0.engine_public_ip_id").Exists(),
 				check.That(data.ResourceName).Key("virtual_network_configuration.0.data_management_public_ip_id").Exists(),
+				check.That(data.ResourceName).Key("virtual_network_configuration.0.state").HasValue("Enabled"),
+			),
+		},
+		{
+			Config: r.vnetUpdate(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("virtual_network_configuration.#").HasValue("1"),
+				check.That(data.ResourceName).Key("virtual_network_configuration.0.subnet_id").Exists(),
+				check.That(data.ResourceName).Key("virtual_network_configuration.0.engine_public_ip_id").Exists(),
+				check.That(data.ResourceName).Key("virtual_network_configuration.0.data_management_public_ip_id").Exists(),
+				check.That(data.ResourceName).Key("virtual_network_configuration.0.state").HasValue("Disabled"),
 			),
 		},
 		data.ImportStep(),
@@ -597,6 +617,32 @@ resource "azurerm_kusto_cluster" "test" {
   }
 
   zones = ["1"]
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
+}
+
+func (KustoClusterResource) withZonesUpdate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_kusto_cluster" "test" {
+  name                = "acctestkc%s"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  sku {
+    name     = "Dev(No SLA)_Standard_D11_v2"
+    capacity = 1
+  }
+
+  zones = ["2"]
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }
@@ -962,6 +1008,117 @@ resource "azurerm_kusto_cluster" "test" {
     subnet_id                    = azurerm_subnet.test.id
     engine_public_ip_id          = azurerm_public_ip.engine_pip.id
     data_management_public_ip_id = azurerm_public_ip.management_pip.id
+  }
+
+  depends_on = [
+    azurerm_subnet_route_table_association.test,
+    azurerm_subnet_network_security_group_association.test,
+  ]
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString, data.RandomString, data.RandomString, data.RandomString, data.RandomString, data.RandomString, data.RandomString)
+}
+
+func (KustoClusterResource) vnetUpdate(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-%d"
+  location = "%s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestkc%s-vnet"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctestkc%s-subnet"
+  resource_group_name  = azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.1.0/24"]
+
+  delegation {
+    name = "delegation"
+
+    service_delegation {
+      name    = "Microsoft.Kusto/clusters"
+      actions = ["Microsoft.Network/virtualNetworks/subnets/join/action", "Microsoft.Network/virtualNetworks/subnets/prepareNetworkPolicies/action", "Microsoft.Network/virtualNetworks/subnets/unprepareNetworkPolicies/action"]
+    }
+  }
+}
+
+resource "azurerm_route_table" "test" {
+  name                = "acctestkc%s-rt"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_subnet_route_table_association" "test" {
+  subnet_id      = azurerm_subnet.test.id
+  route_table_id = azurerm_route_table.test.id
+}
+
+resource "azurerm_network_security_group" "test" {
+  name                = "acctestkc%s-nsg"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+}
+
+resource "azurerm_network_security_rule" "test_allow_management_inbound" {
+  name                        = "AllowAzureDataExplorerManagement"
+  priority                    = 1000
+  direction                   = "Inbound"
+  access                      = "Allow"
+  protocol                    = "Tcp"
+  source_port_range           = "*"
+  destination_port_range      = "443"
+  source_address_prefix       = "AzureDataExplorerManagement"
+  destination_address_prefix  = "VirtualNetwork"
+  resource_group_name         = azurerm_resource_group.test.name
+  network_security_group_name = azurerm_network_security_group.test.name
+}
+
+resource "azurerm_subnet_network_security_group_association" "test" {
+  subnet_id                 = azurerm_subnet.test.id
+  network_security_group_id = azurerm_network_security_group.test.id
+}
+
+resource "azurerm_public_ip" "engine_pip" {
+  name                = "acctestkc%s-engine-pip"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "Standard"
+  allocation_method   = "Static"
+}
+
+resource "azurerm_public_ip" "management_pip" {
+  name                = "acctestkc%s-management-pip"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "Standard"
+  allocation_method   = "Static"
+}
+
+resource "azurerm_kusto_cluster" "test" {
+  name                = "acctestkc%s"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+
+  sku {
+    name     = "Dev(No SLA)_Standard_D11_v2"
+    capacity = 1
+  }
+
+  virtual_network_configuration {
+    subnet_id                    = azurerm_subnet.test.id
+    engine_public_ip_id          = azurerm_public_ip.engine_pip.id
+    data_management_public_ip_id = azurerm_public_ip.management_pip.id
+    state                        = "Disabled"
   }
 
   depends_on = [

--- a/internal/services/kusto/kusto_cluster_resource_test.go
+++ b/internal/services/kusto/kusto_cluster_resource_test.go
@@ -1105,9 +1105,10 @@ resource "azurerm_public_ip" "management_pip" {
 }
 
 resource "azurerm_kusto_cluster" "test" {
-  name                = "acctestkc%s"
-  location            = azurerm_resource_group.test.location
-  resource_group_name = azurerm_resource_group.test.name
+  name                          = "acctestkc%s"
+  location                      = azurerm_resource_group.test.location
+  resource_group_name           = azurerm_resource_group.test.name
+  public_network_access_enabled = false
 
   sku {
     name     = "Dev(No SLA)_Standard_D11_v2"

--- a/website/docs/r/kusto_cluster.html.markdown
+++ b/website/docs/r/kusto_cluster.html.markdown
@@ -106,7 +106,7 @@ A `virtual_network_configuration` block supports the following:
 
 * `state` - (Optional) The state of the virtual network. Possible values are: `Enabled` and `Disabled`. Defaults to `Enabled`.
 
-~> **NOTE:** Currently `state` supports changes only from `Enabled` to `Disabled`.
+~> **NOTE:** Currently `state` supports changes only from `Enabled` to `Disabled` and `public_network_access_enabled` will also be set to `false` when `state` is set to `Disabled`.
 
 ---
 

--- a/website/docs/r/kusto_cluster.html.markdown
+++ b/website/docs/r/kusto_cluster.html.markdown
@@ -68,7 +68,7 @@ The following arguments are supported:
 
 * `purge_enabled` - (Optional) Specifies if the purge operations are enabled.
 
-* `virtual_network_configuration` - (Optional) A `virtual_network_configuration` block as defined below. Changing this forces a new resource to be created.
+* `virtual_network_configuration` - (Optional) A `virtual_network_configuration` block as defined below.
 
 * `language_extensions` - (Optional) An list of `language_extensions` to enable. Valid values are: `PYTHON`, `PYTHON_3.10.8` and `R`. `PYTHON` is used to specify Python 3.6.5 image and `PYTHON_3.10.8` is used to specify Python 3.10.8 image. Note that `PYTHON_3.10.8` is only available in skus which support nested virtualization.
 
@@ -82,7 +82,7 @@ The following arguments are supported:
 
 ~> **NOTE:** In v3.0 of `azurerm` a new or updated Kusto Cluster will only allow your own tenant by default. Explicit configuration of this setting will change from `trusted_external_tenants = ["MyTenantOnly"]` to `trusted_external_tenants = []`.
 
-* `zones` - (Optional) Specifies a list of Availability Zones in which this Kusto Cluster should be located. Changing this forces a new Kusto Cluster to be created.
+* `zones` - (Optional) Specifies a list of Availability Zones in which this Kusto Cluster should be located.
 
 ---
 
@@ -103,6 +103,10 @@ A `virtual_network_configuration` block supports the following:
 * `engine_public_ip_id` - (Required) Engine service's public IP address resource id.
 
 * `data_management_public_ip_id` - (Required) Data management's service public IP address resource id.
+
+* `state` - (Optional) The state of the virtual network. Possible values are: `Enabled` and `Disabled`. Defaults to `Enabled`.
+
+~> **NOTE:** Currently `state` supports changes only from `Enabled` to `Disabled`.
 
 ---
 


### PR DESCRIPTION
Changes:

- Remove `ForceNew` from `virtual_network_configuration` block.
- Add a `state` property to `virtual_network_configuration` block, default `Enabled`. 
- Remove `ForceNew` from `zones` property since this is no longer forceNew in API version 2023-08-15

[Discussion on state property](https://github.com/hashicorp/terraform-provider-azurerm/pull/22747) 

Testing evidence:
`TBD`
```
GOROOT=C:\Program Files\Go #gosetup
GOPATH=C:\Users\yunliu1\go #gosetup
"C:\Program Files\Go\bin\go.exe" test -c -o C:\Users\yunliu1\AppData\Local\JetBrains\GoLand2023.2\tmp\GoLand\___1TestAccKustoCluster_zones_in_github_com_hashicorp_terraform_provider_azurerm_internal_services_kusto.test.exe github.com/hashicorp/terraform-provider-azurerm/internal/services/kusto #gosetup
"C:\Program Files\Go\bin\go.exe" tool test2json -t C:\Users\yunliu1\AppData\Local\JetBrains\GoLand2023.2\tmp\GoLand\___1TestAccKustoCluster_zones_in_github_com_hashicorp_terraform_provider_azurerm_internal_services_kusto.test.exe -test.v -test.paniconexit0 -test.run ^\QTestAccKustoCluster_zones\E$ #gosetup
=== RUN   TestAccKustoCluster_zones
=== PAUSE TestAccKustoCluster_zones
=== CONT  TestAccKustoCluster_zones
--- PASS: TestAccKustoCluster_zones (1945.15s)
PASS


Process finished with the exit code 0
```