### PR TITLE
Add dependency to allow running TeamCity automated tests

### DIFF
--- a/.teamcity/pom.xml
+++ b/.teamcity/pom.xml
@@ -133,5 +133,11 @@
       <version>${kotlin.version}</version>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>org.jetbrains.teamcity</groupId>
+      <artifactId>server-api</artifactId>
+      <version>${teamcity.dsl.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
Closes https://github.com/hashicorp/terraform-provider-azurerm/issues/23633

This PR adds a dependency that allows me to run the [TeamCity tests](https://github.com/hashicorp/terraform-provider-azurerm/blob/415dbc0189a48ebecb3d9279fd1e2c554606e1a5/.teamcity/Makefile#L6) on my laptop. When I run the `make test` command using the main branch I experience the error described in the issue above.

With this dependency I can see the tests running as expected:

```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running tests.ParallelismTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.041 s - in tests.ParallelismTest
[INFO] Running tests.ConfigurationTests
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.073 s - in tests.ConfigurationTests
[INFO] Running tests.VcsTests
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in tests.VcsTests
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
```

Credit to @jrhouston who was the person who figured out what dependency was needed