### PR TITLE
`azurerm_recovery_services_vault`: update `encryption`before update storageCfg

### DIFF
--- a/internal/services/recoveryservices/recovery_services_vault_resource.go
+++ b/internal/services/recoveryservices/recovery_services_vault_resource.go
@@ -258,7 +258,7 @@ func resourceRecoveryServicesVaultCreate(d *pluginsdk.ResourceData, meta interfa
 		return fmt.Errorf("creating %s: %+v", id.String(), err)
 	}
 
-	// `encription` needs to be set before `cross_region_restore_enabled` is set. Or the service will return an error. "If CRR is enabled for the Vault, the storage state will be locked and it will interfere with further operations"
+	// `encryption` needs to be set before `cross_region_restore_enabled` is set. Or the service will return an error. "If CRR is enabled for the Vault, the storage state will be locked and it will interfere with further operations"
 	// recovery vault's encryption config cannot be set while creation, so a standalone update is required.
 	if _, ok := d.GetOk("encryption"); ok {
 		err = client.UpdateThenPoll(ctx, id, vaults.PatchVault{

--- a/internal/services/recoveryservices/recovery_services_vault_resource.go
+++ b/internal/services/recoveryservices/recovery_services_vault_resource.go
@@ -258,6 +258,19 @@ func resourceRecoveryServicesVaultCreate(d *pluginsdk.ResourceData, meta interfa
 		return fmt.Errorf("creating %s: %+v", id.String(), err)
 	}
 
+	// `encription` needs to be set before `cross_region_restore_enabled` is set. Or the service will return an error. "If CRR is enabled for the Vault, the storage state will be locked and it will interfere with further operations"
+	// recovery vault's encryption config cannot be set while creation, so a standalone update is required.
+	if _, ok := d.GetOk("encryption"); ok {
+		err = client.UpdateThenPoll(ctx, id, vaults.PatchVault{
+			Properties: &vaults.VaultProperties{
+				Encryption: expandEncryption(d),
+			},
+		})
+		if err != nil {
+			return fmt.Errorf("updating Recovery Service Encryption %s: %+v, but recovery vault was created, a manually import might be required", id.String(), err)
+		}
+	}
+
 	storageType := backupresourcestorageconfigsnoncrr.StorageType(d.Get("storage_mode_type").(string))
 	storageCfg := backupresourcestorageconfigsnoncrr.BackupResourceConfigResource{
 		Properties: &backupresourcestorageconfigsnoncrr.BackupResourceConfig{
@@ -303,18 +316,6 @@ func resourceRecoveryServicesVaultCreate(d *pluginsdk.ResourceData, meta interfa
 	})
 	if err != nil {
 		return fmt.Errorf("creating %s: %+v", id, err)
-	}
-
-	// recovery vault's encryption config cannot be set while creation, so a standalone update is required.
-	if _, ok := d.GetOk("encryption"); ok {
-		err = client.UpdateThenPoll(ctx, id, vaults.PatchVault{
-			Properties: &vaults.VaultProperties{
-				Encryption: expandEncryption(d),
-			},
-		})
-		if err != nil {
-			return fmt.Errorf("updating Recovery Service Encryption %s: %+v, but recovery vault was created, a manually import might be required", id.String(), err)
-		}
 	}
 
 	// an update on the vault will reset the vault config to default, so we handle it at last.

--- a/internal/services/recoveryservices/recovery_services_vault_resource_test.go
+++ b/internal/services/recoveryservices/recovery_services_vault_resource_test.go
@@ -290,6 +290,21 @@ func TestAccRecoveryServicesVault_crossRegionRestore(t *testing.T) {
 	})
 }
 
+func TestAccRecoveryServicesVault_CrossRegionRestoreWithEncryption(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_recovery_services_vault", "test")
+	r := RecoveryServicesVaultResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.crossRegionRestoreEnabledWithEncryption(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func TestAccRecoveryServicesVault_sku(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_recovery_services_vault", "test")
 	r := RecoveryServicesVaultResource{}
@@ -1167,6 +1182,95 @@ resource "azurerm_recovery_services_vault" "test" {
   cross_region_restore_enabled = true
 }
 `, data.RandomInteger, data.Locations.Primary, data.RandomInteger)
+}
+
+func (RecoveryServicesVaultResource) crossRegionRestoreEnabledWithEncryption(data acceptance.TestData) string {
+
+	return fmt.Sprintf(`
+provider "azurerm" {
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy       = true
+      purge_soft_deleted_keys_on_destroy = false
+    }
+  }
+}
+
+resource "azurerm_resource_group" "test" {
+  name     = "acctestRG-recovery-%[1]d"
+  location = "%[2]s"
+}
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_key_vault" "test" {
+  name                        = "acctest-key-vault-%[3]s"
+  location                    = azurerm_resource_group.test.location
+  resource_group_name         = azurerm_resource_group.test.name
+  enabled_for_disk_encryption = true
+  tenant_id                   = data.azurerm_client_config.current.tenant_id
+  soft_delete_retention_days  = 7
+  purge_protection_enabled    = false
+
+  sku_name = "standard"
+
+  access_policy {
+    tenant_id = data.azurerm_client_config.current.tenant_id
+    object_id = data.azurerm_client_config.current.object_id
+
+    key_permissions = [
+      "Create",
+      "Decrypt",
+      "Encrypt",
+      "Delete",
+      "Get",
+      "List",
+      "Purge",
+      "UnwrapKey",
+      "WrapKey",
+      "Verify",
+      "GetRotationPolicy"
+    ]
+    secret_permissions = [
+      "Set",
+    ]
+  }
+}
+
+resource "azurerm_key_vault_key" "test" {
+  name         = "acctest-key-vault-key"
+  key_vault_id = azurerm_key_vault.test.id
+  key_type     = "RSA"
+  key_size     = 2048
+
+  key_opts = [
+    "decrypt",
+    "encrypt",
+    "sign",
+    "unwrapKey",
+    "verify",
+    "wrapKey",
+  ]
+}
+
+resource "azurerm_recovery_services_vault" "test" {
+  name                = "acctest-Vault-%[1]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  sku                 = "Standard"
+
+  cross_region_restore_enabled = true
+
+  encryption {
+    key_id                            = azurerm_key_vault_key.test.id
+    infrastructure_encryption_enabled = false
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+`, data.RandomInteger, data.Locations.Primary, data.RandomString)
 }
 
 func (RecoveryServicesVaultResource) storageModeTypeDefault(data acceptance.TestData) string {


### PR DESCRIPTION
fix #23375

test
---
```
terraform-provider-azurerm [ tengzh/issue/recovery_vault_crr][$!] [🐹 v1.21.1]
❯ tftest recoveryservices TestAccRecoveryServicesVault   
=== RUN   TestAccRecoveryServicesVault_basic
=== PAUSE TestAccRecoveryServicesVault_basic
=== RUN   TestAccRecoveryServicesVault_ToggleCrossRegionRestore
=== PAUSE TestAccRecoveryServicesVault_ToggleCrossRegionRestore
=== RUN   TestAccRecoveryServicesVault_basicWithCrossRegionRestoreAndWrongStorageType
=== PAUSE TestAccRecoveryServicesVault_basicWithCrossRegionRestoreAndWrongStorageType
=== RUN   TestAccRecoveryServicesVault_zrs
=== PAUSE TestAccRecoveryServicesVault_zrs
=== RUN   TestAccRecoveryServicesVault_complete
=== PAUSE TestAccRecoveryServicesVault_complete
=== RUN   TestAccRecoveryServicesVault_update
=== PAUSE TestAccRecoveryServicesVault_update
=== RUN   TestAccRecoveryServicesVault_requiresImport
=== PAUSE TestAccRecoveryServicesVault_requiresImport
=== RUN   TestAccRecoveryServicesVault_SystemAssignedIdentity
=== PAUSE TestAccRecoveryServicesVault_SystemAssignedIdentity
=== RUN   TestAccRecoveryServicesVault_UserAssignedIdentity
=== PAUSE TestAccRecoveryServicesVault_UserAssignedIdentity
=== RUN   TestAccRecoveryServicesVault_immutability
=== PAUSE TestAccRecoveryServicesVault_immutability
=== RUN   TestAccRecoveryServicesVault_softDelete
=== PAUSE TestAccRecoveryServicesVault_softDelete
=== RUN   TestAccRecoveryServicesVault_storageModeType
=== PAUSE TestAccRecoveryServicesVault_storageModeType
=== RUN   TestAccRecoveryServicesVault_crossRegionRestore
=== PAUSE TestAccRecoveryServicesVault_crossRegionRestore
=== RUN   TestAccRecoveryServicesVault_CrossRegionRestoreWithEncryption
=== PAUSE TestAccRecoveryServicesVault_CrossRegionRestoreWithEncryption
=== RUN   TestAccRecoveryServicesVault_sku
=== PAUSE TestAccRecoveryServicesVault_sku
=== RUN   TestAccRecoveryServicesVault_updateSkuWithExistingEncryption
=== PAUSE TestAccRecoveryServicesVault_updateSkuWithExistingEncryption
=== RUN   TestAccRecoveryServicesVault_encryptionWithKeyVaultKey
=== PAUSE TestAccRecoveryServicesVault_encryptionWithKeyVaultKey
=== RUN   TestAccRecoveryServicesVault_turnOnEncryptionWithKeyVaultKey
=== PAUSE TestAccRecoveryServicesVault_turnOnEncryptionWithKeyVaultKey
=== RUN   TestAccRecoveryServicesVault_turnOffEncryptionWithKeyVaultKeyShouldHaveClearlyErrorMessage
=== PAUSE TestAccRecoveryServicesVault_turnOffEncryptionWithKeyVaultKeyShouldHaveClearlyErrorMessage
=== RUN   TestAccRecoveryServicesVault_changeInfrastructureEncryptionEnabledShouldHaveClearlyErrorMessage
=== PAUSE TestAccRecoveryServicesVault_changeInfrastructureEncryptionEnabledShouldHaveClearlyErrorMessage
=== RUN   TestAccRecoveryServicesVault_encryptionWithInfrastructureEncryption
=== PAUSE TestAccRecoveryServicesVault_encryptionWithInfrastructureEncryption
=== RUN   TestAccRecoveryServicesVault_switchEncryptionKeyVaultKey
=== PAUSE TestAccRecoveryServicesVault_switchEncryptionKeyVaultKey
=== RUN   TestAccRecoveryServicesVault_encryptionWithUserAssignedIdentity
=== PAUSE TestAccRecoveryServicesVault_encryptionWithUserAssignedIdentity
=== RUN   TestAccRecoveryServicesVault_TogglePublicNetworkAccessEnabled
=== PAUSE TestAccRecoveryServicesVault_TogglePublicNetworkAccessEnabled
=== RUN   TestAccRecoveryServicesVault_basicWithClassicVmwareReplicateEnabled
=== PAUSE TestAccRecoveryServicesVault_basicWithClassicVmwareReplicateEnabled
=== RUN   TestAccRecoveryServicesVault_basicWithMonitorDisabled
=== PAUSE TestAccRecoveryServicesVault_basicWithMonitorDisabled
=== CONT  TestAccRecoveryServicesVault_basic
=== CONT  TestAccRecoveryServicesVault_CrossRegionRestoreWithEncryption
=== CONT  TestAccRecoveryServicesVault_encryptionWithInfrastructureEncryption
=== CONT  TestAccRecoveryServicesVault_SystemAssignedIdentity
=== CONT  TestAccRecoveryServicesVault_complete
=== CONT  TestAccRecoveryServicesVault_basicWithCrossRegionRestoreAndWrongStorageType
=== CONT  TestAccRecoveryServicesVault_softDelete
=== CONT  TestAccRecoveryServicesVault_ToggleCrossRegionRestore
--- PASS: TestAccRecoveryServicesVault_basicWithCrossRegionRestoreAndWrongStorageType (122.05s)
=== CONT  TestAccRecoveryServicesVault_immutability
--- PASS: TestAccRecoveryServicesVault_complete (259.96s)
=== CONT  TestAccRecoveryServicesVault_crossRegionRestore
--- PASS: TestAccRecoveryServicesVault_SystemAssignedIdentity (281.35s)
=== CONT  TestAccRecoveryServicesVault_UserAssignedIdentity
--- PASS: TestAccRecoveryServicesVault_basic (301.39s)
=== CONT  TestAccRecoveryServicesVault_requiresImport
--- PASS: TestAccRecoveryServicesVault_requiresImport (188.29s)
=== CONT  TestAccRecoveryServicesVault_storageModeType
--- PASS: TestAccRecoveryServicesVault_immutability (374.45s)
=== CONT  TestAccRecoveryServicesVault_turnOnEncryptionWithKeyVaultKey
--- PASS: TestAccRecoveryServicesVault_ToggleCrossRegionRestore (499.32s)
=== CONT  TestAccRecoveryServicesVault_changeInfrastructureEncryptionEnabledShouldHaveClearlyErrorMessage
--- PASS: TestAccRecoveryServicesVault_encryptionWithInfrastructureEncryption (696.15s)
=== CONT  TestAccRecoveryServicesVault_turnOffEncryptionWithKeyVaultKeyShouldHaveClearlyErrorMessage
--- PASS: TestAccRecoveryServicesVault_CrossRegionRestoreWithEncryption (697.02s)
=== CONT  TestAccRecoveryServicesVault_updateSkuWithExistingEncryption
--- PASS: TestAccRecoveryServicesVault_UserAssignedIdentity (428.79s)
=== CONT  TestAccRecoveryServicesVault_encryptionWithKeyVaultKey
--- PASS: TestAccRecoveryServicesVault_crossRegionRestore (486.55s)
=== CONT  TestAccRecoveryServicesVault_sku
--- PASS: TestAccRecoveryServicesVault_storageModeType (339.16s)
=== CONT  TestAccRecoveryServicesVault_zrs
--- PASS: TestAccRecoveryServicesVault_softDelete (859.26s)
=== CONT  TestAccRecoveryServicesVault_update
--- PASS: TestAccRecoveryServicesVault_changeInfrastructureEncryptionEnabledShouldHaveClearlyErrorMessage (547.09s)
=== CONT  TestAccRecoveryServicesVault_TogglePublicNetworkAccessEnabled
--- PASS: TestAccRecoveryServicesVault_zrs (250.06s)
=== CONT  TestAccRecoveryServicesVault_basicWithMonitorDisabled
--- PASS: TestAccRecoveryServicesVault_turnOnEncryptionWithKeyVaultKey (627.71s)
=== CONT  TestAccRecoveryServicesVault_basicWithClassicVmwareReplicateEnabled
--- PASS: TestAccRecoveryServicesVault_encryptionWithKeyVaultKey (545.79s)
=== CONT  TestAccRecoveryServicesVault_encryptionWithUserAssignedIdentity
--- PASS: TestAccRecoveryServicesVault_update (448.14s)
=== CONT  TestAccRecoveryServicesVault_switchEncryptionKeyVaultKey
--- PASS: TestAccRecoveryServicesVault_basicWithMonitorDisabled (241.94s)
--- PASS: TestAccRecoveryServicesVault_updateSkuWithExistingEncryption (624.60s)
--- PASS: TestAccRecoveryServicesVault_turnOffEncryptionWithKeyVaultKeyShouldHaveClearlyErrorMessage (641.88s)
--- PASS: TestAccRecoveryServicesVault_basicWithClassicVmwareReplicateEnabled (259.07s)
--- PASS: TestAccRecoveryServicesVault_sku (753.87s)
--- PASS: TestAccRecoveryServicesVault_TogglePublicNetworkAccessEnabled (483.00s)
--- PASS: TestAccRecoveryServicesVault_encryptionWithUserAssignedIdentity (514.08s)
--- PASS: TestAccRecoveryServicesVault_switchEncryptionKeyVaultKey (800.67s)
PASS
ok  	github.com/hashicorp/terraform-provider-azurerm/internal/services/recoveryservices	2109.713s

```