### PR TITLE
Docs: Remove unused `azurerm_subnet` block in `azurerm_application_gateway` document

### DIFF
--- a/website/docs/r/application_gateway.html.markdown
+++ b/website/docs/r/application_gateway.html.markdown
@@ -32,13 +32,6 @@ resource "azurerm_subnet" "frontend" {
   address_prefixes     = ["10.254.0.0/24"]
 }
 
-resource "azurerm_subnet" "backend" {
-  name                 = "backend"
-  resource_group_name  = azurerm_resource_group.example.name
-  virtual_network_name = azurerm_virtual_network.example.name
-  address_prefixes     = ["10.254.2.0/24"]
-}
-
 resource "azurerm_public_ip" "example" {
   name                = "example-pip"
   resource_group_name = azurerm_resource_group.example.name


### PR DESCRIPTION
Remove the unused "resource `azurerm_subnet" "backend`  block to fix #23702.