### PR TITLE
`azurerm_cognitive_deployment` - remove `forceNew` tag from `rai_policy_name`

### DIFF
--- a/internal/services/cognitive/cognitive_deployment_resource.go
+++ b/internal/services/cognitive/cognitive_deployment_resource.go
@@ -108,7 +108,6 @@ func (r CognitiveDeploymentResource) Arguments() map[string]*pluginsdk.Schema {
 		"rai_policy_name": {
 			Type:         pluginsdk.TypeString,
 			Optional:     true,
-			ForceNew:     true,
 			ValidateFunc: validation.StringIsNotEmpty,
 		},
 	}
@@ -288,6 +287,10 @@ func (r CognitiveDeploymentResource) Update() sdk.ResourceFunc {
 
 			if metadata.ResourceData.HasChange("scale.0.capacity") {
 				properties.Sku.Capacity = pointer.To(model.ScaleSettings[0].Capacity)
+			}
+
+			if metadata.ResourceData.HasChange("rai_policy_name") {
+				properties.Properties.RaiPolicyName = pointer.To(model.RaiPolicyName)
 			}
 
 			if err := client.CreateOrUpdateThenPoll(ctx, *id, *properties); err != nil {

--- a/internal/services/cognitive/cognitive_deployment_resource_test.go
+++ b/internal/services/cognitive/cognitive_deployment_resource_test.go
@@ -82,10 +82,11 @@ func TestAccCognitiveDeployment_update(t *testing.T) {
 
 	data.ResourceSequentialTest(t, r, []acceptance.TestStep{
 		{
-			Config: r.basic(data),
+			Config: r.complete(data),
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("scale.0.capacity").HasValue("1"),
+				check.That(data.ResourceName).Key("rai_policy_name").HasValue("RAI policy"),
 			),
 		},
 		data.ImportStep(),
@@ -94,6 +95,7 @@ func TestAccCognitiveDeployment_update(t *testing.T) {
 			Check: acceptance.ComposeTestCheckFunc(
 				check.That(data.ResourceName).ExistsInAzure(r),
 				check.That(data.ResourceName).Key("scale.0.capacity").HasValue("2"),
+				check.That(data.ResourceName).Key("rai_policy_name").HasValue("Microsoft.Default"),
 			),
 		},
 		data.ImportStep(),
@@ -213,6 +215,7 @@ func (r CognitiveDeploymentTestResource) update(data acceptance.TestData) string
 resource "azurerm_cognitive_deployment" "test" {
   name                 = "acctest-cd-%d"
   cognitive_account_id = azurerm_cognitive_account.test.id
+  rai_policy_name      = "Microsoft.Default"
   model {
     format  = "OpenAI"
     name    = "text-embedding-ada-002"

--- a/website/docs/r/cognitive_deployment.html.markdown
+++ b/website/docs/r/cognitive_deployment.html.markdown
@@ -54,7 +54,7 @@ The following arguments are supported:
 
 * `scale` - (Required) A `scale` block as defined below. Changing this forces a new resource to be created.
 
-* `rai_policy_name` - (Optional) The name of RAI policy. Changing this forces a new resource to be created.
+* `rai_policy_name` - (Optional) The name of RAI policy.
 
 ---
 


### PR DESCRIPTION
`azurerm_cognitive_deployment` 
- fixes https://github.com/hashicorp/terraform-provider-azurerm/issues/23454
- remove `forceNew` tag from `rai_policy_name`
- add a testcase to verify the result
- update docs

Testing Evidence:

```
GOROOT=C:\Program Files\Go #gosetup
GOPATH=C:\Users\yunliu1\go #gosetup
"C:\Program Files\Go\bin\go.exe" test -c -o C:\Users\yunliu1\AppData\Local\JetBrains\GoLand2023.2\tmp\GoLand\___TestAccCognitiveDeployment_update_in_github_com_hashicorp_terraform_provider_azurerm_internal_services_cognitive.test.exe github.com/hashicorp/terraform-provider-azurerm/internal/services/cognitive #gosetup
"C:\Program Files\Go\bin\go.exe" tool test2json -t C:\Users\yunliu1\AppData\Local\JetBrains\GoLand2023.2\tmp\GoLand\___TestAccCognitiveDeployment_update_in_github_com_hashicorp_terraform_provider_azurerm_internal_services_cognitive.test.exe -test.v -test.paniconexit0 -test.run ^\QTestAccCognitiveDeployment_update\E$ #gosetup
=== RUN   TestAccCognitiveDeployment_update
--- PASS: TestAccCognitiveDeployment_update (295.05s)
PASS


Process finished with the exit code 0
```