### PR TITLE
Fix incorrect documentation on `azurerm_eventhub_namespace_customer_managed_key`

### DIFF
--- a/website/docs/r/eventhub_namespace_customer_managed_key.html.markdown
+++ b/website/docs/r/eventhub_namespace_customer_managed_key.html.markdown
@@ -176,13 +176,9 @@ resource "azurerm_key_vault_key" "example" {
 }
 
 resource "azurerm_eventhub_namespace_customer_managed_key" "example" {
-  eventhub_namespace_id = azurerm_eventhub_namespace.example.id
-  key_vault_key_ids     = [azurerm_key_vault_key.example.id]
-
-  identity {
-    type         = "UserAssigned"
-    identity_ids = [azurerm_user_assigned_identity.example.id]
-  }
+  eventhub_namespace_id     = azurerm_eventhub_namespace.example.id
+  key_vault_key_ids         = [azurerm_key_vault_key.example.id]
+  user_assigned_identity_id = azurerm_user_assigned_identity.example.id
 }
 ```
 


### PR DESCRIPTION
An incorrect format of the syntax snuck into the last release. The fixes the syntax so it is correct.