### PR TITLE
`azurerm_api_management_diagnostic` - the `operation_name_format` property is only available for `applicationinsights` diagnostic

### DIFF
--- a/internal/services/apimanagement/api_management_diagnostic_resource.go
+++ b/internal/services/apimanagement/api_management_diagnostic_resource.go
@@ -157,19 +157,11 @@ func resourceApiManagementDiagnosticCreateUpdate(d *pluginsdk.ResourceData, meta
 		},
 	}
 
-	if !features.FourPointOh() {
-		if d.Get("identifier") == "applicationinsights" {
-			if operationNameFormat, ok := d.GetOk("operation_name_format"); ok {
-				parameters.Properties.OperationNameFormat = pointer.To(diagnostic.OperationNameFormat(operationNameFormat.(string)))
-			} else {
-				parameters.Properties.OperationNameFormat = pointer.To(diagnostic.OperationNameFormatName)
-			}
-		}
-	} else {
-		if d.Get("identifier") == "applicationinsights" {
-			if operationNameFormat, ok := d.GetOk("operation_name_format"); ok {
-				parameters.Properties.OperationNameFormat = pointer.To(diagnostic.OperationNameFormat(operationNameFormat.(string)))
-			}
+	if d.Get("identifier") == "applicationinsights" {
+		if operationNameFormat, ok := d.GetOk("operation_name_format"); ok {
+			parameters.Properties.OperationNameFormat = pointer.To(diagnostic.OperationNameFormat(operationNameFormat.(string)))
+		} else if !features.FourPointOh() {
+			parameters.Properties.OperationNameFormat = pointer.To(diagnostic.OperationNameFormatName)
 		}
 	}
 

--- a/internal/services/apimanagement/api_management_diagnostic_resource.go
+++ b/internal/services/apimanagement/api_management_diagnostic_resource.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/apimanagement/2021-08-01/logger"
 	"github.com/hashicorp/terraform-provider-azurerm/helpers/tf"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/clients"
+	"github.com/hashicorp/terraform-provider-azurerm/internal/features"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/services/apimanagement/schemaz"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/pluginsdk"
 	"github.com/hashicorp/terraform-provider-azurerm/internal/tf/set"
@@ -114,7 +115,12 @@ func resourceApiManagementDiagnostic() *pluginsdk.Resource {
 			"operation_name_format": {
 				Type:     pluginsdk.TypeString,
 				Optional: true,
-				Default:  string(diagnostic.OperationNameFormatName),
+				Default: func() interface{} {
+					if !features.FourPointOh() {
+						return string(diagnostic.OperationNameFormatName)
+					}
+					return nil
+				}(),
 				ValidateFunc: validation.StringInSlice([]string{
 					string(diagnostic.OperationNameFormatName),
 					string(diagnostic.OperationNameFormatUrl),
@@ -147,9 +153,16 @@ func resourceApiManagementDiagnosticCreateUpdate(d *pluginsdk.ResourceData, meta
 
 	parameters := diagnostic.DiagnosticContract{
 		Properties: &diagnostic.DiagnosticContractProperties{
-			LoggerId:            d.Get("api_management_logger_id").(string),
-			OperationNameFormat: pointer.To(diagnostic.OperationNameFormat(d.Get("operation_name_format").(string))),
+			LoggerId: d.Get("api_management_logger_id").(string),
 		},
+	}
+
+	if d.Get("identifier") == "applicationinsights" {
+		if operationNameFormat, ok := d.GetOk("operation_name_format"); ok {
+			parameters.Properties.OperationNameFormat = pointer.To(diagnostic.OperationNameFormat(operationNameFormat.(string)))
+		} else {
+			parameters.Properties.OperationNameFormat = pointer.To(diagnostic.OperationNameFormatName)
+		}
 	}
 
 	if samplingPercentage, ok := d.GetOk("sampling_percentage"); ok {
@@ -259,7 +272,7 @@ func resourceApiManagementDiagnosticRead(d *pluginsdk.ResourceData, meta interfa
 				d.Set("backend_request", nil)
 				d.Set("backend_response", nil)
 			}
-			format := string(diagnostic.OperationNameFormatName)
+			format := ""
 			if props.OperationNameFormat != nil {
 				format = string(pointer.From(props.OperationNameFormat))
 			}

--- a/internal/services/apimanagement/api_management_diagnostic_resource.go
+++ b/internal/services/apimanagement/api_management_diagnostic_resource.go
@@ -157,11 +157,19 @@ func resourceApiManagementDiagnosticCreateUpdate(d *pluginsdk.ResourceData, meta
 		},
 	}
 
-	if d.Get("identifier") == "applicationinsights" {
-		if operationNameFormat, ok := d.GetOk("operation_name_format"); ok {
-			parameters.Properties.OperationNameFormat = pointer.To(diagnostic.OperationNameFormat(operationNameFormat.(string)))
-		} else {
-			parameters.Properties.OperationNameFormat = pointer.To(diagnostic.OperationNameFormatName)
+	if !features.FourPointOh() {
+		if d.Get("identifier") == "applicationinsights" {
+			if operationNameFormat, ok := d.GetOk("operation_name_format"); ok {
+				parameters.Properties.OperationNameFormat = pointer.To(diagnostic.OperationNameFormat(operationNameFormat.(string)))
+			} else {
+				parameters.Properties.OperationNameFormat = pointer.To(diagnostic.OperationNameFormatName)
+			}
+		}
+	} else {
+		if d.Get("identifier") == "applicationinsights" {
+			if operationNameFormat, ok := d.GetOk("operation_name_format"); ok {
+				parameters.Properties.OperationNameFormat = pointer.To(diagnostic.OperationNameFormat(operationNameFormat.(string)))
+			}
 		}
 	}
 
@@ -272,7 +280,11 @@ func resourceApiManagementDiagnosticRead(d *pluginsdk.ResourceData, meta interfa
 				d.Set("backend_request", nil)
 				d.Set("backend_response", nil)
 			}
+
 			format := ""
+			if !features.FourPointOh() {
+				format = string(diagnostic.OperationNameFormatName)
+			}
 			if props.OperationNameFormat != nil {
 				format = string(pointer.From(props.OperationNameFormat))
 			}


### PR DESCRIPTION
Although PR #22545 was submitted to fix #19970, no response was received from the submitter for a long time. Since we received  request from users to fix this issue, submitting this PR to fix it.