### PR TITLE
`azurerm_firewall_policy_rule_collection_group`: add support for `http_headers`

### DIFF
--- a/internal/services/firewall/firewall_policy_rule_collection_group_resource_test.go
+++ b/internal/services/firewall/firewall_policy_rule_collection_group_resource_test.go
@@ -519,6 +519,14 @@ resource "azurerm_firewall_policy_rule_collection_group" "test" {
       destination_urls      = ["www.google.com/en"]
       terminate_tls         = true
       web_categories        = ["News"]
+      http_headers {
+        name  = "head_foo"
+        value = "value_bar"
+      }
+      http_headers {
+        name  = "head_bar"
+        value = "value2"
+      }
     }
     rule {
       name        = "app_rule_collection1_rule2"
@@ -794,6 +802,14 @@ resource "azurerm_firewall_policy_rule_collection_group" "test" {
       destination_urls      = ["www.google.com/en"]
       terminate_tls         = true
       web_categories        = ["News"]
+      http_headers {
+        name  = "head_foo"
+        value = "value_bar"
+      }
+      http_headers {
+        name  = "head_bar"
+        value = "value2"
+      }
     }
     rule {
       name        = "app_rule_collection1_rule2"

--- a/internal/services/firewall/firewall_policy_rule_collection_group_resource_test.go
+++ b/internal/services/firewall/firewall_policy_rule_collection_group_resource_test.go
@@ -804,11 +804,11 @@ resource "azurerm_firewall_policy_rule_collection_group" "test" {
       web_categories        = ["News"]
       http_headers {
         name  = "head_foo"
-        value = "value_bar"
+        value = "value_bar2"
       }
       http_headers {
-        name  = "head_bar"
-        value = "value2"
+        name  = "head_bar2"
+        value = "value_bar2"
       }
     }
     rule {

--- a/website/docs/r/firewall_policy_rule_collection_group.html.markdown
+++ b/website/docs/r/firewall_policy_rule_collection_group.html.markdown
@@ -141,6 +141,8 @@ A `application_rule` (application rule) block supports the following:
 
 * `protocols` - (Optional) One or more `protocols` blocks as defined below.
 
+* `http_headers` - (Required) Specifies a list of HTTP/HTTPS headers to insert. One or more `http_headers` blocks as defined below.
+
 * `source_addresses` - (Optional) Specifies a list of source IP addresses (including CIDR, IP range and `*`).
 
 * `source_ip_groups` - (Optional) Specifies a list of source IP groups.
@@ -212,6 +214,14 @@ A `protocols` block supports the following:
 * `type` - (Required) Protocol type. Possible values are `Http` and `Https`.
 
 * `port` - (Required) Port number of the protocol. Range is 0-64000.
+
+---
+
+A `http_headers` block supports the following:
+
+* `name` - (Required) Specifies the name of the header.
+
+* `value` - (Required) Specifies the value of the value.
 
 ## Attributes Reference
 


### PR DESCRIPTION
support `HTTPHeadersToInsert` in swagger.