### PR TITLE
Remove version/release_trian conflict from arc_kuberenetes_cluster_extension_resource 

### DIFF
--- a/internal/services/arckubernetes/arc_kubernetes_cluster_extension_resource.go
+++ b/internal/services/arckubernetes/arc_kubernetes_cluster_extension_resource.go
@@ -117,12 +117,11 @@ func (r ArcKubernetesClusterExtensionResource) Arguments() map[string]*pluginsdk
 		},
 
 		"release_train": {
-			Type:          pluginsdk.TypeString,
-			Optional:      true,
-			Computed:      true,
-			ForceNew:      true,
-			ConflictsWith: []string{"version"},
-			ValidateFunc:  validation.StringIsNotEmpty,
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			Computed:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
 		},
 
 		"release_namespace": {
@@ -144,11 +143,10 @@ func (r ArcKubernetesClusterExtensionResource) Arguments() map[string]*pluginsdk
 		},
 
 		"version": {
-			Type:          pluginsdk.TypeString,
-			Optional:      true,
-			ForceNew:      true,
-			ConflictsWith: []string{"release_train"},
-			ValidateFunc:  validation.StringIsNotEmpty,
+			Type:         pluginsdk.TypeString,
+			Optional:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.StringIsNotEmpty,
 		},
 	}
 

--- a/internal/services/arckubernetes/arc_kubernetes_cluster_extension_resource_test.go
+++ b/internal/services/arckubernetes/arc_kubernetes_cluster_extension_resource_test.go
@@ -177,6 +177,7 @@ resource "azurerm_arc_kubernetes_cluster_extension" "test" {
   name              = "acctest-kce-%[2]d"
   cluster_id        = azurerm_arc_kubernetes_cluster.test.id
   extension_type    = "microsoft.flux"
+  release_train     = "stable"
   version           = "1.6.3"
   release_namespace = "flux-system"
 


### PR DESCRIPTION
This PR addresses issue #23690.

- Removed the conflict between `version` and `release_train`.

I executed the acceptance tests that relate to `arc_kubernetes_cluster_extension_resource.go` and verified that they all pass. Since this is an edge case where a version and a release train could potentially be removed for an extension in the future, I did not add an acceptance test to avoid a future broken test case.