### PR TITLE
`azurerm_role_definition`: add ValidateFunc for `scope` field

### DIFF
--- a/internal/services/authorization/role_definition_resource.go
+++ b/internal/services/authorization/role_definition_resource.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/authorization/migration"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/authorization/parse"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/validation"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/timeouts"
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
@@ -59,9 +60,10 @@ func resourceArmRoleDefinition() *pluginsdk.Resource {
 			},
 
 			"scope": {
-				Type:     pluginsdk.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         pluginsdk.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringStartsWithOneOf("/subscriptions/", "/providers/Microsoft.Management/managementGroups/"),
 			},
 
 			"description": {

--- a/internal/tf/validation/pluginsdk.go
+++ b/internal/tf/validation/pluginsdk.go
@@ -292,3 +292,20 @@ func StringMatch(r *regexp.Regexp, message string) func(interface{}, string) ([]
 func StringNotInSlice(invalid []string, ignoreCase bool) func(interface{}, string) ([]string, []error) {
 	return validation.StringNotInSlice(invalid, ignoreCase)
 }
+
+func StringStartsWithOneOf(prefixs ...string) func(interface{}, string) ([]string, []error) {
+	return func(i interface{}, k string) (warnings []string, errors []error) {
+		v, ok := i.(string)
+		if !ok {
+			errors = append(errors, fmt.Errorf("expected type of %s to be string", k))
+			return warnings, errors
+		}
+		for _, val := range prefixs {
+			if strings.HasPrefix(v, val) {
+				return warnings, errors
+			}
+		}
+		errors = append(errors, fmt.Errorf("expect %s to start with one of %s, got %q", k, strings.Join(prefixs, ", "), v))
+		return warnings, errors
+	}
+}


### PR DESCRIPTION
fixes #23655.

The scope field is set to part of the ID of the resource and will check the scope field when parse the resource ID in Read/Update. So we need a validation for this field.

https://github.com/hashicorp/terraform-provider-azurerm/blob/1014bf511188b572c0c619105551234be7fcbca3/internal/services/authorization/parse/role_definition.go#L27-L29


![image](https://github.com/hashicorp/terraform-provider-azurerm/assets/2633022/07ffcf40-0338-4567-bbe8-63f215d7ad87)
