### PR TITLE
`azurerm_synapse_workspace` - add support for `azure_ad_only_authentication_enabled`

### DIFF
--- a/internal/services/synapse/client/client.go
+++ b/internal/services/synapse/client/client.go
@@ -31,6 +31,7 @@ type Client struct {
 	SQLPoolWorkloadClassifierClient                   *synapse.SQLPoolWorkloadClassifierClient
 	SQLPoolWorkloadGroupClient                        *synapse.SQLPoolWorkloadGroupClient
 	WorkspaceAadAdminsClient                          *synapse.WorkspaceAadAdminsClient
+	WorkspaceAzureADOnlyAuthenticationsClient         *synapse.AzureADOnlyAuthenticationsClient
 	WorkspaceClient                                   *synapse.WorkspacesClient
 	WorkspaceExtendedBlobAuditingPoliciesClient       *synapse.WorkspaceManagedSQLServerExtendedBlobAuditingPoliciesClient
 	WorkspaceManagedIdentitySQLControlSettingsClient  *synapse.WorkspaceManagedIdentitySQLControlSettingsClient
@@ -91,6 +92,9 @@ func NewClient(o *common.ClientOptions) *Client {
 	workspaceAadAdminsClient := synapse.NewWorkspaceAadAdminsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&workspaceAadAdminsClient.Client, o.ResourceManagerAuthorizer)
 
+	workspaceAzureADOnlyAuthenticationsClient := synapse.NewAzureADOnlyAuthenticationsClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
+	o.ConfigureClient(&workspaceAzureADOnlyAuthenticationsClient.Client, o.ResourceManagerAuthorizer)
+
 	workspaceClient := synapse.NewWorkspacesClientWithBaseURI(o.ResourceManagerEndpoint, o.SubscriptionId)
 	o.ConfigureClient(&workspaceClient.Client, o.ResourceManagerAuthorizer)
 
@@ -125,6 +129,7 @@ func NewClient(o *common.ClientOptions) *Client {
 		SQLPoolVulnerabilityAssessmentRuleBaselinesClient: &sqlPoolVulnerabilityAssessmentRuleBaselinesClient,
 		SQLPoolWorkloadClassifierClient:                   &sqlPoolWorkloadClassifierClient,
 		SQLPoolWorkloadGroupClient:                        &sqlPoolWorkloadGroupClient,
+		WorkspaceAzureADOnlyAuthenticationsClient:         &workspaceAzureADOnlyAuthenticationsClient,
 		WorkspaceAadAdminsClient:                          &workspaceAadAdminsClient,
 		WorkspaceClient:                                   &workspaceClient,
 		WorkspaceExtendedBlobAuditingPoliciesClient:       &workspaceExtendedBlobAuditingPoliciesClient,

--- a/internal/services/synapse/synapse_workspace_resource.go
+++ b/internal/services/synapse/synapse_workspace_resource.go
@@ -313,7 +313,7 @@ func resourceSynapseWorkspace() *pluginsdk.Resource {
 				},
 			},
 
-			"azure_ad_only_authentication_enabled": {
+			"azuread_authentication_only": {
 				Type:     pluginsdk.TypeBool,
 				Optional: true,
 				Default:  false,
@@ -365,7 +365,7 @@ func resourceSynapseWorkspaceCreate(d *pluginsdk.ResourceData, meta interface{})
 			ManagedResourceGroupName:         utils.String(d.Get("managed_resource_group_name").(string)),
 			WorkspaceRepositoryConfiguration: expandWorkspaceRepositoryConfiguration(d),
 			Encryption:                       expandEncryptionDetails(d),
-			AzureADOnlyAuthentication:        utils.Bool(d.Get("azure_ad_only_authentication_enabled").(bool)),
+			AzureADOnlyAuthentication:        utils.Bool(d.Get("azuread_authentication_only").(bool)),
 		},
 		Tags: tags.Expand(d.Get("tags").(map[string]interface{})),
 	}
@@ -527,7 +527,7 @@ func resourceSynapseWorkspaceRead(d *pluginsdk.ResourceData, meta interface{}) e
 		d.Set("managed_resource_group_name", props.ManagedResourceGroupName)
 		d.Set("connectivity_endpoints", utils.FlattenMapStringPtrString(props.ConnectivityEndpoints))
 		d.Set("public_network_access_enabled", resp.PublicNetworkAccess == synapse.WorkspacePublicNetworkAccessEnabled)
-		d.Set("azure_ad_only_authentication_enabled", props.AzureADOnlyAuthentication)
+		d.Set("azuread_authentication_only", props.AzureADOnlyAuthentication)
 		cmk := flattenEncryptionDetails(props.Encryption)
 		if err := d.Set("customer_managed_key", cmk); err != nil {
 			return fmt.Errorf("setting `customer_managed_key`: %+v", err)
@@ -624,18 +624,18 @@ func resourceSynapseWorkspaceUpdate(d *pluginsdk.ResourceData, meta interface{})
 		}
 	}
 
-	if d.HasChange("azure_ad_only_authentication_enabled") {
+	if d.HasChange("azuread_authentication_only") {
 		future, err := azureADOnlyAuthenticationsClient.Create(ctx, id.ResourceGroup, id.Name, synapse.AzureADOnlyAuthentication{
 			AzureADOnlyAuthenticationProperties: &synapse.AzureADOnlyAuthenticationProperties{
-				AzureADOnlyAuthentication: pointer.To(d.Get("azure_ad_only_authentication_enabled").(bool)),
+				AzureADOnlyAuthentication: pointer.To(d.Get("azuread_authentication_only").(bool)),
 			},
 		})
 		if err != nil {
-			return fmt.Errorf("updating azure_ad_only_authentication_enabled for %s: %+v", id, err)
+			return fmt.Errorf("updating azuread_authentication_only for %s: %+v", id, err)
 		}
 
 		if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
-			return fmt.Errorf("waiting for azure_ad_only_authentication_enabled to finish updating for %s: %+v", id, err)
+			return fmt.Errorf("waiting for azuread_authentication_only to finish updating for %s: %+v", id, err)
 		}
 	}
 

