### PR TITLE
`azurerm_redis_enterprise_cluster` - support for new location `Japan East`

### DIFF
--- a/internal/services/redisenterprise/validate/redis_enterprise_cluster_location.go
+++ b/internal/services/redisenterprise/validate/redis_enterprise_cluster_location.go
@@ -52,6 +52,7 @@ func friendlyValidRedisEnterpriseClusterLocations() []string {
 		"Central US EUAP",
 		"East Asia",
 		"East US",
+		"Japan East",
 		"North Central US",
 		"North Europe",
 		"South Central US",


### PR DESCRIPTION
As requested by the service team, the `Japan East` location of resource `azurerm_redis_enterprise_cluster` is supported.

Note: Because of the comment in https://github.com/hashicorp/terraform-provider-azurerm/pull/23185, there is no test case for this change, but it is tested locally.