### PR TITLE
`azurerm_application_gateway` - fix error when `firewall_policy_id` is removed

### DIFF
--- a/internal/services/network/application_gateway_resource.go
+++ b/internal/services/network/application_gateway_resource.go
@@ -1987,8 +1987,12 @@ func resourceApplicationGatewayUpdate(d *pluginsdk.ResourceData, meta interface{
 	}
 
 	if d.HasChange("firewall_policy_id") {
-		applicationGateway.ApplicationGatewayPropertiesFormat.FirewallPolicy = &network.SubResource{
-			ID: utils.String(d.Get("firewall_policy_id").(string)),
+		if d.Get("firewall_policy_id").(string) != "" {
+			applicationGateway.ApplicationGatewayPropertiesFormat.FirewallPolicy = &network.SubResource{
+				ID: utils.String(d.Get("firewall_policy_id").(string)),
+			}
+		} else {
+			applicationGateway.ApplicationGatewayPropertiesFormat.FirewallPolicy = nil
 		}
 	}
 

--- a/internal/services/network/application_gateway_resource_test.go
+++ b/internal/services/network/application_gateway_resource_test.go
@@ -1287,6 +1287,28 @@ func TestAccApplicationGateway_withoutRequestTimeout(t *testing.T) {
 	})
 }
 
+func TestAccApplicationGateway_removeFirewallPolicy(t *testing.T) {
+	data := acceptance.BuildTestData(t, "azurerm_application_gateway", "test")
+	r := ApplicationGatewayResource{}
+
+	data.ResourceTest(t, r, []acceptance.TestStep{
+		{
+			Config: r.basic_wafv2(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+		{
+			Config: r.basic_v2(data),
+			Check: acceptance.ComposeTestCheckFunc(
+				check.That(data.ResourceName).ExistsInAzure(r),
+			),
+		},
+		data.ImportStep(),
+	})
+}
+
 func (t ApplicationGatewayResource) Exists(ctx context.Context, clients *clients.Client, state *pluginsdk.InstanceState) (*bool, error) {
 	id, err := parse.ApplicationGatewayID(state.ID)
 	if err != nil {
@@ -1369,6 +1391,107 @@ resource "azurerm_application_gateway" "test" {
   }
 }
 `, r.template(data), data.RandomInteger)
+}
+
+func (r ApplicationGatewayResource) basic_wafv2(data acceptance.TestData) string {
+	return fmt.Sprintf(`
+%s
+
+# since these variables are re-used - a locals block makes this more maintainable
+locals {
+  backend_address_pool_name      = "${azurerm_virtual_network.test.name}-beap"
+  frontend_port_name             = "${azurerm_virtual_network.test.name}-feport"
+  frontend_ip_configuration_name = "${azurerm_virtual_network.test.name}-feip"
+  http_setting_name              = "${azurerm_virtual_network.test.name}-be-htst"
+  listener_name                  = "${azurerm_virtual_network.test.name}-httplstn"
+  request_routing_rule_name      = "${azurerm_virtual_network.test.name}-rqrt"
+}
+
+resource "azurerm_public_ip" "test_standard" {
+  name                = "acctest-pubip-standard-%d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+}
+
+resource "azurerm_web_application_firewall_policy" "test" {
+  name                = "acctest-fwp-%[2]d"
+  location            = azurerm_resource_group.test.location
+  resource_group_name = azurerm_resource_group.test.name
+  managed_rules {
+    managed_rule_set {
+      type    = "OWASP"
+      version = "3.1"
+    }
+  }
+  policy_settings {
+    enabled                     = true
+    mode                        = "Prevention"
+    request_body_check          = true
+    file_upload_limit_in_mb     = 250
+    max_request_body_size_in_kb = 128
+  }
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "azurerm_application_gateway" "test" {
+  name                = "acctestag-%d"
+  resource_group_name = azurerm_resource_group.test.name
+  location            = azurerm_resource_group.test.location
+  firewall_policy_id                = azurerm_web_application_firewall_policy.test.id
+  sku {
+    name     = "WAF_v2"
+    tier     = "WAF_v2"
+    capacity = 2
+  }
+
+  gateway_ip_configuration {
+    name      = "my-gateway-ip-configuration"
+    subnet_id = azurerm_subnet.test.id
+  }
+
+  frontend_port {
+    name = local.frontend_port_name
+    port = 80
+  }
+
+  frontend_ip_configuration {
+    name                 = local.frontend_ip_configuration_name
+    public_ip_address_id = azurerm_public_ip.test_standard.id
+  }
+
+  backend_address_pool {
+    name = local.backend_address_pool_name
+  }
+
+  backend_http_settings {
+    name                  = local.http_setting_name
+    cookie_based_affinity = "Disabled"
+    port                  = 80
+    protocol              = "Http"
+    request_timeout       = 1
+  }
+
+  http_listener {
+    name                           = local.listener_name
+    frontend_ip_configuration_name = local.frontend_ip_configuration_name
+    frontend_port_name             = local.frontend_port_name
+    protocol                       = "Http"
+  }
+
+  request_routing_rule {
+    name                       = local.request_routing_rule_name
+    rule_type                  = "Basic"
+    http_listener_name         = local.listener_name
+    backend_address_pool_name  = local.backend_address_pool_name
+    backend_http_settings_name = local.http_setting_name
+    priority                   = 10
+  }
+}
+`, r.template(data), data.RandomInteger, data.RandomInteger)
 }
 
 func (r ApplicationGatewayResource) basic_v2(data acceptance.TestData) string {

--- a/internal/services/network/application_gateway_resource_test.go
+++ b/internal/services/network/application_gateway_resource_test.go
@@ -1441,7 +1441,7 @@ resource "azurerm_application_gateway" "test" {
   name                = "acctestag-%d"
   resource_group_name = azurerm_resource_group.test.name
   location            = azurerm_resource_group.test.location
-  firewall_policy_id                = azurerm_web_application_firewall_policy.test.id
+  firewall_policy_id  = azurerm_web_application_firewall_policy.test.id
   sku {
     name     = "WAF_v2"
     tier     = "WAF_v2"


### PR DESCRIPTION
fix https://github.com/hashicorp/terraform-provider-azurerm/issues/23656
 my local test with config provided in the issue can work:
```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the
following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # azurerm_application_gateway.network3 will be updated in-place
  ~ resource "azurerm_application_gateway" "network3" {
      - firewall_policy_id                = "/subscriptions/x/resourceGroups/wt-example-resources/providers/Microsoft.Network/applicationGatewayWebApplicationFirewallPolicies/examplewafpolicy" -> null
      - force_firewall_policy_association = true -> null
        id                                = "/subscriptions/x/resourceGroups/wt-example-resources/providers/Microsoft.Network/applicationGateways/example-appgateway"
        name                              = "example-appgateway"
        tags                              = {}
        # (6 unchanged attributes hidden)

      ~ sku {
          ~ name     = "WAF_v2" -> "Standard_v2"
          ~ tier     = "WAF_v2" -> "Standard_v2"
            # (1 unchanged attribute hidden)
        }

        # (8 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
azurerm_application_gateway.network3: Modifying... [id=/subscriptions/x/resourceGroups/wt-example-resources/providers/Microsoft.Network/applicationGateways/example-appgateway]
azurerm_application_gateway.network3: Still modifying... [id=/subscriptions/x-...applicationGateways/example-appgateway, 10s elapsed]
azurerm_application_gateway.network3: Modifications complete after 12s [id=/subscriptions/x/resourceGroups/wt-example-resources/providers/Microsoft.Network/applicationGateways/example-appgateway]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```