--- a/internal/services/synapse/synapse_workspace_resource.go
+++ b/internal/services/synapse/synapse_workspace_resource.go
@@ -6,7 +6,6 @@ package synapse
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"log"
 	"net/url"
 	"strings"
@@ -14,6 +13,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/synapse/mgmt/v2.0/synapse" // nolint: staticcheck
 	"github.com/gofrs/uuid"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
 	"github.com/hashicorp/go-azure-helpers/lang/response"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonschema"

--- a/internal/services/synapse/synapse_workspace_resource_test.go
+++ b/internal/services/synapse/synapse_workspace_resource_test.go
@@ -184,6 +184,38 @@ func TestAccSynapseWorkspace_customerManagedKeyActivation(t *testing.T) {
 	})
 }
 
+func TestAccSynapseWorkspace_azureAdOnlyAuthentication(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_synapse_workspace", "test")
+	r := SynapseWorkspaceResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.azureAdOnlyAuthentication(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("managed_resource_group_name").Exists(),
+			),
+		},
+		data.ImportStep("sql_administrator_login_password"),
+		{
+			Config: r.basic(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("managed_resource_group_name").Exists(),
+			),
+		},
+		data.ImportStep("sql_administrator_login_password"),
+		{
+			Config: r.azureAdOnlyAuthentication(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+				check.That(data.ResourceName).Key("managed_resource_group_name").Exists(),
+			),
+		},
+		data.ImportStep("sql_administrator_login_password"),
+	})
+}
+
 func (r SynapseWorkspaceResource) Exists(ctx context.Context, client *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := parse.WorkspaceID(state.ID)
 	if err != nil {
@@ -578,6 +610,36 @@ resource "azurerm_synapse_workspace" "test" {
 
   identity {
     type = "SystemAssigned"
+  }
+}
+`, template, data.RandomInteger, data.RandomInteger)
+}
+
+func (r SynapseWorkspaceResource) azureAdOnlyAuthentication(data acceptance.TestData) string {
+	template := r.template(data)
+	return fmt.Sprintf(`
+%s
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_user_assigned_identity" "test" {
+  name                = "acctestuaid%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+}
+
+resource "azurerm_synapse_workspace" "test" {
+  name                                 = "acctestsw%d"
+  resource_group_name                  = azurerm_resource_group.test.name
+  location                             = azurerm_resource_group.test.location
+  storage_data_lake_gen2_filesystem_id = azurerm_storage_data_lake_gen2_filesystem.test.id
+  sql_administrator_login              = "sqladminuser"
+  sql_administrator_login_password     = "H@Sh1CoR3!"
+  azure_ad_only_authentication_enabled = true
+
+  identity {
+    type         = "SystemAssigned, UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.test.id]
   }
 }
 `, template, data.RandomInteger, data.RandomInteger)

--- a/internal/services/synapse/synapse_workspace_resource_test.go
+++ b/internal/services/synapse/synapse_workspace_resource_test.go
@@ -635,7 +635,7 @@ resource "azurerm_synapse_workspace" "test" {
   storage_data_lake_gen2_filesystem_id = azurerm_storage_data_lake_gen2_filesystem.test.id
   sql_administrator_login              = "sqladminuser"
   sql_administrator_login_password     = "H@Sh1CoR3!"
-  azure_ad_only_authentication_enabled = true
+  azuread_authentication_only          = true
 
   identity {
     type         = "SystemAssigned, UserAssigned"

--- a/website/docs/r/synapse_workspace.html.markdown
+++ b/website/docs/r/synapse_workspace.html.markdown
@@ -183,7 +183,7 @@ The following arguments are supported:
 
 * `sql_administrator_login_password` - (Optional) The Password associated with the `sql_administrator_login` for the SQL administrator. If this is not provided `aad_admin` or `customer_managed_key` must be provided.
 
-* `azure_ad_only_authentication_enabled` - (Optional) Is Azure Active Directory Authentication the only way to authenticate with resources inside this synapse Workspace. Defaults to `false`.
+* `azuread_authentication_only` - (Optional) Is Azure Active Directory Authentication the only way to authenticate with resources inside this synapse Workspace. Defaults to `false`.
 
 ---
 

--- a/website/docs/r/synapse_workspace.html.markdown
+++ b/website/docs/r/synapse_workspace.html.markdown
@@ -183,6 +183,8 @@ The following arguments are supported:
 
 * `sql_administrator_login_password` - (Optional) The Password associated with the `sql_administrator_login` for the SQL administrator. If this is not provided `aad_admin` or `customer_managed_key` must be provided.
 
+* `azure_ad_only_authentication_enabled` - (Optional) Is Azure Active Directory Authentication the only way to authenticate with resources inside this synapse Workspace. Defaults to `false`.
+
 ---
 
 * `aad_admin` - (Optional) An `aad_admin` block as defined below. Conflicts with `customer_managed_key`.


### PR DESCRIPTION
Fixes #16002

```
--- PASS: TestAccSynapseWorkspace_azureAdOnlyAuthentication (956.02s)
```